### PR TITLE
refactor(ui/api): handle runner process version and process card updates

### DIFF
--- a/services/ctl-api/internal/app/runners/signals/v2/processhealthcheck/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/v2/processhealthcheck/signal.go
@@ -193,22 +193,33 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return errors.Wrap(err, "unable to create process health check")
 	}
 
-	// Version mismatch check: compare API version to runner's reported version
+	// Version mismatch check: compare configured version to runner's reported version
 	if heartbeat != nil && heartbeat.Version != "" {
-		apiVersion, err := activities.AwaitGetAPIVersion(ctx)
+		runner, err := activities.AwaitGet(ctx, activities.GetRequest{RunnerID: s.RunnerID})
 		if err != nil {
-			l.Warn("unable to get API version for comparison",
-				zap.String("process_id", s.ProcessID),
+			l.Warn("unable to get runner for version comparison",
+				zap.String("runner_id", s.RunnerID),
 				zap.Error(err),
 			)
 		} else {
+			settings := runner.RunnerGroup.Settings
+			var configuredVersion string
+			switch process.Type {
+			case app.RunnerProcessTypeMng:
+				configuredVersion = settings.BinaryVersion
+			default:
+				configuredVersion = settings.ContainerImageTag
+			}
+
 			var metadata map[string]any
-			if apiVersion != heartbeat.Version {
+			if configuredVersion != "" && configuredVersion != heartbeat.Version {
 				metadata = map[string]any{
-					"version_warning": "Reported runner version does not match running API version and could cause issues. Please update the tag to the same version as the control plane (" + apiVersion + ")",
+					"version_warning": fmt.Sprintf(
+						"Reported runner version (%s) does not match configured version (%s). Please update the runner to the correct version.",
+						heartbeat.Version, configuredVersion,
+					),
 				}
 			} else {
-				// Clear the warning if versions now match
 				metadata = map[string]any{
 					"version_warning": "",
 				}

--- a/services/dashboard-ui/client/components/runners/ProcessCard/ProcessCard.stories.tsx
+++ b/services/dashboard-ui/client/components/runners/ProcessCard/ProcessCard.stories.tsx
@@ -2,51 +2,248 @@ export default {
   title: 'Runners/ProcessCard',
 }
 
+import type { TRunnerHealthCheck } from '@/types'
 import { ProcessCard, ProcessCardSkeleton } from './ProcessCard'
 
-const mockProcess = {
-  id: 'proc-123',
-  type: 'runner',
+const now = new Date()
+const minutesAgo = (m: number) => new Date(now.getTime() - m * 60000).toISOString()
+const hoursAgo = (h: number) => new Date(now.getTime() - h * 3600000).toISOString()
+
+const baseProcess = {
+  id: 'rpru3x3uwgappsn730x5lbz8bf',
+  type: 'install',
   composite_status: { status: 'active' },
-  version: '1.2.3',
-  labels: ['primary'],
-  started_at: '2024-01-15T08:00:00Z',
-  warnings: [],
+  version: 'de111c8',
+  labels: [] as string[],
+  started_at: hoursAgo(6),
+  warnings: [] as string[],
 } as any
 
-export const Default = () => (
-  <ProcessCard
-    process={mockProcess}
+const mngProcess = {
+  ...baseProcess,
+  id: 'rpr4cg772hl2ekwvsxla8b4xwc',
+  type: 'mng',
+  version: 'development',
+  labels: ['Local Runner'],
+} as any
 
-    isConnected={true}
-    heartbeatCreatedAt="2024-01-15T12:00:00Z"
-    configuredVersion="1.2.3"
-    reportedVersion="1.2.3"
-    healthchecks={[]}
+const healthyChecks: TRunnerHealthCheck[] = Array.from({ length: 30 }, (_, i) => ({
+  id: `hc-${i}`,
+  status_code: 0,
+  minute_bucket: minutesAgo(30 - i),
+})) as TRunnerHealthCheck[]
+
+const mixedChecks: TRunnerHealthCheck[] = Array.from({ length: 30 }, (_, i) => ({
+  id: `hc-${i}`,
+  status_code: i >= 20 && i <= 25 ? 1 : i >= 26 ? 900 : 0,
+  minute_bucket: minutesAgo(30 - i),
+})) as TRunnerHealthCheck[]
+
+const unknownChecks: TRunnerHealthCheck[] = Array.from({ length: 30 }, (_, i) => ({
+  id: `hc-${i}`,
+  status_code: 900,
+  minute_bucket: minutesAgo(30 - i),
+})) as TRunnerHealthCheck[]
+
+export const ActiveConnected = () => (
+  <ProcessCard
+    process={baseProcess}
+    isConnected
+    heartbeatCreatedAt={minutesAgo(0)}
+    configuredVersion="de111c8"
+    reportedVersion="de111c8"
+    healthchecks={healthyChecks}
   />
 )
 
-export const Disconnected = () => (
+export const ActiveDisconnected = () => (
   <ProcessCard
-    process={mockProcess}
-
+    process={{
+      ...baseProcess,
+      composite_status: { status: 'offline' },
+    }}
     isConnected={false}
-    configuredVersion="1.2.3"
-    reportedVersion="1.2.2"
+    heartbeatCreatedAt={minutesAgo(3)}
+    configuredVersion="de111c8"
+    reportedVersion="de111c8"
+    healthchecks={mixedChecks}
+  />
+)
+
+export const VersionMismatch = () => (
+  <ProcessCard
+    process={{
+      ...baseProcess,
+      warnings: [
+        'Reported runner version (de111c8) does not match configured version (ab98f21). Please update the runner to the correct version.',
+      ],
+    }}
+    isConnected
+    heartbeatCreatedAt={minutesAgo(0)}
+    configuredVersion="ab98f21"
+    reportedVersion="de111c8"
+    healthchecks={healthyChecks}
+  />
+)
+
+export const Initializing = () => (
+  <ProcessCard
+    process={{
+      ...baseProcess,
+      warnings: [
+        'This runner is still initializing and will not process jobs until its first health check',
+      ],
+    }}
+    isConnected
+    heartbeatCreatedAt={minutesAgo(0)}
+    configuredVersion="de111c8"
+    reportedVersion="de111c8"
     healthchecks={[]}
   />
 )
 
-export const WithWarnings = () => (
+export const Pending = () => (
   <ProcessCard
-    process={{ ...mockProcess, warnings: ['Version mismatch detected'] }}
-
-    isConnected={true}
-    heartbeatCreatedAt="2024-01-15T12:00:00Z"
-    configuredVersion="1.2.3"
-    reportedVersion="1.2.2"
+    process={{
+      ...baseProcess,
+      composite_status: { status: 'pending' },
+      labels: ['Local Runner'],
+      started_at: hoursAgo(21),
+    }}
+    isConnected={false}
+    configuredVersion="main"
+    reportedVersion="development"
     healthchecks={[]}
   />
+)
+
+export const MngProcess = () => (
+  <ProcessCard
+    process={mngProcess}
+    isConnected
+    heartbeatCreatedAt={minutesAgo(0)}
+    configuredVersion="latest"
+    reportedVersion="development"
+    healthchecks={healthyChecks}
+  />
+)
+
+export const MngVersionMismatch = () => (
+  <ProcessCard
+    process={{
+      ...mngProcess,
+      warnings: [
+        'Reported runner version (development) does not match configured version (v1.2.0). Please update the runner to the correct version.',
+      ],
+    }}
+    isConnected
+    heartbeatCreatedAt={minutesAgo(0)}
+    configuredVersion="v1.2.0"
+    reportedVersion="development"
+    healthchecks={healthyChecks}
+  />
+)
+
+export const MultipleWarnings = () => (
+  <ProcessCard
+    process={{
+      ...baseProcess,
+      composite_status: { status: 'offline' },
+      warnings: [
+        'Runner is offline and will be marked inactive in 5 minutes',
+        'Reported runner version (de111c8) does not match configured version (ab98f21). Please update the runner to the correct version.',
+      ],
+    }}
+    isConnected={false}
+    heartbeatCreatedAt={minutesAgo(3)}
+    configuredVersion="ab98f21"
+    reportedVersion="de111c8"
+    healthchecks={mixedChecks}
+  />
+)
+
+export const NoHealthData = () => (
+  <ProcessCard
+    process={{
+      ...baseProcess,
+      labels: ['Local Runner'],
+    }}
+    isConnected={false}
+    configuredVersion="main"
+    reportedVersion="-"
+    healthchecks={[]}
+  />
+)
+
+export const AllUnknownHealth = () => (
+  <ProcessCard
+    process={baseProcess}
+    isConnected
+    heartbeatCreatedAt={minutesAgo(0)}
+    configuredVersion="de111c8"
+    reportedVersion="de111c8"
+    healthchecks={unknownChecks}
+  />
+)
+
+export const FewHealthChecks = () => (
+  <ProcessCard
+    process={baseProcess}
+    isConnected
+    heartbeatCreatedAt={minutesAgo(0)}
+    configuredVersion="de111c8"
+    reportedVersion="de111c8"
+    healthchecks={
+      Array.from({ length: 5 }, (_, i) => ({
+        id: `hc-${i}`,
+        status_code: 0,
+        minute_bucket: minutesAgo(4 - i),
+      })) as TRunnerHealthCheck[]
+    }
+  />
+)
+
+export const PendingShutdown = () => (
+  <ProcessCard
+    process={{
+      ...baseProcess,
+      composite_status: { status: 'pending-shutdown', status_description: 'Shutting down for version update' },
+      warnings: ['Shutting down for version update'],
+    }}
+    isConnected
+    heartbeatCreatedAt={minutesAgo(0)}
+    configuredVersion="de111c8"
+    reportedVersion="de111c8"
+    healthchecks={healthyChecks}
+  />
+)
+
+export const SideBySide = () => (
+  <div className="grid grid-cols-2 gap-6 items-start max-w-5xl">
+    <ProcessCard
+      process={{
+        ...baseProcess,
+        warnings: [
+          'This runner is still initializing and will not process jobs until its first health check',
+        ],
+      }}
+      isConnected
+      heartbeatCreatedAt={minutesAgo(0)}
+      configuredVersion="main"
+      reportedVersion="development"
+      healthchecks={[]}
+    />
+    <ProcessCard
+      process={{
+        ...mngProcess,
+        composite_status: { status: 'pending' },
+      }}
+      isConnected={false}
+      configuredVersion="main"
+      reportedVersion="development"
+      healthchecks={[]}
+    />
+  </div>
 )
 
 export const Skeleton = () => <ProcessCardSkeleton />

--- a/services/dashboard-ui/client/components/runners/ProcessCard/ProcessCard.tsx
+++ b/services/dashboard-ui/client/components/runners/ProcessCard/ProcessCard.tsx
@@ -24,7 +24,7 @@ function HealthCheckGraph({
 }) {
   if (!healthchecks?.length) {
     return (
-      <div className="flex items-center justify-center h-10">
+      <div className="flex items-center justify-center h-10 rounded-md border border-white/5 bg-white/[0.02] dark:border-white/5 dark:bg-white/[0.02]">
         <Text variant="subtext" theme="neutral">
           No health data
         </Text>
@@ -137,7 +137,7 @@ export const ProcessCard = ({
 
       <HealthCheckGraph healthchecks={healthchecks} />
 
-      <div className="flex flex-wrap gap-x-8 gap-y-4">
+      <div className="grid grid-cols-3 gap-x-6 gap-y-4">
         <LabeledValue label="Connectivity">
           <Status
             status={isConnected ? 'connected' : 'not-connected'}

--- a/services/dashboard-ui/client/components/runners/ProcessCard/ProcessCardContainer.tsx
+++ b/services/dashboard-ui/client/components/runners/ProcessCard/ProcessCardContainer.tsx
@@ -49,7 +49,10 @@ export const ProcessCardContainer = ({
   })
 
   const isConnected = isLessThan15SecondsOld(heartbeat?.created_at)
-  const configuredVersion = settings?.container_image_tag || '-'
+  const configuredVersion =
+    (process.type === 'mng'
+      ? settings?.binary_version
+      : settings?.container_image_tag) || '-'
   const reportedVersion = heartbeat?.version || process.version || '-'
 
   return (

--- a/services/dashboard-ui/client/views/install/Runner.tsx
+++ b/services/dashboard-ui/client/views/install/Runner.tsx
@@ -58,7 +58,7 @@ const RunnerContent = ({
 
       {processesLoading ? (
         <div className="@container">
-          <div className="grid grid-cols-1 @4xl:grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 @4xl:grid-cols-2 gap-6 items-start">
             <ProcessCardSkeleton />
             <ProcessCardSkeleton />
           </div>
@@ -79,7 +79,7 @@ const RunnerContent = ({
         />
       ) : (
         <div className="@container">
-          <div className="grid grid-cols-1 @4xl:grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 @4xl:grid-cols-2 gap-6 items-start">
             {processes.map((process) => (
               <ProcessCard
                 key={process.id}

--- a/services/dashboard-ui/client/views/org/BuildRunner.tsx
+++ b/services/dashboard-ui/client/views/org/BuildRunner.tsx
@@ -101,7 +101,7 @@ export const BuildRunner = () => {
 
               {processesLoading ? (
                 <div className="@container">
-                  <div className="grid grid-cols-1 @4xl:grid-cols-2 gap-6">
+                  <div className="grid grid-cols-1 @4xl:grid-cols-2 gap-6 items-start">
                     <ProcessCardSkeleton />
                     <ProcessCardSkeleton />
                   </div>
@@ -122,7 +122,7 @@ export const BuildRunner = () => {
                 />
               ) : (
                 <div className="@container">
-                  <div className="grid grid-cols-1 @4xl:grid-cols-2 gap-6">
+                  <div className="grid grid-cols-1 @4xl:grid-cols-2 gap-6 items-start">
                     {processes.map((process) => (
                       <ProcessCard
                         key={process.id}


### PR DESCRIPTION
- Fixed runner version mismatch bug (backend) — processhealthcheck/signal.go was comparing against the ctl-api's own version; now compares
  against settings.BinaryVersion for mng processes and settings.ContainerImageTag for all others; warning message now shows both versions
- Fixed runner version mismatch bug (frontend) — ProcessCardContainer "Configured version" now shows binary_version for mng processes instead
  of always showing container_image_tag
- ProcessCard layout — switched metadata from flex-wrap to grid-cols-3; added border/background to empty health graph state; items-start on
  parent grids in Runner.tsx and BuildRunner.tsx so cards don't stretch to match sibling height
- ProcessCard stories — added 13 stories covering all variants (connected, disconnected, version mismatch, initializing, pending, mng process,
   multiple warnings, few health checks, side-by-side, etc.)