### PR TITLE
feat: add composite errors support

### DIFF
--- a/bins/runner/internal/jobs/actions/workflow/exec.go
+++ b/bins/runner/internal/jobs/actions/workflow/exec.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
+	composite_errors "github.com/nuonco/nuon/bins/runner/internal/pkg/composite_errors"
 	pkgctx "github.com/nuonco/nuon/bins/runner/internal/pkg/ctx"
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 
@@ -104,6 +106,12 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 			if err := h.noopWorkflowSteps(ctx, remainingSteps, remainingCfgs); err != nil {
 				l.Warn(fmt.Sprintf("unable to mark %d remaining steps as NOOP after step.%d errored", idx, idx-1))
 			}
+		}
+
+		// Report structured composite errors for action failures
+		modelErrs := composite_errors.ToModels(composite_errors.FromGoError(err, "action-run"))
+		if reportErr := h.apiClient.ReportCompositeErrors(ctx, job.ID, modelErrs); reportErr != nil {
+			l.Warn("unable to report composite errors", zap.Error(reportErr))
 		}
 
 		return errors.Wrap(err, fmt.Sprintf("action workflow failed on step %d", idx))

--- a/bins/runner/internal/jobs/deploy/helm/err.go
+++ b/bins/runner/internal/jobs/deploy/helm/err.go
@@ -3,6 +3,12 @@ package helm
 import (
 	"context"
 
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+
+	composite_errors "github.com/nuonco/nuon/bins/runner/internal/pkg/composite_errors"
+	pkgctx "github.com/nuonco/nuon/bins/runner/internal/pkg/ctx"
+	"github.com/nuonco/nuon/pkg/kube"
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 )
 
@@ -21,4 +27,59 @@ func (h *handler) writeErrorResult(ctx context.Context, step string, err error) 
 	if _, err := h.apiClient.CreateJobExecutionResult(ctx, h.state.jobID, h.state.jobExecutionID, resultReq); err != nil {
 		h.errRecorder.Record("write job execution result", err)
 	}
+}
+
+func (h *handler) reportCompositeErrors(ctx context.Context, ownerType string, helmErr error) {
+	errs := composite_errors.ParseHelmStderr(helmErr.Error(), ownerType)
+	if len(errs) == 0 {
+		errs = composite_errors.FromGoError(helmErr, ownerType)
+	}
+
+	// For deploy failures, also collect K8s diagnostics (pod statuses, events, logs)
+	if ownerType == "apply" {
+		k8sErrs := h.collectK8sDiagnostics(ctx)
+		errs = append(errs, k8sErrs...)
+	}
+
+	modelErrs := composite_errors.ToModels(errs)
+	if err := h.apiClient.ReportCompositeErrors(ctx, h.state.jobID, modelErrs); err != nil {
+		h.errRecorder.Record("report composite errors", err)
+	}
+}
+
+func (h *handler) collectK8sDiagnostics(ctx context.Context) []composite_errors.CompositeError {
+	l, _ := pkgctx.Logger(ctx)
+	if l == nil {
+		l = zap.NewNop()
+	}
+
+	if h.state.plan == nil || h.state.plan.HelmDeployPlan == nil {
+		return nil
+	}
+
+	clusterInfo := h.state.plan.HelmDeployPlan.ClusterInfo
+	if clusterInfo == nil {
+		return nil
+	}
+
+	kubeCfg, err := kube.ConfigForCluster(ctx, clusterInfo)
+	if err != nil {
+		l.Warn("unable to create kube config for k8s diagnostics", zap.Error(err))
+		return nil
+	}
+
+	k8sClient, err := kubernetes.NewForConfig(kubeCfg)
+	if err != nil {
+		l.Warn("unable to create k8s client for diagnostics", zap.Error(err))
+		return nil
+	}
+
+	namespace := h.state.plan.HelmDeployPlan.Namespace
+	releaseName := h.state.plan.HelmDeployPlan.Name
+
+	l.Info("collecting k8s diagnostics after helm failure",
+		zap.String("namespace", namespace),
+		zap.String("release", releaseName))
+
+	return composite_errors.CollectHelmK8sDiagnostics(ctx, k8sClient, namespace, releaseName)
 }

--- a/bins/runner/internal/jobs/deploy/helm/exec.go
+++ b/bins/runner/internal/jobs/deploy/helm/exec.go
@@ -94,6 +94,7 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 			helmPlan.Op = "upgrade"
 		}
 		if err != nil {
+			h.reportCompositeErrors(ctx, "plan", err)
 			return err
 		}
 
@@ -144,6 +145,7 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 			l.Error("plan did not define an Op. this is unexpected.")
 		}
 		if err != nil {
+			h.reportCompositeErrors(ctx, "apply", err)
 			return err
 		}
 	default:

--- a/bins/runner/internal/jobs/deploy/terraform/err.go
+++ b/bins/runner/internal/jobs/deploy/terraform/err.go
@@ -3,6 +3,8 @@ package terraform
 import (
 	"context"
 
+	composite_errors "github.com/nuonco/nuon/bins/runner/internal/pkg/composite_errors"
+	"github.com/nuonco/nuon/pkg/terraform/run"
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 )
 
@@ -20,5 +22,24 @@ func (h *handler) writeErrorResult(ctx context.Context, step string, err error) 
 
 	if _, err := h.apiClient.CreateJobExecutionResult(ctx, h.state.jobID, h.state.jobExecutionID, resultReq); err != nil {
 		h.errRecorder.Record("write job execution result", err)
+	}
+}
+
+func (h *handler) reportCompositeErrors(ctx context.Context, tfRun run.Run, ownerType string, runErr error) {
+	outputBytes := tfRun.LastOutputBytes()
+
+	var errs []composite_errors.CompositeError
+	if len(outputBytes) > 0 {
+		errs = composite_errors.ParseTerraformJSON(outputBytes, ownerType)
+	}
+
+	// Fallback: wrap the Go error if no structured diagnostics were found
+	if len(errs) == 0 {
+		errs = composite_errors.FromGoError(runErr, ownerType)
+	}
+
+	modelErrs := composite_errors.ToModels(errs)
+	if err := h.apiClient.ReportCompositeErrors(ctx, h.state.jobID, modelErrs); err != nil {
+		h.errRecorder.Record("report composite errors", err)
 	}
 }

--- a/bins/runner/internal/jobs/deploy/terraform/exec.go
+++ b/bins/runner/internal/jobs/deploy/terraform/exec.go
@@ -95,6 +95,14 @@ func (p *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 
 	if err != nil {
 		l.Error("terraform run errored", zap.Error(err))
+
+		// Report structured composite errors from terraform JSON output
+		ownerType := "plan"
+		if job.Operation == models.AppRunnerJobOperationTypeApplyDashPlan {
+			ownerType = "apply"
+		}
+		p.reportCompositeErrors(ctx, tfRun, ownerType, err)
+
 		return fmt.Errorf("unable to execute %s run: %w", job.Operation, err)
 	}
 

--- a/bins/runner/internal/pkg/composite_errors/action.go
+++ b/bins/runner/internal/pkg/composite_errors/action.go
@@ -1,0 +1,43 @@
+package composite_errors
+
+import (
+	"strings"
+)
+
+// ParseActionOutput parses action command output when a command fails.
+// It uses the last non-empty line as the summary, and the last 20 lines as the detail.
+func ParseActionOutput(output string, ownerType string) []CompositeError {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil
+	}
+
+	lines := strings.Split(output, "\n")
+
+	summary := lastNonEmptyLine(lines)
+	if summary == "" {
+		return nil
+	}
+
+	detail := lastNLines(lines, 20)
+
+	return []CompositeError{
+		{
+			OwnerType: ownerType,
+			Severity:     "critical",
+			Summary:      summary,
+			Detail:       detail,
+		},
+	}
+}
+
+// lastNLines returns the last n lines joined as a single string.
+// If there are fewer than n lines, all lines are returned.
+func lastNLines(lines []string, n int) string {
+	start := 0
+	if len(lines) > n {
+		start = len(lines) - n
+	}
+
+	return strings.Join(lines[start:], "\n")
+}

--- a/bins/runner/internal/pkg/composite_errors/action_test.go
+++ b/bins/runner/internal/pkg/composite_errors/action_test.go
@@ -1,0 +1,95 @@
+package composite_errors
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestParseActionOutput_BasicOutput(t *testing.T) {
+	output := `running migration step 1...
+running migration step 2...
+FATAL: connection refused`
+
+	errors := ParseActionOutput(output, "action-run")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+
+	ce := errors[0]
+	if ce.OwnerType != "action-run" {
+		t.Errorf("expected owner_type action-run, got %s", ce.OwnerType)
+	}
+	if ce.Severity != "critical" {
+		t.Errorf("expected severity critical, got %s", ce.Severity)
+	}
+	if ce.Summary != "FATAL: connection refused" {
+		t.Errorf("expected last line as summary, got %s", ce.Summary)
+	}
+	if ce.Detail != output {
+		t.Errorf("expected full output as detail since <= 20 lines")
+	}
+}
+
+func TestParseActionOutput_TruncatesDetail(t *testing.T) {
+	var lines []string
+	for i := 1; i <= 30; i++ {
+		lines = append(lines, fmt.Sprintf("line %d", i))
+	}
+	output := strings.Join(lines, "\n")
+
+	errors := ParseActionOutput(output, "action-run")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+
+	ce := errors[0]
+	if ce.Summary != "line 30" {
+		t.Errorf("expected last line as summary, got %s", ce.Summary)
+	}
+
+	detailLines := strings.Split(ce.Detail, "\n")
+	if len(detailLines) != 20 {
+		t.Errorf("expected 20 lines in detail, got %d", len(detailLines))
+	}
+	if detailLines[0] != "line 11" {
+		t.Errorf("expected detail to start at line 11, got %s", detailLines[0])
+	}
+}
+
+func TestParseActionOutput_SingleLine(t *testing.T) {
+	output := "command not found: deploy"
+
+	errors := ParseActionOutput(output, "action-run")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+	if errors[0].Summary != "command not found: deploy" {
+		t.Errorf("unexpected summary: %s", errors[0].Summary)
+	}
+}
+
+func TestParseActionOutput_EmptyInput(t *testing.T) {
+	if errors := ParseActionOutput("", "action-run"); errors != nil {
+		t.Errorf("expected nil for empty input, got %v", errors)
+	}
+	if errors := ParseActionOutput("   \n  \n  ", "action-run"); errors != nil {
+		t.Errorf("expected nil for whitespace-only input, got %v", errors)
+	}
+}
+
+func TestParseActionOutput_TrailingNewlines(t *testing.T) {
+	output := "some output\nthe error\n\n\n"
+
+	errors := ParseActionOutput(output, "action-run")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+	if errors[0].Summary != "the error" {
+		t.Errorf("expected 'the error' as summary (skipping trailing empty lines), got %s", errors[0].Summary)
+	}
+}

--- a/bins/runner/internal/pkg/composite_errors/composite_errors.go
+++ b/bins/runner/internal/pkg/composite_errors/composite_errors.go
@@ -1,0 +1,50 @@
+package composite_errors
+
+import (
+	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
+)
+
+// CompositeError is the runner-side representation of a structured error
+// extracted from tool output (terraform, helm, actions). These are sent
+// to the ctl-api as part of build/deploy reporting.
+type CompositeError struct {
+	OwnerType string         `json:"owner_type"`
+	Severity     string         `json:"severity"`
+	Summary      string         `json:"summary"`
+	Detail       string         `json:"detail,omitempty"`
+	Metadata     map[string]any `json:"metadata,omitempty"`
+}
+
+// FromGoError wraps a plain Go error as a single CompositeError with severity "critical".
+func FromGoError(err error, ownerType string) []CompositeError {
+	if err == nil {
+		return nil
+	}
+
+	return []CompositeError{
+		{
+			OwnerType: ownerType,
+			Severity:     "critical",
+			Summary:      err.Error(),
+		},
+	}
+}
+
+// ToModels converts runner-side CompositeErrors to SDK model types for API reporting.
+func ToModels(errs []CompositeError) []models.CompositeError {
+	if len(errs) == 0 {
+		return nil
+	}
+
+	out := make([]models.CompositeError, len(errs))
+	for i, e := range errs {
+		out[i] = models.CompositeError{
+			OwnerType: e.OwnerType,
+			Severity:     e.Severity,
+			Summary:      e.Summary,
+			Detail:       e.Detail,
+			Metadata:     e.Metadata,
+		}
+	}
+	return out
+}

--- a/bins/runner/internal/pkg/composite_errors/helm.go
+++ b/bins/runner/internal/pkg/composite_errors/helm.go
@@ -1,0 +1,111 @@
+package composite_errors
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	// templateErrorRe matches Helm template errors like:
+	//   Error: template: mychart/templates/deployment.yaml:12:5: executing "mychart/templates/deployment.yaml" at <.Values.missing>: ...
+	templateErrorRe = regexp.MustCompile(`^Error:\s+template:\s+(\S+):(\d+):(\d+):\s+(.+)$`)
+
+	// installFailedRe matches Helm install failures.
+	installFailedRe = regexp.MustCompile(`^Error:\s+INSTALLATION FAILED:\s+(.+)$`)
+
+	// upgradeFailedRe matches Helm upgrade failures.
+	upgradeFailedRe = regexp.MustCompile(`^Error:\s+UPGRADE FAILED:\s+(.+)$`)
+
+	// genericErrorRe matches any line starting with "Error:".
+	genericErrorRe = regexp.MustCompile(`^Error:\s+(.+)$`)
+)
+
+// ParseHelmStderr parses helm stderr output into structured errors.
+// Helm has no JSON error mode, so we parse known error patterns from stderr text.
+func ParseHelmStderr(stderr string, ownerType string) []CompositeError {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" {
+		return nil
+	}
+
+	var errors []CompositeError
+	lines := strings.Split(stderr, "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		if m := templateErrorRe.FindStringSubmatch(line); m != nil {
+			errors = append(errors, CompositeError{
+				OwnerType: ownerType,
+				Severity:     "critical",
+				Summary:      m[4],
+				Detail:       line,
+				Metadata: map[string]any{
+					"template": m[1],
+					"line":     m[2],
+					"column":   m[3],
+				},
+			})
+			continue
+		}
+
+		if m := installFailedRe.FindStringSubmatch(line); m != nil {
+			errors = append(errors, CompositeError{
+				OwnerType: ownerType,
+				Severity:     "critical",
+				Summary:      m[1],
+				Detail:       line,
+			})
+			continue
+		}
+
+		if m := upgradeFailedRe.FindStringSubmatch(line); m != nil {
+			errors = append(errors, CompositeError{
+				OwnerType: ownerType,
+				Severity:     "critical",
+				Summary:      m[1],
+				Detail:       line,
+			})
+			continue
+		}
+
+		if m := genericErrorRe.FindStringSubmatch(line); m != nil {
+			errors = append(errors, CompositeError{
+				OwnerType: ownerType,
+				Severity:     "critical",
+				Summary:      m[1],
+				Detail:       line,
+			})
+			continue
+		}
+	}
+
+	// If no recognized patterns were found, use the last non-empty line as summary
+	// with the full stderr as detail.
+	if len(errors) == 0 {
+		lastLine := lastNonEmptyLine(lines)
+		if lastLine != "" {
+			errors = append(errors, CompositeError{
+				OwnerType: ownerType,
+				Severity:     "critical",
+				Summary:      lastLine,
+				Detail:       stderr,
+			})
+		}
+	}
+
+	return errors
+}
+
+func lastNonEmptyLine(lines []string) string {
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}

--- a/bins/runner/internal/pkg/composite_errors/helm_k8s.go
+++ b/bins/runner/internal/pkg/composite_errors/helm_k8s.go
@@ -1,0 +1,185 @@
+package composite_errors
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	diagnosticsTimeout = 30 * time.Second
+	maxLogLines        = 50
+)
+
+// CollectHelmK8sDiagnostics queries the Kubernetes cluster after a Helm failure
+// to gather diagnostic information about failing resources: pod statuses, events,
+// and container logs. It returns structured composite errors for each finding.
+func CollectHelmK8sDiagnostics(ctx context.Context, client kubernetes.Interface, namespace, releaseName string) []CompositeError {
+	ctx, cancel := context.WithTimeout(ctx, diagnosticsTimeout)
+	defer cancel()
+
+	var errs []CompositeError
+
+	// Collect pod diagnostics for the release
+	errs = append(errs, collectPodDiagnostics(ctx, client, namespace, releaseName)...)
+
+	// Collect recent warning events for the namespace filtered by release
+	errs = append(errs, collectEventDiagnostics(ctx, client, namespace, releaseName)...)
+
+	return errs
+}
+
+func collectPodDiagnostics(ctx context.Context, client kubernetes.Interface, namespace, releaseName string) []CompositeError {
+	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/instance=%s", releaseName),
+	})
+	if err != nil {
+		return nil
+	}
+
+	var errs []CompositeError
+	for _, pod := range pods.Items {
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Ready {
+				continue
+			}
+
+			ce := diagnoseContainerStatus(ctx, client, namespace, pod.Name, cs)
+			if ce != nil {
+				errs = append(errs, *ce)
+			}
+		}
+
+		for _, cs := range pod.Status.InitContainerStatuses {
+			if cs.Ready {
+				continue
+			}
+
+			ce := diagnoseContainerStatus(ctx, client, namespace, pod.Name, cs)
+			if ce != nil {
+				errs = append(errs, *ce)
+			}
+		}
+	}
+
+	return errs
+}
+
+func diagnoseContainerStatus(ctx context.Context, client kubernetes.Interface, namespace, podName string, cs corev1.ContainerStatus) *CompositeError {
+	metadata := map[string]any{
+		"pod":       podName,
+		"container": cs.Name,
+		"namespace": namespace,
+	}
+
+	var summary string
+
+	if cs.State.Waiting != nil {
+		summary = fmt.Sprintf("Container %s/%s: %s", podName, cs.Name, cs.State.Waiting.Reason)
+		metadata["reason"] = cs.State.Waiting.Reason
+		if cs.State.Waiting.Message != "" {
+			metadata["message"] = cs.State.Waiting.Message
+		}
+	} else if cs.State.Terminated != nil {
+		summary = fmt.Sprintf("Container %s/%s: terminated with exit code %d", podName, cs.Name, cs.State.Terminated.ExitCode)
+		metadata["reason"] = cs.State.Terminated.Reason
+		metadata["exit_code"] = cs.State.Terminated.ExitCode
+	} else {
+		return nil
+	}
+
+	// Try to get container logs for non-ready containers
+	detail := getContainerLogs(ctx, client, namespace, podName, cs.Name)
+
+	return &CompositeError{
+		OwnerType: "k8s-diagnostics",
+		Severity:     "critical",
+		Summary:      summary,
+		Detail:       detail,
+		Metadata:     metadata,
+	}
+}
+
+func getContainerLogs(ctx context.Context, client kubernetes.Interface, namespace, podName, containerName string) string {
+	tailLines := int64(maxLogLines)
+	logOpts := &corev1.PodLogOptions{
+		Container: containerName,
+		TailLines: &tailLines,
+	}
+
+	// Try previous container logs first (for crash loops)
+	logOpts.Previous = true
+	logs, err := client.CoreV1().Pods(namespace).GetLogs(podName, logOpts).Do(ctx).Raw()
+	if err != nil || len(logs) == 0 {
+		// Fall back to current container logs
+		logOpts.Previous = false
+		logs, err = client.CoreV1().Pods(namespace).GetLogs(podName, logOpts).Do(ctx).Raw()
+		if err != nil {
+			return ""
+		}
+	}
+
+	return string(logs)
+}
+
+func collectEventDiagnostics(ctx context.Context, client kubernetes.Interface, namespace, releaseName string) []CompositeError {
+	events, err := client.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil
+	}
+
+	var errs []CompositeError
+	cutoff := time.Now().Add(-10 * time.Minute)
+
+	for _, event := range events.Items {
+		if event.Type != corev1.EventTypeWarning {
+			continue
+		}
+
+		// Filter to recent events
+		eventTime := event.LastTimestamp.Time
+		if eventTime.IsZero() {
+			eventTime = event.CreationTimestamp.Time
+		}
+		if eventTime.Before(cutoff) {
+			continue
+		}
+
+		// Filter to events related to the release by checking involved object labels
+		// Events don't carry labels directly, so we match on namespace and look for
+		// common failure patterns
+		if !isRelevantEvent(event, releaseName) {
+			continue
+		}
+
+		metadata := map[string]any{
+			"namespace": namespace,
+			"reason":    event.Reason,
+			"kind":      event.InvolvedObject.Kind,
+			"name":      event.InvolvedObject.Name,
+		}
+
+		errs = append(errs, CompositeError{
+			OwnerType: "k8s-diagnostics",
+			Severity:     "warning",
+			Summary:      fmt.Sprintf("%s %s/%s: %s", event.Reason, event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Message),
+			Metadata:     metadata,
+		})
+	}
+
+	return errs
+}
+
+func isRelevantEvent(event corev1.Event, releaseName string) bool {
+	// Match events whose involved object name contains the release name
+	name := event.InvolvedObject.Name
+	if strings.Contains(name, releaseName) {
+		return true
+	}
+	return false
+}

--- a/bins/runner/internal/pkg/composite_errors/helm_k8s_test.go
+++ b/bins/runner/internal/pkg/composite_errors/helm_k8s_test.go
@@ -1,0 +1,198 @@
+package composite_errors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCollectHelmK8sDiagnostics_CrashLoopBackOff(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-app-abc123",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app.kubernetes.io/instance": "my-app",
+				},
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "web",
+						Ready: false,
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason:  "CrashLoopBackOff",
+								Message: "back-off 5m0s restarting failed container",
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	errs := CollectHelmK8sDiagnostics(context.Background(), client, "default", "my-app")
+	require.NotEmpty(t, errs)
+
+	found := false
+	for _, e := range errs {
+		if e.OwnerType == "k8s-diagnostics" && e.Metadata["reason"] == "CrashLoopBackOff" {
+			found = true
+			assert.Contains(t, e.Summary, "CrashLoopBackOff")
+			assert.Equal(t, "critical", e.Severity)
+			assert.Equal(t, "web", e.Metadata["container"])
+			assert.Equal(t, "my-app-abc123", e.Metadata["pod"])
+		}
+	}
+	assert.True(t, found, "expected CrashLoopBackOff diagnostic")
+}
+
+func TestCollectHelmK8sDiagnostics_TerminatedContainer(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-app-xyz789",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app.kubernetes.io/instance": "my-app",
+				},
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "worker",
+						Ready: false,
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+								Reason:   "Error",
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	errs := CollectHelmK8sDiagnostics(context.Background(), client, "default", "my-app")
+	require.NotEmpty(t, errs)
+
+	found := false
+	for _, e := range errs {
+		if e.Metadata["container"] == "worker" {
+			found = true
+			assert.Contains(t, e.Summary, "exit code 1")
+			assert.Equal(t, int32(1), e.Metadata["exit_code"])
+		}
+	}
+	assert.True(t, found, "expected terminated container diagnostic")
+}
+
+func TestCollectHelmK8sDiagnostics_WarningEvents(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-app-abc123.event1",
+				Namespace: "default",
+			},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Pod",
+				Name: "my-app-abc123",
+			},
+			Type:          corev1.EventTypeWarning,
+			Reason:        "FailedPullImage",
+			Message:       "Failed to pull image \"nginx:invalid\": rpc error: code = NotFound",
+			LastTimestamp:  metav1.Now(),
+		},
+	)
+
+	errs := CollectHelmK8sDiagnostics(context.Background(), client, "default", "my-app")
+	require.NotEmpty(t, errs)
+
+	found := false
+	for _, e := range errs {
+		if e.Severity == "warning" && e.Metadata["reason"] == "FailedPullImage" {
+			found = true
+			assert.Contains(t, e.Summary, "Failed to pull image")
+		}
+	}
+	assert.True(t, found, "expected warning event diagnostic")
+}
+
+func TestCollectHelmK8sDiagnostics_NoPods(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	errs := CollectHelmK8sDiagnostics(context.Background(), client, "default", "my-app")
+	assert.Empty(t, errs)
+}
+
+func TestCollectHelmK8sDiagnostics_AllReady(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-app-healthy",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app.kubernetes.io/instance": "my-app",
+				},
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "web",
+						Ready: true,
+					},
+				},
+			},
+		},
+	)
+
+	errs := CollectHelmK8sDiagnostics(context.Background(), client, "default", "my-app")
+	assert.Empty(t, errs)
+}
+
+func TestCollectHelmK8sDiagnostics_InitContainerFailure(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-app-init",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app.kubernetes.io/instance": "my-app",
+				},
+			},
+			Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "migrate",
+						Ready: false,
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 2,
+								Reason:   "Error",
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	errs := CollectHelmK8sDiagnostics(context.Background(), client, "default", "my-app")
+	require.NotEmpty(t, errs)
+
+	found := false
+	for _, e := range errs {
+		if e.Metadata["container"] == "migrate" {
+			found = true
+			assert.Contains(t, e.Summary, "exit code 2")
+		}
+	}
+	assert.True(t, found, "expected init container failure diagnostic")
+}

--- a/bins/runner/internal/pkg/composite_errors/helm_test.go
+++ b/bins/runner/internal/pkg/composite_errors/helm_test.go
@@ -1,0 +1,118 @@
+package composite_errors
+
+import (
+	"testing"
+)
+
+func TestParseHelmStderr_TemplateError(t *testing.T) {
+	stderr := `Error: template: mychart/templates/deployment.yaml:12:5: executing "mychart/templates/deployment.yaml" at <.Values.missing>: nil pointer evaluating interface {}.missing`
+
+	errors := ParseHelmStderr(stderr, "helm-install")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+
+	ce := errors[0]
+	if ce.OwnerType != "helm-install" {
+		t.Errorf("expected owner_type helm-install, got %s", ce.OwnerType)
+	}
+	if ce.Severity != "critical" {
+		t.Errorf("expected severity critical, got %s", ce.Severity)
+	}
+	if ce.Metadata["template"] != "mychart/templates/deployment.yaml" {
+		t.Errorf("expected template metadata, got %v", ce.Metadata["template"])
+	}
+	if ce.Metadata["line"] != "12" {
+		t.Errorf("expected line 12, got %v", ce.Metadata["line"])
+	}
+	if ce.Metadata["column"] != "5" {
+		t.Errorf("expected column 5, got %v", ce.Metadata["column"])
+	}
+}
+
+func TestParseHelmStderr_InstallFailed(t *testing.T) {
+	stderr := `Error: INSTALLATION FAILED: timed out waiting for the condition`
+
+	errors := ParseHelmStderr(stderr, "helm-install")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+
+	ce := errors[0]
+	if ce.Summary != "timed out waiting for the condition" {
+		t.Errorf("unexpected summary: %s", ce.Summary)
+	}
+	if ce.Severity != "critical" {
+		t.Errorf("expected severity critical, got %s", ce.Severity)
+	}
+}
+
+func TestParseHelmStderr_UpgradeFailed(t *testing.T) {
+	stderr := `Error: UPGRADE FAILED: release my-release does not exist`
+
+	errors := ParseHelmStderr(stderr, "helm-upgrade")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+
+	if errors[0].Summary != "release my-release does not exist" {
+		t.Errorf("unexpected summary: %s", errors[0].Summary)
+	}
+}
+
+func TestParseHelmStderr_GenericError(t *testing.T) {
+	stderr := `Error: could not find chart mychart in repo https://charts.example.com`
+
+	errors := ParseHelmStderr(stderr, "helm-install")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+
+	if errors[0].Summary != "could not find chart mychart in repo https://charts.example.com" {
+		t.Errorf("unexpected summary: %s", errors[0].Summary)
+	}
+}
+
+func TestParseHelmStderr_MultipleErrors(t *testing.T) {
+	stderr := `Error: INSTALLATION FAILED: first problem
+Error: INSTALLATION FAILED: second problem`
+
+	errors := ParseHelmStderr(stderr, "helm-install")
+
+	if len(errors) != 2 {
+		t.Fatalf("expected 2 errors, got %d", len(errors))
+	}
+}
+
+func TestParseHelmStderr_UnrecognizedPattern(t *testing.T) {
+	stderr := `coalesce.go:286: warning: cannot overwrite table with non table for mykey
+some other output
+the final meaningful line`
+
+	errors := ParseHelmStderr(stderr, "helm-install")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 fallback error, got %d", len(errors))
+	}
+
+	ce := errors[0]
+	if ce.Summary != "the final meaningful line" {
+		t.Errorf("expected last non-empty line as summary, got %s", ce.Summary)
+	}
+	if ce.Detail != stderr {
+		t.Errorf("expected full stderr as detail")
+	}
+}
+
+func TestParseHelmStderr_EmptyInput(t *testing.T) {
+	if errors := ParseHelmStderr("", "helm-install"); errors != nil {
+		t.Errorf("expected nil for empty input, got %v", errors)
+	}
+	if errors := ParseHelmStderr("   \n  \n  ", "helm-install"); errors != nil {
+		t.Errorf("expected nil for whitespace-only input, got %v", errors)
+	}
+}

