### PR TITLE
chore(dashboard-ui): update docker image

### DIFF
--- a/services/dashboard-ui/Dockerfile
+++ b/services/dashboard-ui/Dockerfile
@@ -58,7 +58,7 @@ RUN --mount=type=cache,target=/root/.npm,id=npm-dashboard-ui npm run build
 
 # --- Build Go server ---
 
-FROM golang:1.25.4-alpine AS build-server
+FROM golang:1.25.8-alpine AS build-server
 
 WORKDIR /src
 


### PR DESCRIPTION
### Description

Update `build` image for dhasboard-ui

Note: the `ctl-api` uses `1.25-alpine` w/out a minor version.
