### PR TITLE
fix(ui): only show approve btns when approve obj on step

### DIFF
--- a/services/dashboard-ui/client/components/approvals/ApprovePlan/ApprovePlanContainer.tsx
+++ b/services/dashboard-ui/client/components/approvals/ApprovePlan/ApprovePlanContainer.tsx
@@ -95,6 +95,9 @@ export const ApprovePlanButton = ({
   ...props
 }: IApprovePlan & IButtonAsButton) => {
   const { addModal } = useSurfaces()
+
+  if (!step.approval) return null
+
   const modal = <ApprovePlanModalContainer step={step} />
 
   return (

--- a/services/dashboard-ui/client/components/approvals/DenyPlan/DenyPlanContainer.tsx
+++ b/services/dashboard-ui/client/components/approvals/DenyPlan/DenyPlanContainer.tsx
@@ -103,6 +103,8 @@ export const DenyPlanButton = ({
 }: IDenyPlan & Omit<ISplitButton, 'buttonProps' | 'dropdownProps'>) => {
   const { addModal } = useSurfaces()
 
+  if (!step.approval) return null
+
   const openModal = (denyType: TDenyType) => {
     addModal(<DenyPlanModalContainer step={step} denyType={denyType} />)
   }


### PR DESCRIPTION
Only show approve and deny buttons when a step has an approval object on the step