### PR TITLE
feat: (dashboard-ui) Show a banner when policies check gets skipped

### DIFF
--- a/services/dashboard-ui/client/components/workflows/step-details/StepBanner.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/StepBanner.tsx
@@ -22,6 +22,7 @@ export const StepBanner = ({
     stepStatus === 'discarded'
   const { hasViolations: hasPolicyViolations, hasPolicyData, passedCount } =
     getPolicyViolationCounts(step)
+  const isAutoSkipped = step?.status?.status === 'auto-skipped'
 
   return (
     <>
@@ -51,6 +52,12 @@ export const StepBanner = ({
         <Banner theme="success">
           <Text weight="strong">
             All policy checks passed successfully
+          </Text>
+        </Banner>
+      ) : isAutoSkipped && !hasPolicyData ? (
+        <Banner theme="default">
+          <Text variant="subtext" theme="neutral">
+            Policy checks were skipped because the plan had no changes
           </Text>
         </Banner>
       ) : null}


### PR DESCRIPTION
When a component has no change to deploy, i.e the plan step results in a no-op plan, we skip running policy checks (as there are no inputs to run the policies on anyways). This can sometimes confuse users, so we now show a banner explicitly saying that policy checks are skipped here.