### PR TITLE
feat: (dashboard-ui) add policy analytics page with summary and graphs

### DIFF
--- a/services/ctl-api/cmd/gen/main.go
+++ b/services/ctl-api/cmd/gen/main.go
@@ -105,7 +105,7 @@ func generatePublicSchema(ctx context.Context) error {
 		"--parseInternal",
 		"-g", "public.go",
 		"--markdownFiles", "docs/public/descriptions",
-		"-t", "auth,accounts,apps,actions,components,installs,installers,general,onboarding,orgs,releases,sandboxes,vcs,runners,queues",
+		"-t", "auth,accounts,apps,actions,components,installs,installers,general,onboarding,orgs,policy-reports,releases,sandboxes,vcs,runners,queues",
 	}
 
 	cmd, err := command.New(v,

--- a/services/ctl-api/docs/public/descriptions/get_policy_analytics_breakdown.md
+++ b/services/ctl-api/docs/public/descriptions/get_policy_analytics_breakdown.md
@@ -1,0 +1,1 @@
+Returns policy evaluation counts broken down by a single dimension (policy_id, install_id, or owner_type), sorted by violation count (denies first, then warns). Use this to identify which policies, installs, or lifecycle stages produce the most violations.

--- a/services/ctl-api/internal/app/policy_reports/service/analytics_interval.go
+++ b/services/ctl-api/internal/app/policy_reports/service/analytics_interval.go
@@ -17,6 +17,10 @@ func (t timeInterval) BucketExpr(column string) string {
 func intervalForRange(start, end time.Time) timeInterval {
 	d := end.Sub(start)
 	switch {
+	case d <= 3*time.Hour:
+		return timeInterval{"15m", "toStartOfInterval(%s, INTERVAL 15 MINUTE)"}
+	case d <= 6*time.Hour:
+		return timeInterval{"30m", "toStartOfInterval(%s, INTERVAL 30 MINUTE)"}
 	case d <= 24*time.Hour:
 		return timeInterval{"hour", "toStartOfHour(%s)"}
 	case d <= 7*24*time.Hour:

--- a/services/ctl-api/internal/app/policy_reports/service/analytics_interval_test.go
+++ b/services/ctl-api/internal/app/policy_reports/service/analytics_interval_test.go
@@ -14,7 +14,10 @@ func TestIntervalForRange(t *testing.T) {
 		wantLabel string
 		wantExpr  string
 	}{
-		{"1 hour", time.Hour, "hour", "toStartOfHour(evaluated_at)"},
+		{"1 hour", time.Hour, "15m", "toStartOfInterval(evaluated_at, INTERVAL 15 MINUTE)"},
+		{"3 hours", 3 * time.Hour, "15m", "toStartOfInterval(evaluated_at, INTERVAL 15 MINUTE)"},
+		{"4 hours", 4 * time.Hour, "30m", "toStartOfInterval(evaluated_at, INTERVAL 30 MINUTE)"},
+		{"6 hours", 6 * time.Hour, "30m", "toStartOfInterval(evaluated_at, INTERVAL 30 MINUTE)"},
 		{"exactly 24h", 24 * time.Hour, "hour", "toStartOfHour(evaluated_at)"},
 		{"25 hours", 25 * time.Hour, "6h", "toStartOfInterval(evaluated_at, INTERVAL 6 HOUR)"},
 		{"exactly 7 days", 7 * 24 * time.Hour, "6h", "toStartOfInterval(evaluated_at, INTERVAL 6 HOUR)"},

--- a/services/ctl-api/internal/app/policy_reports/service/get_policy_analytics_breakdown.go
+++ b/services/ctl-api/internal/app/policy_reports/service/get_policy_analytics_breakdown.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+)
+
+type BreakdownEntry struct {
+	Key         string `json:"key" gorm:"column:dimension_key"`
+	Evaluations int    `json:"evaluations" gorm:"column:evaluations"`
+	Denies      int    `json:"denies" gorm:"column:denies"`
+	Warns       int    `json:"warns" gorm:"column:warns"`
+	Passes      int    `json:"passes" gorm:"column:passes"`
+}
+
+type PolicyAnalyticsBreakdown struct {
+	Dimension string            `json:"dimension"`
+	Start     time.Time         `json:"start"`
+	End       time.Time         `json:"end"`
+	Entries   []*BreakdownEntry `json:"entries"`
+}
+
+var validBreakdownDimensions = map[string]struct{}{
+	"policy_id":  {},
+	"install_id": {},
+	"owner_type": {},
+}
+
+// @ID						GetPolicyAnalyticsBreakdown
+// @Summary				get policy analytics breakdown by dimension
+// @Description.markdown	get_policy_analytics_breakdown.md
+// @Param					app_id		path	string	true	"app ID"
+// @Param					dimension	query	string	true	"dimension to break down by: policy_id, install_id, owner_type"
+// @Param					start		query	string	false	"start time (RFC3339)"
+// @Param					end			query	string	false	"end time (RFC3339)"
+// @Param					install_id	query	string	false	"filter by install ID"
+// @Param					policy_id	query	string	false	"filter by policy ID"
+// @Param					limit		query	int		false	"max entries to return (default 10)"
+// @Tags					policy-reports
+// @Accept					json
+// @Produce				json
+// @Security				APIKey
+// @Security				OrgID
+// @Failure				400	{object}	stderr.ErrResponse
+// @Failure				401	{object}	stderr.ErrResponse
+// @Failure				403	{object}	stderr.ErrResponse
+// @Failure				500	{object}	stderr.ErrResponse
+// @Success				200	{object}	PolicyAnalyticsBreakdown
+// @Router					/v1/apps/{app_id}/policy-analytics/breakdown [get]
+func (s *service) GetPolicyAnalyticsBreakdown(ctx *gin.Context) {
+	org, err := cctx.OrgFromContext(ctx)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	appID := ctx.Param("app_id")
+	start, end, err := parseTimeRange(ctx)
+	if err != nil {
+		ctx.Error(stderr.ErrUser{Err: err, Description: "invalid time range"})
+		return
+	}
+
+	dimension := ctx.Query("dimension")
+	if _, ok := validBreakdownDimensions[dimension]; !ok {
+		ctx.Error(stderr.ErrUser{
+			Err:         fmt.Errorf("invalid dimension: %s", dimension),
+			Description: "valid dimensions: policy_id, install_id, owner_type",
+		})
+		return
+	}
+
+	limit := 10
+	if limitStr := ctx.Query("limit"); limitStr != "" {
+		parsed, err := strconv.Atoi(limitStr)
+		if err != nil || parsed < 1 {
+			ctx.Error(stderr.ErrUser{Err: fmt.Errorf("invalid limit: %s", limitStr), Description: "limit must be a positive integer"})
+			return
+		}
+		limit = parsed
+	}
+
+	installID := ctx.Query("install_id")
+	policyID := ctx.Query("policy_id")
+
+	breakdown, err := s.getPolicyAnalyticsBreakdown(ctx, org.ID, appID, start, end, dimension, limit, installID, policyID)
+	if err != nil {
+		ctx.Error(fmt.Errorf("unable to get policy analytics breakdown: %w", err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, breakdown)
+}
+
+func (s *service) getPolicyAnalyticsBreakdown(ctx context.Context, orgID, appID string, start, end time.Time, dimension string, limit int, installID, policyID string) (*PolicyAnalyticsBreakdown, error) {
+	whereClause, params := buildBaseWhereClause(analyticsFilter{
+		OrgID: orgID, AppID: appID,
+		Start: start, End: end,
+		InstallID: installID, PolicyID: policyID,
+	})
+
+	query := fmt.Sprintf(`SELECT
+			%s AS dimension_key,
+			count()                   AS evaluations,
+			countIf(outcome = 'deny') AS denies,
+			countIf(outcome = 'warn') AS warns,
+			countIf(outcome = 'pass') AS passes
+		FROM policy_report_events
+		%s
+		GROUP BY dimension_key
+		ORDER BY denies DESC, warns DESC, evaluations DESC
+		LIMIT ?`,
+		dimension, whereClause)
+
+	params = append(params, limit)
+
+	var entries []*BreakdownEntry
+	if err := s.chDB.WithContext(ctx).Raw(query, params...).Scan(&entries).Error; err != nil {
+		return nil, fmt.Errorf("unable to query clickhouse: %w", err)
+	}
+
+	return &PolicyAnalyticsBreakdown{
+		Dimension: dimension,
+		Start:     start,
+		End:       end,
+		Entries:   entries,
+	}, nil
+}

--- a/services/ctl-api/internal/app/policy_reports/service/service.go
+++ b/services/ctl-api/internal/app/policy_reports/service/service.go
@@ -48,6 +48,7 @@ func (s *service) RegisterPublicRoutes(ge *gin.Engine) error {
 	{
 		analytics.GET("/summary", s.GetPolicyAnalyticsSummary)
 		analytics.GET("/timeseries", s.GetPolicyAnalyticsTimeseries)
+		analytics.GET("/breakdown", s.GetPolicyAnalyticsBreakdown)
 	}
 
 	return nil

--- a/services/dashboard-ui/client/components/policies/PolicyAnalytics/BreakdownChart.tsx
+++ b/services/dashboard-ui/client/components/policies/PolicyAnalytics/BreakdownChart.tsx
@@ -1,0 +1,96 @@
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts'
+import { Text } from '@/components/common/Text'
+import type { TPolicyAnalyticsBreakdown } from '@/types'
+
+interface IBreakdownChart {
+  breakdown: TPolicyAnalyticsBreakdown | undefined
+  title: string
+  formatLabel?: (key: string) => string
+}
+
+function truncateId(id: string) {
+  if (id.length <= 16) return id
+  return `${id.slice(0, 6)}…${id.slice(-6)}`
+}
+
+const OWNER_TYPE_LABELS: Record<string, string> = {
+  install_deploys: 'Deploy',
+  component_builds: 'Build',
+  install_sandbox_runs: 'Sandbox',
+}
+
+function defaultFormatLabel(key: string) {
+  return OWNER_TYPE_LABELS[key] ?? truncateId(key)
+}
+
+export const BreakdownChart = ({
+  breakdown,
+  title,
+  formatLabel = defaultFormatLabel,
+}: IBreakdownChart) => {
+  const entries = breakdown?.entries ?? []
+
+  if (!entries.length) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-[120px]">
+        <Text variant="subtext" theme="neutral">
+          No data
+        </Text>
+      </div>
+    )
+  }
+
+  const data = entries.map((e) => ({
+    name: formatLabel(e.key ?? ''),
+    denies: e.denies ?? 0,
+    warns: e.warns ?? 0,
+    passes: e.passes ?? 0,
+  }))
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Text weight="strong" variant="body">
+        {title}
+      </Text>
+      <ResponsiveContainer width="100%" height={Math.max(120, data.length * 40 + 40)}>
+        <BarChart
+          data={data}
+          layout="vertical"
+          margin={{ top: 0, right: 8, bottom: 0, left: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" opacity={0.3} horizontal={false} />
+          <XAxis type="number" tick={{ fontSize: 12 }} tickLine={false} axisLine={false} allowDecimals={false} />
+          <YAxis
+            type="category"
+            dataKey="name"
+            tick={{ fontSize: 12 }}
+            tickLine={false}
+            axisLine={false}
+            width={120}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: 'var(--color-surface, #fff)',
+              border: '1px solid var(--color-border, #e5e7eb)',
+              borderRadius: '8px',
+              fontSize: '13px',
+            }}
+          />
+          <Legend wrapperStyle={{ fontSize: '12px' }} />
+          <Bar dataKey="denies" name="Denied" stackId="1" fill="#ef4444" fillOpacity={0.85} />
+          <Bar dataKey="warns" name="Warnings" stackId="1" fill="#f97316" fillOpacity={0.85} />
+          <Bar dataKey="passes" name="Passed" stackId="1" fill="#22c55e" fillOpacity={0.85} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalytics.stories.tsx
+++ b/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalytics.stories.tsx
@@ -1,0 +1,99 @@
+import { DateTime } from 'luxon'
+import { PolicyAnalytics } from './PolicyAnalytics'
+import type { TPolicyAnalyticsSummary, TPolicyAnalyticsTimeseries } from '@/types'
+
+export default { title: 'Policies/PolicyAnalytics' }
+
+const now = DateTime.now().toUTC()
+
+const mockSummary: TPolicyAnalyticsSummary = {
+  total_evaluations: 1247,
+  total_denies: 23,
+  total_warns: 89,
+  total_passes: 1135,
+  unique_reports: 312,
+  unique_policies: 8,
+  start: now.minus({ days: 30 }).toISO()!,
+  end: now.toISO()!,
+}
+
+const mockTimeseries: TPolicyAnalyticsTimeseries = {
+  interval: 'day',
+  group_by: [],
+  start: now.minus({ days: 30 }).toISO()!,
+  end: now.toISO()!,
+  buckets: Array.from({ length: 15 }, (_, i) => ({
+    time: now.minus({ days: 30 - i * 2 }).toISO()!,
+    evaluations: 30 + Math.floor(Math.random() * 60),
+    passes: 25 + Math.floor(Math.random() * 50),
+    warns: Math.floor(Math.random() * 8),
+    denies: Math.floor(Math.random() * 3),
+  })),
+}
+
+export const Default = () => (
+  <PolicyAnalytics
+    summary={mockSummary}
+    timeseries={mockTimeseries}
+    isLoading={false}
+    selectedRange="30d"
+    onRangeChange={() => {}}
+  />
+)
+
+export const Loading = () => (
+  <PolicyAnalytics
+    summary={undefined}
+    timeseries={undefined}
+    isLoading={true}
+    selectedRange="30d"
+    onRangeChange={() => {}}
+  />
+)
+
+export const Empty = () => (
+  <PolicyAnalytics
+    summary={{
+      total_evaluations: 0,
+      total_denies: 0,
+      total_warns: 0,
+      total_passes: 0,
+      unique_reports: 0,
+      unique_policies: 0,
+      start: '',
+      end: '',
+    }}
+    timeseries={{
+      interval: 'day',
+      group_by: [],
+      start: '',
+      end: '',
+      buckets: [],
+    }}
+    isLoading={false}
+    selectedRange="30d"
+    onRangeChange={() => {}}
+  />
+)
+
+export const HighViolations = () => (
+  <PolicyAnalytics
+    summary={{
+      ...mockSummary,
+      total_denies: 156,
+      total_warns: 234,
+      total_passes: 857,
+    }}
+    timeseries={{
+      ...mockTimeseries,
+      buckets: mockTimeseries.buckets.map((b) => ({
+        ...b,
+        denies: 5 + Math.floor(Math.random() * 10),
+        warns: 8 + Math.floor(Math.random() * 15),
+      })),
+    }}
+    isLoading={false}
+    selectedRange="7d"
+    onRangeChange={() => {}}
+  />
+)

--- a/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalytics.stories.tsx
+++ b/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalytics.stories.tsx
@@ -1,6 +1,10 @@
 import { DateTime } from 'luxon'
 import { PolicyAnalytics } from './PolicyAnalytics'
-import type { TPolicyAnalyticsSummary, TPolicyAnalyticsTimeseries } from '@/types'
+import type {
+  TPolicyAnalyticsBreakdown,
+  TPolicyAnalyticsSummary,
+  TPolicyAnalyticsTimeseries,
+} from '@/types'
 
 export default { title: 'Policies/PolicyAnalytics' }
 
@@ -31,13 +35,63 @@ const mockTimeseries: TPolicyAnalyticsTimeseries = {
   })),
 }
 
+const mockByPolicy: TPolicyAnalyticsBreakdown = {
+  dimension: 'policy_id',
+  entries: [
+    { key: 'pol_restrict_ns', evaluations: 400, denies: 12, warns: 20, passes: 368 },
+    { key: 'pol_ecr_only', evaluations: 350, denies: 8, warns: 30, passes: 312 },
+    { key: 'pol_resource_limits', evaluations: 300, denies: 3, warns: 25, passes: 272 },
+    { key: 'pol_no_latest_tag', evaluations: 197, denies: 0, warns: 14, passes: 183 },
+  ],
+}
+
+const mockByInstall: TPolicyAnalyticsBreakdown = {
+  dimension: 'install_id',
+  entries: [
+    { key: 'ins_customer_acme', evaluations: 500, denies: 15, warns: 40, passes: 445 },
+    { key: 'ins_customer_globex', evaluations: 400, denies: 5, warns: 30, passes: 365 },
+    { key: 'ins_customer_initech', evaluations: 347, denies: 3, warns: 19, passes: 325 },
+  ],
+}
+
+const mockByOwnerType: TPolicyAnalyticsBreakdown = {
+  dimension: 'owner_type',
+  entries: [
+    { key: 'install_deploys', evaluations: 850, denies: 18, warns: 60, passes: 772 },
+    { key: 'component_builds', evaluations: 310, denies: 5, warns: 22, passes: 283 },
+    { key: 'install_sandbox_runs', evaluations: 87, denies: 0, warns: 7, passes: 80 },
+  ],
+}
+
+const mockPolicyNames: Record<string, string> = {
+  pol_restrict_ns: 'Restricted namespaces',
+  pol_ecr_only: 'ECR images only',
+  pol_resource_limits: 'Resource limits',
+  pol_no_latest_tag: 'No latest tag',
+}
+
+const mockInstallNames: Record<string, string> = {
+  ins_customer_acme: 'Acme Corp',
+  ins_customer_globex: 'Globex Inc',
+  ins_customer_initech: 'Initech Ltd',
+}
+
+const defaultProps = {
+  policyNames: mockPolicyNames,
+  installNames: mockInstallNames,
+  selectedRange: '30d',
+  onRangeChange: () => {},
+}
+
 export const Default = () => (
   <PolicyAnalytics
     summary={mockSummary}
     timeseries={mockTimeseries}
+    byPolicy={mockByPolicy}
+    byInstall={mockByInstall}
+    byOwnerType={mockByOwnerType}
     isLoading={false}
-    selectedRange="30d"
-    onRangeChange={() => {}}
+    {...defaultProps}
   />
 )
 
@@ -45,9 +99,11 @@ export const Loading = () => (
   <PolicyAnalytics
     summary={undefined}
     timeseries={undefined}
+    byPolicy={undefined}
+    byInstall={undefined}
+    byOwnerType={undefined}
     isLoading={true}
-    selectedRange="30d"
-    onRangeChange={() => {}}
+    {...defaultProps}
   />
 )
 
@@ -63,16 +119,12 @@ export const Empty = () => (
       start: '',
       end: '',
     }}
-    timeseries={{
-      interval: 'day',
-      group_by: [],
-      start: '',
-      end: '',
-      buckets: [],
-    }}
+    timeseries={{ interval: 'day', group_by: [], start: '', end: '', buckets: [] }}
+    byPolicy={{ dimension: 'policy_id', entries: [] }}
+    byInstall={{ dimension: 'install_id', entries: [] }}
+    byOwnerType={{ dimension: 'owner_type', entries: [] }}
     isLoading={false}
-    selectedRange="30d"
-    onRangeChange={() => {}}
+    {...defaultProps}
   />
 )
 
@@ -83,6 +135,7 @@ export const HighViolations = () => (
       total_denies: 156,
       total_warns: 234,
       total_passes: 857,
+      total_evaluations: 1247,
     }}
     timeseries={{
       ...mockTimeseries,
@@ -92,8 +145,13 @@ export const HighViolations = () => (
         warns: 8 + Math.floor(Math.random() * 15),
       })),
     }}
