### PR TITLE
fix: await signal can fail when worker restarted

### DIFF
--- a/pkg/temporal/heartbeat/heartbeat.go
+++ b/pkg/temporal/heartbeat/heartbeat.go
@@ -1,0 +1,30 @@
+package heartbeat
+
+import (
+	"context"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+)
+
+// WithHeartbeat starts periodic heartbeating, runs fn, then stops heartbeating.
+// Use this to wrap blocking activity work so Temporal can detect dead workers.
+func WithHeartbeat[T any](ctx context.Context, interval time.Duration, fn func(context.Context) (T, error)) (T, error) {
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				activity.RecordHeartbeat(ctx, nil)
+			}
+		}
+	}()
+	return fn(ctx)
+}

--- a/services/ctl-api/internal/pkg/queue/client/await_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/await_signal.go
@@ -20,7 +20,6 @@ import (
 // @start-to-close-timeout 5m
 // @schedule-to-close-timeout 2h
 // @heartbeat-timeout 10s
-// @max-retries 1
 func (c *Client) AwaitSignal(ctx context.Context, queueSignalID string) (*handler.FinishedResponse, error) {
 	q, err := c.getQueueSignal(ctx, queueSignalID)
 	if err != nil {

--- a/services/ctl-api/internal/pkg/queue/client/await_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/await_signal.go
@@ -3,9 +3,11 @@ package client
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 
+	"go.temporal.io/sdk/activity"
 	tclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 
@@ -15,7 +17,9 @@ import (
 )
 
 // @temporal-gen-v2 activity
-// @start-to-close-timeout 2h
+// @start-to-close-timeout 5m
+// @schedule-to-close-timeout 2h
+// @heartbeat-timeout 10s
 // @max-retries 1
 func (c *Client) AwaitSignal(ctx context.Context, queueSignalID string) (*handler.FinishedResponse, error) {
 	q, err := c.getQueueSignal(ctx, queueSignalID)
@@ -32,6 +36,24 @@ func (c *Client) AwaitSignal(ctx context.Context, queueSignalID string) (*handle
 		}
 		return &handler.FinishedResponse{}, nil
 	}
+
+	// Heartbeat so Temporal knows this activity is alive during the blocking update call.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		ticker := time.NewTicker(3 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				activity.RecordHeartbeat(ctx, nil)
+			}
+		}
+	}()
 
 	rawResp, err := c.tClient.UpdateWorkflowInNamespace(ctx, q.Workflow.Namespace, tclient.UpdateWorkflowOptions{
 		WorkflowID:   q.Workflow.ID,

--- a/services/ctl-api/internal/pkg/queue/client/await_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/await_signal.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"go.temporal.io/sdk/activity"
 	tclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 
+	"github.com/nuonco/nuon/pkg/temporal/heartbeat"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	dbgenerics "github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler"
@@ -36,68 +36,53 @@ func (c *Client) AwaitSignal(ctx context.Context, queueSignalID string) (*handle
 		return &handler.FinishedResponse{}, nil
 	}
 
-	// Heartbeat so Temporal knows this activity is alive during the blocking update call.
-	done := make(chan struct{})
-	defer close(done)
-	go func() {
-		ticker := time.NewTicker(3 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-done:
-				return
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				activity.RecordHeartbeat(ctx, nil)
+	return heartbeat.WithHeartbeat(ctx, 3*time.Second, func(ctx context.Context) (*handler.FinishedResponse, error) {
+		rawResp, err := c.tClient.UpdateWorkflowInNamespace(ctx, q.Workflow.Namespace, tclient.UpdateWorkflowOptions{
+			UpdateID:     queueSignalID + "-finished",
+			WorkflowID:   q.Workflow.ID,
+			UpdateName:   handler.FinishedHandlerName,
+			WaitForStage: tclient.WorkflowUpdateStageCompleted,
+			Args: []any{
+				handler.FinishedRequest{},
+			},
+		})
+		if err != nil {
+			// Workflow may have been slept/terminated between our DB check and now.
+			// Re-check DB status to confirm.
+			fresh, dbErr := c.getQueueSignal(ctx, queueSignalID)
+			if dbErr != nil {
+				return nil, errors.Wrap(dbErr, "unable to get queue signal from db")
 			}
+			if isTerminalStatus(fresh.Status.Status) {
+				if fresh.Status.Status == app.StatusError {
+					return nil, temporal.NewNonRetryableApplicationError(
+						fmt.Sprintf("signal execution failed with status: %s", fresh.Status.Status),
+						"SIGNAL_FAILED", nil)
+				}
+				return &handler.FinishedResponse{}, nil
+			}
+			return nil, errors.Wrap(err, "unable to call finished handler")
 		}
-	}()
 
-	rawResp, err := c.tClient.UpdateWorkflowInNamespace(ctx, q.Workflow.Namespace, tclient.UpdateWorkflowOptions{
-		WorkflowID:   q.Workflow.ID,
-		UpdateName:   handler.FinishedHandlerName,
-		WaitForStage: tclient.WorkflowUpdateStageCompleted,
-		Args: []any{
-			handler.FinishedRequest{},
-		},
+		var resp handler.FinishedResponse
+		if err := rawResp.Get(ctx, &resp); err != nil {
+			return nil, errors.Wrap(err, "unable get response")
+		}
+
+		// Re-check DB status after workflow update completes, since the finishedHandler
+		// returns FinishedResponse{} regardless of whether signal execution succeeded or failed.
+		fresh, err := c.getQueueSignal(ctx, queueSignalID)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to verify signal status after completion")
+		}
+		if fresh.Status.Status == app.StatusError {
+			return nil, temporal.NewNonRetryableApplicationError(
+				fmt.Sprintf("signal execution failed with status: %s", fresh.Status.Status),
+				"SIGNAL_FAILED", nil)
+		}
+
+		return &resp, nil
 	})
-	if err != nil {
-		// Workflow may have been slept/terminated between our DB check and now.
-		// Re-check DB status to confirm.
-		fresh, dbErr := c.getQueueSignal(ctx, queueSignalID)
-		if dbErr != nil {
-			return nil, errors.Wrap(dbErr, "unable to get queue signal from db")
-		}
-		if isTerminalStatus(fresh.Status.Status) {
-			if fresh.Status.Status == app.StatusError {
-				return nil, temporal.NewNonRetryableApplicationError(
-					fmt.Sprintf("signal execution failed with status: %s", fresh.Status.Status),
-					"SIGNAL_FAILED", nil)
-			}
-			return &handler.FinishedResponse{}, nil
-		}
-		return nil, errors.Wrap(err, "unable to call finished handler")
-	}
-
-	var resp handler.FinishedResponse
-	if err := rawResp.Get(ctx, &resp); err != nil {
-		return nil, errors.Wrap(err, "unable get response")
-	}
-
-	// Re-check DB status after workflow update completes, since the finishedHandler
-	// returns FinishedResponse{} regardless of whether signal execution succeeded or failed.
-	fresh, err := c.getQueueSignal(ctx, queueSignalID)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to verify signal status after completion")
-	}
-	if fresh.Status.Status == app.StatusError {
-		return nil, temporal.NewNonRetryableApplicationError(
-			fmt.Sprintf("signal execution failed with status: %s", fresh.Status.Status),
-			"SIGNAL_FAILED", nil)
-	}
-
-	return &resp, nil
 }
 
 func (c *Client) getQueueSignal(ctx context.Context, id string) (*app.QueueSignal, error) {

--- a/services/ctl-api/internal/pkg/queue/handle_signal.go
+++ b/services/ctl-api/internal/pkg/queue/handle_signal.go
@@ -18,7 +18,9 @@ import (
 // (validate, execute) which block until the signal finishes. These can run for
 // extended periods and must not be retried by Temporal.
 var noRetryLongTimeout = &workflow.ActivityOptions{
-	StartToCloseTimeout: 2 * time.Hour,
+	StartToCloseTimeout:    5 * time.Minute,
+	ScheduleToCloseTimeout: 2 * time.Hour,
+	HeartbeatTimeout:       10 * time.Second,
 	RetryPolicy: &temporal.RetryPolicy{
 		MaximumAttempts: 1,
 	},

--- a/services/ctl-api/internal/pkg/queue/handle_signal.go
+++ b/services/ctl-api/internal/pkg/queue/handle_signal.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
@@ -14,16 +13,14 @@ import (
 	handleractivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler/activities"
 )
 
-// noRetryLongTimeout is used for activities that call workflow update handlers
+// longRunningActivityOptions is used for activities that call workflow update handlers
 // (validate, execute) which block until the signal finishes. These can run for
-// extended periods and must not be retried by Temporal.
-var noRetryLongTimeout = &workflow.ActivityOptions{
+// extended periods. Heartbeating ensures Temporal can detect dead workers and retry.
+// Idempotent update IDs ensure retried update calls are deduplicated by Temporal.
+var longRunningActivityOptions = &workflow.ActivityOptions{
 	StartToCloseTimeout:    5 * time.Minute,
 	ScheduleToCloseTimeout: 2 * time.Hour,
 	HeartbeatTimeout:       10 * time.Second,
-	RetryPolicy: &temporal.RetryPolicy{
-		MaximumAttempts: 1,
-	},
 }
 
 func (q *queue) handleQueueSignal(ctx workflow.Context, queueRef QueueRef) error {
@@ -87,7 +84,7 @@ func (q *queue) processQueueSignal(ctx workflow.Context, l *zap.Logger, queueSig
 		UpdateID:   queueSignal.ID,
 		WorkflowID: queueRef.WorkflowID,
 		QueueID:    queueSignal.QueueID,
-	}, noRetryLongTimeout); err != nil {
+	}, longRunningActivityOptions); err != nil {
 		return errors.Wrap(err, "unable to validate")
 	}
 
@@ -95,7 +92,7 @@ func (q *queue) processQueueSignal(ctx workflow.Context, l *zap.Logger, queueSig
 		UpdateID:   queueSignal.ID,
 		WorkflowID: queueRef.WorkflowID,
 		QueueID:    queueSignal.QueueID,
-	}, noRetryLongTimeout); err != nil {
+	}, longRunningActivityOptions); err != nil {
 		return errors.Wrap(err, "unable to execute")
 	}
 

--- a/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__execute.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/sdk/activity"
 	tclient "go.temporal.io/sdk/client"
 
+	"github.com/nuonco/nuon/pkg/temporal/heartbeat"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler"
 )
 
@@ -16,49 +17,33 @@ import (
 // @start-to-close-timeout 5m
 // @schedule-to-close-timeout 2h
 // @heartbeat-timeout 10s
-// @max-retries 1
 // @as-wrapper
 // @wrapper-prefix HandlerInternal
 // @by-field WorkflowID
 func (a *Activities) updateWorkflowExecute(ctx context.Context, workflowID string, updateID string, queueID string) (*handler.ExecuteResponse, error) {
-	// Heartbeat so Temporal knows this activity is alive during the blocking update call.
-	done := make(chan struct{})
-	defer close(done)
-	go func() {
-		ticker := time.NewTicker(3 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-done:
-				return
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				activity.RecordHeartbeat(ctx, nil)
-			}
+	return heartbeat.WithHeartbeat(ctx, 3*time.Second, func(ctx context.Context) (*handler.ExecuteResponse, error) {
+		info := activity.GetInfo(ctx)
+
+		rawResp, err := a.tclient.UpdateWithStartWorkflowInNamespace(ctx,
+			info.WorkflowNamespace,
+			tclient.UpdateWithStartWorkflowOptions{
+				UpdateOptions: tclient.UpdateWorkflowOptions{
+					UpdateID:     updateID + "-execute",
+					WorkflowID:   workflowID,
+					UpdateName:   handler.ExecuteUpdateName,
+					WaitForStage: tclient.WorkflowUpdateStageCompleted,
+				},
+				StartWorkflowOperation: a.handlerStartOperation(workflowID, queueID, updateID),
+			})
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to call query handler")
 		}
-	}()
 
-	info := activity.GetInfo(ctx)
+		var resp handler.ExecuteResponse
+		if err := rawResp.Get(ctx, &resp); err != nil {
+			return nil, errors.Wrap(err, "unable get response")
+		}
 
-	rawResp, err := a.tclient.UpdateWithStartWorkflowInNamespace(ctx,
-		info.WorkflowNamespace,
-		tclient.UpdateWithStartWorkflowOptions{
-			UpdateOptions: tclient.UpdateWorkflowOptions{
-				WorkflowID:   workflowID,
-				UpdateName:   handler.ExecuteUpdateName,
-				WaitForStage: tclient.WorkflowUpdateStageCompleted,
-			},
-			StartWorkflowOperation: a.handlerStartOperation(workflowID, queueID, updateID),
-		})
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to call query handler")
-	}
-
-	var resp handler.ExecuteResponse
-	if err := rawResp.Get(ctx, &resp); err != nil {
-		return nil, errors.Wrap(err, "unable get response")
-	}
-
-	return &resp, nil
+		return &resp, nil
+	})
 }

--- a/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__execute.go
@@ -2,6 +2,7 @@ package activities
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -12,12 +13,32 @@ import (
 )
 
 // @temporal-gen-v2 activity
-// @start-to-close-timeout 2h
+// @start-to-close-timeout 5m
+// @schedule-to-close-timeout 2h
+// @heartbeat-timeout 10s
 // @max-retries 1
 // @as-wrapper
 // @wrapper-prefix HandlerInternal
 // @by-field WorkflowID
 func (a *Activities) updateWorkflowExecute(ctx context.Context, workflowID string, updateID string, queueID string) (*handler.ExecuteResponse, error) {
+	// Heartbeat so Temporal knows this activity is alive during the blocking update call.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		ticker := time.NewTicker(3 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				activity.RecordHeartbeat(ctx, nil)
+			}
+		}
+	}()
+
 	info := activity.GetInfo(ctx)
 
 	rawResp, err := a.tclient.UpdateWithStartWorkflowInNamespace(ctx,

--- a/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__validate.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/sdk/activity"
 	tclient "go.temporal.io/sdk/client"
 
+	"github.com/nuonco/nuon/pkg/temporal/heartbeat"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler"
 )
 
