### PR TITLE
refactor(ui): use JSONViewer for install state

### DIFF
--- a/services/dashboard-ui/src/components/common/JSONViewer.tsx
+++ b/services/dashboard-ui/src/components/common/JSONViewer.tsx
@@ -1,18 +1,15 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import React, { useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
+import { Skeleton } from '@/components/common/Skeleton'
 import { useSystemTheme } from '@/hooks/use-system-theme'
 import { cn } from '@/utils/classnames'
 
 const JsonViewer = dynamic(
   () => import('@andypf/json-viewer/dist/esm/react/JsonViewer'),
   {
-    loading: () => (
-      <div className="border rounded-md overflow-auto p-4 animate-pulse">
-        <div className="h-20 bg-cool-grey-200 dark:bg-dark-grey-700 rounded"></div>
-      </div>
-    ),
+    loading: () => <Skeleton height="450px" width="100%" />,
     ssr: false,
   }
 ) as typeof import('@andypf/json-viewer/dist/esm/react/JsonViewer')
@@ -42,7 +39,7 @@ export const JSONViewer = ({
 }: IJSONViewer) => {
   const colorScheme = useSystemTheme()
   const containerRef = useRef<HTMLDivElement>(null)
-  
+
   // Custom dark theme with correct JSONViewer Base16 mapping
   const customDarkTheme = {
     base00: '#19171C', // Default Background (bg-code dark)
@@ -90,10 +87,11 @@ export const JSONViewer = ({
   useEffect(() => {
     const injectShadowCSS = () => {
       if (!containerRef.current) return
-      
-      const jsonViewer = containerRef.current.querySelector('andypf-json-viewer')
+
+      const jsonViewer =
+        containerRef.current.querySelector('andypf-json-viewer')
       if (!jsonViewer || !jsonViewer.shadowRoot) return
-      
+
       // Create a new stylesheet
       const sheet = new CSSStyleSheet()
       const css = `
@@ -112,31 +110,28 @@ export const JSONViewer = ({
           font-size: 0.875rem !important;
         }
       `
-      
+
       sheet.replaceSync(css)
-      
+
       // Add the stylesheet to the shadow root
       if (jsonViewer.shadowRoot.adoptedStyleSheets) {
         jsonViewer.shadowRoot.adoptedStyleSheets = [
           ...jsonViewer.shadowRoot.adoptedStyleSheets,
-          sheet
+          sheet,
         ]
       }
     }
-    
+
     // Try injecting after a short delay to ensure the component is rendered
     const timer = setTimeout(injectShadowCSS, 100)
-    
+
     return () => clearTimeout(timer)
   }, [data, colorScheme])
 
   return (
     <div
       ref={containerRef}
-      className={cn(
-        'border rounded-md overflow-auto',
-        className
-      )}
+      className={cn('border rounded-md overflow-auto', className)}
       {...props}
     >
       <style jsx>{`

--- a/services/dashboard-ui/src/components/installs/management/ViewState.tsx
+++ b/services/dashboard-ui/src/components/installs/management/ViewState.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Button, type IButtonAsButton } from '@/components/common/Button'
-import { CodeBlock } from '@/components/common/CodeBlock'
+import { JSONViewer } from "@/components/common/JSONViewer"
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
 import { Banner } from '@/components/common/Banner'
@@ -16,7 +16,6 @@ import { useQuery } from '@/hooks/use-query'
 interface IViewState {}
 
 export const ViewStateModal = ({ ...props }: IViewState & IModal) => {
-  const { removeModal } = useSurfaces()
   const { org } = useOrg()
   const { install } = useInstall()
 
@@ -55,7 +54,7 @@ export const ViewStateModal = ({ ...props }: IViewState & IModal) => {
             <div className="flex justify-end">
               <Skeleton height="26px" width="26px" />
             </div>
-            <Skeleton height="600px" width="100%" />
+            <Skeleton height="458px" width="100%" />
           </div>
         ) : state ? (
           <div className="flex flex-col gap-4">
@@ -65,12 +64,7 @@ export const ViewStateModal = ({ ...props }: IViewState & IModal) => {
                 className="w-fit"
               />
             </div>
-            <CodeBlock 
-              language="json"
-              className="max-h-[600px]"
-            >
-              {JSON.stringify(state, null, 2)}
-            </CodeBlock>
+            <JSONViewer className="min-h-[458px] max-h-[600px] bg-code" data={state} expanded={1}  />          
           </div>
         ) : (
           <div className="flex items-center justify-center p-8">


### PR DESCRIPTION
Update install state modal to use the JSONViewer instead of a CodeBlock. JSONViewer is more performant at rendering large JSON objects like the install state