### PR TITLE
chore(ctl-api): dynamically load params from vpc template

### DIFF
--- a/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
@@ -20,11 +20,13 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 	}
 
 	// build nested resources
-	tmpl.Resources["VPC"] = t.getVPCNestedStack(inp, tb)
-	vpcParams := t.getVPCNestedStackParams()
+	stack, vpcParams := t.getVPCNestedStack(inp, tb)
+	tmpl.Resources["VPC"] = stack
+	// vpcParams := t.getVPCNestedStackParams(inp)
 	maps.Copy(tmpl.Parameters, vpcParams)
 
-	// NOTE(fd): this uses the configurable neste runner asg cf stack
+	// NOTE(fd): we branch here to choose the cf stack based on
+	// NOTE(fd): this uses the configurable nested runner asg cf stack
 	tmpl.Resources["RunnerAutoScalingGroup"] = t.getRunnerASGNestedStack(inp, tb)
 
 	// runner ASG and launch template
@@ -76,7 +78,7 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 			"Label": map[string]any{
 				"default": "VPC Configuration",
 			},
-			"Parameters": pkggenerics.MapToKeys(t.getVPCNestedStackParams()),
+			"Parameters": pkggenerics.MapToKeys(vpcParams),
 		},
 		{
 			"Label": map[string]any{

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc.go
@@ -1,88 +1,109 @@
 package cloudformation
 
 import (
+	"io"
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/awslabs/goformation/v7"
 	"github.com/awslabs/goformation/v7/cloudformation"
 	nestedcloudformation "github.com/awslabs/goformation/v7/cloudformation/cloudformation"
 
-	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
 )
 
+// these parameter values should never be provided by the customer. these are always provided by nuon.
+// as a result, if they are specified as input Params, we ensure the values are configurable only by us
+// by excluding them from the Parameters for the nested stack.
+var ReservedParamNames = []string{"ClusterName", "NuonInstallID", "NuonAppID", "NuonOrgID"}
+
+func (tpl *Templates) getClusterName(inp *stacks.TemplateInput) string {
+	// NOTE: we need to provide a cluster name to the eks vpc template in order to pre-tag the subnets
+	// historically, we've pre-emptively used the install.id. this is not necessarily the best
+	// because it's forced us to re-tag subnets in the sandbox. that's fine but we prefer it to be
+	// more correct. this method attempts to fetch a cluster_name from the inputs and uses that, if
+	// present.
+	// NOTE: this decision is essentially encoding a convention but this is fine because we consider mapping
+	// one well-known input to a parameter to be uncontroversial.
+
+	if inp.Install.CurrentInstallInputs != nil {
+		if val, ok := inp.Install.CurrentInstallInputs.Values["cluster_name"]; ok && val != nil {
+			return *val
+		}
+	}
+
+	return inp.Install.ID
+}
+
 // VPCNestedStack returns a nested stack template for VPC resources
-func (a *Templates) getVPCNestedStack(inp *stacks.TemplateInput, t tagBuilder) *nestedcloudformation.Stack {
-	return &nestedcloudformation.Stack{
-		Parameters: map[string]string{
-			"VpcCIDR":           cloudformation.Ref("VpcCIDR"),
-			"PublicSubnet1CIDR": cloudformation.Ref("PublicSubnet1CIDR"),
-			"PublicSubnet2CIDR": cloudformation.Ref("PublicSubnet2CIDR"),
-			"PublicSubnet3CIDR": cloudformation.Ref("PublicSubnet3CIDR"),
+func (tpl *Templates) getVPCNestedStack(inp *stacks.TemplateInput, t tagBuilder) (*nestedcloudformation.Stack, map[string]cloudformation.Parameter) {
+	// these common params should always be set by nuon so they are explicitly
+	// set aside so they can override any template values
+	commonParams := map[string]string{
+		"ClusterName":   tpl.getClusterName(inp),
+		"NuonInstallID": inp.Install.ID,
+		"NuonAppID":     inp.Install.AppID,
+		"NuonOrgID":     inp.Install.OrgID,
+	}
 
-			"PrivateSubnet1CIDR": cloudformation.Ref("PrivateSubnet1CIDR"),
-			"PrivateSubnet2CIDR": cloudformation.Ref("PrivateSubnet2CIDR"),
-			"PrivateSubnet3CIDR": cloudformation.Ref("PrivateSubnet3CIDR"),
+	parameters, defaultParameters := tpl.extractNestedStackParameters(inp.AppCfg.StackConfig.VPCNestedTemplateURL)
 
-			"RunnerSubnetCIDR": cloudformation.Ref("RunnerSubnetCIDR"),
+	// merge specific params into common params
+	maps.Copy(parameters, commonParams)
 
-			"ClusterName":   inp.Install.ID,
-			"NuonInstallID": inp.Install.ID,
-			"NuonAppID":     inp.Install.AppID,
-			"NuonOrgID":     inp.Install.OrgID,
-		},
-		TemplateURL: cloudformation.Join("", []interface{}{
+	stack := &nestedcloudformation.Stack{
+		Parameters: parameters,
+		TemplateURL: cloudformation.Join("", []any{
 			inp.AppCfg.StackConfig.VPCNestedTemplateURL,
 		}),
 		Tags: t.apply(nil, "vpc"),
 	}
+
+	return stack, defaultParameters
+
 }
 
-// VPCNestedStackParameters returns the parameters for the VPC nested stack
-func (a *Templates) getVPCNestedStackParams() map[string]cloudformation.Parameter {
-	return map[string]cloudformation.Parameter{
-		"VpcCIDR": {
-			Type:        "String",
-			Default:     "10.128.0.0/16",
-			Description: generics.ToPtr("CIDR block for the VPC"),
-		},
+func (tpl *Templates) extractNestedStackParameters(templateURL string) (map[string]string, map[string]cloudformation.Parameter) {
+	params := map[string]string{}
+	defaultParams := map[string]cloudformation.Parameter{}
 
-		// private subnet cidrs
-		"PrivateSubnet1CIDR": {
-			Type:        "String",
-			Default:     "10.128.130.0/24",
-			Description: generics.ToPtr("CIDR block for private subnet 1"),
-		},
-		"PrivateSubnet2CIDR": {
-			Type:        "String",
-			Default:     "10.128.132.0/24",
-			Description: generics.ToPtr("CIDR block for private subnet 2"),
-		},
-		"PrivateSubnet3CIDR": {
-			Type:        "String",
-			Default:     "10.128.134.0/24",
-			Description: generics.ToPtr("CIDR block for private subnet 3"),
-		},
-
-		// runner subnet cidr
-		"RunnerSubnetCIDR": {
-			Type:        "String",
-			Default:     "10.128.128.0/24",
-			Description: generics.ToPtr("CIDR block for the Runner Subnet"),
-		},
-
-		// public subnet cidr
-		"PublicSubnet1CIDR": {
-			Type:        "String",
-			Default:     "10.128.0.0/26",
-			Description: generics.ToPtr("CIDR block for public subnet 1"),
-		},
-		"PublicSubnet2CIDR": {
-			Type:        "String",
-			Default:     "10.128.0.64/26",
-			Description: generics.ToPtr("CIDR block for public subnet 2"),
-		},
-		"PublicSubnet3CIDR": {
-			Type:        "String",
-			Default:     "10.128.0.128/26",
-			Description: generics.ToPtr("CIDR block for public subnet 3"),
-		},
+	resp, err := http.Get(templateURL)
+	if err != nil {
+		return params, defaultParams
 	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return params, defaultParams
+	}
+
+	// TODO(fd): pretty sure we only support yaml atm
+	var tmpl *cloudformation.Template
+	if strings.HasSuffix(templateURL, ".json") {
+		tmpl, err = goformation.ParseJSON(body)
+	} else {
+		tmpl, err = goformation.ParseYAML(body)
+	}
+	if err != nil {
+		return params, defaultParams
+	}
+
+	for paramName, param := range tmpl.Parameters {
+		if slices.Contains(ReservedParamNames, paramName) {
+			continue
+		}
+
+		params[paramName] = cloudformation.Ref(paramName)
+
+		defaultParams[paramName] = cloudformation.Parameter{
+			Type:        param.Type,
+			Description: param.Description,
+			Default:     param.Default,
+		}
+	}
+
+	return params, defaultParams
 }

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc_test.go
@@ -1,0 +1,319 @@
+package cloudformation
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const mockVPCTemplateYAML = `
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Deploys a VPC w/ 1 to 3 public subnets (one per az), 1 to 3 private subnets (one per az), a Nat gateway, and an internet gateway.
+Parameters:
+  ClusterName:
+    Description: The name for the EKS Cluster that will be deployed on this VPC.
+    Type: String
+  NuonInstallID:
+    Description: The Nuon Install ID; prefixed to resource names.
+    Type: String
+  NuonOrgID:
+    Description: The Nuon Org ID. Used in tags.
+    Type: String
+  NuonAppID:
+    Description: The Nuon Install ID. Used in tags.
+    Type: String
+  VpcCIDR:
+    Description: Please enter the IP range (CIDR notation) for this VPC.
+    Type: String
+    Default: 10.128.0.0/16
+  PublicSubnet1CIDR:
+    Description: Please enter the IP range (CIDR notation) for the public subnet in the first Availability Zone
+    Type: String
+    Default: 10.128.0.0/26
+  PublicSubnet2CIDR:
+    Description: Please enter the IP range (CIDR notation) for the public subnet in the second Availability Zone
+    Type: String
+    Default: 10.128.0.64/26
+  PublicSubnet3CIDR:
+    Description: Please enter the IP range (CIDR notation) for the public subnet in the third Availability Zone
+    Type: String
+    Default: 10.128.0.128/26
+  RunnerSubnetCIDR:
+    Description: Please enter the IP range (CIDR notation) for the dedicated private subnet for the runner.
+    Type: String
+    Default: 10.128.128.0/24
+  PrivateSubnet1CIDR:
+    Description: Please enter the IP range (CIDR notation) for the private subnet in the first Availability Zone
+    Type: String
+    Default: 10.128.130.0/24
+  PrivateSubnet2CIDR:
+    Description: Please enter the IP range (CIDR notation) for the private subnet in the second Availability Zone
+    Type: String
+    Default: 10.128.132.0/24
+  PrivateSubnet3CIDR:
+    Description: Please enter the IP range (CIDR notation) for the private subnet in the third Availability Zone
+    Type: String
+    Default: 10.128.134.0/24
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCIDR
+`
+
+func TestExtractNestedStackParameters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/yaml")
+		w.Write([]byte(mockVPCTemplateYAML))
+	}))
+	defer server.Close()
+
+	tpl := &Templates{}
+	params, defaultParams := tpl.extractNestedStackParameters(server.URL + "/stack.yaml")
+
+	expectedParams := []string{
+		"ClusterName",
+		"VpcCIDR",
+		"PublicSubnet1CIDR",
+		"PublicSubnet2CIDR",
+		"PublicSubnet3CIDR",
+		"RunnerSubnetCIDR",
+		"PrivateSubnet1CIDR",
+		"PrivateSubnet2CIDR",
+		"PrivateSubnet3CIDR",
+	}
+
+	reservedParams := []string{"NuonInstallID", "NuonOrgID", "NuonAppID"}
+
+	for _, paramName := range expectedParams {
+		t.Run("params_contains_"+paramName, func(t *testing.T) {
+			_, ok := params[paramName]
+			assert.True(t, ok, "params should contain %s", paramName)
+		})
+		t.Run("defaultParams_contains_"+paramName, func(t *testing.T) {
+			_, ok := defaultParams[paramName]
+			assert.True(t, ok, "defaultParams should contain %s", paramName)
+		})
+	}
+
+	for _, paramName := range reservedParams {
+		t.Run("params_excludes_reserved_"+paramName, func(t *testing.T) {
+			_, ok := params[paramName]
+			assert.False(t, ok, "params should not contain reserved param %s", paramName)
+		})
+		t.Run("defaultParams_excludes_reserved_"+paramName, func(t *testing.T) {
+			_, ok := defaultParams[paramName]
+			assert.False(t, ok, "defaultParams should not contain reserved param %s", paramName)
+		})
+	}
+
+	require.Contains(t, defaultParams, "VpcCIDR")
+	assert.Equal(t, "String", defaultParams["VpcCIDR"].Type)
+	assert.Equal(t, "10.128.0.0/16", defaultParams["VpcCIDR"].Default)
+	require.NotNil(t, defaultParams["VpcCIDR"].Description)
+	assert.Equal(t, "Please enter the IP range (CIDR notation) for this VPC.", *defaultParams["VpcCIDR"].Description)
+}
+
+const mockRunnerASGTemplateYAML = `
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Runner ASG template
+Parameters:
+  SubnetId:
+    Description: The subnet on which the app will run within the selected VPC.
+    Type: AWS::EC2::Subnet::Id
+  RunnerEgressGroupId:
+    Description: The security group for the runner instance that allows outbound traffic.
+    Type: AWS::EC2::SecurityGroup::Id
+  InstallId:
+    Type: String
+    Description: The install ID
+  RunnerId:
+    Type: String
+    Description: The runner ID
+  RunnerApiToken:
+    Type: String
+    Description: API token for the runner
+  RunnerApiUrl:
+    Type: String
+    Description: API URL for the runner
+    Default: https://runner.nuon.co
+  RunnerInitScriptUrl:
+    Type: String
+    Description: URL for the init script that is added to the use data for the Runner ASG VM instances.
+    Default: https://raw.githubusercontent.com/nuonco/runner/refs/heads/main/scripts/aws/init.sh
+  InstanceType:
+    Type: String
+    Description: EC2 instance type for the runner
+    Default: t3a.medium
+  RootVolumeSize:
+    Type: Number
+    Description: Size of the root EBS volume in GB
+    Default: 30
+Resources:
+  RunnerAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      MaxSize: "1"
+      MinSize: "1"
+`
+
+func TestExtractNestedStackParameters_RunnerASG(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/yaml")
+		w.Write([]byte(mockRunnerASGTemplateYAML))
+	}))
+	defer server.Close()
+
+	tpl := &Templates{}
+	params, defaultParams := tpl.extractNestedStackParameters(server.URL + "/stack.yaml")
+
+	expectedParams := []string{
+		"SubnetId",
+		"RunnerEgressGroupId",
+		"InstallId",
+		"RunnerId",
+		"RunnerApiToken",
+		"RunnerApiUrl",
+		"RunnerInitScriptUrl",
+		"InstanceType",
+		"RootVolumeSize",
+	}
+
+	for _, paramName := range expectedParams {
+		t.Run("params_contains_"+paramName, func(t *testing.T) {
+			_, ok := params[paramName]
+			assert.True(t, ok, "params should contain %s", paramName)
+		})
+		t.Run("defaultParams_contains_"+paramName, func(t *testing.T) {
+			_, ok := defaultParams[paramName]
+			assert.True(t, ok, "defaultParams should contain %s", paramName)
+		})
+	}
+
+	require.Contains(t, defaultParams, "InstanceType")
+	assert.Equal(t, "String", defaultParams["InstanceType"].Type)
+	assert.Equal(t, "t3a.medium", defaultParams["InstanceType"].Default)
+
+	require.Contains(t, defaultParams, "RootVolumeSize")
+	assert.Equal(t, "Number", defaultParams["RootVolumeSize"].Type)
+	assert.Equal(t, float64(30), defaultParams["RootVolumeSize"].Default)
+
+	require.Contains(t, defaultParams, "SubnetId")
+	assert.Equal(t, "AWS::EC2::Subnet::Id", defaultParams["SubnetId"].Type)
+	assert.Nil(t, defaultParams["SubnetId"].Default)
+}
+
+const mockBYOVPCTemplateYAML = `
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Pass-through CloudFormation stack for BYO-VPC. Accepts existing VPC and subnet IDs, validates they belong together, and outputs them for use by Nuon.
+Parameters:
+  VpcID:
+    Description: The ID of the existing VPC (e.g., vpc-xxxxxxxxx).
+    Type: AWS::EC2::VPC::Id
+  PublicSubnetIDs:
+    Description: Comma-separated list of existing public subnet IDs.
+    Type: String
+  PrivateSubnetIDs:
+    Description: Comma-separated list of existing private subnet IDs.
+    Type: String
+  RunnerSubnetID:
+    Description: Subnet ID for the Nuon runner. Must have outbound internet access (e.g., via NAT Gateway).
+    Type: AWS::EC2::Subnet::Id
+  NuonInstallID:
+    Description: The Nuon Install ID.
+    Type: String
+  NuonOrgID:
+    Description: The Nuon Org ID. Used in tags.
+    Type: String
+  NuonAppID:
+    Description: The Nuon App ID. Used in tags.
+    Type: String
+Resources:
+  SubnetValidatorRole:
+    Type: AWS::IAM::Role
+`
+
+func TestExtractNestedStackParameters_BYOVPC(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/yaml")
+		w.Write([]byte(mockBYOVPCTemplateYAML))
+	}))
+	defer server.Close()
+
+	tpl := &Templates{}
+	params, defaultParams := tpl.extractNestedStackParameters(server.URL + "/stack.yaml")
+
+	expectedParams := []string{
+		"VpcID",
+		"PublicSubnetIDs",
+		"PrivateSubnetIDs",
+		"RunnerSubnetID",
+	}
+
+	reservedParams := []string{"NuonInstallID", "NuonOrgID", "NuonAppID"}
+
+	for _, paramName := range expectedParams {
+		t.Run("params_contains_"+paramName, func(t *testing.T) {
+			_, ok := params[paramName]
+			assert.True(t, ok, "params should contain %s", paramName)
+		})
+		t.Run("defaultParams_contains_"+paramName, func(t *testing.T) {
+			_, ok := defaultParams[paramName]
+			assert.True(t, ok, "defaultParams should contain %s", paramName)
+		})
+	}
+
+	for _, paramName := range reservedParams {
+		t.Run("params_excludes_reserved_"+paramName, func(t *testing.T) {
+			_, ok := params[paramName]
+			assert.False(t, ok, "params should not contain reserved param %s", paramName)
+		})
+		t.Run("defaultParams_excludes_reserved_"+paramName, func(t *testing.T) {
+			_, ok := defaultParams[paramName]
+			assert.False(t, ok, "defaultParams should not contain reserved param %s", paramName)
+		})
+	}
+
+	// Verify VpcID parameter details
+	require.Contains(t, defaultParams, "VpcID")
+	assert.Equal(t, "AWS::EC2::VPC::Id", defaultParams["VpcID"].Type)
+	assert.Nil(t, defaultParams["VpcID"].Default)
+	require.NotNil(t, defaultParams["VpcID"].Description)
+	assert.Equal(t, "The ID of the existing VPC (e.g., vpc-xxxxxxxxx).", *defaultParams["VpcID"].Description)
+
+	// Verify RunnerSubnetID parameter details
+	require.Contains(t, defaultParams, "RunnerSubnetID")
+	assert.Equal(t, "AWS::EC2::Subnet::Id", defaultParams["RunnerSubnetID"].Type)
+	assert.Nil(t, defaultParams["RunnerSubnetID"].Default)
+
+	// Verify String type parameters
+	require.Contains(t, defaultParams, "PublicSubnetIDs")
+	assert.Equal(t, "String", defaultParams["PublicSubnetIDs"].Type)
+
+	require.Contains(t, defaultParams, "PrivateSubnetIDs")
+	assert.Equal(t, "String", defaultParams["PrivateSubnetIDs"].Type)
+}
+
+func TestExtractNestedStackParameters_InvalidURL(t *testing.T) {
+	tpl := &Templates{}
+	params, defaultParams := tpl.extractNestedStackParameters("http://invalid.localhost.test/template.yaml")
+
+	assert.Empty(t, params)
+	assert.Empty(t, defaultParams)
+}
+
+func TestExtractNestedStackParameters_InvalidTemplate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not valid yaml: [[["))
+	}))
+	defer server.Close()
+
+	tpl := &Templates{}
+	params, defaultParams := tpl.extractNestedStackParameters(server.URL + "/stack.yaml")
+
+	assert.Empty(t, params)
+	assert.Empty(t, defaultParams)
+}

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/template.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/template.go
@@ -14,7 +14,7 @@ import (
 func (t *Templates) Template(inputs *stacks.TemplateInput) (*cloudformation.Template, string, error) {
 	tmpl, err := t.getAWSTemplate(inputs)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "unable to create aws-eks template")
+		return nil, "", errors.Wrap(err, "unable to create aws template")
 	}
 
 	// Marshal the template to JSON


