### PR TITLE
test(ui): create a seed user during e2e test setup

### DIFF
--- a/services/dashboard-ui/AGENTS.md
+++ b/services/dashboard-ui/AGENTS.md
@@ -582,6 +582,12 @@ npm run test:e2e:headed # Playwright with visible browser
 
 Smoke tests in `e2e/` that run against a live local or staging environment. Chromium only.
 
+### Prerequisites
+
+- Local dev stack running (dashboard-ui + ctl-api + postgres + temporal)
+- An admin account email with access to the admin API
+- Playwright browsers installed: `npx playwright install chromium`
+
 ### Running
 
 ```bash

--- a/services/dashboard-ui/AGENTS.md
+++ b/services/dashboard-ui/AGENTS.md
@@ -585,6 +585,10 @@ Smoke tests in `e2e/` that run against a live local or staging environment. Chro
 ### Running
 
 ```bash
+# Creates a fresh test org, runs tests, deletes org on teardown
+E2E_EMAIL=you@nuon.co npm run test:e2e
+
+# Use an existing org (skips create/teardown)
 E2E_EMAIL=you@nuon.co E2E_ORG_ID=orgXXX npm run test:e2e
 ```
 
@@ -594,20 +598,27 @@ E2E_EMAIL=you@nuon.co E2E_ORG_ID=orgXXX npm run test:e2e
 |----------|---------|----------|---------|
 | `E2E_BASE_URL` | `http://127.0.0.1:4000` | no | Dashboard URL |
 | `E2E_ADMIN_API_URL` | `http://127.0.0.1:8082` | no | Admin API for token generation |
+| `E2E_PUBLIC_API_URL` | `http://127.0.0.1:8081` | no | Public API for org creation |
 | `E2E_EMAIL` | — | yes | Admin email (used to auth and generate token) |
-| `E2E_ORG_ID` | — | yes | Org ID for test navigation |
+| `E2E_ORG_ID` | — | no | Existing org ID (if omitted, a fresh org is created and deleted after tests) |
 
-### How auth works
+### How it works
 
-Global setup (`e2e/global-setup.ts`) calls `POST /v1/general/admin-static-token` on the admin API to generate a short-lived (1h) token, injects it as the `X-Nuon-Auth` cookie, and saves browser state to `e2e/.auth/user.json`. All specs reuse this saved auth state — no login UI involved.
+1. Global setup generates a static token via the admin API (`POST /v1/general/admin-static-token`)
+2. If no `E2E_ORG_ID` is set, creates a fresh org via the public API (`POST /v1/orgs`) — the token user becomes org admin automatically
+3. Injects the token as the `X-Nuon-Auth` cookie and saves browser state to `e2e/.auth/user.json`
+4. Org ID is written to `e2e/.auth/org.json` so fixtures and teardown can read it
+5. Tests run against the org
+6. Global teardown deletes the org via admin API if it was created by setup
 
 ### Structure
 
 ```
 e2e/
 ├── playwright.config.ts    # Config (Chromium, auth state, output dirs)
-├── global-setup.ts         # Token generation + cookie injection
-├── fixtures.ts             # Custom test fixture (orgId from env)
+├── global-setup.ts         # Token gen + org creation + cookie injection
+├── global-teardown.ts      # Org cleanup (if created by setup)
+├── fixtures.ts             # Custom test fixture (orgId from state file)
 ├── env.ts                  # Env var loader with defaults
 ├── specs/                  # Playwright test files
 └── flows/                  # Markdown flow specs (source-of-truth docs)

--- a/services/dashboard-ui/README.md
+++ b/services/dashboard-ui/README.md
@@ -55,6 +55,10 @@ Playwright smoke tests that run against a live local (or staging) environment. C
 ### Running
 
 ```bash
+# Creates a fresh test org, runs tests, deletes org on teardown
+E2E_EMAIL=you@nuon.co npm run test:e2e
+
+# Use an existing org (skips create/teardown)
 E2E_EMAIL=you@nuon.co E2E_ORG_ID=orgXXX npm run test:e2e
 ```
 
@@ -64,12 +68,17 @@ E2E_EMAIL=you@nuon.co E2E_ORG_ID=orgXXX npm run test:e2e
 |----------|---------|----------|---------|
 | `E2E_BASE_URL` | `http://127.0.0.1:4000` | no | Dashboard URL |
 | `E2E_ADMIN_API_URL` | `http://127.0.0.1:8082` | no | Admin API for token generation |
+| `E2E_PUBLIC_API_URL` | `http://127.0.0.1:8081` | no | Public API for org creation |
 | `E2E_EMAIL` | — | yes | Admin email (used to auth and generate token) |
-| `E2E_ORG_ID` | — | yes | Org ID for test navigation |
+| `E2E_ORG_ID` | — | no | Existing org ID (if omitted, a fresh org is created and deleted after tests) |
 