+    byPolicy={mockByPolicy}
+    byInstall={mockByInstall}
+    byOwnerType={mockByOwnerType}
     isLoading={false}
     selectedRange="7d"
     onRangeChange={() => {}}
+    policyNames={mockPolicyNames}
+    installNames={mockInstallNames}
   />
 )

--- a/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalytics.tsx
+++ b/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalytics.tsx
@@ -1,0 +1,138 @@
+import { Button } from '@/components/common/Button'
+import { Card } from '@/components/common/Card'
+import { Skeleton } from '@/components/common/Skeleton'
+import { Text } from '@/components/common/Text'
+import type { TPolicyAnalyticsSummary, TPolicyAnalyticsTimeseries } from '@/types'
+import { PolicyAnalyticsChart } from './PolicyAnalyticsChart'
+
+const RANGE_OPTIONS = ['7d', '30d', '90d', '1y'] as const
+
+function formatInterval(interval: string) {
+  switch (interval) {
+    case 'hour':
+      return 'Hourly'
+    case '6h':
+      return 'Every 6 hours'
+    case 'day':
+      return 'Daily'
+    case 'week':
+      return 'Weekly'
+    case 'month':
+      return 'Monthly'
+    default:
+      return interval
+  }
+}
+
+export interface IPolicyAnalytics {
+  summary: TPolicyAnalyticsSummary | undefined
+  timeseries: TPolicyAnalyticsTimeseries | undefined
+  isLoading: boolean
+  selectedRange: string
+  onRangeChange: (range: string) => void
+}
+
+export const PolicyAnalytics = ({
+  summary,
+  timeseries,
+  isLoading,
+  selectedRange,
+  onRangeChange,
+}: IPolicyAnalytics) => {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-2">
+        {RANGE_OPTIONS.map((range) => (
+          <Button
+            key={range}
+            variant={selectedRange === range ? 'primary' : 'secondary'}
+            onClick={() => onRangeChange(range)}
+            size="sm"
+          >
+            {range}
+          </Button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {isLoading ? (
+          <>
+            <SummaryCardSkeleton />
+            <SummaryCardSkeleton />
+            <SummaryCardSkeleton />
+          </>
+        ) : (
+          <>
+            <Card>
+              <div className="flex flex-col gap-1">
+                <Text variant="h2" weight="strong">
+                  {summary?.total_evaluations ?? 0}
+                </Text>
+                <Text variant="subtext" theme="neutral">
+                  Total evaluations
+                </Text>
+              </div>
+            </Card>
+            <Card>
+              <div className="flex flex-col gap-1">
+                <Text
+                  variant="h2"
+                  weight="strong"
+                  className="text-red-600 dark:text-red-400"
+                >
+                  {summary?.total_denies ?? 0}
+                </Text>
+                <Text variant="subtext" theme="neutral">
+                  Denied
+                </Text>
+              </div>
+            </Card>
+            <Card>
+              <div className="flex flex-col gap-1">
+                <Text
+                  variant="h2"
+                  weight="strong"
+                  className="text-orange-600 dark:text-orange-400"
+                >
+                  {summary?.total_warns ?? 0}
+                </Text>
+                <Text variant="subtext" theme="neutral">
+                  Warnings
+                </Text>
+              </div>
+            </Card>
+          </>
+        )}
+      </div>
+
+      <Card className="!p-0 overflow-hidden">
+        <div className="flex items-center justify-between p-4 border-b border-cool-grey-200 dark:border-dark-grey-600">
+          <Text weight="strong" variant="body">
+            Evaluations over time
+          </Text>
+          {timeseries?.interval && (
+            <Text variant="subtext" theme="neutral">
+              {formatInterval(timeseries.interval)}
+            </Text>
+          )}
+        </div>
+        <div className="p-4">
+          {isLoading ? (
+            <Skeleton height="300px" width="100%" />
+          ) : (
+            <PolicyAnalyticsChart timeseries={timeseries} />
+          )}
+        </div>
+      </Card>
+    </div>
+  )
+}
+
+const SummaryCardSkeleton = () => (
+  <Card>
+    <div className="flex flex-col gap-2">
+      <Skeleton height="32px" width="80px" />
+      <Skeleton height="16px" width="120px" />
+    </div>
+  </Card>
+)

--- a/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalytics.tsx
+++ b/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalytics.tsx
@@ -2,13 +2,22 @@ import { Button } from '@/components/common/Button'
 import { Card } from '@/components/common/Card'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Text } from '@/components/common/Text'
-import type { TPolicyAnalyticsSummary, TPolicyAnalyticsTimeseries } from '@/types'
+import type {
+  TPolicyAnalyticsBreakdown,
+  TPolicyAnalyticsSummary,
+  TPolicyAnalyticsTimeseries,
+} from '@/types'
+import { BreakdownChart } from './BreakdownChart'
 import { PolicyAnalyticsChart } from './PolicyAnalyticsChart'
 
-const RANGE_OPTIONS = ['7d', '30d', '90d', '1y'] as const
+const RANGE_OPTIONS = ['2h', '24h', '7d', '30d', '90d', '1y'] as const
 
 function formatInterval(interval: string) {
   switch (interval) {
+    case '15m':
+      return 'Every 15 min'
+    case '30m':
+      return 'Every 30 min'
     case 'hour':
       return 'Hourly'
     case '6h':
@@ -24,9 +33,21 @@ function formatInterval(interval: string) {
   }
 }
 
+function computePassRate(summary: TPolicyAnalyticsSummary | undefined): string {
+  const total = summary?.total_evaluations ?? 0
+  if (total === 0) return '—'
+  const passes = summary?.total_passes ?? 0
+  return `${Math.round((passes / total) * 100)}%`
+}
+
 export interface IPolicyAnalytics {
   summary: TPolicyAnalyticsSummary | undefined
   timeseries: TPolicyAnalyticsTimeseries | undefined
+  byPolicy: TPolicyAnalyticsBreakdown | undefined
+  byInstall: TPolicyAnalyticsBreakdown | undefined
+  byOwnerType: TPolicyAnalyticsBreakdown | undefined
+  policyNames: Record<string, string>
+  installNames: Record<string, string>
   isLoading: boolean
   selectedRange: string
   onRangeChange: (range: string) => void
@@ -35,6 +56,11 @@ export interface IPolicyAnalytics {
 export const PolicyAnalytics = ({
   summary,
   timeseries,
+  byPolicy,
+  byInstall,
+  byOwnerType,
+  policyNames,
+  installNames,
   isLoading,
   selectedRange,
   onRangeChange,
@@ -54,9 +80,10 @@ export const PolicyAnalytics = ({
         ))}
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         {isLoading ? (
           <>
+            <SummaryCardSkeleton />
             <SummaryCardSkeleton />
             <SummaryCardSkeleton />
             <SummaryCardSkeleton />
@@ -101,6 +128,20 @@ export const PolicyAnalytics = ({
                 </Text>
               </div>
             </Card>
+            <Card>
+              <div className="flex flex-col gap-1">
+                <Text
+                  variant="h2"
+                  weight="strong"
+                  className="text-green-600 dark:text-green-400"
+                >
+                  {computePassRate(summary)}
+                </Text>
+                <Text variant="subtext" theme="neutral">
+                  Pass rate
+                </Text>
+              </div>
+            </Card>
           </>
         )}
       </div>
@@ -123,6 +164,27 @@ export const PolicyAnalytics = ({
             <PolicyAnalyticsChart timeseries={timeseries} />
           )}
         </div>
+      </Card>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <BreakdownChart
+            breakdown={byPolicy}
+            title="Violations by policy"
+            formatLabel={(key) => policyNames[key] ?? key}
+          />
+        </Card>
+        <Card>
+          <BreakdownChart
+            breakdown={byInstall}
+            title="Violations by install"
+            formatLabel={(key) => installNames[key] ?? key}
+          />
+        </Card>
+      </div>
+
+      <Card>
+        <BreakdownChart breakdown={byOwnerType} title="Evaluations by stage" />
       </Card>
     </div>
   )

--- a/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalyticsChart.tsx
+++ b/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalyticsChart.tsx
@@ -1,0 +1,116 @@
+import { useMemo } from 'react'
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from 'recharts'
+import { DateTime } from 'luxon'
+import { Text } from '@/components/common/Text'
+import type { TPolicyAnalyticsTimeseries } from '@/types'
+
+interface IPolicyAnalyticsChart {
+  timeseries: TPolicyAnalyticsTimeseries | undefined
+}
+
+function formatTick(value: string, interval: string) {
+  const dt = DateTime.fromISO(value)
+  if (!dt.isValid) return value
+  if (interval === 'hour' || interval === '6h') {
+    return dt.toFormat('MMM d HH:mm')
+  }
+  return dt.toFormat('MMM d')
+}
+
+function formatTooltipLabel(value: string) {
+  const dt = DateTime.fromISO(value)
+  if (!dt.isValid) return value
+  return dt.toFormat('MMM d, yyyy HH:mm')
+}
+
+export const PolicyAnalyticsChart = ({ timeseries }: IPolicyAnalyticsChart) => {
+  const data = useMemo(() => {
+    if (!timeseries?.buckets?.length) return []
+    return timeseries.buckets.map((b) => ({
+      time: b.time,
+      passes: b.passes,
+      warns: b.warns,
+      denies: b.denies,
+    }))
+  }, [timeseries])
+
+  if (!data.length) {
+    return (
+      <div className="flex items-center justify-center h-[300px]">
+        <Text variant="subtext" theme="neutral">
+          No evaluation data for this time range
+        </Text>
+      </div>
+    )
+  }
+
+  const interval = timeseries?.interval ?? 'day'
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <AreaChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+        <XAxis
+          dataKey="time"
+          tickFormatter={(v) => formatTick(v, interval)}
+          tick={{ fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          tick={{ fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+          allowDecimals={false}
+        />
+        <Tooltip
+          labelFormatter={formatTooltipLabel}
+          contentStyle={{
+            backgroundColor: 'var(--color-surface, #fff)',
+            border: '1px solid var(--color-border, #e5e7eb)',
+            borderRadius: '8px',
+            fontSize: '13px',
+          }}
+        />
+        <Area
+          type="monotone"
+          dataKey="passes"
+          name="Passed"
+          stackId="1"
+          stroke="#22c55e"
+          fill="#22c55e"
+          fillOpacity={0.3}
+          strokeWidth={2}
+        />
+        <Area
+          type="monotone"
+          dataKey="warns"
+          name="Warnings"
+          stackId="1"
+          stroke="#f97316"
+          fill="#f97316"
+          fillOpacity={0.3}
+          strokeWidth={2}
+        />
+        <Area
+          type="monotone"
+          dataKey="denies"
+          name="Denied"
+          stackId="1"
+          stroke="#ef4444"
+          fill="#ef4444"
+          fillOpacity={0.3}
+          strokeWidth={2}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  )
+}

--- a/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalyticsChart.tsx
+++ b/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalyticsChart.tsx
@@ -19,6 +19,9 @@ interface IPolicyAnalyticsChart {
 function formatTick(value: string, interval: string) {
   const dt = DateTime.fromISO(value)
   if (!dt.isValid) return value
+  if (interval === '15m' || interval === '30m') {
+    return dt.toFormat('HH:mm')
+  }
   if (interval === 'hour' || interval === '6h') {
     return dt.toFormat('MMM d HH:mm')
   }

--- a/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalyticsContainer.tsx
+++ b/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalyticsContainer.tsx
@@ -1,0 +1,62 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { DateTime } from 'luxon'
+import { useApp } from '@/hooks/use-app'
+import { useOrg } from '@/hooks/use-org'
+import { getPolicyAnalyticsSummary, getPolicyAnalyticsTimeseries } from '@/lib'
+import { PolicyAnalytics } from './PolicyAnalytics'
+
+const RANGES: Record<string, number> = {
+  '7d': 7,
+  '30d': 30,
+  '90d': 90,
+  '1y': 365,
+}
+
+export const PolicyAnalyticsContainer = () => {
+  const { org } = useOrg()
+  const { app } = useApp()
+  const [selectedRange, setSelectedRange] = useState('30d')
+
+  const { start, end } = useMemo(() => {
+    const now = DateTime.now().toUTC().startOf('minute')
+    return {
+      end: now.toISO()!,
+      start: now.minus({ days: RANGES[selectedRange] }).toISO()!,
+    }
+  }, [selectedRange])
+
+  const { data: summary, isLoading: isLoadingSummary } = useQuery({
+    queryKey: ['policy-analytics-summary', org?.id, app?.id, selectedRange],
+    queryFn: () =>
+      getPolicyAnalyticsSummary({
+        orgId: org.id,
+        appId: app.id,
+        start,
+        end,
+      }),
+    enabled: !!org?.id && !!app?.id,
+  })
+
+  const { data: timeseries, isLoading: isLoadingTimeseries } = useQuery({
+    queryKey: ['policy-analytics-timeseries', org?.id, app?.id, selectedRange],
+    queryFn: () =>
+      getPolicyAnalyticsTimeseries({
+        orgId: org.id,
+        appId: app.id,
+        start,
+        end,
+      }),
+    enabled: !!org?.id && !!app?.id,
+  })
+
+  return (
+    <PolicyAnalytics
+      summary={summary}
+      timeseries={timeseries}
+      isLoading={isLoadingSummary || isLoadingTimeseries}
+      selectedRange={selectedRange}
+      onRangeChange={setSelectedRange}
+    />
+  )
+}

--- a/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalyticsContainer.tsx
+++ b/services/dashboard-ui/client/components/policies/PolicyAnalytics/PolicyAnalyticsContainer.tsx
@@ -3,14 +3,22 @@ import { useQuery } from '@tanstack/react-query'
 import { DateTime } from 'luxon'
 import { useApp } from '@/hooks/use-app'
 import { useOrg } from '@/hooks/use-org'
-import { getPolicyAnalyticsSummary, getPolicyAnalyticsTimeseries } from '@/lib'
+import {
+  getAppInstalls,
+  getAppPoliciesConfigs,
+  getPolicyAnalyticsBreakdown,
+  getPolicyAnalyticsSummary,
+  getPolicyAnalyticsTimeseries,
+} from '@/lib'
 import { PolicyAnalytics } from './PolicyAnalytics'
 
-const RANGES: Record<string, number> = {
-  '7d': 7,
-  '30d': 30,
-  '90d': 90,
-  '1y': 365,
+const RANGES: Record<string, { hours: number }> = {
+  '2h': { hours: 2 },
+  '24h': { hours: 24 },
+  '7d': { hours: 7 * 24 },
+  '30d': { hours: 30 * 24 },
+  '90d': { hours: 90 * 24 },
+  '1y': { hours: 365 * 24 },
 }
 
 export const PolicyAnalyticsContainer = () => {
@@ -22,24 +30,22 @@ export const PolicyAnalyticsContainer = () => {
     const now = DateTime.now().toUTC().startOf('minute')
     return {
       end: now.toISO()!,
-      start: now.minus({ days: RANGES[selectedRange] }).toISO()!,
+      start: now.minus({ hours: RANGES[selectedRange].hours }).toISO()!,
     }
   }, [selectedRange])
 
+  const enabled = !!org?.id && !!app?.id
+  const baseKey = [org?.id, app?.id, selectedRange]
+
   const { data: summary, isLoading: isLoadingSummary } = useQuery({
-    queryKey: ['policy-analytics-summary', org?.id, app?.id, selectedRange],
+    queryKey: ['policy-analytics-summary', ...baseKey],
     queryFn: () =>
-      getPolicyAnalyticsSummary({
-        orgId: org.id,
-        appId: app.id,
-        start,
-        end,
-      }),
-    enabled: !!org?.id && !!app?.id,
+      getPolicyAnalyticsSummary({ orgId: org.id, appId: app.id, start, end }),
+    enabled,
   })
 
   const { data: timeseries, isLoading: isLoadingTimeseries } = useQuery({
-    queryKey: ['policy-analytics-timeseries', org?.id, app?.id, selectedRange],
+    queryKey: ['policy-analytics-timeseries', ...baseKey],
     queryFn: () =>
       getPolicyAnalyticsTimeseries({
         orgId: org.id,
@@ -47,13 +53,87 @@ export const PolicyAnalyticsContainer = () => {
         start,
         end,
       }),
-    enabled: !!org?.id && !!app?.id,
+    enabled,
   })
+
+  const { data: byPolicy } = useQuery({
+    queryKey: ['policy-analytics-breakdown', 'policy_id', ...baseKey],
+    queryFn: () =>
+      getPolicyAnalyticsBreakdown({
+        orgId: org.id,
+        appId: app.id,
+        dimension: 'policy_id',
+        start,
+        end,
+      }),
+    enabled,
+  })
+
+  const { data: byInstall } = useQuery({
+    queryKey: ['policy-analytics-breakdown', 'install_id', ...baseKey],
+    queryFn: () =>
+      getPolicyAnalyticsBreakdown({
+        orgId: org.id,
+        appId: app.id,
+        dimension: 'install_id',
+        start,
+        end,
+      }),
+    enabled,
+  })
+
+  const { data: byOwnerType } = useQuery({
+    queryKey: ['policy-analytics-breakdown', 'owner_type', ...baseKey],
+    queryFn: () =>
+      getPolicyAnalyticsBreakdown({
+        orgId: org.id,
+        appId: app.id,
+        dimension: 'owner_type',
+        start,
+        end,
+      }),
+    enabled,
+  })
+
+  const { data: installs } = useQuery({
+    queryKey: ['app-installs', org?.id, app?.id],
+    queryFn: () => getAppInstalls({ orgId: org.id, appId: app.id }),
+    enabled,
+  })
+
+  const { data: policiesConfigs } = useQuery({
+    queryKey: ['app-policies-configs', org?.id, app?.id],
+    queryFn: () => getAppPoliciesConfigs({ orgId: org.id, appId: app.id }),
+    enabled,
+  })
+
+  const installNames = useMemo(() => {
+    const map: Record<string, string> = {}
+    for (const inst of installs?.data ?? []) {
+      if (inst.id && inst.name) map[inst.id] = inst.name
+    }
+    return map
+  }, [installs])
+
+  const policyNames = useMemo(() => {
+    const map: Record<string, string> = {}
+    for (const cfg of policiesConfigs ?? []) {
+      for (const p of cfg.policies ?? []) {
+        if (p.id && p.name) map[p.id] = p.name
+      }
+    }
+    return map
+  }, [policiesConfigs])
 
   return (
     <PolicyAnalytics
       summary={summary}
       timeseries={timeseries}
+      byPolicy={byPolicy}
+      byInstall={byInstall}
+      byOwnerType={byOwnerType}
+      policyNames={policyNames}
+      installNames={installNames}
       isLoading={isLoadingSummary || isLoadingTimeseries}
       selectedRange={selectedRange}
       onRangeChange={setSelectedRange}

--- a/services/dashboard-ui/client/components/policies/PolicyAnalytics/index.ts
+++ b/services/dashboard-ui/client/components/policies/PolicyAnalytics/index.ts
@@ -1,0 +1,2 @@
+export { PolicyAnalyticsContainer as PolicyAnalytics } from './PolicyAnalyticsContainer'
+export { PolicyAnalytics as PolicyAnalyticsComponent } from './PolicyAnalytics'

--- a/services/dashboard-ui/client/components/policies/index.ts
+++ b/services/dashboard-ui/client/components/policies/index.ts
@@ -1,4 +1,5 @@
 export * from './PoliciesTable'
+export * from './PolicyAnalytics'
 export * from './PolicyReportPanel'
 export * from './PolicyReportsFilter'
 export * from './PolicyReportsTable'

--- a/services/dashboard-ui/client/lib/ctl-api/apps/policies/get-policy-analytics-breakdown.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/policies/get-policy-analytics-breakdown.ts
@@ -1,5 +1,6 @@
 import { api } from '@/lib/api'
 import type { TPolicyAnalyticsBreakdown } from '@/types'
+import { buildQueryParams } from '@/utils/build-query-params'
 
 export const getPolicyAnalyticsBreakdown = ({
   appId,
@@ -19,16 +20,8 @@ export const getPolicyAnalyticsBreakdown = ({
   limit?: number
   installId?: string
   policyId?: string
-}) => {
-  const params = new URLSearchParams()
-  params.set('dimension', dimension)
-  if (start) params.set('start', start)
-  if (end) params.set('end', end)
-  if (limit) params.set('limit', String(limit))
-  if (installId) params.set('install_id', installId)
-  if (policyId) params.set('policy_id', policyId)
-  return api<TPolicyAnalyticsBreakdown>({
-    path: `apps/${appId}/policy-analytics/breakdown?${params.toString()}`,
+}) =>
+  api<TPolicyAnalyticsBreakdown>({
+    path: `apps/${appId}/policy-analytics/breakdown${buildQueryParams({ dimension, start, end, limit, install_id: installId, policy_id: policyId })}`,
     orgId,
   })
-}

--- a/services/dashboard-ui/client/lib/ctl-api/apps/policies/get-policy-analytics-breakdown.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/policies/get-policy-analytics-breakdown.ts
@@ -1,0 +1,34 @@
+import { api } from '@/lib/api'
+import type { TPolicyAnalyticsBreakdown } from '@/types'
+
+export const getPolicyAnalyticsBreakdown = ({
+  appId,
+  orgId,
+  dimension,
+  start,
+  end,
+  limit,
+  installId,
+  policyId,
+}: {
+  appId: string
+  orgId: string
+  dimension: string
+  start?: string
+  end?: string
+  limit?: number
+  installId?: string
+  policyId?: string
+}) => {
+  const params = new URLSearchParams()
+  params.set('dimension', dimension)
+  if (start) params.set('start', start)
+  if (end) params.set('end', end)
+  if (limit) params.set('limit', String(limit))
+  if (installId) params.set('install_id', installId)
+  if (policyId) params.set('policy_id', policyId)
+  return api<TPolicyAnalyticsBreakdown>({
+    path: `apps/${appId}/policy-analytics/breakdown?${params.toString()}`,
+    orgId,
+  })
+}

--- a/services/dashboard-ui/client/lib/ctl-api/apps/policies/get-policy-analytics-summary.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/policies/get-policy-analytics-summary.ts
@@ -1,5 +1,6 @@
 import { api } from '@/lib/api'
 import type { TPolicyAnalyticsSummary } from '@/types'
+import { buildQueryParams } from '@/utils/build-query-params'
 
 export const getPolicyAnalyticsSummary = ({
   appId,
@@ -15,15 +16,8 @@ export const getPolicyAnalyticsSummary = ({
   end?: string
   installId?: string
   policyId?: string
-}) => {
-  const params = new URLSearchParams()
-  if (start) params.set('start', start)
-  if (end) params.set('end', end)
-  if (installId) params.set('install_id', installId)
-  if (policyId) params.set('policy_id', policyId)
-  const qs = params.toString()
-  return api<TPolicyAnalyticsSummary>({
-    path: `apps/${appId}/policy-analytics/summary${qs ? `?${qs}` : ''}`,
+}) =>
+  api<TPolicyAnalyticsSummary>({
+    path: `apps/${appId}/policy-analytics/summary${buildQueryParams({ start, end, install_id: installId, policy_id: policyId })}`,
     orgId,
   })
-}

--- a/services/dashboard-ui/client/lib/ctl-api/apps/policies/get-policy-analytics-summary.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/policies/get-policy-analytics-summary.ts
@@ -1,0 +1,29 @@
+import { api } from '@/lib/api'
+import type { TPolicyAnalyticsSummary } from '@/types'
+
+export const getPolicyAnalyticsSummary = ({
+  appId,
+  orgId,
+  start,
+  end,
+  installId,
+  policyId,
+}: {
+  appId: string
+  orgId: string
+  start?: string
+  end?: string
+  installId?: string
+  policyId?: string
+}) => {
+  const params = new URLSearchParams()
+  if (start) params.set('start', start)
+  if (end) params.set('end', end)
+  if (installId) params.set('install_id', installId)
+  if (policyId) params.set('policy_id', policyId)
+  const qs = params.toString()
+  return api<TPolicyAnalyticsSummary>({
+    path: `apps/${appId}/policy-analytics/summary${qs ? `?${qs}` : ''}`,
+    orgId,
+  })
+}

--- a/services/dashboard-ui/client/lib/ctl-api/apps/policies/get-policy-analytics-timeseries.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/policies/get-policy-analytics-timeseries.ts
@@ -1,5 +1,6 @@
 import { api } from '@/lib/api'
 import type { TPolicyAnalyticsTimeseries } from '@/types'
+import { buildQueryParams } from '@/utils/build-query-params'
 
 export const getPolicyAnalyticsTimeseries = ({
   appId,
@@ -17,16 +18,8 @@ export const getPolicyAnalyticsTimeseries = ({
   groupBy?: string
   installId?: string
   policyId?: string
-}) => {
-  const params = new URLSearchParams()
-  if (start) params.set('start', start)
-  if (end) params.set('end', end)
-  if (groupBy) params.set('group_by', groupBy)
-  if (installId) params.set('install_id', installId)
-  if (policyId) params.set('policy_id', policyId)
-  const qs = params.toString()
-  return api<TPolicyAnalyticsTimeseries>({
-    path: `apps/${appId}/policy-analytics/timeseries${qs ? `?${qs}` : ''}`,
+}) =>
+  api<TPolicyAnalyticsTimeseries>({
+    path: `apps/${appId}/policy-analytics/timeseries${buildQueryParams({ start, end, group_by: groupBy, install_id: installId, policy_id: policyId })}`,
     orgId,
   })
-}

--- a/services/dashboard-ui/client/lib/ctl-api/apps/policies/get-policy-analytics-timeseries.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/policies/get-policy-analytics-timeseries.ts
@@ -1,0 +1,32 @@
+import { api } from '@/lib/api'
+import type { TPolicyAnalyticsTimeseries } from '@/types'
+
+export const getPolicyAnalyticsTimeseries = ({
+  appId,
+  orgId,
+  start,
+  end,
+  groupBy,
+  installId,
+  policyId,
+}: {
+  appId: string
+  orgId: string
+  start?: string
+  end?: string
+  groupBy?: string
+  installId?: string
+  policyId?: string
+}) => {
+  const params = new URLSearchParams()
+  if (start) params.set('start', start)
+  if (end) params.set('end', end)
+  if (groupBy) params.set('group_by', groupBy)
+  if (installId) params.set('install_id', installId)
+  if (policyId) params.set('policy_id', policyId)
+  const qs = params.toString()
+  return api<TPolicyAnalyticsTimeseries>({
+    path: `apps/${appId}/policy-analytics/timeseries${qs ? `?${qs}` : ''}`,
+    orgId,
+  })
+}

--- a/services/dashboard-ui/client/lib/ctl-api/apps/policies/index.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/policies/index.ts
@@ -1,1 +1,3 @@
 export * from './get-app-policy'
+export * from './get-policy-analytics-summary'
+export * from './get-policy-analytics-timeseries'

--- a/services/dashboard-ui/client/lib/ctl-api/apps/policies/index.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/policies/index.ts
@@ -1,3 +1,4 @@
 export * from './get-app-policy'
+export * from './get-policy-analytics-breakdown'
 export * from './get-policy-analytics-summary'
 export * from './get-policy-analytics-timeseries'

--- a/services/dashboard-ui/client/types/ctl-api.types.ts
+++ b/services/dashboard-ui/client/types/ctl-api.types.ts
@@ -79,41 +79,13 @@ export type TPolicyViolation = components['schemas']['app.PolicyViolation']
 export type TPolicyInputRef = components['schemas']['app.PolicyInputRef']
 
 // policy analytics
-export type TPolicyAnalyticsSummary = {
-  total_evaluations: number
-  total_denies: number
-  total_warns: number
-  total_passes: number
-  unique_reports: number
-  unique_policies: number
-  start: string
-  end: string
-}
-
-export type TSeriesPoint = {
-  labels: Record<string, string>
-  evaluations: number
-  denies: number
-  warns: number
-  passes: number
-}
-
-export type TTimeseriesBucket = {
-  time: string
-  evaluations: number
-  denies: number
-  warns: number
-  passes: number
-  series?: TSeriesPoint[]
-}
-
-export type TPolicyAnalyticsTimeseries = {
-  interval: string
-  group_by: string[]
-  start: string
-  end: string
-  buckets: TTimeseriesBucket[]
-}
+export type TPolicyAnalyticsSummary =
+  components['schemas']['service.PolicyAnalyticsSummary']
+export type TPolicyAnalyticsTimeseries =
+  components['schemas']['service.PolicyAnalyticsTimeseries']
+export type TTimeseriesBucket =
+  components['schemas']['service.TimeseriesBucket']
+export type TSeriesPoint = components['schemas']['service.SeriesPoint']
 
 // component
 export type TComponent = components['schemas']['app.Component']

--- a/services/dashboard-ui/client/types/ctl-api.types.ts
+++ b/services/dashboard-ui/client/types/ctl-api.types.ts
@@ -86,6 +86,9 @@ export type TPolicyAnalyticsTimeseries =
 export type TTimeseriesBucket =
   components['schemas']['service.TimeseriesBucket']
 export type TSeriesPoint = components['schemas']['service.SeriesPoint']
+export type TPolicyAnalyticsBreakdown =
+  components['schemas']['service.PolicyAnalyticsBreakdown']
+export type TBreakdownEntry = components['schemas']['service.BreakdownEntry']
 
 // component
 export type TComponent = components['schemas']['app.Component']

--- a/services/dashboard-ui/client/types/ctl-api.types.ts
+++ b/services/dashboard-ui/client/types/ctl-api.types.ts
@@ -78,6 +78,43 @@ export type TPolicyResult = components['schemas']['app.PolicyResult']
 export type TPolicyViolation = components['schemas']['app.PolicyViolation']
 export type TPolicyInputRef = components['schemas']['app.PolicyInputRef']
 
+// policy analytics
+export type TPolicyAnalyticsSummary = {
+  total_evaluations: number
+  total_denies: number
+  total_warns: number
+  total_passes: number
+  unique_reports: number
+  unique_policies: number
+  start: string
+  end: string
+}
+
+export type TSeriesPoint = {
+  labels: Record<string, string>
+  evaluations: number
+  denies: number
+  warns: number
+  passes: number
+}
+
+export type TTimeseriesBucket = {
+  time: string
+  evaluations: number
+  denies: number
+  warns: number
+  passes: number
+  series?: TSeriesPoint[]
+}
+
+export type TPolicyAnalyticsTimeseries = {
+  interval: string
+  group_by: string[]
+  start: string
+  end: string
+  buckets: TTimeseriesBucket[]
+}
+
 // component
 export type TComponent = components['schemas']['app.Component']
 export type TComponentConfig =

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -605,6 +605,13 @@ export interface paths {
      */
     get: operations["GetAppPoliciesConfig"];
   };
+  "/v1/apps/{app_id}/policy-analytics/breakdown": {
+    /**
+     * get policy analytics breakdown by dimension
+     * @description Returns policy evaluation counts broken down by a single dimension (policy_id, install_id, or owner_type), sorted by violation count (denies first, then warns). Use this to identify which policies, installs, or lifecycle stages produce the most violations.
+     */
+    get: operations["GetPolicyAnalyticsBreakdown"];
+  };
   "/v1/apps/{app_id}/policy-analytics/summary": {
     /**
      * get policy analytics summary
@@ -5563,6 +5570,13 @@ export interface components {
     "service.Branch": {
       name?: string;
     };
+    "service.BreakdownEntry": {
+      denies?: number;
+      evaluations?: number;
+      key?: string;
+      passes?: number;
+      warns?: number;
+    };
     "service.BuildAllComponentsRequest": Record<string, never>;
     "service.CLIConfig": {
       auth_audience?: string;
@@ -6140,6 +6154,12 @@ export interface components {
     };
     "service.PatchInstallConfigParams": {
       approval_option?: components["schemas"]["app.InstallApprovalOption"];
+    };
+    "service.PolicyAnalyticsBreakdown": {
+      dimension?: string;
+      end?: string;
+      entries?: components["schemas"]["service.BreakdownEntry"][];
+      start?: string;
     };
     "service.PolicyAnalyticsSummary": {
       end?: string;
@@ -11550,6 +11570,64 @@ export interface operations {
       };
       /** @description Not Found */
       404: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * get policy analytics breakdown by dimension
+   * @description Returns policy evaluation counts broken down by a single dimension (policy_id, install_id, or owner_type), sorted by violation count (denies first, then warns). Use this to identify which policies, installs, or lifecycle stages produce the most violations.
+   */
+  GetPolicyAnalyticsBreakdown: {
+    parameters: {
+      query: {
+        /** @description dimension to break down by: policy_id, install_id, owner_type */
+        dimension: string;
+        /** @description start time (RFC3339) */
+        start?: string;
+        /** @description end time (RFC3339) */
+        end?: string;
+        /** @description filter by install ID */
+        install_id?: string;
+        /** @description filter by policy ID */
+        policy_id?: string;
+        /** @description max entries to return (default 10) */
+        limit?: number;
+      };
+      path: {
+        /** @description app ID */
+        app_id: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["service.PolicyAnalyticsBreakdown"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
         content: {
           "application/json": components["schemas"]["stderr.ErrResponse"];
         };

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -605,6 +605,20 @@ export interface paths {
      */
     get: operations["GetAppPoliciesConfig"];
   };
+  "/v1/apps/{app_id}/policy-analytics/summary": {
+    /**
+     * get policy analytics summary
+     * @description Returns aggregate policy evaluation counts for an app over a time range, with optional drill-down by install or policy.
+     */
+    get: operations["GetPolicyAnalyticsSummary"];
+  };
+  "/v1/apps/{app_id}/policy-analytics/timeseries": {
+    /**
+     * get policy analytics timeseries
+     * @description Returns policy evaluation counts bucketed over time for charting, with optional grouping by policy, install, or component.
+     */
+    get: operations["GetPolicyAnalyticsTimeseries"];
+  };
   "/v1/apps/{app_id}/policy-config/{policy_config_id}": {
     /**
      * get app policy config
@@ -1888,6 +1902,27 @@ export interface paths {
      * Feature flags control access to specific platform capabilities and can be managed by administrators through the admin API endpoints.
      */
     get: operations["GetOrgFeatures"];
+  };
+  "/v1/policy-reports": {
+    /**
+     * get policy reports
+     * @description Returns policy reports for the current organization.
+     */
+    get: operations["GetPolicyReports"];
+  };
+  "/v1/policy-reports/{report_id}": {
+    /**
+     * get policy report
+     * @description Returns a single policy report by ID.
+     */
+    get: operations["GetPolicyReport"];
+  };
+  "/v1/policy-reports/{report_id}/export": {
+    /**
+     * export policy report
+     * @description Exports a policy report as JSON, SARIF, or PDF.
+     */
+    get: operations["ExportPolicyReport"];
   };
   "/v1/queues": {
     /**
@@ -6106,6 +6141,23 @@ export interface components {
     "service.PatchInstallConfigParams": {
       approval_option?: components["schemas"]["app.InstallApprovalOption"];
     };
+    "service.PolicyAnalyticsSummary": {
+      end?: string;
+      start?: string;
+      total_denies?: number;
+      total_evaluations?: number;
+      total_passes?: number;
+      total_warns?: number;
+      unique_policies?: number;
+      unique_reports?: number;
+    };
+    "service.PolicyAnalyticsTimeseries": {
+      buckets?: components["schemas"]["service.TimeseriesBucket"][];
+      end?: string;
+      group_by?: string[];
+      interval?: string;
+      start?: string;
+    };
     "service.PruneTokensResponse": {
       invalidated_count?: number;
     };
@@ -6158,6 +6210,15 @@ export interface components {
       connected?: boolean;
       latest_heartbeat_timestamp?: number;
     };
+    "service.SeriesPoint": {
+      denies?: number;
+      evaluations?: number;
+      labels?: {
+        [key: string]: string;
+      };
+      passes?: number;
+      warns?: number;
+    };
     "service.ShutdownRunnerProcessRequest": {
       shutdown_type: string;
     };
@@ -6175,6 +6236,14 @@ export interface components {
     "service.TeardownInstallComponentsRequest": {
       plan_only?: boolean;
       role?: string;
+    };
+    "service.TimeseriesBucket": {
+      denies?: number;
+      evaluations?: number;
+      passes?: number;
+      series?: components["schemas"]["service.SeriesPoint"][];
+      time?: string;
+      warns?: number;
     };
     "service.TriggerAppBranchRunRequest": {
       /** @description optional - use latest if not provided */
@@ -11481,6 +11550,116 @@ export interface operations {
       };
       /** @description Not Found */
       404: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * get policy analytics summary
+   * @description Returns aggregate policy evaluation counts for an app over a time range, with optional drill-down by install or policy.
+   */
+  GetPolicyAnalyticsSummary: {
+    parameters: {
+      query?: {
+        /** @description start time (RFC3339) */
+        start?: string;
+        /** @description end time (RFC3339) */
+        end?: string;
+        /** @description filter by install ID */
+        install_id?: string;
+        /** @description filter by policy ID */
+        policy_id?: string;
+      };
+      path: {
+        /** @description app ID */
+        app_id: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["service.PolicyAnalyticsSummary"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * get policy analytics timeseries
+   * @description Returns policy evaluation counts bucketed over time for charting, with optional grouping by policy, install, or component.
+   */
+  GetPolicyAnalyticsTimeseries: {
+    parameters: {
+      query?: {
+        /** @description start time (RFC3339) */
+        start?: string;
+        /** @description end time (RFC3339) */
+        end?: string;
+        /** @description comma-separated dimensions: policy_id, install_id, component_id, owner_type */
+        group_by?: string;
+        /** @description filter by install ID */
+        install_id?: string;
+        /** @description filter by policy ID */
+        policy_id?: string;
+      };
+      path: {
+        /** @description app ID */
+        app_id: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["service.PolicyAnalyticsTimeseries"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
         content: {
           "application/json": components["schemas"]["stderr.ErrResponse"];
         };
@@ -19958,6 +20137,180 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["app.OrgFeatureInfo"][];
+        };
+      };
+    };
+  };
+  /**
+   * get policy reports
+   * @description Returns policy reports for the current organization.
+   */
+  GetPolicyReports: {
+    parameters: {
+      query?: {
+        /** @description offset of results to return */
+        offset?: number;
+        /** @description limit of results to return */
+        limit?: number;
+        /** @description page number of results to return */
+        page?: number;
+        /** @description owner type (install_deploys, install_sandbox_runs, component_builds) */
+        owner_type?: string;
+        /** @description owner id */
+        owner_id?: string;
+        /** @description app id */
+        app_id?: string;
+        /** @description install id */
+        install_id?: string;
+        /** @description report status */
+        status?: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["app.PolicyReport"][];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * get policy report
+   * @description Returns a single policy report by ID.
+   */
+  GetPolicyReport: {
+    parameters: {
+      path: {
+        /** @description policy report ID */
+        report_id: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["app.PolicyReport"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * export policy report
+   * @description Exports a policy report as JSON, SARIF, or PDF.
+   */
+  ExportPolicyReport: {
+    parameters: {
+      query?: {
+        /** @description export format: json, sarif, pdf (default: json) */
+        format?: string;
+      };
+      path: {
+        /** @description policy report ID */
+        report_id: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": unknown;
+          "application/pdf": unknown;
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+          "application/pdf": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+          "application/pdf": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+          "application/pdf": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+          "application/pdf": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+          "application/pdf": components["schemas"]["stderr.ErrResponse"];
         };
       };
     };

--- a/services/dashboard-ui/client/views/app/Policies.tsx
+++ b/services/dashboard-ui/client/views/app/Policies.tsx
@@ -1,11 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { PoliciesTable, policiesTableColumns } from '@/components/policies/PoliciesTable'
-import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { TableSkeleton } from '@/components/common/TableSkeleton'
-import { Text } from '@/components/common/Text'
-import { PageSection } from '@/components/layout/PageSection'
-import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
-import { PageTitle } from '@/components/navigation/PageTitle'
 import { useApp } from '@/hooks/use-app'
 import { useOrg } from '@/hooks/use-org'
 import { getAppPoliciesConfigs } from '@/lib'
@@ -31,36 +26,16 @@ export const Policies = () => {
   const policies = latestConfig?.policies ?? []
 
   return (
-    <PageSection>
-      <PageTitle title={`Policies | ${app?.name}`} />
-      <Breadcrumbs
-        breadcrumbs={[
-          { path: `/${org?.id}`, text: org?.name },
-          { path: `/${org?.id}/apps`, text: 'Apps' },
-          { path: `/${org?.id}/apps/${app?.id}`, text: app?.name },
-          { path: `/${org?.id}/apps/${app?.id}/policies`, text: 'Policies' },
-        ]}
-      />
-      <HeadingGroup>
-        <Text variant="base" weight="strong">
-          App policies
-        </Text>
-        <Text variant="subtext" theme="neutral">
-          Define validation rules that run against builds and deploys.
-        </Text>
-      </HeadingGroup>
-
-      <div className="flex flex-auto">
-        {isLoading ? (
-          <TableSkeleton columns={policiesTableColumns} skeletonRows={5} />
-        ) : (
-          <PoliciesTable
-            policies={policies}
-            orgId={org?.id}
-            appId={app?.id}
-          />
-        )}
-      </div>
-    </PageSection>
+    <div className="flex flex-auto">
+      {isLoading ? (
+        <TableSkeleton columns={policiesTableColumns} skeletonRows={5} />
+      ) : (
+        <PoliciesTable
+          policies={policies}
+          orgId={org?.id}
+          appId={app?.id}
+        />
+      )}
+    </div>
   )
 }

--- a/services/dashboard-ui/client/views/app/PoliciesLayout.tsx
+++ b/services/dashboard-ui/client/views/app/PoliciesLayout.tsx
@@ -1,0 +1,46 @@
+import { Outlet } from 'react-router'
+import { HeadingGroup } from '@/components/common/HeadingGroup'
+import { Text } from '@/components/common/Text'
+import { PageSection } from '@/components/layout/PageSection'
+import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
+import { PageTitle } from '@/components/navigation/PageTitle'
+import { TabNav } from '@/components/navigation/TabNav'
+import { useApp } from '@/hooks/use-app'
+import { useOrg } from '@/hooks/use-org'
+
+export const PoliciesLayout = () => {
+  const { org } = useOrg()
+  const { app } = useApp()
+
+  const basePath = `/${org?.id}/apps/${app?.id}/policies`
+
+  return (
+    <PageSection>
+      <PageTitle title={`Policies | ${app?.name}`} />
+      <Breadcrumbs
+        breadcrumbs={[
+          { path: `/${org?.id}`, text: org?.name },
+          { path: `/${org?.id}/apps`, text: 'Apps' },
+          { path: `/${org?.id}/apps/${app?.id}`, text: app?.name },
+          { path: `/${org?.id}/apps/${app?.id}/policies`, text: 'Policies' },
+        ]}
+      />
+      <HeadingGroup>
+        <Text variant="base" weight="strong">
+          App policies
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          Define validation rules that run against builds and deploys.
+        </Text>
+      </HeadingGroup>
+      <TabNav
+        basePath={basePath}
+        tabs={[
+          { path: '/', text: 'Definitions' },
+          { path: '/analytics', text: 'Analytics' },
+        ]}
+      />
+      <Outlet />
+    </PageSection>
+  )
+}

--- a/services/dashboard-ui/client/views/app/PolicyAnalytics.tsx
+++ b/services/dashboard-ui/client/views/app/PolicyAnalytics.tsx
@@ -1,0 +1,3 @@
+import { PolicyAnalytics } from '@/components/policies/PolicyAnalytics'
+
+export { PolicyAnalytics }

--- a/services/dashboard-ui/client/views/app/routes.tsx
+++ b/services/dashboard-ui/client/views/app/routes.tsx
@@ -7,7 +7,9 @@ import { BuildDetail } from './BuildDetail'
 import { Actions } from './Actions'
 import { ActionDetail } from './ActionDetail'
 import { Roles } from './Roles'
+import { PoliciesLayout } from './PoliciesLayout'
 import { Policies } from './Policies'
+import { PolicyAnalytics } from './PolicyAnalytics'
 import { PolicyDetail } from './PolicyDetail'
 import { Installs } from './Installs'
 import { Readme } from './Readme'
@@ -45,7 +47,14 @@ export const appRoutes: RouteObject[] = [
         element: <ActionDetail />,
       },
       { path: ':orgId/apps/:appId/roles', element: <Roles /> },
-      { path: ':orgId/apps/:appId/policies', element: <Policies /> },
+      {
+        path: ':orgId/apps/:appId/policies',
+        element: <PoliciesLayout />,
+        children: [
+          { index: true, element: <Policies /> },
+          { path: 'analytics', element: <PolicyAnalytics /> },
+        ],
+      },
       {
         path: ':orgId/apps/:appId/policies/:policyId',
         element: <PolicyDetail />,

--- a/services/dashboard-ui/package-lock.json
+++ b/services/dashboard-ui/package-lock.json
@@ -39,6 +39,7 @@
         "react-router": "^7.13.1",
         "react-syntax-highlighter": "^15.6.1",
         "react-tailwindcss-select": "^1.8.5",
+        "recharts": "^3.8.1",
         "showdown": "^2.1.0",
         "uuid": "^11.1.0",
         "yaml": "^2.7.1"
@@ -2312,6 +2313,42 @@
         "node": ">=18"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2751,6 +2788,18 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/core": {
@@ -4075,6 +4124,12 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs-parser": {
@@ -5701,7 +5756,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6720,6 +6774,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
@@ -7108,6 +7168,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esast-util-from-estree": {
       "version": "2.0.0",
@@ -11435,6 +11505,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/immutable": {
@@ -15813,7 +15893,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -15850,6 +15929,29 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -16170,6 +16272,42 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/recma-build-jsx": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
@@ -16286,6 +16424,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/refractor": {
@@ -16890,6 +17043,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resp-modifier": {
@@ -18895,6 +19054,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -19905,6 +20070,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -19997,6 +20171,28 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "7.1.11",
@@ -21150,15 +21346,6 @@
         "react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/zustand/node_modules/use-sync-external-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/zwitch": {

--- a/services/dashboard-ui/package.json
+++ b/services/dashboard-ui/package.json
@@ -55,6 +55,7 @@
     "react-router": "^7.13.1",
     "react-syntax-highlighter": "^15.6.1",
     "react-tailwindcss-select": "^1.8.5",
+    "recharts": "^3.8.1",
     "showdown": "^2.1.0",
     "uuid": "^11.1.0",
     "yaml": "^2.7.1"


### PR DESCRIPTION
This PR adds a new "Analytics" tab under App/Policies which provides users with graphs and panels with stats around app policies reports.

We show users graphs with warning and deny vs passed policy runs, grouped by installs, or policy.

<img width="2217" height="1191" alt="Screenshot 2026-04-21 at 9 13 05 PM" src="https://github.com/user-attachments/assets/6654d873-e2f2-4e1b-b765-51a9914e8482" />

