### PR TITLE
chore(ctl-api): add a new endpoint for public runner settings

### DIFF
--- a/services/ctl-api/docs/runner/descriptions/get_runner_public_settings.md
+++ b/services/ctl-api/docs/runner/descriptions/get_runner_public_settings.md
@@ -1,0 +1,1 @@
+Return runner settings for the provided runner.

--- a/services/ctl-api/internal/app/queue.go
+++ b/services/ctl-api/internal/app/queue.go
@@ -19,14 +19,14 @@ type Queue struct {
 	CreatedByID string  `json:"created_by_id,omitzero" gorm:"not null;default:null" temporaljson:"created_by_id,omitzero,omitempty"`
 	CreatedBy   Account `json:"-" temporaljson:"created_by,omitzero,omitempty"`
 
-	CreatedAt time.Time             `json:"created_at,omitzero" gorm:"notnull;index:idx_runner_jobs_query,priority:4,sort:desc;index:idx_runner_jobs_owner_id,priority:2,sort:desc" temporaljson:"created_at,omitzero,omitempty"`
+	CreatedAt time.Time             `json:"created_at,omitzero" gorm:"notnull" temporaljson:"created_at,omitzero,omitempty"`
 	UpdatedAt time.Time             `json:"updated_at,omitzero" gorm:"notnull" temporaljson:"updated_at,omitzero,omitempty"`
 	DeletedAt soft_delete.DeletedAt `json:"-" temporaljson:"deleted_at,omitzero,omitempty"`
 
 	OrgID *string `json:"org_id,omitempty" temporaljson:"org_id,omitzero,omitempty"`
 	Org   *Org    `json:"-" temporaljson:"org,omitzero,omitempty"`
 
-	OwnerID   string `json:"owner_id,omitzero" gorm:"type:text;check:owner_id_checker,char_length(id)=26;index:idx_runner_jobs_owner_id,priority:1" temporaljson:"owner_id,omitzero,omitempty"`
+	OwnerID   string `json:"owner_id,omitzero" gorm:"type:text;check:owner_id_checker,char_length(id)=26;" temporaljson:"owner_id,omitzero,omitempty"`
 	OwnerType string `json:"owner_type,omitzero" gorm:"type:text;" temporaljson:"owner_type,omitzero,omitempty"`
 
 	Name        string        `json:"name,omitzero" gorm:"default:''" temporaljson:"name,omitzero,omitempty"`
@@ -47,6 +47,13 @@ func (r *Queue) Indexes(db *gorm.DB) []migrations.Index {
 			Name: indexes.Name(db, &Queue{}, "org_id"),
 			Columns: []string{
 				"org_id",
+			},
+		},
+		{
+			Name: indexes.Name(db, &Queue{}, "owner"),
+			Columns: []string{
+				"owner_id",
+				"owner_type",
 			},
 		},
 	}

