### PR TITLE
fix: skip input update workflow on provision and reprovision

### DIFF
--- a/services/ctl-api/internal/app/installs/workflows/v2/provision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/provision.go
@@ -70,7 +70,8 @@ func Provision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, er
 	steps = append(steps, step)
 
 	step, err = sg.installSignalStep(ctx, installID, "update install stack outputs", pgtype.Hstore{}, &updateinstallstackoutputs.Signal{
-		InstallStackID: stackID,
+		InstallStackID:          stackID,
+		SkipInputUpdateWorkflow: true,
 	}, flw.PlanOnly)
 	if err != nil {
 		return nil, err

--- a/services/ctl-api/internal/app/installs/workflows/v2/reprovision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/reprovision.go
@@ -67,7 +67,8 @@ func Reprovision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 	steps = append(steps, step)
 
 	step, err = sg.installSignalStep(ctx, installID, "update install stack outputs", pgtype.Hstore{}, &updateinstallstackoutputs.Signal{
-		InstallStackID: stack.ID,
+		InstallStackID:          stack.ID,
+		SkipInputUpdateWorkflow: true,
 	}, flw.PlanOnly)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
On install creation, there's an unwanted input update workflow triggered due to it being part of updateinstallstackoutput workflow. This should not happen on install creation, we fixed this in old signal system, this patch adds the same to new signal system.