### PR TITLE
feat(auth):  styles for auth service pages

### DIFF
--- a/services/ctl-api/internal/app/auth/service/templates/auth.html.tmpl
+++ b/services/ctl-api/internal/app/auth/service/templates/auth.html.tmpl
@@ -1,11 +1,25 @@
 {{ define "auth/auth.tmpl" }}
-{{ template "auth/base.tmpl" . }}
-{{ end }}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    {{template "head.tmpl"}}
+    <title>Authenticating | Nuon</title>
+</head>
+<body class="min-h-screen bg-gray-100 relative" style="background-image: url('https://nuon.co/Rightsideimage.jpg'); background-size: cover; background-position: center; background-repeat: no-repeat;">
+    <div class="absolute inset-0 bg-[#121212] opacity-75"></div>
+    <main class="min-h-screen flex items-center justify-center p-4 relative z-10">
+        <div class="w-full max-w-md">
+            <div class="mb-8 -mt-24">
+                {{template "logo.tmpl"}}
+            </div>
+            <div class="bg-white rounded-lg shadow-sm p-8 text-center">
+                <h2 class="text-2xl font-bold mb-4">Authenticating...</h2>
+                <p class="text-gray-600">Please wait while we complete your authentication.</p>
+            </div>
+        </div>
+    </main>
 
-{{ define "title" }}Authenticate | Nuon Auth{{ end }}
-
-{{ define "content" }}
-<main>
-  <h1>Authenticate</h1>
-</main>
+    {{template "footer.tmpl"}}
+</body>
+</html>
 {{ end }}

--- a/services/ctl-api/internal/app/auth/service/templates/base.html.tmpl
+++ b/services/ctl-api/internal/app/auth/service/templates/base.html.tmpl
@@ -1,18 +1,52 @@
-<!-- vi: set syntax=html -->
-{{ define "auth/head.tmpl" }}
+{{define "head.tmpl"}}
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta http-equiv="X-UA-Compatible" content="ie=edge">
-{{ end }}
+<link rel="icon" type="image/svg+xml" href="https://nuon.co/favicon.svg">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+<script src="https://cdn.tailwindcss.com"></script>
+<script>
+  tailwind.config = {
+    theme: {
+      extend: {
+        colors: {
+          'nuon-blue': '#1976d2',
+          'nuon-blue-dark': '#1565c0',
+        },
+        fontFamily: {
+          'sans': ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+        },
+        fontWeight: {
+          'normal': '400',
+          'semibold': '500',
+          'bold': '600',
+        }
+      }
+    }
+  }
+</script>
+{{end}}
 