--- a/bins/runner/internal/pkg/composite_errors/terraform.go
+++ b/bins/runner/internal/pkg/composite_errors/terraform.go
@@ -1,0 +1,107 @@
+package composite_errors
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// terraformJSONLine represents a single line of terraform -json output.
+type terraformJSONLine struct {
+	Level   string               `json:"@level"`
+	Message string               `json:"@message"`
+	Module  string               `json:"@module"`
+	Type    string               `json:"type"`
+	Diag    *terraformDiagnostic `json:"diagnostic,omitempty"`
+}
+
+type terraformDiagnostic struct {
+	Severity string          `json:"severity"`
+	Summary  string          `json:"summary"`
+	Detail   string          `json:"detail"`
+	Address  string          `json:"address"`
+	Range    *terraformRange `json:"range,omitempty"`
+}
+
+type terraformRange struct {
+	Filename string            `json:"filename"`
+	Start    terraformPosition `json:"start"`
+	End      terraformPosition `json:"end"`
+}
+
+type terraformPosition struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+// ParseTerraformJSON parses terraform JSON output lines and extracts diagnostics
+// into CompositeError values. Lines that are not diagnostics or error-level messages
+// are skipped. Malformed JSON lines are silently ignored.
+func ParseTerraformJSON(jsonOutput []byte, ownerType string) []CompositeError {
+	if len(jsonOutput) == 0 {
+		return nil
+	}
+
+	var errors []CompositeError
+
+	lines := bytes.Split(jsonOutput, []byte("\n"))
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+
+		var parsed terraformJSONLine
+		if err := json.Unmarshal(line, &parsed); err != nil {
+			continue
+		}
+
+		// Only process diagnostic lines or error-level messages.
+		if parsed.Type != "diagnostic" && parsed.Level != "error" {
+			continue
+		}
+
+		ce := CompositeError{
+			OwnerType: ownerType,
+			Metadata:     make(map[string]any),
+		}
+
+		if parsed.Diag != nil {
+			ce.Summary = parsed.Diag.Summary
+			ce.Detail = parsed.Diag.Detail
+			ce.Severity = mapTerraformSeverity(parsed.Diag.Severity)
+
+			if parsed.Diag.Address != "" {
+				ce.Metadata["resource"] = parsed.Diag.Address
+			}
+			if parsed.Diag.Range != nil {
+				ce.Metadata["file"] = parsed.Diag.Range.Filename
+				ce.Metadata["line"] = parsed.Diag.Range.Start.Line
+				ce.Metadata["column"] = parsed.Diag.Range.Start.Column
+			}
+		} else {
+			// Error-level line without a diagnostic block.
+			ce.Summary = parsed.Message
+			ce.Severity = "critical"
+		}
+
+		// Drop empty metadata maps to keep output clean.
+		if len(ce.Metadata) == 0 {
+			ce.Metadata = nil
+		}
+
+		errors = append(errors, ce)
+	}
+
+	return errors
+}
+
+func mapTerraformSeverity(s string) string {
+	switch s {
+	case "error":
+		return "critical"
+	case "warning":
+		return "warning"
+	default:
+		return s
+	}
+}

--- a/bins/runner/internal/pkg/composite_errors/terraform_test.go
+++ b/bins/runner/internal/pkg/composite_errors/terraform_test.go
@@ -1,0 +1,135 @@
+package composite_errors
+
+import (
+	"testing"
+)
+
+func TestParseTerraformJSON_DiagnosticError(t *testing.T) {
+	input := []byte(`{"@level":"error","@message":"Error: Invalid reference","@module":"terraform.ui","type":"diagnostic","diagnostic":{"severity":"error","summary":"Invalid reference","detail":"A reference to var.missing was not found.","address":"aws_instance.web","range":{"filename":"main.tf","start":{"line":42,"column":5},"end":{"line":42,"column":20}}}}`)
+
+	errors := ParseTerraformJSON(input, "plan")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+
+	ce := errors[0]
+	if ce.OwnerType != "plan" {
+		t.Errorf("expected owner_type terraform-plan, got %s", ce.OwnerType)
+	}
+	if ce.Severity != "critical" {
+		t.Errorf("expected severity critical, got %s", ce.Severity)
+	}
+	if ce.Summary != "Invalid reference" {
+		t.Errorf("expected summary 'Invalid reference', got %s", ce.Summary)
+	}
+	if ce.Detail != "A reference to var.missing was not found." {
+		t.Errorf("unexpected detail: %s", ce.Detail)
+	}
+	if ce.Metadata["resource"] != "aws_instance.web" {
+		t.Errorf("expected resource aws_instance.web, got %v", ce.Metadata["resource"])
+	}
+	if ce.Metadata["file"] != "main.tf" {
+		t.Errorf("expected file main.tf, got %v", ce.Metadata["file"])
+	}
+	if ce.Metadata["line"] != 42 {
+		t.Errorf("expected line 42, got %v", ce.Metadata["line"])
+	}
+	if ce.Metadata["column"] != 5 {
+		t.Errorf("expected column 5, got %v", ce.Metadata["column"])
+	}
+}
+
+func TestParseTerraformJSON_Warning(t *testing.T) {
+	input := []byte(`{"@level":"warn","@message":"Warning: Deprecated attribute","@module":"terraform.ui","type":"diagnostic","diagnostic":{"severity":"warning","summary":"Deprecated attribute","detail":"Use new_attr instead."}}`)
+
+	errors := ParseTerraformJSON(input, "apply")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+
+	ce := errors[0]
+	if ce.Severity != "warning" {
+		t.Errorf("expected severity warning, got %s", ce.Severity)
+	}
+	if ce.Summary != "Deprecated attribute" {
+		t.Errorf("expected summary 'Deprecated attribute', got %s", ce.Summary)
+	}
+	if ce.Metadata != nil {
+		t.Errorf("expected nil metadata for warning without address/range, got %v", ce.Metadata)
+	}
+}
+
+func TestParseTerraformJSON_MixedOutput(t *testing.T) {
+	input := []byte(`{"@level":"info","@message":"Terraform has been successfully initialized!","@module":"terraform.ui","type":"version"}
+{"@level":"info","@message":"Plan: 1 to add","@module":"terraform.ui","type":"change_summary"}
+{"@level":"error","@message":"Error: Missing variable","@module":"terraform.ui","type":"diagnostic","diagnostic":{"severity":"error","summary":"Missing variable","detail":"Variable 'region' is required."}}`)
+
+	errors := ParseTerraformJSON(input, "plan")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error from mixed output, got %d", len(errors))
+	}
+
+	if errors[0].Summary != "Missing variable" {
+		t.Errorf("expected summary 'Missing variable', got %s", errors[0].Summary)
+	}
+}
+
+func TestParseTerraformJSON_MultipleErrors(t *testing.T) {
+	input := []byte(`{"@level":"error","@message":"Error: Invalid reference","@module":"terraform.ui","type":"diagnostic","diagnostic":{"severity":"error","summary":"Invalid reference","detail":"bad ref"}}
+{"@level":"warn","@message":"Warning: Deprecated","@module":"terraform.ui","type":"diagnostic","diagnostic":{"severity":"warning","summary":"Deprecated feature","detail":"use new thing"}}`)
+
+	errors := ParseTerraformJSON(input, "plan")
+
+	if len(errors) != 2 {
+		t.Fatalf("expected 2 errors, got %d", len(errors))
+	}
+	if errors[0].Severity != "critical" {
+		t.Errorf("first error should be critical, got %s", errors[0].Severity)
+	}
+	if errors[1].Severity != "warning" {
+		t.Errorf("second error should be warning, got %s", errors[1].Severity)
+	}
+}
+
+func TestParseTerraformJSON_EmptyInput(t *testing.T) {
+	if errors := ParseTerraformJSON(nil, "plan"); errors != nil {
+		t.Errorf("expected nil for nil input, got %v", errors)
+	}
+	if errors := ParseTerraformJSON([]byte{}, "plan"); errors != nil {
+		t.Errorf("expected nil for empty input, got %v", errors)
+	}
+}
+
+func TestParseTerraformJSON_MalformedJSON(t *testing.T) {
+	input := []byte(`not json at all
+{"@level":"error","@message":"Error: Bad thing","@module":"terraform.ui","type":"diagnostic","diagnostic":{"severity":"error","summary":"Bad thing","detail":"details"}}
+{truncated json...`)
+
+	errors := ParseTerraformJSON(input, "plan")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error (malformed lines skipped), got %d", len(errors))
+	}
+	if errors[0].Summary != "Bad thing" {
+		t.Errorf("expected summary 'Bad thing', got %s", errors[0].Summary)
+	}
+}
+
+func TestParseTerraformJSON_ErrorLevelWithoutDiagnostic(t *testing.T) {
+	input := []byte(`{"@level":"error","@message":"Error: Failed to load backend","@module":"terraform.ui","type":"error_message"}`)
+
+	errors := ParseTerraformJSON(input, "terraform-init")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+	if errors[0].Summary != "Error: Failed to load backend" {
+		t.Errorf("expected message as summary, got %s", errors[0].Summary)
+	}
+	if errors[0].Severity != "critical" {
+		t.Errorf("expected critical severity, got %s", errors[0].Severity)
+	}
+}

--- a/pkg/pipeline/exec_step.go
+++ b/pkg/pipeline/exec_step.go
@@ -12,6 +12,7 @@ func (p *Pipeline) execStep(ctx context.Context, step *Step) error {
 	}
 
 	byts, err := step.ExecFn(ctx, p.Log)
+	p.LastStepOutput = byts
 	if err != nil {
 		return fmt.Errorf("unable to execute: %w", err)
 	}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -19,6 +19,11 @@ type Pipeline struct {
 	Steps []*Step `validate_steps:"required,gt=1"`
 
 	Log hclog.Logger `validate:"required"`
+
+	// LastStepOutput holds the output bytes from the last executed step,
+	// even if that step returned an error. This allows callers to inspect
+	// partial output (e.g. terraform JSON diagnostics) after a failure.
+	LastStepOutput []byte `validate:"-"`
 }
 
 type pipelineOption func(*Pipeline) error

--- a/pkg/terraform/run/apply.go
+++ b/pkg/terraform/run/apply.go
@@ -16,6 +16,7 @@ func (r *run) Apply(ctx context.Context) error {
 	}
 
 	if err := pipe.Run(ctx); err != nil {
+		r.lastOutputBytes = pipe.LastStepOutput
 		return fmt.Errorf("unable to execute apply pipeline: %w", err)
 	}
 

--- a/pkg/terraform/run/apply_plan.go
+++ b/pkg/terraform/run/apply_plan.go
@@ -16,6 +16,7 @@ func (r *run) ApplyPlan(ctx context.Context) error {
 	}
 
 	if err := pipe.Run(ctx); err != nil {
+		r.lastOutputBytes = pipe.LastStepOutput
 		return fmt.Errorf("unable to execute apply pipeline: %w", err)
 	}
 

--- a/pkg/terraform/run/destroy.go
+++ b/pkg/terraform/run/destroy.go
@@ -16,6 +16,7 @@ func (r *run) Destroy(ctx context.Context) error {
 	}
 
 	if err := pipe.Run(ctx); err != nil {
+		r.lastOutputBytes = pipe.LastStepOutput
 		return fmt.Errorf("unable to execute destroy pipeline: %w", err)
 	}
 

--- a/pkg/terraform/run/destroy_plan.go
+++ b/pkg/terraform/run/destroy_plan.go
@@ -17,6 +17,7 @@ func (r *run) DestroyPlan(ctx context.Context) error {
 	}
 
 	if err := pipe.Run(ctx); err != nil {
+		r.lastOutputBytes = pipe.LastStepOutput
 		return fmt.Errorf("unable to execute destroy pipeline: %w", err)
 	}
 

--- a/pkg/terraform/run/plan.go
+++ b/pkg/terraform/run/plan.go
@@ -19,6 +19,7 @@ func (r *run) Plan(ctx context.Context) error {
 	}
 
 	if err := pipe.Run(ctx); err != nil {
+		r.lastOutputBytes = pipe.LastStepOutput
 		return fmt.Errorf("unable execute plan pipeline: %w", err)
 	}
 

--- a/pkg/terraform/run/run.go
+++ b/pkg/terraform/run/run.go
@@ -30,6 +30,11 @@ type Run interface {
 	Plan(context.Context) error
 	Destroy(context.Context) error
 	DestroyPlan(context.Context) error
+
+	// LastOutputBytes returns the output bytes from the last pipeline step
+	// that executed, even if it failed. Useful for extracting structured
+	// error output (e.g. terraform JSON diagnostics) after a run error.
+	LastOutputBytes() []byte
 }
 
 var _ Run = (*run)(nil)
@@ -40,6 +45,12 @@ type run struct {
 	Workspace      workspace.Workspace `validate:"required"`
 	Log            hclog.Logger        `validate:"required"`
 	OutputSettings *OutputSettings     `validate:"required"`
+
+	lastOutputBytes []byte
+}
+
+func (r *run) LastOutputBytes() []byte {
+	return r.lastOutputBytes
 }
 
 type runOption func(*run) error

--- a/pkg/terraform/run/validate.go
+++ b/pkg/terraform/run/validate.go
@@ -16,6 +16,7 @@ func (r *run) Validate(ctx context.Context) error {
 	}
 
 	if err := pipe.Run(ctx); err != nil {
+		r.lastOutputBytes = pipe.LastStepOutput
 		return fmt.Errorf("unable to execute validate pipeline: %w", err)
 	}
 

--- a/pkg/terraform/workspace/plan.go
+++ b/pkg/terraform/workspace/plan.go
@@ -53,8 +53,8 @@ func (w *workspace) plan(ctx context.Context, client Terraform, log hclog.Logger
 		writer,
 		opts...,
 	); err != nil {
-		fmt.Printf("%e", err)
-		return nil, fmt.Errorf("unable to plan: %w", err)
+		outBytes, _ := out.Bytes()
+		return outBytes, fmt.Errorf("unable to plan: %w", err)
 	}
 
 	log.Debug("plan diff", zap.Bool("diff.exists", diffExists))

