### PR TITLE
fix(ui): pass correct platform from app on create install form

### DIFF
--- a/services/dashboard-ui/src/components/apps/CreateInstall.tsx
+++ b/services/dashboard-ui/src/components/apps/CreateInstall.tsx
@@ -259,15 +259,11 @@ const CreateInstallFormContent = forwardRef<
       : []
   }
 
-  const getPlatform = (): 'aws' | 'azure' => {
-    return 'aws'
-  }
-
   return (
     <CreateInstallForm
       ref={ref}
       appId={app.id}
-      platform={getPlatform()}
+      platform={app?.runner_config?.app_runner_type as 'aws' | 'azure'}
       inputConfig={{
         ...config?.input,
         input_groups: nestInputsUnderGroups(


### PR DESCRIPTION
Pass correct platform type to CreateInstallForm on the app detail pages