### PR TITLE
fix: manifest shouldn't be required

### DIFF
--- a/pkg/config/kubernetes_manifest_component.go
+++ b/pkg/config/kubernetes_manifest_component.go
@@ -51,7 +51,7 @@ func (k KustomizeConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 
 func (k KubernetesManifestComponentConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 	NewSchemaBuilder(schema).
-		Field("manifest").Short("Kubernetes manifest").Required().
+		Field("manifest").Short("Kubernetes manifest").
 		Long("YAML manifest content for Kubernetes resources. Supports templating with variables like {{.nuon.install.id}}").
 		Example("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: app-config\ndata:\n  env: production").
 		OneOfRequired("manifest_source").


### PR DESCRIPTION
Manifest should be an optional parameter as we support Kustomize component that cannot have it. Ex: 
```
name = "kustomizeapp1"
type = "kubernetes_manifest"

namespace = "{{.nuon.install.id}}"

[public_repo]
directory = "."
repo      = "argoproj/argocd-example-apps"
branch    = "master"

[kustomize]
path = "./kustomize-guestbook"
patches = []
enable_helm = false


```