### PR TITLE
fix: pre-fetch app config & action workflows and re-use it 

### DIFF
--- a/services/ctl-api/internal/app/apps/helpers/scopes.go
+++ b/services/ctl-api/internal/app/apps/helpers/scopes.go
@@ -68,7 +68,8 @@ func PreloadAppConfigRunnerConfig(db *gorm.DB) *gorm.DB {
 // preload action workflow configs
 func PreloadAppActionWorkflowConfigs(db *gorm.DB) *gorm.DB {
 	return db.
-		Preload("ActionWorkflowConfigs")
+		Preload("ActionWorkflowConfigs").
+		Preload("ActionWorkflowConfigs.Triggers")
 }
 
 // component config connections

--- a/services/ctl-api/internal/app/installs/workflows/v2/deploy_components.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/deploy_components.go
@@ -19,6 +19,11 @@ func DeployAllComponents(ctx workflow.Context, flw *app.Workflow) ([]*app.Workfl
 		return nil, errors.Wrap(err, "unable to get install")
 	}
 
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get app config")
+	}
+
 	steps := make([]*app.WorkflowStep, 0)
 	sg := newStepGroup()
 
@@ -49,14 +54,14 @@ func DeployAllComponents(ctx workflow.Context, flw *app.Workflow) ([]*app.Workfl
 
 	var lifecycleSteps []*app.WorkflowStep
 	if !flw.PlanOnly {
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeployAllComponents, sg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeployAllComponents, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}
 		steps = append(steps, lifecycleSteps...)
 	}
 