@@ -16,49 +17,33 @@ import (
 // @start-to-close-timeout 5m
 // @schedule-to-close-timeout 2h
 // @heartbeat-timeout 10s
-// @max-retries 1
 // @as-wrapper
 // @wrapper-prefix HandlerInternal
 // @by-field WorkflowID
 func (a *Activities) updateWorkflowValidate(ctx context.Context, workflowID string, updateID string, queueID string) (*handler.ValidateResponse, error) {
-	// Heartbeat so Temporal knows this activity is alive during the blocking update call.
-	done := make(chan struct{})
-	defer close(done)
-	go func() {
-		ticker := time.NewTicker(3 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-done:
-				return
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				activity.RecordHeartbeat(ctx, nil)
-			}
+	return heartbeat.WithHeartbeat(ctx, 3*time.Second, func(ctx context.Context) (*handler.ValidateResponse, error) {
+		info := activity.GetInfo(ctx)
+
+		rawResp, err := a.tclient.UpdateWithStartWorkflowInNamespace(ctx,
+			info.WorkflowNamespace,
+			tclient.UpdateWithStartWorkflowOptions{
+				UpdateOptions: tclient.UpdateWorkflowOptions{
+					UpdateID:     updateID + "-validate",
+					WorkflowID:   workflowID,
+					UpdateName:   handler.ValidateUpdateName,
+					WaitForStage: tclient.WorkflowUpdateStageCompleted,
+				},
+				StartWorkflowOperation: a.handlerStartOperation(workflowID, queueID, updateID),
+			})
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to call query handler")
 		}
-	}()
 
-	info := activity.GetInfo(ctx)
+		var resp handler.ValidateResponse
+		if err := rawResp.Get(ctx, &resp); err != nil {
+			return nil, errors.Wrap(err, "unable get response")
+		}
 
-	rawResp, err := a.tclient.UpdateWithStartWorkflowInNamespace(ctx,
-		info.WorkflowNamespace,
-		tclient.UpdateWithStartWorkflowOptions{
-			UpdateOptions: tclient.UpdateWorkflowOptions{
-				WorkflowID:   workflowID,
-				UpdateName:   handler.ValidateUpdateName,
-				WaitForStage: tclient.WorkflowUpdateStageCompleted,
-			},
-			StartWorkflowOperation: a.handlerStartOperation(workflowID, queueID, updateID),
-		})
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to call query handler")
-	}
-
-	var resp handler.ValidateResponse
-	if err := rawResp.Get(ctx, &resp); err != nil {
-		return nil, errors.Wrap(err, "unable get response")
-	}
-
-	return &resp, nil
+		return &resp, nil
+	})
 }

--- a/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__validate.go
@@ -2,6 +2,7 @@ package activities
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -12,12 +13,32 @@ import (
 )
 
 // @temporal-gen-v2 activity
-// @start-to-close-timeout 2h
+// @start-to-close-timeout 5m
+// @schedule-to-close-timeout 2h
+// @heartbeat-timeout 10s
 // @max-retries 1
 // @as-wrapper
 // @wrapper-prefix HandlerInternal
 // @by-field WorkflowID
 func (a *Activities) updateWorkflowValidate(ctx context.Context, workflowID string, updateID string, queueID string) (*handler.ValidateResponse, error) {
+	// Heartbeat so Temporal knows this activity is alive during the blocking update call.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		ticker := time.NewTicker(3 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				activity.RecordHeartbeat(ctx, nil)
+			}
+		}
+	}()
+
 	info := activity.GetInfo(ctx)
 
 	rawResp, err := a.tclient.UpdateWithStartWorkflowInNamespace(ctx,


### PR DESCRIPTION
Fixes an issue where a queue signal can be awaited upon, and the worker can restart causing it to hang indefinitely.