-### How auth works
+### How it works
 
-The global setup calls `POST /v1/general/admin-static-token` on the admin API to generate a short-lived (1h) token, injects it as the `X-Nuon-Auth` cookie, and saves the browser state. All specs reuse this saved auth state.
+1. Global setup generates a static token via the admin API
+2. If no `E2E_ORG_ID` is set, creates a fresh org via the public API (the token user becomes org admin)
+3. Injects the token as the `X-Nuon-Auth` cookie and saves browser state
+4. Tests run against the org
+5. Global teardown deletes the org if it was created by the setup
 
 ### Flow docs
 

--- a/services/dashboard-ui/README.md
+++ b/services/dashboard-ui/README.md
@@ -51,6 +51,7 @@ Playwright smoke tests that run against a live local (or staging) environment. C
 
 - Local dev stack running (dashboard-ui + ctl-api + postgres + temporal)
 - An admin account email with access to the admin API
+- Playwright browsers installed: `npx playwright install chromium`
 
 ### Running
 

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -5919,12 +5919,14 @@ export interface components {
       role?: string;
     };
     "service.ExampleApp": {
+      branch?: string;
       category?: string;
       cloud_provider?: string;
       description?: string;
       difficulty?: string;
       directory?: string;
       display_name?: string;
+      repo?: string;
       slug?: string;
       tags?: string[];
     };

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -5919,14 +5919,12 @@ export interface components {
       role?: string;
     };
     "service.ExampleApp": {
-      branch?: string;
       category?: string;
       cloud_provider?: string;
       description?: string;
       difficulty?: string;
       directory?: string;
       display_name?: string;
-      repo?: string;
       slug?: string;
       tags?: string[];
     };