-	deploySteps, err := getComponentDeploySteps(ctx, installID, flw, componentIDs, sg)
+	deploySteps, err := getComponentDeploySteps(ctx, installID, flw, componentIDs, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +69,7 @@ func DeployAllComponents(ctx workflow.Context, flw *app.Workflow) ([]*app.Workfl
 	steps = append(steps, deploySteps...)
 
 	if !flw.PlanOnly {
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeployAllComponents, sg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeployAllComponents, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/services/ctl-api/internal/app/installs/workflows/v2/deploy_components.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/deploy_components.go
@@ -24,6 +24,13 @@ func DeployAllComponents(ctx workflow.Context, flw *app.Workflow) ([]*app.Workfl
 		return nil, errors.Wrap(err, "unable to get app config")
 	}
 
+	awData, err := activities.AwaitGetActionWorkflows(ctx, &activities.GetActionWorkflows{
+		InstallID: installID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflows")
+	}
+
 	steps := make([]*app.WorkflowStep, 0)
 	sg := newStepGroup()
 
@@ -54,14 +61,14 @@ func DeployAllComponents(ctx workflow.Context, flw *app.Workflow) ([]*app.Workfl
 
 	var lifecycleSteps []*app.WorkflowStep
 	if !flw.PlanOnly {
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeployAllComponents, sg, appCfg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeployAllComponents, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}
 		steps = append(steps, lifecycleSteps...)
 	}
 
-	deploySteps, err := getComponentDeploySteps(ctx, installID, flw, componentIDs, sg, appCfg)
+	deploySteps, err := getComponentDeploySteps(ctx, installID, flw, componentIDs, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +76,7 @@ func DeployAllComponents(ctx workflow.Context, flw *app.Workflow) ([]*app.Workfl
 	steps = append(steps, deploySteps...)
 
 	if !flw.PlanOnly {
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeployAllComponents, sg, appCfg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeployAllComponents, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}

--- a/services/ctl-api/internal/app/installs/workflows/v2/deprovision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/deprovision.go
@@ -4,6 +4,8 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"go.temporal.io/sdk/workflow"
 
+	"github.com/pkg/errors"
+
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/awaitrunnerhealthy"
@@ -37,13 +39,23 @@ func Deprovision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeprovision, sg)
+	install, err := activities.AwaitGetByInstallID(ctx, installID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get install")
+	}
+
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get app config")
+	}
+
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeprovision, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
 	steps = append(steps, lifecycleSteps...)
 
-	deploySteps, err := teardownComponents(ctx, flw, sg)
+	deploySteps, err := teardownComponents(ctx, flw, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +84,7 @@ func Deprovision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeprovision, sg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeprovision, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/deprovision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/deprovision.go
@@ -49,13 +49,20 @@ func Deprovision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 		return nil, errors.Wrap(err, "unable to get app config")
 	}
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeprovision, sg, appCfg)
+	awData, err := activities.AwaitGetActionWorkflows(ctx, &activities.GetActionWorkflows{
+		InstallID: installID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflows")
+	}
+
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeprovision, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
 	steps = append(steps, lifecycleSteps...)
 
-	deploySteps, err := teardownComponents(ctx, flw, sg, appCfg)
+	deploySteps, err := teardownComponents(ctx, flw, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +91,7 @@ func Deprovision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeprovision, sg, appCfg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeprovision, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/deprovision_sandbox.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/deprovision_sandbox.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/pkg/generics"
@@ -17,6 +18,16 @@ func DeprovisionSandbox(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflo
 	installID := generics.FromPtrStr(flw.Metadata["install_id"])
 	steps := make([]*app.WorkflowStep, 0)
 	sg := newStepGroup()
+
+	install, err := activities.AwaitGetByInstallID(ctx, installID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get install")
+	}
+
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get app config")
+	}
 
 	sg.nextGroup() // generate install state
 	step, err := sg.installSignalStep(ctx, installID, "generate install state", pgtype.Hstore{}, &generatestate.Signal{
@@ -36,7 +47,7 @@ func DeprovisionSandbox(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflo
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeprovisionSandbox, sg)
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeprovisionSandbox, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +76,7 @@ func DeprovisionSandbox(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflo
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeprovisionSandbox, sg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeprovisionSandbox, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/deprovision_sandbox.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/deprovision_sandbox.go
@@ -29,6 +29,13 @@ func DeprovisionSandbox(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflo
 		return nil, errors.Wrap(err, "unable to get app config")
 	}
 
+	awData, err := activities.AwaitGetActionWorkflows(ctx, &activities.GetActionWorkflows{
+		InstallID: installID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflows")
+	}
+
 	sg.nextGroup() // generate install state
 	step, err := sg.installSignalStep(ctx, installID, "generate install state", pgtype.Hstore{}, &generatestate.Signal{
 		InstallID: installID,
@@ -47,7 +54,7 @@ func DeprovisionSandbox(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflo
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeprovisionSandbox, sg, appCfg)
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeprovisionSandbox, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +83,7 @@ func DeprovisionSandbox(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflo
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeprovisionSandbox, sg, appCfg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeprovisionSandbox, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/manual_deploy.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/manual_deploy.go
@@ -56,6 +56,10 @@ func ManualDeploySteps(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get install")
 	}
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get app config")
+	}
 
 	// first, provision the deploy with before and after triggers
 	comp, err := activities.AwaitGetComponentByComponentID(ctx, installDeploy.ComponentID)
@@ -79,6 +83,7 @@ func ManualDeploySteps(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 		installID,
 		app.ActionWorkflowTriggerTypePreDeployComponent,
 		sg,
+		appCfg,
 	)
 	if err != nil {
 		return nil, err
@@ -131,7 +136,7 @@ func ManualDeploySteps(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 		}
 	}
 
-	postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, comp, installID, app.ActionWorkflowTriggerTypePostDeployComponent, sg)
+	postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, comp, installID, app.ActionWorkflowTriggerTypePostDeployComponent, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +154,7 @@ func ManualDeploySteps(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 	}
 
 	dependencyCompIDs := generics.SliceAfterValue(componentIDs, comp.ID)
-	dependencyDeploySteps, err := getComponentDeploySteps(ctx, installID, flw, dependencyCompIDs, sg)
+	dependencyDeploySteps, err := getComponentDeploySteps(ctx, installID, flw, dependencyCompIDs, sg, appCfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get component deploy steps")
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/manual_deploy.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/manual_deploy.go
@@ -60,6 +60,12 @@ func ManualDeploySteps(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get app config")
 	}
+	awData, err := activities.AwaitGetActionWorkflows(ctx, &activities.GetActionWorkflows{
+		InstallID: installID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflows")
+	}
 
 	// first, provision the deploy with before and after triggers
 	comp, err := activities.AwaitGetComponentByComponentID(ctx, installDeploy.ComponentID)
@@ -84,6 +90,7 @@ func ManualDeploySteps(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 		app.ActionWorkflowTriggerTypePreDeployComponent,
 		sg,
 		appCfg,
+		awData,
 	)
 	if err != nil {
 		return nil, err
@@ -136,7 +143,7 @@ func ManualDeploySteps(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 		}
 	}
 
-	postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, comp, installID, app.ActionWorkflowTriggerTypePostDeployComponent, sg, appCfg)
+	postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, comp, installID, app.ActionWorkflowTriggerTypePostDeployComponent, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +161,7 @@ func ManualDeploySteps(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 	}
 
 	dependencyCompIDs := generics.SliceAfterValue(componentIDs, comp.ID)
-	dependencyDeploySteps, err := getComponentDeploySteps(ctx, installID, flw, dependencyCompIDs, sg, appCfg)
+	dependencyDeploySteps, err := getComponentDeploySteps(ctx, installID, flw, dependencyCompIDs, sg, appCfg, awData)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get component deploy steps")
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/provision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/provision.go
@@ -99,7 +99,14 @@ func Provision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, er
 		return nil, errors.Wrap(err, "unable to get app config")
 	}
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreProvision, sg, appCfg)
+	awData, err := activities.AwaitGetActionWorkflows(ctx, &activities.GetActionWorkflows{
+		InstallID: installID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflows")
+	}
+
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreProvision, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +138,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, er
 		}
 		steps = append(steps, step)
 
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg, appCfg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}
@@ -146,7 +153,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, er
 		}
 		steps = append(steps, step)
 
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg, appCfg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}
@@ -161,13 +168,13 @@ func Provision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, er
 		}
 		steps = append(steps, step)
 
-		deploySteps, err := deployAllComponents(ctx, installID, flw, sg, appCfg)
+		deploySteps, err := deployAllComponents(ctx, installID, flw, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}
 		steps = append(steps, deploySteps...)
 
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostProvision, sg, appCfg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostProvision, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}

--- a/services/ctl-api/internal/app/installs/workflows/v2/provision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/provision.go
@@ -4,6 +4,8 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"go.temporal.io/sdk/workflow"
 
+	"github.com/pkg/errors"
+
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/awaitinstallstackversionrun"
@@ -87,7 +89,17 @@ func Provision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, er
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreProvision, sg)
+	install, err := activities.AwaitGetByInstallID(ctx, installID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get install")
+	}
+
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get app config")
+	}
+
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreProvision, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +131,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, er
 		}
 		steps = append(steps, step)
 
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +146,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, er
 		}
 		steps = append(steps, step)
 
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -149,13 +161,13 @@ func Provision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, er
 		}
 		steps = append(steps, step)
 
