### PR TITLE
fix(ui): approval banner showing on failed steps

### DIFF
--- a/services/dashboard-ui/client/components/workflows/step-details/StepBanner.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/StepBanner.tsx
@@ -15,12 +15,17 @@ export const StepBanner = ({
 }) => {
   const hasApproval = Boolean(step?.approval)
   const bannerCfg = getStepBanner(step)
+  const stepStatus = step?.status?.status
+  const isTerminal =
+    stepStatus === 'error' ||
+    stepStatus === 'cancelled' ||
+    stepStatus === 'discarded'
   const { hasViolations: hasPolicyViolations, hasPolicyData, passedCount } =
     getPolicyViolationCounts(step)
 
   return (
     <>
-      {hasApproval && !planOnly ? (
+      {hasApproval && !planOnly && !isTerminal ? (
         <ApprovalBanner step={step} />
       ) : bannerCfg ? (
         <Banner theme={bannerCfg.theme}>

--- a/services/dashboard-ui/client/utils/workflow-utils.ts
+++ b/services/dashboard-ui/client/utils/workflow-utils.ts
@@ -51,6 +51,11 @@ export function getStepBadge(
       return WORKFLOW_BADGE_MAP['approved']
     } else if (step?.status?.status === 'pending') {
       return WORKFLOW_BADGE_MAP['auto-approved']
+    } else if (
+      step?.approval?.type === 'approve-all' ||
+      step?.approval?.response?.type === 'auto-approve'
+    ) {
+      return WORKFLOW_BADGE_MAP['auto-approved']
     }
   }
   const status = step?.status?.status

--- a/services/dashboard-ui/client/views/install/DeployDetail.tsx
+++ b/services/dashboard-ui/client/views/install/DeployDetail.tsx
@@ -55,10 +55,12 @@ const DeployDetailContent = ({ componentId }: { componentId: string }) => {
     ?.at(-1) ?? null
   const responded = step ? hasResponded(step.id) : false
   const logStream = deploy?.log_stream
+  const stepStatus = step?.status?.status
+  const isTerminal = stepStatus === 'error' || stepStatus === 'cancelled' || stepStatus === 'discarded'
   const pendingApproval =
-    step?.approval && !step?.approval?.response && !responded && step?.status?.status !== 'auto-skipped'
+    step?.approval && !step?.approval?.response && !responded && !isTerminal && stepStatus !== 'auto-skipped'
   const completedApproval =
-    step?.approval && (!!step?.approval?.response || responded) && step?.status?.status !== 'auto-skipped'
+    step?.approval && (!!step?.approval?.response || responded) && !isTerminal && stepStatus !== 'auto-skipped'
 
   return (
     <PageSection flush>

--- a/services/dashboard-ui/client/views/install/SandboxRunDetail.tsx
+++ b/services/dashboard-ui/client/views/install/SandboxRunDetail.tsx
@@ -47,10 +47,12 @@ const SandboxRunDetailContent = () => {
   const { hasResponded } = useRespondedApprovals()
   const responded = step ? hasResponded(step.id) : false
   const logStream = sandboxRun?.log_stream
+  const stepStatus = step?.status?.status
+  const isTerminal = stepStatus === 'error' || stepStatus === 'cancelled' || stepStatus === 'discarded'
   const pendingApproval =
-    step?.approval && !step?.approval?.response && !responded && step?.status?.status !== 'auto-skipped'
+    step?.approval && !step?.approval?.response && !responded && !isTerminal && stepStatus !== 'auto-skipped'
   const completedApproval =
-    step?.approval && (!!step?.approval?.response || responded) && step?.status?.status !== 'auto-skipped'
+    step?.approval && (!!step?.approval?.response || responded) && !isTerminal && stepStatus !== 'auto-skipped'
 
   return (
     <PageSection flush>


### PR DESCRIPTION
Hide approval banner on failed workflow steps
Never show awaiting approval for auto approved workflows