### PR TITLE
chore(ui): readded dd metrics for the BFF

### DIFF
--- a/services/dashboard-ui/server/internal/config.go
+++ b/services/dashboard-ui/server/internal/config.go
@@ -16,11 +16,14 @@ func init() {
 	config.RegisterDefault("dist_dir", "./dist")
 	config.RegisterDefault("public_dir", "./public")
 	config.RegisterDefault("middlewares", []string{
+		"metrics",
 		"cors",
 	})
 	config.RegisterDefault("nuon_api_url", "https://api.nuon.co")
 	config.RegisterDefault("nuon_app_url", "http://localhost:4000")
 	config.RegisterDefault("github_app_name", "nuon-connect")
+	config.RegisterDefault("disable_metrics", true)
+	config.RegisterDefault("service_deployment", "local")
 }
 
 type Config struct {
@@ -46,6 +49,8 @@ type Config struct {
 	DatadogApplicationKey string `config:"datadog_application_key"`
 	DatadogTraceDebug     bool   `config:"datadog_trace_debug"`
 	DatadogAPIUrl         string `config:"datadog_api_url"`
+	DisableMetrics        bool   `config:"disable_metrics"`
+	ServiceDeployment     string `config:"service_deployment"`
 	IsBYOC                bool   `config:"nuon_byoc"`
 	SFTrialEndpoint       string `config:"sf_trial_access_endpoint"`
 	OnboardingV2          bool   `config:"nuon_onboarding_v2"`

--- a/services/dashboard-ui/server/internal/fxmodules/infrastructure.go
+++ b/services/dashboard-ui/server/internal/fxmodules/infrastructure.go
@@ -17,4 +17,5 @@ func newLogger(cfg *internal.Config) (*zap.Logger, error) {
 var InfrastructureModule = fx.Module("infrastructure",
 	fx.Provide(internal.NewConfig),
 	fx.Provide(newLogger),
+	fx.Provide(NewMetricsWriter),
 )

--- a/services/dashboard-ui/server/internal/fxmodules/metrics.go
+++ b/services/dashboard-ui/server/internal/fxmodules/metrics.go
@@ -1,0 +1,47 @@
+package fxmodules
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/go-playground/validator/v10"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/pkg/metrics"
+	"github.com/nuonco/nuon/services/dashboard-ui/server/internal"
+)
+
+func NewMetricsWriter(lc fx.Lifecycle, cfg *internal.Config, l *zap.Logger) (metrics.Writer, error) {
+	v := validator.New()
+
+	mw, err := metrics.New(v,
+		metrics.WithDisable(cfg.DisableMetrics),
+		metrics.WithTags(
+			fmt.Sprintf("service_deployment:%s", cfg.ServiceDeployment),
+			"service_type:dashboard_ui",
+		),
+		metrics.WithLogger(l),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create metrics writer: %w", err)
+	}
+
+	if !cfg.DisableMetrics {
+		tracer.Start(
+			tracer.WithRuntimeMetrics(),
+			tracer.WithDogstatsdAddr(fmt.Sprintf("%s:8125", os.Getenv("HOST_IP"))),
+		)
+
+		lc.Append(fx.Hook{
+			OnStop: func(ctx context.Context) error {
+				tracer.Stop()
+				return nil
+			},
+		})
+	}
+
+	return mw, nil
+}

--- a/services/dashboard-ui/server/internal/fxmodules/middlewares.go
+++ b/services/dashboard-ui/server/internal/fxmodules/middlewares.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/nuonco/nuon/pkg/ginmw"
 	corsmw "github.com/nuonco/nuon/services/dashboard-ui/server/internal/middlewares/cors"
+	metricsmw "github.com/nuonco/nuon/services/dashboard-ui/server/internal/middlewares/metrics"
 )
 
 var MiddlewaresModule = fx.Module("middlewares",
+	fx.Provide(ginmw.AsMiddleware(metricsmw.New)),
 	fx.Provide(ginmw.AsMiddleware(corsmw.New)),
 )

--- a/services/dashboard-ui/server/internal/fxmodules/services.go
+++ b/services/dashboard-ui/server/internal/fxmodules/services.go
@@ -29,4 +29,5 @@ var ServicesModule = fx.Module("services",
 	fx.Provide(asService(handlers.NewProxyHandler)),
 	fx.Provide(asService(handlers.NewAPIProxyHandler)),
 	fx.Provide(asService(handlers.NewRandomNamesHandler)),
+	fx.Provide(asService(handlers.NewDDProxyHandler)),
 )

--- a/services/dashboard-ui/server/internal/handlers/ddproxy.go
+++ b/services/dashboard-ui/server/internal/handlers/ddproxy.go
@@ -1,0 +1,106 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+const ddIntakeURL = "https://browser-intake-us5-datadoghq.com"
+
+var hopByHopRequestHeaders = map[string]struct{}{
+	"host":                {},
+	"content-length":      {},
+	"transfer-encoding":   {},
+	"connection":          {},
+	"keep-alive":          {},
+	"proxy-authorization": {},
+	"te":                  {},
+	"upgrade":             {},
+	"expect":              {},
+}
+
+var hopByHopResponseHeaders = map[string]struct{}{
+	"connection":         {},
+	"keep-alive":         {},
+	"proxy-authenticate": {},
+	"transfer-encoding":  {},
+	"upgrade":            {},
+	"trailer":            {},
+}
+
+type DDProxyHandler struct {
+	l      *zap.Logger
+	client *http.Client
+}
+
+func NewDDProxyHandler(l *zap.Logger) *DDProxyHandler {
+	return &DDProxyHandler{
+		l: l,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func (h *DDProxyHandler) RegisterRoutes(e *gin.Engine) error {
+	e.Any("/api/ddp", h.Handle)
+	return nil
+}
+
+func (h *DDProxyHandler) Handle(c *gin.Context) {
+	ddforward := c.Query("ddforward")
+	if ddforward == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing ddforward parameter"})
+		return
+	}
+
+	upstreamURL := ddIntakeURL + ddforward
+
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, upstreamURL, c.Request.Body)
+	if err != nil {
+		h.l.Error("failed to create upstream request", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create upstream request"})
+		return
+	}
+
+	for key, values := range c.Request.Header {
+		if _, skip := hopByHopRequestHeaders[strings.ToLower(key)]; skip {
+			continue
+		}
+		for _, v := range values {
+			req.Header.Add(key, v)
+		}
+	}
+
+	clientIP := c.ClientIP()
+	if existing := req.Header.Get("X-Forwarded-For"); existing != "" {
+		req.Header.Set("X-Forwarded-For", clientIP+", "+existing)
+	} else {
+		req.Header.Set("X-Forwarded-For", clientIP)
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		h.l.Error("upstream request failed", zap.Error(err))
+		c.JSON(http.StatusBadGateway, gin.H{"error": "upstream request failed"})
+		return
+	}
+	defer resp.Body.Close()
+
+	for key, values := range resp.Header {
+		if _, skip := hopByHopResponseHeaders[strings.ToLower(key)]; skip {
+			continue
+		}
+		for _, v := range values {
+			c.Header(key, v)
+		}
+	}
+
+	c.Status(resp.StatusCode)
+	io.Copy(c.Writer, resp.Body)
+}

--- a/services/dashboard-ui/server/internal/middlewares/metrics/metrics.go
+++ b/services/dashboard-ui/server/internal/middlewares/metrics/metrics.go
@@ -1,0 +1,58 @@
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/pkg/metrics"
+	"github.com/nuonco/nuon/services/dashboard-ui/server/internal"
+)
+
+type middleware struct {
+	l      *zap.Logger
+	writer metrics.Writer
+}
+
+func New(cfg *internal.Config, l *zap.Logger, writer metrics.Writer) *middleware {
+	return &middleware{l: l, writer: writer}
+}
+
+func (m *middleware) Name() string {
+	return "metrics"
+}
+
+func (m *middleware) Handler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		startTS := time.Now()
+
+		c.Next()
+
+		path := c.FullPath()
+		if path == "" {
+			return
+		}
+
+		status := "ok"
+		if len(c.Errors) > 0 {
+			status = "err"
+		}
+
+		endpoint := strings.ReplaceAll(path, "-", "_")
+		statusCodeClass := fmt.Sprintf("%dxx", c.Writer.Status()/100)
+
+		tags := []string{
+			"status:" + status,
+			"status_code_class:" + statusCodeClass,
+			"endpoint:" + endpoint,
+			"method:" + c.Request.Method,
+			"context:bff",
+		}
+
+		m.writer.Timing("ui.request.latency", time.Since(startTS), tags)
+		m.writer.Gauge("ui.request.size", float64(c.Request.ContentLength), tags)
+	}
+}


### PR DESCRIPTION
- Add server-side StatsD metrics to the Go BFF — emits ui.request.latency and ui.request.size with endpoint/method/status tags via                  
  pkg/metrics.Writer                                                
- Add /api/ddp proxy handler forwarding browser RUM/Logs SDK traffic to DataDog intake — fixes silent 404s since the client SDKs are already        
  configured with proxy: '/api/ddp'                                                                                                                   
- Metrics disabled by default (DISABLE_METRICS=true) for safe local dev; enable in deployed environments via k8s values (DISABLE_METRICS=false,     
  SERVICE_DEPLOYMENT=<env>) 