### PR TITLE
chore: convert component signals into queues

### DIFF
--- a/services/ctl-api/internal/app/components/service/create_component.go
+++ b/services/ctl-api/internal/app/components/service/create_component.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
@@ -73,15 +72,11 @@ func (s *service) CreateComponent(ctx *gin.Context) {
 		return
 	}
 
-	s.evClient.Send(ctx, component.ID, &signals.Signal{
-		Type: signals.OperationCreated,
-	})
-	s.evClient.Send(ctx, component.ID, &signals.Signal{
-		Type: signals.OperationProvision,
-	})
-	s.evClient.Send(ctx, component.ID, &signals.Signal{
-		Type: signals.OperationPollDependencies,
-	})
+	if err := s.onComponentCreated(ctx, component.ID); err != nil {
+		ctx.Error(err)
+		return
+	}
+
 	ctx.JSON(http.StatusCreated, component)
 }
 

--- a/services/ctl-api/internal/app/components/service/create_docker_build_component_config.go
+++ b/services/ctl-api/internal/app/components/service/create_docker_build_component_config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
@@ -134,14 +133,10 @@ func (s *service) CreateDockerBuildComponentConfig(ctx *gin.Context) {
 		return
 	}
 
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type: signals.OperationConfigCreated,
-	})
-
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type:          signals.OperationUpdateComponentType,
-		ComponentType: app.ComponentTypeDockerBuild,
-	})
+	if err := s.onConfigCreated(ctx, cmpID, app.ComponentTypeDockerBuild); err != nil {
+		ctx.Error(err)
+		return
+	}
 
 	ctx.JSON(http.StatusCreated, cfg)
 }

--- a/services/ctl-api/internal/app/components/service/create_external_image_config.go
+++ b/services/ctl-api/internal/app/components/service/create_external_image_config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
@@ -186,14 +185,10 @@ func (s *service) CreateExternalImageComponentConfig(ctx *gin.Context) {
 		return
 	}
 
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type: signals.OperationConfigCreated,
-	})
-
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type:          signals.OperationUpdateComponentType,
-		ComponentType: app.ComponentTypeExternalImage,
-	})
+	if err := s.onConfigCreated(ctx, cmpID, app.ComponentTypeExternalImage); err != nil {
+		ctx.Error(err)
+		return
+	}
 
 	ctx.JSON(http.StatusCreated, cfg)
 }

--- a/services/ctl-api/internal/app/components/service/create_helm_component_config.go
+++ b/services/ctl-api/internal/app/components/service/create_helm_component_config.go
@@ -14,7 +14,6 @@ import (
 	"github.com/robfig/cron"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
@@ -153,13 +152,11 @@ func (s *service) CreateHelmComponentConfig(ctx *gin.Context) {
 		return
 	}
 
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type: signals.OperationConfigCreated,
-	})
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type:          signals.OperationUpdateComponentType,
-		ComponentType: app.ComponentTypeHelmChart,
-	})
+	if err := s.onConfigCreated(ctx, cmpID, app.ComponentTypeHelmChart); err != nil {
+		ctx.Error(err)
+		return
+	}
+
 	ctx.JSON(http.StatusCreated, cfg)
 }
 

--- a/services/ctl-api/internal/app/components/service/create_job_component_config.go
+++ b/services/ctl-api/internal/app/components/service/create_job_component_config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
@@ -126,13 +125,11 @@ func (s *service) CreateJobComponentConfig(ctx *gin.Context) {
 		return
 	}
 
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type: signals.OperationConfigCreated,
-	})
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type:          signals.OperationUpdateComponentType,
-		ComponentType: app.ComponentTypeJob,
-	})
+	if err := s.onConfigCreated(ctx, cmpID, app.ComponentTypeJob); err != nil {
+		ctx.Error(err)
+		return
+	}
+
 	ctx.JSON(http.StatusCreated, cfg)
 }
 

--- a/services/ctl-api/internal/app/components/service/create_kubernetes_manifest_component_config.go
+++ b/services/ctl-api/internal/app/components/service/create_kubernetes_manifest_component_config.go
@@ -14,7 +14,6 @@ import (
 	"github.com/robfig/cron"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
@@ -180,14 +179,11 @@ func (s *service) CreateKubernetesManifestComponentConfig(ctx *gin.Context) {
 		return
 	}
 
-	// sk: this triggers queue build
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type: signals.OperationConfigCreated,
-	})
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type:          signals.OperationUpdateComponentType,
-		ComponentType: app.ComponentTypeKubernetesManifest,
-	})
+	if err := s.onConfigCreated(ctx, cmpID, app.ComponentTypeKubernetesManifest); err != nil {
+		ctx.Error(err)
+		return
+	}
+
 	ctx.JSON(http.StatusCreated, cfg)
 }
 

