### PR TITLE
fix(ctl-api): swagger type on string-based enum

### DIFF
--- a/sdks/nuon-go/client/operations/operations_client.go
+++ b/sdks/nuon-go/client/operations/operations_client.go
@@ -7312,11 +7312,9 @@ func (a *Client) GetDriftedObjects(params *GetDriftedObjectsParams, authInfo run
 }
 
 /*
-	GetInstall gets an install
+GetInstall gets an install
 
-	Forget an install that has been deleted outside of nuon.
-
-This should only be used in cases where an install was broken in an unordinary way and needs to be manually deleted so the parent resources can be deleted.
+Return an install by id.
 */
 func (a *Client) GetInstall(params *GetInstallParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetInstallOK, error) {
 	// NOTE: parameters are not validated before sending

--- a/sdks/nuon-go/models/app_workflow.go
+++ b/sdks/nuon-go/models/app_workflow.go
@@ -78,9 +78,7 @@ type AppWorkflow struct {
 	Status *AppCompositeStatus `json:"status,omitempty"`
 
 	// DEPRECATED: for now we always abort on step errors
-	StepErrorBehavior struct {
-		AppStepErrorBehavior
-	} `json:"step_error_behavior,omitempty"`
+	StepErrorBehavior string `json:"step_error_behavior,omitempty"`
 
 	// steps represent each piece of the workflow
 	Steps []*AppWorkflowStep `json:"steps"`
@@ -117,10 +115,6 @@ func (m *AppWorkflow) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateStatus(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateStepErrorBehavior(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -295,14 +289,6 @@ func (m *AppWorkflow) validateStatus(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *AppWorkflow) validateStepErrorBehavior(formats strfmt.Registry) error {
-	if swag.IsZero(m.StepErrorBehavior) { // not required
-		return nil
-	}
-
-	return nil
-}
-
 func (m *AppWorkflow) validateSteps(formats strfmt.Registry) error {
 	if swag.IsZero(m.Steps) { // not required
 		return nil
@@ -379,10 +365,6 @@ func (m *AppWorkflow) ContextValidate(ctx context.Context, formats strfmt.Regist
 	}
 
 	if err := m.contextValidateStatus(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateStepErrorBehavior(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -555,11 +537,6 @@ func (m *AppWorkflow) contextValidateStatus(ctx context.Context, formats strfmt.
 			return err
 		}
 	}
-
-	return nil
-}
-
-func (m *AppWorkflow) contextValidateStepErrorBehavior(ctx context.Context, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/sdks/nuon-runner-go/models/app_workflow.go
+++ b/sdks/nuon-runner-go/models/app_workflow.go
@@ -78,9 +78,7 @@ type AppWorkflow struct {
 	Status *AppCompositeStatus `json:"status,omitempty"`
 
 	// DEPRECATED: for now we always abort on step errors
-	StepErrorBehavior struct {
-		AppStepErrorBehavior
-	} `json:"step_error_behavior,omitempty"`
+	StepErrorBehavior string `json:"step_error_behavior,omitempty"`
 
 	// steps represent each piece of the workflow
 	Steps []*AppWorkflowStep `json:"steps"`
@@ -117,10 +115,6 @@ func (m *AppWorkflow) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateStatus(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateStepErrorBehavior(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -295,14 +289,6 @@ func (m *AppWorkflow) validateStatus(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *AppWorkflow) validateStepErrorBehavior(formats strfmt.Registry) error {
-	if swag.IsZero(m.StepErrorBehavior) { // not required
-		return nil
-	}
-
-	return nil
-}
-
 func (m *AppWorkflow) validateSteps(formats strfmt.Registry) error {
 	if swag.IsZero(m.Steps) { // not required
 		return nil
@@ -379,10 +365,6 @@ func (m *AppWorkflow) ContextValidate(ctx context.Context, formats strfmt.Regist
 	}
 
 	if err := m.contextValidateStatus(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateStepErrorBehavior(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -555,11 +537,6 @@ func (m *AppWorkflow) contextValidateStatus(ctx context.Context, formats strfmt.
 			return err
 		}
 	}
-
-	return nil
-}
-
-func (m *AppWorkflow) contextValidateStepErrorBehavior(ctx context.Context, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/services/ctl-api/internal/app/workflow.go
+++ b/services/ctl-api/internal/app/workflow.go
@@ -163,7 +163,7 @@ type Workflow struct {
 	Status   CompositeStatus `json:"status,omitzero" temporaljson:"status,omitzero,omitempty"`
 
 	// DEPRECATED: for now we always abort on step errors
-	StepErrorBehavior StepErrorBehavior `json:"step_error_behavior,omitzero" temporaljson:"step_error_behavior,omitzero,omitempty"`
+	StepErrorBehavior StepErrorBehavior `json:"step_error_behavior,omitzero" temporaljson:"step_error_behavior,omitzero,omitempty" swaggertype:"string"`
 
 	ApprovalOption InstallApprovalOption `json:"approval_option,omitzero" gorm:"default 'auto'" temporaljson:"approval_option,omitzero,omitempty"`
 


### PR DESCRIPTION
### Description

enum was missing a swagger type so the sdk didn't quite know what to do
