### PR TITLE
feat(dashboard): install detail architecture

### DIFF
--- a/services/dashboard-ui/.gitignore
+++ b/services/dashboard-ui/.gitignore
@@ -9,6 +9,11 @@
 
 # production
 /build
+/.next/
+/out/
+
+# next.js (removed but may be generated locally)
+next-env.d.ts
 
 # misc
 .DS_Store

--- a/services/dashboard-ui/client/components/apps/AppInstallsTable/AppInstallsTable.tsx
+++ b/services/dashboard-ui/client/components/apps/AppInstallsTable/AppInstallsTable.tsx
@@ -46,6 +46,8 @@ export function parseInstallsToTableData(
         platform={(install?.cloud_platform as TCloudPlatform) || 'unknown'}
         variant="subtext"
         colorVariant="color"
+        displayVariant="icon-only"
+        iconSize="20"
       />
     ),
   }))
@@ -74,12 +76,6 @@ const columns: ColumnDef<InstallRow>[] = [
     cell: (info) => info.getValue() as ReactNode,
   },
   {
-    enableSorting: true,
-    accessorKey: 'region',
-    header: 'Region',
-    cell: (info) => <Text>{info.getValue() as string}</Text>,
-  },
-  {
     accessorKey: 'platform',
     header: 'Platform',
     cell: (info) => (
@@ -88,6 +84,12 @@ const columns: ColumnDef<InstallRow>[] = [
       </Text>
     ),
     enableSorting: true,
+  },
+  {
+    enableSorting: true,
+    accessorKey: 'region',
+    header: 'Region',
+    cell: (info) => <Text>{info.getValue() as string}</Text>,
   },
   {
     enableSorting: false,

--- a/services/dashboard-ui/client/components/common/ContextTooltip.tsx
+++ b/services/dashboard-ui/client/components/common/ContextTooltip.tsx
@@ -64,7 +64,7 @@ export const ContextTooltip = ({
                   {item.leftContent ? (
                     <span className="h-full">{item.leftContent}</span>
                   ) : null}
-                  <span className="flex flex-col text-left">
+                  <span className="flex flex-col gap-0.5 text-left">
                     <Text
                       className="max-w-36 truncate"
                       variant="label"

--- a/services/dashboard-ui/client/components/installs/ArchitectureDiagram/ArchitectureDiagramContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/ArchitectureDiagram/ArchitectureDiagramContainer.tsx
@@ -1,13 +1,26 @@
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
+import { Banner } from '@/components/common/Banner'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
-import { Icon } from '@/components/common/Icon'
+import { CloudPlatform } from '@/components/common/CloudPlatform'
+import { CloudRegion } from '@/components/common/CloudRegion'
+import { Icon, type TIconVariant } from '@/components/common/Icon'
+import { ID } from '@/components/common/ID'
+import { LabeledValue } from '@/components/common/LabeledValue'
+import { Link } from '@/components/common/Link'
+import { RadioInput } from '@/components/common/form/RadioInput'
 import { Text } from '@/components/common/Text'
+import { Time } from '@/components/common/Time'
 import { Modal, type IModal } from '@/components/surfaces/Modal'
 import { useInstall } from '@/hooks/use-install'
 import { useOrg } from '@/hooks/use-org'
 import { useSurfaces } from '@/hooks/use-surfaces'
-import { getInstallComponents, getInstallStack, getAppConfig, getInstallAppPermissionsConfig } from '@/lib'
+import { getInstallComponents, getInstallStack, getAppConfig, getInstallAppPermissionsConfig, getInstallAuditLog } from '@/lib'
+import type { TCloudPlatform } from '@/types'
+import { downloadFileOnClick } from '@/utils/file-download'
+import { slugify } from '@/utils/string-utils'
+import { cn } from '@/utils/classnames'
 import { ArchitectureDiagram } from './ArchitectureDiagram'
 
 const ArchitectureDiagramContainer = () => {
@@ -79,27 +92,266 @@ const ArchitectureDiagramContainer = () => {
   )
 }
 
-const ArchitectureDiagramModal = ({ ...props }: IModal) => (
-  <Modal
-    heading={
-      <Text className="inline-flex gap-2 items-center" variant="h3" weight="strong">
-        <Icon variant="TreeStructure" size="20" />
-        Architecture
-      </Text>
-    }
-    size="xl"
-    showFooter={false}
-    childrenClassName="!p-0 flex-1 min-h-0"
-    className="h-[80vh]"
-    {...props}
-  >
-    <div className="w-full h-full">
-      <ArchitectureDiagramContainer />
-    </div>
-  </Modal>
-)
+type TabId = 'architecture' | 'details' | 'auditLogs'
 
-export const ArchitectureDiagramButton = ({
+const TAB_CONFIG: { id: TabId; label: string; icon: TIconVariant }[] = [
+  { id: 'architecture', label: 'Architecture', icon: 'TreeStructure' },
+  { id: 'details', label: 'Install details', icon: 'Info' },
+  { id: 'auditLogs', label: 'Audit logs', icon: 'ClockClockwise' },
+]
+
+const InstallDetailsTab = () => {
+  const { org } = useOrg()
+  const { install } = useInstall()
+
+  if (!install) return null
+
+  const platform = install.gcp_account
+    ? 'gcp'
+    : install.aws_account
+      ? 'aws'
+      : install.azure_account
+        ? 'azure'
+        : undefined
+
+  const region =
+    install.gcp_account?.region || install.aws_account?.region
+  const location = install.azure_account?.location
+
+  const isManagedByConfig =
+    install.metadata?.managed_by === 'nuon/cli/install-config'
+
+  return (
+    <div className="flex flex-col gap-5 p-5 overflow-y-auto h-full">
+      <div className="flex flex-col gap-1">
+        <Text variant="body" weight="strong">Install details</Text>
+        <Text variant="subtext" theme="neutral">
+          Metadata and configuration for this install.
+        </Text>
+      </div>
+
+      <LabeledValue label="Install ID">
+        <ID>{install.id}</ID>
+      </LabeledValue>
+
+      {install.install_number != null && (
+        <LabeledValue label="Install number">
+          <Text variant="subtext">#{install.install_number}</Text>
+        </LabeledValue>
+      )}
+
+      {install.created_by?.email && (
+        <LabeledValue label="Created by">
+          <Text variant="subtext">{install.created_by.email}</Text>
+        </LabeledValue>
+      )}
+
+      <LabeledValue label="App">
+        <Text variant="subtext">
+          <Link href={`/${org?.id}/apps/${install.app_id}`}>
+            {install.app?.name || install.app_id}
+          </Link>
+        </Text>
+      </LabeledValue>
+
+      {isManagedByConfig && (
+        <LabeledValue label="Managed by">
+          <Text variant="subtext">
+            <span className="flex items-center gap-1">
+              <Icon variant="FileCodeIcon" size={14} /> Install config
+            </span>
+          </Text>
+        </LabeledValue>
+      )}
+
+      <LabeledValue label="Created">
+        <Time variant="subtext" time={install.created_at} format="long-datetime" />
+      </LabeledValue>
+
+      <LabeledValue label="Updated">
+        <Time variant="subtext" time={install.updated_at} format="long-datetime" />
+      </LabeledValue>
+
+      {install.cloud_platform && (
+        <LabeledValue label="Platform">
+          <CloudPlatform
+            platform={(install.cloud_platform as TCloudPlatform) || 'unknown'}
+            variant="subtext"
+            colorVariant="color"
+          />
+        </LabeledValue>
+      )}
+
+      {(region || location) && platform && (
+        <LabeledValue label="Region">
+          <CloudRegion
+            variant="subtext"
+            platform={platform}
+            region={region}
+            location={location}
+          />
+        </LabeledValue>
+      )}
+    </div>
+  )
+}
+
+const AuditLogsTab = () => {
+  const { org } = useOrg()
+  const { install } = useInstall()
+
+  const [dateRange, setDateRange] = useState({
+    start: new Date(new Date().getTime() - 7 * 24 * 60 * 60 * 1000),
+    end: new Date(),
+  })
+
+  const {
+    data: auditLog,
+    error,
+    isLoading,
+  } = useQuery({
+    queryKey: ['install-audit-log', org.id, install.id, dateRange.start.toISOString(), dateRange.end.toISOString()],
+    queryFn: () =>
+      getInstallAuditLog({
+        orgId: org.id,
+        installId: install.id,
+        start: dateRange.start.toISOString(),
+        end: dateRange.end.toISOString(),
+      }),
+  })
+
+  const handleDateChange = (hoursAgo: number) => {
+    const end = new Date()
+    const start = new Date(end.getTime() - hoursAgo * 60 * 60 * 1000)
+    setDateRange({ start, end })
+  }
+
+  const handleDownload = () => {
+    if (auditLog?.content) {
+      downloadFileOnClick({
+        ...auditLog,
+        filename: `${slugify(install.name)}-audit-log.csv`,
+        fileType: 'csv',
+        mimeType: 'text/csv',
+      })
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-5 p-5 overflow-y-auto h-full">
+      <div className="flex flex-col gap-1">
+        <Text variant="body" weight="strong">Audit logs</Text>
+        <Text variant="subtext" theme="neutral">
+          See a complete record of all activities performed in this install.
+        </Text>
+      </div>
+
+      {error ? (
+        <Banner theme="error">
+          {error?.error || 'Unable to load audit logs for the selected date range'}
+        </Banner>
+      ) : null}
+
+      <div className="flex flex-col gap-3">
+        <RadioInput
+          name="date-range"
+          value="1"
+          onChange={() => handleDateChange(1)}
+          labelProps={{ labelText: 'Last one hour' }}
+        />
+        <RadioInput
+          name="date-range"
+          value="24"
+          onChange={() => handleDateChange(24)}
+          labelProps={{ labelText: 'Last 24 hours' }}
+        />
+        <RadioInput
+          name="date-range"
+          value="168"
+          onChange={() => handleDateChange(7 * 24)}
+          defaultChecked={true}
+          labelProps={{ labelText: 'Last week' }}
+        />
+        <RadioInput
+          name="date-range"
+          value="720"
+          onChange={() => handleDateChange(30 * 24)}
+          labelProps={{ labelText: 'Last 30 days' }}
+        />
+        <RadioInput
+          name="date-range"
+          value="1440"
+          onChange={() => handleDateChange(60 * 24)}
+          labelProps={{ labelText: 'Last 60 days' }}
+        />
+      </div>
+
+      <Button
+        variant="primary"
+        disabled={isLoading || !auditLog?.content}
+        onClick={handleDownload}
+        className="w-fit"
+      >
+        {isLoading ? (
+          <span className="flex items-center gap-2">
+            <Icon variant="Loading" /> Download CSV
+          </span>
+        ) : (
+          <span className="flex items-center gap-2">
+            <Icon variant="DownloadSimple" size="18" /> Download CSV
+          </span>
+        )}
+      </Button>
+    </div>
+  )
+}
+
+const InstallDetailsModal = ({ ...props }: IModal) => {
+  const [activeTab, setActiveTab] = useState<TabId>('architecture')
+
+  return (
+    <Modal
+      heading={
+        <Text className="inline-flex gap-2 items-center" variant="h3" weight="strong">
+          <Icon variant="Info" size="20" />
+          Install details
+        </Text>
+      }
+      size="xl"
+      showFooter={false}
+      childrenClassName="!p-0 flex-1 min-h-0"
+      className="h-[80vh]"
+      {...props}
+    >
+      <div className="flex w-full h-full">
+        <nav className="w-[200px] shrink-0 border-r border-cool-grey-300 dark:border-dark-grey-300 flex flex-col gap-1 p-2">
+          {TAB_CONFIG.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={cn(
+                'flex items-center gap-2 px-3 py-2.5 rounded-md text-left text-[14px] leading-[21px] tracking-[-0.2px] transition-colors w-full cursor-pointer',
+                activeTab === tab.id
+                  ? 'text-primary-800 dark:text-primary-400 bg-primary-200 dark:bg-primary-600/25'
+                  : 'text-cool-grey-800 dark:text-cool-grey-400 hover:bg-black/5 dark:hover:bg-white/10'
+              )}
+            >
+              <Icon variant={tab.icon} size={16} />
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+        <div className="flex-1 min-w-0 min-h-0">
+          {activeTab === 'architecture' && <ArchitectureDiagramContainer />}
+          {activeTab === 'details' && <InstallDetailsTab />}
+          {activeTab === 'auditLogs' && <AuditLogsTab />}
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+export const InstallDetailsButton = ({
   ...props
 }: Omit<IButtonAsButton, 'onClick'>) => {
   const { addModal } = useSurfaces()
@@ -108,13 +360,13 @@ export const ArchitectureDiagramButton = ({
     <Button
       variant="ghost"
       onClick={() => {
-        const modal = <ArchitectureDiagramModal />
+        const modal = <InstallDetailsModal />
         addModal(modal)
       }}
       {...props}
     >
-      <Icon variant="TreeStructure" />
-      Architecture   
+      <Icon variant="Info" />
+      Install details
     </Button>
   )
 }

--- a/services/dashboard-ui/client/components/installs/ArchitectureDiagram/diagram-layout.ts
+++ b/services/dashboard-ui/client/components/installs/ArchitectureDiagram/diagram-layout.ts
@@ -27,7 +27,7 @@ export type TRoleInfo = {
   policies: Array<{ name?: string; contents?: string }>
 }
 
-const CARD_W = 240
+const CARD_W = 280
 const CARD_H = 64
 const CARD_GAP = 12
 const PAD = 16

--- a/services/dashboard-ui/client/components/installs/ArchitectureDiagram/diagram-nodes.tsx
+++ b/services/dashboard-ui/client/components/installs/ArchitectureDiagram/diagram-nodes.tsx
@@ -55,16 +55,17 @@ export const ContainerNode = memo(({ data }: NodeProps) => {
       )}
       style={{ width, height }}
     >
-      <div className="flex items-center gap-1.5 px-3 py-2">
+      <div className="flex items-center gap-1.5 px-3 py-2 overflow-hidden">
         <Icon
           variant={data.icon as TIconVariant}
           size={14}
           theme="neutral"
+          className="shrink-0"
         />
-        <Text variant="label" weight="strong" theme="neutral">
+        <Text variant="label" weight="strong" theme="neutral" className="truncate !block min-w-0">
           {data.label as string}
         </Text>
-        {status ? <Status status={status} variant="badge" /> : null}
+        {status ? <Status status={status} variant="badge" className="shrink-0" /> : null}
       </div>
     </div>
   )
@@ -203,7 +204,7 @@ export const ComponentCardNode = memo(({ data }: NodeProps) => {
       <div
         aria-label={`${name} — ${COMPONENT_TYPE_LABELS[componentType] || 'Component'}`}
         className={cn(
-          'rounded-lg border bg-white dark:bg-dark-grey-900 px-3 py-2 flex items-center gap-2 transition-shadow hover:shadow-sm',
+          'rounded-lg border bg-white dark:bg-dark-grey-900 px-3 py-2 flex items-center gap-2 transition-shadow hover:shadow-sm overflow-hidden',
           isDrifted && '!border-orange-400 dark:!border-orange-500/40'
         )}
         style={{ width, height: 56 }}
@@ -215,17 +216,16 @@ export const ComponentCardNode = memo(({ data }: NodeProps) => {
           colorVariant="color"
           iconSize="16"
         />
-        <div className="flex flex-col gap-0.5 min-w-0 flex-1">
-          <Text
-            variant="label"
-            weight="strong"
-            className="truncate !block"
+        <div className="flex flex-col gap-0.5 min-w-0 flex-1 overflow-hidden">
+          <span
+            className="text-[11px] leading-[16px] font-strong overflow-hidden text-ellipsis whitespace-nowrap block"
+            title={name}
           >
             {name}
-          </Text>
-          <Text variant="label" theme="neutral" className="truncate !block">
+          </span>
+          <span className="text-[11px] leading-[16px] text-cool-grey-600 dark:text-white/70 overflow-hidden text-ellipsis whitespace-nowrap block">
             {COMPONENT_TYPE_LABELS[componentType] || 'Component'}
-          </Text>
+          </span>
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
           {isDrifted && (

--- a/services/dashboard-ui/client/components/installs/ArchitectureDiagram/index.ts
+++ b/services/dashboard-ui/client/components/installs/ArchitectureDiagram/index.ts
@@ -1,3 +1,3 @@
 export { ArchitectureDiagramContainer as ArchitectureDiagram } from './ArchitectureDiagramContainer'
 export { ArchitectureDiagram as ArchitectureDiagramComponent } from './ArchitectureDiagram'
-export { ArchitectureDiagramButton } from './ArchitectureDiagramContainer'
+export { InstallDetailsButton } from './ArchitectureDiagramContainer'

--- a/services/dashboard-ui/client/components/installs/InstallsTable/InstallsTable.stories.tsx
+++ b/services/dashboard-ui/client/components/installs/InstallsTable/InstallsTable.stories.tsx
@@ -14,8 +14,7 @@ const mockRows: InstallRow[] = Array.from({ length: 5 }, (_, i) => ({
   statuses: <span className="text-sm text-foreground-muted">active</span>,
   region: <span className="text-sm text-foreground-muted">us-west-2</span>,
   platform: <span className="text-sm text-foreground-muted">AWS</span>,
-  created_at: new Date(Date.now() - i * 86400000).toISOString(),
-  updated_at: new Date(Date.now() - i * 3600000).toISOString(),
+  activity: <span className="text-sm text-foreground-muted">{i + 1}h ago</span>,
   action: <Button size="sm" variant="ghost">Manage</Button>,
 }))
 

--- a/services/dashboard-ui/client/components/installs/InstallsTable/InstallsTable.tsx
+++ b/services/dashboard-ui/client/components/installs/InstallsTable/InstallsTable.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from 'react'
 import type { ColumnDef } from '@tanstack/react-table'
 import { CloudPlatform } from '@/components/common/CloudPlatform'
 import { CloudRegion } from '@/components/common/CloudRegion'
+import { ContextTooltip } from '@/components/common/ContextTooltip'
+import { Icon } from '@/components/common/Icon'
 import { ID } from '@/components/common/ID'
 import { Link } from '@/components/common/Link'
 import { Skeleton } from '@/components/common/Skeleton'
@@ -54,16 +56,66 @@ const ActionSkeleton = () => (
 
 export type InstallRow = {
   action: ReactNode
+  activity: ReactNode
   appHref: string
   appName: string
-  created_at: string
   installId: string
   name: string
   nameHref: string
   region?: ReactNode
   statuses: ReactNode
   platform: ReactNode
-  updated_at: string
+}
+
+function getCreatedBySubtitle(install: TInstall): { email: string; source: string } | undefined {
+  const account = install?.created_by
+  if (!account?.email) return undefined
+  const source = account.account_type === 'service' ? 'API / CLI' : 'Dashboard'
+  return { email: account.email, source }
+}
+
+function ActivityCell({ install }: { install: TInstall }) {
+  const createdBy = getCreatedBySubtitle(install)
+
+  return (
+    <ContextTooltip
+      position="top"
+      width="w-64"
+      items={[
+        ...(createdBy
+          ? [
+              {
+                id: 'created-by',
+                title: createdBy.email,
+                subtitle: `via ${createdBy.source}`,
+                leftContent: <Icon variant="User" size={16} />,
+              },
+            ]
+          : []),
+        {
+          id: 'created',
+          title: 'Created',
+          subtitle: (
+            <Time variant="label" time={install?.created_at} format="long-datetime" />
+          ),
+          leftContent: <Icon variant="PlusCircle" size={16} />,
+        },
+        {
+          id: 'updated',
+          title: 'Updated',
+          subtitle: (
+            <Time variant="label" time={install?.updated_at} format="long-datetime" />
+          ),
+          leftContent: <Icon variant="ClockCounterClockwise" size={16} />,
+        },
+      ]}
+    >
+      <span className="inline-flex items-center gap-1.5 cursor-default">
+        <Time time={install?.updated_at} variant="subtext" format="relative" />
+        <Icon variant="Info" size={12} theme="neutral" />
+      </span>
+    </ContextTooltip>
+  )
 }
 
 export function parseInstallsToTableData(
@@ -93,10 +145,10 @@ export function parseInstallsToTableData(
         variant="subtext"
         colorVariant="color"
         displayVariant="icon-only"
+        iconSize="20"
       />
     ),
-    created_at: install?.created_at,
-    updated_at: install?.updated_at,
+    activity: <ActivityCell install={install} />,
     action: (
       <div className="hidden md:block">
         <QuickManagementDropdown install={install} />
@@ -135,12 +187,6 @@ const columns: ColumnDef<InstallRow>[] = [
     cell: (info) => info.getValue() as ReactNode,
   },
   {
-    enableSorting: true,
-    accessorKey: 'region',
-    header: 'Region',
-    cell: (info) => <Text>{info.getValue() as string}</Text>,
-  },
-  {
     accessorKey: 'platform',
     header: 'Platform',
     cell: (info) => (
@@ -151,20 +197,16 @@ const columns: ColumnDef<InstallRow>[] = [
     enableSorting: true,
   },
   {
-    accessorKey: 'created_at',
-    header: 'Created',
-    cell: (info) => <Time time={info.getValue<string>()} variant="subtext" format="relative" />,
+    enableSorting: true,
+    accessorKey: 'region',
+    header: 'Region',
+    cell: (info) => <Text>{info.getValue() as string}</Text>,
   },
   {
-    accessorKey: 'updated_at',
-    header: 'Updated',
-    cell: (info) => (
-      <Time
-        time={info.getValue<string>()}
-        variant="subtext"
-        format="relative"
-      />
-    ),
+    enableSorting: false,
+    accessorKey: 'activity',
+    header: 'Activity',
+    cell: (info) => info.getValue() as ReactNode,
   },
   {
     enableSorting: false,
@@ -221,8 +263,7 @@ export const InstallsTableSkeleton = () => {
     region: <RegionSkeleton />,
     statuses: <StatusesSkeleton />,
     platform: <PlatformSkeleton />,
-    created_at: '',
-    updated_at: '',
+    activity: <Skeleton height="14px" width="80px" />,
     action: '',
   }))
 
@@ -245,28 +286,22 @@ export const InstallsTableSkeleton = () => {
       cell: (info) => info.getValue() as ReactNode,
     },
     {
-      enableSorting: true,
-      accessorKey: 'region',
-      header: 'Region',
-      cell: (info) => info.getValue() as ReactNode,
-    },
-    {
       accessorKey: 'platform',
       header: 'Platform',
       cell: (info) => info.getValue() as ReactNode,
       enableSorting: true,
     },
     {
-      accessorKey: 'created_at',
-      header: 'Created',
-      cell: () => <Skeleton height="16px" width="100px" />,
       enableSorting: true,
+      accessorKey: 'region',
+      header: 'Region',
+      cell: (info) => info.getValue() as ReactNode,
     },
     {
-      accessorKey: 'updated_at',
-      header: 'Updated',
-      cell: () => <Skeleton height="16px" width="100px" />,
-      enableSorting: true,
+      enableSorting: false,
+      accessorKey: 'activity',
+      header: 'Activity',
+      cell: (info) => info.getValue() as ReactNode,
     },
     {
       enableSorting: false,

--- a/services/dashboard-ui/client/components/installs/management/Forget/ForgetContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/Forget/ForgetContainer.tsx
@@ -60,6 +60,7 @@ export const ForgetModalContainer = ({ ...props }: IForget & Omit<IModal, 'onSub
 }
 
 export const ForgetButton = ({
+  isMenuButton: _isMenuButton,
   ...props
 }: IForget & IButtonAsButton) => {
   const { addModal } = useSurfaces()
@@ -71,7 +72,7 @@ export const ForgetButton = ({
         addModal(modal)
       }}
       variant="ghost"
-      className="!text-red-800 dark:!text-red-500 !p-2 w-full justify-between"
+      className="!bg-transparent !border-0 !p-2 text-sm !leading-none h-8 w-full flex justify-between !rounded-md !text-red-800 dark:!text-red-500 hover:!bg-red-50 dark:hover:!bg-[#1D0D10] active:!bg-red-100 dark:active:!bg-[#2E1013]"
       {...props}
     >
       Forget install

--- a/services/dashboard-ui/client/components/installs/management/QuickManagementDropdown/QuickManagementDropdown.tsx
+++ b/services/dashboard-ui/client/components/installs/management/QuickManagementDropdown/QuickManagementDropdown.tsx
@@ -27,6 +27,7 @@ const QuickManagementMenu = ({ orgId, installId }: IQuickManagementMenu) => {
         View details
         <Icon variant="CaretRightIcon" />
       </Button>
+      <hr />
       <Text variant="label" theme="neutral">
         Settings
       </Text>

--- a/services/dashboard-ui/client/components/installs/management/ViewCurrentInputs/ViewCurrentInputsContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/ViewCurrentInputs/ViewCurrentInputsContainer.tsx
@@ -56,7 +56,6 @@ export const ViewCurrentInputsButton = ({ ...props }: IButtonAsButton) => {
 
   return (
     <Button
-      className="text-sm !font-medium !py-2 !px-3 h-[36px] flex items-center gap-3 w-full"
       variant="ghost"
       onClick={() => {
         const modal = <ViewCurrentInputsModalContainer />

--- a/services/dashboard-ui/client/components/terraform-workspace/TerraformBackendConfig/TerraformBackendConfig.tsx
+++ b/services/dashboard-ui/client/components/terraform-workspace/TerraformBackendConfig/TerraformBackendConfig.tsx
@@ -20,7 +20,7 @@ export const TerraformBackendConfigModal = ({
         onClick: onDownload,
         variant: 'primary',
       }}
-      size="sm"
+      size="lg"
       {...props}
     >
       <div className="flex flex-col gap-4">

--- a/services/dashboard-ui/client/types/ctl-api.types.ts
+++ b/services/dashboard-ui/client/types/ctl-api.types.ts
@@ -100,6 +100,7 @@ export type TOrgStats = {
 // install
 export type TInstall = components['schemas']['app.Install'] & {
   app?: components['schemas']['app.App']
+  created_by?: components['schemas']['app.Account']
   gcp_account?: { project_id?: string; region?: string }
   org_id?: string
 }

--- a/services/dashboard-ui/client/views/install/Overview.tsx
+++ b/services/dashboard-ui/client/views/install/Overview.tsx
@@ -6,7 +6,7 @@ import { Text } from '@/components/common/Text'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
 import { PageTitle } from '@/components/navigation/PageTitle'
-import { ArchitectureDiagramButton } from '@/components/installs/ArchitectureDiagram'
+import { InstallDetailsButton } from '@/components/installs/ArchitectureDiagram'
 import { ViewCurrentInputsButton } from '@/components/installs/management/ViewCurrentInputs'
 import { useInstall } from '@/hooks/use-install'
 import { useOrg } from '@/hooks/use-org'
@@ -43,7 +43,7 @@ export const Overview = () => {
           </Text>
         </HeadingGroup>
         <div className="flex items-center gap-2">
-          <ArchitectureDiagramButton variant="secondary" />
+          <InstallDetailsButton variant="secondary" />
           <ViewCurrentInputsButton variant="secondary" />
         </div>
       </div>


### PR DESCRIPTION
## Summary

- **Tabbed Install Details modal**: Restructured the "Architecture" modal into a three-tab "Install Details" modal with vertical left navigation:
  - **Architecture**: Existing architecture diagram
  - **Install details**: Install metadata (ID, install number, created by, app, managed by, created/updated timestamps, platform, region)
  - **Audit logs**: Date range selection and CSV download (previously a separate modal)
- **Activity column**: Consolidated "Created" and "Updated" columns in install tables into a single "Activity" column with a rich tooltip showing created by, created at, and updated at
- **Column reorder**: Moved "Platform" before "Region" in both `InstallsTable` and `AppInstallsTable`
- **Consistent cloud icons**: Unified `CloudPlatform` to `icon-only` display with `iconSize="20"` across both tables
- **Diagram truncation**: Added text overflow handling to diagram nodes so long component names truncate instead of wrapping
- **UI polish**:
  - Divider after "View details" in Quick Management dropdown
  - Danger styling on "Forget install" button with proper hover/active states
  - Removed hardcoded className overrides from `ViewCurrentInputsButton`
  - Increased "Use Terraform CLI" modal to `lg` size
  - Added `gap-0.5` spacing between title/subtitle in `ContextTooltip`
  - Card width increased from 240→280 in architecture diagram

## Test plan

- [x] Open Install Details modal — verify all three tabs render and switch correctly
- [x] Architecture tab shows the diagram as before
- [x] Install details tab displays metadata fields with title/subtitle header
- [x] Audit logs tab shows date range radios and download button
- [x] Install tables show Activity column with rich tooltip on hover
- [x] Platform column appears before Region in both org-level and app-level install tables
- [x] Cloud platform icons are consistent size across tables
- [x] Long component names in diagram truncate with ellipsis
- [x] "Forget install" button shows red text and red hover background
- [x] Quick Management dropdown has divider after "View details"