--- a/services/ctl-api/internal/app/runner_group_settings.go
+++ b/services/ctl-api/internal/app/runner_group_settings.go
@@ -43,10 +43,15 @@ type RunnerGroupSettings struct {
 	RunnerGroupID string `json:"runner_group_id,omitzero" gorm:"index:idx_runner_group_settings,unique" temporaljson:"runner_group_id,omitzero,omitempty"`
 
 	// configuration for deploying the runner
-	ContainerImageURL string `json:"container_image_url,omitzero" gorm:"default null;not null" temporaljson:"container_image_url,omitzero,omitempty"`
-	ContainerImageTag string `json:"container_image_tag,omitzero" gorm:"default null;not null" temporaljson:"container_image_tag,omitzero,omitempty"`
-	ExpectedVersion   string `json:"-" gorm:"-" temporaljson:"expected_version,omitzero,omitempty"`
-	RunnerAPIURL      string `json:"runner_api_url,omitzero" gorm:"default null;not null" temporaljson:"runner_apiurl,omitzero,omitempty"`
+	ContainerImageURL  string `json:"container_image_url,omitzero" gorm:"default null;not null" temporaljson:"container_image_url,omitzero,omitempty"`
+	ContainerImageTag  string `json:"container_image_tag,omitzero" gorm:"default null;not null" temporaljson:"container_image_tag,omitzero,omitempty"`
+	ContainerMaxUptime int    `json:"container_max_uptime,omitzero" gorm:"default: 14400;" temporaljson:"container_max_uptime,omitzero,omitempty"`
+	ExpectedVersion    string `json:"-" gorm:"-" temporaljson:"expected_version,omitzero,omitempty"`
+	RunnerAPIURL       string `json:"runner_api_url,omitzero" gorm:"default null;not null" temporaljson:"runner_apiurl,omitzero,omitempty"`
+
+	// configuration for managing the runner binary version (for mng mode, not the install runner)
+	BinaryVersion string `json:"binary_version,omitzero" gorm:"default null;" temporaljson:"binary_version,omitzero,omitempty"`
+	VMMaxUptime   int    `json:"vm_max_uptime,omitzero" gorm:"default: 604800;" temporaljson:"vm_max_uptime,omitzero,omitempty"`
 
 	// configuration for managing the runner server side
 	SandboxMode bool `json:"sandbox_mode,omitzero" temporaljson:"sandbox_mode,omitzero,omitempty"`
@@ -143,6 +148,12 @@ func (r *RunnerGroupSettings) AfterQuery(tx *gorm.DB) error {
 	}
 	if r.OrgAzureClientID != "" {
 		r.Platform = CloudPlatformAzure
+	}
+	if r.BinaryVersion == "" {
+		// TODO: implement versionFromContext(tx.Statement.Context)
+		if r.BinaryVersion == "" {
+			r.BinaryVersion = "latest"
+		}
 	}
 	return nil
 }

