### PR TITLE
chore: remove org region pinning

### DIFF
--- a/services/ctl-api/internal/app/apps/worker/ecrrepository/create_repository.go
+++ b/services/ctl-api/internal/app/apps/worker/ecrrepository/create_repository.go
@@ -55,7 +55,7 @@ func (a *Activities) CreateRepository(ctx context.Context, req *CreateRepository
 		resp.RepositoryName = *repo.RepositoryName
 		resp.RepositoryArn = *repo.RepositoryArn
 		resp.RepositoryURI = *repo.RepositoryUri
-		resp.Region = "us-west-2"
+		resp.Region = a.cfg.AppRegion
 		return &resp, nil
 	}
 	if !isEntityExistsException(err) {
@@ -71,7 +71,7 @@ func (a *Activities) CreateRepository(ctx context.Context, req *CreateRepository
 	resp.RepositoryName = *repo.RepositoryName
 	resp.RepositoryArn = *repo.RepositoryArn
 	resp.RepositoryURI = *repo.RepositoryUri
-	resp.Region = "us-west-2"
+	resp.Region = a.cfg.AppRegion
 	return &resp, nil
 }
 

--- a/services/ctl-api/internal/app/orgs/worker/event_loop_workflow.go
+++ b/services/ctl-api/internal/app/orgs/worker/event_loop_workflow.go
@@ -10,10 +10,6 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/eventloop/loop"
 )
 
-const (
-	defaultOrgRegion string = "us-west-2"
-)
-
 type OrgEventLoopRequest struct {
 	OrgID       string
 	SandboxMode bool

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -55,7 +55,7 @@ func init() {
 	config.RegisterDefault("max_request_duration", time.Second*30)
 
 	config.RegisterDefault("app_repository_name_template", "%s/%s")
-	config.RegisterDefault("app_repository_region", "%s/%s")
+	config.RegisterDefault("app_region", "us-west-2")
 
 	config.RegisterDefault("org_runner_helm_chart_dir", "/bundle/helm")
 	config.RegisterDefault("org_runner_instance_type", "t3a.medium")
@@ -226,6 +226,9 @@ type Config struct {
 	OrgRunnerK8sIAMRoleARN      string `config:"org_runner_k8s_iam_role_arn" validate:"required"`
 	OrgRunnerK8sUseDefaultCreds bool   `config:"org_runner_k8s_use_default_creds"`
 	OrgRunnerInstanceType       string `config:"org_runner_instance_type" validate:"required"`
+
+	// configuration for apps
+	AppRegion string `config:"app_region" validate:"required"`
 
 	// configuration for managing the public dns zone
 	DNSManagementIAMRoleARN string `config:"dns_management_iam_role_arn" validate:"required"`


### PR DESCRIPTION
This removes some places where we were forcing `us-west-2` in the codebase. It exposes a new `APP_REGION` variable to 
control where app infrastructure is set. In general, this should be set to the same region as the install of Nuon 
itself.

Secondly, @fidiego / @jordan-acosta, there is a `DB_REGION` env-var that needs to be set to control how we do RDS IAM 
Auth for the db connection, and an `OrgRunnerRegion` which is used to control where org runners are provisioned.