-		deploySteps, err := deployAllComponents(ctx, installID, flw, sg)
+		deploySteps, err := deployAllComponents(ctx, installID, flw, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}
 		steps = append(steps, deploySteps...)
 
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostProvision, sg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostProvision, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/services/ctl-api/internal/app/installs/workflows/v2/reprovision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/reprovision.go
@@ -4,6 +4,8 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"go.temporal.io/sdk/workflow"
 
+	"github.com/pkg/errors"
+
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/awaitinstallstackversionrun"
@@ -84,7 +86,17 @@ func Reprovision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreReprovision, sg)
+	install, err := activities.AwaitGetByInstallID(ctx, installID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get install")
+	}
+
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get app config")
+	}
+
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreReprovision, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +126,7 @@ func Reprovision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 		}
 		steps = append(steps, step)
 
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -129,7 +141,7 @@ func Reprovision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 		}
 		steps = append(steps, step)
 
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -144,13 +156,13 @@ func Reprovision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 		}
 		steps = append(steps, step)
 
-		deploySteps, err := deployAllComponents(ctx, installID, flw, sg)
+		deploySteps, err := deployAllComponents(ctx, installID, flw, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}
 		steps = append(steps, deploySteps...)
 
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostReprovision, sg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostReprovision, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/services/ctl-api/internal/app/installs/workflows/v2/reprovision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/reprovision.go
@@ -96,7 +96,14 @@ func Reprovision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 		return nil, errors.Wrap(err, "unable to get app config")
 	}
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreReprovision, sg, appCfg)
+	awData, err := activities.AwaitGetActionWorkflows(ctx, &activities.GetActionWorkflows{
+		InstallID: installID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflows")
+	}
+
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreReprovision, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +133,7 @@ func Reprovision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 		}
 		steps = append(steps, step)
 
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg, appCfg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}
@@ -141,7 +148,7 @@ func Reprovision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 		}
 		steps = append(steps, step)
 
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg, appCfg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}
@@ -156,13 +163,13 @@ func Reprovision(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 		}
 		steps = append(steps, step)
 
-		deploySteps, err := deployAllComponents(ctx, installID, flw, sg, appCfg)
+		deploySteps, err := deployAllComponents(ctx, installID, flw, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}
 		steps = append(steps, deploySteps...)
 
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostReprovision, sg, appCfg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostReprovision, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}

--- a/services/ctl-api/internal/app/installs/workflows/v2/reprovision_sandbox.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/reprovision_sandbox.go
@@ -31,7 +31,14 @@ func ReprovisionSandbox(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflo
 		return nil, errors.Wrap(err, "unable to get app config")
 	}
 