--- a/services/dashboard-ui/e2e/env.ts
+++ b/services/dashboard-ui/e2e/env.ts
@@ -7,10 +7,9 @@ function required(name: string): string {
 export const env = {
   baseUrl: process.env.E2E_BASE_URL ?? "http://127.0.0.1:4000",
   adminApiUrl: process.env.E2E_ADMIN_API_URL ?? "http://127.0.0.1:8082",
+  publicApiUrl: process.env.E2E_PUBLIC_API_URL ?? "http://127.0.0.1:8081",
   get email() {
     return required("E2E_EMAIL");
   },
-  get orgId() {
-    return required("E2E_ORG_ID");
-  },
+  orgId: process.env.E2E_ORG_ID,
 };

--- a/services/dashboard-ui/e2e/fixtures.ts
+++ b/services/dashboard-ui/e2e/fixtures.ts
@@ -1,5 +1,14 @@
 import { test as base, expect } from "@playwright/test";
-import { env } from "./env";
+import fs from "node:fs";
+
+const ORG_STATE_PATH = "e2e/.auth/org.json";
+
+function getOrgId(): string {
+  const state = JSON.parse(fs.readFileSync(ORG_STATE_PATH, "utf-8")) as {
+    orgId: string;
+  };
+  return state.orgId;
+}
 
 type Fixtures = {
   orgId: string;
@@ -7,7 +16,7 @@ type Fixtures = {
 
 export const test = base.extend<Fixtures>({
   orgId: async ({}, use) => {
-    await use(env.orgId);
+    await use(getOrgId());
   },
 });
 

--- a/services/dashboard-ui/e2e/global-setup.ts
+++ b/services/dashboard-ui/e2e/global-setup.ts
@@ -43,11 +43,30 @@ async function apiFetch(
 }
 
 export default async function globalSetup(_config: FullConfig) {
-  const seedRes = await adminFetch("/v1/general/seed-user", {
-    method: "POST",
-    body: JSON.stringify({}),
-  });
-  const { api_token } = (await seedRes.json()) as { api_token: string };
+  // seed-user creates the account if it doesn't exist and returns a token.
+  // The admin middleware may append an error to the response body if the
+  // X-Nuon-Admin-Email account doesn't exist yet, resulting in two concatenated
+  // JSON objects. We parse only the first one.
+  const seedRes = await fetch(
+    `${env.adminApiUrl}/v1/general/seed-user`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Nuon-Admin-Email": env.email,
+      },
+      body: JSON.stringify({}),
+    },
+  );
+  const seedBody = await seedRes.text();
+  const firstJson = seedBody.match(/^\{[^}]*\}/);
+  if (!firstJson) {
+    throw new Error(`seed-user returned unexpected response: ${seedBody}`);
+  }
+  const { api_token } = JSON.parse(firstJson[0]) as { api_token: string };
+  if (!api_token) {
+    throw new Error(`seed-user did not return a token: ${seedBody}`);
+  }
 
   let orgId = env.orgId;
   let createdOrg = false;

--- a/services/dashboard-ui/e2e/global-setup.ts
+++ b/services/dashboard-ui/e2e/global-setup.ts
@@ -1,32 +1,73 @@
 import { chromium, type FullConfig } from "@playwright/test";
 import { env } from "./env";
+import fs from "node:fs";
+import path from "node:path";
 
 const AUTH_STATE_PATH = "e2e/.auth/user.json";
+const ORG_STATE_PATH = "e2e/.auth/org.json";
 
-export default async function globalSetup(_config: FullConfig) {
-  const res = await fetch(
-    `${env.adminApiUrl}/v1/general/admin-static-token`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Nuon-Admin-Email": env.email,
-      },
-      body: JSON.stringify({
-        email_or_subject: env.email,
-        duration: "1h",
-      }),
+async function adminFetch(path: string, options: RequestInit = {}) {
+  const res = await fetch(`${env.adminApiUrl}${path}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Nuon-Admin-Email": env.email,
+      ...options.headers,
     },
-  );
-
+  });
   if (!res.ok) {
     const body = await res.text();
-    throw new Error(
-      `Failed to generate static token (${res.status}): ${body}`,
-    );
+    throw new Error(`Admin API ${path} failed (${res.status}): ${body}`);
+  }
+  return res;
+}
+
+async function apiFetch(
+  token: string,
+  apiPath: string,
+  options: RequestInit = {},
+) {
+  const res = await fetch(`${env.publicApiUrl}${apiPath}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      ...options.headers,
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Public API ${apiPath} failed (${res.status}): ${body}`);
+  }
+  return res;
+}
+
+export default async function globalSetup(_config: FullConfig) {
+  const seedRes = await adminFetch("/v1/general/seed-user", {
+    method: "POST",
+    body: JSON.stringify({}),
+  });
+  const { api_token } = (await seedRes.json()) as { api_token: string };
+
+  let orgId = env.orgId;
+  let createdOrg = false;
+
+  if (!orgId) {
+    const orgName = `e2e-test-${Date.now()}`;
+    const orgRes = await apiFetch(api_token, "/v1/orgs", {
+      method: "POST",
+      body: JSON.stringify({ name: orgName, use_sandbox_mode: true }),
+    });
+    const org = (await orgRes.json()) as { id: string };
+    orgId = org.id;
+    createdOrg = true;
   }
 
-  const { api_token } = (await res.json()) as { api_token: string };
+  fs.mkdirSync(path.dirname(ORG_STATE_PATH), { recursive: true });
+  fs.writeFileSync(
+    ORG_STATE_PATH,
+    JSON.stringify({ orgId, createdOrg }),
+  );
 
   const baseUrl = new URL(env.baseUrl);
   const browser = await chromium.launch();
@@ -44,7 +85,7 @@ export default async function globalSetup(_config: FullConfig) {
   ]);
 
   const page = await context.newPage();
-  await page.goto(`${env.baseUrl}/${env.orgId}`);
+  await page.goto(`${env.baseUrl}/${orgId}`);
   await page.waitForLoadState("networkidle");
 
   await context.storageState({ path: AUTH_STATE_PATH });

--- a/services/dashboard-ui/e2e/global-teardown.ts
+++ b/services/dashboard-ui/e2e/global-teardown.ts
@@ -1,0 +1,33 @@
+import { type FullConfig } from "@playwright/test";
+import { env } from "./env";
+import fs from "node:fs";
+
+const ORG_STATE_PATH = "e2e/.auth/org.json";
+
+export default async function globalTeardown(_config: FullConfig) {
+  if (!fs.existsSync(ORG_STATE_PATH)) return;
+
+  const state = JSON.parse(fs.readFileSync(ORG_STATE_PATH, "utf-8")) as {
+    orgId: string;
+    createdOrg: boolean;
+  };
+
+  if (!state.createdOrg) return;
+
+  const res = await fetch(
+    `${env.adminApiUrl}/v1/orgs/${state.orgId}/admin-delete`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Nuon-Admin-Email": env.email,
+      },
+      body: JSON.stringify({}),
+    },
+  );
+
+  if (!res.ok) {
+    const body = await res.text();
+    console.warn(`Failed to delete test org ${state.orgId}: ${body}`);
+  }
+}

--- a/services/dashboard-ui/e2e/playwright.config.ts
+++ b/services/dashboard-ui/e2e/playwright.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   reporter: process.env.CI ? "github" : [["html", { outputFolder: "./.report" }]],
 
   globalSetup: "./global-setup.ts",
+  globalTeardown: "./global-teardown.ts",
 
   use: {
     baseURL: env.baseUrl,


### PR DESCRIPTION
- better e2e test setup
  - creates test user and test org
  - cleans up afterwards
- updates readme and agents about e2e setup