-{{ define "auth/header.tmpl" }}
-<header>
-  <nav>Nuon Auth</nav>
+{{define "logo.tmpl"}}
+<a href="https://nuon.co" class="w-fit">
+    <span class="sr-only">Nuon</span>   
+    <svg class="transition-transform duration-fast ease-cubic shrink-0 block" width="154" height="64" viewBox="0 0 77 32" fill="none" xmlns="http://www.w3.org/2000/svg"><g id="logo-white"><path id="Vector" d="M16.9922 0L10.8687 3.53672V9.26271L5.91167 6.3983H5.90884L0 9.81073V28.5876L5.90602 32H5.90884L12.2498 28.3362V22.8616L16.9922 25.5989L23.1157 22.0621V3.53672L16.9922 0ZM1.384 10.6102L5.90602 8H5.90884L10.8658 10.8616V20.4633L1.384 14.9887V10.6102ZM10.8658 27.5367L5.90602 30.3983L1.384 27.7881V16.5876L10.8658 22.0621V27.5367ZM21.7317 21.2599L16.9922 23.9972L12.2527 21.2627V11.661L21.7345 17.1356V21.2599H21.7317ZM21.7317 15.5367L12.2498 10.0621V4.33616L16.9922 1.59887L21.7317 4.33616V15.5367Z" fill="white"></path><g id="nuon" class="whitespace-nowrap transition-opacity duration-fast ease-cubic"><path id="Vector_2" d="M40.8237 19.172V25.6127H38.0444V19.8274C38.0444 18.1324 37.2535 17.4093 35.8978 17.4093C34.4742 17.4093 33.4574 18.2454 33.4574 20.5053V25.6127H30.7007V15.172H33.4348V16.7539H33.48C34.1805 15.5562 35.3554 14.833 36.892 14.833C39.1516 14.833 40.8237 16.0985 40.8237 19.172Z" fill="white"></path><path id="Vector_3" d="M42.623 21.5674V15.1719H45.4701V21.0702C45.4701 22.6973 46.2384 23.3979 47.436 23.3979C48.8143 23.3979 49.7408 22.4939 49.7408 20.1888V15.1719H52.5201V25.6126H49.786V24.008H49.7408C49.1081 25.138 48.1139 25.9515 46.487 25.9515C44.3629 25.9515 42.623 24.6634 42.623 21.5674Z" fill="white"></path><path id="Vector_4" d="M65.49 20.3923C65.49 23.6692 63.0271 25.9517 59.7055 25.9517C56.3839 25.9517 53.9209 23.6692 53.9209 20.3923C53.9209 17.1155 56.3839 14.833 59.7055 14.833C63.0271 14.833 65.49 17.1155 65.49 20.3923ZM56.768 20.3923C56.768 22.1776 58.0108 23.3302 59.7055 23.3302C61.4002 23.3302 62.6203 22.1776 62.6203 20.3923C62.6203 18.607 61.4002 17.4545 59.7055 17.4545C58.0108 17.4545 56.768 18.607 56.768 20.3923Z" fill="white"></path><path id="Vector_5" d="M76.9999 19.172V25.6127H74.2206V19.8274C74.2206 18.1324 73.4298 17.4093 72.074 17.4093C70.6505 17.4093 69.6337 18.2454 69.6337 20.5053V25.6127H66.877V15.172H69.6111V16.7539H69.6563C70.3567 15.5562 71.5317 14.833 73.0682 14.833C75.3278 14.833 76.9999 16.0985 76.9999 19.172Z" fill="white"></path></g></g></svg>
+</a>
+{{end}}
+
+{{define "header.tmpl"}}
+<header class="bg-white border-b border-gray-200">
+    <div class="max-w-7xl mx-auto px-4 py-4">
+        {{template "logo.tmpl"}}
+    </div>
 </header>
-{{ end }}
+{{end}}
 
-{{ define "auth/footer.tmpl" }}
-<footer>
-  <p>&copy; Nuon</p>
+{{define "footer.tmpl"}}
+<footer class="bg-white border-t border-gray-200 py-4">
+    <div class="max-w-7xl mx-auto px-4 text-center text-sm text-gray-600">
+        © 2026 Nuon. All rights reserved.
+    </div>
 </footer>
-{{ end }}
+{{end}}

--- a/services/ctl-api/internal/app/auth/service/templates/error.html.tmpl
+++ b/services/ctl-api/internal/app/auth/service/templates/error.html.tmpl
@@ -2,16 +2,35 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  {{ template "auth/head.tmpl" . }}
-  <title>Error | Nuon Auth</title>
+    {{template "head.tmpl"}}
+    <title>Error | Nuon</title>
 </head>
