### PR TITLE
feat(dashboard): policy and roles design

### DIFF
--- a/services/dashboard-ui/client/components/policies/PoliciesTable.tsx
+++ b/services/dashboard-ui/client/components/policies/PoliciesTable.tsx
@@ -1,8 +1,8 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import { Badge } from '@/components/common/Badge'
-import { Button } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { ID } from '@/components/common/ID'
+import { Link } from '@/components/common/Link'
 import { Table } from '@/components/common/Table'
 import { Text } from '@/components/common/Text'
 import type { TAppPolicyConfig } from '@/types'
@@ -10,6 +10,7 @@ import type { TAppPolicyConfig } from '@/types'
 type TPolicyRow = {
   id: string
   name: string
+  nameHref: string
   type: string
   engine: string
   components: string[]
@@ -40,11 +41,16 @@ function formatPolicyType(type: string): string {
     .join(' ')
 }
 
-function parsePolicyToTableData(policies: TAppPolicyConfig[]): TPolicyRow[] {
+function parsePolicyToTableData(
+  policies: TAppPolicyConfig[],
+  orgId: string,
+  appId: string,
+): TPolicyRow[] {
   return policies.map((policy) => ({
     id: policy.id || '',
     name:
       policy.name || extractPolicyName(policy.contents || '', policy.engine || ''),
+    nameHref: `/${orgId}/apps/${appId}/policies/${policy.id}`,
     type: policy.type || '',
     engine: policy.engine || '',
     components: policy.components || [],
@@ -59,7 +65,11 @@ export const policiesTableColumns: ColumnDef<TPolicyRow>[] = [
     header: 'Policy Name',
     cell: (info) => (
       <span>
-        <Text variant="body">{info.getValue() as string}</Text>
+        <Text variant="body">
+          <Link href={info.row.original.nameHref}>
+            {info.getValue() as string}
+          </Link>
+        </Text>
         <ID>{info.row.original.id}</ID>
       </span>
     ),
@@ -69,20 +79,15 @@ export const policiesTableColumns: ColumnDef<TPolicyRow>[] = [
     accessorKey: 'type',
     header: 'Type',
     cell: (info) => (
-      <Badge theme="default" size="sm">
-        {formatPolicyType(info.getValue() as string)}
-      </Badge>
+      <Text variant="subtext">{formatPolicyType(info.getValue() as string)}</Text>
     ),
   },
   {
     accessorKey: 'engine',
     header: 'Engine',
     cell: (info) => (
-      <Badge
-        theme={info.getValue() === 'kyverno' ? 'brand' : 'info'}
-        size="sm"
-      >
-        {(info.getValue() as string).toUpperCase()}
+      <Badge variant="code" theme="neutral">
+        {info.getValue() as string}
       </Badge>
     ),
   },
@@ -93,27 +98,19 @@ export const policiesTableColumns: ColumnDef<TPolicyRow>[] = [
       const components = info.getValue() as string[]
       const isSandbox = info.row.original.type === 'sandbox'
       if (isSandbox) {
-        return (
-          <Text variant="subtext" className="italic">
-            Sandbox
-          </Text>
-        )
+        return <Text variant="subtext">Sandbox</Text>
       }
       const isAllComponents =
         !components ||
         components.length === 0 ||
         (components.length === 1 && components[0] === '*')
       if (isAllComponents) {
-        return (
-          <Text variant="subtext" className="italic">
-            All components
-          </Text>
-        )
+        return <Text variant="subtext">All components</Text>
       }
       return (
         <div className="flex flex-wrap gap-1">
           {components.slice(0, 3).map((comp) => (
-            <Badge key={comp} theme="neutral" size="sm">
+            <Badge key={comp} theme="neutral">
               {comp}
             </Badge>
           ))}
@@ -142,20 +139,18 @@ export const PoliciesTable = ({
   orgId: string
   appId: string
 }) => {
-  const data = parsePolicyToTableData(policies)
+  const data = parsePolicyToTableData(policies, orgId, appId)
 
   const columns: ColumnDef<TPolicyRow>[] = policiesTableColumns.map((col) => {
     if (col.id === 'actions') {
       return {
         ...col,
         cell: (info) => (
-          <Button
-            variant="ghost"
-            size="sm"
-            href={`/${orgId}/apps/${appId}/policies/${info.row.original.id}`}
-          >
-            View <Icon variant="CaretRightIcon" />
-          </Button>
+          <Text>
+            <Link href={`/${orgId}/apps/${appId}/policies/${info.row.original.id}`}>
+              View <Icon variant="CaretRightIcon" />
+            </Link>
+          </Text>
         ),
       }
     }

--- a/services/dashboard-ui/client/components/roles/AppRolesTable/AppRolesTable.tsx
+++ b/services/dashboard-ui/client/components/roles/AppRolesTable/AppRolesTable.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import type { ColumnDef } from '@tanstack/react-table'
 import { Badge } from '@/components/common/Badge'
+import { Icon } from '@/components/common/Icon'
 import { Table } from '@/components/common/Table'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
@@ -23,6 +24,15 @@ type TAppRole = {
   permissions_boundary?: string
 }
 
+const RolePanelHeading = ({ role }: { role: TAppRole }) => (
+  <div className="flex flex-col">
+    <Text variant="h3">{role.display_name}</Text>
+    <Text variant="subtext" theme="neutral" weight="normal">
+      {role.description}
+    </Text>
+  </div>
+)
+
 export const AppRolesTable = ({
   roles,
   isLoading,
@@ -35,15 +45,27 @@ export const AppRolesTable = ({
       {
         accessorKey: 'display_name',
         header: 'Name',
-        cell: (info) => (
-          <Text weight="strong">{info.getValue() as string}</Text>
+        cell: ({ row }) => (
+          <Panel
+            size="3/4"
+            panelKey={`${row.original.id}-name`}
+            heading={<RolePanelHeading role={row.original} />}
+            triggerButton={{
+              variant: 'ghost',
+              className:
+                '!p-0 !border-none !bg-transparent text-primary-600 dark:text-primary-500 hover:text-primary-800 dark:hover:text-primary-400 hover:!bg-transparent',
+              children: row.original.display_name,
+            }}
+          >
+            <AppRoleDetail role={row.original} />
+          </Panel>
         ),
       },
       {
         accessorKey: 'type',
         header: 'Type',
         cell: (info) => (
-          <Badge variant="code" size="sm">
+          <Badge variant="code" theme="neutral">
             {info.getValue() as string}
           </Badge>
         ),
@@ -66,20 +88,17 @@ export const AppRolesTable = ({
         cell: ({ row }) => (
           <Panel
             size="3/4"
-            panelKey={row.original.id}
-
-            heading={
-              <div className="flex flex-col">
-                <Text variant="h3">{row.original.display_name}</Text>
-                <Text variant="subtext" theme="neutral" weight="normal">
-                  {row.original.description}
-                </Text>
-              </div>
-            }
+            panelKey={`${row.original.id}-action`}
+            heading={<RolePanelHeading role={row.original} />}
             triggerButton={{
-              size: 'sm',
               variant: 'ghost',
-              children: 'View details',
+              className:
+                '!p-0 !border-none !bg-transparent text-primary-600 dark:text-primary-500 hover:text-primary-800 dark:hover:text-primary-400 hover:!bg-transparent',
+              children: (
+                <span className="flex items-center gap-1">
+                  View <Icon variant="CaretRightIcon" size={14} />
+                </span>
+              ),
             }}
           >
             <AppRoleDetail role={row.original} />

--- a/services/dashboard-ui/client/components/roles/AppRolesTable/AppRolesTable.tsx
+++ b/services/dashboard-ui/client/components/roles/AppRolesTable/AppRolesTable.tsx
@@ -24,6 +24,9 @@ type TAppRole = {
   permissions_boundary?: string
 }
 
+const panelLinkClass =
+  '!p-0 !h-auto !border-none !rounded-none !bg-transparent hover:!bg-transparent active:!bg-transparent focus:!shadow-none text-primary-600 dark:text-primary-500 hover:text-primary-800 hover:dark:text-primary-400 active:text-primary-900 active:dark:text-primary-600'
+
 const RolePanelHeading = ({ role }: { role: TAppRole }) => (
   <div className="flex flex-col">
     <Text variant="h3">{role.display_name}</Text>
@@ -44,7 +47,7 @@ export const AppRolesTable = ({
     () => [
       {
         accessorKey: 'display_name',
-        header: 'Name',
+        header: 'Role Name',
         cell: ({ row }) => (
           <Panel
             size="3/4"
@@ -52,8 +55,7 @@ export const AppRolesTable = ({
             heading={<RolePanelHeading role={row.original} />}
             triggerButton={{
               variant: 'ghost',
-              className:
-                '!p-0 !border-none !bg-transparent text-primary-600 dark:text-primary-500 hover:text-primary-800 dark:hover:text-primary-400 hover:!bg-transparent',
+              className: panelLinkClass,
               children: row.original.display_name,
             }}
           >
@@ -92,11 +94,10 @@ export const AppRolesTable = ({
             heading={<RolePanelHeading role={row.original} />}
             triggerButton={{
               variant: 'ghost',
-              className:
-                '!p-0 !border-none !bg-transparent text-primary-600 dark:text-primary-500 hover:text-primary-800 dark:hover:text-primary-400 hover:!bg-transparent',
+              className: panelLinkClass,
               children: (
-                <span className="flex items-center gap-1">
-                  View <Icon variant="CaretRightIcon" size={14} />
+                <span className="flex items-center gap-1.5">
+                  View <Icon variant="CaretRightIcon" />
                 </span>
               ),
             }}

--- a/services/dashboard-ui/client/components/roles/InstallRolesTable/InstallRolesTable.tsx
+++ b/services/dashboard-ui/client/components/roles/InstallRolesTable/InstallRolesTable.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import type { ColumnDef } from '@tanstack/react-table'
 import { Badge } from '@/components/common/Badge'
+import { Icon } from '@/components/common/Icon'
 import { type IPagination } from '@/components/common/Pagination'
 import { Table } from '@/components/common/Table'
 import { Text } from '@/components/common/Text'
@@ -8,6 +9,9 @@ import { Time } from '@/components/common/Time'
 import { Panel } from '@/components/surfaces/Panel'
 import { InstallRoleDetail } from '../InstallRoleDetail'
 import type { TInstallRole } from '@/lib/ctl-api/installs/get-latest-install-roles'
+
+const panelLinkClass =
+  '!p-0 !h-auto !border-none !rounded-none !bg-transparent hover:!bg-transparent active:!bg-transparent focus:!shadow-none text-primary-600 dark:text-primary-500 hover:text-primary-800 hover:dark:text-primary-400 active:text-primary-900 active:dark:text-primary-600'
 
 export const InstallRolesTable = ({
   roles,
@@ -24,16 +28,34 @@ export const InstallRolesTable = ({
         accessorKey: 'app_role_config.display_name',
         header: 'Name',
         cell: ({ row }) => (
-          <Text weight="strong">
-            {row.original.app_role_config?.display_name}
-          </Text>
+          <Panel
+            size="3/4"
+            panelKey={`${row.original.id}-name`}
+            heading={
+              <div className="flex flex-col">
+                <Text variant="h3">
+                  {row.original.app_role_config?.display_name}
+                </Text>
+                <Text variant="subtext" theme="neutral" weight="normal">
+                  {row.original.app_role_config?.description}
+                </Text>
+              </div>
+            }
+            triggerButton={{
+              variant: 'ghost',
+              className: panelLinkClass,
+              children: row.original.app_role_config?.display_name,
+            }}
+          >
+            <InstallRoleDetail installRole={row.original} />
+          </Panel>
         ),
       },
       {
         accessorKey: 'app_role_config.type',
         header: 'Type',
         cell: ({ row }) => (
-          <Badge variant="code" size="sm">
+          <Badge variant="code" theme="neutral">
             {row.original.app_role_config?.type}
           </Badge>
         ),
@@ -56,8 +78,7 @@ export const InstallRolesTable = ({
         cell: ({ row }) => (
           <Panel
             size="3/4"
-            panelKey={row.original.id}
-
+            panelKey={`${row.original.id}-action`}
             heading={
               <div className="flex flex-col">
                 <Text variant="h3">
@@ -69,9 +90,13 @@ export const InstallRolesTable = ({
               </div>
             }
             triggerButton={{
-              size: 'sm',
               variant: 'ghost',
-              children: 'View details',
+              className: panelLinkClass,
+              children: (
+                <span className="flex items-center gap-1.5">
+                  View <Icon variant="CaretRightIcon" />
+                </span>
+              ),
             }}
           >
             <InstallRoleDetail installRole={row.original} />

--- a/services/dashboard-ui/client/views/app/Actions.tsx
+++ b/services/dashboard-ui/client/views/app/Actions.tsx
@@ -26,6 +26,9 @@ export const Actions = () => {
         <Text variant="base" weight="strong">
           App actions
         </Text>
+        <Text variant="subtext" theme="neutral">
+          Configure and run day-2 operations on your installs.
+        </Text>
       </HeadingGroup>
       <ActionsTable />
     </PageSection>

--- a/services/dashboard-ui/client/views/app/Components.tsx
+++ b/services/dashboard-ui/client/views/app/Components.tsx
@@ -26,6 +26,9 @@ export const Components = () => {
         <Text variant="base" weight="strong">
           App components
         </Text>
+        <Text variant="subtext" theme="neutral">
+          Manage the components that make up your application.
+        </Text>
       </HeadingGroup>
       <div className="flex flex-auto">
         <ComponentsTable />

--- a/services/dashboard-ui/client/views/app/Installs.tsx
+++ b/services/dashboard-ui/client/views/app/Installs.tsx
@@ -26,6 +26,9 @@ export const Installs = () => {
         <Text variant="base" weight="strong">
           App installs
         </Text>
+        <Text variant="subtext" theme="neutral">
+          View and manage deployments of your app into customer cloud accounts.
+        </Text>
       </HeadingGroup>
       <AppInstallsTable appId={app?.id} />
     </PageSection>

--- a/services/dashboard-ui/client/views/app/Overview.tsx
+++ b/services/dashboard-ui/client/views/app/Overview.tsx
@@ -61,76 +61,76 @@ export const Overview = () => {
         <Text variant="base" weight="strong">
           Inputs config
         </Text>
-          {isLoading ? (
-            <InputsSkeleton />
-          ) : appConfig?.input?.input_groups?.length ? (
-            <AppInputs appConfig={appConfig} />
-          ) : (
-            <EmptyState
-              variant="diagram"
-              emptyTitle="No app inputs configured"
-              emptyMessage="Configure app inputs in your application configuration to see them here."
-            />
-          )}
-        </div>
-
         {isLoading ? (
-          <SandboxSkeleton />
-        ) : appConfig?.sandbox ? (
-          <Card className="h-fit flex flex-col gap-4">
-            <Text weight="strong">Sandbox config</Text>
-            <AppSandbox appConfig={appConfig} />
-          </Card>
+          <InputsSkeleton />
+        ) : appConfig?.input?.input_groups?.length ? (
+          <AppInputs appConfig={appConfig} />
         ) : (
-          <Card className="h-full">
-            <EmptyState
-              variant="diagram"
-              emptyTitle="No sandbox configuration"
-              emptyMessage="Configure a sandbox in your application configuration to see it here."
-            />
-          </Card>
+          <EmptyState
+            variant="diagram"
+            emptyTitle="No app inputs configured"
+            emptyMessage="Configure app inputs in your application configuration to see them here."
+          />
         )}
+      </div>
 
-        <div className="@container">
-          <div className="grid grid-cols-1 @lg:grid-cols-5 gap-6">
-            <div className="@lg:col-span-2">
-              {isLoading ? (
-                <RunnerSkeleton />
-              ) : appConfig?.runner ? (
-                <Card className="h-fit flex flex-col gap-4">
-                  <Text weight="strong">Runner config</Text>
-                  <AppRunner appConfig={appConfig} />
-                </Card>
-              ) : (
-                <Card className="h-full">
-                  <EmptyState
-                    variant="diagram"
-                    emptyTitle="No runner configuration"
-                    emptyMessage="Configure a runner in your application configuration to see it here."
-                  />
-                </Card>
-              )}
-            </div>
-            <div className="@lg:col-span-3">
-              {isLoading ? (
-                <StackSkeleton />
-              ) : appConfig?.stack ? (
-                <Card className="h-fit flex flex-col gap-4">
-                  <Text weight="strong">Stack config</Text>
-                  <AppStack appConfig={appConfig} />
-                </Card>
-              ) : (
-                <Card className="h-full">
-                  <EmptyState
-                    variant="diagram"
-                    emptyTitle="No stack configuration"
-                    emptyMessage="Configure a stack in your application configuration to see it here."
-                  />
-                </Card>
-              )}
-            </div>
+      {isLoading ? (
+        <SandboxSkeleton />
+      ) : appConfig?.sandbox ? (
+        <Card className="h-fit flex flex-col gap-4">
+          <Text weight="strong">Sandbox config</Text>
+          <AppSandbox appConfig={appConfig} />
+        </Card>
+      ) : (
+        <Card className="h-full">
+          <EmptyState
+            variant="diagram"
+            emptyTitle="No sandbox configuration"
+            emptyMessage="Configure a sandbox in your application configuration to see it here."
+          />
+        </Card>
+      )}
+
+      <div className="@container">
+        <div className="grid grid-cols-1 @lg:grid-cols-5 gap-6">
+          <div className="@lg:col-span-2">
+            {isLoading ? (
+              <RunnerSkeleton />
+            ) : appConfig?.runner ? (
+              <Card className="h-fit flex flex-col gap-4">
+                <Text weight="strong">Runner config</Text>
+                <AppRunner appConfig={appConfig} />
+              </Card>
+            ) : (
+              <Card className="h-full">
+                <EmptyState
+                  variant="diagram"
+                  emptyTitle="No runner configuration"
+                  emptyMessage="Configure a runner in your application configuration to see it here."
+                />
+              </Card>
+            )}
+          </div>
+          <div className="@lg:col-span-3">
+            {isLoading ? (
+              <StackSkeleton />
+            ) : appConfig?.stack ? (
+              <Card className="h-fit flex flex-col gap-4">
+                <Text weight="strong">Stack config</Text>
+                <AppStack appConfig={appConfig} />
+              </Card>
+            ) : (
+              <Card className="h-full">
+                <EmptyState
+                  variant="diagram"
+                  emptyTitle="No stack configuration"
+                  emptyMessage="Configure a stack in your application configuration to see it here."
+                />
+              </Card>
+            )}
           </div>
         </div>
+      </div>
 
     </PageSection>
   )

--- a/services/dashboard-ui/client/views/app/Overview.tsx
+++ b/services/dashboard-ui/client/views/app/Overview.tsx
@@ -5,6 +5,7 @@ import { AppSandbox } from '@/components/apps/config/AppSandbox'
 import { AppStack } from '@/components/apps/config/AppStack'
 import { Card } from '@/components/common/Card'
 import { EmptyState } from '@/components/common/EmptyState/EmptyState'
+import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { PropertyGridSkeleton } from '@/components/common/PropertyGrid'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Text } from '@/components/common/Text'
@@ -37,7 +38,7 @@ export const Overview = () => {
   const isLoading = isLoadingConfigs || isLoadingConfig
 
   return (
-    <>
+    <PageSection>
       <PageTitle title={`Configuration | ${app?.name}`} />
       <Breadcrumbs
         breadcrumbs={[
@@ -47,11 +48,19 @@ export const Overview = () => {
         ]}
       />
 
-      <PageSection>
-        <div className="flex flex-col gap-4">
-          <Text variant="h3" weight="strong">
-            Inputs config
-          </Text>
+      <HeadingGroup>
+        <Text variant="base" weight="strong">
+          App overview
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          View your app configuration, inputs, sandbox, runner, and stack settings.
+        </Text>
+      </HeadingGroup>
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          Inputs config
+        </Text>
           {isLoading ? (
             <InputsSkeleton />
           ) : appConfig?.input?.input_groups?.length ? (
@@ -123,8 +132,7 @@ export const Overview = () => {
           </div>
         </div>
 
-      </PageSection>
-    </>
+    </PageSection>
   )
 }
 

--- a/services/dashboard-ui/client/views/app/Policies.tsx
+++ b/services/dashboard-ui/client/views/app/Policies.tsx
@@ -45,6 +45,9 @@ export const Policies = () => {
         <Text variant="base" weight="strong">
           App policies
         </Text>
+        <Text variant="subtext" theme="neutral">
+          Define validation rules that run against builds and deploys.
+        </Text>
       </HeadingGroup>
 
       <div className="flex flex-auto">

--- a/services/dashboard-ui/client/views/app/PolicyDetail.tsx
+++ b/services/dashboard-ui/client/views/app/PolicyDetail.tsx
@@ -82,12 +82,9 @@ export const PolicyDetail = () => {
       <div className="flex items-center justify-between">
         <HeadingGroup>
           <BackLink className="mb-4" />
-          <span className="flex items-center gap-3">
-            <Icon variant="ShieldCheck" size={24} />
-            <Text variant="base" weight="strong">
-              {policy?.name}
-            </Text>
-          </span>
+          <Text variant="base" weight="strong">
+            {policy?.name}
+          </Text>
           {policy?.id && <ID>{policy.id}</ID>}
         </HeadingGroup>
       </div>
@@ -140,7 +137,7 @@ export const PolicyDetail = () => {
               </div>
             ) : isAllComponents ? (
               <div className="flex items-center gap-2">
-                <Icon variant="Stack" size={16} />
+                <Icon variant="Cards" size={16} />
                 <Text variant="subtext">All components</Text>
               </div>
             ) : (
@@ -153,7 +150,7 @@ export const PolicyDetail = () => {
                       to={`/${org?.id}/apps/${app?.id}/components/${componentId}`}
                       className="flex items-center gap-2 rounded px-3 py-2 text-sm border border-cool-grey-200 dark:border-dark-grey-600 hover:bg-grey-50 dark:hover:bg-dark-grey-800 transition-colors"
                     >
-                      <Icon variant="Cube" size={14} />
+                      <Icon variant="Cards" size={14} />
                       <Text variant="body">{comp}</Text>
                       <Icon
                         variant="ArrowSquareOut"
@@ -166,7 +163,7 @@ export const PolicyDetail = () => {
                       key={comp}
                       className="flex items-center gap-2 rounded px-3 py-2 text-sm border border-cool-grey-200 dark:border-dark-grey-600"
                     >
-                      <Icon variant="Cube" size={14} />
+                      <Icon variant="Cards" size={14} />
                       <Text variant="body">{comp}</Text>
                     </div>
                   )

--- a/services/dashboard-ui/client/views/app/PolicyDetail.tsx
+++ b/services/dashboard-ui/client/views/app/PolicyDetail.tsx
@@ -1,13 +1,13 @@
 import { Link, useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import { BackLink } from '@/components/common/BackLink'
-import { Badge } from '@/components/common/Badge'
 import { Card } from '@/components/common/Card'
 import { ClickToCopyButton } from '@/components/common/ClickToCopy'
 import { CodeBlock } from '@/components/common/CodeBlock'
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Icon } from '@/components/common/Icon'
 import { ID } from '@/components/common/ID'
+import { LabeledValue } from '@/components/common/LabeledValue'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
 import { PageSection } from '@/components/layout/PageSection'
@@ -92,101 +92,87 @@ export const PolicyDetail = () => {
         </HeadingGroup>
       </div>
 
-      <div className="flex flex-wrap items-center gap-3">
+      <div className="flex items-start gap-10">
         {policy?.type && (
-          <Badge theme="default" size="md">
-            {formatPolicyType(policy.type)}
-          </Badge>
+          <LabeledValue label="Type">
+            <Text variant="subtext">{formatPolicyType(policy.type)}</Text>
+          </LabeledValue>
         )}
         {policy?.engine && (
-          <Badge theme={policy.engine === 'kyverno' ? 'brand' : 'info'} size="md">
-            {policy.engine.toUpperCase()}
-          </Badge>
+          <LabeledValue label="Engine">
+            <Text variant="subtext">{policy.engine}</Text>
+          </LabeledValue>
         )}
         {policy?.created_at && (
-          <Text variant="subtext" className="flex items-center gap-1">
-            Created <Time time={policy.created_at} format="relative" />
-          </Text>
+          <LabeledValue label="Created">
+            <Time variant="subtext" time={policy.created_at} format="relative" />
+          </LabeledValue>
         )}
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-4">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">
-          <Card className="!p-0 overflow-hidden">
-            <div className="flex items-center justify-between p-4 border-b border-cool-grey-200 dark:border-dark-grey-600">
-              <Text weight="strong" variant="body">
-                Policy Definition
-              </Text>
+          <Card className="!p-5 !gap-4">
+            <div className="flex items-center justify-between">
+              <Text weight="strong">Policy Definition</Text>
               <ClickToCopyButton
                 textToCopy={policy?.contents ?? ''}
                 className="w-fit"
               />
             </div>
-            <div className="p-4">
-              <CodeBlock
-                language={getCodeLanguage(policy?.engine ?? '')}
-                className="max-h-[600px]"
-                showLineNumbers
-              >
-                {policy?.contents ?? ''}
-              </CodeBlock>
-            </div>
+            <CodeBlock
+              language={getCodeLanguage(policy?.engine ?? '')}
+              showLineNumbers
+              className="!max-h-none"
+            >
+              {policy?.contents ?? ''}
+            </CodeBlock>
           </Card>
         </div>
 
         <div className="lg:col-span-1">
-          <Card className="!p-0 overflow-hidden">
-            <div className="flex items-center justify-between p-4 border-b border-cool-grey-200 dark:border-dark-grey-600">
-              <Text weight="strong" variant="body">
-                Applicable Components
-              </Text>
-            </div>
-            <div className="p-4">
-              {isSandboxPolicy ? (
-                <div className="flex items-center gap-2 text-grey-600 dark:text-grey-400">
-                  <Icon variant="ShippingContainer" size={16} />
-                  <Text variant="body" className="italic">
-                    Sandbox
-                  </Text>
-                </div>
-              ) : isAllComponents ? (
-                <div className="flex items-center gap-2 text-grey-600 dark:text-grey-400">
-                  <Icon variant="Stack" size={16} />
-                  <Text variant="body" className="italic">
-                    All components
-                  </Text>
-                </div>
-              ) : (
-                <div className="flex flex-col gap-2">
-                  {policyComponents.map((comp) => {
-                    const componentId = componentNameToId[comp]
-                    return componentId ? (
-                      <Link
-                        key={comp}
-                        to={`/${org?.id}/apps/${app?.id}/components/${componentId}`}
-                        className="flex items-center gap-2 rounded px-3 py-2 text-sm border border-cool-grey-200 dark:border-dark-grey-600 hover:bg-grey-50 dark:hover:bg-dark-grey-800 transition-colors"
-                      >
-                        <Icon variant="Cube" size={14} />
-                        <Text variant="body">{comp}</Text>
-                        <Icon
-                          variant="ArrowSquareOut"
-                          size={12}
-                          className="ml-auto text-grey-400"
-                        />
-                      </Link>
-                    ) : (
-                      <div
-                        key={comp}
-                        className="flex items-center gap-2 rounded px-3 py-2 text-sm border border-cool-grey-200 dark:border-dark-grey-600"
-                      >
-                        <Icon variant="Cube" size={14} />
-                        <Text variant="body">{comp}</Text>
-                      </div>
-                    )
-                  })}
-                </div>
-              )}
-            </div>
+          <Card className="!p-5 !gap-4">
+            <Text weight="strong">Applicable Components</Text>
+            {isSandboxPolicy ? (
+              <div className="flex items-center gap-2">
+                <Icon variant="ShippingContainer" size={16} />
+                <Text variant="subtext">Sandbox</Text>
+              </div>
+            ) : isAllComponents ? (
+              <div className="flex items-center gap-2">
+                <Icon variant="Stack" size={16} />
+                <Text variant="subtext">All components</Text>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {policyComponents.map((comp) => {
+                  const componentId = componentNameToId[comp]
+                  return componentId ? (
+                    <Link
+                      key={comp}
+                      to={`/${org?.id}/apps/${app?.id}/components/${componentId}`}
+                      className="flex items-center gap-2 rounded px-3 py-2 text-sm border border-cool-grey-200 dark:border-dark-grey-600 hover:bg-grey-50 dark:hover:bg-dark-grey-800 transition-colors"
+                    >
+                      <Icon variant="Cube" size={14} />
+                      <Text variant="body">{comp}</Text>
+                      <Icon
+                        variant="ArrowSquareOut"
+                        size={12}
+                        className="ml-auto text-grey-400"
+                      />
+                    </Link>
+                  ) : (
+                    <div
+                      key={comp}
+                      className="flex items-center gap-2 rounded px-3 py-2 text-sm border border-cool-grey-200 dark:border-dark-grey-600"
+                    >
+                      <Icon variant="Cube" size={14} />
+                      <Text variant="body">{comp}</Text>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
           </Card>
         </div>
       </div>

--- a/services/dashboard-ui/client/views/app/Readme.tsx
+++ b/services/dashboard-ui/client/views/app/Readme.tsx
@@ -1,7 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
 import { EmptyState } from '@/components/common/EmptyState/EmptyState'
+import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Markdown } from '@/components/common/Markdown'
 import { Skeleton } from '@/components/common/Skeleton'
+import { Text } from '@/components/common/Text'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
 import { PageTitle } from '@/components/navigation/PageTitle'
@@ -41,6 +43,15 @@ export const Readme = () => {
           { path: `/${org?.id}/apps/${app?.id}/readme`, text: 'README' },
         ]}
       />
+
+      <HeadingGroup>
+        <Text variant="base" weight="strong">
+          README
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          Documentation provided with your app configuration.
+        </Text>
+      </HeadingGroup>
 
       {isLoading ? (
         <ReadmeSkeleton />

--- a/services/dashboard-ui/client/views/app/Roles.tsx
+++ b/services/dashboard-ui/client/views/app/Roles.tsx
@@ -27,7 +27,7 @@ export const Roles = () => {
           App roles
         </Text>
         <Text variant="subtext" theme="neutral">
-          View the IAM roles that your app uses to access customer AWS resources.
+          View the IAM roles that your app uses to access customer cloud resources.
         </Text>
       </HeadingGroup>
 

--- a/services/dashboard-ui/client/views/app/Sandbox.tsx
+++ b/services/dashboard-ui/client/views/app/Sandbox.tsx
@@ -49,6 +49,9 @@ export const Sandbox = () => {
           <Text variant="base" weight="strong">
             Sandbox
           </Text>
+          <Text variant="subtext" theme="neutral">
+            Test builds in an isolated environment before deploying to installs.
+          </Text>
         </HeadingGroup>
         <BuildSandboxButton variant="primary" />
       </div>


### PR DESCRIPTION
## Summary
- **Policy pages redesigned** for consistency: refactored `PolicyDetail` to use `LabeledValue` for metadata (Type, Engine, Created), replaced `Badge` with `Text` for policy type/engine, switched to `Card` layout with page-scrolling code blocks, removed shield icon from header, and fixed component icons to use `Cards` (matching navbar). `PoliciesTable` updated with `Text` for type column, proper `Link` for view action, and removed italic styling.
- **App roles table fixed**: name is now a clickable link that opens the detail panel, "View details" button replaced with inline "View >" link matching the policies table style, removed `size="sm"` from Badge, added `theme="neutral"`.
- **Standardized all app sub-nav page headings**: every page (Overview, Components, Actions, Roles, Policies, Installs, Sandbox, README) now uses a consistent `HeadingGroup` with `Text variant="base" weight="strong"` title and `Text variant="subtext" theme="neutral"` subtitle. Fixed Overview from using `variant="h3"` without `HeadingGroup`, and added a heading to README which had none.
