### PR TITLE
feat: Update OPA terraform plan input to match well known format

### DIFF
--- a/pkg/types/components/plan/terraform.go
+++ b/pkg/types/components/plan/terraform.go
@@ -1,0 +1,25 @@
+package plan
+
+import (
+	"encoding/json"
+
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+// TerraformPlan wraps the Terraform JSON plan in a format
+// expected by OPA policies prevalent in the ecosystem.
+type TerraformPlan struct {
+	Plan tfjson.Plan `json:"plan"`
+}
+
+// ParseTerraformPlan parses the given Terraform plan JSON into a TerraformPlan structure.
+func ParseTerraformPlan(planJSON []byte) (*TerraformPlan, error) {
+	var plan tfjson.Plan
+	if err := json.Unmarshal(planJSON, &plan); err != nil {
+		return nil, err
+	}
+
+	return &TerraformPlan{
+		Plan: plan,
+	}, nil
+}

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/evaluate_single_policy.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/evaluate_single_policy.go
@@ -101,7 +101,7 @@ func (a *Activities) evaluateRule(
 		for _, expr := range result.Expressions {
 			ruleResults, ok := expr.Value.([]interface{})
 			if !ok {
-				l.Debug("expression value is not a slice, skipping", zap.String("query", queryStr))
+				l.Warn("expression value is not a slice, skipping", zap.String("query", queryStr))
 				continue
 			}
 			for _, item := range ruleResults {

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/prep_policy_evaluation.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/prep_policy_evaluation.go
@@ -244,7 +244,7 @@ func componentTypeToPolicyType(ct app.ComponentType) config.AppPolicyType {
 func (a *Activities) preparePolicyInputs(planContentsJSON []byte, componentType app.ComponentType) ([][]byte, error) {
 	switch componentType {
 	case app.ComponentTypeTerraformModule:
-		return [][]byte{planContentsJSON}, nil
+		return a.prepareTerraformPolicyInputs(planContentsJSON)
 	case app.ComponentTypeHelmChart:
 		return a.prepareHelmPolicyInputs(planContentsJSON)
 	case app.ComponentTypeKubernetesManifest:
@@ -252,6 +252,20 @@ func (a *Activities) preparePolicyInputs(planContentsJSON []byte, componentType 
 	default:
 		return nil, fmt.Errorf("unsupported component type for policy input preparation: %s", componentType)
 	}
+}
+
+func (a *Activities) prepareTerraformPolicyInputs(planContentsJSON []byte) ([][]byte, error) {
+	plan, err := plan.ParseTerraformPlan(planContentsJSON)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse terraform plan")
+	}
+
+	planJSON, err := json.Marshal(plan)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal terraform plan for policy input")
+	}
+
+	return [][]byte{planJSON}, nil
 }
 
 func (a *Activities) prepareKubernetesManifestPolicyInputs(planContentsJSON []byte) ([][]byte, error) {


### PR DESCRIPTION
This patch updates the input passed to OPA evaluator (to enforce policies) in case of `terraform_module` component to a structure that is expected by many existing policies in the ecosystem.