-<body>
-  {{ template "auth/header.tmpl" . }}
-  <main>
-    <h1>{{.Status}}</h1>
-    {{.Error}}
-  </main>
-  {{ template "auth/footer.tmpl" . }}
+<body class="min-h-screen bg-gray-100 relative" style="background-image: url('https://nuon.co/Rightsideimage.jpg'); background-size: cover; background-position: center; background-repeat: no-repeat;">
+    <div class="absolute inset-0 bg-[#121212] opacity-75"></div>
+    <main class="min-h-screen flex items-center justify-center p-4 relative z-10">
+        <div class="w-full max-w-md">
+            <div class="mb-8 -mt-24">
+                {{template "logo.tmpl"}}
+            </div>
+            <div class="bg-white rounded-lg shadow-sm p-8">
+                <h2 class="text-xl font-normal text-gray-900 mb-2">Authentication error</h2>
+
+                {{if .Status}}
+                    <p class="text-sm text-gray-600 mb-2">Status: {{.Status}}</p>
+                {{end}}
+
+                {{if .Error}}
+                    <p class="text-sm text-red-600 mb-8">{{.Error}}</p>
+                {{else}}
+                    <p class="text-sm text-gray-600 mb-8">An error occurred during authentication.</p>
+                {{end}}
+
+                <a href="/" class="flex items-center justify-center w-full py-3 px-4 bg-white border border-gray-300 rounded-md hover:bg-gray-50 text-gray-700 font-semibold transition-colors">
+                    Try again
+                </a>
+            </div>
+        </div>
+    </main>
 </body>
 </html>
 {{ end }}

