### PR TITLE
feat(ui): adds markdown support for group tag

### DIFF
--- a/services/dashboard-ui/client/components/common/Markdown/Markdown.stories.tsx
+++ b/services/dashboard-ui/client/components/common/Markdown/Markdown.stories.tsx
@@ -1434,3 +1434,44 @@ Regular markdown continues to work perfectly alongside the HTML elements.
   </div>
 )
 
+export const NuonGroup = () => (
+  <div className="space-y-6">
+    <div className="space-y-3">
+      <h3 className="text-lg font-semibold">nuon-group</h3>
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        Use {'<nuon-group>'} to lay out child elements horizontally with flexbox.
+        Supports gap, align, justify, and wrap attributes.
+      </p>
+    </div>
+
+    <div className="space-y-4">
+      <h4 className="text-sm font-medium">Badges in a row</h4>
+      <div className="p-4 border rounded-lg">
+        <Markdown
+          content={`Status overview:
+
+<nuon-group gap="2" align="center">
+  <nuon-badge theme="green">Healthy</nuon-badge>
+  <nuon-badge theme="yellow">Deploying</nuon-badge>
+  <nuon-badge theme="red">Failed</nuon-badge>
+</nuon-group>`}
+        />
+      </div>
+    </div>
+
+    <div className="space-y-4">
+      <h4 className="text-sm font-medium">With wrap and justify</h4>
+      <div className="p-4 border rounded-lg">
+        <Markdown
+          content={`<nuon-group gap="3" wrap="true" justify="between">
+  <nuon-badge theme="blue" variant="outline">us-east-1</nuon-badge>
+  <nuon-badge theme="blue" variant="outline">us-west-2</nuon-badge>
+  <nuon-badge theme="blue" variant="outline">eu-west-1</nuon-badge>
+  <nuon-badge theme="blue" variant="outline">ap-southeast-1</nuon-badge>
+</nuon-group>`}
+        />
+      </div>
+    </div>
+  </div>
+)
+

--- a/services/dashboard-ui/client/components/common/Markdown/nuon-components.tsx
+++ b/services/dashboard-ui/client/components/common/Markdown/nuon-components.tsx
@@ -7,6 +7,7 @@ import { InstallConfigGraph } from '@/components/installs/InstallConfigGraph'
 import { SandboxCard } from '@/components/sandbox/SandboxCard'
 import { RunnerCard } from '@/components/runners/RunnerCard'
 import { StackCard } from '@/components/stacks/StackCard'
+import { Group } from '@/components/common/Group'
 import { ViewStateButton } from '@/components/installs/management/ViewState'
 
 export type MarkdownMode = 'app' | 'install'
@@ -75,6 +76,16 @@ const registry: Record<string, NuonComponent> = {
     component: StackCard,
     mapProps: noProps,
     requiresInstall: true,
+  },
+  'nuon-group': {
+    component: Group,
+    mapProps: (attrs) => ({
+      children: attrs.children,
+      gap: attrs.gap ? Number(attrs.gap) : undefined,
+      align: attrs.align,
+      justify: attrs.justify,
+      wrap: attrs.wrap === 'false' ? false : true,
+    }),
   },
 }
 


### PR DESCRIPTION
Adds support for `<nuon-group></nuon-group>` in app READMEs