### PR TITLE
fix: support signal deadlock / panics

### DIFF
--- a/services/ctl-api/internal/app/installs/signals/v2/awaitrunnerhealthy/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/awaitrunnerhealthy/signal.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/go-playground/validator/v10"
+
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
@@ -24,10 +25,12 @@ type Signal struct {
 	v *validator.Validate
 }
 
-var _ signal.Signal = (*Signal)(nil)
-var _ signal.SignalWithParams = (*Signal)(nil)
-var _ signal.SignalWithStepContext = (*Signal)(nil)
-var _ signal.SignalWithAutoRetry = (*Signal)(nil)
+var (
+	_ signal.Signal                = (*Signal)(nil)
+	_ signal.SignalWithParams      = (*Signal)(nil)
+	_ signal.SignalWithStepContext = (*Signal)(nil)
+	_ signal.SignalWithAutoRetry   = (*Signal)(nil)
+)
 
 func (s *Signal) AutoRetry() bool { return true }
 
@@ -58,6 +61,8 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 }
 
 func (s *Signal) Execute(ctx workflow.Context) error {
+	time.Sleep(time.Second)
+
 	// Get the install
 	install, err := activities.AwaitGetByInstallID(ctx, s.InstallID)
 	if err != nil {

--- a/services/ctl-api/internal/app/installs/signals/v2/awaitrunnerhealthy/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/awaitrunnerhealthy/signal.go
@@ -61,8 +61,6 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 }
 
 func (s *Signal) Execute(ctx workflow.Context) error {
-	time.Sleep(time.Second)
-
 	// Get the install
 	install, err := activities.AwaitGetByInstallID(ctx, s.InstallID)
 	if err != nil {

--- a/services/ctl-api/internal/pkg/queue/handle_signal.go
+++ b/services/ctl-api/internal/pkg/queue/handle_signal.go
@@ -80,11 +80,12 @@ func (q *queue) handleQueueSignal(ctx workflow.Context, queueRef QueueRef) error
 
 func (q *queue) processQueueSignal(ctx workflow.Context, l *zap.Logger, queueSignal *app.QueueSignal, queueRef QueueRef) error {
 	l.Info("making sure queue signal workflow is ready")
-	if _, err := handleractivities.AwaitUpdateWorkflowReady(ctx, handleractivities.UpdateWorkflowReadyRequest{
+	readyResp, err := handleractivities.AwaitUpdateWorkflowReady(ctx, handleractivities.UpdateWorkflowReadyRequest{
 		UpdateID:   queueSignal.ID,
 		WorkflowID: queueRef.WorkflowID,
 		QueueID:    queueSignal.QueueID,
-	}); err != nil {
+	})
+	if err != nil {
 		return errors.Wrap(err, "unable to update")
 	}
 
@@ -93,6 +94,7 @@ func (q *queue) processQueueSignal(ctx workflow.Context, l *zap.Logger, queueSig
 		UpdateID:   queueSignal.ID,
 		WorkflowID: queueRef.WorkflowID,
 		QueueID:    queueSignal.QueueID,
+		RunID:      readyResp.RunID,
 	}, longRunningActivityOptions); err != nil {
 		return errors.Wrap(err, "unable to validate")
 	}
@@ -101,6 +103,7 @@ func (q *queue) processQueueSignal(ctx workflow.Context, l *zap.Logger, queueSig
 		UpdateID:   queueSignal.ID,
 		WorkflowID: queueRef.WorkflowID,
 		QueueID:    queueSignal.QueueID,
+		RunID:      readyResp.RunID,
 	}, longRunningActivityOptions); err != nil {
 		return errors.Wrap(err, "unable to execute")
 	}

--- a/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__execute.go
@@ -20,23 +20,21 @@ import (
 // @as-wrapper
 // @wrapper-prefix HandlerInternal
 // @by-field WorkflowID
-func (a *Activities) updateWorkflowExecute(ctx context.Context, workflowID string, updateID string, queueID string) (*handler.ExecuteResponse, error) {
+func (a *Activities) updateWorkflowExecute(ctx context.Context, workflowID string, updateID string, queueID string, runID string) (*handler.ExecuteResponse, error) {
 	return heartbeat.WithHeartbeat(ctx, 3*time.Second, func(ctx context.Context) (*handler.ExecuteResponse, error) {
 		info := activity.GetInfo(ctx)
 
-		rawResp, err := a.tclient.UpdateWithStartWorkflowInNamespace(ctx,
+		rawResp, err := a.tclient.UpdateWorkflowInNamespace(ctx,
 			info.WorkflowNamespace,
-			tclient.UpdateWithStartWorkflowOptions{
-				UpdateOptions: tclient.UpdateWorkflowOptions{
-					UpdateID:     updateID + "-execute",
-					WorkflowID:   workflowID,
-					UpdateName:   handler.ExecuteUpdateName,
-					WaitForStage: tclient.WorkflowUpdateStageCompleted,
-				},
-				StartWorkflowOperation: a.handlerStartOperation(workflowID, queueID, updateID),
+			tclient.UpdateWorkflowOptions{
+				UpdateID:     updateID + "-execute",
+				WorkflowID:   workflowID,
+				RunID:        runID,
+				UpdateName:   handler.ExecuteUpdateName,
+				WaitForStage: tclient.WorkflowUpdateStageCompleted,
 			})
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to call query handler")
+			return nil, errors.Wrap(err, "unable to call update handler")
 		}
 
 		var resp handler.ExecuteResponse

--- a/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__execute.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/activity"
 	tclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 
 	"github.com/nuonco/nuon/pkg/temporal/heartbeat"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler"
@@ -39,7 +40,16 @@ func (a *Activities) updateWorkflowExecute(ctx context.Context, workflowID strin
 
 		var resp handler.ExecuteResponse
 		if err := rawResp.Get(ctx, &resp); err != nil {
-			return nil, errors.Wrap(err, "unable get response")
+			wrapped := errors.Wrap(err, "unable get response")
+			var appErr *temporal.ApplicationError
+			if errors.As(err, &appErr) && appErr.Type() == "AcceptedUpdateCompletedWorkflow" {
+				return nil, temporal.NewNonRetryableApplicationError(
+					appErr.Message(),
+					appErr.Type(),
+					wrapped,
+				)
+			}
+			return nil, wrapped
 		}
 
 		return &resp, nil

--- a/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__ready.go
+++ b/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__ready.go
@@ -19,6 +19,7 @@ import (
 func (a *Activities) updateWorkflowReady(ctx context.Context, workflowID string, updateID string, queueID string) (*handler.ReadyResponse, error) {
 	info := activity.GetInfo(ctx)
 
+	startOp := a.handlerStartOperation(workflowID, queueID, updateID)
 	rawResp, err := a.tclient.UpdateWithStartWorkflowInNamespace(ctx,
 		info.WorkflowNamespace,
 		tclient.UpdateWithStartWorkflowOptions{
@@ -27,7 +28,7 @@ func (a *Activities) updateWorkflowReady(ctx context.Context, workflowID string,
 				UpdateName:   handler.ReadyHandlerName,
 				WaitForStage: tclient.WorkflowUpdateStageCompleted,
 			},
-			StartWorkflowOperation: a.handlerStartOperation(workflowID, queueID, updateID),
+			StartWorkflowOperation: startOp,
 		})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to call query handler")
@@ -37,6 +38,13 @@ func (a *Activities) updateWorkflowReady(ctx context.Context, workflowID string,
 	if err := rawResp.Get(ctx, &resp); err != nil {
 		return nil, errors.Wrap(err, "unable get response")
 	}
+
+	// Resolve the run-id so callers can pin subsequent updates to this exact run.
+	run, err := startOp.Get(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get handler workflow run")
+	}
+	resp.RunID = run.GetRunID()
 
 	return &resp, nil
 }

--- a/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__ready.go
+++ b/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__ready.go
@@ -7,6 +7,7 @@ import (
 
 	"go.temporal.io/sdk/activity"
 	tclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler"
 )
@@ -36,7 +37,16 @@ func (a *Activities) updateWorkflowReady(ctx context.Context, workflowID string,
 
 	var resp handler.ReadyResponse
 	if err := rawResp.Get(ctx, &resp); err != nil {
-		return nil, errors.Wrap(err, "unable get response")
+		wrapped := errors.Wrap(err, "unable get response")
+		var appErr *temporal.ApplicationError
+		if errors.As(err, &appErr) && appErr.Type() == "AcceptedUpdateCompletedWorkflow" {
+			return nil, temporal.NewNonRetryableApplicationError(
+				appErr.Message(),
+				appErr.Type(),
+				wrapped,
+			)
+		}
+		return nil, wrapped
 	}
 
 	// Resolve the run-id so callers can pin subsequent updates to this exact run.

--- a/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__validate.go
@@ -8,6 +8,7 @@ import (
 
 	"go.temporal.io/sdk/activity"
 	tclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 
 	"github.com/nuonco/nuon/pkg/temporal/heartbeat"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler"
@@ -39,7 +40,16 @@ func (a *Activities) updateWorkflowValidate(ctx context.Context, workflowID stri
 
 		var resp handler.ValidateResponse
 		if err := rawResp.Get(ctx, &resp); err != nil {
-			return nil, errors.Wrap(err, "unable get response")
+			wrapped := errors.Wrap(err, "unable get response")
+			var appErr *temporal.ApplicationError
+			if errors.As(err, &appErr) && appErr.Type() == "AcceptedUpdateCompletedWorkflow" {
+				return nil, temporal.NewNonRetryableApplicationError(
+					appErr.Message(),
+					appErr.Type(),
+					wrapped,
+				)
+			}
+			return nil, wrapped
 		}
 
 		return &resp, nil

--- a/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__validate.go
@@ -20,23 +20,21 @@ import (
 // @as-wrapper
 // @wrapper-prefix HandlerInternal
 // @by-field WorkflowID
-func (a *Activities) updateWorkflowValidate(ctx context.Context, workflowID string, updateID string, queueID string) (*handler.ValidateResponse, error) {
+func (a *Activities) updateWorkflowValidate(ctx context.Context, workflowID string, updateID string, queueID string, runID string) (*handler.ValidateResponse, error) {
 	return heartbeat.WithHeartbeat(ctx, 3*time.Second, func(ctx context.Context) (*handler.ValidateResponse, error) {
 		info := activity.GetInfo(ctx)
 
-		rawResp, err := a.tclient.UpdateWithStartWorkflowInNamespace(ctx,
+		rawResp, err := a.tclient.UpdateWorkflowInNamespace(ctx,
 			info.WorkflowNamespace,
-			tclient.UpdateWithStartWorkflowOptions{
-				UpdateOptions: tclient.UpdateWorkflowOptions{
-					UpdateID:     updateID + "-validate",
-					WorkflowID:   workflowID,
-					UpdateName:   handler.ValidateUpdateName,
-					WaitForStage: tclient.WorkflowUpdateStageCompleted,
-				},
-				StartWorkflowOperation: a.handlerStartOperation(workflowID, queueID, updateID),
+			tclient.UpdateWorkflowOptions{
+				UpdateID:     updateID + "-validate",
+				WorkflowID:   workflowID,
+				RunID:        runID,
+				UpdateName:   handler.ValidateUpdateName,
+				WaitForStage: tclient.WorkflowUpdateStageCompleted,
 			})
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to call query handler")
+			return nil, errors.Wrap(err, "unable to call update handler")
 		}
 
 		var resp handler.ValidateResponse

--- a/services/ctl-api/internal/pkg/queue/handler/execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/execute.go
@@ -18,23 +18,11 @@ const executeUpdateType = handlerTypeUpdate
 
 type ExecuteResponse struct{}
 
-func (h *handler) executeHandler(ctx workflow.Context) (resp *ExecuteResponse, retErr error) {
+func (h *handler) executeHandler(ctx workflow.Context) (*ExecuteResponse, error) {
 	defer func() {
 		h.finished = true
 		h.executingCtx = nil
 		h.executingCancel = nil
-	}()
-
-	defer func() {
-		if r := recover(); r != nil {
-			panicErr := &signal.SignalErrPanic{Value: r, Phase: "execute"}
-			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
-				QueueSignalID:     h.queueSignalID,
-				Status:            app.StatusError,
-				StatusDescription: panicErr.Error(),
-			})
-			retErr = panicErr
-		}
 	}()
 
 	// Increment execution count to track how many times this signal has been executed.
@@ -74,13 +62,27 @@ func (h *handler) executeHandler(ctx workflow.Context) (resp *ExecuteResponse, r
 		},
 	})
 
-	err := h.sig.Execute(execCtx)
+	err := h.runSignalExecute(execCtx)
 	dur := workflow.Now(ctx).Sub(start)
 
 	// run after-phase hooks (best-effort)
 	h.runAfterPhaseSafe(ctx, event, outcomeFromError(err, dur))
 
 	if err != nil {
+		// If the signal panicked, write error status here (outside the panic boundary).
+		var panicErr *signal.SignalErrPanic
+		if errors.As(err, &panicErr) {
+			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+				QueueSignalID:     h.queueSignalID,
+				Status:            app.StatusError,
+				StatusDescription: panicErr.Error(),
+				Metadata: map[string]any{
+					"execute_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
+				},
+			})
+			return nil, panicErr
+		}
+
 		if h.canceled {
 			// canceled mid-execute — cancelHandler already wrote StatusCancelled
 			return nil, errors.Wrap(err, "signal was canceled during execution")
@@ -108,4 +110,15 @@ func (h *handler) executeHandler(ctx workflow.Context) (resp *ExecuteResponse, r
 	})
 
 	return nil, nil
+}
+
+// runSignalExecute calls the user-provided signal Execute in a panic-safe boundary.
+func (h *handler) runSignalExecute(ctx workflow.Context) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = &signal.SignalErrPanic{Value: r, Phase: "execute"}
+		}
+	}()
+
+	return h.sig.Execute(ctx)
 }

--- a/services/ctl-api/internal/pkg/queue/handler/ready.go
+++ b/services/ctl-api/internal/pkg/queue/handler/ready.go
@@ -12,7 +12,9 @@ const (
 
 type ReadyRequest struct{}
 
-type ReadyResponse struct{}
+type ReadyResponse struct {
+	RunID string
+}
 
 func (h *handler) readyHandler(ctx workflow.Context, req *ReadyRequest) (*ReadyResponse, error) {
 	if err := workflow.Await(ctx, func() bool {

--- a/services/ctl-api/internal/pkg/queue/handler/state.go
+++ b/services/ctl-api/internal/pkg/queue/handler/state.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
@@ -16,17 +18,38 @@ func (h *handler) initializeState(ctx workflow.Context) error {
 		return errors.Wrap(err, "unable to get queue signal")
 	}
 
-	// If the signal is already in-progress, a previous handler was abandoned (e.g. panic).
-	// Mark it as failed so anything waiting on it gets unblocked.
-	//if queueSignal.Status.Status == app.StatusInProgress {
-	//abandonErr := errors.New("previous execution was abandoned, marking as failed")
-	//_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
-	//QueueSignalID:     h.queueSignalID,
-	//Status:            app.StatusError,
-	//StatusDescription: abandonErr.Error(),
-	//})
-	//return nil
-	//}
+	// Detect abandoned previous runs by checking for started-but-not-finished timestamps.
+	// If a previous handler crashed mid-validate or mid-execute, the started_at timestamp
+	// will exist but the finished_at timestamp will not.
+	if meta := queueSignal.Status.Metadata; meta != nil {
+		_, valStarted := meta["validate_started_at"]
+		_, valFinished := meta["validate_finished_at"]
+		if valStarted && !valFinished {
+			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+				QueueSignalID:     h.queueSignalID,
+				Status:            app.StatusError,
+				StatusDescription: "previous execution was abandoned (crashed mid-validate), marking as failed",
+				Metadata: map[string]any{
+					"validate_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
+				},
+			})
+			return nil
+		}
+
+		_, execStarted := meta["execute_started_at"]
+		_, execFinished := meta["execute_finished_at"]
+		if execStarted && !execFinished {
+			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+				QueueSignalID:     h.queueSignalID,
+				Status:            app.StatusError,
+				StatusDescription: "previous execution was abandoned (crashed mid-execute), marking as failed",
+				Metadata: map[string]any{
+					"execute_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
+				},
+			})
+			return nil
+		}
+	}
 
 	sig, err := activities.AwaitGetQueueSignalSignalByQueueSignalID(ctx, h.queueSignalID)
 	if err != nil {

--- a/services/ctl-api/internal/pkg/queue/handler/state.go
+++ b/services/ctl-api/internal/pkg/queue/handler/state.go
@@ -16,6 +16,18 @@ func (h *handler) initializeState(ctx workflow.Context) error {
 		return errors.Wrap(err, "unable to get queue signal")
 	}
 
+	// If the signal is already in-progress, a previous handler was abandoned (e.g. panic).
+	// Mark it as failed so anything waiting on it gets unblocked.
+	//if queueSignal.Status.Status == app.StatusInProgress {
+	//abandonErr := errors.New("previous execution was abandoned, marking as failed")
+	//_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+	//QueueSignalID:     h.queueSignalID,
+	//Status:            app.StatusError,
+	//StatusDescription: abandonErr.Error(),
+	//})
+	//return nil
+	//}
+
 	sig, err := activities.AwaitGetQueueSignalSignalByQueueSignalID(ctx, h.queueSignalID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get signal")

--- a/services/ctl-api/internal/pkg/queue/handler/validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/validate.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
@@ -24,6 +26,9 @@ func (h *handler) validateHandler(ctx workflow.Context) (*ValidateResponse, erro
 	_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 		QueueSignalID: h.queueSignalID,
 		Status:        app.StatusInProgress,
+		Metadata: map[string]any{
+			"validate_started_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
+		},
 	})
 
 	event := h.buildSignalPhaseEvent(signal.SignalPhaseValidate)
@@ -36,6 +41,9 @@ func (h *handler) validateHandler(ctx workflow.Context) (*ValidateResponse, erro
 			QueueSignalID:     h.queueSignalID,
 			Status:            app.StatusError,
 			StatusDescription: blockedErr.Error(),
+			Metadata: map[string]any{
+				"validate_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
+			},
 		})
 		return nil, blockedErr
 	}
@@ -55,6 +63,9 @@ func (h *handler) validateHandler(ctx workflow.Context) (*ValidateResponse, erro
 				QueueSignalID:     h.queueSignalID,
 				Status:            app.StatusError,
 				StatusDescription: panicErr.Error(),
+				Metadata: map[string]any{
+					"validate_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
+				},
 			})
 			return nil, panicErr
 		}
@@ -64,9 +75,21 @@ func (h *handler) validateHandler(ctx workflow.Context) (*ValidateResponse, erro
 			QueueSignalID:     h.queueSignalID,
 			Status:            app.StatusError,
 			StatusDescription: validateErr.Error(),
+			Metadata: map[string]any{
+				"validate_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
+			},
 		})
 		return nil, validateErr
 	}
+
+	// record validate completion timestamp
+	_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+		QueueSignalID: h.queueSignalID,
+		Status:        app.StatusInProgress,
+		Metadata: map[string]any{
+			"validate_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
+		},
+	})
 
 	return nil, nil
 }

--- a/services/ctl-api/internal/pkg/queue/handler/validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/validate.go
@@ -15,19 +15,7 @@ const validateUpdateType = handlerTypeUpdate
 
 type ValidateResponse struct{}
 
-func (h *handler) validateHandler(ctx workflow.Context) (resp *ValidateResponse, retErr error) {
-	defer func() {
-		if r := recover(); r != nil {
-			panicErr := &signal.SignalErrPanic{Value: r, Phase: "validate"}
-			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
-				QueueSignalID:     h.queueSignalID,
-				Status:            app.StatusError,
-				StatusDescription: panicErr.Error(),
-			})
-			retErr = panicErr
-		}
-	}()
-
+func (h *handler) validateHandler(ctx workflow.Context) (*ValidateResponse, error) {
 	if h.sig == nil {
 		return nil, errors.New("signal was empty can not proceed")
 	}
@@ -53,13 +41,24 @@ func (h *handler) validateHandler(ctx workflow.Context) (resp *ValidateResponse,
 	}
 
 	start := workflow.Now(ctx)
-	err := h.sig.Validate(ctx)
+	err := h.runSignalValidate(ctx)
 	dur := workflow.Now(ctx).Sub(start)
 
 	// run after-phase hooks (best-effort)
 	h.runAfterPhaseSafe(ctx, event, outcomeFromError(err, dur))
 
 	if err != nil {
+		// If the signal panicked, write error status here (outside the panic boundary).
+		var panicErr *signal.SignalErrPanic
+		if errors.As(err, &panicErr) {
+			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+				QueueSignalID:     h.queueSignalID,
+				Status:            app.StatusError,
+				StatusDescription: panicErr.Error(),
+			})
+			return nil, panicErr
+		}
+
 		validateErr := &signal.SignalErrValidate{Err: err}
 		_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 			QueueSignalID:     h.queueSignalID,
@@ -70,4 +69,15 @@ func (h *handler) validateHandler(ctx workflow.Context) (resp *ValidateResponse,
 	}
 
 	return nil, nil
+}
+
+// runSignalValidate calls the user-provided signal Validate in a panic-safe boundary.
+func (h *handler) runSignalValidate(ctx workflow.Context) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = &signal.SignalErrPanic{Value: r, Phase: "validate"}
+		}
+	}()
+
+	return h.sig.Validate(ctx)
 }


### PR DESCRIPTION
This PR improves the way that we handle panics within a queue signal, or handler. There's a few notes:

1. if the update handler panics, the handler will auto restart. That's fine in most cases _unless_ it's mid-execute. To counter this, we try and capture errors we have and do status updates before killing the workflow. however, if a workflow dies mid-execution we actually will check to clean up the status on the next running instance. We do this by  using our status metadata.
2. if an activity calling an update gets an error denoting that the accepted update workflow has restarted, then we mark the update as non-retryable and no longer poll it. This prevents a situation where a workflow could hold the queue.
