### PR TITLE
chore(ctl-api): pin the runner binary version for mng process

### DIFF
--- a/services/ctl-api/internal/app/installs/signals/v2/generateinstallstackversion/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/generateinstallstackversion/signal.go
@@ -181,7 +181,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 			Runner:                     runner,
 			Settings:                   &runner.RunnerGroup.Settings,
 			RunnerInitScriptURL:        initScriptURL,
-			RunnerEnvVars:              stacks.FormatRunnerEnvVars(&cfg.RunnerConfig),
+			RunnerEnvVars:              stacks.FormatRunnerEnvVars(&cfg.RunnerConfig, s.cfg.RunnerContainerImageTag),
 		}
 
 		// Legacy init.sh needs a pre-provisioned bootstrap token.

--- a/services/ctl-api/internal/app/installs/signals/v2/generateinstallstackversion/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/generateinstallstackversion/signal.go
@@ -234,6 +234,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		Runner:                     runner,
 		Settings:                   &runner.RunnerGroup.Settings,
 		APIToken:                   generics.FromPtrStr(token),
+		RunnerEnvVars:              stacks.FormatRunnerEnvVars(&cfg.RunnerConfig, s.cfg.RunnerContainerImageTag),
 	}
 
 	switch cfg.RunnerConfig.Type {

--- a/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
+++ b/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
@@ -140,7 +140,7 @@ func (w *Workflows) GenerateInstallStackVersion(ctx workflow.Context, sreq signa
 			Runner:                     runner,
 			Settings:                   &runner.RunnerGroup.Settings,
 			RunnerInitScriptURL:        initScriptURL,
-			RunnerEnvVars:              stacks.FormatRunnerEnvVars(&cfg.RunnerConfig),
+			RunnerEnvVars:              stacks.FormatRunnerEnvVars(&cfg.RunnerConfig, w.cfg.RunnerContainerImageTag),
 		}
 
 		// Legacy init.sh needs a pre-provisioned bootstrap token.
@@ -189,7 +189,7 @@ func (w *Workflows) GenerateInstallStackVersion(ctx workflow.Context, sreq signa
 		Runner:                     runner,
 		Settings:                   &runner.RunnerGroup.Settings,
 		APIToken:                   generics.FromPtrStr(token),
-		RunnerEnvVars:              stacks.FormatRunnerEnvVars(&cfg.RunnerConfig),
+		RunnerEnvVars:              stacks.FormatRunnerEnvVars(&cfg.RunnerConfig, w.cfg.RunnerContainerImageTag),
 	}
 
 	switch cfg.RunnerConfig.Type {

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
@@ -11,6 +11,12 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
 )
 
+// TODO: there are some runner env vars we want to provide defaults for IFF
+// the user provides a value for them in `env_vars` block in the `runner.toml`.
+func (a *Templates) getRunnerEnvVars(inp *stacks.TemplateInput) (string, error) {
+	return inp.RunnerEnvVars, nil
+}
+
 // getRunnerASGNestedStack returns a nested stack template for runner ASG resources.
 // It fetches the runner template to discover its parameters, conditionally including
 // RunnerApiToken only if the template defines it.

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/resource_ec2_launch_template.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/resource_ec2_launch_template.go
@@ -48,7 +48,8 @@ func (a *Templates) getRunnerLaunchTemplateData(inp *stacks.TemplateInput, t tag
 		// NOTE(fd): this script is loaded from the RunnerConfig.InitScript field.
 		// this field is a url or a bash script. it is retrieved in the activity that generates the stack.
 		UserData: cloudformation.Base64Ptr(fmt.Sprintf(`#!/bin/bash
+%s
 curl %s | bash
-`, inp.RunnerInitScriptURL)),
+`, inp.RunnerEnvVars, inp.RunnerInitScriptURL)),
 	}
 }

--- a/services/ctl-api/internal/pkg/stacks/template_input.go
+++ b/services/ctl-api/internal/pkg/stacks/template_input.go
@@ -33,21 +33,37 @@ type TemplateInput struct {
 }
 
 // FormatRunnerEnvVars converts an AppRunnerConfig's EnvVars hstore into a
-// newline-delimited string of "export key=value" statements.
-func FormatRunnerEnvVars(cfg *app.AppRunnerConfig) string {
-	if cfg == nil || len(cfg.EnvVars) == 0 {
+// newline-delimited string of "export key=value" statements. Default values
+// are injected only when not already defined in cfg.EnvVars.
+func FormatRunnerEnvVars(cfg *app.AppRunnerConfig, runnerBinaryVersion string) string {
+	if cfg == nil {
+		cfg = &app.AppRunnerConfig{}
+	}
+
+	// Shallow-copy so we don't mutate the caller's map.
+	merged := make(map[string]*string, len(cfg.EnvVars)+1)
+	for k, v := range cfg.EnvVars {
+		merged[k] = v
+	}
+
+	// Inject defaults only when not already present.
+	if _, ok := merged["RUNNER_BINARY_VERSION"]; !ok {
+		merged["RUNNER_BINARY_VERSION"] = &runnerBinaryVersion
+	}
+
+	if len(merged) == 0 {
 		return ""
 	}
 
-	keys := make([]string, 0, len(cfg.EnvVars))
-	for k := range cfg.EnvVars {
+	keys := make([]string, 0, len(merged))
+	for k := range merged {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
 	lines := make([]string, 0, len(keys))
 	for _, k := range keys {
-		v := cfg.EnvVars[k]
+		v := merged[k]
 		if v != nil {
 			lines = append(lines, fmt.Sprintf("export %s=%s", k, *v))
 		}


### PR DESCRIPTION
### Description

We want to be able to do two things:

1. override the version of the binary in use on the runner vm so we can more easily test runner mng -mode changes
2. in byoc, pin the runner binary to the same version as the control plane

This change modifies the RunnerEnvVar handling. If it is not defined in the runner.toml file, `RUNNER_BINARY_VERSION` will be set to the value of `cfg.RunnerContainerImageTag`.

### Notes

- This is one half of the work, the other half is adding support for that env var in the init script. 
- w/ app-branches, this will enable pinning a single install to a specific version combo which would help in the case an install requires a specific combination of values (rare). 