--- a/services/ctl-api/internal/app/components/service/create_terraform_module_component_config.go
+++ b/services/ctl-api/internal/app/components/service/create_terraform_module_component_config.go
@@ -15,7 +15,6 @@ import (
 	"github.com/robfig/cron"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
@@ -178,14 +177,11 @@ func (s *service) CreateTerraformModuleComponentConfig(ctx *gin.Context) {
 		return
 	}
 
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type: signals.OperationConfigCreated,
-	})
+	if err := s.onConfigCreated(ctx, cmpID, app.ComponentTypeTerraformModule); err != nil {
+		ctx.Error(err)
+		return
+	}
 
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type:          signals.OperationUpdateComponentType,
-		ComponentType: app.ComponentTypeTerraformModule,
-	})
 	ctx.JSON(http.StatusCreated, cfg)
 }
 

--- a/services/ctl-api/internal/app/components/service/on_component_created.go
+++ b/services/ctl-api/internal/app/components/service/on_component_created.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
+	createdsignal "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/v2/created"
+	polldependencies "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/v2/polldependencies"
+	provision "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/v2/provision"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+)
+
+// onComponentCreated handles the component creation signal dispatch.
+// When queues are enabled, it enqueues created, provision, and polldependencies queue signals.
+// Otherwise, it falls back to the event loop.
+func (s *service) onComponentCreated(ctx *gin.Context, cmpID string) error {
+	useQueues, err := s.featuresClient.AllFeaturesEnabled(ctx, app.OrgFeatureAppBranches, app.OrgFeatureQueues)
+	if err != nil {
+		return fmt.Errorf("unable to check features: %w", err)
+	}
+
+	if useQueues {
+		q, err := s.queueClient.GetQueueByOwner(ctx, cmpID, "components")
+		if err != nil {
+			return fmt.Errorf("unable to get component queue: %w", err)
+		}
+
+		if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID:   q.ID,
+			OwnerID:   cmpID,
+			OwnerType: "components",
+			Signal: &createdsignal.Signal{
+				ComponentID: cmpID,
+			},
+		}); err != nil {
+			return fmt.Errorf("unable to enqueue created signal: %w", err)
+		}
+
+		if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID:   q.ID,
+			OwnerID:   cmpID,
+			OwnerType: "components",
+			Signal: &provision.Signal{
+				ComponentID: cmpID,
+			},
+		}); err != nil {
+			return fmt.Errorf("unable to enqueue provision signal: %w", err)
+		}
+
+		if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID:   q.ID,
+			OwnerID:   cmpID,
+			OwnerType: "components",
+			Signal: &polldependencies.Signal{
+				ComponentID: cmpID,
+			},
+		}); err != nil {
+			return fmt.Errorf("unable to enqueue poll dependencies signal: %w", err)
+		}
+	} else {
+		s.evClient.Send(ctx, cmpID, &signals.Signal{
+			Type: signals.OperationCreated,
+		})
+		s.evClient.Send(ctx, cmpID, &signals.Signal{
+			Type: signals.OperationProvision,
+		})
+		s.evClient.Send(ctx, cmpID, &signals.Signal{
+			Type: signals.OperationPollDependencies,
+		})
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/app/components/service/on_config_created.go
+++ b/services/ctl-api/internal/app/components/service/on_config_created.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
+	configcreated "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/v2/configcreated"
+	updatecomponenttype "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/v2/updatecomponenttype"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+)
+
+// onConfigCreated handles the component config creation signal dispatch.
+// When queues are enabled, it enqueues configcreated and updatecomponenttype queue signals.
+// Otherwise, it falls back to the event loop.
+func (s *service) onConfigCreated(ctx *gin.Context, cmpID string, componentType app.ComponentType) error {
+	useQueues, err := s.featuresClient.AllFeaturesEnabled(ctx, app.OrgFeatureAppBranches, app.OrgFeatureQueues)
+	if err != nil {
+		return fmt.Errorf("unable to check features: %w", err)
+	}
+
+	if useQueues {
+		q, err := s.queueClient.GetQueueByOwner(ctx, cmpID, "components")
+		if err != nil {
+			return fmt.Errorf("unable to get component queue: %w", err)
+		}
+
+		if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID:   q.ID,
+			OwnerID:   cmpID,
+			OwnerType: "components",
+			Signal: &configcreated.Signal{
+				ComponentID: cmpID,
+			},
+		}); err != nil {
+			return fmt.Errorf("unable to enqueue config created signal: %w", err)
+		}
+
+		if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID:   q.ID,
+			OwnerID:   cmpID,
+			OwnerType: "components",
+			Signal: &updatecomponenttype.Signal{
+				ComponentID:   cmpID,
+				ComponentType: componentType,
+			},
+		}); err != nil {
+			return fmt.Errorf("unable to enqueue update component type signal: %w", err)
+		}
+	} else {
+		s.evClient.Send(ctx, cmpID, &signals.Signal{
+			Type: signals.OperationConfigCreated,
+		})
+		s.evClient.Send(ctx, cmpID, &signals.Signal{
+			Type:          signals.OperationUpdateComponentType,
+			ComponentType: componentType,
+		})
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/app/components/signals/v2/configcreated/signal.go
+++ b/services/ctl-api/internal/app/components/signals/v2/configcreated/signal.go
@@ -6,8 +6,10 @@ import (
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
+	buildsignal "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/v2/build"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 )
 
 type Signal struct {
@@ -28,19 +30,34 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 }
 
 func (s *Signal) Execute(ctx workflow.Context) error {
-	// Same logic as queuebuild - get component then queue a build
 	cmp, err := activities.AwaitGetComponentByComponentID(ctx, s.ComponentID)
 	if err != nil {
 		return fmt.Errorf("unable to get component: %w", err)
 	}
 
-	_, err = activities.AwaitQueueComponentBuild(ctx, activities.QueueComponentBuildRequest{
+	build, err := activities.AwaitCreateComponentBuildRecord(ctx, activities.CreateComponentBuildRecordRequest{
 		CreatedByID: cmp.CreatedByID,
 		ComponentID: s.ComponentID,
 		OrgID:       cmp.OrgID,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to queue component build: %w", err)
+	}
+
+	// Enqueue the build signal to the component's queue. Fire and forget —
+	// the build signal runs independently on the component queue.
+	_, err = sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
+		OwnerID:   s.ComponentID,
+		OwnerType: "components",
+		Signal: &buildsignal.Signal{
+			ComponentID: s.ComponentID,
+			BuildID:     build.ID,
+		},
+		SignalOwnerID:   build.ID,
+		SignalOwnerType: "component_builds",
+	})
+	if err != nil {
+		return fmt.Errorf("unable to enqueue build signal: %w", err)
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/components/signals/v2/queuebuild/signal.go
+++ b/services/ctl-api/internal/app/components/signals/v2/queuebuild/signal.go
@@ -10,6 +10,7 @@ import (
 	buildsignal "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/v2/build"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 )
 
 type Signal struct {
@@ -32,44 +33,58 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 }
 
 func (s *Signal) Execute(ctx workflow.Context) error {
-	// If a pre-created BuildID is provided, delegate directly to the build signal.
-	if s.BuildID != "" {
-		return (&buildsignal.Signal{
+	buildID := s.BuildID
+
+	// If no pre-created build, create the build record.
+	if buildID == "" {
+		cmp, err := activities.AwaitGetComponentByComponentID(ctx, s.ComponentID)
+		if err != nil {
+			return fmt.Errorf("unable to get component: %w", err)
+		}
+
+		req := activities.CreateComponentBuildRecordRequest{
+			CreatedByID: cmp.CreatedByID,
 			ComponentID: s.ComponentID,
-			BuildID:     s.BuildID,
-		}).Execute(ctx)
-	}
+			OrgID:       cmp.OrgID,
+		}
 
-	cmp, err := activities.AwaitGetComponentByComponentID(ctx, s.ComponentID)
-	if err != nil {
-		return fmt.Errorf("unable to get component: %w", err)
-	}
-
-	req := activities.QueueComponentBuildRequest{
-		CreatedByID: cmp.CreatedByID,
-		ComponentID: s.ComponentID,
-		OrgID:       cmp.OrgID,
-	}
-
-	// If AppConfigID is provided, try to use the branch's VCS commit when the
-	// component shares the same VCS config as the triggering branch run.
-	if s.AppConfigID != "" {
-		run, err := activities.AwaitGetAppBranchRunByAppConfigIDByAppConfigID(ctx, s.AppConfigID)
-		if err == nil && run.VCSConnectionCommit != nil {
-			commitOwnerID := run.VCSConnectionCommit.OwnerID
-			componentVCSConfigID := resolveComponentVCSConfigID(cmp)
-			if componentVCSConfigID != "" && componentVCSConfigID == commitOwnerID {
-				sha := run.VCSConnectionCommit.SHA
-				commitID := run.VCSConnectionCommit.ID
-				req.GitRef = &sha
-				req.VCSConnectionCommitID = &commitID
+		// If AppConfigID is provided, try to use the branch's VCS commit when the
+		// component shares the same VCS config as the triggering branch run.
+		if s.AppConfigID != "" {
+			run, err := activities.AwaitGetAppBranchRunByAppConfigIDByAppConfigID(ctx, s.AppConfigID)
+			if err == nil && run.VCSConnectionCommit != nil {
+				commitOwnerID := run.VCSConnectionCommit.OwnerID
+				componentVCSConfigID := resolveComponentVCSConfigID(cmp)
+				if componentVCSConfigID != "" && componentVCSConfigID == commitOwnerID {
+					sha := run.VCSConnectionCommit.SHA
+					commitID := run.VCSConnectionCommit.ID
+					req.GitRef = &sha
+					req.VCSConnectionCommitID = &commitID
+				}
 			}
 		}
+
+		build, err := activities.AwaitCreateComponentBuildRecord(ctx, req)
+		if err != nil {
+			return fmt.Errorf("unable to queue component build: %w", err)
+		}
+		buildID = build.ID
 	}
 
-	_, err = activities.AwaitQueueComponentBuild(ctx, req)
+	// Enqueue the build signal to the component's queue. The caller awaits this
+	// queuebuild signal; the build signal runs independently on the component queue.
+	_, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
+		OwnerID:   s.ComponentID,
+		OwnerType: "components",
+		Signal: &buildsignal.Signal{
+			ComponentID: s.ComponentID,
+			BuildID:     buildID,
+		},
+		SignalOwnerID:   buildID,
+		SignalOwnerType: "component_builds",
+	})
 	if err != nil {
-		return fmt.Errorf("unable to queue component build: %w", err)
+		return fmt.Errorf("unable to enqueue build signal: %w", err)
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/components/worker/activities/create_component_build_record.go
+++ b/services/ctl-api/internal/app/components/worker/activities/create_component_build_record.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 )
 
-type QueueComponentBuildRequest struct {
+type CreateComponentBuildRecordRequest struct {
 	ComponentID string `validate:"required"`
 	OrgID       string `validate:"required"`
 	CreatedByID string `validate:"required"`
@@ -20,9 +19,11 @@ type QueueComponentBuildRequest struct {
 	VCSConnectionCommitID *string
 }
 
+// CreateComponentBuildRecord creates a component build record without dispatching to the
+// event loop. Used by queue signals that handle build execution themselves.
+//
 // @temporal-gen-v2 activity
-func (a *Activities) QueueComponentBuild(ctx context.Context, req QueueComponentBuildRequest) (*app.ComponentBuild, error) {
-	// set the orgID on the context, for all writes
+func (a *Activities) CreateComponentBuildRecord(ctx context.Context, req CreateComponentBuildRecordRequest) (*app.ComponentBuild, error) {
 	ctx = cctx.SetOrgIDContext(ctx, req.OrgID)
 	ctx = cctx.SetAccountIDContext(ctx, req.CreatedByID)
 
@@ -39,22 +40,6 @@ func (a *Activities) QueueComponentBuild(ctx context.Context, req QueueComponent
 		}
 		build.VCSConnectionCommitID = req.VCSConnectionCommitID
 	}
-
-	// Ensure the component event loop is running before sending the build signal.
-	// In the normal flow, the event loop is started by OperationCreated when the component
-	// is created via the HTTP API. But in the onboarding flow (and other paths that create
-	// components through SyncAppConfig), the event loop may not exist yet.
-	// OperationRestart has Restart()=true, so evClient.Send checks the workflow status
-	// and starts the event loop if it's not running. The Restarted handler is a no-op
-	// (just sets component status to active).
-	a.evClient.Send(ctx, req.ComponentID, &signals.Signal{
-		Type: signals.OperationRestart,
-	})
-
-	a.evClient.Send(ctx, req.ComponentID, &signals.Signal{
-		Type:    signals.OperationBuild,
-		BuildID: build.ID,
-	})
 
 	return build, nil
 }

--- a/services/ctl-api/internal/pkg/workflows/job/exec.go
+++ b/services/ctl-api/internal/pkg/workflows/job/exec.go
@@ -49,12 +49,22 @@ func (w *Workflows) ExecuteJob(ctx workflow.Context, req *ExecuteJobRequest) (ap
 		return w.pollJob(ctx, req)
 	}
 
-	if err := w.queueJob(ctx, req.RunnerID, req.JobID); err != nil {
+	queueSignalID, err := w.queueJob(ctx, req.RunnerID, req.JobID)
+	if err != nil {
 		return app.RunnerJobStatusUnknown, errors.Wrap(err, "unable to queue job")
 	}
 
-	if _, err := w.pollJob(ctx, req); err != nil {
-		return app.RunnerJobStatus(""), err
+	if queueSignalID != "" {
+		// Queue path: await signal completion via Temporal workflow updates
+		// instead of polling the job status.
+		if _, err := queueclient.AwaitAwaitSignal(ctx, queueSignalID); err != nil {
+			return app.RunnerJobStatusUnknown, errors.Wrap(err, "queue signal failed")
+		}
+	} else {
+		// Legacy event loop path: poll job status.
+		if _, err := w.pollJob(ctx, req); err != nil {
+			return app.RunnerJobStatus(""), err
+		}
 	}
 
 	job, err := activities.AwaitPkgWorkflowsJobGetJobByID(ctx, req.JobID)
@@ -65,10 +75,12 @@ func (w *Workflows) ExecuteJob(ctx workflow.Context, req *ExecuteJobRequest) (ap
 	return job.Status, nil
 }
 
-func (j *Workflows) queueJob(ctx workflow.Context, runnerID, jobID string) error {
+// queueJob dispatches the job for execution. Returns the queue signal ID when the
+// queue path is used (non-empty string), or empty string for the legacy event loop path.
+func (j *Workflows) queueJob(ctx workflow.Context, runnerID, jobID string) (string, error) {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
-		return errors.Wrap(err, "expected a log stream in the context to poll job")
+		return "", errors.Wrap(err, "expected a log stream in the context to poll job")
 	}
 
 	// Check if this runner uses queue-based job dispatch (parallel-runner-jobs feature flag).
@@ -79,18 +91,21 @@ func (j *Workflows) queueJob(ctx workflow.Context, runnerID, jobID string) error
 		JobID:    jobID,
 	})
 	if err != nil {
-		return errors.Wrap(err, "unable to check runner job group queue")
+		return "", errors.Wrap(err, "unable to check runner job group queue")
 	}
 
 	if queueResp.QueueID != "" {
 		l.Info("queueing job via job-group queue", zap.String("runner-id", runnerID), zap.String("queue-id", queueResp.QueueID))
-		_, err := queueclient.AwaitEnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+		enqueueResp, err := queueclient.AwaitEnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
 			QueueID:   queueResp.QueueID,
 			Signal:    &processjobsignal.Signal{RunnerID: runnerID, JobID: jobID},
 			OwnerID:   jobID,
 			OwnerType: "runner_jobs",
 		})
-		return errors.Wrap(err, "unable to enqueue job to queue")
+		if err != nil {
+			return "", errors.Wrap(err, "unable to enqueue job to queue")
+		}
+		return enqueueResp.ID, nil
 	}
 
 	// Legacy path: dispatch through the runner event loop.
@@ -100,7 +115,7 @@ func (j *Workflows) queueJob(ctx workflow.Context, runnerID, jobID string) error
 		JobID: jobID,
 	})
 
-	return nil
+	return "", nil
 }
 
 func (j *Workflows) pollJob(ctx workflow.Context, req *ExecuteJobRequest) (app.RunnerJobStatus, error) {


### PR DESCRIPTION
This updates some places where the components namespace was not using queues.

Within here, we also move the execute-job workflow to use await-signal for polling.
