### PR TITLE
fix: [cli] installs sync: Correctly decode inputs using mapstructure

### DIFF
--- a/bins/cli/internal/services/installs/sync.go
+++ b/bins/cli/internal/services/installs/sync.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/nuonco/nuon/sdks/nuon-go/models"
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 
 	"github.com/nuonco/nuon/bins/cli/internal/lookup"
 	"github.com/nuonco/nuon/bins/cli/internal/ui"
@@ -165,7 +165,6 @@ func parseInstallConfigFromFile(filePath string) (*config.Install, error) {
 
 func parseInstallConfig(raw io.Reader) (*config.Install, error) {
 	tomlDec := toml.NewDecoder(raw)
-	tomlDec.SetTagName("mapstructure")
 
 	obj := make(map[string]interface{})
 	err := tomlDec.Decode(&obj)

--- a/bins/cli/internal/ui/toml.go
+++ b/bins/cli/internal/ui/toml.go
@@ -4,13 +4,12 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 )
 
 func PrintTOML(data interface{}) {
 	var buf bytes.Buffer
 	enc := toml.NewEncoder(&buf)
-	enc.SetTagName("mapstructure")
 
 	_ = enc.Encode(data)
 

--- a/pkg/config/decode_install.go
+++ b/pkg/config/decode_install.go
@@ -9,23 +9,28 @@ import (
 
 // DecodeInstallInputs decodes inputs for an install.
 func DecodeInstallInputs(fromType reflect.Type, toType reflect.Type, from interface{}) (interface{}, error) {
-	if fromType != reflect.TypeOf(map[string]interface{}{}) {
+	if fromType != reflect.TypeOf([]interface{}{}) {
 		return from, nil
 	}
 	if toType != reflect.TypeOf([]InputGroup{}) {
 		return from, nil
 	}
 
-	var list []InputGroup
+	var list []map[string]string
 	err := mapstructure.Decode(from, &list)
 	if err != nil {
-		var group InputGroup
+		var group map[string]string
 		err = mapstructure.Decode(from, &group)
 		if err != nil {
 			return from, fmt.Errorf("unable to convert install inputs: %w", err)
 		}
-		return []InputGroup{group}, nil
+		return []InputGroup{{Inputs: group}}, nil
 	}
 
-	return list, nil
+	result := make([]InputGroup, 0, len(list))
+	for _, item := range list {
+		result = append(result, InputGroup{Inputs: item})
+	}
+
+	return result, nil
 }

--- a/pkg/config/parse/parse.go
+++ b/pkg/config/parse/parse.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/mitchellh/mapstructure"
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 
 	"github.com/nuonco/nuon/pkg/config"
 )
@@ -51,7 +51,6 @@ func Parse(parseCfg ParseConfig) (*config.AppConfig, error) {
 	// go from toml -> map[string]interface{}
 	buf := bytes.NewReader(byts)
 	tomlDec := toml.NewDecoder(buf)
-	tomlDec.SetTagName("mapstructure")
 
 	obj := make(map[string]interface{})
 	err = tomlDec.Decode(&obj)

--- a/pkg/config/parse/toml.go
+++ b/pkg/config/parse/toml.go
@@ -4,7 +4,7 @@ import (
 	"io"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 
 	"github.com/nuonco/nuon/pkg/config"
 )
@@ -15,7 +15,6 @@ type FileProcessor func(string, map[string]any) map[string]any
 func parseTomlFile(rw io.ReadCloser, name string, out any, processor FileProcessor) error {
 
 	tomlDec := toml.NewDecoder(rw)
-	tomlDec.SetTagName("mapstructure")
 
 	obj := make(map[string]interface{})
 	err := tomlDec.Decode(&obj)

--- a/pkg/config/toml.go
+++ b/pkg/config/toml.go
@@ -3,13 +3,12 @@ package config
 import (
 	"bytes"
 
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 )
 
 func ToTOML(a interface{}) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := toml.NewEncoder(&buf)
-	enc.SetTagName("mapstructure")
 
 	err := enc.Encode(a)
 	if err != nil {

--- a/services/ctl-api/internal/app/installs/service/generate_cli_install_config.go
+++ b/services/ctl-api/internal/app/installs/service/generate_cli_install_config.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/iancoleman/strcase"
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/pkg/config"
@@ -45,8 +45,6 @@ func (s *service) GenerateCLIInstallConfig(ctx *gin.Context) {
 
 	var response bytes.Buffer
 	enc := toml.NewEncoder(&response)
-	enc.SetTagName("mapstructure")
-	enc.Order(toml.OrderAlphabetical)
 
 	err = enc.Encode(installCfg)
 	if err != nil {


### PR DESCRIPTION
This patch fixes a bug where some inputs were being skipped over by mapstructure due to a bug in custom decoding logic.