-	sandboxReprovisionSteps, err := getSandboxReprovisionSteps(ctx, installID, flw, sg, appCfg)
+	awData, err := activities.AwaitGetActionWorkflows(ctx, &activities.GetActionWorkflows{
+		InstallID: installID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflows")
+	}
+
+	sandboxReprovisionSteps, err := getSandboxReprovisionSteps(ctx, installID, flw, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +47,7 @@ func ReprovisionSandbox(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflo
 	return steps, nil
 }
 
-func getSandboxReprovisionSteps(ctx workflow.Context, installID string, flw *app.Workflow, sg *stepGroup, appCfg *app.AppConfig) ([]*app.WorkflowStep, error) {
+func getSandboxReprovisionSteps(ctx workflow.Context, installID string, flw *app.Workflow, sg *stepGroup, appCfg *app.AppConfig, awData []*app.InstallActionWorkflow) ([]*app.WorkflowStep, error) {
 	steps := make([]*app.WorkflowStep, 0)
 
 	sg.nextGroup() // generate install state
@@ -61,7 +68,7 @@ func getSandboxReprovisionSteps(ctx workflow.Context, installID string, flw *app
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreReprovisionSandbox, sg, appCfg)
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreReprovisionSandbox, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +100,7 @@ func getSandboxReprovisionSteps(ctx workflow.Context, installID string, flw *app
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg, appCfg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +115,7 @@ func getSandboxReprovisionSteps(ctx workflow.Context, installID string, flw *app
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg, appCfg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -124,14 +131,14 @@ func getSandboxReprovisionSteps(ctx workflow.Context, installID string, flw *app
 	steps = append(steps, step)
 
 	if generics.FromPtrStr(flw.Metadata["skip_components"]) != "true" {
-		deploySteps, err := deployAllComponents(ctx, installID, flw, sg, appCfg)
+		deploySteps, err := deployAllComponents(ctx, installID, flw, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}
 		steps = append(steps, deploySteps...)
 	}
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostReprovisionSandbox, sg, appCfg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostReprovisionSandbox, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/reprovision_sandbox.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/reprovision_sandbox.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/pkg/generics"
@@ -20,7 +21,17 @@ func ReprovisionSandbox(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflo
 	steps := make([]*app.WorkflowStep, 0)
 	sg := newStepGroup()
 
-	sandboxReprovisionSteps, err := getSandboxReprovisionSteps(ctx, installID, flw, sg)
+	install, err := activities.AwaitGetByInstallID(ctx, installID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get install")
+	}
+
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get app config")
+	}
+
+	sandboxReprovisionSteps, err := getSandboxReprovisionSteps(ctx, installID, flw, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +40,7 @@ func ReprovisionSandbox(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflo
 	return steps, nil
 }
 
-func getSandboxReprovisionSteps(ctx workflow.Context, installID string, flw *app.Workflow, sg *stepGroup) ([]*app.WorkflowStep, error) {
+func getSandboxReprovisionSteps(ctx workflow.Context, installID string, flw *app.Workflow, sg *stepGroup, appCfg *app.AppConfig) ([]*app.WorkflowStep, error) {
 	steps := make([]*app.WorkflowStep, 0)
 
 	sg.nextGroup() // generate install state
@@ -50,7 +61,7 @@ func getSandboxReprovisionSteps(ctx workflow.Context, installID string, flw *app
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreReprovisionSandbox, sg)
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreReprovisionSandbox, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +93,7 @@ func getSandboxReprovisionSteps(ctx workflow.Context, installID string, flw *app
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +108,7 @@ func getSandboxReprovisionSteps(ctx workflow.Context, installID string, flw *app
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -113,14 +124,14 @@ func getSandboxReprovisionSteps(ctx workflow.Context, installID string, flw *app
 	steps = append(steps, step)
 
 	if generics.FromPtrStr(flw.Metadata["skip_components"]) != "true" {
-		deploySteps, err := deployAllComponents(ctx, installID, flw, sg)
+		deploySteps, err := deployAllComponents(ctx, installID, flw, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}
 		steps = append(steps, deploySteps...)
 	}
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostReprovisionSandbox, sg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostReprovisionSandbox, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 )
 
-func getComponentLifecycleActionsSteps(ctx workflow.Context, flw *app.Workflow, comp *app.Component, installID string, triggerTyp app.ActionWorkflowTriggerType, sg *stepGroup) ([]*app.WorkflowStep, error) {
+func getComponentLifecycleActionsSteps(ctx workflow.Context, flw *app.Workflow, comp *app.Component, installID string, triggerTyp app.ActionWorkflowTriggerType, sg *stepGroup, appCfg *app.AppConfig) ([]*app.WorkflowStep, error) {
 	steps := make([]*app.WorkflowStep, 0)
 	installActions, err := activities.AwaitGetInstallActionWorkflowsByTriggerType(ctx, activities.GetInstallActionWorkflowsByTriggerTypeRequest{
 		ComponentID: comp.ID,
@@ -26,16 +26,6 @@ func getComponentLifecycleActionsSteps(ctx workflow.Context, flw *app.Workflow, 
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get action workflows")
-	}
-
-	install, err := activities.AwaitGetByInstallID(ctx, installID)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get install")
-	}
-
-	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get current app config")
 	}
 
 	awcMap := make(map[string]app.ActionWorkflowConfig, len(appCfg.ActionWorkflowConfigs))
@@ -75,7 +65,7 @@ func getComponentLifecycleActionsSteps(ctx workflow.Context, flw *app.Workflow, 
 	return steps, nil
 }
 
-func getLifecycleActionsSteps(ctx workflow.Context, installID string, flw *app.Workflow, triggerTyp app.ActionWorkflowTriggerType, sg *stepGroup) ([]*app.WorkflowStep, error) {
+func getLifecycleActionsSteps(ctx workflow.Context, installID string, flw *app.Workflow, triggerTyp app.ActionWorkflowTriggerType, sg *stepGroup, appCfg *app.AppConfig) ([]*app.WorkflowStep, error) {
 	steps := make([]*app.WorkflowStep, 0)
 
 	installActions, err := activities.AwaitGetInstallActionWorkflowsByTriggerType(ctx, activities.GetInstallActionWorkflowsByTriggerTypeRequest{
@@ -84,16 +74,6 @@ func getLifecycleActionsSteps(ctx workflow.Context, installID string, flw *app.W
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get action workflows")
-	}
-
-	install, err := activities.AwaitGetByInstallID(ctx, installID)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get install")
-	}
-
-	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get current app config")
 	}
 
 	awcMap := make(map[string]app.ActionWorkflowConfig, len(appCfg.ActionWorkflowConfigs))
@@ -138,20 +118,11 @@ func getLifecycleActionsSteps(ctx workflow.Context, installID string, flw *app.W
 	return steps, nil
 }
 
-func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Workflow, componentIDs []string, sg *stepGroup) ([]*app.WorkflowStep, error) {
+func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Workflow, componentIDs []string, sg *stepGroup, appCfg *app.AppConfig) ([]*app.WorkflowStep, error) {
 	steps := make([]*app.WorkflowStep, 0)
 
-	install, err := activities.AwaitGetByInstallID(ctx, installID)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get install")
-	}
-
-	appcfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get app config")
-	}
 	components := make(map[string]app.Component)
-	for _, ccc := range appcfg.ComponentConfigConnections {
+	for _, ccc := range appCfg.ComponentConfigConnections {
 		components[ccc.ComponentID] = ccc.Component
 	}
 
@@ -177,7 +148,7 @@ func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Wo
 		}
 
 		if !flw.PlanOnly {
-			preDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePreDeployComponent, sg)
+			preDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePreDeployComponent, sg, appCfg)
 			if err != nil {
 				return nil, err
 			}
@@ -222,7 +193,7 @@ func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Wo
 			}
 		}
 		if !flw.PlanOnly {
-			postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePostDeployComponent, sg)
+			postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePostDeployComponent, sg, appCfg)
 			if err != nil {
 				return nil, err
 			}
@@ -233,14 +204,9 @@ func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Wo
 	return steps, nil
 }
 
-func deployAllComponents(ctx workflow.Context, installID string, flw *app.Workflow, sg *stepGroup) ([]*app.WorkflowStep, error) {
-	install, err := activities.AwaitGetByInstallID(ctx, installID)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get install")
-	}
-
+func deployAllComponents(ctx workflow.Context, installID string, flw *app.Workflow, sg *stepGroup, appCfg *app.AppConfig) ([]*app.WorkflowStep, error) {
 	componentIDs, err := activities.AwaitGetAppGraph(ctx, activities.GetAppGraphRequest{
-		InstallID: install.ID,
+		InstallID: installID,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get install graph")
@@ -260,19 +226,19 @@ func deployAllComponents(ctx workflow.Context, installID string, flw *app.Workfl
 
 	var lifecycleSteps []*app.WorkflowStep
 	if !flw.PlanOnly {
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeployAllComponents, sg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeployAllComponents, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}
 		steps = append(steps, lifecycleSteps...)
 	}
-	deploySteps, err := getComponentDeploySteps(ctx, installID, flw, componentIDs, sg)
+	deploySteps, err := getComponentDeploySteps(ctx, installID, flw, componentIDs, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
 	steps = append(steps, deploySteps...)
 	if !flw.PlanOnly {
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeployAllComponents, sg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeployAllComponents, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/pkg/errors"
@@ -17,28 +18,63 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 )
 
-func getComponentLifecycleActionsSteps(ctx workflow.Context, flw *app.Workflow, comp *app.Component, installID string, triggerTyp app.ActionWorkflowTriggerType, sg *stepGroup, appCfg *app.AppConfig) ([]*app.WorkflowStep, error) {
-	steps := make([]*app.WorkflowStep, 0)
-	installActions, err := activities.AwaitGetInstallActionWorkflowsByTriggerType(ctx, activities.GetInstallActionWorkflowsByTriggerTypeRequest{
-		ComponentID: comp.ID,
-		InstallID:   installID,
-		TriggerType: triggerTyp,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get action workflows")
-	}
-
+// filterActionWorkflowsByTrigger filters pre-fetched install action workflows by trigger type,
+// optionally scoped to a specific component. It uses the version-pinned configs from
+// appCfg.ActionWorkflowConfigs (with Triggers preloaded) instead of fetching latest configs.
+// This replaces individual AwaitGetInstallActionWorkflowsByTriggerType activity calls
+// with in-memory filtering.
+func filterActionWorkflowsByTrigger(installActionWorkflows []*app.InstallActionWorkflow, triggerTyp app.ActionWorkflowTriggerType, componentID string, appCfg *app.AppConfig) []*app.InstallActionWorkflow {
 	awcMap := make(map[string]app.ActionWorkflowConfig, len(appCfg.ActionWorkflowConfigs))
 	for _, awc := range appCfg.ActionWorkflowConfigs {
 		awcMap[awc.ActionWorkflowID] = awc
 	}
 
-	for _, installAction := range installActions {
-		if _, ok := awcMap[installAction.ActionWorkflowID]; !ok {
-			// skip actions that are not part of current app config
+	indices := map[string]int{}
+	wkflows := make(map[string]*app.InstallActionWorkflow, len(installActionWorkflows))
+
+	for _, wf := range installActionWorkflows {
+		cfg, ok := awcMap[wf.ActionWorkflowID]
+		if !ok {
 			continue
 		}
 
+		if componentID == "" {
+			if cfg.HasTrigger(triggerTyp) {
+				wkflows[wf.ID] = wf
+				indices[wf.ID] = cfg.GetTriggerIndex(triggerTyp)
+			}
+		} else {
+			if cfg.HasComponentTrigger(triggerTyp, componentID) {
+				wkflows[wf.ID] = wf
+				indices[wf.ID] = cfg.GetComponentTriggerIndex(triggerTyp, componentID)
+			}
+		}
+	}
+
+	workflowIDs := make([]string, 0, len(indices))
+	for wkflowID := range indices {
+		workflowIDs = append(workflowIDs, wkflowID)
+	}
+
+	sort.SliceStable(workflowIDs, func(i, j int) bool {
+		return indices[workflowIDs[i]] < indices[workflowIDs[j]]
+	})
+
+	result := make([]*app.InstallActionWorkflow, 0, len(workflowIDs))
+	for _, wkflowID := range workflowIDs {
+		if wf, ok := wkflows[wkflowID]; ok {
+			result = append(result, wf)
+		}
+	}
+
+	return result
+}
+
+func getComponentLifecycleActionsSteps(ctx workflow.Context, flw *app.Workflow, comp *app.Component, installID string, triggerTyp app.ActionWorkflowTriggerType, sg *stepGroup, appCfg *app.AppConfig, awData []*app.InstallActionWorkflow) ([]*app.WorkflowStep, error) {
+	steps := make([]*app.WorkflowStep, 0)
+	installActions := filterActionWorkflowsByTrigger(awData, triggerTyp, comp.ID, appCfg)
+
+	for _, installAction := range installActions {
 		sig := &executeactionworkflow.Signal{
 			Signal: &actionworkflowrun.Signal{
 				InstallID:               installID,
@@ -65,30 +101,13 @@ func getComponentLifecycleActionsSteps(ctx workflow.Context, flw *app.Workflow, 
 	return steps, nil
 }
 
-func getLifecycleActionsSteps(ctx workflow.Context, installID string, flw *app.Workflow, triggerTyp app.ActionWorkflowTriggerType, sg *stepGroup, appCfg *app.AppConfig) ([]*app.WorkflowStep, error) {
+func getLifecycleActionsSteps(ctx workflow.Context, installID string, flw *app.Workflow, triggerTyp app.ActionWorkflowTriggerType, sg *stepGroup, appCfg *app.AppConfig, awData []*app.InstallActionWorkflow) ([]*app.WorkflowStep, error) {
 	steps := make([]*app.WorkflowStep, 0)
-
-	installActions, err := activities.AwaitGetInstallActionWorkflowsByTriggerType(ctx, activities.GetInstallActionWorkflowsByTriggerTypeRequest{
-		InstallID:   installID,
-		TriggerType: triggerTyp,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get action workflows")
-	}
-
-	awcMap := make(map[string]app.ActionWorkflowConfig, len(appCfg.ActionWorkflowConfigs))
-	for _, awc := range appCfg.ActionWorkflowConfigs {
-		awcMap[awc.ActionWorkflowID] = awc
-	}
+	installActions := filterActionWorkflowsByTrigger(awData, triggerTyp, "", appCfg)
 
 	sg.nextGroup() // lifecycleSteps
 
 	for _, installAction := range installActions {
-		if _, ok := awcMap[installAction.ActionWorkflowID]; !ok {
-			// skip actions that are not part of current app config
-			continue
-		}
-
 		sig := &executeactionworkflow.Signal{
 			Signal: &actionworkflowrun.Signal{
 				InstallID:               installID,
@@ -118,7 +137,7 @@ func getLifecycleActionsSteps(ctx workflow.Context, installID string, flw *app.W
 	return steps, nil
 }
 
-func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Workflow, componentIDs []string, sg *stepGroup, appCfg *app.AppConfig) ([]*app.WorkflowStep, error) {
+func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Workflow, componentIDs []string, sg *stepGroup, appCfg *app.AppConfig, awData []*app.InstallActionWorkflow) ([]*app.WorkflowStep, error) {
 	steps := make([]*app.WorkflowStep, 0)
 
 	components := make(map[string]app.Component)
@@ -148,7 +167,7 @@ func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Wo
 		}
 
 		if !flw.PlanOnly {
-			preDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePreDeployComponent, sg, appCfg)
+			preDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePreDeployComponent, sg, appCfg, awData)
 			if err != nil {
 				return nil, err
 			}
@@ -193,7 +212,7 @@ func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Wo
 			}
 		}
 		if !flw.PlanOnly {
-			postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePostDeployComponent, sg, appCfg)
+			postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePostDeployComponent, sg, appCfg, awData)
 			if err != nil {
 				return nil, err
 			}
@@ -204,7 +223,7 @@ func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Wo
 	return steps, nil
 }
 
-func deployAllComponents(ctx workflow.Context, installID string, flw *app.Workflow, sg *stepGroup, appCfg *app.AppConfig) ([]*app.WorkflowStep, error) {
+func deployAllComponents(ctx workflow.Context, installID string, flw *app.Workflow, sg *stepGroup, appCfg *app.AppConfig, awData []*app.InstallActionWorkflow) ([]*app.WorkflowStep, error) {
 	componentIDs, err := activities.AwaitGetAppGraph(ctx, activities.GetAppGraphRequest{
 		InstallID: installID,
 	})
@@ -226,19 +245,19 @@ func deployAllComponents(ctx workflow.Context, installID string, flw *app.Workfl
 
 	var lifecycleSteps []*app.WorkflowStep
 	if !flw.PlanOnly {
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeployAllComponents, sg, appCfg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreDeployAllComponents, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}
 		steps = append(steps, lifecycleSteps...)
 	}
-	deploySteps, err := getComponentDeploySteps(ctx, installID, flw, componentIDs, sg, appCfg)
+	deploySteps, err := getComponentDeploySteps(ctx, installID, flw, componentIDs, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
 	steps = append(steps, deploySteps...)
 	if !flw.PlanOnly {
-		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeployAllComponents, sg, appCfg)
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostDeployAllComponents, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}

--- a/services/ctl-api/internal/app/installs/workflows/v2/sync_secrets.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/sync_secrets.go
@@ -26,6 +26,13 @@ func SyncSecrets(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 		return nil, errors.Wrap(err, "unable to get app config")
 	}
 
+	awData, err := activities.AwaitGetActionWorkflows(ctx, &activities.GetActionWorkflows{
+		InstallID: installID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflows")
+	}
+
 	steps := make([]*app.WorkflowStep, 0)
 
 	sg.nextGroup() // generate install state
@@ -37,7 +44,7 @@ func SyncSecrets(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg, appCfg)
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +61,7 @@ func SyncSecrets(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg, appCfg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/sync_secrets.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/sync_secrets.go
@@ -2,17 +2,29 @@ package v2
 
 import (
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/generatestate"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/syncsecrets"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 )
 
 func SyncSecrets(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, error) {
 	installID := generics.FromPtrStr(flw.Metadata["install_id"])
 	sg := newStepGroup()
+
+	install, err := activities.AwaitGetByInstallID(ctx, installID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get install")
+	}
+
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get app config")
+	}
 
 	steps := make([]*app.WorkflowStep, 0)
 
@@ -25,7 +37,7 @@ func SyncSecrets(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg)
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreSecretsSync, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +54,7 @@ func SyncSecrets(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 	}
 	steps = append(steps, step)
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostSecretsSync, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/teardown_component.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/teardown_component.go
@@ -26,6 +26,13 @@ func TeardownComponent(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 		return nil, errors.Wrap(err, "unable to get app config")
 	}
 
+	awData, err := activities.AwaitGetActionWorkflows(ctx, &activities.GetActionWorkflows{
+		InstallID: installID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflows")
+	}
+
 	sg := newStepGroup()
 	steps := make([]*app.WorkflowStep, 0)
 
@@ -57,7 +64,7 @@ func TeardownComponent(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 		return nil, errors.Wrap(err, "unable to get component")
 	}
 
-	preDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, comp, installID, app.ActionWorkflowTriggerTypePreTeardownComponent, sg, appCfg)
+	preDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, comp, installID, app.ActionWorkflowTriggerTypePreTeardownComponent, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +112,7 @@ func TeardownComponent(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 		steps = append(steps, deployStep)
 	}
 
-	postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, comp, installID, app.ActionWorkflowTriggerTypePostTeardownComponent, sg, appCfg)
+	postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, comp, installID, app.ActionWorkflowTriggerTypePostTeardownComponent, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/teardown_component.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/teardown_component.go
@@ -21,6 +21,11 @@ func TeardownComponent(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 		return nil, errors.Wrap(err, "unable to get install")
 	}
 
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get app config")
+	}
+
 	sg := newStepGroup()
 	steps := make([]*app.WorkflowStep, 0)
 
@@ -52,7 +57,7 @@ func TeardownComponent(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 		return nil, errors.Wrap(err, "unable to get component")
 	}
 
-	preDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, comp, installID, app.ActionWorkflowTriggerTypePreTeardownComponent, sg)
+	preDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, comp, installID, app.ActionWorkflowTriggerTypePreTeardownComponent, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +105,7 @@ func TeardownComponent(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflow
 		steps = append(steps, deployStep)
 	}
 
-	postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, comp, installID, app.ActionWorkflowTriggerTypePostTeardownComponent, sg)
+	postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, comp, installID, app.ActionWorkflowTriggerTypePostTeardownComponent, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/teardown_components.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/teardown_components.go
@@ -27,10 +27,17 @@ func TeardownComponents(ctx workflow.Context, flw *app.Workflow) ([]*app.Workflo
 		return nil, errors.Wrap(err, "unable to get app config")
 	}
 
-	return teardownComponents(ctx, flw, newStepGroup(), appCfg)
+	awData, err := activities.AwaitGetActionWorkflows(ctx, &activities.GetActionWorkflows{
+		InstallID: installID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflows")
+	}
+
+	return teardownComponents(ctx, flw, newStepGroup(), appCfg, awData)
 }
 
-func teardownComponents(ctx workflow.Context, flw *app.Workflow, sg *stepGroup, appCfg *app.AppConfig) ([]*app.WorkflowStep, error) {
+func teardownComponents(ctx workflow.Context, flw *app.Workflow, sg *stepGroup, appCfg *app.AppConfig, awData []*app.InstallActionWorkflow) ([]*app.WorkflowStep, error) {
 	installID := generics.FromPtrStr(flw.Metadata["install_id"])
 	install, err := activities.AwaitGetByInstallID(ctx, installID)
 	if err != nil {
@@ -49,7 +56,7 @@ func teardownComponents(ctx workflow.Context, flw *app.Workflow, sg *stepGroup, 
 
 	steps = append(steps, step)
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreTeardownAllComponents, sg, appCfg)
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreTeardownAllComponents, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +122,7 @@ func teardownComponents(ctx workflow.Context, flw *app.Workflow, sg *stepGroup, 
 			continue
 		}
 
-		preDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePreTeardownComponent, sg, appCfg)
+		preDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePreTeardownComponent, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}
@@ -143,14 +150,14 @@ func teardownComponents(ctx workflow.Context, flw *app.Workflow, sg *stepGroup, 
 		}
 		steps = append(steps, deployStep)
 
-		postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePostTeardownComponent, sg, appCfg)
+		postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePostTeardownComponent, sg, appCfg, awData)
 		if err != nil {
 			return nil, err
 		}
 		steps = append(steps, postDeploySteps...)
 	}
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostTeardownAllComponents, sg, appCfg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostTeardownAllComponents, sg, appCfg, awData)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/teardown_components.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/teardown_components.go
@@ -16,10 +16,21 @@ import (
 )
 
 func TeardownComponents(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, error) {
-	return teardownComponents(ctx, flw, newStepGroup())
+	installID := generics.FromPtrStr(flw.Metadata["install_id"])
+	install, err := activities.AwaitGetByInstallID(ctx, installID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get install")
+	}
+
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get app config")
+	}
+
+	return teardownComponents(ctx, flw, newStepGroup(), appCfg)
 }
 
-func teardownComponents(ctx workflow.Context, flw *app.Workflow, sg *stepGroup) ([]*app.WorkflowStep, error) {
+func teardownComponents(ctx workflow.Context, flw *app.Workflow, sg *stepGroup, appCfg *app.AppConfig) ([]*app.WorkflowStep, error) {
 	installID := generics.FromPtrStr(flw.Metadata["install_id"])
 	install, err := activities.AwaitGetByInstallID(ctx, installID)
 	if err != nil {
@@ -38,7 +49,7 @@ func teardownComponents(ctx workflow.Context, flw *app.Workflow, sg *stepGroup) 
 
 	steps = append(steps, step)
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreTeardownAllComponents, sg)
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreTeardownAllComponents, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -52,12 +63,8 @@ func teardownComponents(ctx workflow.Context, flw *app.Workflow, sg *stepGroup) 
 		return nil, errors.Wrap(err, "unable to get install graph")
 	}
 
-	appcfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get app config")
-	}
 	components := make(map[string]app.Component)
-	for _, ccc := range appcfg.ComponentConfigConnections {
+	for _, ccc := range appCfg.ComponentConfigConnections {
 		components[ccc.ComponentID] = ccc.Component
 	}
 
@@ -108,7 +115,7 @@ func teardownComponents(ctx workflow.Context, flw *app.Workflow, sg *stepGroup) 
 			continue
 		}
 
-		preDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePreTeardownComponent, sg)
+		preDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePreTeardownComponent, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -136,14 +143,14 @@ func teardownComponents(ctx workflow.Context, flw *app.Workflow, sg *stepGroup) 
 		}
 		steps = append(steps, deployStep)
 
-		postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePostTeardownComponent, sg)
+		postDeploySteps, err := getComponentLifecycleActionsSteps(ctx, flw, &comp, installID, app.ActionWorkflowTriggerTypePostTeardownComponent, sg, appCfg)
 		if err != nil {
 			return nil, err
 		}
 		steps = append(steps, postDeploySteps...)
 	}
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostTeardownAllComponents, sg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostTeardownAllComponents, sg, appCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
@@ -44,7 +44,14 @@ func InputUpdate(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 		return nil, errors.Wrapf(err, "unable to get app config for install %s", installID)
 	}
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreUpdateInputs, sg, appConfig)
+	awData, err := activities.AwaitGetActionWorkflows(ctx, &activities.GetActionWorkflows{
+		InstallID: installID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflows")
+	}
+
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreUpdateInputs, sg, appConfig, awData)
 	if err != nil {
 		return nil, err
 	}
@@ -87,20 +94,20 @@ func InputUpdate(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 
 	// If sandbox needs reprovision, add sandbox reprovision steps before component deploys
 	if sandboxNeedsReprovision {
-		sandboxSteps, err := getSandboxReprovisionSteps(ctx, installID, flw, sg, appConfig)
+		sandboxSteps, err := getSandboxReprovisionSteps(ctx, installID, flw, sg, appConfig, awData)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to get sandbox reprovision steps")
 		}
 		steps = append(steps, sandboxSteps...)
 	} else {
-		deploySteps, err := getComponentDeploySteps(ctx, installID, flw, componentIDs, sg, appConfig)
+		deploySteps, err := getComponentDeploySteps(ctx, installID, flw, componentIDs, sg, appConfig, awData)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to get component deploy steps")
 		}
 		steps = append(steps, deploySteps...)
 	}
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostUpdateInputs, sg, appConfig)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostUpdateInputs, sg, appConfig, awData)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
@@ -37,18 +37,18 @@ func InputUpdate(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 		return nil, errors.Wrap(err, "unable to get install")
 	}
 
-	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreUpdateInputs, sg)
-	if err != nil {
-		return nil, err
-	}
-	steps = append(steps, lifecycleSteps...)
-
 	appConfig, err := activities.AwaitGetAppConfig(ctx, activities.GetAppConfigRequest{
 		ID: install.AppConfigID,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to get app config for install %s", installID)
 	}
+
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreUpdateInputs, sg, appConfig)
+	if err != nil {
+		return nil, err
+	}
+	steps = append(steps, lifecycleSteps...)
 
 	var changedRefs []refs.Ref
 	for _, input := range changedInputs {
@@ -87,20 +87,20 @@ func InputUpdate(ctx workflow.Context, flw *app.Workflow) ([]*app.WorkflowStep, 
 
 	// If sandbox needs reprovision, add sandbox reprovision steps before component deploys
 	if sandboxNeedsReprovision {
-		sandboxSteps, err := getSandboxReprovisionSteps(ctx, installID, flw, sg)
+		sandboxSteps, err := getSandboxReprovisionSteps(ctx, installID, flw, sg, appConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to get sandbox reprovision steps")
 		}
 		steps = append(steps, sandboxSteps...)
 	} else {
-		deploySteps, err := getComponentDeploySteps(ctx, installID, flw, componentIDs, sg)
+		deploySteps, err := getComponentDeploySteps(ctx, installID, flw, componentIDs, sg, appConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to get component deploy steps")
 		}
 		steps = append(steps, deploySteps...)
 	}
 
-	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostUpdateInputs, sg)
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostUpdateInputs, sg, appConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For an app config with 25 components, we see:

* 1332 events, 8.8MB history, 235 workflow tasks
* GetInstall called 58 times, GetAppConfig 57 times, GetInstallActionWorkflowsByTriggerType 56 times
* 77% of wall clock time was pure scheduling + replay overhead, not actual work
* 2 workflow task timeouts because history grew so large that replay exceeded the 10s task timeout

getComponentLifecycleActionsSteps, getComponentDeploySteps, and getLifecycleActionsSteps each independently fetched install, app config, and action workflows on every invocation , even though the data never changes within a single step generation.


With this change, we pre-fetch app config & action workflows and re-use it. 

