### PR TITLE
refactor(api/ui): workflow status description, counts &panel auto-open

### DIFF
--- a/services/ctl-api/internal/pkg/flow/execute_workflow_step.go
+++ b/services/ctl-api/internal/pkg/flow/execute_workflow_step.go
@@ -63,7 +63,7 @@ func (c *WorkflowConductor[DomainSignal]) executeFlowStep(ctx workflow.Context, 
 		ID: flw.ID,
 		Status: app.CompositeStatus{
 			Status:                 app.StatusInProgress,
-			StatusHumanDescription: "executing step " + strconv.Itoa(step.Idx+1),
+			StatusHumanDescription: "executing step " + step.Name,
 			Metadata:               map[string]any{},
 		},
 	}); err != nil {
@@ -112,7 +112,7 @@ func (c *WorkflowConductor[DomainSignal]) executeFlowStep(ctx workflow.Context, 
 			ID: flw.ID,
 			Status: app.CompositeStatus{
 				Status:                 app.StatusSuccess,
-				StatusHumanDescription: "finished executing step " + strconv.Itoa(step.Idx+1),
+				StatusHumanDescription: "finished executing step " + step.Name,
 				Metadata: map[string]any{
 					"step_idx": step.Idx,
 					"status":   "ok",
@@ -278,7 +278,7 @@ func (c *WorkflowConductor[DomainSignal]) executeFlowStep(ctx workflow.Context, 
 		ID: step.ID,
 		Status: app.CompositeStatus{
 			Status:                 app.AwaitingApproval,
-			StatusHumanDescription: "awaiting approval " + strconv.Itoa(step.Idx+1),
+			StatusHumanDescription: "awaiting approval for " + step.Name,
 			Metadata: map[string]any{
 				"step_idx": step.Idx,
 				"status":   "ok",
@@ -309,7 +309,7 @@ func (c *WorkflowConductor[DomainSignal]) executeFlowStep(ctx workflow.Context, 
 			ID: step.ID,
 			Status: app.CompositeStatus{
 				Status:                 app.WorkflowStepApprovalStatusApproved,
-				StatusHumanDescription: "approved " + strconv.Itoa(step.Idx+1),
+				StatusHumanDescription: "approved " + step.Name,
 				Metadata: map[string]any{
 					"step_idx": step.Idx,
 					"status":   "ok",
@@ -336,7 +336,7 @@ func (c *WorkflowConductor[DomainSignal]) executeFlowStep(ctx workflow.Context, 
 			ID: step.ID,
 			Status: app.CompositeStatus{
 				Status:                 app.WorkflowStepApprovalStatusApprovalRetryPlan,
-				StatusHumanDescription: "retrying " + strconv.Itoa(step.Idx),
+				StatusHumanDescription: "retrying " + step.Name,
 				Metadata: map[string]any{
 					"step_idx": step.Idx,
 					"status":   "retrying",
@@ -349,7 +349,7 @@ func (c *WorkflowConductor[DomainSignal]) executeFlowStep(ctx workflow.Context, 
 		if err := activities.AwaitPkgWorkflowsFlowUpdateFlowStepTargetStatus(ctx, activities.UpdateFlowStepTargetStatusRequest{
 			StepID:            step.ID,
 			Status:            app.StatusDiscarded,
-			StatusDescription: "Retrying step " + strconv.Itoa(step.Idx),
+			StatusDescription: "Retrying step " + step.Name,
 		}); err != nil {
 			return refetchStepsInfo, errors.Wrap(err, "unable to update step target status")
 		}
@@ -688,7 +688,7 @@ func (c *WorkflowConductor[DomainSignal]) handleNoopDeployPlan(ctx workflow.Cont
 		ID: step.ID,
 		Status: app.CompositeStatus{
 			Status:                 app.StatusAutoSkipped,
-			StatusHumanDescription: "Noop Plan, automatically skipped " + strconv.Itoa(step.Idx+1),
+			StatusHumanDescription: "Noop Plan, automatically skipped " + step.Name,
 			Metadata: map[string]any{
 				"step_idx": step.Idx,
 				"status":   "auto-skipped",
@@ -715,7 +715,7 @@ func (c *WorkflowConductor[DomainSignal]) handleNoopDeployPlan(ctx workflow.Cont
 		ID: nextStep.ID,
 		Status: app.CompositeStatus{
 			Status:                 app.StatusAutoSkipped,
-			StatusHumanDescription: "Noop Plan, automatically skipped " + strconv.Itoa(nextStep.Idx),
+			StatusHumanDescription: "Noop Plan, automatically skipped " + nextStep.Name,
 			Metadata: map[string]any{
 				"step_idx": nextStep.Idx,
 				"status":   "auto-skipped",
@@ -770,7 +770,7 @@ func (c *WorkflowConductor[DomainSignal]) handlePlanOnlyApproval(ctx workflow.Co
 		ID: step.ID,
 		Status: app.CompositeStatus{
 			Status:                 app.WorkflowStepApprovalStatusApproved,
-			StatusHumanDescription: "auto-approved (plan-only mode) " + strconv.Itoa(step.Idx+1),
+			StatusHumanDescription: "auto-approved (plan-only mode) " + step.Name,
 			Metadata: map[string]any{
 				"step_idx":  step.Idx,
 				"status":    "auto-approved",

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/execute_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/execute_step.go
@@ -1,8 +1,6 @@
 package executeworkflowstep
 
 import (
-	"strconv"
-
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
@@ -58,7 +56,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		ID: flw.ID,
 		Status: app.CompositeStatus{
 			Status:                 app.StatusInProgress,
-			StatusHumanDescription: "executing step " + strconv.Itoa(step.Idx+1),
+			StatusHumanDescription: "executing step " + step.Name,
 			Metadata:               map[string]any{},
 		},
 	}); err != nil {
@@ -95,7 +93,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 			ID: flw.ID,
 			Status: app.CompositeStatus{
 				Status:                 app.StatusInProgress,
-				StatusHumanDescription: "finished executing step " + strconv.Itoa(step.Idx+1),
+				StatusHumanDescription: "finished executing step " + step.Name,
 				Metadata: map[string]any{
 					"step_idx": step.Idx,
 					"status":   "ok",

--- a/services/dashboard-ui/Dockerfile
+++ b/services/dashboard-ui/Dockerfile
@@ -58,7 +58,7 @@ RUN --mount=type=cache,target=/root/.npm,id=npm-dashboard-ui npm run build
 
 # --- Build Go server ---
 
-FROM 431927561584.dkr.ecr.us-west-2.amazonaws.com/mirror/golang:1.25.8-alpine AS build-server
+FROM public.ecr.aws/p7e3r5y0/mirror/golang:1.25.8-alpine AS build-server
 
 WORKDIR /src
 

--- a/services/dashboard-ui/Dockerfile
+++ b/services/dashboard-ui/Dockerfile
@@ -58,7 +58,7 @@ RUN --mount=type=cache,target=/root/.npm,id=npm-dashboard-ui npm run build
 
 # --- Build Go server ---
 
-FROM golang:1.25.8-alpine AS build-server
+FROM 431927561584.dkr.ecr.us-west-2.amazonaws.com/mirror/golang:1.25.8-alpine AS build-server
 
 WORKDIR /src
 

--- a/services/dashboard-ui/client/components/workflows/WorkflowSteps/WorkflowStepsContainer.tsx
+++ b/services/dashboard-ui/client/components/workflows/WorkflowSteps/WorkflowStepsContainer.tsx
@@ -1,8 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
-import { useOrg } from '@/hooks/use-org'
 import { useWorkflow } from '@/hooks/use-workflow'
-import { getWorkflowSteps } from '@/lib'
-import type { TWorkflowStep } from '@/types'
 import { WorkflowSteps, WorkflowStepsSkeleton } from './WorkflowSteps'
 
 export { WorkflowStepsSkeleton }
@@ -10,31 +6,13 @@ export { WorkflowStepsSkeleton }
 interface IWorkflowStepsContainer {
   approvalPrompt?: boolean
   planOnly?: boolean
-  pollInterval?: number
-  shouldPoll?: boolean
-  workflowId: string
 }
 
 export const WorkflowStepsContainer = ({
   approvalPrompt = false,
   planOnly = false,
-  pollInterval = 4000,
-  shouldPoll = false,
-  workflowId,
 }: IWorkflowStepsContainer) => {
-  const { org } = useOrg()
-  const { workflow } = useWorkflow()
-
-  const shouldStopPolling = workflow?.finished || workflow?.status?.status === 'cancelled'
-  const effectiveShouldPoll = shouldPoll && !shouldStopPolling
-
-  const { data: workflowSteps = [] } = useQuery<TWorkflowStep[]>({
-    queryKey: ['workflow-steps', org?.id, workflowId],
-    queryFn: () => getWorkflowSteps({ orgId: org.id, workflowId }),
-    refetchOnMount: 'always',
-    refetchInterval: effectiveShouldPoll ? pollInterval : false,
-    enabled: !!org?.id && !!workflowId,
-  })
+  const { workflowSteps } = useWorkflow()
 
   return (
     <WorkflowSteps

--- a/services/dashboard-ui/client/components/workflows/step-details/StepDetailPanel/StepDetailPanelContainer.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/StepDetailPanel/StepDetailPanelContainer.tsx
@@ -122,25 +122,21 @@ export const StepDetailPanelButton = ({
 
   const workflowStatus = workflow?.status?.status
   const workflowBlocked = workflowStatus === 'cancelled' || workflowStatus === 'error'
+  const suppressAutoOpen = planOnly || workflow?.type === 'drift_run' || workflow?.type === 'drift_run_reprovision_sandbox'
 
   useEffect(() => {
-    if (step.id && step.id === searchParams?.get('panel')) {
+    if (!suppressAutoOpen && step.id && step.id === searchParams?.get('panel')) {
       handleAddPanel()
-      return
     }
   }, [])
 
   useEffect(() => {
     if (autoOpened.current || !workflow) return
-    if (
-      !workflowBlocked &&
-      (isPendingApproval || isPendingAwaitStack) &&
-      panels.length === 0
-    ) {
+    if (!workflowBlocked && !suppressAutoOpen && (isPendingApproval || isPendingAwaitStack) && panels.length === 0) {
       autoOpened.current = true
       handleAddPanel()
     }
-  }, [workflow?.id, workflowBlocked, isPendingApproval, isPendingAwaitStack])
+  }, [workflow?.id, workflowBlocked, suppressAutoOpen, isPendingApproval, isPendingAwaitStack])
 
   return (
     <Button

--- a/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowStatusSection/WorkflowStatusSection.tsx
+++ b/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowStatusSection/WorkflowStatusSection.tsx
@@ -14,13 +14,18 @@ export const WorkflowStatusSection = ({ workflow }: IWorkflowStatusSection) => {
       <Text
         variant="h3"
         weight="stronger"
-        className="inline-flex gap-2"
+        className="inline-flex gap-2 max-w-[600px]"
         theme={getStatusTheme(workflow.status.status) as any}
-      >
-        <Status status={workflow.status.status} variant="timeline" />
-        {toSentenceCase(
+        title={toSentenceCase(
           workflow.status.status_human_description || workflow.status.status
         )}
+      >
+        <Status status={workflow.status.status} variant="timeline" />
+        <span className="truncate">
+          {toSentenceCase(
+            workflow.status.status_human_description || workflow.status.status
+          )}
+        </span>
       </Text>
 
       <Text variant="h3" weight="stronger">

--- a/services/dashboard-ui/client/hooks/use-workflow-metrics.ts
+++ b/services/dashboard-ui/client/hooks/use-workflow-metrics.ts
@@ -3,7 +3,8 @@ import type { TWorkflow } from '@/types'
 
 export const useWorkflowMetrics = (workflow: TWorkflow | undefined) => {
   return useMemo(() => {
-    const workflowSteps = workflow?.steps?.filter((s) => s?.execution_type !== 'hidden') || []
+    const workflowSteps =
+      workflow?.steps?.filter((s) => s?.execution_type !== 'hidden' && !s?.retried) || []
     
     const hasApprovals = workflowSteps.some(
       (step) => step?.execution_type === 'approval'

--- a/services/dashboard-ui/client/providers/workflow-provider.tsx
+++ b/services/dashboard-ui/client/providers/workflow-provider.tsx
@@ -30,7 +30,7 @@ export const WorkflowContext = createContext<WorkflowContextValue | undefined>(u
 export const WorkflowProvider = ({
   children,
   workflowId,
-  pollInterval = 10000,
+  pollInterval = 4000,
   shouldPoll = false,
 }: {
   children: ReactNode

--- a/services/dashboard-ui/client/views/install/WorkflowDetail.tsx
+++ b/services/dashboard-ui/client/views/install/WorkflowDetail.tsx
@@ -57,8 +57,6 @@ const WorkflowDetailContent = () => {
           <WorkflowSteps
             approvalPrompt={workflow?.approval_option === 'prompt'}
             planOnly={workflow?.plan_only}
-            workflowId={workflowId!}
-            shouldPoll
           />
         ) : (
           <WorkflowStepsSkeleton />


### PR DESCRIPTION
- Updates ctl-api to use step name for workflow status description
- Updates workflow detail page to only poll the workflow and not workflow and steps
- Update workflow detail metrics to show og step counts
- Don't auto-open panels for drift scans 