### PR DESCRIPTION
### Description

Modify `pkg/cloudformation` to pull the parameters out of the nested VPC template defined in `stack.toml` and  "hoist" them up to the parent stack so they can be filled out as part of the creation of the parent CF stack. These values are simply passed to the nested VPC template. 

<details><summary>Install Stack Outputs</summary>
<p>

```
{
  "ServiceToken": "arn:aws:lambda:us-east-1:000000000000:function:nuon-byo-eks-xxxxxxxxxxxxxxxxxxxxx-RunnerPhoneHome-xxxxxxxxxxxx",
  "account_id": "000000000000",
  "break_glass_role_arns": {},
  "deprovision_iam_role_arn": "arn:aws:iam::000000000000:role/inletcamq9fhix1dnw6mt65psl-deprovision",
  "install_inputs": {},
  "maintenance_iam_role_arn": "arn:aws:iam::000000000000:role/inletcamq9fhix1dnw6mt65psl-maintenance",
  "phone_home_type": "aws",
  "private_subnets": "subnet-xxxxxxxxxxxxxxxxx,subnet-xxxxxxxxxxxxxxxxx,subnet-xxxxxxxxxxxxxxxxx,subnet-xxxxxxxxxxxxxxxxx",
  "provision_iam_role_arn": "arn:aws:iam::000000000000:role/xxxxxxxxxxxxxxxxxxxxxxxxxx-provision",
  "public_subnets": "subnet-xxxxxxxxxxxxxxxxx,subnet-xxxxxxxxxxxxxxxxx,subnet-xxxxxxxxxxxxxxxxx",
  "region": "us-east-1",
  "request_type": "Create",
  "runner_iam_role_arn": "nuon-byo-eks-xxxxxxxxxxxxxxxxxxx-RunnerInstanceRole-xxxxxxxxxxxx",
  "runner_subnet": "subnet-xxxxxxxxxxxxxxxxx",
  "url": "https://local.ngrok.tunnel/v1/installs/xxxxxxxxxxxxxxxxxxxxxxxxxx/phone-home/xxxxxxxxxxxxxxxxxxxxxxxxxx",
  "vpc_id": "vpc-xxxxxxxxxxxxxxxxx"
}


```

</p>
</details> 

### Caveats

> [!WARNING]
> Nested stacks cannot receive parameters of complex types from the parent stack so all parameters must be strings. 

We'd like to have used `List<aws::vpc::subnet>` but we are limited to using strings. While it would be ideal to use complex parameters in the parent template and process into strings before passing to the nested template, as it currently stands, we are simply pulling the params out of the nested template so we can present it in the parent stack and therefore the parameters must be strings (or trivially stringifiable by CF itself, as in the case of VPC ID of type `AWS::EC2::VPC::Id`). 

> [!WARNING]
> This is not compatible w/ the 0.18 vpc template (invalid yaml)

Seems the go yaml parser rejects the cloudformation template. This is fixed in the latest version of the cf stacks. ~We can modify/patch and backport the fix to the version to avoid requiring everyone to upgrade.~ 

**Edit:** all vpc templates must use the new version (`v.0.1.9`) in order to be compatible with the newest promotion.