--- a/services/ctl-api/internal/app/runners/service/admin_get_runner_settings.go
+++ b/services/ctl-api/internal/app/runners/service/admin_get_runner_settings.go
@@ -22,7 +22,7 @@ func (s *service) AdminGetRunnerSettings(ctx *gin.Context) {
 
 	runner, err := s.getRunner(ctx, runnerID)
 	if err != nil {
-		ctx.Error(fmt.Errorf("unable to get runner job: %w", err))
+		ctx.Error(fmt.Errorf("unable to get runner: %w", err))
 		return
 	}
 

--- a/services/ctl-api/internal/app/runners/service/admin_update_settings.go
+++ b/services/ctl-api/internal/app/runners/service/admin_update_settings.go
@@ -19,9 +19,12 @@ import (
 )
 
 type AdminUpdateRunnerSettingsRequest struct {
-	ContainerImageURL string `json:"container_image_url"`
-	ContainerImageTag string `json:"container_image_tag"`
-	RunnerAPIURL      string `json:"runner_api_url"`
+	ContainerImageURL  string `json:"container_image_url"`
+	ContainerImageTag  string `json:"container_image_tag"`
+	RunnerAPIURL       string `json:"runner_api_url"`
+	BinaryVersion      string `json:"binary_version"`
+	ContainerMaxUptime int    `json:"container_max_uptime"`
+	VMMaxUptime        int    `json:"vm_max_uptime"`
 
 	K8sServiceAccountName string `json:"k8s_service_account_name"`
 	AWSIAMRoleARN         string `json:"aws_iam_role_arn"`
@@ -87,6 +90,9 @@ func (s *service) adminUpdateRunnerSettings(ctx context.Context, runnerID string
 		ContainerImageURL:        req.ContainerImageURL,
 		ContainerImageTag:        req.ContainerImageTag,
 		RunnerAPIURL:             req.RunnerAPIURL,
+		BinaryVersion:            req.BinaryVersion,
+		ContainerMaxUptime:       req.ContainerMaxUptime,
+		VMMaxUptime:              req.VMMaxUptime,
 		OrgK8sServiceAccountName: req.K8sServiceAccountName,
 		OrgAWSIAMRoleARN:         req.AWSIAMRoleARN,
 		RunnerBinaryURL:          req.RunnerBinaryURL,

--- a/services/ctl-api/internal/app/runners/service/get_runner_public_settings.go
+++ b/services/ctl-api/internal/app/runners/service/get_runner_public_settings.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type RunnerPublicSettings struct {
+	BinaryVersion string `json:"binary_version"`
+}
+
+// @ID						GetRunnerPublicSettings
+// @summary				get runner public settings
+// @Description.markdown	get_runner_public_settings.md
+// @Param					runner_id	path	string	true	"runner ID"
+// @Tags					runners/runner
+// @Accept					json
+// @Produce				json
+// @Security				APIKey
+// @Security				OrgID
+// @Failure				400	{object}	stderr.ErrResponse
+// @Failure				401	{object}	stderr.ErrResponse
+// @Failure				403	{object}	stderr.ErrResponse
+// @Failure				404	{object}	stderr.ErrResponse
+// @Failure				500	{object}	stderr.ErrResponse
+// @Success				200	{object}	RunnerPublicSettings
+// @Router					/v1/runners/{runner_id}/public-settings [get]
+func (s *service) GetRunnerPublicSettings(ctx *gin.Context) {
+	runnerID := ctx.Param("runner_id")
+
+	runner, err := s.getRunner(ctx, runnerID)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	settings := RunnerPublicSettings{
+		BinaryVersion: runner.RunnerGroup.Settings.BinaryVersion,
+	}
+
+	ctx.JSON(http.StatusOK, settings)
+}

--- a/services/ctl-api/internal/app/runners/service/service.go
+++ b/services/ctl-api/internal/app/runners/service/service.go
@@ -208,6 +208,7 @@ func (s *service) RegisterRunnerRoutes(api *gin.Engine) error {
 	runners.GET("", s.GetRunner)
 	runners.GET("/jobs", s.GetRunnerJobs)
 	runners.GET("/settings", s.GetRunnerSettings)
+	runners.GET("/public-settings", s.GetRunnerPublicSettings)
 	runners.POST("/traces", s.OtelWriteTraces)
 	runners.POST("/metrics", s.OtelWriteMetrics)
 	runners.GET("/jobs/:job_id/plan", s.GetRunnerJobPlanV2)

--- a/services/ctl-api/internal/app/runners/service/update_runner_settings.go
+++ b/services/ctl-api/internal/app/runners/service/update_runner_settings.go
@@ -20,9 +20,12 @@ import (
 )
 
 type UpdateRunnerSettingsRequest struct {
-	ContainerImageURL string `json:"container_image_url"`
-	ContainerImageTag string `json:"container_image_tag"`
-	RunnerAPIURL      string `json:"runner_api_url"`
+	ContainerImageURL  string `json:"container_image_url"`
+	ContainerImageTag  string `json:"container_image_tag"`
+	RunnerAPIURL       string `json:"runner_api_url"`
+	BinaryVersion      string `json:"binary_version"`
+	ContainerMaxUptime int    `json:"container_max_uptime"`
+	VMMaxUptime        int    `json:"vm_max_uptime"`
 
 	K8sServiceAccountName string `json:"org_k8s_service_account_name"`
 	AWSIAMRoleARN         string `json:"org_awsiam_role_arn"`
@@ -102,6 +105,9 @@ func (s *service) updateRunnerSettings(ctx context.Context, runnerID, orgID stri
 		ContainerImageURL:        req.ContainerImageURL,
 		ContainerImageTag:        req.ContainerImageTag,
 		RunnerAPIURL:             req.RunnerAPIURL,
+		BinaryVersion:            req.BinaryVersion,
+		ContainerMaxUptime:       req.ContainerMaxUptime,
+		VMMaxUptime:              req.VMMaxUptime,
 		OrgK8sServiceAccountName: req.K8sServiceAccountName,
 		OrgAWSIAMRoleARN:         req.AWSIAMRoleARN,
 	}


### PR DESCRIPTION
/v1/runners/{runner_id}/public-settings

holds the binary version for the mng mode runner binary

pairs well with this change: https://github.com/nuonco/runner/pull/24
