### PR TITLE
fix: add ordering to migrate install on app sync (#857)

### DIFF
--- a/services/ctl-api/internal/app/installs/helpers/migrate_install_inputs.go
+++ b/services/ctl-api/internal/app/installs/helpers/migrate_install_inputs.go
@@ -78,7 +78,9 @@ func (h *Helpers) migrateInstallInputs(
 			InstallID:        installID,
 			AppInputConfigID: oldAppConfig.InputConfig.ID,
 		}).
-		First(&existingInputs)
+		Order("created_at DESC").
+		Limit(1).
+		Find(&existingInputs)
 
 	if res.Error != nil && res.Error == gorm.ErrRecordNotFound {
 		// for backward compatibility for older installs where older installs dont have install in puts set

--- a/services/ctl-api/internal/app/installs/helpers/update_install_inputs_from_stack.go
+++ b/services/ctl-api/internal/app/installs/helpers/update_install_inputs_from_stack.go
@@ -83,6 +83,7 @@ func (h *Helpers) UpdateInstallInputsFromStackOutputs(
 			InstallID:        installID,
 			AppInputConfigID: appInputConfig.ID,
 		}).
+		Order("created_at DESC").
 		Attrs(app.InstallInputs{Values: pgtype.Hstore{}}).
 		FirstOrCreate(&installInputs)
 


### PR DESCRIPTION
* fix: add ordering to migrate install on app sync

* fix: query order on UpdateInstallInputsFromStack

---------