### PR TITLE
fix(ctl-api): retain bw compat w/ cli

### DIFF
--- a/sdks/nuon-go/client/nuon_client.go
+++ b/sdks/nuon-go/client/nuon_client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+
 	"github.com/nuonco/nuon/sdks/nuon-go/client/operations"
 )
 

--- a/sdks/nuon-go/models/service_c_l_i_config.go
+++ b/sdks/nuon-go/models/service_c_l_i_config.go
@@ -17,6 +17,15 @@ import (
 // swagger:model service.CLIConfig
 type ServiceCLIConfig struct {
 
+	// auth audience
+	AuthAudience string `json:"auth_audience,omitempty"`
+
+	// auth client id
+	AuthClientID string `json:"auth_client_id,omitempty"`
+
+	// auth domain
+	AuthDomain string `json:"auth_domain,omitempty"`
+
 	// dashboard url
 	DashboardURL string `json:"dashboard_url,omitempty"`
 

--- a/services/ctl-api/internal/app/general/service/cli_config.go
+++ b/services/ctl-api/internal/app/general/service/cli_config.go
@@ -7,6 +7,9 @@ import (
 )
 
 type CLIConfig struct {
+	AuthDomain      string `json:"auth_domain"`
+	AuthClientID    string `json:"auth_client_id"`
+	AuthAudience    string `json:"auth_audience"`
 	DashboardURL    string `json:"dashboard_url"`
 	NuonAuthEnabled bool   `json:"nuon_auth_enabled"`
 	RootDomain      string `json:"root_domain"`
@@ -27,6 +30,9 @@ type CLIConfig struct {
 // @Router					/v1/general/cli-config [GET]
 func (s *service) GetCLIConfig(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, &CLIConfig{
+		AuthDomain:      "",
+		AuthClientID:    "",
+		AuthAudience:    "",
 		DashboardURL:    s.cfg.AppURL,
 		NuonAuthEnabled: s.cfg.NuonAuthProviderType != "",
 		RootDomain:      s.cfg.RootDomain,

--- a/services/ctl-api/internal/app/general/service/cli_config.go
+++ b/services/ctl-api/internal/app/general/service/cli_config.go
@@ -34,7 +34,7 @@ func (s *service) GetCLIConfig(ctx *gin.Context) {
 		AuthClientID:    "",
 		AuthAudience:    "",
 		DashboardURL:    s.cfg.AppURL,
-		NuonAuthEnabled: s.cfg.NuonAuthProviderType != "",
+		NuonAuthEnabled: true,
 		RootDomain:      s.cfg.RootDomain,
 	})
 }


### PR DESCRIPTION
### Description

Keep the `Auth0*` values in the CLIConfig payload for another version to prevent breaking bw compat

### Commits

- **fix(ctl-api): let's retain these values for bw compat**
- **chore(sdks/nuon-go): re-generate for cli/config changes**