--- a/services/ctl-api/internal/app/auth/service/templates/index.html.tmpl
+++ b/services/ctl-api/internal/app/auth/service/templates/index.html.tmpl
@@ -2,80 +2,53 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  {{ template "auth/head.tmpl" . }}
-  <title>Sign In | Nuon Auth</title>
-  <style>
-    main {
-      max-width: 400px;
-      margin: 2rem auto;
-      padding: 2rem;
-      text-align: center;
-    }
-    .login-options {
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
-      margin-top: 2rem;
-    }
-    .login-btn {
-      display: block;
-      padding: 0.75rem 1.5rem;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      background: #fff;
-      color: #333;
-      text-decoration: none;
-      font-size: 1rem;
-      cursor: pointer;
-      transition: background-color 0.2s;
-    }
-    .login-btn:hover {
-      background: #f5f5f5;
-    }
-    .login-btn.google { border-color: #4285f4; color: #4285f4; }
-    .login-btn.github { border-color: #333; color: #333; }
-    .login-btn.oidc { border-color: #6c757d; color: #6c757d; }
-    .authenticated {
-      margin-top: 2rem;
-      padding: 1rem;
-      background: #e8f5e9;
-      border-radius: 4px;
-    }
-    .logout-btn {
-      margin-top: 1rem;
-      display: inline-block;
-      padding: 0.5rem 1rem;
-      background: #dc3545;
-      color: #fff;
-      text-decoration: none;
-      border-radius: 4px;
-    }
-  </style>
+    {{template "head.tmpl"}}
+    <title>Sign In | Nuon</title>
 </head>
-<body>
-  {{ template "auth/header.tmpl" . }}
-  <main>
-    {{ if .IsAuthenticated }}
-      <div class="authenticated">
-        <p>Signed in as <strong>{{ .Email }}</strong></p>
-        <a href="/logout" class="logout-btn">Sign Out</a>
-      </div>
-    {{ else }}
-      <h1>Sign In</h1>
-      <p>Choose a login method:</p>
-      <div class="login-options">
-        {{ $redirectURL := .RedirectURL }}
-        {{ range .Providers }}
-          <a href="/login?provider={{ .ProviderType }}{{ if $redirectURL }}&url={{ $redirectURL }}{{ end }}" class="login-btn {{ .ProviderType }}">
-            Continue with {{ .Name }}
-          </a>
-        {{ else }}
-          <p>No login providers configured.</p>
-        {{ end }}
-      </div>
-    {{ end }}
-  </main>
-  {{ template "auth/footer.tmpl" . }}
+<body class="min-h-screen bg-gray-100 relative" style="background-image: url('https://nuon.co/Rightsideimage.jpg'); background-size: cover; background-position: center; background-repeat: no-repeat;">
+    <div class="absolute inset-0 bg-[#121212] opacity-75"></div>
+    <main class="min-h-screen flex items-center justify-center p-4 relative z-10">
+        <div class="w-full max-w-md">
+            <div class="mb-8 -mt-24">
+                {{template "logo.tmpl"}}
+            </div>
+            <div class="bg-white rounded-lg shadow-sm p-8">
+                {{ if .IsAuthenticated }}
+                    <h2 class="text-xl font-normal text-gray-900 mb-2">Signed in</h2>
+                    <p class="text-sm text-gray-600 mb-8">{{ .Email }}</p>
+                    <a href="/logout" class="flex items-center justify-center w-full py-3 px-4 bg-white border border-red-300 rounded-md hover:bg-red-50 text-red-600 font-semibold transition-colors">
+                        Sign out
+                    </a>
+                {{ else }}
+                    <h2 class="text-xl font-normal text-gray-900 mb-8">Sign in to your account</h2>
+
+                    <div class="space-y-3">
+                        {{ $redirectURL := .RedirectURL }}
+                        {{ range .Providers }}
+                            <a href="/login?provider={{ .ProviderType }}{{ if $redirectURL }}&url={{ $redirectURL }}{{ end }}"
+                               class="flex items-center justify-center gap-3 w-full py-3 px-4 bg-white border border-gray-300 rounded-md hover:bg-gray-50 text-gray-700 font-semibold transition-colors">
+                                {{if eq .ProviderType "google"}}
+                                <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path d="M17.64 9.20443C17.64 8.56625 17.5827 7.95262 17.4764 7.36353H9V10.8449H13.8436C13.635 11.9699 13.0009 12.9231 12.0477 13.5613V15.8194H14.9564C16.6582 14.2526 17.64 11.9453 17.64 9.20443Z" fill="#4285F4"/>
+                                    <path d="M8.99976 18C11.4298 18 13.467 17.1941 14.9561 15.8195L12.0475 13.5613C11.2416 14.1013 10.2107 14.4204 8.99976 14.4204C6.65567 14.4204 4.67158 12.8372 3.96385 10.71H0.957031V13.0418C2.43794 15.9831 5.48158 18 8.99976 18Z" fill="#34A853"/>
+                                    <path d="M3.96409 10.7098C3.78409 10.1698 3.68182 9.59301 3.68182 8.99983C3.68182 8.40665 3.78409 7.82983 3.96409 7.28983V4.95801H0.957273C0.347727 6.17301 0 7.54756 0 8.99983C0 10.4521 0.347727 11.8266 0.957273 13.0416L3.96409 10.7098Z" fill="#FBBC05"/>
+                                    <path d="M8.99976 3.57955C10.3211 3.57955 11.5075 4.03364 12.4402 4.92545L15.0216 2.34409C13.4629 0.891818 11.4257 0 8.99976 0C5.48158 0 2.43794 2.01682 0.957031 4.95818L3.96385 7.29C4.67158 5.16273 6.65567 3.57955 8.99976 3.57955Z" fill="#EA4335"/>
+                                </svg>
+                                {{else if eq .ProviderType "github"}}
+                                <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M9 0C4.0275 0 0 4.13211 0 9.22838C0 13.3065 2.5785 16.7648 6.15375 17.9841C6.60375 18.0709 6.76875 17.7853 6.76875 17.5403C6.76875 17.3212 6.76125 16.7405 6.7575 15.9712C4.254 16.5277 3.726 14.7332 3.726 14.7332C3.3165 13.6681 2.72475 13.3832 2.72475 13.3832C1.9095 12.8111 2.78775 12.8229 2.78775 12.8229C3.6915 12.887 4.16625 13.7737 4.16625 13.7737C4.96875 15.1847 6.273 14.777 6.7875 14.5414C6.8685 13.9443 7.10025 13.5381 7.3575 13.3073C5.35875 13.0764 3.258 12.2829 3.258 8.74788C3.258 7.73938 3.60675 6.91612 4.18425 6.27152C4.083 6.03728 3.77925 5.0994 4.263 3.82846C4.263 3.82846 5.01675 3.58018 6.738 4.77462C7.458 4.56958 8.223 4.46794 8.988 4.46431C9.753 4.46794 10.518 4.56958 11.238 4.77462C12.948 3.58018 13.7017 3.82846 13.7017 3.82846C14.1855 5.0994 13.8818 6.03728 13.7917 6.27152C14.3655 6.91612 14.7142 7.73938 14.7142 8.74788C14.7142 12.2923 12.6105 13.0725 10.608 13.2995C10.923 13.5765 11.2155 14.1423 11.2155 15.0071C11.2155 16.242 11.205 17.2406 11.205 17.5403C11.205 17.7879 11.3625 18.0761 11.8207 17.9832C15.4162 16.7609 18 13.3049 18 9.22838C18 4.13211 13.9703 0 9 0Z" fill="#181717"/>
+                                </svg>
+                                {{end}}
+                                Continue with {{ .Name }}
+                            </a>
+                        {{ else }}
+                            <p class="text-gray-600 text-center">No login providers configured.</p>
+                        {{ end }}
+                    </div>
+                {{ end }}
+            </div>
+        </div>
+    </main>
 </body>
 </html>
 {{ end }}

--- a/services/ctl-api/internal/app/auth/service/templates/login.html.tmpl
+++ b/services/ctl-api/internal/app/auth/service/templates/login.html.tmpl
@@ -2,15 +2,24 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  {{ template "auth/head.tmpl" . }}
-  <title>Login | Nuon Auth</title>
+    {{template "head.tmpl"}}
+    <title>Logging In | Nuon</title>
 </head>
-<body>
-  {{ template "auth/header.tmpl" . }}
-  <main>
-    <h1>Login</h1>
-  </main>
-  {{ template "auth/footer.tmpl" . }}
+<body class="min-h-screen bg-gray-100 relative" style="background-image: url('https://nuon.co/Rightsideimage.jpg'); background-size: cover; background-position: center; background-repeat: no-repeat;">
+    <div class="absolute inset-0 bg-[#121212] opacity-75"></div>
+    <main class="min-h-screen flex items-center justify-center p-4 relative z-10">
+        <div class="w-full max-w-md">
+            <div class="mb-8 -mt-24">
+                {{template "logo.tmpl"}}
+            </div>
+            <div class="bg-white rounded-lg shadow-sm p-8 text-center">
+                <h2 class="text-2xl font-bold mb-4">Logging In...</h2>
+                <p class="text-gray-600">Redirecting to authentication provider...</p>
+            </div>
+        </div>
+    </main>
+
+    {{template "footer.tmpl"}}
 </body>
 </html>
 {{ end }}

--- a/services/ctl-api/internal/app/auth/service/templates/logout.html.tmpl
+++ b/services/ctl-api/internal/app/auth/service/templates/logout.html.tmpl
@@ -2,82 +2,54 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  {{ template "auth/head.tmpl" . }}
-  <title>Signed Out | Nuon Auth</title>
-  <style>
-    main {
-      max-width: 400px;
-      margin: 2rem auto;
-      padding: 2rem;
-      text-align: center;
-    }
-    .logout-box {
-      padding: 1.5rem;
-      background: #f5f5f5;
-      border: 1px solid #e0e0e0;
-      border-radius: 4px;
-      margin-bottom: 1.5rem;
-    }
-    .logout-box h1 {
-      color: #333;
-      margin: 0 0 0.5rem 0;
-      font-size: 1.5rem;
-    }
-    .logout-box p {
-      color: #666;
-      margin: 0.5rem 0 0 0;
-    }
-    .redirect-notice {
-      color: #888;
-      font-size: 0.9rem;
-      margin-top: 1rem;
-    }
-    .actions {
-      margin-top: 1.5rem;
-    }
-    .btn {
-      display: inline-block;
-      padding: 0.75rem 1.5rem;
-      border-radius: 4px;
-      text-decoration: none;
-      font-size: 1rem;
-      cursor: pointer;
-      background: #1976d2;
-      color: #fff;
-      border: none;
-    }
-    .btn:hover {
-      background: #1565c0;
-    }
-  </style>
+    {{template "head.tmpl"}}
+    <title>Signed Out | Nuon</title>
 </head>
-<body>
-  {{ template "auth/header.tmpl" . }}
-  <main>
-    <div class="logout-box">
-      <h1>Signed Out</h1>
-      <p>{{ .Message }}</p>
-    </div>
-    <p class="redirect-notice">Redirecting to sign in page in <span id="countdown">5</span> seconds...</p>
-    <div class="actions">
-      <a href="/" class="btn">Sign In Now</a>
-    </div>
-  </main>
-  {{ template "auth/footer.tmpl" . }}
-  <script>
-    (function() {
-      var seconds = 5;
-      var countdown = document.getElementById('countdown');
-      var interval = setInterval(function() {
-        seconds--;
-        countdown.textContent = seconds;
-        if (seconds <= 0) {
-          clearInterval(interval);
-          window.location.href = '/';
+<body class="min-h-screen bg-gray-100 relative" style="background-image: url('https://nuon.co/Rightsideimage.jpg'); background-size: cover; background-position: center; background-repeat: no-repeat;">
+    <div class="absolute inset-0 bg-[#121212] opacity-75"></div>
+    <main class="min-h-screen flex items-center justify-center p-4 relative z-10">
+        <div class="w-full max-w-md">
+            <div class="mb-8 -mt-24">
+                {{template "logo.tmpl"}}
+            </div>
+            <div class="bg-white rounded-lg shadow-sm p-8">
+                <h2 class="text-xl font-normal text-gray-900 mb-2">Signed out</h2>
+
+                {{if .Message}}
+                    <p class="text-sm text-gray-600 mb-6">{{.Message}}</p>
+                {{else}}
+                    <p class="text-sm text-gray-600 mb-6">You have been successfully signed out.</p>
+                {{end}}
+
+                <p class="text-sm text-gray-500 mb-8">Redirecting in <span id="countdown">5</span> seconds</p>
+
+                <a href="/" class="flex items-center justify-center w-full py-3 px-4 bg-white border border-gray-300 rounded-md hover:bg-gray-50 text-gray-700 font-semibold transition-colors">
+                    Sign in again
+                </a>
+            </div>
+        </div>
+    </main>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', () => {
+        let seconds = 5;
+        const countdown = document.getElementById('countdown');
+
+        if (!countdown) {
+            console.error('Countdown element not found');
+            return;
         }
-      }, 1000);
-    })();
-  </script>
+
+        const interval = setInterval(() => {
+            seconds--;
+            countdown.textContent = seconds;
+            if (seconds <= 0) {
+                clearInterval(interval);
+                window.location.href = '/';
+            }
+        }, 1000);
+    });
+    </script>
 </body>
 </html>
 {{ end }}

--- a/services/ctl-api/internal/app/auth/service/templates/success.html.tmpl
+++ b/services/ctl-api/internal/app/auth/service/templates/success.html.tmpl
@@ -2,85 +2,31 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  {{ template "auth/head.tmpl" . }}
-  <title>Success | Nuon Auth</title>
-  <style>
-    main {
-      max-width: 400px;
-      margin: 2rem auto;
-      padding: 2rem;
-      text-align: center;
-    }
-    .success-box {
-      padding: 1.5rem;
-      background: #e8f5e9;
-      border: 1px solid #c8e6c9;
-      border-radius: 4px;
-      margin-bottom: 1.5rem;
-    }
-    .success-box h1 {
-      color: #2e7d32;
-      margin: 0 0 0.5rem 0;
-      font-size: 1.5rem;
-    }
-    .user-info {
-      margin: 1rem 0;
-      color: #333;
-    }
-    .user-info strong {
-      display: block;
-      font-size: 1.1rem;
-      margin-top: 0.25rem;
-    }
-    .actions {
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-      margin-top: 1.5rem;
-    }
-    .btn {
-      display: inline-block;
-      padding: 0.75rem 1.5rem;
-      border-radius: 4px;
-      text-decoration: none;
-      font-size: 1rem;
-      cursor: pointer;
-      transition: background-color 0.2s;
-    }
-    .btn-primary {
-      background: #1976d2;
-      color: #fff;
-      border: none;
-    }
-    .btn-primary:hover {
-      background: #1565c0;
-    }
-    .btn-secondary {
-      background: #fff;
-      color: #333;
-      border: 1px solid #ccc;
-    }
-    .btn-secondary:hover {
-      background: #f5f5f5;
-    }
-  </style>
+    {{template "head.tmpl"}}
+    <title>Success | Nuon</title>
 </head>
-<body>
-  {{ template "auth/header.tmpl" . }}
-  <main>
-    <div class="success-box">
-      <h1>Authentication Successful</h1>
-      <div class="user-info">
-        Signed in as
-        <strong>{{ if .Email }}{{ .Email }}{{ else }}{{ .Username }}{{ end }}</strong>
-      </div>
-    </div>
-    <div class="actions">
-      <a href="/" class="btn btn-primary">Continue</a>
-      <a href="/logout" class="btn btn-secondary">Sign Out</a>
-    </div>
-  </main>
-  {{ template "auth/footer.tmpl" . }}
+<body class="min-h-screen bg-gray-100 relative" style="background-image: url('https://nuon.co/Rightsideimage.jpg'); background-size: cover; background-position: center; background-repeat: no-repeat;">
+    <div class="absolute inset-0 bg-[#121212] opacity-75"></div>
+    <main class="min-h-screen flex items-center justify-center p-4 relative z-10">
+        <div class="w-full max-w-md">
+            <div class="mb-8 -mt-24">
+                {{template "logo.tmpl"}}
+            </div>
+            <div class="bg-white rounded-lg shadow-sm p-8">
+                <h2 class="text-xl font-normal text-gray-900 mb-2">Authentication successful</h2>
+                <p class="text-sm text-gray-600 mb-8">{{ if .Email }}{{ .Email }}{{ else }}{{ .Username }}{{ end }}</p>
+
+                <div class="space-y-3">
+                    <a href="/" class="flex items-center justify-center w-full py-3 px-4 bg-white border border-gray-300 rounded-md hover:bg-gray-50 text-gray-700 font-semibold transition-colors">
+                        Continue
+                    </a>
+                    <a href="/logout" class="flex items-center justify-center w-full py-3 px-4 bg-white border border-red-300 rounded-md hover:bg-red-50 text-red-600 font-semibold transition-colors">
+                        Sign out
+                    </a>
+                </div>
+            </div>
+        </div>
+    </main>
 </body>
 </html>
 {{ end }}

--- a/services/ctl-api/internal/app/auth/service/templates/validate.html.tmpl
+++ b/services/ctl-api/internal/app/auth/service/templates/validate.html.tmpl
@@ -2,15 +2,24 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  {{ template "auth/head.tmpl" . }}
-  <title>Validate | Nuon Auth</title>
+    {{template "head.tmpl"}}
+    <title>Validating | Nuon</title>
 </head>
-<body>
-  {{ template "auth/header.tmpl" . }}
-  <main>
-    <h1>Validate</h1>
-  </main>
-  {{ template "auth/footer.tmpl" . }}
+<body class="min-h-screen bg-gray-100 relative" style="background-image: url('https://nuon.co/Rightsideimage.jpg'); background-size: cover; background-position: center; background-repeat: no-repeat;">
+    <div class="absolute inset-0 bg-[#121212] opacity-75"></div>
+    <main class="min-h-screen flex items-center justify-center p-4 relative z-10">
+        <div class="w-full max-w-md">
+            <div class="mb-8 -mt-24">
+                {{template "logo.tmpl"}}
+            </div>
+            <div class="bg-white rounded-lg shadow-sm p-8">
+                <h2 class="text-xl font-normal text-gray-900 mb-2">Validating</h2>
+                <p class="text-sm text-gray-600">Please wait while we validate your session.</p>
+            </div>
+        </div>
+    </main>
+
+    {{template "footer.tmpl"}}
 </body>
 </html>
 {{ end }}


### PR DESCRIPTION
Simple styling of auth service pages using tailwindcss cdn and assets from the nuon.co website
<img width="1535" height="1164" alt="auth-styles" src="https://github.com/user-attachments/assets/5e51685d-33d2-4572-adbe-3246b0ae3e63" />
