### PR TITLE
docs: add more active sandboxes to sandbox list

### DIFF
--- a/docs/concepts/sandboxes.mdx
+++ b/docs/concepts/sandboxes.mdx
@@ -88,9 +88,19 @@ reference in your `sandbox.toml`.
 
 [AWS EKS with Karpenter sandbox](https://github.com/nuonco/aws-eks-karpenter-sandbox)
 
+[AWS EKS Auto sandbox](https://github.com/nuonco/aws-eks-auto-sandbox)
+
+[AWS BYO EKS sandbox](https://github.com/nuonco/aws-byo-eks-sandbox)
+
 [AWS Min sandbox](https://github.com/nuonco/aws-min-sandbox)
 
 [Azure AKS sandbox](https://github.com/nuonco/azure-aks-sandbox)
+
+[Azure Min sandbox](https://github.com/nuonco/azure-min-sandbox)
+
+[GCP GKE sandbox](https://github.com/nuonco/gcp-gke-sandbox)
+
+[GCP Min sandbox](https://github.com/nuonco/gcp-min-sandbox)
 
 <Note>
 	The AWS Min sandbox does not create a Kubernetes cluster, but still provisions


### PR DESCRIPTION
add more active sandboxes to sandbox list

added sandboxes include: 

- AWS EKS Auto sandbox

- AWS BYO EKS sandbox

- Azure Min sandbox

- GCP GKE sandbox

- GCP Min sandbox