### PR TITLE
fix: limit and offset for nuon orgs list

### DIFF
--- a/bins/cli/cmd/config.go
+++ b/bins/cli/cmd/config.go
@@ -33,7 +33,7 @@ func (c *cli) configCmd() *cobra.Command {
 		Long:  "Select your current org from a list or by org ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			svc := orgs.New(c.apiClient, c.cfg)
-			return svc.Select(cmd.Context(), id, PrintJSON)
+			return svc.Select(cmd.Context(), id, 0, 50, PrintJSON)
 		}),
 	}
 	orgCmd.Flags().StringVar(&id, "org", "", "The ID of the org you want to use")

--- a/bins/cli/cmd/orgs.go
+++ b/bins/cli/cmd/orgs.go
@@ -135,10 +135,12 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Long:  "Select your current org from a list or by org ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			svc := orgs.New(c.apiClient, c.cfg)
-			return svc.Select(cmd.Context(), id, PrintJSON)
+			return svc.Select(cmd.Context(), id, offset, limit, PrintJSON)
 		}),
 	}
 	selectOrgCmd.Flags().StringVar(&id, "org", "", "The ID of the org you want to use")
+	selectOrgCmd.Flags().IntVarP(&offset, "offset", "o", 0, "Offset for pagination")
+	selectOrgCmd.Flags().IntVarP(&limit, "limit", "l", 50, "Limit for pagination")
 	orgsCmd.AddCommand(selectOrgCmd)
 
 	deselectOrgCmd := &cobra.Command{

--- a/bins/cli/internal/services/orgs/select.go
+++ b/bins/cli/internal/services/orgs/select.go
@@ -8,13 +8,13 @@ import (
 	"github.com/nuonco/nuon/sdks/nuon-go/models"
 )
 
-func (s *Service) Select(ctx context.Context, orgID string, asJSON bool) error {
+func (s *Service) Select(ctx context.Context, orgID string, offset, limit int, asJSON bool) error {
 	view := ui.NewGetView()
 
 	if orgID != "" {
 		s.SetCurrent(ctx, orgID, asJSON)
 	} else {
-		orgs, _, err := s.list(ctx, 0, 50)
+		orgs, _, err := s.list(ctx, offset, limit)
 		if err != nil {
 			return view.Error(err)
 		}


### PR DESCRIPTION
This pull request updates the organization selection commands in the CLI to support pagination when listing organizations. The main improvements are the addition of `offset` and `limit` parameters, allowing users to control which subset of organizations is displayed when selecting an org.

Enhancements to organization selection and pagination:

* Added `offset` and `limit` flags to the `orgs select` CLI command to support pagination when listing organizations. (`bins/cli/cmd/orgs.go`, [bins/cli/cmd/orgs.goL138-R143](diffhunk://#diff-e5e71819b6839fba5bc07e789b20ee48d7170f5fa063905ceb4f3136bfaa2c10L138-R143))
* Updated the `Select` method in the `orgs` service to accept `offset` and `limit` parameters, passing them through to the underlying list call. (`bins/cli/internal/services/orgs/select.go`, [bins/cli/internal/services/orgs/select.goL11-R17](diffhunk://#diff-7e89ad44f47a951fbed9cce7e35a2eca0ff1c237dc0645e88b16384b817f84ddL11-R17))
* Updated the `config` command to use the new `Select` method signature, defaulting to `offset=0` and `limit=50`. (`bins/cli/cmd/config.go`, [bins/cli/cmd/config.goL36-R36](diffhunk://#diff-203a37d2e8702488fbea1d28f0535a6780552fac087caf9e109159c81e5a9ca1L36-R36))