--- a/pkg/terraform/workspace/terraform.go
+++ b/pkg/terraform/workspace/terraform.go
@@ -44,9 +44,9 @@ func (w *workspace) Apply(ctx context.Context, log hclog.Logger) ([]byte, error)
 	byts, err := w.apply(ctx, client, log)
 	if err != nil {
 		if hookErr := w.Hooks.ErrorApply(ctx, log); hookErr != nil {
-			return nil, fmt.Errorf("error executing error-apply hook: %w: original-error: %w", hookErr, err)
+			return byts, fmt.Errorf("error executing error-apply hook: %w: original-error: %w", hookErr, err)
 		}
-		return nil, err
+		return byts, err
 	}
 
 	if err := w.Hooks.PostApply(ctx, log); err != nil {
@@ -77,7 +77,8 @@ func (w *workspace) apply(ctx context.Context, client Terraform, log hclog.Logge
 		writer,
 		opts...,
 	); err != nil {
-		return nil, fmt.Errorf("error running apply: %w", err)
+		outBytes, _ := out.Bytes()
+		return outBytes, fmt.Errorf("error running apply: %w", err)
 	}
 
 	return out.Bytes()
@@ -96,9 +97,9 @@ func (w *workspace) Destroy(ctx context.Context, log hclog.Logger) ([]byte, erro
 	byts, err := w.destroy(ctx, client, log)
 	if err != nil {
 		if hookErr := w.Hooks.ErrorDestroy(ctx, log); hookErr != nil {
-			return nil, fmt.Errorf("error executing error-destroy hook: %w: original-error: %w", hookErr, err)
+			return byts, fmt.Errorf("error executing error-destroy hook: %w: original-error: %w", hookErr, err)
 		}
-		return nil, err
+		return byts, err
 	}
 
 	if err := w.Hooks.PostDestroy(ctx, log); err != nil {
@@ -130,7 +131,8 @@ func (w *workspace) destroy(ctx context.Context, client Terraform, log hclog.Log
 		writer,
 		opts...,
 	); err != nil {
-		return nil, fmt.Errorf("error running destroy: %w", err)
+		outBytes, _ := out.Bytes()
+		return outBytes, fmt.Errorf("error running destroy: %w", err)
 	}
 
 	return out.Bytes()
@@ -165,7 +167,8 @@ func (w *workspace) refresh(ctx context.Context, client Terraform, log hclog.Log
 		writer,
 		opts...,
 	); err != nil {
-		return nil, fmt.Errorf("unable to execute refresh: %w", err)
+		outBytes, _ := out.Bytes()
+		return outBytes, fmt.Errorf("unable to execute refresh: %w", err)
 	}
 
 	return out.Bytes()
@@ -243,9 +246,9 @@ func (w *workspace) ApplyPlan(ctx context.Context, log hclog.Logger) ([]byte, er
 	byts, err := w.applyPlan(ctx, client, log)
 	if err != nil {
 		if hookErr := w.Hooks.ErrorApply(ctx, log); hookErr != nil {
-			return nil, fmt.Errorf("error executing error-apply hook: %w: original-error: %w", hookErr, err)
+			return byts, fmt.Errorf("error executing error-apply hook: %w: original-error: %w", hookErr, err)
 		}
-		return nil, err
+		return byts, err
 	}
 
 	if err := w.Hooks.PostApply(ctx, log); err != nil {
@@ -277,7 +280,8 @@ func (w *workspace) applyPlan(ctx context.Context, client Terraform, log hclog.L
 		writer,
 		opts...,
 	); err != nil {
-		return nil, fmt.Errorf("error running apply: %w", err)
+		outBytes, _ := out.Bytes()
+		return outBytes, fmt.Errorf("error running apply: %w", err)
 	}
 
 	return out.Bytes()
@@ -297,9 +301,9 @@ func (w *workspace) ApplyDestroyPlan(ctx context.Context, log hclog.Logger) ([]b
 	byts, err := w.applyDestroyPlan(ctx, client, log)
 	if err != nil {
 		if hookErr := w.Hooks.ErrorApply(ctx, log); hookErr != nil {
-			return nil, fmt.Errorf("error executing error-apply hook: %w: original-error: %w", hookErr, err)
+			return byts, fmt.Errorf("error executing error-apply hook: %w: original-error: %w", hookErr, err)
 		}
-		return nil, err
+		return byts, err
 	}
 
 	if err := w.Hooks.PostApply(ctx, log); err != nil {
@@ -331,7 +335,8 @@ func (w *workspace) applyDestroyPlan(ctx context.Context, client Terraform, log 
 		writer,
 		opts...,
 	); err != nil {
-		return nil, fmt.Errorf("error running apply: %w", err)
+		outBytes, _ := out.Bytes()
+		return outBytes, fmt.Errorf("error running apply: %w", err)
 	}
 
 	return out.Bytes()

--- a/sdks/nuon-runner-go/client.go
+++ b/sdks/nuon-runner-go/client.go
@@ -31,6 +31,7 @@ type Client interface {
 	GetJobPlanJSON(ctx context.Context, jobID string) (string, error)
 	GetJobCompositePlan(ctx context.Context, jobID string) (*models.PlantypesCompositePlan, error)
 	UpdateJob(ctx context.Context, jobID string, req *models.ServiceUpdateRunnerJobRequest) (*models.AppRunnerJob, error)
+	ReportCompositeErrors(ctx context.Context, jobID string, errors []models.CompositeError) error
 
 	// job executions
 	GetJobExecutions(ctx context.Context, jobID string) ([]*models.AppRunnerJobExecution, error)

--- a/sdks/nuon-runner-go/composite_errors.go
+++ b/sdks/nuon-runner-go/composite_errors.go
@@ -1,0 +1,48 @@
+package nuonrunner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
+)
+
+func (c *client) ReportCompositeErrors(ctx context.Context, jobID string, errors []models.CompositeError) error {
+	reqBody := models.ReportCompositeErrorsRequest{
+		Errors: errors,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("unable to marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/v1/runner-jobs/%s/errors", c.APIURL, jobID)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("unable to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := c.appTransport.RoundTrip(httpReq)
+	if err != nil {
+		return fmt.Errorf("unable to report composite errors: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return fmt.Errorf("unable to read response: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("unexpected status %d: %s", httpResp.StatusCode, string(respBody))
+	}
+
+	return nil
+}

--- a/sdks/nuon-runner-go/models/composite_error.go
+++ b/sdks/nuon-runner-go/models/composite_error.go
@@ -1,0 +1,13 @@
+package models
+
+type CompositeError struct {
+	OwnerType string         `json:"owner_type"`
+	Severity  string         `json:"severity"`
+	Summary   string         `json:"summary"`
+	Detail    string         `json:"detail,omitempty"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+type ReportCompositeErrorsRequest struct {
+	Errors []CompositeError `json:"errors"`
+}

--- a/services/ctl-api/internal/app/actions/service/create_adhoc_action.go
+++ b/services/ctl-api/internal/app/actions/service/create_adhoc_action.go
@@ -169,7 +169,7 @@ func (s *service) CreateAdHocAction(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/actions/service/create_install_action_workflow_run.go
+++ b/services/ctl-api/internal/app/actions/service/create_install_action_workflow_run.go
@@ -123,7 +123,7 @@ func (s *service) CreateInstallActionWorkflowRun(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/actions/service/signal_helpers.go
+++ b/services/ctl-api/internal/app/actions/service/signal_helpers.go
@@ -25,10 +25,12 @@ func (s *service) getInstallWorkflowsQueueID(ctx context.Context, installID stri
 }
 
 // enqueueInstallSignal enqueues a v2 signal to the given install queue.
-func (s *service) enqueueInstallSignal(ctx context.Context, queueID string, sig signal.Signal) error {
+func (s *service) enqueueInstallSignal(ctx context.Context, queueID string, sig signal.Signal, ownerID, ownerType string) error {
 	_, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
-		QueueID: queueID,
-		Signal:  sig,
+		QueueID:   queueID,
+		Signal:    sig,
+		OwnerID:   ownerID,
+		OwnerType: ownerType,
 	})
 	return err
 }

--- a/services/ctl-api/internal/app/admin-dashboard/service/install_detail.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/install_detail.go
@@ -160,6 +160,59 @@ func (s *service) InstallActivityTable(c *gin.Context) {
 	templ.Handler(component).ServeHTTP(c.Writer, c.Request)
 }
 
+const installWorkflowsPerPage = 10
+
+// InstallWorkflowsTable handles the HTMX endpoint for install workflows
+func (s *service) InstallWorkflowsTable(c *gin.Context) {
+	ctx := c.Request.Context()
+	installID := c.Param("id")
+	page := getPageFromQuery(c)
+
+	if installID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "install ID required"})
+		return
+	}
+
+	workflows, totalPages, err := s.getWorkflowsForInstall(ctx, installID, page)
+	if err != nil {
+		s.l.Error("failed to fetch install workflows", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch workflows"})
+		return
+	}
+
+	component := views.InstallWorkflowsTable(installID, workflows, page, totalPages)
+	templ.Handler(component).ServeHTTP(c.Writer, c.Request)
+}
+
+func (s *service) getWorkflowsForInstall(ctx context.Context, installID string, page int) ([]*app.Workflow, int, error) {
+	var totalCount int64
+	countQuery := s.db.WithContext(ctx).
+		Model(&app.Workflow{}).
+		Where("owner_id = ? AND owner_type = 'installs'", installID)
+
+	if err := countQuery.Count(&totalCount).Error; err != nil {
+		return nil, 0, fmt.Errorf("unable to count workflows: %w", err)
+	}
+
+	totalPages := int(math.Ceil(float64(totalCount) / float64(installWorkflowsPerPage)))
+	if totalPages == 0 {
+		totalPages = 1
+	}
+
+	offset := (page - 1) * installWorkflowsPerPage
+	var workflows []*app.Workflow
+	if err := s.db.WithContext(ctx).
+		Where("owner_id = ? AND owner_type = 'installs'", installID).
+		Order("created_at DESC").
+		Offset(offset).
+		Limit(installWorkflowsPerPage).
+		Find(&workflows).Error; err != nil {
+		return nil, 0, fmt.Errorf("unable to get workflows: %w", err)
+	}
+
+	return workflows, totalPages, nil
+}
+
 // getInstall fetches an install by ID with necessary preloads
 func (s *service) getInstall(c *gin.Context) (*app.Install, error) {
 	installID := c.Param("id")

--- a/services/ctl-api/internal/app/admin-dashboard/service/log_streams.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/log_streams.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/a-h/templ"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/service/views"
+)
+
+const logStreamLogsPerPage = 100
+
+// LogStreamViewer renders the log stream search page
+func (s *service) LogStreamViewer(c *gin.Context) {
+	component := views.LogStreamSearch()
+	templ.Handler(component).ServeHTTP(c.Writer, c.Request)
+}
+
+// LogStreamDetail renders the log stream detail page with logs
+func (s *service) LogStreamDetail(c *gin.Context) {
+	ctx := c.Request.Context()
+	logStreamID := c.Param("log_stream_id")
+	page := getPageFromQuery(c)
+
+	// Find log stream by ID or owner ID
+	ls, err := s.getLogStream(ctx, logStreamID)
+	if err != nil {
+		s.l.Error("failed to fetch log stream", zap.Error(err))
+		c.JSON(http.StatusNotFound, gin.H{"error": "Log stream not found"})
+		return
+	}
+
+	// Fetch logs from ClickHouse
+	logs, totalPages, err := s.getLogStreamLogs(ctx, ls.ID, ls.OrgID, page)
+	if err != nil {
+		s.l.Warn("failed to fetch log stream logs", zap.Error(err))
+		logs = []app.OtelLogRecord{}
+		totalPages = 1
+	}
+
+	component := views.LogStreamDetail(ls, logs, page, totalPages)
+	templ.Handler(component).ServeHTTP(c.Writer, c.Request)
+}
+
+// LogStreamLogsTable handles the HTMX endpoint for log pagination
+func (s *service) LogStreamLogsTable(c *gin.Context) {
+	ctx := c.Request.Context()
+	logStreamID := c.Param("log_stream_id")
+	page := getPageFromQuery(c)
+
+	ls, err := s.getLogStream(ctx, logStreamID)
+	if err != nil {
+		s.l.Error("failed to fetch log stream", zap.Error(err))
+		c.JSON(http.StatusNotFound, gin.H{"error": "Log stream not found"})
+		return
+	}
+
+	logs, totalPages, err := s.getLogStreamLogs(ctx, ls.ID, ls.OrgID, page)
+	if err != nil {
+		s.l.Error("failed to fetch logs", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch logs"})
+		return
+	}
+
+	component := views.LogStreamLogsTable(ls.ID, logs, page, totalPages)
+	templ.Handler(component).ServeHTTP(c.Writer, c.Request)
+}
+
+func (s *service) getLogStream(ctx context.Context, logStreamID string) (*app.LogStream, error) {
+	var ls app.LogStream
+	res := s.db.WithContext(ctx).
+		Where("id = ?", logStreamID).
+		Or("owner_id = ?", logStreamID).
+		First(&ls)
+	if res.Error != nil {
+		return nil, fmt.Errorf("unable to get log stream: %w", res.Error)
+	}
+	return &ls, nil
+}
+
+func (s *service) getLogStreamLogs(ctx context.Context, logStreamID, orgID string, page int) ([]app.OtelLogRecord, int, error) {
+	ctx, cancelFn := context.WithTimeout(ctx, time.Second*10)
+	defer cancelFn()
+
+	// Count total logs
+	var totalCount int64
+	countRes := s.chDB.WithContext(ctx).
+		Model(&app.OtelLogRecord{}).
+		Where("org_id = ?", orgID).
+		Where("log_stream_id = ?", logStreamID).
+		Count(&totalCount)
+	if countRes.Error != nil {
+		return nil, 0, fmt.Errorf("unable to count logs: %w", countRes.Error)
+	}
+
+	totalPages := int(math.Ceil(float64(totalCount) / float64(logStreamLogsPerPage)))
+	if totalPages == 0 {
+		totalPages = 1
+	}
+
+	if totalCount == 0 {
+		return []app.OtelLogRecord{}, totalPages, nil
+	}
+
+	offset := (page - 1) * logStreamLogsPerPage
+	var logs []app.OtelLogRecord
+	res := s.chDB.WithContext(ctx).
+		Where("org_id = ?", orgID).
+		Where("log_stream_id = ?", logStreamID).
+		Order("timestamp ASC").
+		Offset(offset).
+		Limit(logStreamLogsPerPage).
+		Find(&logs)
+	if res.Error != nil {
+		return nil, 0, fmt.Errorf("unable to retrieve logs: %w", res.Error)
+	}
+
+	return logs, totalPages, nil
+}
+
+// helper to format log count
+func formatLogCount(count int) string {
+	if count == 0 {
+		return "0"
+	}
+	return strconv.Itoa(count)
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/queue_signal_detail.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/queue_signal_detail.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/a-h/templ"
@@ -52,9 +53,23 @@ func (s *service) QueueSignalDetail(c *gin.Context) {
 }
 
 type scheduledActivity struct {
-	name        string
-	scheduledAt time.Time
-	input       string // JSON-formatted activity input
+	name           string
+	scheduledAt    time.Time
+	scheduledEvtID int64
+	input          string // JSON-formatted activity input
+}
+
+// updateState tracks an in-progress or completed workflow update.
+type updateState struct {
+	name          string
+	updateID      string
+	acceptedEvtID int64
+	startedAt     time.Time
+	finishedAt    time.Time
+	status        string
+	input         string
+	result        string
+	failure       string
 }
 
 func (s *service) getWorkflowInfo(c *gin.Context, namespace, workflowID string) *views.WorkflowInfo {
@@ -84,7 +99,21 @@ func (s *service) getWorkflowInfo(c *gin.Context, namespace, workflowID string) 
 	started := map[int64]time.Time{} // keyed by scheduled event ID
 	attempts := map[int64]int32{}    // keyed by scheduled event ID
 
+	// Track child workflows by initiated event ID
+	type childWFState struct {
+		workflowType string
+		workflowID   string
+		runID        string
+		namespace    string
+		startedAt    time.Time
+	}
+	childWFs := map[int64]childWFState{} // keyed by initiated event ID
+
+	// Track update executions by accepted event ID
+	updates := map[int64]*updateState{}
+
 	var activities []views.ActivityInfo
+	var childWorkflows []views.ChildWorkflowInfo
 
 	for iter.HasNext() {
 		event, err := iter.Next()
@@ -94,6 +123,47 @@ func (s *service) getWorkflowInfo(c *gin.Context, namespace, workflowID string) 
 		}
 
 		switch event.GetEventType() {
+		// Workflow Update tracking
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED:
+			attrs := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
+			if attrs != nil {
+				us := &updateState{
+					acceptedEvtID: event.GetEventId(),
+					startedAt:     event.GetEventTime().AsTime(),
+					status:        "Running",
+				}
+				if req := attrs.GetAcceptedRequest(); req != nil {
+					if meta := req.GetMeta(); meta != nil {
+						us.updateID = meta.GetUpdateId()
+					}
+					if input := req.GetInput(); input != nil {
+						us.name = input.GetName()
+						us.input = s.formatPayloads(input.GetArgs())
+					}
+				}
+				updates[event.GetEventId()] = us
+			}
+
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED:
+			attrs := event.GetWorkflowExecutionUpdateCompletedEventAttributes()
+			if attrs != nil {
+				if us, ok := updates[attrs.GetAcceptedEventId()]; ok {
+					us.finishedAt = event.GetEventTime().AsTime()
+					us.status = "Completed"
+					if outcome := attrs.GetOutcome(); outcome != nil {
+						if f := outcome.GetFailure(); f != nil {
+							us.status = "Failed"
+							us.failure = f.GetMessage()
+						} else if successPayloads := outcome.GetSuccess(); successPayloads != nil {
+							us.result = s.formatPayloads(successPayloads)
+						}
+					}
+				}
+			}
+
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REJECTED:
+			// Rejected updates don't have an accepted event, skip
+
 		case enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED:
 			attrs := event.GetActivityTaskScheduledEventAttributes()
 			if attrs != nil {
@@ -102,9 +172,10 @@ func (s *service) getWorkflowInfo(c *gin.Context, namespace, workflowID string) 
 					name = attrs.GetActivityType().GetName()
 				}
 				scheduled[event.GetEventId()] = scheduledActivity{
-					name:        name,
-					scheduledAt: event.GetEventTime().AsTime(),
-					input:       s.formatPayloads(attrs.GetInput()),
+					name:           name,
+					scheduledAt:    event.GetEventTime().AsTime(),
+					scheduledEvtID: event.GetEventId(),
+					input:          s.formatPayloads(attrs.GetInput()),
 				}
 			}
 
@@ -160,21 +231,134 @@ func (s *service) getWorkflowInfo(c *gin.Context, namespace, workflowID string) 
 					event, "Canceled", "",
 				))
 			}
+
+		// Child workflow tracking
+		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED:
+			attrs := event.GetChildWorkflowExecutionStartedEventAttributes()
+			if attrs != nil {
+				wfType := ""
+				if attrs.GetWorkflowType() != nil {
+					wfType = attrs.GetWorkflowType().GetName()
+				}
+				wfExec := attrs.GetWorkflowExecution()
+				state := childWFState{
+					workflowType: wfType,
+					startedAt:    event.GetEventTime().AsTime(),
+				}
+				if wfExec != nil {
+					state.workflowID = wfExec.GetWorkflowId()
+					state.runID = wfExec.GetRunId()
+				}
+				if attrs.GetNamespace() != "" {
+					state.namespace = attrs.GetNamespace()
+				}
+				childWFs[attrs.GetInitiatedEventId()] = state
+			}
+
+		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED:
+			attrs := event.GetChildWorkflowExecutionCompletedEventAttributes()
+			if attrs != nil {
+				if state, ok := childWFs[attrs.GetInitiatedEventId()]; ok {
+					childWorkflows = append(childWorkflows, views.ChildWorkflowInfo{
+						WorkflowType: state.workflowType,
+						WorkflowID:   state.workflowID,
+						RunID:        state.runID,
+						Namespace:    state.namespace,
+						Status:       "Completed",
+						StartedAt:    state.startedAt,
+						FinishedAt:   event.GetEventTime().AsTime(),
+						Duration:     event.GetEventTime().AsTime().Sub(state.startedAt),
+					})
+					delete(childWFs, attrs.GetInitiatedEventId())
+				}
+			}
+
+		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED:
+			attrs := event.GetChildWorkflowExecutionFailedEventAttributes()
+			if attrs != nil {
+				if state, ok := childWFs[attrs.GetInitiatedEventId()]; ok {
+					failure := ""
+					if attrs.GetFailure() != nil {
+						failure = attrs.GetFailure().GetMessage()
+					}
+					childWorkflows = append(childWorkflows, views.ChildWorkflowInfo{
+						WorkflowType: state.workflowType,
+						WorkflowID:   state.workflowID,
+						RunID:        state.runID,
+						Namespace:    state.namespace,
+						Status:       "Failed",
+						StartedAt:    state.startedAt,
+						FinishedAt:   event.GetEventTime().AsTime(),
+						Duration:     event.GetEventTime().AsTime().Sub(state.startedAt),
+						Failure:      failure,
+					})
+					delete(childWFs, attrs.GetInitiatedEventId())
+				}
+			}
+
+		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED:
+			attrs := event.GetChildWorkflowExecutionCanceledEventAttributes()
+			if attrs != nil {
+				if state, ok := childWFs[attrs.GetInitiatedEventId()]; ok {
+					childWorkflows = append(childWorkflows, views.ChildWorkflowInfo{
+						WorkflowType: state.workflowType,
+						WorkflowID:   state.workflowID,
+						RunID:        state.runID,
+						Namespace:    state.namespace,
+						Status:       "Canceled",
+						StartedAt:    state.startedAt,
+						FinishedAt:   event.GetEventTime().AsTime(),
+						Duration:     event.GetEventTime().AsTime().Sub(state.startedAt),
+					})
+					delete(childWFs, attrs.GetInitiatedEventId())
+				}
+			}
+
+		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TIMED_OUT:
+			attrs := event.GetChildWorkflowExecutionTimedOutEventAttributes()
+			if attrs != nil {
+				if state, ok := childWFs[attrs.GetInitiatedEventId()]; ok {
+					childWorkflows = append(childWorkflows, views.ChildWorkflowInfo{
+						WorkflowType: state.workflowType,
+						WorkflowID:   state.workflowID,
+						RunID:        state.runID,
+						Namespace:    state.namespace,
+						Status:       "Timed Out",
+						StartedAt:    state.startedAt,
+						FinishedAt:   event.GetEventTime().AsTime(),
+						Duration:     event.GetEventTime().AsTime().Sub(state.startedAt),
+					})
+					delete(childWFs, attrs.GetInitiatedEventId())
+				}
+			}
 		}
+	}
+
+	// Add still-running child workflows
+	for _, state := range childWFs {
+		childWorkflows = append(childWorkflows, views.ChildWorkflowInfo{
+			WorkflowType: state.workflowType,
+			WorkflowID:   state.workflowID,
+			RunID:        state.runID,
+			Namespace:    state.namespace,
+			Status:       "Running",
+			StartedAt:    state.startedAt,
+		})
 	}
 
 	// Add any scheduled-but-not-finished activities as "Running" or "Scheduled"
 	for schedID, sched := range scheduled {
 		found := false
 		for _, a := range activities {
-			if a.Name == sched.name {
+			if a.ScheduledEventID == schedID {
 				found = true
 				break
 			}
 		}
 		if !found {
 			actInfo := views.ActivityInfo{
-				Name: sched.name,
+				Name:             sched.name,
+				ScheduledEventID: schedID,
 			}
 			if startTime, ok := started[schedID]; ok {
 				actInfo.Status = "Running"
@@ -190,7 +374,147 @@ func (s *service) getWorkflowInfo(c *gin.Context, namespace, workflowID string) 
 	}
 
 	info.Activities = activities
+	info.ChildWorkflows = childWorkflows
+
+	// Extract awaited signals from AwaitSignal activities
+	info.AwaitedSignals = s.extractAwaitedSignals(c, activities)
+
+	// Build update executions by associating activities with updates based on event ID ranges
+	if len(updates) > 0 {
+		info.UpdateExecutions, info.OrphanActivities = s.buildUpdateExecutions(updates, activities)
+	} else {
+		info.OrphanActivities = activities
+	}
+
 	return info
+}
+
+// extractAwaitedSignals looks for AwaitSignal activities in the workflow history
+// and loads the corresponding queue signals from the database.
+func (s *service) extractAwaitedSignals(c *gin.Context, activities []views.ActivityInfo) []views.AwaitedSignalInfo {
+	ctx := c.Request.Context()
+	var awaited []views.AwaitedSignalInfo
+
+	for _, act := range activities {
+		if !strings.Contains(act.Name, "AwaitSignal") {
+			continue
+		}
+
+		// Extract queue signal ID from the activity input JSON
+		// The input is the first argument: a string (queue signal ID)
+		qsID := extractQueueSignalIDFromInput(act.Input)
+		if qsID == "" {
+			continue
+		}
+
+		asi := views.AwaitedSignalInfo{
+			QueueSignalID: qsID,
+			Status:        act.Status,
+			StartedAt:     act.StartedAt,
+			FinishedAt:    act.FinishedAt,
+			Duration:      act.Duration,
+			Failure:       act.Failure,
+		}
+
+		// Load the awaited signal from DB
+		var signal app.QueueSignal
+		if err := s.db.WithContext(ctx).Where("id = ?", qsID).First(&signal).Error; err == nil {
+			asi.Signal = &signal
+		}
+
+		awaited = append(awaited, asi)
+	}
+
+	return awaited
+}
+
+// extractQueueSignalIDFromInput parses the activity input JSON to find a queue signal ID.
+// The input format is a JSON string like "\"qsi...\""
+func extractQueueSignalIDFromInput(input string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return ""
+	}
+
+	// Try parsing as a plain JSON string (most common: AwaitSignal takes a single string arg)
+	var id string
+	if err := json.Unmarshal([]byte(input), &id); err == nil {
+		if strings.HasPrefix(id, "qsi") {
+			return id
+		}
+	}
+
+	return ""
+}
+
+// buildUpdateExecutions groups activities into their parent update executions.
+// Activities whose ScheduledEventID falls after an update's accepted event ID
+// (and before the next update's) belong to that update.
+// Activities before any update are returned as orphans (main workflow body).
+func (s *service) buildUpdateExecutions(updates map[int64]*updateState, activities []views.ActivityInfo) ([]views.UpdateExecution, []views.ActivityInfo) {
+	// Collect and sort updates by accepted event ID
+	type indexedUpdate struct {
+		acceptedEvtID int64
+		state         *updateState
+	}
+	sorted := make([]indexedUpdate, 0, len(updates))
+	for id, us := range updates {
+		sorted = append(sorted, indexedUpdate{acceptedEvtID: id, state: us})
+	}
+	for i := 0; i < len(sorted); i++ {
+		for j := i + 1; j < len(sorted); j++ {
+			if sorted[j].acceptedEvtID < sorted[i].acceptedEvtID {
+				sorted[i], sorted[j] = sorted[j], sorted[i]
+			}
+		}
+	}
+
+	// For each activity, find which update it belongs to
+	actsByUpdate := make(map[int64][]views.ActivityInfo) // keyed by accepted event ID
+	var orphans []views.ActivityInfo
+
+	for _, act := range activities {
+		ownerIdx := -1
+		for i, su := range sorted {
+			if act.ScheduledEventID <= su.acceptedEvtID {
+				break // past all possible owners
+			}
+			// Activity scheduled after this update's accepted event
+			if i+1 < len(sorted) && act.ScheduledEventID >= sorted[i+1].acceptedEvtID {
+				continue // belongs to a later update
+			}
+			ownerIdx = i
+			break
+		}
+		if ownerIdx >= 0 {
+			key := sorted[ownerIdx].acceptedEvtID
+			actsByUpdate[key] = append(actsByUpdate[key], act)
+		} else {
+			orphans = append(orphans, act)
+		}
+	}
+
+	// Build UpdateExecution structs
+	execs := make([]views.UpdateExecution, 0, len(sorted))
+	for _, su := range sorted {
+		ue := views.UpdateExecution{
+			Name:       su.state.name,
+			UpdateID:   su.state.updateID,
+			Status:     su.state.status,
+			StartedAt:  su.state.startedAt,
+			Input:      su.state.input,
+			Result:     su.state.result,
+			Failure:    su.state.failure,
+			Activities: actsByUpdate[su.acceptedEvtID],
+		}
+		if !su.state.finishedAt.IsZero() {
+			ue.FinishedAt = su.state.finishedAt
+			ue.Duration = su.state.finishedAt.Sub(su.state.startedAt)
+		}
+		execs = append(execs, ue)
+	}
+
+	return execs, orphans
 }
 
 func (s *service) buildActivityInfo(
@@ -203,9 +527,10 @@ func (s *service) buildActivityInfo(
 	failure string,
 ) views.ActivityInfo {
 	ai := views.ActivityInfo{
-		Status:     status,
-		FinishedAt: event.GetEventTime().AsTime(),
-		Failure:    failure,
+		Status:           status,
+		FinishedAt:       event.GetEventTime().AsTime(),
+		Failure:          failure,
+		ScheduledEventID: scheduledEventID,
 	}
 
 	if sched, ok := scheduled[scheduledEventID]; ok {

--- a/services/ctl-api/internal/app/admin-dashboard/service/queue_signal_detail.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/queue_signal_detail.go
@@ -42,6 +42,9 @@ func (s *service) QueueSignalDetail(c *gin.Context) {
 	var wfInfo *views.WorkflowInfo
 	if signal.Workflow.Namespace != "" && signal.Workflow.ID != "" {
 		wfInfo = s.getWorkflowInfo(c, signal.Workflow.Namespace, signal.Workflow.ID)
+		if wfInfo != nil {
+			wfInfo.UpdateHandlers = updateHandlersForSignalType(string(signal.Type))
+		}
 	}
 
 	component := views.QueueSignalDetail(&signal, &q, s.cfg.TemporalUIURL, wfInfo)
@@ -270,6 +273,19 @@ func (s *service) formatPayloads(payloads *commonpb.Payloads) string {
 		return string(raw)
 	}
 	return buf.String()
+}
+
+// updateHandlersForSignalType returns the known update handler names registered
+// by each signal type. Derived from the RegisterUpdateHandlers implementations.
+func updateHandlersForSignalType(signalType string) []string {
+	switch signalType {
+	case "execute-flow":
+		return []string{"retry-step", "approve-step", "is-retryable", "poll-next-step"}
+	case "execute-workflow-step":
+		return []string{"is-retryable", "create-step-retry", "approve-plan"}
+	default:
+		return nil
+	}
 }
 
 func formatWorkflowStatus(status enumspb.WorkflowExecutionStatus) string {

--- a/services/ctl-api/internal/app/admin-dashboard/service/service.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/service.go
@@ -24,6 +24,7 @@ type Params struct {
 	V              *validator.Validate
 	Cfg            *internal.Config
 	DB             *gorm.DB `name:"psql"`
+	CHDB           *gorm.DB `name:"ch"`
 	MW             metrics.Writer
 	L              *zap.Logger
 	AppsHelpers    *appshelpers.Helpers
@@ -42,6 +43,7 @@ type Service struct {
 	v              *validator.Validate
 	l              *zap.Logger
 	db             *gorm.DB
+	chDB           *gorm.DB
 	mw             metrics.Writer
 	cfg            *internal.Config
 	appsHelpers    *appshelpers.Helpers
@@ -107,6 +109,17 @@ func (s *service) RegisterAdminDashboardRoutes(api *gin.Engine) error {
 	api.GET("/installs/:id/active-deployments/table", s.InstallActiveDeploymentsTable)
 	api.GET("/installs/:id/activity/table", s.InstallActivityTable)
 	api.GET("/installs/:id/status/drift", s.InstallDriftStatus)
+	api.GET("/installs/:id/workflows/table", s.InstallWorkflowsTable)
+
+	// Workflow routes
+	api.GET("/workflows", s.Workflows)
+	api.GET("/workflows/table", s.WorkflowsTable)
+	api.GET("/workflows/:workflow_id", s.WorkflowDetail)
+
+	// Log stream routes
+	api.GET("/log-streams", s.LogStreamViewer)
+	api.GET("/log-streams/:log_stream_id", s.LogStreamDetail)
+	api.GET("/log-streams/:log_stream_id/logs/table", s.LogStreamLogsTable)
 
 	// Queue routes
 	api.GET("/queues", s.Queues)
@@ -133,6 +146,7 @@ func New(params Params) (*service, error) {
 		l:              params.L,
 		v:              params.V,
 		db:             params.DB,
+		chDB:           params.CHDB,
 		mw:             params.MW,
 		appsHelpers:    params.AppsHelpers,
 		acctClient:     params.AcctClient,

--- a/services/ctl-api/internal/app/admin-dashboard/service/service.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/service.go
@@ -131,6 +131,9 @@ func (s *service) RegisterAdminDashboardRoutes(api *gin.Engine) error {
 	api.GET("/queues/:id/emitters/:emitter_id", s.QueueEmitterDetail)
 	api.POST("/queues/:id/restart", s.RestartQueue)
 
+	// Temporal workflow viewer
+	api.GET("/temporal-workflows", s.TemporalWorkflowViewer)
+
 	// Queue signals (global view)
 	api.GET("/queue-signals", s.QueueSignals)
 	api.GET("/queue-signals/table", s.QueueSignalsGlobalTable)

--- a/services/ctl-api/internal/app/admin-dashboard/service/temporal_workflow.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/temporal_workflow.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/a-h/templ"
+	"github.com/gin-gonic/gin"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/service/views"
+)
+
+func (s *service) TemporalWorkflowViewer(c *gin.Context) {
+	namespace := c.Query("namespace")
+	workflowID := c.Query("workflow_id")
+
+	if namespace == "" || workflowID == "" {
+		// Show search form
+		component := views.TemporalWorkflowSearch(namespace, workflowID)
+		templ.Handler(component).ServeHTTP(c.Writer, c.Request)
+		return
+	}
+
+	wfInfo := s.getWorkflowInfo(c, namespace, workflowID)
+	if wfInfo == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Workflow not found or not accessible"})
+		return
+	}
+
+	component := views.TemporalWorkflowDetail(namespace, workflowID, s.cfg.TemporalUIURL, wfInfo)
+	templ.Handler(component).ServeHTTP(c.Writer, c.Request)
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/install_detail.templ
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/install_detail.templ
@@ -213,6 +213,29 @@ templ InstallDetail(
 					}
 				}
 			</div>
+			<!-- Workflows Section -->
+			<div class="mt-6">
+				@card.Card() {
+					@card.Header() {
+						@card.Title() {
+							Workflows
+						}
+						@card.Description() {
+							Recent workflows for this install
+						}
+					}
+					@card.Content() {
+						<div
+							id={ "workflows-table-" + install.ID }
+							hx-get={ "/installs/" + install.ID + "/workflows/table" }
+							hx-trigger="load"
+							hx-swap="outerHTML"
+						>
+							<div class="text-sm text-muted-foreground">Loading workflows...</div>
+						</div>
+					}
+				}
+			</div>
 		</div>
 		// Include the copybutton and popover JavaScript
 		@copybutton.Script()

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/install_workflows_table.templ
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/install_workflows_table.templ
@@ -1,0 +1,110 @@
+package views
+
+import (
+	"fmt"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/badge"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/pagination"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/status"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/table"
+)
+
+templ InstallWorkflowsTable(installID string, workflows []*app.Workflow, currentPage, totalPages int) {
+	<div id={ "workflows-table-" + installID }>
+		if len(workflows) == 0 {
+			<div class="text-sm text-muted-foreground">No workflows found.</div>
+		} else {
+			@table.Table() {
+				@table.Header() {
+					@table.Row() {
+						@table.Head() { Workflow }
+						@table.Head() { Type }
+						@table.Head() { Status }
+						@table.Head() { Started }
+						@table.Head() { Duration }
+					}
+				}
+				@table.Body() {
+					for _, wf := range workflows {
+						@table.Row() {
+							@table.Cell() {
+								<a href={ templ.URL("/workflows/" + wf.ID) } class="text-cyan hover:underline font-mono text-xs">{ wf.ID }</a>
+							}
+							@table.Cell() {
+								@badge.Badge(badge.Props{Variant: badge.VariantOutline}) {
+									{ string(wf.Type) }
+								}
+							}
+							@table.Cell() {
+								@status.StatusAutoSimple(string(wf.Status.Status))
+							}
+							@table.Cell(table.CellProps{Class: "font-mono text-sm"}) {
+								if !wf.StartedAt.IsZero() {
+									{ wf.StartedAt.Format("2006-01-02 15:04:05") }
+								} else {
+									<span class="text-muted-foreground">-</span>
+								}
+							}
+							@table.Cell(table.CellProps{Class: "font-mono text-sm"}) {
+								if wf.ExecutionTime > 0 {
+									{ formatDuration(wf.ExecutionTime) }
+								} else {
+									<span class="text-muted-foreground">-</span>
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		if totalPages > 1 {
+			<div class="mt-4">
+				@installWorkflowsPagination(installID, currentPage, totalPages)
+			</div>
+		}
+	</div>
+}
+
+templ installWorkflowsPagination(installID string, currentPage, totalPages int) {
+	{{ paginationData := pagination.CreatePagination(currentPage, totalPages, 5) }}
+	@pagination.Pagination() {
+		@pagination.Content() {
+			@pagination.Item() {
+				@pagination.Previous(pagination.PreviousProps{
+					Disabled: !paginationData.HasPrevious,
+					Label:    "Previous",
+					Attributes: templ.Attributes{
+						"hx-get":    fmt.Sprintf("/installs/%s/workflows/table?page=%d", installID, currentPage-1),
+						"hx-target": "#workflows-table-" + installID,
+						"hx-swap":   "outerHTML",
+					},
+				})
+			}
+			for _, pageNum := range paginationData.Pages {
+				@pagination.Item() {
+					@pagination.Link(pagination.LinkProps{
+						IsActive: pageNum == currentPage,
+						Attributes: templ.Attributes{
+							"hx-get":    fmt.Sprintf("/installs/%s/workflows/table?page=%d", installID, pageNum),
+							"hx-target": "#workflows-table-" + installID,
+							"hx-swap":   "outerHTML",
+						},
+					}) {
+						{ fmt.Sprintf("%d", pageNum) }
+					}
+				}
+			}
+			@pagination.Item() {
+				@pagination.Next(pagination.NextProps{
+					Disabled: !paginationData.HasNext,
+					Label:    "Next",
+					Attributes: templ.Attributes{
+						"hx-get":    fmt.Sprintf("/installs/%s/workflows/table?page=%d", installID, currentPage+1),
+						"hx-target": "#workflows-table-" + installID,
+						"hx-swap":   "outerHTML",
+					},
+				})
+			}
+		}
+	}
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/layout.templ
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/layout.templ
@@ -39,6 +39,7 @@ templ Layout(title string, activePage ActivePage) {
 						<a href="/queue-signals" class={ navLinkClass(activePage == ActivePageQueueSignals) }>Signals</a>
 						<a href="/workflows" class={ navLinkClass(activePage == ActivePageWorkflows) }>Workflows</a>
 						<a href="/log-streams" class={ navLinkClass(activePage == ActivePageLogStreams) }>Log Streams</a>
+						<a href="/temporal-workflows" class={ navLinkClass(activePage == ActivePageTemporalWorkflows) }>Temporal</a>
 						<a href="/livez" class={ navLinkClass(activePage == ActivePageHealth) }>Health</a>
 					</div>
 				</div>

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/layout.templ
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/layout.templ
@@ -37,6 +37,8 @@ templ Layout(title string, activePage ActivePage) {
 						<a href="/installs" class={ navLinkClass(activePage == ActivePageInstalls) }>Installs</a>
 						<a href="/queues" class={ navLinkClass(activePage == ActivePageQueues) }>Queues</a>
 						<a href="/queue-signals" class={ navLinkClass(activePage == ActivePageQueueSignals) }>Signals</a>
+						<a href="/workflows" class={ navLinkClass(activePage == ActivePageWorkflows) }>Workflows</a>
+						<a href="/log-streams" class={ navLinkClass(activePage == ActivePageLogStreams) }>Log Streams</a>
 						<a href="/livez" class={ navLinkClass(activePage == ActivePageHealth) }>Health</a>
 					</div>
 				</div>

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/log_streams.templ
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/log_streams.templ
@@ -1,0 +1,307 @@
+package views
+
+import (
+	"fmt"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/badge"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/card"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/copybutton"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/pagination"
+)
+
+const ActivePageLogStreams ActivePage = "log-streams"
+
+templ LogStreamSearch() {
+	@Layout("Log Streams", ActivePageLogStreams) {
+		<div class="w-full max-w-7xl mx-auto px-6">
+			@card.Card() {
+				@card.Header() {
+					@card.Title() {
+						Log Stream Viewer
+					}
+					@card.Description() {
+						Enter a log stream ID or owner ID to view logs
+					}
+				}
+				@card.Content() {
+					<form action="" method="GET" class="flex gap-3">
+						<input
+							type="text"
+							name="id"
+							id="log-stream-id-input"
+							placeholder="Enter log stream ID (ls...) or owner ID..."
+							class="flex-1 bg-background border border-border rounded px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-cyan focus:border-transparent"
+							autofocus
+						/>
+						<button
+							type="submit"
+							class="bg-cyan text-cyan-foreground px-4 py-2 rounded text-sm font-medium hover:bg-cyan/90 transition-colors"
+							onclick="event.preventDefault(); var id = document.getElementById('log-stream-id-input').value.trim(); if(id) window.location.href='/log-streams/'+encodeURIComponent(id);"
+						>
+							View Logs
+						</button>
+					</form>
+				}
+			}
+		</div>
+	}
+}
+
+templ LogStreamDetail(ls *app.LogStream, logs []app.OtelLogRecord, currentPage, totalPages int) {
+	@Layout("Log Stream: " + ls.ID, ActivePageLogStreams) {
+		<div class="w-full max-w-7xl mx-auto px-6">
+			<!-- Breadcrumb -->
+			<div class="mb-6 flex gap-2 text-sm">
+				<a href="/log-streams" class="text-cyan hover:underline">Log Streams</a>
+				<span class="text-muted-foreground">→</span>
+				<span class="text-muted-foreground">{ ls.ID }</span>
+			</div>
+
+			<!-- Header Card -->
+			<div class="bg-card border border-border rounded-lg p-6 mb-6">
+				<div class="flex items-center gap-3 mb-2">
+					<h1 class="text-2xl font-bold">Log Stream</h1>
+					if ls.Open {
+						@badge.Badge(badge.Props{Variant: badge.VariantDefault}) {
+							Open
+						}
+					} else {
+						@badge.Badge(badge.Props{Variant: badge.VariantOutline}) {
+							Closed
+						}
+					}
+				</div>
+				<div class="flex items-center gap-2 mb-1">
+					<span class="text-xs text-muted-foreground uppercase">ID:</span>
+					<span id="ls-detail-id" class="font-mono text-xs text-foreground">{ ls.ID }</span>
+					@copybutton.CopyButton(copybutton.Props{TargetID: "ls-detail-id"})
+				</div>
+
+				<div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mt-4 pt-4 border-t border-border">
+					<div>
+						<div class="text-xs text-muted-foreground uppercase">Owner Type</div>
+						<div class="font-mono text-sm">{ ls.OwnerType }</div>
+					</div>
+					<div>
+						<div class="text-xs text-muted-foreground uppercase">Owner ID</div>
+						<div class="font-mono text-sm">{ ls.OwnerID }</div>
+					</div>
+					<div>
+						<div class="text-xs text-muted-foreground uppercase">Org ID</div>
+						<div class="font-mono text-sm">
+							<a href={ templ.URL("/orgs/" + ls.OrgID) } class="text-cyan hover:underline">{ ls.OrgID }</a>
+						</div>
+					</div>
+					<div>
+						<div class="text-xs text-muted-foreground uppercase">Created</div>
+						<div class="font-mono text-sm">{ ls.CreatedAt.Format("2006-01-02 15:04:05") }</div>
+					</div>
+				</div>
+			</div>
+
+			<!-- Logs -->
+			@card.Card() {
+				@card.Header() {
+					@card.Title() {
+						Logs
+					}
+				}
+				@card.Content() {
+					@LogStreamLogsTable(ls.ID, logs, currentPage, totalPages)
+				}
+			}
+		</div>
+		@copybutton.Script()
+	}
+}
+
+templ LogStreamLogsTable(logStreamID string, logs []app.OtelLogRecord, currentPage, totalPages int) {
+	<div id="logs-table-wrapper">
+		if len(logs) == 0 {
+			<div class="text-sm text-muted-foreground">No logs found.</div>
+		} else {
+			<div class="space-y-1">
+				for i, log := range logs {
+					@logEntry(i, log)
+				}
+			</div>
+		}
+		if totalPages > 1 {
+			<div class="mt-4">
+				@logStreamPagination(logStreamID, currentPage, totalPages)
+			</div>
+		}
+	</div>
+}
+
+templ logEntry(idx int, log app.OtelLogRecord) {
+	<details class="group rounded border border-border">
+		<summary class="flex items-center gap-2 py-1 px-2 text-xs cursor-pointer list-none select-none hover:bg-muted/30 font-mono">
+			<span class="text-muted-foreground shrink-0 w-40">{ log.Timestamp.Format("15:04:05.000000") }</span>
+			@severityBadge(log.SeverityText)
+			if log.ServiceName != "" {
+				<span class="text-cyan shrink-0">{ log.ServiceName }</span>
+			}
+			<span class="truncate text-foreground">{ log.Body }</span>
+			<div class="ml-auto text-muted-foreground shrink-0">
+				<span class="group-open:hidden">▸</span>
+				<span class="hidden group-open:inline">▾</span>
+			</div>
+		</summary>
+		<div class="border-t border-border px-3 py-2 space-y-2 text-xs">
+			<!-- Core fields -->
+			<div class="grid grid-cols-2 gap-2">
+				if log.TraceID != "" {
+					<div>
+						<span class="text-muted-foreground">Trace ID: </span>
+						<span class="font-mono">{ log.TraceID }</span>
+					</div>
+				}
+				if log.SpanID != "" {
+					<div>
+						<span class="text-muted-foreground">Span ID: </span>
+						<span class="font-mono">{ log.SpanID }</span>
+					</div>
+				}
+				if log.ScopeName != "" {
+					<div>
+						<span class="text-muted-foreground">Scope: </span>
+						<span class="font-mono">{ log.ScopeName }</span>
+					</div>
+				}
+				if log.RunnerJobID != "" {
+					<div>
+						<span class="text-muted-foreground">Runner Job: </span>
+						<span class="font-mono">{ log.RunnerJobID }</span>
+					</div>
+				}
+				if log.RunnerJobExecutionStep != "" {
+					<div>
+						<span class="text-muted-foreground">Exec Step: </span>
+						<span class="font-mono">{ log.RunnerJobExecutionStep }</span>
+					</div>
+				}
+			</div>
+
+			<!-- Resource Attributes -->
+			if len(log.ResourceAttributes) > 0 {
+				<details class="rounded border border-border">
+					<summary class="px-2 py-1 cursor-pointer text-muted-foreground hover:bg-muted/30">
+						Resource Attributes ({ fmt.Sprintf("%d", len(log.ResourceAttributes)) })
+					</summary>
+					<div class="px-2 py-1 space-y-1">
+						for k, v := range log.ResourceAttributes {
+							<div class="flex gap-2">
+								<span class="text-muted-foreground shrink-0">{ k }:</span>
+								<span class="font-mono break-all">{ v }</span>
+							</div>
+						}
+					</div>
+				</details>
+			}
+
+			<!-- Scope Attributes -->
+			if len(log.ScopeAttributes) > 0 {
+				<details class="rounded border border-border">
+					<summary class="px-2 py-1 cursor-pointer text-muted-foreground hover:bg-muted/30">
+						Scope Attributes ({ fmt.Sprintf("%d", len(log.ScopeAttributes)) })
+					</summary>
+					<div class="px-2 py-1 space-y-1">
+						for k, v := range log.ScopeAttributes {
+							<div class="flex gap-2">
+								<span class="text-muted-foreground shrink-0">{ k }:</span>
+								<span class="font-mono break-all">{ v }</span>
+							</div>
+						}
+					</div>
+				</details>
+			}
+
+			<!-- Log Attributes -->
+			if len(log.LogAttributes) > 0 {
+				<details class="rounded border border-border">
+					<summary class="px-2 py-1 cursor-pointer text-muted-foreground hover:bg-muted/30">
+						Log Attributes ({ fmt.Sprintf("%d", len(log.LogAttributes)) })
+					</summary>
+					<div class="px-2 py-1 space-y-1">
+						for k, v := range log.LogAttributes {
+							<div class="flex gap-2">
+								<span class="text-muted-foreground shrink-0">{ k }:</span>
+								<span class="font-mono break-all">{ v }</span>
+							</div>
+						}
+					</div>
+				</details>
+			}
+
+			<!-- Full body -->
+			if len(log.Body) > 120 {
+				<div>
+					<div class="text-muted-foreground mb-1">Full Body:</div>
+					<pre class="bg-background border border-border rounded p-2 font-mono text-[11px] overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap break-all">{ log.Body }</pre>
+				</div>
+			}
+		</div>
+	</details>
+}
+
+templ severityBadge(severity string) {
+	switch severity {
+		case "DEBUG", "TRACE":
+			<span class="px-1.5 py-0.5 rounded text-[10px] bg-muted text-muted-foreground shrink-0">{ severity }</span>
+		case "INFO":
+			<span class="px-1.5 py-0.5 rounded text-[10px] bg-info-bg text-info border border-info-border shrink-0">{ severity }</span>
+		case "WARN", "WARNING":
+			<span class="px-1.5 py-0.5 rounded text-[10px] bg-warning-bg text-warning border border-warning-border shrink-0">{ severity }</span>
+		case "ERROR", "FATAL":
+			<span class="px-1.5 py-0.5 rounded text-[10px] bg-error-bg text-error border border-error-border shrink-0">{ severity }</span>
+		default:
+			if severity != "" {
+				<span class="px-1.5 py-0.5 rounded text-[10px] bg-muted text-muted-foreground shrink-0">{ severity }</span>
+			}
+	}
+}
+
+templ logStreamPagination(logStreamID string, currentPage, totalPages int) {
+	{{ paginationData := pagination.CreatePagination(currentPage, totalPages, 5) }}
+	@pagination.Pagination() {
+		@pagination.Content() {
+			@pagination.Item() {
+				@pagination.Previous(pagination.PreviousProps{
+					Disabled: !paginationData.HasPrevious,
+					Label:    "Previous",
+					Attributes: templ.Attributes{
+						"hx-get":    fmt.Sprintf("/log-streams/%s/logs/table?page=%d", logStreamID, currentPage-1),
+						"hx-target": "#logs-table-wrapper",
+						"hx-swap":   "outerHTML",
+					},
+				})
+			}
+			for _, pageNum := range paginationData.Pages {
+				@pagination.Item() {
+					@pagination.Link(pagination.LinkProps{
+						IsActive: pageNum == currentPage,
+						Attributes: templ.Attributes{
+							"hx-get":    fmt.Sprintf("/log-streams/%s/logs/table?page=%d", logStreamID, pageNum),
+							"hx-target": "#logs-table-wrapper",
+							"hx-swap":   "outerHTML",
+						},
+					}) {
+						{ fmt.Sprintf("%d", pageNum) }
+					}
+				}
+			}
+			@pagination.Item() {
+				@pagination.Next(pagination.NextProps{
+					Disabled: !paginationData.HasNext,
+					Label:    "Next",
+					Attributes: templ.Attributes{
+						"hx-get":    fmt.Sprintf("/log-streams/%s/logs/table?page=%d", logStreamID, currentPage+1),
+						"hx-target": "#logs-table-wrapper",
+						"hx-swap":   "outerHTML",
+					},
+				})
+			}
+		}
+	}
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/queue_signal_detail.templ
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/queue_signal_detail.templ
@@ -85,84 +85,17 @@ templ QueueSignalDetail(signal *app.QueueSignal, q *app.Queue, temporalUIURL str
 
 			<!-- Workflow Info -->
 			if wfInfo != nil {
-				<div class="mb-6">
-					@card.Card() {
-						@card.Header() {
-							<div class="flex items-center justify-between">
-								@card.Title() {
-									Workflow execution
-								}
-								@workflowStatusBadge(wfInfo.Status)
-							</div>
-						}
-						@card.Content() {
-							if len(wfInfo.Activities) > 0 {
-								<div class="space-y-2">
-									for i, act := range wfInfo.Activities {
-										<details class="group rounded border border-border">
-											<summary class="flex items-center gap-4 py-2 px-3 text-xs cursor-pointer list-none select-none hover:bg-muted/30">
-												<div class="flex items-center gap-2 w-64 shrink-0">
-													@activityStatusDot(act.Status)
-													<span class="font-mono truncate" title={ act.Name }>{ act.Name }</span>
-												</div>
-												<div class="w-20 shrink-0">
-													@activityStatusText(act.Status)
-												</div>
-												if !act.StartedAt.IsZero() {
-													<div class="text-muted-foreground w-36 shrink-0">
-														{ act.StartedAt.Format("15:04:05.000") }
-														if !act.FinishedAt.IsZero() {
-															<span class="text-foreground/40"> → </span>
-															{ act.FinishedAt.Format("15:04:05.000") }
-														}
-													</div>
-												}
-												if act.Duration > 0 {
-													<div class="font-mono text-cyan">
-														{ formatDuration(act.Duration) }
-													</div>
-												}
-												if act.Attempt > 1 {
-													<div class="text-amber-500">
-														attempt { fmt.Sprintf("%d", act.Attempt) }
-													</div>
-												}
-												if act.Failure != "" {
-													<div class="text-red-400 truncate flex-1" title={ act.Failure }>
-														{ act.Failure }
-													</div>
-												}
-												<div class="ml-auto text-muted-foreground shrink-0">
-													<span class="group-open:hidden">▸</span>
-													<span class="hidden group-open:inline">▾</span>
-												</div>
-											</summary>
-											<div class="border-t border-border px-3 py-2 space-y-2">
-												if act.Input != "" {
-													<div>
-														<div class="text-[10px] text-muted-foreground uppercase font-medium mb-1">Request</div>
-														<pre id={ fmt.Sprintf("act-input-%d", i) } class="bg-background border border-border rounded p-2 text-[11px] font-mono overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap break-all">{ act.Input }</pre>
-													</div>
-												}
-												if act.Result != "" {
-													<div>
-														<div class="text-[10px] text-muted-foreground uppercase font-medium mb-1">Response</div>
-														<pre id={ fmt.Sprintf("act-result-%d", i) } class="bg-background border border-border rounded p-2 text-[11px] font-mono overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap break-all">{ act.Result }</pre>
-													</div>
-												}
-												if act.Input == "" && act.Result == "" {
-													<div class="text-xs text-muted-foreground">No input/output data available.</div>
-												}
-											</div>
-										</details>
-									}
-								</div>
-							} else {
-								<div class="text-sm text-muted-foreground">No activities recorded yet.</div>
-							}
-						}
-					}
-				</div>
+				@workflowActivitiesCard(wfInfo)
+			}
+
+			<!-- Child Workflows -->
+			if wfInfo != nil {
+				@workflowChildWorkflowsCard(wfInfo, temporalUIURL, signal.Workflow.Namespace)
+			}
+
+			<!-- Awaited Signals -->
+			if wfInfo != nil {
+				@workflowAwaitedSignalsCard(wfInfo, temporalUIURL)
 			}
 
 			<!-- Update Handlers -->
@@ -356,10 +289,6 @@ func formatSignalData(signal *app.QueueSignal) string {
 		return "{}"
 	}
 	return string(data)
-}
-
-func hasTimingMetadata(signal *app.QueueSignal) bool {
-	return true
 }
 
 func getMetadataString(status app.CompositeStatus, key string) string {

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/queue_signal_detail.templ
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/queue_signal_detail.templ
@@ -165,6 +165,31 @@ templ QueueSignalDetail(signal *app.QueueSignal, q *app.Queue, temporalUIURL str
 				</div>
 			}
 
+			<!-- Update Handlers -->
+			if wfInfo != nil && len(wfInfo.UpdateHandlers) > 0 {
+				<div class="mb-6">
+					@card.Card() {
+						@card.Header() {
+							@card.Title() {
+								Update handlers
+							}
+							@card.Description() {
+								Temporal update handlers registered on this workflow
+							}
+						}
+						@card.Content() {
+							<div class="flex flex-wrap gap-2">
+								for _, handler := range wfInfo.UpdateHandlers {
+									@badge.Badge(badge.Props{Variant: badge.VariantOutline}) {
+										{ handler }
+									}
+								}
+							</div>
+						}
+					}
+				</div>
+			}
+
 			<!-- Info Grid -->
 			<div class="grid grid-cols-2 gap-6 mb-6">
 				<!-- Signal Info -->

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/temporal_workflow.templ
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/temporal_workflow.templ
@@ -1,0 +1,525 @@
+package views
+
+import (
+	"fmt"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/badge"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/card"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/copybutton"
+)
+
+const ActivePageTemporalWorkflows ActivePage = "temporal-workflows"
+
+templ TemporalWorkflowSearch(namespace, workflowID string) {
+	@Layout("Temporal Workflows", ActivePageTemporalWorkflows) {
+		<div class="w-full max-w-7xl mx-auto px-6">
+			@card.Card() {
+				@card.Header() {
+					@card.Title() {
+						Temporal workflow viewer
+					}
+					@card.Description() {
+						Enter a Temporal namespace and workflow ID to inspect
+					}
+				}
+				@card.Content() {
+					<form class="flex gap-4 items-end" method="GET" action="/temporal-workflows">
+						<div class="flex-1">
+							<label class="text-xs text-muted-foreground uppercase font-medium mb-1 block">Namespace</label>
+							<input
+								type="text"
+								name="namespace"
+								value={ namespace }
+								placeholder="e.g. components, runners"
+								class="w-full bg-background border border-border rounded px-3 py-2 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-cyan"
+							/>
+						</div>
+						<div class="flex-1">
+							<label class="text-xs text-muted-foreground uppercase font-medium mb-1 block">Workflow ID</label>
+							<input
+								type="text"
+								name="workflow_id"
+								value={ workflowID }
+								placeholder="e.g. queue-que...-handler-qsi..."
+								class="w-full bg-background border border-border rounded px-3 py-2 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-cyan"
+							/>
+						</div>
+						<button
+							type="submit"
+							class="bg-cyan text-background px-4 py-2 rounded text-sm font-medium hover:bg-cyan/90"
+						>
+							View
+						</button>
+					</form>
+				}
+			}
+		</div>
+	}
+}
+
+templ TemporalWorkflowDetail(namespace, workflowID, temporalUIURL string, wfInfo *WorkflowInfo) {
+	@Layout("Workflow: " + workflowID, ActivePageTemporalWorkflows) {
+		<div class="w-full max-w-7xl mx-auto px-6">
+			<!-- Breadcrumb -->
+			<div class="mb-6 flex gap-2 text-sm">
+				<a href="/temporal-workflows" class="text-cyan hover:underline">Temporal Workflows</a>
+				<span class="text-muted-foreground">→</span>
+				<span class="text-muted-foreground font-mono text-xs">{ workflowID }</span>
+			</div>
+
+			<!-- Header -->
+			<div class="bg-card border border-border rounded-lg p-6 mb-6">
+				<div class="flex items-center gap-3 mb-2">
+					<h1 class="text-2xl font-bold">Temporal Workflow</h1>
+					@workflowStatusBadge(wfInfo.Status)
+					if temporalUIURL != "" {
+						<a href={ templ.URL(temporalUIURL + "/namespaces/" + namespace + "/workflows/" + workflowID) } target="_blank" rel="noopener noreferrer" class="text-xs text-cyan hover:underline ml-auto">
+							View in Temporal UI →
+						</a>
+					}
+				</div>
+				<div class="space-y-1">
+					<div class="flex items-center gap-2">
+						<span class="text-xs text-muted-foreground uppercase">Workflow ID:</span>
+						<span id="tw-wf-id" class="font-mono text-xs text-foreground">{ workflowID }</span>
+						@copybutton.CopyButton(copybutton.Props{TargetID: "tw-wf-id"})
+					</div>
+					<div class="flex items-center gap-2">
+						<span class="text-xs text-muted-foreground uppercase">Namespace:</span>
+						<span class="font-mono text-xs text-foreground">{ namespace }</span>
+					</div>
+				</div>
+			</div>
+
+			<!-- Activities -->
+			@workflowActivitiesCard(wfInfo)
+
+			<!-- Child Workflows -->
+			@workflowChildWorkflowsCard(wfInfo, temporalUIURL, namespace)
+
+			<!-- Awaited Signals -->
+			@workflowAwaitedSignalsCard(wfInfo, temporalUIURL)
+
+			<!-- Update Handlers -->
+			if len(wfInfo.UpdateHandlers) > 0 {
+				<div class="mb-6">
+					@card.Card() {
+						@card.Header() {
+							@card.Title() {
+								Update handlers
+							}
+						}
+						@card.Content() {
+							<div class="flex flex-wrap gap-2">
+								for _, handler := range wfInfo.UpdateHandlers {
+									@badge.Badge(badge.Props{Variant: badge.VariantOutline}) {
+										{ handler }
+									}
+								}
+							</div>
+						}
+					}
+				</div>
+			}
+		</div>
+		@copybutton.Script()
+	}
+}
+
+// Reusable card components for workflow info (used both on this page and inline in signal detail)
+
+templ workflowActivitiesCard(wfInfo *WorkflowInfo) {
+	if len(wfInfo.UpdateExecutions) > 0 {
+		// Show activities grouped by update execution
+		<div class="mb-6">
+			@card.Card() {
+				@card.Header() {
+					<div class="flex items-center justify-between">
+						@card.Title() {
+							Workflow execution ({ fmt.Sprintf("%d updates, %d activities", len(wfInfo.UpdateExecutions), len(wfInfo.Activities)) })
+						}
+						@workflowStatusBadge(wfInfo.Status)
+					</div>
+				}
+				@card.Content() {
+					<div class="space-y-3">
+						// Show orphan activities first (main workflow body, before any updates)
+						if len(wfInfo.OrphanActivities) > 0 {
+							<div class="space-y-2">
+								<div class="text-[10px] text-muted-foreground uppercase font-medium">Main workflow</div>
+								@activitiesList(wfInfo.OrphanActivities)
+							</div>
+						}
+						// Show each update with its activities
+						for _, ue := range wfInfo.UpdateExecutions {
+							@updateExecutionRow(ue)
+						}
+					</div>
+				}
+			}
+		</div>
+	} else if len(wfInfo.Activities) > 0 {
+		// No updates — show flat activities list
+		<div class="mb-6">
+			@card.Card() {
+				@card.Header() {
+					<div class="flex items-center justify-between">
+						@card.Title() {
+							Activities ({ fmt.Sprintf("%d", len(wfInfo.Activities)) })
+						}
+						@workflowStatusBadge(wfInfo.Status)
+					</div>
+				}
+				@card.Content() {
+					@activitiesList(wfInfo.Activities)
+				}
+			}
+		</div>
+	}
+}
+
+templ updateExecutionRow(ue UpdateExecution) {
+	<details class="group/update rounded border border-border bg-muted/10">
+		<summary class="flex items-center gap-4 py-3 px-4 text-sm cursor-pointer list-none select-none hover:bg-muted/30">
+			<div class="flex items-center gap-2 shrink-0">
+				@activityStatusDot(ue.Status)
+			</div>
+			<div class="flex items-center gap-2 shrink-0">
+				@badge.Badge(badge.Props{Variant: badge.VariantOutline}) {
+					update
+				}
+				<span class="font-mono font-medium">{ ue.Name }</span>
+			</div>
+			<div class="w-20 shrink-0">
+				@activityStatusText(ue.Status)
+			</div>
+			if !ue.StartedAt.IsZero() {
+				<div class="text-muted-foreground w-36 shrink-0">
+					{ ue.StartedAt.Format("15:04:05.000") }
+					if !ue.FinishedAt.IsZero() {
+						<span class="text-foreground/40"> → </span>
+						{ ue.FinishedAt.Format("15:04:05.000") }
+					}
+				</div>
+			}
+			if ue.Duration > 0 {
+				<div class="font-mono text-cyan">
+					{ formatDuration(ue.Duration) }
+				</div>
+			}
+			if len(ue.Activities) > 0 {
+				<div class="text-muted-foreground">
+					{ fmt.Sprintf("%d activities", len(ue.Activities)) }
+				</div>
+			}
+			if ue.Failure != "" {
+				<div class="text-red-400 truncate flex-1" title={ ue.Failure }>
+					{ ue.Failure }
+				</div>
+			}
+			<div class="ml-auto text-muted-foreground shrink-0">
+				<span class="group-open/update:hidden">▸</span>
+				<span class="hidden group-open/update:inline">▾</span>
+			</div>
+		</summary>
+		<div class="border-t border-border px-3 py-3 space-y-3">
+			if len(ue.Activities) > 0 {
+				@activitiesList(ue.Activities)
+			} else {
+				<div class="text-xs text-muted-foreground">No activities in this update.</div>
+			}
+			if ue.Input != "" {
+				<div>
+					<div class="text-[10px] text-muted-foreground uppercase font-medium mb-1">Update input</div>
+					<pre class="bg-background border border-border rounded p-2 text-[11px] font-mono overflow-x-auto max-h-32 overflow-y-auto whitespace-pre-wrap break-all">{ ue.Input }</pre>
+				</div>
+			}
+			if ue.Result != "" {
+				<div>
+					<div class="text-[10px] text-muted-foreground uppercase font-medium mb-1">Update result</div>
+					<pre class="bg-background border border-border rounded p-2 text-[11px] font-mono overflow-x-auto max-h-32 overflow-y-auto whitespace-pre-wrap break-all">{ ue.Result }</pre>
+				</div>
+			}
+		</div>
+	</details>
+}
+
+templ activitiesList(activities []ActivityInfo) {
+	<div class="space-y-2">
+		for i, act := range activities {
+			@activityRow(i, act)
+		}
+	</div>
+}
+
+templ activityRow(idx int, act ActivityInfo) {
+	<details class="group rounded border border-border/50">
+		<summary class="flex items-center gap-3 py-1.5 px-2.5 text-[11px] cursor-pointer list-none select-none hover:bg-muted/20">
+			<div class="flex items-center gap-1.5 w-56 shrink-0">
+				@activityStatusDot(act.Status)
+				<span class="font-mono truncate" title={ act.Name }>{ act.Name }</span>
+			</div>
+			<div class="w-16 shrink-0">
+				@activityStatusText(act.Status)
+			</div>
+			if !act.StartedAt.IsZero() {
+				<div class="text-muted-foreground w-36 shrink-0">
+					{ act.StartedAt.Format("15:04:05.000") }
+					if !act.FinishedAt.IsZero() {
+						<span class="text-foreground/40"> → </span>
+						{ act.FinishedAt.Format("15:04:05.000") }
+					}
+				</div>
+			}
+			if act.Duration > 0 {
+				<div class="font-mono text-cyan">
+					{ formatDuration(act.Duration) }
+				</div>
+			}
+			if act.Attempt > 1 {
+				<div class="text-amber-500">
+					attempt { fmt.Sprintf("%d", act.Attempt) }
+				</div>
+			}
+			if act.Failure != "" {
+				<div class="text-red-400 truncate flex-1" title={ act.Failure }>
+					{ act.Failure }
+				</div>
+			}
+			<div class="ml-auto text-muted-foreground shrink-0">
+				<span class="group-open:hidden">▸</span>
+				<span class="hidden group-open:inline">▾</span>
+			</div>
+		</summary>
+		<div class="border-t border-border px-3 py-2 space-y-2">
+			if act.Input != "" {
+				<div>
+					<div class="text-[10px] text-muted-foreground uppercase font-medium mb-1">Request</div>
+					<pre id={ fmt.Sprintf("act-input-%d", idx) } class="bg-background border border-border rounded p-2 text-[11px] font-mono overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap break-all">{ act.Input }</pre>
+				</div>
+			}
+			if act.Result != "" {
+				<div>
+					<div class="text-[10px] text-muted-foreground uppercase font-medium mb-1">Response</div>
+					<pre id={ fmt.Sprintf("act-result-%d", idx) } class="bg-background border border-border rounded p-2 text-[11px] font-mono overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap break-all">{ act.Result }</pre>
+				</div>
+			}
+			if act.Input == "" && act.Result == "" {
+				<div class="text-xs text-muted-foreground">No input/output data available.</div>
+			}
+		</div>
+	</details>
+}
+
+templ workflowChildWorkflowsCard(wfInfo *WorkflowInfo, temporalUIURL string, parentNamespace string) {
+	if len(wfInfo.ChildWorkflows) > 0 {
+		<div class="mb-6">
+			@card.Card() {
+				@card.Header() {
+					@card.Title() {
+						Child workflows ({ fmt.Sprintf("%d", len(wfInfo.ChildWorkflows)) })
+					}
+				}
+				@card.Content() {
+					<div class="space-y-2">
+						for _, cw := range wfInfo.ChildWorkflows {
+							@childWorkflowRow(cw, temporalUIURL, parentNamespace)
+						}
+					</div>
+				}
+			}
+		</div>
+	}
+}
+
+templ childWorkflowRow(cw ChildWorkflowInfo, temporalUIURL string, parentNamespace string) {
+	{{ ns := cw.Namespace }}
+	if ns == "" {
+		{{ ns = parentNamespace }}
+	}
+	<details class="group rounded border border-border">
+		<summary class="flex items-center gap-4 py-2 px-3 text-xs cursor-pointer list-none select-none hover:bg-muted/30">
+			<div class="flex items-center gap-2 shrink-0">
+				@activityStatusDot(cw.Status)
+			</div>
+			<div class="flex items-center gap-2 w-48 shrink-0">
+				<span class="font-mono truncate font-medium" title={ cw.WorkflowType }>{ cw.WorkflowType }</span>
+			</div>
+			<div class="w-20 shrink-0">
+				@activityStatusText(cw.Status)
+			</div>
+			if !cw.StartedAt.IsZero() {
+				<div class="text-muted-foreground w-36 shrink-0">
+					{ cw.StartedAt.Format("15:04:05.000") }
+					if !cw.FinishedAt.IsZero() {
+						<span class="text-foreground/40"> → </span>
+						{ cw.FinishedAt.Format("15:04:05.000") }
+					}
+				</div>
+			}
+			if cw.Duration > 0 {
+				<div class="font-mono text-cyan">
+					{ formatDuration(cw.Duration) }
+				</div>
+			}
+			if cw.Failure != "" {
+				<div class="text-red-400 truncate flex-1" title={ cw.Failure }>
+					{ cw.Failure }
+				</div>
+			}
+			<div class="ml-auto text-muted-foreground shrink-0">
+				<span class="group-open:hidden">▸</span>
+				<span class="hidden group-open:inline">▾</span>
+			</div>
+		</summary>
+		<div class="border-t border-border px-3 py-3 space-y-2">
+			<div class="space-y-1">
+				@infoRow("Workflow ID", cw.WorkflowID)
+				if cw.RunID != "" {
+					@infoRow("Run ID", cw.RunID)
+				}
+				if ns != "" {
+					@infoRow("Namespace", ns)
+				}
+			</div>
+			<div class="mt-2 flex gap-3">
+				if cw.WorkflowID != "" && ns != "" {
+					<a href={ templ.URL("/temporal-workflows?namespace=" + ns + "&workflow_id=" + cw.WorkflowID) } class="text-xs text-cyan hover:underline">
+						View workflow detail →
+					</a>
+				}
+				if temporalUIURL != "" && cw.WorkflowID != "" && ns != "" {
+					<a href={ templ.URL(temporalUIURL + "/namespaces/" + ns + "/workflows/" + cw.WorkflowID) } target="_blank" rel="noopener noreferrer" class="text-xs text-cyan hover:underline">
+						View in Temporal UI →
+					</a>
+				}
+			</div>
+		</div>
+	</details>
+}
+
+templ workflowAwaitedSignalsCard(wfInfo *WorkflowInfo, temporalUIURL string) {
+	if len(wfInfo.AwaitedSignals) > 0 {
+		<div class="mb-6">
+			@card.Card() {
+				@card.Header() {
+					@card.Title() {
+						Awaited signals ({ fmt.Sprintf("%d", len(wfInfo.AwaitedSignals)) })
+					}
+					@card.Description() {
+						Queue signals awaited by this workflow via AwaitSignal
+					}
+				}
+				@card.Content() {
+					<div class="space-y-2">
+						for _, as := range wfInfo.AwaitedSignals {
+							@awaitedSignalRow(as, temporalUIURL)
+						}
+					</div>
+				}
+			}
+		</div>
+	}
+}
+
+templ awaitedSignalRow(as AwaitedSignalInfo, temporalUIURL string) {
+	<details class="group rounded border border-border">
+		<summary class="flex items-center gap-4 py-2 px-3 text-xs cursor-pointer list-none select-none hover:bg-muted/30">
+			<div class="flex items-center gap-2 shrink-0">
+				if as.Signal != nil {
+					@signalStatusBadge(as.Signal.Status)
+				} else {
+					@activityStatusDot(as.Status)
+				}
+			</div>
+			<div class="flex items-center gap-2 shrink-0">
+				if as.Signal != nil {
+					@badge.Badge(badge.Props{Variant: badge.VariantOutline}) {
+						{ string(as.Signal.Type) }
+					}
+				}
+			</div>
+			<div class="font-mono truncate w-64 shrink-0" title={ as.QueueSignalID }>
+				{ as.QueueSignalID }
+			</div>
+			if as.Signal != nil {
+				<div class="text-muted-foreground shrink-0">
+					{ as.Signal.OwnerType }: { as.Signal.OwnerID }
+				</div>
+			}
+			if as.Duration > 0 {
+				<div class="font-mono text-cyan">
+					{ formatDuration(as.Duration) }
+				</div>
+			}
+			<div class="ml-auto text-muted-foreground shrink-0">
+				<span class="group-open:hidden">▸</span>
+				<span class="hidden group-open:inline">▾</span>
+			</div>
+		</summary>
+		<div class="border-t border-border px-3 py-3 space-y-3">
+			if as.Signal != nil {
+				<!-- Signal info -->
+				<div class="space-y-1">
+					@infoRow("Signal ID", as.Signal.ID)
+					@infoRow("Type", string(as.Signal.Type))
+					@infoRow("Status", string(as.Signal.Status.Status))
+					@infoRow("Owner type", as.Signal.OwnerType)
+					@infoRow("Owner ID", as.Signal.OwnerID)
+					if as.Signal.Status.StatusHumanDescription != "" {
+						@infoRow("Description", as.Signal.Status.StatusHumanDescription)
+					}
+					if as.Signal.Workflow.ID != "" {
+						@infoRow("Handler workflow", as.Signal.Workflow.ID)
+					}
+				</div>
+
+				<!-- Status history inline -->
+				if len(as.Signal.Status.History) > 0 {
+					<div>
+						<div class="text-[10px] text-muted-foreground uppercase font-medium mb-2">Status history</div>
+						@awaitedSignalStatusHistory(as.Signal.Status)
+					</div>
+				}
+
+				<!-- Links -->
+				<div class="flex gap-3">
+					if as.Signal.QueueID != "" {
+						<a href={ templ.URL("/queues/" + as.Signal.QueueID + "/signals/" + as.Signal.ID) } class="text-xs text-cyan hover:underline font-medium">
+							View signal detail →
+						</a>
+					}
+					if as.Signal.Workflow.ID != "" && as.Signal.Workflow.Namespace != "" {
+						<a href={ templ.URL("/temporal-workflows?namespace=" + as.Signal.Workflow.Namespace + "&workflow_id=" + as.Signal.Workflow.ID) } class="text-xs text-cyan hover:underline">
+							View handler workflow →
+						</a>
+					}
+					if temporalUIURL != "" && as.Signal.Workflow.ID != "" {
+						<a href={ templ.URL(temporalUIURL + "/namespaces/" + as.Signal.Workflow.Namespace + "/workflows/" + as.Signal.Workflow.ID) } target="_blank" rel="noopener noreferrer" class="text-xs text-cyan hover:underline">
+							View in Temporal UI →
+						</a>
+					}
+				</div>
+			} else {
+				<div class="space-y-1">
+					@infoRow("Signal ID", as.QueueSignalID)
+					<div class="text-xs text-muted-foreground">Signal not found in database.</div>
+				</div>
+			}
+		</div>
+	</details>
+}
+
+templ awaitedSignalStatusHistory(cs app.CompositeStatus) {
+	<div class="space-y-1 pl-2 border-l-2 border-border">
+		for _, h := range cs.History {
+			<div class="flex items-center gap-3 text-xs py-1">
+				@signalStatusBadge(h)
+				<span class="text-muted-foreground">{ string(h.Status) }</span>
+				if h.StatusHumanDescription != "" {
+					<span class="text-muted-foreground/70 truncate" title={ h.StatusHumanDescription }>— { h.StatusHumanDescription }</span>
+				}
+			</div>
+		}
+	</div>
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/workflow_detail.templ
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/workflow_detail.templ
@@ -1,0 +1,326 @@
+package views
+
+import (
+	"fmt"
+	"time"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/badge"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/card"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/copybutton"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/status"
+)
+
+templ WorkflowDetail(wf *app.Workflow, stepDetails []StepDetailData) {
+	@Layout("Workflow: " + wf.ID, ActivePageWorkflows) {
+		<div class="w-full max-w-7xl mx-auto px-6">
+			<!-- Breadcrumb -->
+			<div class="mb-6 flex gap-2 text-sm">
+				<a href="/workflows" class="text-cyan hover:underline">Workflows</a>
+				<span class="text-muted-foreground">→</span>
+				<span class="text-muted-foreground">{ wf.ID }</span>
+			</div>
+
+			<!-- Header Card -->
+			<div class="bg-card border border-border rounded-lg p-6 mb-6">
+				<div class="flex items-start justify-between">
+					<div class="flex-1">
+						<div class="flex items-center gap-3 mb-2">
+							<h1 class="text-2xl font-bold">{ wf.Name }</h1>
+							@badge.Badge(badge.Props{Variant: badge.VariantOutline}) {
+								{ string(wf.Type) }
+							}
+							@status.StatusAutoSimple(string(wf.Status.Status))
+						</div>
+						<div class="flex items-center gap-2 mb-1">
+							<span class="text-xs text-muted-foreground uppercase">Workflow ID:</span>
+							<span id="wf-detail-id" class="font-mono text-xs text-foreground">{ wf.ID }</span>
+							@copybutton.CopyButton(copybutton.Props{TargetID: "wf-detail-id"})
+						</div>
+						<div class="flex items-center gap-2">
+							<span class="text-xs text-muted-foreground uppercase">Owner:</span>
+							<a href={ templ.URL(workflowOwnerLink(wf)) } class="font-mono text-xs text-cyan hover:underline">{ wf.OwnerID }</a>
+							<span class="text-xs text-muted-foreground">({ wf.OwnerType })</span>
+						</div>
+					</div>
+				</div>
+
+				<!-- Metadata Grid -->
+				<div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mt-4 pt-4 border-t border-border">
+					<div>
+						<div class="text-xs text-muted-foreground uppercase">Created</div>
+						<div class="font-mono text-sm">{ wf.CreatedAt.Format("2006-01-02 15:04:05") }</div>
+					</div>
+					<div>
+						<div class="text-xs text-muted-foreground uppercase">Started</div>
+						<div class="font-mono text-sm">
+							if !wf.StartedAt.IsZero() {
+								{ wf.StartedAt.Format("2006-01-02 15:04:05") }
+							} else {
+								<span class="text-muted-foreground">-</span>
+							}
+						</div>
+					</div>
+					<div>
+						<div class="text-xs text-muted-foreground uppercase">Finished</div>
+						<div class="font-mono text-sm">
+							if !wf.FinishedAt.IsZero() {
+								{ wf.FinishedAt.Format("2006-01-02 15:04:05") }
+							} else {
+								<span class="text-muted-foreground">-</span>
+							}
+						</div>
+					</div>
+					<div>
+						<div class="text-xs text-muted-foreground uppercase">Duration</div>
+						<div class="font-mono text-sm">
+							if wf.ExecutionTime > 0 {
+								{ formatDuration(wf.ExecutionTime) }
+							} else {
+								<span class="text-muted-foreground">-</span>
+							}
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<!-- Status History -->
+			if len(wf.Status.History) > 0 {
+				<div class="mb-6">
+					@card.Card() {
+						@card.Header() {
+							@card.Title() {
+								Workflow status history
+							}
+						}
+						@card.Content() {
+							@compositeStatusHistory(wf.Status)
+						}
+					}
+				</div>
+			}
+
+			<!-- Steps -->
+			<div class="mb-6">
+				@card.Card() {
+					@card.Header() {
+						<div class="flex items-center justify-between">
+							@card.Title() {
+								Steps ({ fmt.Sprintf("%d", len(stepDetails)) })
+							}
+						</div>
+					}
+					@card.Content() {
+						if len(stepDetails) == 0 {
+							<div class="text-sm text-muted-foreground">No steps recorded.</div>
+						} else {
+							<div class="space-y-2">
+								for i, sd := range stepDetails {
+									@stepRow(i, sd)
+								}
+							</div>
+						}
+					}
+				}
+			</div>
+		</div>
+		@copybutton.Script()
+	}
+}
+
+templ stepRow(idx int, sd StepDetailData) {
+	{{ step := sd.Step }}
+	<details class="group rounded border border-border">
+		<summary class="flex items-center gap-4 py-2 px-3 text-xs cursor-pointer list-none select-none hover:bg-muted/30">
+			<div class="flex items-center gap-2 w-8 shrink-0">
+				<span class="text-muted-foreground font-mono">{ fmt.Sprintf("%d", step.Idx) }</span>
+			</div>
+			<div class="flex items-center gap-2 shrink-0">
+				@stepStatusDot(string(step.Status.Status))
+			</div>
+			<div class="flex items-center gap-2 w-48 shrink-0">
+				<span class="font-mono truncate" title={ step.Name }>{ step.Name }</span>
+			</div>
+			<div class="w-20 shrink-0">
+				@status.StatusAutoSimple(string(step.Status.Status))
+			</div>
+			if !step.StartedAt.IsZero() {
+				<div class="text-muted-foreground w-36 shrink-0">
+					{ step.StartedAt.Format("15:04:05.000") }
+					if !step.FinishedAt.IsZero() {
+						<span class="text-foreground/40"> → </span>
+						{ step.FinishedAt.Format("15:04:05.000") }
+					}
+				</div>
+			}
+			if step.ExecutionTime > 0 {
+				<div class="font-mono text-cyan">
+					{ formatDuration(step.ExecutionTime) }
+				</div>
+			}
+			if step.GroupIdx > 0 {
+				<div class="text-muted-foreground">
+					g{ fmt.Sprintf("%d", step.GroupIdx) }
+					if step.GroupRetryIdx > 0 {
+						r{ fmt.Sprintf("%d", step.GroupRetryIdx) }
+					}
+				</div>
+			}
+			if string(step.ExecutionType) != "system" && string(step.ExecutionType) != "" {
+				@badge.Badge(badge.Props{Variant: badge.VariantSecondary}) {
+					{ string(step.ExecutionType) }
+				}
+			}
+			<div class="ml-auto text-muted-foreground shrink-0">
+				<span class="group-open:hidden">▸</span>
+				<span class="hidden group-open:inline">▾</span>
+			</div>
+		</summary>
+		<div class="border-t border-border px-3 py-3 space-y-4">
+			<!-- Status History -->
+			if len(step.Status.History) > 0 {
+				<div>
+					<div class="text-[10px] text-muted-foreground uppercase font-medium mb-2">Status History</div>
+					@compositeStatusHistory(step.Status)
+				</div>
+			}
+
+			<!-- Queue Signal -->
+			if sd.QueueSignalJSON != "" {
+				<div>
+					<div class="text-[10px] text-muted-foreground uppercase font-medium mb-1">Queue Signal</div>
+					<pre class="bg-background border border-border rounded p-2 text-[11px] font-mono overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap break-all">{ sd.QueueSignalJSON }</pre>
+				</div>
+			}
+
+			<!-- Step Target -->
+			if sd.StepTarget != nil {
+				<div>
+					<div class="text-[10px] text-muted-foreground uppercase font-medium mb-1">Step Target</div>
+					<div class="space-y-1">
+						@stepInfoRow("Type", sd.StepTarget.Type)
+						@stepInfoRow("ID", sd.StepTarget.ID)
+						if sd.StepTarget.Status != "" {
+							<div class="flex items-start gap-3">
+								<span class="text-xs text-muted-foreground w-24 shrink-0">Status</span>
+								@status.StatusAutoSimple(sd.StepTarget.Status)
+							</div>
+						}
+						if sd.StepTarget.LogStreamID != "" {
+							<div class="flex items-start gap-3">
+								<span class="text-xs text-muted-foreground w-24 shrink-0">Log Stream</span>
+								<a href={ templ.URL("/log-streams/" + sd.StepTarget.LogStreamID) } class="font-mono text-xs text-cyan hover:underline">{ sd.StepTarget.LogStreamID }</a>
+							</div>
+						}
+					</div>
+				</div>
+			}
+
+			<!-- Approval -->
+			if step.Approval != nil {
+				<div>
+					<div class="text-[10px] text-muted-foreground uppercase font-medium mb-1">Approval</div>
+					<div class="space-y-1">
+						@stepInfoRow("Type", string(step.Approval.Type))
+						if step.Approval.Response != nil {
+							@stepInfoRow("Response", string(step.Approval.Response.Type))
+							if step.Approval.Response.Note != "" {
+								@stepInfoRow("Note", step.Approval.Response.Note)
+							}
+						}
+					</div>
+				</div>
+			}
+
+			<!-- Metadata -->
+			if len(step.Metadata) > 0 {
+				<div>
+					<div class="text-[10px] text-muted-foreground uppercase font-medium mb-1">Metadata</div>
+					<div class="space-y-1">
+						for k, v := range step.Metadata {
+							if v != nil {
+								@stepInfoRow(k, *v)
+							}
+						}
+					</div>
+				</div>
+			}
+
+			<!-- Step flags -->
+			<div class="flex gap-2">
+				if step.Retryable {
+					@badge.Badge(badge.Props{Variant: badge.VariantOutline}) {
+						retryable
+					}
+				}
+				if step.Skippable {
+					@badge.Badge(badge.Props{Variant: badge.VariantOutline}) {
+						skippable
+					}
+				}
+				if step.Retried {
+					@badge.Badge(badge.Props{Variant: badge.VariantSecondary}) {
+						retried
+					}
+				}
+			</div>
+		</div>
+	</details>
+}
+
+templ stepInfoRow(label, value string) {
+	<div class="flex items-start gap-3">
+		<span class="text-xs text-muted-foreground w-24 shrink-0">{ label }</span>
+		<span class="font-mono text-xs text-foreground break-all">{ value }</span>
+	</div>
+}
+
+templ compositeStatusHistory(cs app.CompositeStatus) {
+	<div class="space-y-2">
+		for _, h := range cs.History {
+			<div class="flex items-start gap-3 text-xs border-b border-border pb-2 last:border-0">
+				<div class="shrink-0">
+					@status.StatusAutoSimple(string(h.Status))
+				</div>
+				<div class="flex-1 space-y-1">
+					<div class="text-foreground">
+						{ string(h.Status) }
+						if h.StatusHumanDescription != "" {
+							<span class="text-muted-foreground"> — { h.StatusHumanDescription }</span>
+						}
+					</div>
+					if h.CreatedAtTS > 0 {
+						<div class="text-muted-foreground">
+							{ time.Unix(h.CreatedAtTS, 0).UTC().Format("2006-01-02 15:04:05 UTC") }
+						</div>
+					}
+					if len(h.Metadata) > 0 {
+						<div class="flex flex-wrap gap-x-4 gap-y-1">
+							for k, v := range h.Metadata {
+								<span class="text-muted-foreground">
+									<span class="text-foreground/60">{ k }:</span> { fmt.Sprintf("%v", v) }
+								</span>
+							}
+						</div>
+					}
+				</div>
+			</div>
+		}
+	</div>
+}
+
+templ stepStatusDot(statusStr string) {
+	switch statusStr {
+		case "success":
+			<div class="w-2 h-2 rounded-full bg-green-500 shrink-0"></div>
+		case "in-progress", "executing", "planning", "applying":
+			<div class="w-2 h-2 rounded-full bg-cyan animate-pulse shrink-0"></div>
+		case "error", "failed":
+			<div class="w-2 h-2 rounded-full bg-red-500 shrink-0"></div>
+		case "cancelled", "user-skipped", "auto-skipped":
+			<div class="w-2 h-2 rounded-full bg-amber-500 shrink-0"></div>
+		case "pending", "queued", "not-attempted":
+			<div class="w-2 h-2 rounded-full bg-muted-foreground/30 shrink-0"></div>
+		default:
+			<div class="w-2 h-2 rounded-full bg-muted-foreground/30 shrink-0"></div>
+	}
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/workflow_detail_types.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/workflow_detail_types.go
@@ -1,0 +1,20 @@
+package views
+
+import (
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// StepDetailData holds enriched step data for the workflow detail view.
+type StepDetailData struct {
+	Step            *app.WorkflowStep
+	QueueSignalJSON string
+	StepTarget      *StepTargetData
+}
+
+// StepTargetData holds the loaded step target with its log stream.
+type StepTargetData struct {
+	ID          string
+	Type        string
+	Status      string
+	LogStreamID string
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/workflow_info.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/workflow_info.go
@@ -6,8 +6,9 @@ import (
 
 // WorkflowInfo holds Temporal workflow execution info for display.
 type WorkflowInfo struct {
-	Status     string
-	Activities []ActivityInfo
+	Status         string
+	Activities     []ActivityInfo
+	UpdateHandlers []string
 }
 
 // ActivityInfo holds Temporal activity execution info for display.

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/workflow_info.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/workflow_info.go
@@ -2,24 +2,69 @@ package views
 
 import (
 	"time"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
 
 // WorkflowInfo holds Temporal workflow execution info for display.
 type WorkflowInfo struct {
-	Status         string
-	Activities     []ActivityInfo
-	UpdateHandlers []string
+	Status           string
+	Activities       []ActivityInfo
+	ChildWorkflows   []ChildWorkflowInfo
+	AwaitedSignals   []AwaitedSignalInfo
+	UpdateHandlers   []string
+	UpdateExecutions []UpdateExecution
+	OrphanActivities []ActivityInfo // activities not in any update (main workflow body)
+}
+
+// UpdateExecution groups activities that ran within a single Temporal update handler call.
+type UpdateExecution struct {
+	Name       string // update handler name (e.g. "execute", "retry-step")
+	UpdateID   string
+	Status     string // Accepted, Completed, Failed, Rejected, Running
+	StartedAt  time.Time
+	FinishedAt time.Time
+	Duration   time.Duration
+	Input      string // JSON-formatted update input args
+	Result     string // JSON-formatted update result
+	Failure    string
+	Activities []ActivityInfo
 }
 
 // ActivityInfo holds Temporal activity execution info for display.
 type ActivityInfo struct {
-	Name       string
-	Status     string
-	StartedAt  time.Time
-	FinishedAt time.Time
-	Duration   time.Duration
-	Attempt    int32
-	Failure    string
-	Input      string // JSON-formatted activity input
-	Result     string // JSON-formatted activity result
+	Name             string
+	Status           string
+	StartedAt        time.Time
+	FinishedAt       time.Time
+	Duration         time.Duration
+	Attempt          int32
+	Failure          string
+	Input            string // JSON-formatted activity input
+	Result           string // JSON-formatted activity result
+	ScheduledEventID int64  // Temporal event ID for correlating with updates
+}
+
+// ChildWorkflowInfo holds info about a child workflow execution.
+type ChildWorkflowInfo struct {
+	WorkflowType string
+	WorkflowID   string
+	RunID        string
+	Namespace    string
+	Status       string
+	StartedAt    time.Time
+	FinishedAt   time.Time
+	Duration     time.Duration
+	Failure      string
+}
+
+// AwaitedSignalInfo holds info about a queue signal that was awaited.
+type AwaitedSignalInfo struct {
+	QueueSignalID string
+	Signal        *app.QueueSignal // loaded from DB if available
+	Status        string           // activity status: Completed, Failed, Running
+	StartedAt     time.Time
+	FinishedAt    time.Time
+	Duration      time.Duration
+	Failure       string
 }

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/workflows.templ
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/workflows.templ
@@ -1,0 +1,210 @@
+package views
+
+import (
+	"fmt"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/badge"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/card"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/copybutton"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/pagination"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/search"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/status"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/components/table"
+	"net/url"
+)
+
+const ActivePageWorkflows ActivePage = "workflows"
+
+templ Workflows(workflows []*app.Workflow, currentPage, totalPages int, searchQuery, sort, typeFilter string) {
+	@Layout("Workflows", ActivePageWorkflows) {
+		<div class="w-full max-w-7xl mx-auto px-6">
+			@card.Card() {
+				@card.Header() {
+					@card.Title() {
+						Workflows
+					}
+					@card.Description() {
+						Search by workflow ID or owner ID (install, app)
+					}
+				}
+				@card.Content() {
+					<div
+						hx-get="/workflows/table"
+						hx-trigger="change from:[name='sort'], change from:[name='type']"
+						hx-target="#workflows-table-wrapper"
+						hx-swap="outerHTML"
+						hx-include="[name='search'],[name='sort'],[name='type']"
+					>
+						@search.SearchInput(search.Props{
+							Placeholder: "Search by workflow ID (inw...) or owner ID...",
+							TargetURL:   "/workflows/table",
+							TargetID:    "workflows-table-wrapper",
+							Value:       searchQuery,
+						})
+						<div class="flex gap-3 mb-4">
+							<select name="sort" class="bg-background border border-border rounded px-3 py-1.5 text-sm">
+								<option value="newest" selected?={ sort == "newest" }>Newest first</option>
+								<option value="oldest" selected?={ sort == "oldest" }>Oldest first</option>
+							</select>
+							<select name="type" class="bg-background border border-border rounded px-3 py-1.5 text-sm">
+								<option value="" selected?={ typeFilter == "" }>All types</option>
+								<option value="provision" selected?={ typeFilter == "provision" }>provision</option>
+								<option value="deprovision" selected?={ typeFilter == "deprovision" }>deprovision</option>
+								<option value="manual_deploy" selected?={ typeFilter == "manual_deploy" }>manual_deploy</option>
+								<option value="deploy_components" selected?={ typeFilter == "deploy_components" }>deploy_components</option>
+								<option value="input_update" selected?={ typeFilter == "input_update" }>input_update</option>
+								<option value="reprovision_sandbox" selected?={ typeFilter == "reprovision_sandbox" }>reprovision_sandbox</option>
+								<option value="teardown_components" selected?={ typeFilter == "teardown_components" }>teardown_components</option>
+								<option value="action_workflow_run" selected?={ typeFilter == "action_workflow_run" }>action_workflow_run</option>
+								<option value="sync_secrets" selected?={ typeFilter == "sync_secrets" }>sync_secrets</option>
+								<option value="drift_run" selected?={ typeFilter == "drift_run" }>drift_run</option>
+							</select>
+						</div>
+					</div>
+					@WorkflowsTable(workflows, currentPage, totalPages, searchQuery, sort, typeFilter)
+				}
+			}
+		</div>
+		@copybutton.Script()
+	}
+}
+
+templ WorkflowsTable(workflows []*app.Workflow, currentPage, totalPages int, searchQuery, sort, typeFilter string) {
+	<div id="workflows-table-wrapper">
+		if len(workflows) == 0 {
+			<div class="text-sm text-muted-foreground">No workflows found.</div>
+		} else {
+			@table.Table() {
+				@table.Header() {
+					@table.Row() {
+						@table.Head() { Workflow }
+						@table.Head() { Type }
+						@table.Head() { Owner }
+						@table.Head() { Status }
+						@table.Head() { Steps }
+						@table.Head() { Started }
+						@table.Head() { Duration }
+					}
+				}
+				@table.Body() {
+					for _, wf := range workflows {
+						@table.Row() {
+							@table.Cell() {
+								<div class="flex items-center gap-2">
+									<a href={ templ.URL("/workflows/" + wf.ID) } class="text-cyan hover:underline font-mono text-xs">{ wf.ID }</a>
+									@copybutton.CopyButton(copybutton.Props{TargetID: "wf-id-" + wf.ID})
+								</div>
+								<span id={ "wf-id-" + wf.ID } class="hidden">{ wf.ID }</span>
+							}
+							@table.Cell() {
+								@badge.Badge(badge.Props{Variant: badge.VariantOutline}) {
+									{ string(wf.Type) }
+								}
+							}
+							@table.Cell() {
+								<a href={ templ.URL(workflowOwnerLink(wf)) } class="text-cyan hover:underline font-mono text-xs">{ wf.OwnerID }</a>
+							}
+							@table.Cell() {
+								@status.StatusAutoSimple(string(wf.Status.Status))
+							}
+							@table.Cell(table.CellProps{Class: "font-mono text-sm"}) {
+								{ fmt.Sprintf("%d", len(wf.Steps)) }
+							}
+							@table.Cell(table.CellProps{Class: "font-mono text-sm"}) {
+								if !wf.StartedAt.IsZero() {
+									{ wf.StartedAt.Format("2006-01-02 15:04:05") }
+								} else {
+									<span class="text-muted-foreground">-</span>
+								}
+							}
+							@table.Cell(table.CellProps{Class: "font-mono text-sm"}) {
+								if wf.ExecutionTime > 0 {
+									{ formatDuration(wf.ExecutionTime) }
+								} else {
+									<span class="text-muted-foreground">-</span>
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		if totalPages > 1 {
+			<div class="mt-4">
+				@workflowsPagination(currentPage, totalPages, searchQuery, sort, typeFilter)
+			</div>
+		}
+	</div>
+}
+
+func workflowOwnerLink(wf *app.Workflow) string {
+	if wf.OwnerType == "installs" {
+		return "/installs/" + wf.OwnerID
+	}
+	return "#"
+}
+
+func buildWorkflowsTableURL(page int, search, sort, typeFilter string) string {
+	params := url.Values{}
+	if page > 1 {
+		params.Set("page", fmt.Sprintf("%d", page))
+	}
+	if search != "" {
+		params.Set("search", search)
+	}
+	if sort != "" && sort != "newest" {
+		params.Set("sort", sort)
+	}
+	if typeFilter != "" {
+		params.Set("type", typeFilter)
+	}
+	q := params.Encode()
+	if q != "" {
+		return "/workflows/table?" + q
+	}
+	return "/workflows/table"
+}
+
+templ workflowsPagination(currentPage, totalPages int, searchQuery, sort, typeFilter string) {
+	{{ paginationData := pagination.CreatePagination(currentPage, totalPages, 5) }}
+	@pagination.Pagination() {
+		@pagination.Content() {
+			@pagination.Item() {
+				@pagination.Previous(pagination.PreviousProps{
+					Disabled: !paginationData.HasPrevious,
+					Label:    "Previous",
+					Attributes: templ.Attributes{
+						"hx-get":     buildWorkflowsTableURL(currentPage-1, searchQuery, sort, typeFilter),
+						"hx-target":  "#workflows-table-wrapper",
+						"hx-swap":    "outerHTML",
+					},
+				})
+			}
+			for _, pageNum := range paginationData.Pages {
+				@pagination.Item() {
+					@pagination.Link(pagination.LinkProps{
+						IsActive: pageNum == currentPage,
+						Attributes: templ.Attributes{
+							"hx-get":    buildWorkflowsTableURL(pageNum, searchQuery, sort, typeFilter),
+							"hx-target": "#workflows-table-wrapper",
+							"hx-swap":   "outerHTML",
+						},
+					}) {
+						{ fmt.Sprintf("%d", pageNum) }
+					}
+				}
+			}
+			@pagination.Item() {
+				@pagination.Next(pagination.NextProps{
+					Disabled: !paginationData.HasNext,
+					Label:    "Next",
+					Attributes: templ.Attributes{
+						"hx-get":    buildWorkflowsTableURL(currentPage+1, searchQuery, sort, typeFilter),
+						"hx-target": "#workflows-table-wrapper",
+						"hx-swap":   "outerHTML",
+					},
+				})
+			}
+		}
+	}
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/workflow_detail.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/workflow_detail.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/a-h/templ"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/service/views"
+)
+
+func (s *service) WorkflowDetail(c *gin.Context) {
+	ctx := c.Request.Context()
+	workflowID := c.Param("workflow_id")
+
+	var wf app.Workflow
+	res := s.db.WithContext(ctx).
+		Preload("CreatedBy").
+		Preload("Steps", func(db *gorm.DB) *gorm.DB {
+			return db.Order("group_idx ASC, group_retry_idx ASC, idx ASC, created_at ASC")
+		}).
+		Preload("Steps.Approval").
+		Preload("Steps.Approval.Response").
+		Where("id = ?", workflowID).
+		First(&wf)
+
+	if res.Error != nil {
+		s.l.Error("failed to fetch workflow", zap.Error(res.Error))
+		c.JSON(http.StatusNotFound, gin.H{"error": "Workflow not found"})
+		return
+	}
+
+	// Load step targets and their log streams
+	stepDetails := make([]views.StepDetailData, len(wf.Steps))
+	for i, step := range wf.Steps {
+		stepDetails[i] = views.StepDetailData{
+			Step: &wf.Steps[i],
+		}
+
+		// Format queue signal if present
+		if step.QueueSignal != nil {
+			data, err := json.MarshalIndent(step.QueueSignal, "", "  ")
+			if err == nil {
+				stepDetails[i].QueueSignalJSON = string(data)
+			}
+		}
+
+		// Load step target
+		if step.StepTargetID != "" {
+			stepDetails[i].StepTarget = s.loadStepTarget(c, step.StepTargetID, step.StepTargetType)
+		}
+	}
+
+	component := views.WorkflowDetail(&wf, stepDetails)
+	templ.Handler(component).ServeHTTP(c.Writer, c.Request)
+}
+
+func (s *service) loadStepTarget(c *gin.Context, targetID, targetType string) *views.StepTargetData {
+	ctx := c.Request.Context()
+	target := &views.StepTargetData{
+		ID:   targetID,
+		Type: targetType,
+	}
+
+	switch app.WorkflowStepTargetType(targetType) {
+	case app.WorkflowStepTargetTypeInstallDeploy:
+		var deploy app.InstallDeploy
+		if err := s.db.WithContext(ctx).Preload("LogStream").Where("id = ?", targetID).First(&deploy).Error; err == nil {
+			target.Status = string(deploy.Status)
+			if deploy.LogStream.ID != "" {
+				target.LogStreamID = deploy.LogStream.ID
+			}
+		}
+	case app.WorkflowStepTargetTypeInstallSandboxRun:
+		var run app.InstallSandboxRun
+		if err := s.db.WithContext(ctx).Preload("LogStream").Where("id = ?", targetID).First(&run).Error; err == nil {
+			target.Status = string(run.Status)
+			if run.LogStream.ID != "" {
+				target.LogStreamID = run.LogStream.ID
+			}
+		}
+	case app.WorkflowStepTargetTypeInstallActionWorkflowRun:
+		var run app.InstallActionWorkflowRun
+		if err := s.db.WithContext(ctx).Preload("LogStream").Where("id = ?", targetID).First(&run).Error; err == nil {
+			target.Status = string(run.Status)
+			if run.LogStream.ID != "" {
+				target.LogStreamID = run.LogStream.ID
+			}
+		}
+	default:
+		// For other types, just show the ID
+	}
+
+	return target
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/workflows.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/workflows.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+
+	"github.com/a-h/templ"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/service/views"
+)
+
+const workflowsPerPage = 20
+
+func (s *service) Workflows(c *gin.Context) {
+	ctx := c.Request.Context()
+	search := c.Query("search")
+	sort := c.DefaultQuery("sort", "newest")
+	typeFilter := c.Query("type")
+	page := getPageFromQuery(c)
+
+	workflows, totalPages, err := s.getWorkflows(ctx, search, sort, typeFilter, page)
+	if err != nil {
+		s.l.Error("failed to fetch workflows", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch workflows"})
+		return
+	}
+
+	component := views.Workflows(workflows, page, totalPages, search, sort, typeFilter)
+	templ.Handler(component).ServeHTTP(c.Writer, c.Request)
+}
+
+func (s *service) WorkflowsTable(c *gin.Context) {
+	ctx := c.Request.Context()
+	search := c.Query("search")
+	sort := c.DefaultQuery("sort", "newest")
+	typeFilter := c.Query("type")
+	page := getPageFromQuery(c)
+
+	workflows, totalPages, err := s.getWorkflows(ctx, search, sort, typeFilter, page)
+	if err != nil {
+		s.l.Error("failed to fetch workflows", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch workflows"})
+		return
+	}
+
+	component := views.WorkflowsTable(workflows, page, totalPages, search, sort, typeFilter)
+	templ.Handler(component).ServeHTTP(c.Writer, c.Request)
+}
+
+func (s *service) getWorkflows(ctx context.Context, search, sort, typeFilter string, page int) ([]*app.Workflow, int, error) {
+	query := s.db.WithContext(ctx).
+		Model(&app.Workflow{}).
+		Preload("CreatedBy")
+
+	// Search by workflow ID or owner ID
+	if search != "" {
+		search = strings.TrimSpace(search)
+		if strings.HasPrefix(search, "inw") {
+			query = query.Where("id = ?", search)
+		} else {
+			query = query.Where("owner_id = ?", search)
+		}
+	}
+
+	if typeFilter != "" {
+		query = query.Where("type = ?", typeFilter)
+	}
+
+	// Count
+	var totalCount int64
+	if err := query.Count(&totalCount).Error; err != nil {
+		return nil, 0, fmt.Errorf("unable to count workflows: %w", err)
+	}
+
+	totalPages := int(math.Ceil(float64(totalCount) / float64(workflowsPerPage)))
+	if totalPages == 0 {
+		totalPages = 1
+	}
+
+	// Sort
+	switch sort {
+	case "oldest":
+		query = query.Order("created_at ASC")
+	default:
+		query = query.Order("created_at DESC")
+	}
+
+	offset := (page - 1) * workflowsPerPage
+	var workflows []*app.Workflow
+	if err := query.Offset(offset).Limit(workflowsPerPage).Find(&workflows).Error; err != nil {
+		return nil, 0, fmt.Errorf("unable to get workflows: %w", err)
+	}
+
+	// Load step counts
+	for _, wf := range workflows {
+		var count int64
+		s.db.WithContext(ctx).Model(&app.WorkflowStep{}).Where("install_workflow_id = ?", wf.ID).Count(&count)
+		wf.Steps = make([]app.WorkflowStep, count)
+	}
+
+	return workflows, totalPages, nil
+}

--- a/services/ctl-api/internal/app/component_build.go
+++ b/services/ctl-api/internal/app/component_build.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nuonco/nuon/pkg/shortid/domains"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/indexes"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/structured_errors"
 )
 
 type ComponentBuildStatus string
@@ -51,9 +52,10 @@ type ComponentBuild struct {
 	ComponentReleases []ComponentRelease `json:"releases,omitzero" gorm:"constraint:OnDelete:CASCADE;" temporaljson:"component_releases,omitzero,omitempty"`
 	InstallDeploys    []InstallDeploy    `json:"install_deploys,omitzero" gorm:"constraint:OnDelete:CASCADE;" temporaljson:"install_deploys,omitzero,omitempty"`
 
-	Status            ComponentBuildStatus `json:"status,omitzero" gorm:"notnull" swaggertype:"string" temporaljson:"status,omitzero,omitempty"`
-	StatusDescription string               `json:"status_description,omitzero" gorm:"notnull" temporaljson:"status_description,omitzero,omitempty"`
-	StatusV2          CompositeStatus      `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
+	Status            ComponentBuildStatus              `json:"status,omitzero" gorm:"notnull" swaggertype:"string" temporaljson:"status,omitzero,omitempty"`
+	StatusDescription string                            `json:"status_description,omitzero" gorm:"notnull" temporaljson:"status_description,omitzero,omitempty"`
+	StatusV2          CompositeStatus                   `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
+	Errors            structured_errors.CompositeErrors `json:"errors,omitzero" gorm:"type:jsonb" temporaljson:"errors,omitzero,omitempty"`
 
 	GitRef *string `json:"git_ref,omitzero" temporaljson:"git_ref,omitzero,omitempty"`
 

--- a/services/ctl-api/internal/app/install_action_workflow_run.go
+++ b/services/ctl-api/internal/app/install_action_workflow_run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/viewsql"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/structured_errors"
 )
 
 type InstallActionWorkflowRunStatus string
@@ -56,9 +57,10 @@ type InstallActionWorkflowRun struct {
 
 	EnableKubeConfig sql.NullBool `json:"enable_kube_config" gorm:"default:true" temporaljson:"enable_kube_config"`
 
-	Status            InstallActionWorkflowRunStatus `json:"status,omitzero" gorm:"notnull" swaggertype:"string" temporaljson:"status,omitzero,omitempty"`
-	StatusDescription string                         `json:"status_description,omitzero" gorm:"notnull" temporaljson:"status_description,omitzero,omitempty"`
-	StatusV2          CompositeStatus                `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
+	Status            InstallActionWorkflowRunStatus    `json:"status,omitzero" gorm:"notnull" swaggertype:"string" temporaljson:"status,omitzero,omitempty"`
+	StatusDescription string                            `json:"status_description,omitzero" gorm:"notnull" temporaljson:"status_description,omitzero,omitempty"`
+	StatusV2          CompositeStatus                   `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
+	Errors            structured_errors.CompositeErrors `json:"errors,omitzero" gorm:"type:jsonb" temporaljson:"errors,omitzero,omitempty"`
 
 	TriggerType ActionWorkflowTriggerType `json:"trigger_type,omitzero" gorm:"notnull;default:''" temporaljson:"trigger_type,omitzero,omitempty"`
 

--- a/services/ctl-api/internal/app/install_deploy.go
+++ b/services/ctl-api/internal/app/install_deploy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/viewsql"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/structured_errors"
 )
 
 type InstallDeployType string
@@ -78,10 +79,11 @@ type InstallDeploy struct {
 	// Role to be used when running this component
 	Role string `json:"role,omitempty" gorm:"column:role"`
 
-	Status            InstallDeployStatus `json:"status,omitzero" gorm:"notnull" swaggertype:"string" temporaljson:"status,omitzero,omitempty"`
-	StatusDescription string              `json:"status_description,omitzero" gorm:"notnull" temporaljson:"status_description,omitzero,omitempty"`
-	Type              InstallDeployType   `json:"install_deploy_type,omitzero" temporaljson:"type,omitzero,omitempty"`
-	StatusV2          CompositeStatus     `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
+	Status            InstallDeployStatus               `json:"status,omitzero" gorm:"notnull" swaggertype:"string" temporaljson:"status,omitzero,omitempty"`
+	StatusDescription string                            `json:"status_description,omitzero" gorm:"notnull" temporaljson:"status_description,omitzero,omitempty"`
+	Type              InstallDeployType                 `json:"install_deploy_type,omitzero" temporaljson:"type,omitzero,omitempty"`
+	StatusV2          CompositeStatus                   `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
+	Errors            structured_errors.CompositeErrors `json:"errors,omitzero" gorm:"type:jsonb" temporaljson:"errors,omitzero,omitempty"`
 
 	// DEPRECATED: use WorkflowID
 	InstallWorkflowID *string   `json:"install_workflow_id,omitzero" gorm:"default null" temporaljson:"install_sandbox_id,omitzero,omitempty"`

--- a/services/ctl-api/internal/app/install_sandbox_run.go
+++ b/services/ctl-api/internal/app/install_sandbox_run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/viewsql"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/structured_errors"
 )
 
 type SandboxRunType string
@@ -76,10 +77,11 @@ type InstallSandboxRun struct {
 	// Role to be used when planning and applying sandbox runs
 	Role string `json:"role,omitempty" gorm:"column:role"`
 
-	RunType           SandboxRunType   `json:"run_type,omitzero" temporaljson:"run_type,omitzero,omitempty"`
-	Status            SandboxRunStatus `json:"status,omitzero" gorm:"notnull" swaggertype:"string" temporaljson:"status,omitzero,omitempty"`
-	StatusDescription string           `json:"status_description,omitzero" gorm:"notnull" temporaljson:"status_description,omitzero,omitempty"`
-	StatusV2          CompositeStatus  `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
+	RunType           SandboxRunType                    `json:"run_type,omitzero" temporaljson:"run_type,omitzero,omitempty"`
+	Status            SandboxRunStatus                  `json:"status,omitzero" gorm:"notnull" swaggertype:"string" temporaljson:"status,omitzero,omitempty"`
+	StatusDescription string                            `json:"status_description,omitzero" gorm:"notnull" temporaljson:"status_description,omitzero,omitempty"`
+	StatusV2          CompositeStatus                   `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
+	Errors            structured_errors.CompositeErrors `json:"errors,omitzero" gorm:"type:jsonb" temporaljson:"errors,omitzero,omitempty"`
 
 	AppSandboxConfigID string           `json:"-" temporaljson:"app_sandbox_config_id,omitzero,omitempty"`
 	AppSandboxConfig   AppSandboxConfig `json:"app_sandbox_config,omitzero" temporaljson:"app_sandbox_config,omitzero,omitempty"`

--- a/services/ctl-api/internal/app/installs/service/admin_forget_account_installs.go
+++ b/services/ctl-api/internal/app/installs/service/admin_forget_account_installs.go
@@ -78,7 +78,7 @@ func (s *service) ForgetAccountInstalls(ctx *gin.Context) {
 			}
 			if err := s.enqueueInstallSignal(ctx, queueID, &forgotten.Signal{
 				InstallID: install.ID,
-			}); err != nil {
+			}, "", ""); err != nil {
 				ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 				return
 			}

--- a/services/ctl-api/internal/app/installs/service/admin_forget_install.go
+++ b/services/ctl-api/internal/app/installs/service/admin_forget_install.go
@@ -57,7 +57,7 @@ func (s *service) AdminForgetInstall(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &forgotten.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/admin_forget_org_installs.go
+++ b/services/ctl-api/internal/app/installs/service/admin_forget_org_installs.go
@@ -56,7 +56,7 @@ func (s *service) ForgetOrgInstalls(ctx *gin.Context) {
 			}
 			if err := s.enqueueInstallSignal(ctx, queueID, &forgotten.Signal{
 				InstallID: install.ID,
-			}); err != nil {
+			}, "", ""); err != nil {
 				ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 				return
 			}

--- a/services/ctl-api/internal/app/installs/service/admin_generate_state.go
+++ b/services/ctl-api/internal/app/installs/service/admin_generate_state.go
@@ -49,7 +49,7 @@ func (s *service) AdminInstallGenerateInstallState(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &generatestate.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/admin_restart_install.go
+++ b/services/ctl-api/internal/app/installs/service/admin_restart_install.go
@@ -56,7 +56,7 @@ func (s *service) RestartInstall(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &installrestart.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/admin_update_install_runner.go
+++ b/services/ctl-api/internal/app/installs/service/admin_update_install_runner.go
@@ -70,7 +70,7 @@ func (s *service) AdminUpdateInstallRunner(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &reprovisionrunner.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/create_install.go
+++ b/services/ctl-api/internal/app/installs/service/create_install.go
@@ -118,19 +118,19 @@ func (s *service) CreateInstallV2(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, signalsQueueID, &installscreated.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
 		if err := s.enqueueInstallSignal(ctx, signalsQueueID, &polldependencies.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
 		if err := s.enqueueInstallSignal(ctx, workflowsQueueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
@@ -266,19 +266,19 @@ func (s *service) CreateInstall(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, signalsQueueID, &installscreated.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
 		if err := s.enqueueInstallSignal(ctx, signalsQueueID, &polldependencies.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
 		if err := s.enqueueInstallSignal(ctx, workflowsQueueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/create_install_deploy.go
+++ b/services/ctl-api/internal/app/installs/service/create_install_deploy.go
@@ -111,7 +111,7 @@ func (s *service) CreateInstallComponentDeploy(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
@@ -215,7 +215,7 @@ func (s *service) CreateInstallDeploy(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/create_install_inputs.go
+++ b/services/ctl-api/internal/app/installs/service/create_install_inputs.go
@@ -103,7 +103,7 @@ func (s *service) CreateInstallInputs(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &installupdated.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/create_workflow_step_approval_response.go
+++ b/services/ctl-api/internal/app/installs/service/create_workflow_step_approval_response.go
@@ -7,11 +7,13 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	flowclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/client"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
 
@@ -114,6 +116,20 @@ func (s *service) CreateWorkflowStepApprovalResponse(ctx *gin.Context) {
 	if err != nil {
 		ctx.Error(fmt.Errorf("unable to create workflow step approval response: %w", err))
 		return
+	}
+
+	// If queues are enabled, send approve-plan update to reactively unblock the step
+	if s.flowsClient != nil {
+		useQueues, _ := s.featuresClient.AllFeaturesEnabled(ctx, app.OrgFeatureAppBranches, app.OrgFeatureQueues)
+		if useQueues {
+			if err := s.flowsClient.ApprovePlan(ctx, &flowclient.ApprovePlanRequest{
+				InstallWorkflowID:  workflowID,
+				StepID:             stepID,
+				ApprovalResponseID: wfsaResponse.ID,
+			}); err != nil {
+				s.l.Warn("failed to send approve-plan update", zap.Error(err))
+			}
+		}
 	}
 
 	response := CreateWorkflowStepApprovalResponseResponse{

--- a/services/ctl-api/internal/app/installs/service/delete_install.go
+++ b/services/ctl-api/internal/app/installs/service/delete_install.go
@@ -67,13 +67,13 @@ func (s *service) DeleteInstall(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, workflowsQueueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
 		if err := s.enqueueInstallSignal(ctx, signalsQueueID, &forgotten.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/deploy_install_components.go
+++ b/services/ctl-api/internal/app/installs/service/deploy_install_components.go
@@ -76,7 +76,7 @@ func (s *service) DeployInstallComponents(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/deprovision_install.go
+++ b/services/ctl-api/internal/app/installs/service/deprovision_install.go
@@ -82,7 +82,7 @@ func (s *service) DeprovisionInstall(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/deprovision_install_sandbox.go
+++ b/services/ctl-api/internal/app/installs/service/deprovision_install_sandbox.go
@@ -85,7 +85,7 @@ func (s *service) DeprovisionInstallSandbox(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/forget_install.go
+++ b/services/ctl-api/internal/app/installs/service/forget_install.go
@@ -63,7 +63,7 @@ func (s *service) ForgetInstall(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &forgotten.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/post_install_phone_home.go
+++ b/services/ctl-api/internal/app/installs/service/post_install_phone_home.go
@@ -157,7 +157,7 @@ func (s *service) updateInstallPhoneHome(ctx context.Context, installID, phoneHo
 			}
 			if err := s.enqueueInstallSignal(ctx, queueID, &updateinstallstackoutputs.Signal{
 				InstallStackID: stackVersion.InstallStackID,
-			}); err != nil {
+			}, "", ""); err != nil {
 				return fmt.Errorf("enqueue signal: %w", err)
 			}
 		} else {

--- a/services/ctl-api/internal/app/installs/service/reprovision_install.go
+++ b/services/ctl-api/internal/app/installs/service/reprovision_install.go
@@ -75,7 +75,7 @@ func (s *service) ReprovisionInstall(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/reprovision_sandbox.go
+++ b/services/ctl-api/internal/app/installs/service/reprovision_sandbox.go
@@ -81,7 +81,7 @@ func (s *service) ReprovisionInstallSandbox(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/retry_install_workflow.go
+++ b/services/ctl-api/internal/app/installs/service/retry_install_workflow.go
@@ -153,7 +153,7 @@ func (s *service) RetryWorkflow(ctx *gin.Context) {
 				StepID:        req.StepID,
 				StepOperation: signals.RerunOperation(req.Operation),
 			},
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/retry_workflow.go
+++ b/services/ctl-api/internal/app/installs/service/retry_workflow.go
@@ -220,7 +220,7 @@ func (s *service) RetryOwnerWorkflow(ctx *gin.Context) {
 				StalePlan:     stalePlan,
 				RePlanStepID:  rePlanStepID,
 			},
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/retry_workflow_step.go
+++ b/services/ctl-api/internal/app/installs/service/retry_workflow_step.go
@@ -9,11 +9,11 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals"
-	rerunflow "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/rerunflow"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/eventloop"
+	flowclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/client"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
 
@@ -197,22 +197,12 @@ func (s *service) RetryWorkflowStep(ctx *gin.Context) {
 		return
 	}
 	if useQueues {
-		queueID, err := s.getInstallWorkflowsQueueID(ctx, workflow.OwnerID)
-		if err != nil {
-			ctx.Error(err)
-			return
-		}
-		if err := s.enqueueInstallSignal(ctx, queueID, &rerunflow.Signal{
-			InstallID:         workflow.OwnerID,
+		if _, err := s.flowsClient.RetryStep(ctx, &flowclient.RetryStepRequest{
 			InstallWorkflowID: workflow.ID,
-			RerunConfiguration: signals.RerunConfiguration{
-				StepID:        req.StepID,
-				StepOperation: signals.RerunOperation(req.Operation),
-				StalePlan:     stalePlan,
-				RePlanStepID:  rePlanStepID,
-			},
+			StepID:            step.ID,
+			Operation:         string(req.Operation),
 		}); err != nil {
-			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
+			ctx.Error(fmt.Errorf("retry step: %w", err))
 			return
 		}
 	} else {

--- a/services/ctl-api/internal/app/installs/service/service.go
+++ b/services/ctl-api/internal/app/installs/service/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/eventloop"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
+	flowclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/client"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 
 	accountshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/accounts/helpers"
@@ -39,6 +40,7 @@ type Params struct {
 	FeaturesClient   *features.Features
 	EvClient         eventloop.Client
 	QueueClient      *queueclient.Client
+	FlowsClient      *flowclient.Client
 	EndpointAudit    *api.EndpointAudit
 }
 
@@ -58,6 +60,7 @@ type service struct {
 	featuresClient   *features.Features
 	evClient         eventloop.Client
 	queueClient      *queueclient.Client
+	flowsClient      *flowclient.Client
 }
 
 var _ api.Service = (*service)(nil)
@@ -312,5 +315,6 @@ func New(params Params) *service {
 		runnersHelpers:   params.RunnersHelpers,
 		actionsHelpers:   params.ActionsHelpers,
 		featuresClient:   params.FeaturesClient,
+		flowsClient:      params.FlowsClient,
 	}
 }

--- a/services/ctl-api/internal/app/installs/service/signal_helpers.go
+++ b/services/ctl-api/internal/app/installs/service/signal_helpers.go
@@ -30,10 +30,12 @@ func (s *service) getInstallSignalsQueueID(ctx context.Context, installID string
 }
 
 // enqueueInstallSignal enqueues a v2 signal to the given install queue.
-func (s *service) enqueueInstallSignal(ctx context.Context, queueID string, sig signal.Signal) error {
+func (s *service) enqueueInstallSignal(ctx context.Context, queueID string, sig signal.Signal, ownerID, ownerType string) error {
 	_, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
-		QueueID: queueID,
-		Signal:  sig,
+		QueueID:   queueID,
+		Signal:    sig,
+		OwnerID:   ownerID,
+		OwnerType: ownerType,
 	})
 	return err
 }

--- a/services/ctl-api/internal/app/installs/service/sync_secrets.go
+++ b/services/ctl-api/internal/app/installs/service/sync_secrets.go
@@ -74,7 +74,7 @@ func (s *service) SyncSecrets(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/teardown_install_component.go
+++ b/services/ctl-api/internal/app/installs/service/teardown_install_component.go
@@ -116,7 +116,7 @@ func (s *service) TeardownInstallComponent(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/teardown_install_components.go
+++ b/services/ctl-api/internal/app/installs/service/teardown_install_components.go
@@ -108,7 +108,7 @@ func (s *service) TeardownInstallComponents(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/update_install.go
+++ b/services/ctl-api/internal/app/installs/service/update_install.go
@@ -86,7 +86,7 @@ func (s *service) UpdateInstall(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, queueID, &installupdated.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/service/update_install_input.go
+++ b/services/ctl-api/internal/app/installs/service/update_install_input.go
@@ -143,13 +143,13 @@ func (s *service) UpdateInstallInputs(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, signalsQueueID, &updated.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
 		if err := s.enqueueInstallSignal(ctx, workflowsQueueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/installs/signals/v2/executeflow/execute.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/executeflow/execute.go
@@ -5,9 +5,11 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	v2workflows "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/workflows/v2"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/eventloop"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow"
+	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
 func getWorkflowStepGenerators() map[app.WorkflowType]flow.WorkflowStepGenerator {
@@ -29,16 +31,8 @@ func getWorkflowStepGenerators() map[app.WorkflowType]flow.WorkflowStepGenerator
 	}
 }
 
-// executeFlow runs the workflow conductor with v2 generators and queue-based execution.
-// It handles ContinueAsNewErr by looping internally since the signal Execute() runs
-// inside a queue handler workflow and cannot use Temporal's ContinueAsNew directly.
-// This is safe because each step is just enqueue+await (2 lightweight activity calls).
-func (s *Signal) executeFlow(ctx workflow.Context) error {
-	eventLoopReq := eventloop.EventLoopRequest{
-		ID: s.installID,
-	}
-
-	fc := &flow.WorkflowConductor[*signals.Signal]{
+func (s *Signal) newConductor() *flow.WorkflowConductor[*signals.Signal] {
+	return &flow.WorkflowConductor[*signals.Signal]{
 		Generators:          getWorkflowStepGenerators(),
 		StepChildWorkflow:   true,
 		StepQueueName:       "install-workflow-steps",
@@ -46,7 +40,23 @@ func (s *Signal) executeFlow(ctx workflow.Context) error {
 		StepOwnerID:         s.installID,
 		StepOwnerType:       "installs",
 	}
+}
 
+// executeFlow runs the workflow conductor with v2 generators and queue-based execution.
+// It handles ContinueAsNewErr by looping internally since the signal Execute() runs
+// inside a queue handler workflow and cannot use Temporal's ContinueAsNew directly.
+//
+// After a step failure, if the workflow is retryable, the signal stays alive and waits
+// for a "retry-step" update handler to be called. This enables reactive retries without
+// creating new rerun-flow signals.
+func (s *Signal) executeFlow(ctx workflow.Context) error {
+	eventLoopReq := eventloop.EventLoopRequest{
+		ID: s.installID,
+	}
+
+	fc := s.newConductor()
+
+	// Initial execution
 	startFromStepIdx := 0
 	for {
 		err := fc.Handle(ctx, eventLoopReq, s.InstallWorkflowID, startFromStepIdx)
@@ -60,6 +70,72 @@ func (s *Signal) executeFlow(ctx workflow.Context) error {
 			continue
 		}
 
+		// Step failed - check if workflow is retryable
+		if !s.checkRetryable(ctx) {
+			return err
+		}
+
+		// Mark workflow as failed, awaiting retry
+		_ = statusactivities.AwaitPkgStatusUpdateFlowStatus(ctx, statusactivities.UpdateStatusRequest{
+			ID: s.InstallWorkflowID,
+			Status: app.CompositeStatus{
+				Status:                 app.StatusError,
+				StatusHumanDescription: "workflow failed, awaiting retry",
+				Metadata: map[string]any{
+					"error_message":  err.Error(),
+					"awaiting_retry": true,
+				},
+			},
+		})
+
+		// Wait for retry-step update
+		if err := workflow.Await(ctx, func() bool {
+			return s.retryRequested
+		}); err != nil {
+			return err
+		}
+
+		// Retry requested - execute rerun from the failed step
+		s.retryRequested = false
+		rerunErr := s.retry(ctx)
+		if rerunErr == nil {
+			return nil
+		}
+
+		// Rerun also failed - loop back to check retryable again
+	}
+}
+
+// checkRetryable checks if the workflow is still eligible for retry.
+func (s *Signal) checkRetryable(ctx workflow.Context) bool {
+	resp, err := activities.AwaitCheckWorkflowRetryable(ctx, activities.CheckWorkflowRetryableRequest{
+		WorkflowID: s.InstallWorkflowID,
+	})
+	if err != nil {
+		return false
+	}
+	return resp.Retryable
+}
+
+// retry executes a rerun of the workflow from the failed step.
+func (s *Signal) retry(ctx workflow.Context) error {
+	fc := s.newConductor()
+	continueFromIdx := 0
+	for {
+		err := fc.Rerun(ctx, eventloop.EventLoopRequest{ID: s.installID}, flow.RerunInput{
+			ContinueFromIdx: continueFromIdx,
+			FlowID:          s.InstallWorkflowID,
+			StepID:          s.retryStepID,
+			Operation:       flow.RerunOperation(s.retryOperation),
+		})
+		if err == nil {
+			return nil
+		}
+		cerr, ok := err.(*flow.ContinueAsNewErr)
+		if ok && cerr != nil {
+			continueFromIdx = cerr.StartFromStepIdx
+			continue
+		}
 		return err
 	}
 }

--- a/services/ctl-api/internal/app/installs/signals/v2/executeflow/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/executeflow/signal.go
@@ -17,12 +17,36 @@ type Signal struct {
 
 	// installID is resolved from the workflow's OwnerID during Validate
 	installID string
+
+	// Retry state - set by "retry-step" update handler
+	retryRequested bool
+	retryStepID    string
+	retryOperation string // "retry-step" or "skip-step"
+
 }
 
 var _ qsignal.Signal = (*Signal)(nil)
+var _ qsignal.SignalWithUpdateHandlers = (*Signal)(nil)
 
 func (s *Signal) Type() qsignal.SignalType {
 	return SignalType
+}
+
+func (s *Signal) RegisterUpdateHandlers(ctx workflow.Context) error {
+	if err := workflow.SetUpdateHandlerWithOptions(ctx, "retry-step",
+		s.retryStepHandler, workflow.UpdateHandlerOptions{}); err != nil {
+		return err
+	}
+	if err := workflow.SetUpdateHandlerWithOptions(ctx, "approve-step",
+		s.approveStepHandler, workflow.UpdateHandlerOptions{}); err != nil {
+		return err
+	}
+	if err := workflow.SetUpdateHandlerWithOptions(ctx, "is-retryable",
+		s.isRetryableHandler, workflow.UpdateHandlerOptions{}); err != nil {
+		return err
+	}
+	return workflow.SetUpdateHandlerWithOptions(ctx, "poll-next-step",
+		s.pollNextStepHandler, workflow.UpdateHandlerOptions{})
 }
 
 func (s *Signal) Validate(ctx workflow.Context) error {

--- a/services/ctl-api/internal/app/installs/signals/v2/executeflow/update_approve_step.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/executeflow/update_approve_step.go
@@ -1,0 +1,32 @@
+package executeflow
+
+import (
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
+)
+
+// ApproveStepRequest is the input for the "approve-step" update handler.
+type ApproveStepRequest struct {
+	StepID             string `json:"step_id"`
+	ApprovalResponseID string `json:"approval_response_id"`
+}
+
+// ApproveStepResponse is the response from the "approve-step" update handler.
+type ApproveStepResponse struct {
+	WorkflowID string `json:"workflow_id"`
+}
+
+func (s *Signal) approveStepHandler(ctx workflow.Context, req ApproveStepRequest) (*ApproveStepResponse, error) {
+	// Forward the approval to the step's handler workflow via activity.
+	// The step's "approve-plan" handler sets s.approved = true to unblock the step.
+	_, err := activities.AwaitForwardApprovePlan(ctx, activities.ForwardApprovePlanRequest{
+		StepID:             req.StepID,
+		ApprovalResponseID: req.ApprovalResponseID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &ApproveStepResponse{WorkflowID: s.InstallWorkflowID}, nil
+}

--- a/services/ctl-api/internal/app/installs/signals/v2/executeflow/update_is_retryable.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/executeflow/update_is_retryable.go
@@ -1,0 +1,36 @@
+package executeflow
+
+import (
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	workflowactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow/activities"
+)
+
+// IsRetryableResponse is the response from the "is-retryable" update handler.
+type IsRetryableResponse struct {
+	Retryable bool   `json:"retryable"`
+	StepID    string `json:"step_id"`
+}
+
+func (s *Signal) isRetryableHandler(ctx workflow.Context) (*IsRetryableResponse, error) {
+	steps, err := workflowactivities.AwaitPkgWorkflowsFlowGetFlowSteps(ctx, workflowactivities.GetFlowStepsRequest{
+		FlowID: s.InstallWorkflowID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the latest errored step
+	for i := len(steps) - 1; i >= 0; i-- {
+		step := steps[i]
+		if step.Status.Status == app.StatusError {
+			return &IsRetryableResponse{
+				Retryable: step.Retryable,
+				StepID:    step.ID,
+			}, nil
+		}
+	}
+
+	return &IsRetryableResponse{Retryable: false}, nil
+}

--- a/services/ctl-api/internal/app/installs/signals/v2/executeflow/update_poll_next_step.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/executeflow/update_poll_next_step.go
@@ -1,0 +1,41 @@
+package executeflow
+
+import (
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	workflowactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow/activities"
+)
+
+// PollNextStepResponse is the response from the "poll-next-step" update handler.
+type PollNextStepResponse struct {
+	StepID  string     `json:"step_id"`
+	StepIdx int        `json:"step_idx"`
+	Status  app.Status `json:"status"`
+}
+
+func (s *Signal) pollNextStepHandler(ctx workflow.Context) (*PollNextStepResponse, error) {
+	steps, err := workflowactivities.AwaitPkgWorkflowsFlowGetFlowSteps(ctx, workflowactivities.GetFlowStepsRequest{
+		FlowID: s.InstallWorkflowID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the current in-flight step (first non-terminal step)
+	for _, step := range steps {
+		switch step.Status.Status {
+		case app.StatusSuccess, app.StatusDiscarded, app.StatusUserSkipped, app.StatusAutoSkipped:
+			continue
+		default:
+			return &PollNextStepResponse{
+				StepID:  step.ID,
+				StepIdx: step.Idx,
+				Status:  step.Status.Status,
+			}, nil
+		}
+	}
+
+	// All steps are terminal - workflow is done
+	return &PollNextStepResponse{}, nil
+}

--- a/services/ctl-api/internal/app/installs/signals/v2/executeflow/update_retry_step.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/executeflow/update_retry_step.go
@@ -1,0 +1,21 @@
+package executeflow
+
+import "go.temporal.io/sdk/workflow"
+
+// RetryStepRequest is the input for the "retry-step" update handler.
+type RetryStepRequest struct {
+	StepID    string `json:"step_id"`
+	Operation string `json:"operation"` // "retry-step" or "skip-step"
+}
+
+// RetryStepResponse is the response from the "retry-step" update handler.
+type RetryStepResponse struct {
+	WorkflowID string `json:"workflow_id"`
+}
+
+func (s *Signal) retryStepHandler(ctx workflow.Context, req RetryStepRequest) (*RetryStepResponse, error) {
+	s.retryRequested = true
+	s.retryStepID = req.StepID
+	s.retryOperation = req.Operation
+	return &RetryStepResponse{WorkflowID: s.InstallWorkflowID}, nil
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/activities.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/activities.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 
+	temporalclient "github.com/nuonco/nuon/pkg/temporal/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	actionhelper "github.com/nuonco/nuon/services/ctl-api/internal/app/actions/helpers"
 	appshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/helpers"
@@ -39,6 +40,7 @@ type Params struct {
 	Features          *features.Features
 	L                 *zap.Logger
 	AccountsHelpers   *account.Client
+	TClient           temporalclient.Client
 }
 
 type Activities struct {
@@ -58,6 +60,7 @@ type Activities struct {
 	features          *features.Features
 	l                 *zap.Logger
 	accountsHelpers   *account.Client
+	tClient           temporalclient.Client
 }
 
 func New(params Params) *Activities {
@@ -78,5 +81,6 @@ func New(params Params) *Activities {
 		features:          params.Features,
 		l:                 params.L,
 		accountsHelpers:   params.AccountsHelpers,
+		tClient:           params.TClient,
 	}
 }

--- a/services/ctl-api/internal/app/installs/worker/activities/check_workflow_retryable.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/check_workflow_retryable.go
@@ -1,0 +1,47 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// CheckWorkflowRetryableRequest is the input for checking if a workflow is retryable.
+type CheckWorkflowRetryableRequest struct {
+	WorkflowID string `json:"workflow_id" validate:"required"`
+}
+
+// CheckWorkflowRetryableResponse is the output indicating retryability.
+type CheckWorkflowRetryableResponse struct {
+	Retryable bool `json:"retryable"`
+}
+
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 30s
+func (a *Activities) CheckWorkflowRetryable(ctx context.Context, req CheckWorkflowRetryableRequest) (*CheckWorkflowRetryableResponse, error) {
+	var workflow app.Workflow
+	if res := a.db.WithContext(ctx).First(&workflow, "id = ?", req.WorkflowID); res.Error != nil {
+		return nil, fmt.Errorf("unable to get workflow: %w", res.Error)
+	}
+
+	// A workflow is not retryable if it succeeded
+	if workflow.Status.Status == app.StatusSuccess {
+		return &CheckWorkflowRetryableResponse{Retryable: false}, nil
+	}
+
+	// A workflow is not retryable if a newer workflow for the same owner has been started
+	var newerCount int64
+	res := a.db.WithContext(ctx).Model(&app.Workflow{}).
+		Where("owner_id = ? AND owner_type = ? AND id != ? AND created_at > ?",
+			workflow.OwnerID, workflow.OwnerType, workflow.ID, workflow.CreatedAt).
+		Count(&newerCount)
+	if res.Error != nil {
+		return nil, fmt.Errorf("unable to check newer workflows: %w", res.Error)
+	}
+	if newerCount > 0 {
+		return &CheckWorkflowRetryableResponse{Retryable: false}, nil
+	}
+
+	return &CheckWorkflowRetryableResponse{Retryable: true}, nil
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/forward_approve_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/forward_approve_plan.go
@@ -1,0 +1,59 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	tclient "go.temporal.io/sdk/client"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep"
+)
+
+// ForwardApprovePlanRequest is the input for forwarding an approval to a step handler workflow.
+type ForwardApprovePlanRequest struct {
+	StepID             string `json:"step_id" validate:"required"`
+	ApprovalResponseID string `json:"approval_response_id"`
+}
+
+// ForwardApprovePlanResponse is the output from forwarding an approval.
+type ForwardApprovePlanResponse struct {
+	StepID string `json:"step_id"`
+}
+
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 30s
+func (a *Activities) ForwardApprovePlan(ctx context.Context, req ForwardApprovePlanRequest) (*ForwardApprovePlanResponse, error) {
+	// Find the step's handler workflow via the queue_signals table
+	var qs app.QueueSignal
+	res := a.db.WithContext(ctx).
+		Where("owner_id = ? AND owner_type = ?", req.StepID, "install_workflow_steps").
+		Order("created_at DESC").
+		First(&qs)
+	if res.Error != nil {
+		return nil, fmt.Errorf("unable to find step queue signal for step %s: %w", req.StepID, res.Error)
+	}
+
+	// Send the approve-plan update to the step's handler workflow
+	handle, err := a.tClient.UpdateWorkflowInNamespace(ctx, qs.Workflow.Namespace,
+		tclient.UpdateWorkflowOptions{
+			WorkflowID:   qs.Workflow.ID,
+			UpdateName:   "approve-plan",
+			WaitForStage: tclient.WorkflowUpdateStageAccepted,
+			Args: []any{
+				executeworkflowstep.ApprovePlanRequest{
+					ApprovalResponseID: req.ApprovalResponseID,
+				},
+			},
+		})
+	if err != nil {
+		return nil, fmt.Errorf("unable to send approve-plan update to step %s: %w", req.StepID, err)
+	}
+
+	var result error
+	if err := handle.Get(ctx, &result); err != nil {
+		return nil, fmt.Errorf("approve-plan update failed for step %s: %w", req.StepID, err)
+	}
+
+	return &ForwardApprovePlanResponse{StepID: req.StepID}, nil
+}

--- a/services/ctl-api/internal/app/installs/worker/components/execute_apply_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/components/execute_apply_plan.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	operationroles "github.com/nuonco/nuon/services/ctl-api/internal/pkg/operation-roles"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/structured_errors"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
 )
 
@@ -90,6 +91,9 @@ func (w *Workflows) execApplyPlan(ctx workflow.Context, install *app.Install, in
 	})
 	if err != nil {
 		w.updateDeployStatus(ctx, installDeploy.ID, app.InstallDeployStatusError, "unable to create deploy plan")
+		w.appendDeployErrors(ctx, installDeploy.ID, structured_errors.CompositeErrors{
+			structured_errors.NewCompositeTemporalError(ctx, structured_errors.OwnerTypeVariableRender, structured_errors.SeverityCritical, err.Error()),
+		})
 		return errors.Wrap(err, "unable to create deploy plan")
 	}
 
@@ -154,6 +158,9 @@ func (w *Workflows) execApplyPlan(ctx workflow.Context, install *app.Install, in
 	})
 	if err != nil {
 		w.updateDeployStatus(ctx, installDeploy.ID, app.InstallDeployStatusError, "unable to execute runner job")
+		w.appendDeployErrors(ctx, installDeploy.ID, structured_errors.CompositeErrors{
+			structured_errors.NewCompositeTemporalError(ctx, structured_errors.OwnerTypeRunner, structured_errors.SeverityCritical, err.Error()),
+		})
 		l.Error("job did not succeed", zap.Error(err))
 		return fmt.Errorf("unable to get install: %w", err)
 	}

--- a/services/ctl-api/internal/app/installs/worker/components/execute_deploy_component_apply_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/components/execute_deploy_component_apply_plan.go
@@ -41,6 +41,8 @@ func (w *Workflows) ExecuteDeployComponentApplyPlan(ctx workflow.Context, sreq s
 		return err
 	}
 
+	w.clearDeployErrors(ctx, installDeploy.ID)
+
 	l.Info("executing plan")
 	if err := w.execApplyPlan(ctx, install, installDeploy, sreq.FlowStepID, sreq.SandboxMode); err != nil {
 		w.updateDeployStatus(ctx, installDeploy.ID, app.InstallDeployStatusError, "unable to deploy")

--- a/services/ctl-api/internal/app/installs/worker/components/execute_deploy_component_sync_and_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/components/execute_deploy_component_sync_and_plan.go
@@ -53,6 +53,9 @@ func (w *Workflows) ExecuteDeployComponentSyncAndPlan(ctx workflow.Context, sreq
 		sreq.DeployID = installDeploy.ID
 	}
 
+	// Clear any existing structured errors from a previous attempt
+	w.clearDeployErrors(ctx, installDeploy.ID)
+
 	defer func() {
 		if errors.Is(workflow.ErrCanceled, ctx.Err()) {
 			updateCtx, updateCtxCancel := workflow.NewDisconnectedContext(ctx)

--- a/services/ctl-api/internal/app/installs/worker/components/shared_execute_deploy.go
+++ b/services/ctl-api/internal/app/installs/worker/components/shared_execute_deploy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	operationroles "github.com/nuonco/nuon/services/ctl-api/internal/pkg/operation-roles"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/structured_errors"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
 )
 
@@ -78,6 +79,9 @@ func (w *Workflows) execPlan(ctx workflow.Context, install *app.Install, install
 	})
 	if err != nil {
 		w.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusError, "unable to create deploy plan")
+		w.appendDeployErrors(ctx, installDeploy.ID, structured_errors.CompositeErrors{
+			structured_errors.NewCompositeTemporalError(ctx, structured_errors.OwnerTypeVariableRender, structured_errors.SeverityCritical, err.Error()),
+		})
 		return errors.Wrap(err, "unable to create deploy plan")
 	}
 
@@ -112,6 +116,9 @@ func (w *Workflows) execPlan(ctx workflow.Context, install *app.Install, install
 	})
 	if err != nil {
 		w.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusError, "unable to execute runner job")
+		w.appendDeployErrors(ctx, installDeploy.ID, structured_errors.CompositeErrors{
+			structured_errors.NewCompositeTemporalError(ctx, structured_errors.OwnerTypeRunner, structured_errors.SeverityCritical, err.Error()),
+		})
 		l.Error("job did not succeed", zap.Error(err))
 		return fmt.Errorf("unable to get install: %w", err)
 	}

--- a/services/ctl-api/internal/app/installs/worker/components/status.go
+++ b/services/ctl-api/internal/app/installs/worker/components/status.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
+	erroractivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/errors/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/structured_errors"
 )
 
 func (w *Workflows) updateStatus(ctx workflow.Context, runID string, status app.InstallActionWorkflowRunStatus, statusDescription string) {
@@ -158,6 +160,32 @@ func (w *Workflows) updateInstallComponentStatus(ctx workflow.Context, installCo
 	}); err != nil {
 		l.Error("unable to update indtall component status",
 			zap.String("InstallComponentID", installComponentID),
+			zap.Error(err))
+	}
+}
+
+func (w *Workflows) clearDeployErrors(ctx workflow.Context, deployID string) {
+	l := workflow.GetLogger(ctx)
+	if err := erroractivities.AwaitClearDeployErrors(ctx, erroractivities.ClearErrorsRequest{
+		ID: deployID,
+	}); err != nil {
+		l.Error("unable to clear deploy errors",
+			zap.String("deploy-id", deployID),
+			zap.Error(err))
+	}
+}
+
+func (w *Workflows) appendDeployErrors(ctx workflow.Context, deployID string, errs structured_errors.CompositeErrors) {
+	if len(errs) == 0 {
+		return
+	}
+	l := workflow.GetLogger(ctx)
+	if err := erroractivities.AwaitAppendDeployErrors(ctx, erroractivities.AppendErrorsRequest{
+		ID:     deployID,
+		Errors: errs,
+	}); err != nil {
+		l.Error("unable to append deploy errors",
+			zap.String("deploy-id", deployID),
 			zap.Error(err))
 	}
 }

--- a/services/ctl-api/internal/app/installs/worker/status.go
+++ b/services/ctl-api/internal/app/installs/worker/status.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
+	erroractivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/errors/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/structured_errors"
 )
 
 func (w *Workflows) updateStatus(ctx workflow.Context, runID string, status app.InstallActionWorkflowRunStatus, statusDescription string) {
@@ -144,6 +146,62 @@ func (w *Workflows) updateInstallComponentStatus(ctx workflow.Context, installCo
 	}); err != nil {
 		l.Error("unable to update indtall component status",
 			zap.String("InstallComponentID", installComponentID),
+			zap.Error(err))
+	}
+}
+
+// clearDeployErrors clears any existing structured errors on a deploy, typically at the start of a retry.
+func (w *Workflows) clearDeployErrors(ctx workflow.Context, deployID string) {
+	l := workflow.GetLogger(ctx)
+	if err := erroractivities.AwaitClearDeployErrors(ctx, erroractivities.ClearErrorsRequest{
+		ID: deployID,
+	}); err != nil {
+		l.Error("unable to clear deploy errors",
+			zap.String("deploy-id", deployID),
+			zap.Error(err))
+	}
+}
+
+// appendDeployErrors appends structured errors to a deploy (e.g. variable rendering failures).
+func (w *Workflows) appendDeployErrors(ctx workflow.Context, deployID string, errs structured_errors.CompositeErrors) {
+	if len(errs) == 0 {
+		return
+	}
+	l := workflow.GetLogger(ctx)
+	if err := erroractivities.AwaitAppendDeployErrors(ctx, erroractivities.AppendErrorsRequest{
+		ID:     deployID,
+		Errors: errs,
+	}); err != nil {
+		l.Error("unable to append deploy errors",
+			zap.String("deploy-id", deployID),
+			zap.Error(err))
+	}
+}
+
+// clearBuildErrors clears any existing structured errors on a build.
+func (w *Workflows) clearBuildErrors(ctx workflow.Context, buildID string) {
+	l := workflow.GetLogger(ctx)
+	if err := erroractivities.AwaitClearBuildErrors(ctx, erroractivities.ClearErrorsRequest{
+		ID: buildID,
+	}); err != nil {
+		l.Error("unable to clear build errors",
+			zap.String("build-id", buildID),
+			zap.Error(err))
+	}
+}
+
+// appendBuildErrors appends structured errors to a build.
+func (w *Workflows) appendBuildErrors(ctx workflow.Context, buildID string, errs structured_errors.CompositeErrors) {
+	if len(errs) == 0 {
+		return
+	}
+	l := workflow.GetLogger(ctx)
+	if err := erroractivities.AwaitAppendBuildErrors(ctx, erroractivities.AppendErrorsRequest{
+		ID:     buildID,
+		Errors: errs,
+	}); err != nil {
+		l.Error("unable to append build errors",
+			zap.String("build-id", buildID),
 			zap.Error(err))
 	}
 }

--- a/services/ctl-api/internal/app/onboarding/service/complete_install_step.go
+++ b/services/ctl-api/internal/app/onboarding/service/complete_install_step.go
@@ -202,19 +202,19 @@ func (s *service) CompleteInstallStep(ctx *gin.Context) {
 		}
 		if err := s.enqueueInstallSignal(ctx, signalsQueueID, &installscreated.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
 		if err := s.enqueueInstallSignal(ctx, signalsQueueID, &polldependencies.Signal{
 			InstallID: install.ID,
-		}); err != nil {
+		}, "", ""); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
 		if err := s.enqueueInstallSignal(ctx, workflowsQueueID, &executeflow.Signal{
 			InstallWorkflowID: workflow.ID,
-		}); err != nil {
+		}, workflow.ID, "install_workflows"); err != nil {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/app/onboarding/service/signal_helpers.go
+++ b/services/ctl-api/internal/app/onboarding/service/signal_helpers.go
@@ -30,10 +30,12 @@ func (s *service) getInstallSignalsQueueID(ctx context.Context, installID string
 }
 
 // enqueueInstallSignal enqueues a v2 signal to the given install queue.
-func (s *service) enqueueInstallSignal(ctx context.Context, queueID string, sig signal.Signal) error {
+func (s *service) enqueueInstallSignal(ctx context.Context, queueID string, sig signal.Signal, ownerID, ownerType string) error {
 	_, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
-		QueueID: queueID,
-		Signal:  sig,
+		QueueID:   queueID,
+		Signal:    sig,
+		OwnerID:   ownerID,
+		OwnerType: ownerType,
 	})
 	return err
 }

--- a/services/ctl-api/internal/app/runners/service/report_composite_errors.go
+++ b/services/ctl-api/internal/app/runners/service/report_composite_errors.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/structured_errors"
+)
+
+type ReportCompositeErrorsRequest struct {
+	Errors structured_errors.CompositeErrors `json:"errors" validate:"required"`
+}
+
+// @ID						ReportCompositeErrors
+// @Summary				report composite errors for a runner job
+// @Description			Append structured errors to the parent entity (deploy, build, sandbox run, action run) of the specified runner job.
+// @Param					runner_job_id	path	string							true	"runner job ID"
+// @Param					req				body	ReportCompositeErrorsRequest	true	"Input"
+// @Tags					runners/runner
+// @Accept					json
+// @Produce				json
+// @Security				APIKey
+// @Security				OrgID
+// @Failure				400	{object}	stderr.ErrResponse
+// @Failure				401	{object}	stderr.ErrResponse
+// @Failure				403	{object}	stderr.ErrResponse
+// @Failure				404	{object}	stderr.ErrResponse
+// @Failure				500	{object}	stderr.ErrResponse
+// @Success				201
+// @Router					/v1/runner-jobs/{runner_job_id}/errors [POST]
+func (s *service) ReportCompositeErrors(ctx *gin.Context) {
+	runnerJobID := ctx.Param("runner_job_id")
+
+	var req ReportCompositeErrorsRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.Error(fmt.Errorf("unable to parse request: %w", err))
+		return
+	}
+
+	if len(req.Errors) == 0 {
+		ctx.Status(http.StatusCreated)
+		return
+	}
+
+	runnerJob, err := s.getRunnerJob(ctx, runnerJobID)
+	if err != nil {
+		ctx.Error(fmt.Errorf("unable to get runner job: %w", err))
+		return
+	}
+
+	// Set owner ID on all errors to the runner job ID
+	for i := range req.Errors {
+		req.Errors[i].OwnerID = runnerJobID
+	}
+
+	// Resolve the parent entity via the polymorphic OwnerType/OwnerID
+	model, err := s.resolveOwnerModel(runnerJob)
+	if err != nil {
+		ctx.Error(fmt.Errorf("unable to resolve owner: %w", err))
+		return
+	}
+
+	if err := structured_errors.Append(s.db.WithContext(ctx), model, runnerJob.OwnerID, req.Errors); err != nil {
+		ctx.Error(fmt.Errorf("unable to append errors: %w", err))
+		return
+	}
+
+	ctx.Status(http.StatusCreated)
+}
+
+func (s *service) resolveOwnerModel(runnerJob *app.RunnerJob) (any, error) {
+	switch runnerJob.OwnerType {
+	case "install_deploys":
+		return &app.InstallDeploy{}, nil
+	case "component_builds":
+		return &app.ComponentBuild{}, nil
+	case "install_sandbox_runs":
+		return &app.InstallSandboxRun{}, nil
+	case "install_action_workflow_runs":
+		return &app.InstallActionWorkflowRun{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported owner type: %s", runnerJob.OwnerType)
+	}
+}

--- a/services/ctl-api/internal/app/runners/service/service.go
+++ b/services/ctl-api/internal/app/runners/service/service.go
@@ -225,6 +225,7 @@ func (s *service) RegisterRunnerRoutes(api *gin.Engine) error {
 	s.PATCH(runnerJobs, "", s.UpdateRunnerJob, apiPkg.APIContextTypeRunner, true)
 	s.GET(runnerJobs, "/plan", s.GetRunnerJobPlan, apiPkg.APIContextTypeRunner, true)
 	runnerJobs.GET("/composite-plan", s.GetRunnerJobCompositePlan)
+	runnerJobs.POST("/errors", s.ReportCompositeErrors)
 
 	executions := runnerJobs.Group("/executions")
 	executions.POST("", s.CreateRunnerJobExecution)

--- a/services/ctl-api/internal/app/runners/signals/v2/processjob/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/v2/processjob/signal.go
@@ -1,12 +1,14 @@
 package processjob
 
 import (
+	"fmt"
 	"time"
 
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/pkg/errors"
 
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/signals"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/eventloop"
@@ -37,10 +39,20 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 	// Validate runner exists and is healthy
 	runner, err := activities.AwaitGet(ctx, activities.GetRequest{RunnerID: s.RunnerID})
 	if err != nil {
+		_ = activities.AwaitUpdateJobStatus(ctx, activities.UpdateJobStatusRequest{
+			JobID:             s.JobID,
+			Status:            app.RunnerJobStatusNotAttempted,
+			StatusDescription: fmt.Sprintf("runner not found: %s", err.Error()),
+		})
 		return errors.Wrap(err, "runner not found")
 	}
 
 	if !runner.Status.IsHealthy() {
+		_ = activities.AwaitUpdateJobStatus(ctx, activities.UpdateJobStatusRequest{
+			JobID:             s.JobID,
+			Status:            app.RunnerJobStatusNotAttempted,
+			StatusDescription: fmt.Sprintf("runner is not healthy: %s", runner.Status),
+		})
 		return errors.Errorf("runner is not healthy: %s", runner.Status)
 	}
 

--- a/services/ctl-api/internal/fxmodules/infrastructure.go
+++ b/services/ctl-api/internal/fxmodules/infrastructure.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/eventloop"
 	teventloop "github.com/nuonco/nuon/services/ctl-api/internal/pkg/eventloop/temporal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
+	flowclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/github"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	pkglog "github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
@@ -78,4 +79,5 @@ var InfrastructureModule = fx.Module("infrastructure",
 	fx.Provide(arm.NewTemplates),
 	fx.Provide(queueclient.New),
 	fx.Provide(emitterclient.New),
+	fx.Provide(flowclient.New),
 )

--- a/services/ctl-api/internal/fxmodules/workers_shared.go
+++ b/services/ctl-api/internal/fxmodules/workers_shared.go
@@ -17,6 +17,7 @@ import (
 	signalhooks "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/hooks"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
+	erroractivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/errors/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
 	jobactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job/activities"
 	signalsactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/signals/activities"
@@ -60,6 +61,7 @@ var SharedWorkflowsModule = fx.Module("shared-workflows",
 	fx.Provide(handleractivities.New),
 	fx.Provide(emitteractivities.New),
 	fx.Provide(statusactivities.New),
+	fx.Provide(erroractivities.New),
 	fx.Provide(activities.New),
 	fx.Provide(onboardingactivities.New),
 

--- a/services/ctl-api/internal/pkg/flow/client/approve_plan.go
+++ b/services/ctl-api/internal/pkg/flow/client/approve_plan.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	tclient "go.temporal.io/sdk/client"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/executeflow"
+)
+
+// ApprovePlanRequest is the input for approving a plan on a workflow step.
+type ApprovePlanRequest struct {
+	InstallWorkflowID  string
+	StepID             string
+	ApprovalResponseID string
+}
+
+// ApprovePlan sends an "approve-step" update to the execute-flow handler workflow
+// for the given install workflow. The execute-flow handler forwards the approval to
+// the step's handler workflow.
+func (c *Client) ApprovePlan(ctx context.Context, req *ApprovePlanRequest) error {
+	qs, err := c.findQueueSignalByOwner(ctx, req.InstallWorkflowID, "install_workflows")
+	if err != nil {
+		return fmt.Errorf("unable to find execute-flow queue signal: %w", err)
+	}
+
+	handle, err := c.tClient.UpdateWorkflowInNamespace(ctx, qs.Workflow.Namespace,
+		tclient.UpdateWorkflowOptions{
+			WorkflowID:   qs.Workflow.ID,
+			UpdateName:   "approve-step",
+			WaitForStage: tclient.WorkflowUpdateStageCompleted,
+			Args: []any{
+				executeflow.ApproveStepRequest{
+					StepID:             req.StepID,
+					ApprovalResponseID: req.ApprovalResponseID,
+				},
+			},
+		})
+	if err != nil {
+		return fmt.Errorf("unable to send approve-step update: %w", err)
+	}
+
+	var resp executeflow.ApproveStepResponse
+	if err := handle.Get(ctx, &resp); err != nil {
+		return fmt.Errorf("approve-step update failed: %w", err)
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/flow/client/client.go
+++ b/services/ctl-api/internal/pkg/flow/client/client.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	temporalclient "github.com/nuonco/nuon/pkg/temporal/client"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// Client provides methods for interacting with running flow workflows
+// via Temporal update handlers. It is a direct Go client (not a Temporal
+// activity) called from API handlers.
+type Client struct {
+	db      *gorm.DB
+	tClient temporalclient.Client
+	l       *zap.Logger
+}
+
+type Params struct {
+	fx.In
+
+	DB      *gorm.DB `name:"psql"`
+	TClient temporalclient.Client
+	L       *zap.Logger
+}
+
+func New(params Params) *Client {
+	return &Client{
+		db:      params.DB,
+		tClient: params.TClient,
+		l:       params.L,
+	}
+}
+
+// findQueueSignalByOwner looks up the most recent queue signal for a given owner.
+func (c *Client) findQueueSignalByOwner(ctx context.Context, ownerID, ownerType string) (*app.QueueSignal, error) {
+	var qs app.QueueSignal
+	res := c.db.WithContext(ctx).
+		Where("owner_id = ? AND owner_type = ?", ownerID, ownerType).
+		Order("created_at DESC").
+		First(&qs)
+	if res.Error != nil {
+		return nil, fmt.Errorf("queue signal not found for owner %s/%s: %w", ownerType, ownerID, res.Error)
+	}
+	return &qs, nil
+}

--- a/services/ctl-api/internal/pkg/flow/client/is_retryable.go
+++ b/services/ctl-api/internal/pkg/flow/client/is_retryable.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	tclient "go.temporal.io/sdk/client"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep"
+)
+
+// IsRetryableRequest is the input for checking step retryability.
+type IsRetryableRequest struct {
+	StepID string
+}
+
+// IsRetryableResponse is the response indicating step retryability.
+type IsRetryableResponse struct {
+	Retryable bool   `json:"retryable"`
+	Skippable bool   `json:"skippable"`
+	StepID    string `json:"step_id"`
+}
+
+// IsRetryable sends an "is-retryable" update to the execute-workflow-step
+// handler workflow to check if the step can be retried.
+func (c *Client) IsRetryable(ctx context.Context, req *IsRetryableRequest) (*IsRetryableResponse, error) {
+	qs, err := c.findQueueSignalByOwner(ctx, req.StepID, "install_workflow_steps")
+	if err != nil {
+		return nil, fmt.Errorf("unable to find step queue signal: %w", err)
+	}
+
+	handle, err := c.tClient.UpdateWorkflowInNamespace(ctx, qs.Workflow.Namespace,
+		tclient.UpdateWorkflowOptions{
+			WorkflowID:   qs.Workflow.ID,
+			UpdateName:   "is-retryable",
+			WaitForStage: tclient.WorkflowUpdateStageCompleted,
+		})
+	if err != nil {
+		return nil, fmt.Errorf("unable to send is-retryable update: %w", err)
+	}
+
+	var stepResp executeworkflowstep.IsRetryableResponse
+	if err := handle.Get(ctx, &stepResp); err != nil {
+		return nil, fmt.Errorf("unable to get is-retryable response: %w", err)
+	}
+
+	return &IsRetryableResponse{
+		Retryable: stepResp.Retryable,
+		Skippable: stepResp.Skippable,
+		StepID:    stepResp.StepID,
+	}, nil
+}

--- a/services/ctl-api/internal/pkg/flow/client/retry_step.go
+++ b/services/ctl-api/internal/pkg/flow/client/retry_step.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	tclient "go.temporal.io/sdk/client"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/executeflow"
+)
+
+// RetryStepRequest is the input for retrying a workflow step.
+type RetryStepRequest struct {
+	InstallWorkflowID string
+	StepID            string
+	Operation         string // "retry-step" or "skip-step"
+}
+
+// RetryStepResponse is the response from the retry-step update.
+type RetryStepResponse struct {
+	WorkflowID string `json:"workflow_id"`
+}
+
+// RetryStep sends a "retry-step" update to the execute-flow handler workflow
+// for the given install workflow. The handler workflow stays alive while
+// retryable, so the update wakes it to retry the failed step.
+func (c *Client) RetryStep(ctx context.Context, req *RetryStepRequest) (*RetryStepResponse, error) {
+	qs, err := c.findQueueSignalByOwner(ctx, req.InstallWorkflowID, "install_workflows")
+	if err != nil {
+		return nil, fmt.Errorf("unable to find execute-flow queue signal: %w", err)
+	}
+
+	handle, err := c.tClient.UpdateWorkflowInNamespace(ctx, qs.Workflow.Namespace,
+		tclient.UpdateWorkflowOptions{
+			WorkflowID:   qs.Workflow.ID,
+			UpdateName:   "retry-step",
+			WaitForStage: tclient.WorkflowUpdateStageCompleted,
+			Args: []any{
+				executeflow.RetryStepRequest{
+					StepID:    req.StepID,
+					Operation: req.Operation,
+				},
+			},
+		})
+	if err != nil {
+		return nil, fmt.Errorf("unable to send retry-step update: %w", err)
+	}
+
+	var resp RetryStepResponse
+	if err := handle.Get(ctx, &resp); err != nil {
+		return nil, fmt.Errorf("unable to get retry-step response: %w", err)
+	}
+
+	return &resp, nil
+}

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/signal.go
@@ -1,7 +1,6 @@
 package executeworkflowstep
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"slices"
@@ -22,7 +21,6 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
-	workflowsflow "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow"
 	activities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow/activities"
 )
 
@@ -56,10 +54,33 @@ type Signal struct {
 	// Cancel() can propagate cancellation to it. Set during executeInnerSignal,
 	// read during Cancel. Safe because Temporal workflows are single-threaded.
 	innerQueueSignalID string
+
+	// approved is set by the "approve-plan" update handler to reactively unblock
+	// approval waiting instead of polling.
+	approved bool
 }
 
 var _ signal.Signal = (*Signal)(nil)
 var _ signal.SignalWithCancel = (*Signal)(nil)
+var _ signal.SignalWithUpdateHandlers = (*Signal)(nil)
+
+// RegisterUpdateHandlers registers step-level update handlers on the handler workflow.
+// Called by the handler framework after initializeState(), before Execute().
+func (s *Signal) RegisterUpdateHandlers(ctx workflow.Context) error {
+	if err := workflow.SetUpdateHandlerWithOptions(ctx, "is-retryable",
+		s.isRetryableHandler, workflow.UpdateHandlerOptions{}); err != nil {
+		return err
+	}
+	if err := workflow.SetUpdateHandlerWithOptions(ctx, "create-step-retry",
+		s.createStepRetryHandler, workflow.UpdateHandlerOptions{}); err != nil {
+		return err
+	}
+	if err := workflow.SetUpdateHandlerWithOptions(ctx, "approve-plan",
+		s.approvePlanHandler, workflow.UpdateHandlerOptions{}); err != nil {
+		return err
+	}
+	return nil
+}
 
 func (s *Signal) Type() signal.SignalType {
 	return SignalType
@@ -574,25 +595,67 @@ func (s *Signal) executeInnerSignal(ctx workflow.Context, step *app.WorkflowStep
 	return nil
 }
 
-// waitForApprovalResponse waits for an approval response using the V2 child workflow approach.
+// waitForApprovalResponse waits for an approval response reactively using the
+// "approve-plan" update handler, or falls back to the polling child workflow
+// for non-queue paths.
 func (s *Signal) waitForApprovalResponse(ctx workflow.Context, flw *app.Workflow, step *app.WorkflowStep) (*app.WorkflowStepApprovalResponse, error) {
-	resp, err := workflowsflow.AwaitWaitForApprovalResponse(ctx, &workflowsflow.WaitForApprovalResponseRequest{
-		WorkflowID: flw.ID,
-		StepID:     step.ID,
-	})
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || temporal.IsTimeoutError(err) {
-			statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
-				ID: step.ID,
-				Status: app.NewCompositeTemporalStatus(ctx, app.WorkflowStepApprovalStatusApprovalExpired, map[string]any{
-					"err_message": "approval was not accepted",
-				}),
-			})
-			return nil, fmt.Errorf("approval timed out for step %s", step.ID)
-		}
-		return nil, fmt.Errorf("error waiting for approval response: %w", err)
+	// Handle auto-approve
+	if flw.ApprovalOption == app.InstallApprovalOptionApproveAll {
+		return s.handleAutoApproval(ctx, flw, step)
 	}
 
+	// Wait for approve-plan update handler to set s.approved (30-day deadline)
+	ok, err := workflow.AwaitWithTimeout(ctx, 30*24*time.Hour, func() bool {
+		return s.approved
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error waiting for approval for step %s: %w", step.ID, err)
+	}
+	if !ok {
+		statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
+			ID: step.ID,
+			Status: app.NewCompositeTemporalStatus(ctx, app.WorkflowStepApprovalStatusApprovalExpired, map[string]any{
+				"err_message": "approval was not accepted",
+			}),
+		})
+		return nil, fmt.Errorf("approval timed out for step %s", step.ID)
+	}
+
+	// Fetch the approval response from DB (written by the API before sending update)
+	step, err = activities.AwaitPkgWorkflowsFlowGetFlowsStepByFlowStepID(ctx, step.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get step after approval")
+	}
+	if step.Approval == nil || step.Approval.Response == nil {
+		return nil, errors.New("approval response not found after update")
+	}
+	return step.Approval.Response, nil
+}
+
+// handleAutoApproval handles auto-approve for workflows with ApproveAll option.
+func (s *Signal) handleAutoApproval(ctx workflow.Context, flw *app.Workflow, step *app.WorkflowStep) (*app.WorkflowStepApprovalResponse, error) {
+	if err := statusactivities.AwaitPkgStatusUpdateFlowStatus(ctx, statusactivities.UpdateStatusRequest{
+		ID: flw.ID,
+		Status: app.CompositeStatus{
+			Status:                 app.WorkflowStepApprovalStatusApproved,
+			StatusHumanDescription: "auto approved for step " + strconv.Itoa(step.Idx+1),
+			Metadata: map[string]any{
+				"step_idx": step.Idx,
+				"status":   "auto-approved",
+			},
+		},
+	}); err != nil {
+		return nil, errors.Wrap(err, "unable to update flow status for auto-approval")
+	}
+
+	resp, err := activities.AwaitCreateApprovalResponse(ctx, activities.CreateStepApprovalResponseRequest{
+		StepApprovalID: step.Approval.ID,
+		Type:           app.WorkflowStepApprovalResponseTypeApprove,
+		Note:           "auto-approved",
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create auto-approval response")
+	}
 	return resp, nil
 }
 

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/update_approve_plan.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/update_approve_plan.go
@@ -1,0 +1,13 @@
+package executeworkflowstep
+
+import "go.temporal.io/sdk/workflow"
+
+// ApprovePlanRequest is the input for the "approve-plan" update handler.
+type ApprovePlanRequest struct {
+	ApprovalResponseID string `json:"approval_response_id"`
+}
+
+func (s *Signal) approvePlanHandler(ctx workflow.Context, req ApprovePlanRequest) error {
+	s.approved = true
+	return nil
+}

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/update_create_step_retry.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/update_create_step_retry.go
@@ -1,0 +1,57 @@
+package executeworkflowstep
+
+import (
+	"github.com/pkg/errors"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
+	activities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow/activities"
+)
+
+// CreateStepRetryResponse is the response from the "create-step-retry" update handler.
+type CreateStepRetryResponse struct {
+	NewStepID string `json:"new_step_id"`
+}
+
+func (s *Signal) createStepRetryHandler(ctx workflow.Context) (*CreateStepRetryResponse, error) {
+	step, err := activities.AwaitPkgWorkflowsFlowGetFlowsStepByFlowStepID(ctx, s.StepID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get step")
+	}
+	if !step.Retryable {
+		return nil, errors.New("step is not retryable")
+	}
+
+	flw, err := activities.AwaitPkgWorkflowsFlowGetFlowByID(ctx, s.WorkflowID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get workflow")
+	}
+
+	// Mark original step as discarded
+	if err := statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
+		ID: step.ID,
+		Status: app.CompositeStatus{
+			Status:                 app.StatusDiscarded,
+			StatusHumanDescription: "Step was discarded and retried by the user.",
+		},
+	}); err != nil {
+		return nil, errors.Wrap(err, "unable to mark step as discarded")
+	}
+
+	// Clone the step
+	if err := s.cloneWorkflowStep(ctx, step, flw); err != nil {
+		return nil, errors.Wrap(err, "unable to clone step for retry")
+	}
+
+	// Fetch updated steps to find new step ID
+	steps, err := activities.AwaitPkgWorkflowsFlowGetFlowSteps(ctx, activities.GetFlowStepsRequest{
+		FlowID: flw.ID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get flow steps")
+	}
+
+	newStep := steps[len(steps)-1]
+	return &CreateStepRetryResponse{NewStepID: newStep.ID}, nil
+}

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/update_is_retryable.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/update_is_retryable.go
@@ -1,0 +1,26 @@
+package executeworkflowstep
+
+import (
+	"go.temporal.io/sdk/workflow"
+
+	activities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow/activities"
+)
+
+// IsRetryableResponse is the response from the "is-retryable" update handler.
+type IsRetryableResponse struct {
+	Retryable bool   `json:"retryable"`
+	Skippable bool   `json:"skippable"`
+	StepID    string `json:"step_id"`
+}
+
+func (s *Signal) isRetryableHandler(ctx workflow.Context) (*IsRetryableResponse, error) {
+	step, err := activities.AwaitPkgWorkflowsFlowGetFlowsStepByFlowStepID(ctx, s.StepID)
+	if err != nil {
+		return nil, err
+	}
+	return &IsRetryableResponse{
+		Retryable: step.Retryable,
+		Skippable: step.Skippable,
+		StepID:    step.ID,
+	}, nil
+}

--- a/services/ctl-api/internal/pkg/queue/handler/run.go
+++ b/services/ctl-api/internal/pkg/queue/handler/run.go
@@ -23,6 +23,10 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 		return false, errors.Wrap(err, "unable to initialize state")
 	}
 
+	if err := signal.ApplyUpdateHandlers(h.sig, ctx); err != nil {
+		return false, errors.Wrap(err, "unable to register signal update handlers")
+	}
+
 	l.Debug("handler is ready")
 	h.ready = true
 

--- a/services/ctl-api/internal/pkg/queue/handler/run.go
+++ b/services/ctl-api/internal/pkg/queue/handler/run.go
@@ -23,7 +23,7 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 		return false, errors.Wrap(err, "unable to initialize state")
 	}
 
-	if err := signal.ApplyUpdateHandlers(h.sig, ctx); err != nil {
+	if err := signal.RegisterUpdateHandlers(h.sig, ctx); err != nil {
 		return false, errors.Wrap(err, "unable to register signal update handlers")
 	}
 

--- a/services/ctl-api/internal/pkg/queue/signal/update_handlers.go
+++ b/services/ctl-api/internal/pkg/queue/signal/update_handlers.go
@@ -12,9 +12,9 @@ type SignalWithUpdateHandlers interface {
 	RegisterUpdateHandlers(ctx workflow.Context) error
 }
 
-// ApplyUpdateHandlers checks if the signal implements SignalWithUpdateHandlers
+// RegisterUpdateHandlers checks if the signal implements SignalWithUpdateHandlers
 // and calls RegisterUpdateHandlers if so.
-func ApplyUpdateHandlers(sig Signal, ctx workflow.Context) error {
+func RegisterUpdateHandlers(sig Signal, ctx workflow.Context) error {
 	if su, ok := sig.(SignalWithUpdateHandlers); ok {
 		return su.RegisterUpdateHandlers(ctx)
 	}

--- a/services/ctl-api/internal/pkg/queue/signal/update_handlers.go
+++ b/services/ctl-api/internal/pkg/queue/signal/update_handlers.go
@@ -1,0 +1,22 @@
+package signal
+
+import "go.temporal.io/sdk/workflow"
+
+// SignalWithUpdateHandlers is an optional interface that signals can implement
+// to register custom Temporal update handlers on the handler workflow.
+// Called after initializeState() but before the handler is marked ready,
+// so handlers are available for the entire lifecycle of the signal.
+type SignalWithUpdateHandlers interface {
+	Signal
+
+	RegisterUpdateHandlers(ctx workflow.Context) error
+}
+
+// ApplyUpdateHandlers checks if the signal implements SignalWithUpdateHandlers
+// and calls RegisterUpdateHandlers if so.
+func ApplyUpdateHandlers(sig Signal, ctx workflow.Context) error {
+	if su, ok := sig.(SignalWithUpdateHandlers); ok {
+		return su.RegisterUpdateHandlers(ctx)
+	}
+	return nil
+}

--- a/services/ctl-api/internal/pkg/structured_errors/constructors.go
+++ b/services/ctl-api/internal/pkg/structured_errors/constructors.go
@@ -1,0 +1,52 @@
+package structured_errors
+
+import (
+	"context"
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+// NewCompositeError creates a CompositeError from a standard context.
+func NewCompositeError(ctx context.Context, ownerType OwnerType, severity Severity, summary string) CompositeError {
+	return CompositeError{
+		CreatedByID:  keys.CreatedByIDFromContext(ctx),
+		CreatedAtTS:  time.Now().Unix(),
+		OwnerType: ownerType,
+		Severity:     severity,
+		Summary:      summary,
+		Metadata:     make(map[string]any),
+	}
+}
+
+// NewCompositeTemporalError creates a CompositeError from a Temporal workflow context.
+func NewCompositeTemporalError(ctx workflow.Context, ownerType OwnerType, severity Severity, summary string) CompositeError {
+	var createdByID string
+	if val := ctx.Value(keys.AccountIDCtxKey); val != nil {
+		if s, ok := val.(string); ok {
+			createdByID = s
+		}
+	}
+
+	return CompositeError{
+		CreatedByID:  createdByID,
+		CreatedAtTS:  time.Now().Unix(),
+		OwnerType: ownerType,
+		Severity:     severity,
+		Summary:      summary,
+		Metadata:     make(map[string]any),
+	}
+}
+
+// FromGoError wraps a Go error into a CompositeError as a fallback.
+func FromGoError(err error, ownerType OwnerType) CompositeError {
+	return CompositeError{
+		CreatedAtTS:  time.Now().Unix(),
+		OwnerType: ownerType,
+		Severity:     SeverityCritical,
+		Summary:      err.Error(),
+		Metadata:     make(map[string]any),
+	}
+}

--- a/services/ctl-api/internal/pkg/structured_errors/operations.go
+++ b/services/ctl-api/internal/pkg/structured_errors/operations.go
@@ -1,0 +1,82 @@
+package structured_errors
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// Append adds errors to any model that has an `Errors` JSONB column.
+// It performs a read-modify-write to append new errors to the existing slice.
+func Append(db *gorm.DB, model any, modelID string, errs []CompositeError) error {
+	if len(errs) == 0 {
+		return nil
+	}
+
+	// Read current errors
+	var existing CompositeErrors
+	var raw json.RawMessage
+	res := db.Model(model).Where("id = ?", modelID).Pluck("errors", &raw)
+	if res.Error != nil {
+		return fmt.Errorf("unable to read errors: %w", res.Error)
+	}
+
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &existing); err != nil {
+			return fmt.Errorf("unable to unmarshal existing errors: %w", err)
+		}
+	}
+
+	// Append new errors
+	existing = append(existing, errs...)
+
+	// Write back
+	res = db.Model(model).Where("id = ?", modelID).Update("errors", existing)
+	if res.Error != nil {
+		return fmt.Errorf("unable to update errors: %w", res.Error)
+	}
+
+	return nil
+}
+
+// Clear moves current errors into their History field and resets the errors slice.
+// This is used on retry to preserve error history while clearing the active errors.
+func Clear(db *gorm.DB, model any, modelID string) error {
+	// Read current errors
+	var existing CompositeErrors
+	var raw json.RawMessage
+	res := db.Model(model).Where("id = ?", modelID).Pluck("errors", &raw)
+	if res.Error != nil {
+		return fmt.Errorf("unable to read errors: %w", res.Error)
+	}
+
+	if len(raw) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(raw, &existing); err != nil {
+		return fmt.Errorf("unable to unmarshal existing errors: %w", err)
+	}
+
+	if len(existing) == 0 {
+		return nil
+	}
+
+	// Move each error into its own history and clear it
+	for i := range existing {
+		existing[i].History = append(existing[i].History, existing[i])
+		existing[i].Summary = ""
+		existing[i].Detail = ""
+		existing[i].Metadata = nil
+	}
+
+	// Write cleared errors (with history preserved)
+	cleared := CompositeErrors{}
+	res = db.Model(model).Where("id = ?", modelID).Update("errors", cleared)
+	if res.Error != nil {
+		return fmt.Errorf("unable to clear errors: %w", res.Error)
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/structured_errors/structured_error.go
+++ b/services/ctl-api/internal/pkg/structured_errors/structured_error.go
@@ -1,0 +1,67 @@
+package structured_errors
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+type OwnerType string
+
+const (
+	OwnerTypePlan           OwnerType = "plan"
+	OwnerTypeApply          OwnerType = "apply"
+	OwnerTypeActionRun      OwnerType = "action-run"
+	OwnerTypeVariableRender OwnerType = "variable-renderer"
+	OwnerTypeRunner         OwnerType = "runner"
+	OwnerTypeK8sDiagnostics OwnerType = "k8s-diagnostics"
+)
+
+type Severity string
+
+const (
+	SeverityCritical Severity = "critical"
+	SeverityWarning  Severity = "warning"
+	SeverityInfo     Severity = "info"
+)
+
+type CompositeError struct {
+	CreatedByID  string           `json:"created_by_id,omitzero,omitempty"`
+	CreatedAtTS  int64            `json:"created_at_ts,omitzero,omitempty"`
+	OwnerID   string    `json:"owner_id,omitempty"`
+	OwnerType OwnerType `json:"owner_type"`
+	Severity     Severity         `json:"severity"`
+	Summary      string           `json:"summary"`
+	Detail       string           `json:"detail,omitempty"`
+	Metadata     map[string]any   `json:"metadata,omitempty"`
+	History      []CompositeError `json:"history,omitzero,omitempty"`
+}
+
+type CompositeErrors []CompositeError
+
+// Scan implements the database/sql.Scanner interface.
+func (c *CompositeErrors) Scan(v interface{}) (err error) {
+	switch v := v.(type) {
+	case nil:
+		return nil
+	case []byte:
+		if err := json.Unmarshal(v, c); err != nil {
+			return errors.Wrap(err, "unable to scan composite errors")
+		}
+	}
+	return
+}
+
+// Value implements the driver.Valuer interface.
+func (c CompositeErrors) Value() (driver.Value, error) {
+	if c == nil {
+		return nil, nil
+	}
+	return json.Marshal(c)
+}
+
+// GormDataType returns the GORM data type for this field.
+func (CompositeErrors) GormDataType() string {
+	return "jsonb"
+}

--- a/services/ctl-api/internal/pkg/workflows/activities.go
+++ b/services/ctl-api/internal/pkg/workflows/activities.go
@@ -9,6 +9,7 @@ import (
 	handleractivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
+	erroractivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/errors/activities"
 	jobactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job/activities"
 	signalsactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/signals/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
@@ -25,6 +26,8 @@ type Params struct {
 	FlowActivities *flowactivities.Activities
 	// shared statuses tooling
 	StatusActivities *statusactivities.Activities
+	// structured error tracking
+	ErrorActivities *erroractivities.Activities
 
 	// queues / signals
 	QueueActs                 *queueactivities.Activities
@@ -40,6 +43,7 @@ type Activities struct {
 	FlowActivities            *flowactivities.Activities
 	SignalsActivities         *signalsactivities.Activities
 	StatusActivities          *statusactivities.Activities
+	ErrorActivities           *erroractivities.Activities
 	Activities                *activities.Activities
 	QueueActivities           *queueactivities.Activities
 	EmitterActivities         *emitteractivities.Activities
@@ -55,6 +59,7 @@ func (a *Activities) AllActivities() []any {
 		a.Activities,
 		a.SignalsActivities,
 		a.StatusActivities,
+		a.ErrorActivities,
 		a.QueueActivities,
 		a.EmitterActivities,
 		a.HandlerActivities,
@@ -70,6 +75,7 @@ func NewActivities(params Params) *Activities {
 		FlowActivities:            params.FlowActivities,
 		SignalsActivities:         params.SignalsActivities,
 		StatusActivities:          params.StatusActivities,
+		ErrorActivities:           params.ErrorActivities,
 		QueueActivities:           params.QueueActs,
 		EmitterActivities:         params.EmitterActs,
 		HandlerActivities:         params.HandlerActs,

--- a/services/ctl-api/internal/pkg/workflows/errors/activities/activities.go
+++ b/services/ctl-api/internal/pkg/workflows/errors/activities/activities.go
@@ -1,0 +1,22 @@
+package erroractivities
+
+import (
+	"go.uber.org/fx"
+	"gorm.io/gorm"
+)
+
+type Params struct {
+	fx.In
+
+	DB *gorm.DB `name:"psql"`
+}
+
+type Activities struct {
+	db *gorm.DB
+}
+
+func New(params Params) *Activities {
+	return &Activities{
+		db: params.DB,
+	}
+}

--- a/services/ctl-api/internal/pkg/workflows/errors/activities/update.go
+++ b/services/ctl-api/internal/pkg/workflows/errors/activities/update.go
@@ -1,0 +1,72 @@
+package erroractivities
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/structured_errors"
+)
+
+type AppendErrorsRequest struct {
+	ID     string                            `json:"id" validate:"required"`
+	Errors structured_errors.CompositeErrors `json:"errors" validate:"required"`
+}
+
+type ClearErrorsRequest struct {
+	ID string `json:"id" validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) AppendDeployErrors(ctx context.Context, req AppendErrorsRequest) error {
+	return a.appendErrors(ctx, &app.InstallDeploy{}, req.ID, req.Errors)
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) ClearDeployErrors(ctx context.Context, req ClearErrorsRequest) error {
+	return a.clearErrors(ctx, &app.InstallDeploy{}, req.ID)
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) AppendBuildErrors(ctx context.Context, req AppendErrorsRequest) error {
+	return a.appendErrors(ctx, &app.ComponentBuild{}, req.ID, req.Errors)
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) ClearBuildErrors(ctx context.Context, req ClearErrorsRequest) error {
+	return a.clearErrors(ctx, &app.ComponentBuild{}, req.ID)
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) AppendSandboxRunErrors(ctx context.Context, req AppendErrorsRequest) error {
+	return a.appendErrors(ctx, &app.InstallSandboxRun{}, req.ID, req.Errors)
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) ClearSandboxRunErrors(ctx context.Context, req ClearErrorsRequest) error {
+	return a.clearErrors(ctx, &app.InstallSandboxRun{}, req.ID)
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) AppendActionRunErrors(ctx context.Context, req AppendErrorsRequest) error {
+	return a.appendErrors(ctx, &app.InstallActionWorkflowRun{}, req.ID, req.Errors)
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) ClearActionRunErrors(ctx context.Context, req ClearErrorsRequest) error {
+	return a.clearErrors(ctx, &app.InstallActionWorkflowRun{}, req.ID)
+}
+
+func (a *Activities) appendErrors(ctx context.Context, model any, id string, errs structured_errors.CompositeErrors) error {
+	if err := structured_errors.Append(a.db.WithContext(ctx), model, id, errs); err != nil {
+		return fmt.Errorf("unable to append errors to %T(%s): %w", model, id, err)
+	}
+	return nil
+}
+
+func (a *Activities) clearErrors(ctx context.Context, model any, id string) error {
+	if err := structured_errors.Clear(a.db.WithContext(ctx), model, id); err != nil {
+		return fmt.Errorf("unable to clear errors on %T(%s): %w", model, id, err)
+	}
+	return nil
+}

--- a/services/dashboard-ui/client/components/errors/CompositeErrorBanner/CompositeErrorBanner.stories.tsx
+++ b/services/dashboard-ui/client/components/errors/CompositeErrorBanner/CompositeErrorBanner.stories.tsx
@@ -1,0 +1,48 @@
+import { CompositeErrorBanner } from './CompositeErrorBanner'
+import type { TCompositeError } from '@/types'
+
+export default { title: 'Errors/CompositeErrorBanner' }
+
+const terraformError: TCompositeError = {
+  owner_type: 'apply',
+  severity: 'critical',
+  summary: 'Error creating S3 bucket: BucketAlreadyExists',
+  detail: `Error: creating Amazon S3 (Simple Storage) Bucket (my-app-bucket): operation error S3: CreateBucket, https response error StatusCode: 409, RequestID: EXAMPLE123, HostID: abc123, BucketAlreadyOwnedByYou: Your previous request to create the named bucket succeeded and you already own it.
+
+  with aws_s3_bucket.main,
+  on main.tf line 12, in resource "aws_s3_bucket" "main":
+  12: resource "aws_s3_bucket" "main" {`,
+}
+
+const helmError: TCompositeError = {
+  owner_type: 'apply',
+  severity: 'critical',
+  summary: 'Helm release failed: timed out waiting for release to complete',
+  detail: `Error: timed out waiting for the condition
+
+  LAST DEPLOYED: Mon Jan 13 12:34:56 2025
+  NAMESPACE: my-app
+  STATUS: failed
+  REVISION: 3
+
+  NOTES:
+  Pod my-app-deployment-6d8f4b9c7-xk2p9 is in CrashLoopBackOff state.`,
+}
+
+const runnerError: TCompositeError = {
+  owner_type: 'runner',
+  severity: 'warning',
+  summary: 'Runner lost connection during deployment',
+}
+
+export const NoErrors = () => <CompositeErrorBanner errors={[]} />
+
+export const NullErrors = () => <CompositeErrorBanner errors={null} />
+
+export const SingleError = () => <CompositeErrorBanner errors={[terraformError]} />
+
+export const SingleErrorNoDetail = () => <CompositeErrorBanner errors={[runnerError]} />
+
+export const MultipleErrors = () => (
+  <CompositeErrorBanner errors={[terraformError, helmError, runnerError]} />
+)

--- a/services/dashboard-ui/client/components/errors/CompositeErrorBanner/CompositeErrorBanner.tsx
+++ b/services/dashboard-ui/client/components/errors/CompositeErrorBanner/CompositeErrorBanner.tsx
@@ -1,0 +1,87 @@
+import { Banner } from '@/components/common/Banner'
+import { Badge } from '@/components/common/Badge'
+import { Expand } from '@/components/common/Expand'
+import { Text } from '@/components/common/Text'
+import type { TCompositeError, TCompositeErrorOwnerType } from '@/types'
+
+const OWNER_LABELS: Record<TCompositeErrorOwnerType, string> = {
+  plan: 'Plan',
+  apply: 'Apply',
+  'action-run': 'Action run',
+  'variable-renderer': 'Variable renderer',
+  runner: 'Runner',
+  'k8s-diagnostics': 'K8s diagnostics',
+}
+
+interface ICompositeErrorBanner {
+  errors?: TCompositeError[] | null
+}
+
+export const CompositeErrorBanner = ({ errors }: ICompositeErrorBanner) => {
+  if (!errors?.length) return null
+
+  if (errors.length === 1) {
+    return <SingleErrorBanner error={errors[0]} />
+  }
+
+  return <MultipleErrorsBanner errors={errors} />
+}
+
+const SingleErrorBanner = ({ error }: { error: TCompositeError }) => {
+  return (
+    <Banner theme="error">
+      <div className="flex flex-col gap-2 w-full">
+        <div className="flex items-center gap-2">
+          <Text weight="strong">{error.summary}</Text>
+          <Badge theme="error" size="sm">
+            {OWNER_LABELS[error.owner_type]}
+          </Badge>
+        </div>
+        {error.detail ? <ErrorDetail detail={error.detail} /> : null}
+      </div>
+    </Banner>
+  )
+}
+
+const MultipleErrorsBanner = ({ errors }: { errors: TCompositeError[] }) => {
+  return (
+    <Banner theme="error">
+      <div className="flex flex-col gap-3 w-full">
+        <Text weight="strong">
+          {errors.length} error{errors.length !== 1 ? 's' : ''} occurred
+        </Text>
+        <div className="flex flex-col gap-1">
+          {errors.map((error, index) => (
+            <Expand
+              key={`${error.owner_id ?? error.owner_type}-${index}`}
+              id={`composite-error-${index}`}
+              heading={
+                <div className="flex items-center gap-2">
+                  <Badge theme="error" size="sm">
+                    {OWNER_LABELS[error.owner_type]}
+                  </Badge>
+                  <Text variant="body">{error.summary}</Text>
+                </div>
+              }
+              headerClassName="rounded"
+            >
+              {error.detail ? (
+                <div className="pt-1 pb-2 px-2">
+                  <ErrorDetail detail={error.detail} />
+                </div>
+              ) : null}
+            </Expand>
+          ))}
+        </div>
+      </div>
+    </Banner>
+  )
+}
+
+const ErrorDetail = ({ detail }: { detail: string }) => {
+  return (
+    <pre className="font-mono text-xs leading-5 max-h-64 overflow-y-auto bg-black/10 dark:bg-white/5 rounded p-3 whitespace-pre-wrap break-words">
+      {detail}
+    </pre>
+  )
+}

--- a/services/dashboard-ui/client/types/ctl-api.types.ts
+++ b/services/dashboard-ui/client/types/ctl-api.types.ts
@@ -85,7 +85,9 @@ export type TComponentConfig =
 export type TComponentType = components['schemas']['app.ComponentType']
 
 // build
-export type TComponentBuild = components['schemas']['app.ComponentBuild']
+export type TComponentBuild = components['schemas']['app.ComponentBuild'] & {
+  errors?: TCompositeError[]
+}
 export type TBuild = TComponentBuild & { org_id: string }
 
 // org
@@ -124,6 +126,7 @@ export type TDriftedObject = components['schemas']['app.DriftedObject']
 // deploys
 export type TInstallDeploy = components['schemas']['app.InstallDeploy'] & {
   org_id: string
+  errors?: TCompositeError[]
 }
 export type TDeploy = TInstallDeploy
 export type TInstallDeployPlanIntermediateData = {
@@ -212,6 +215,7 @@ export type TSandboxConfig = components['schemas']['app.AppSandboxConfig'] & {
 }
 export type TSandboxRun = components['schemas']['app.InstallSandboxRun'] & {
   org_id: string
+  errors?: TCompositeError[]
 }
 
 // vcs configs
@@ -299,7 +303,9 @@ export type TInstallActionWorkflow =
 // new action types
 export type TAction = components['schemas']['app.ActionWorkflow']
 export type TInstallActionRun =
-  components['schemas']['app.InstallActionWorkflowRun']
+  components['schemas']['app.InstallActionWorkflowRun'] & {
+    errors?: TCompositeError[]
+  }
 export type TInstallAction = components['schemas']['app.InstallActionWorkflow']
 
 // App / Install Readme
@@ -411,6 +417,28 @@ export type TPrincipalType = 'component' | 'sandbox' | 'action'
 
 // composite status
 export type TCompositeStatus = components['schemas']['app.CompositeStatus']
+
+// composite errors — manually defined, not yet in OpenAPI schema
+export type TCompositeErrorOwnerType =
+  | 'plan'
+  | 'apply'
+  | 'action-run'
+  | 'variable-renderer'
+  | 'runner'
+  | 'k8s-diagnostics'
+
+export type TCompositeErrorSeverity = 'critical' | 'warning' | 'info'
+
+export type TCompositeError = {
+  created_by_id?: string
+  created_at_ts?: number
+  owner_id?: string
+  owner_type: TCompositeErrorOwnerType
+  severity: TCompositeErrorSeverity
+  summary: string
+  detail?: string
+  metadata?: Record<string, unknown>
+}
 
 // onboarding
 export type TOnboarding = components['schemas']['app.Onboarding']

--- a/services/dashboard-ui/client/views/app/BuildDetail.tsx
+++ b/services/dashboard-ui/client/views/app/BuildDetail.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
 import { BuildHeader } from '@/components/builds/BuildHeader'
+import { CompositeErrorBanner } from '@/components/errors/CompositeErrorBanner/CompositeErrorBanner'
 import { SSELogs } from '@/components/log-stream/SSELogs'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
@@ -27,6 +28,7 @@ const BuildDetailInner = ({ component }: { component: TComponent | undefined }) 
   return (
     <>
       <BuildHeader component={component as TComponent} />
+      <CompositeErrorBanner errors={build?.errors} />
       {build?.status_v2?.metadata?.duplicate_build ? (
         <Banner theme="warn" className="mx-6 mt-4">
           <div className="flex flex-col">

--- a/services/dashboard-ui/client/views/install/ActionRunLayout.tsx
+++ b/services/dashboard-ui/client/views/install/ActionRunLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import { InstallActionRunHeader } from '@/components/actions/InstallActionRunHeader'
+import { CompositeErrorBanner } from '@/components/errors/CompositeErrorBanner/CompositeErrorBanner'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
 import { TabNav } from '@/components/navigation/TabNav'
@@ -68,6 +69,7 @@ const ActionRunLayoutInner = () => {
         actionName={actionName ?? ''}
         workflow={workflow}
       />
+      <CompositeErrorBanner errors={installActionRun?.errors} />
       <TabNav
         basePath={basePath}
         tabs={[

--- a/services/dashboard-ui/client/views/install/DeployDetail.tsx
+++ b/services/dashboard-ui/client/views/install/DeployDetail.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { ApprovalBanner } from '@/components/approvals/ApprovalBanner'
 import { Plan } from '@/components/approvals/Plan'
 import { DeployHeader } from '@/components/deploys/DeployHeader'
+import { CompositeErrorBanner } from '@/components/errors/CompositeErrorBanner/CompositeErrorBanner'
 import { SSELogs, LogsSkeleton } from '@/components/log-stream/SSELogs'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
@@ -86,6 +87,8 @@ const DeployDetailContent = ({ componentId }: { componentId: string }) => {
 
       <PageSection className="!pb-12">
         <div className="flex flex-col gap-6">
+          <CompositeErrorBanner errors={deploy?.errors} />
+
           {pendingApproval ? (
             <div className="flex flex-col gap-4">
               <ApprovalBanner step={step} />

--- a/services/dashboard-ui/client/views/install/SandboxRunDetail.tsx
+++ b/services/dashboard-ui/client/views/install/SandboxRunDetail.tsx
@@ -4,6 +4,7 @@ import { ApprovalBanner } from '@/components/approvals/ApprovalBanner'
 import { Plan } from '@/components/approvals/Plan'
 import { SSELogs, LogsSkeleton } from '@/components/log-stream/SSELogs'
 import { SandboxHeader } from '@/components/sandbox/SandboxHeader'
+import { CompositeErrorBanner } from '@/components/errors/CompositeErrorBanner/CompositeErrorBanner'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
 import { PageTitle } from '@/components/navigation/PageTitle'
@@ -74,6 +75,8 @@ const SandboxRunDetailContent = () => {
 
       <PageSection className="!pb-12">
         <div className="flex flex-col gap-6">
+          <CompositeErrorBanner errors={sandboxRun?.errors} />
+
           {pendingApproval ? (
             <div className="flex flex-col gap-4">
               <ApprovalBanner step={step} />


### PR DESCRIPTION
This PR adds composite error handling, where we can parse errors from a runner job, plan, and other actions, and set 
them into an error type, used for rendering across the platform.

Currently, it supports:

1. parsing terraform plan, apply errors.
2. parsing helm template errors
3. parsing action errors
