### PR TITLE
feat: store attribution in user journey for marketing ROI analysis

### DIFF
--- a/services/ctl-api/internal/middlewares/auth/account_token.go
+++ b/services/ctl-api/internal/middlewares/auth/account_token.go
@@ -52,7 +52,7 @@ func (c customClaims) Validate(ctx context.Context) error {
 	return nil
 }
 
-func (m *middleware) saveAccountToken(ctx context.Context, token string, claims *validator.ValidatedClaims) (*app.Token, error) {
+func (m *middleware) saveAccountToken(ctx context.Context, token string, claims *validator.ValidatedClaims, attribution map[string]interface{}) (*app.Token, error) {
 	customClaims, ok := claims.CustomClaims.(*customClaims)
 	if !ok {
 		return nil, fmt.Errorf("unable to get custom claims")
@@ -82,8 +82,12 @@ func (m *middleware) saveAccountToken(ctx context.Context, token string, claims 
 		} else {
 			// No pending invite - self-signup user, check deployment configuration
 			if m.cfg.EvaluationJourneyEnabled {
-				// Multi-tenant deployment: Enable evaluation journey
-				userJourneys = account.DefaultEvaluationJourney()
+				// Multi-tenant deployment: Enable evaluation journey with attribution
+				if len(attribution) > 0 {
+					userJourneys = account.DefaultEvaluationJourneyWithAttribution(attribution)
+				} else {
+					userJourneys = account.DefaultEvaluationJourney()
+				}
 			} else {
 				// BYOC deployment: Skip evaluation journey for clean first-run experience
 				userJourneys = account.NoUserJourneys()

--- a/services/ctl-api/internal/middlewares/auth/auth.go
+++ b/services/ctl-api/internal/middlewares/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -109,8 +110,11 @@ func (m *middleware) Handler() gin.HandlerFunc {
 			return
 		}
 
+		// Extract attribution from cookie (set by customer-dashboard during auth flow)
+		attribution := m.extractAttributionFromCookie(ctx)
+
 		// store the token
-		acctToken, err = m.saveAccountToken(ctx, token, claims)
+		acctToken, err = m.saveAccountToken(ctx, token, claims, attribution)
 		if err != nil {
 			ctx.Error(fmt.Errorf("unable to save account token: %w", err))
 			ctx.Abort()
@@ -179,4 +183,21 @@ func New(params Params) *middleware {
 		runnersHelpers:  params.RunnersHelpers,
 		evClient:        params.EvClient,
 	}
+}
+
+// extractAttributionFromCookie reads marketing attribution data from the nuon_attribution cookie
+// set by customer-dashboard during the auth flow. Returns nil if no attribution is present.
+func (m *middleware) extractAttributionFromCookie(ctx *gin.Context) map[string]interface{} {
+	cookie, err := ctx.Cookie("nuon_attribution")
+	if err != nil || cookie == "" {
+		return nil
+	}
+
+	var attribution map[string]interface{}
+	if err := json.Unmarshal([]byte(cookie), &attribution); err != nil {
+		m.l.Debug("failed to parse attribution cookie", zap.Error(err))
+		return nil
+	}
+
+	return attribution
 }

--- a/services/ctl-api/internal/pkg/account/create.go
+++ b/services/ctl-api/internal/pkg/account/create.go
@@ -105,3 +105,25 @@ func DefaultEvaluationJourney() app.UserJourneys {
 func NoUserJourneys() app.UserJourneys {
 	return app.UserJourneys{}
 }
+
+// DefaultEvaluationJourneyWithAttribution returns the evaluation journey with attribution data
+// stored in the account_created step's metadata. This enables tracking marketing source
+// for ROI analysis.
+func DefaultEvaluationJourneyWithAttribution(attribution map[string]interface{}) app.UserJourneys {
+	journey := DefaultEvaluationJourney()
+
+	// Store attribution in the first step (account_created) metadata
+	if len(attribution) > 0 && len(journey) > 0 && len(journey[0].Steps) > 0 {
+		for i, step := range journey[0].Steps {
+			if step.Name == "account_created" {
+				if journey[0].Steps[i].Metadata == nil {
+					journey[0].Steps[i].Metadata = make(map[string]interface{})
+				}
+				journey[0].Steps[i].Metadata["attribution"] = attribution
+				break
+			}
+		}
+	}
+
+	return journey
+}

--- a/services/ctl-api/internal/pkg/analytics/fns.go
+++ b/services/ctl-api/internal/pkg/analytics/fns.go
@@ -31,9 +31,30 @@ func identifyFn(ctx context.Context) (*segment.Identify, error) {
 		return nil, errors.Wrap(err, "no account found")
 	}
 
+	traits := segment.NewTraits().SetEmail(acct.Email)
+
+	// Extract attribution from user journey metadata and add as traits
+	// This enables GA4 user_id linking for marketing ROI analysis
+	if len(acct.UserJourneys) > 0 {
+		for _, journey := range acct.UserJourneys {
+			for _, step := range journey.Steps {
+				if step.Name == "account_created" && step.Metadata != nil {
+					if attr, ok := step.Metadata["attribution"].(map[string]interface{}); ok {
+						for k, v := range attr {
+							if s, ok := v.(string); ok && s != "" {
+								traits.Set(k, s)
+							}
+						}
+					}
+					break
+				}
+			}
+		}
+	}
+
 	return &segment.Identify{
 		UserId: acct.ID,
-		Traits: segment.NewTraits().SetEmail(acct.Email),
+		Traits: traits,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- Extract attribution from cookie set by customer-dashboard during auth flow
- Store attribution data in `account_created` journey step metadata
- Include attribution traits in Segment identify calls for GA4 user_id linking

## Related
- Requires nuonco/mono#11701 for customer-dashboard and website changes

## Data Flow
1. Customer-dashboard sets `nuon_attribution` cookie during auth callback
2. ctl-api auth middleware extracts attribution from cookie
3. On new account creation, attribution stored in user journey metadata
4. Segment identify includes attribution traits → flows to GA4

## Files Changed
- `services/ctl-api/internal/middlewares/auth/auth.go` - Cookie extraction
- `services/ctl-api/internal/middlewares/auth/account_token.go` - Pass attribution to account creation
- `services/ctl-api/internal/pkg/account/create.go` - `DefaultEvaluationJourneyWithAttribution()`
- `services/ctl-api/internal/pkg/analytics/fns.go` - Attribution traits in Segment identify

## Verification (Metabase)
```sql
SELECT
  id, email, created_at,
  user_journeys->0->'steps'->0->'metadata'->'attribution' as attribution
FROM accounts
WHERE user_journeys->0->'steps'->0->'metadata'->'attribution' IS NOT NULL
ORDER BY created_at DESC
LIMIT 10;
```

## Test plan
- [ ] Deploy both PRs to staging
- [ ] Sign up with UTM params in URL
- [ ] Verify attribution in Metabase query above
- [ ] Check Segment debugger for attribution traits in identify calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)