### PR TITLE
feat(ctl-api): add step groups to API

### DIFF
--- a/services/ctl-api/docs/public/descriptions/get_workflow_step_group.md
+++ b/services/ctl-api/docs/public/descriptions/get_workflow_step_group.md
@@ -1,0 +1,1 @@
+Get a single workflow step group by ID, including its nested steps.

--- a/services/ctl-api/docs/public/descriptions/get_workflow_step_groups.md
+++ b/services/ctl-api/docs/public/descriptions/get_workflow_step_groups.md
@@ -1,0 +1,1 @@
+Get all step groups for a workflow, ordered by group index. Each group contains its nested steps.

--- a/services/ctl-api/internal/app/installs/service/get_workflow.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow.go
@@ -92,6 +92,12 @@ func (s *service) getWorkflow(ctx *gin.Context, orgID, workflowID string) (*app.
 		Preload("Steps.CreatedBy").
 		Preload("Steps.Approval").
 		Preload("Steps.Approval.Response").
+		Preload("StepGroups", func(db *gorm.DB) *gorm.DB {
+			return db.Order("group_idx asc")
+		}).
+		Preload("StepGroups.Steps", func(db *gorm.DB) *gorm.DB {
+			return db.Order("group_retry_idx, idx, created_at asc")
+		}).
 		Where("id = ? AND org_id = ?", workflowID, orgID).
 		First(&installWorkflow)
 	if res.Error != nil {

--- a/services/ctl-api/internal/app/installs/service/get_workflow_step_group.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow_step_group.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+)
+
+// @ID						GetWorkflowStepGroup
+// @Summary					get a workflow step group
+// @Description.markdown	get_workflow_step_group.md
+// @Param					workflow_id		path	string	true	"workflow ID"
+// @Param					step_group_id	path	string	true	"step group ID"
+// @Tags					installs
+// @Accept					json
+// @Produce					json
+// @Security				APIKey
+// @Security				OrgID
+// @Failure					400	{object}	stderr.ErrResponse
+// @Failure					401	{object}	stderr.ErrResponse
+// @Failure					403	{object}	stderr.ErrResponse
+// @Failure					404	{object}	stderr.ErrResponse
+// @Failure					500	{object}	stderr.ErrResponse
+// @Success					200	{object}	app.WorkflowStepGroup
+// @Router					/v1/workflows/{workflow_id}/step-groups/{step_group_id} [GET]
+func (s *service) GetWorkflowStepGroup(ctx *gin.Context) {
+	org, err := cctx.OrgFromContext(ctx)
+	if err != nil {
+		ctx.Error(errors.Wrap(err, "unable to get org from context"))
+		return
+	}
+
+	workflowID := ctx.Param("workflow_id")
+	stepGroupID := ctx.Param("step_group_id")
+
+	group, err := s.getWorkflowStepGroup(ctx, org.ID, workflowID, stepGroupID)
+	if err != nil {
+		ctx.Error(errors.Wrap(err, "unable to get workflow step group"))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, group)
+}
+
+func (s *service) getWorkflowStepGroup(ctx *gin.Context, orgID, workflowID, stepGroupID string) (*app.WorkflowStepGroup, error) {
+	var group app.WorkflowStepGroup
+	res := s.db.WithContext(ctx).
+		Where("id = ? AND workflow_id = ? AND org_id = ?", stepGroupID, workflowID, orgID).
+		Preload("Steps", func(db *gorm.DB) *gorm.DB {
+			return db.Order("group_retry_idx, idx, created_at asc")
+		}).
+		First(&group)
+	if res.Error != nil {
+		return nil, errors.Wrap(res.Error, "unable to get workflow step group")
+	}
+
+	return &group, nil
+}

--- a/services/ctl-api/internal/app/installs/service/get_workflow_step_groups.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow_step_groups.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+)
+
+// @ID						GetWorkflowStepGroups
+// @Summary					get all step groups for a workflow
+// @Description.markdown	get_workflow_step_groups.md
+// @Param					workflow_id	path	string	true	"workflow ID"
+// @Tags					installs
+// @Accept					json
+// @Produce					json
+// @Security				APIKey
+// @Security				OrgID
+// @Failure					400	{object}	stderr.ErrResponse
+// @Failure					401	{object}	stderr.ErrResponse
+// @Failure					403	{object}	stderr.ErrResponse
+// @Failure					404	{object}	stderr.ErrResponse
+// @Failure					500	{object}	stderr.ErrResponse
+// @Success					200	{array}		app.WorkflowStepGroup
+// @Router					/v1/workflows/{workflow_id}/step-groups [GET]
+func (s *service) GetWorkflowStepGroups(ctx *gin.Context) {
+	org, err := cctx.OrgFromContext(ctx)
+	if err != nil {
+		ctx.Error(errors.Wrap(err, "unable to get org from context"))
+		return
+	}
+
+	workflowID := ctx.Param("workflow_id")
+
+	groups, err := s.getWorkflowStepGroups(ctx, org.ID, workflowID)
+	if err != nil {
+		ctx.Error(errors.Wrap(err, "unable to get workflow step groups"))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, groups)
+}
+
+func (s *service) getWorkflowStepGroups(ctx *gin.Context, orgID, workflowID string) ([]app.WorkflowStepGroup, error) {
+	var groups []app.WorkflowStepGroup
+
+	res := s.db.WithContext(ctx).
+		Where(app.WorkflowStepGroup{
+			WorkflowID: workflowID,
+			OrgID:      orgID,
+		}).
+		Preload("Steps", func(db *gorm.DB) *gorm.DB {
+			return db.Order("group_retry_idx, idx, created_at asc")
+		}).
+		Order("group_idx asc").
+		Find(&groups)
+	if res.Error != nil {
+		return nil, errors.Wrap(res.Error, "unable to get workflow step groups")
+	}
+
+	return groups, nil
+}

--- a/services/ctl-api/internal/app/installs/service/service.go
+++ b/services/ctl-api/internal/app/installs/service/service.go
@@ -226,6 +226,12 @@ func (s *service) RegisterPublicRoutes(ge *gin.Engine) error {
 		workflows.PATCH("", s.UpdateWorkflow)
 		workflows.POST("/cancel", s.CancelWorkflow)
 
+		stepGroups := workflows.Group("/step-groups")
+		{
+			stepGroups.GET("", s.GetWorkflowStepGroups)
+			stepGroups.GET("/:step_group_id", s.GetWorkflowStepGroup)
+		}
+
 		steps := workflows.Group("/steps")
 		{
 			steps.GET("", s.GetWorkflowSteps)

--- a/services/ctl-api/internal/app/installs/workflows/shared.go
+++ b/services/ctl-api/internal/app/installs/workflows/shared.go
@@ -304,12 +304,16 @@ func getLifecycleActionsSteps(ctx workflow.Context, installID string, flw *app.W
 		awcMap[awc.ActionWorkflowID] = awc
 	}
 
-	sg.nextGroup() // lifecycleSteps
-
+	groupCreated := false
 	for _, installAction := range installActions {
 		if _, ok := awcMap[installAction.ActionWorkflowID]; !ok {
 			// skip actions that are not part of current app config
 			continue
+		}
+
+		if !groupCreated {
+			sg.nextGroup() // lifecycleSteps
+			groupCreated = true
 		}
 
 		sig := &signals.Signal{

--- a/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
@@ -106,6 +106,10 @@ func getLifecycleActionsSteps(ctx workflow.Context, installID string, flw *app.W
 	steps := make([]*app.WorkflowStep, 0)
 	installActions := filterActionWorkflowsByTrigger(awData, triggerTyp, "", appCfg)
 
+	if len(installActions) == 0 {
+		return steps, nil
+	}
+
 	sg.nextGroup() // lifecycleSteps
 
 	for _, installAction := range installActions {

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -2398,6 +2398,20 @@ export interface paths {
      */
     post: operations["CancelWorkflow"];
   };
+  "/v1/workflows/{workflow_id}/step-groups": {
+    /**
+     * get all step groups for a workflow
+     * @description Get all step groups for a workflow, ordered by group index. Each group contains its nested steps.
+     */
+    get: operations["GetWorkflowStepGroups"];
+  };
+  "/v1/workflows/{workflow_id}/step-groups/{step_group_id}": {
+    /**
+     * get a workflow step group
+     * @description Get a single workflow step group by ID, including its nested steps.
+     */
+    get: operations["GetWorkflowStepGroup"];
+  };
   "/v1/workflows/{workflow_id}/steps": {
     /**
      * get all of the steps for a given workflow
@@ -23275,6 +23289,108 @@ export interface operations {
       202: {
         content: {
           "application/json": components["schemas"]["app.EmptyResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * get all step groups for a workflow
+   * @description Get all step groups for a workflow, ordered by group index. Each group contains its nested steps.
+   */
+  GetWorkflowStepGroups: {
+    parameters: {
+      path: {
+        /** @description workflow ID */
+        workflow_id: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["app.WorkflowStepGroup"][];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * get a workflow step group
+   * @description Get a single workflow step group by ID, including its nested steps.
+   */
+  GetWorkflowStepGroup: {
+    parameters: {
+      path: {
+        /** @description workflow ID */
+        workflow_id: string;
+        /** @description step group ID */
+        step_group_id: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["app.WorkflowStepGroup"];
         };
       };
       /** @description Bad Request */


### PR DESCRIPTION
## Problem

We added step groups to our data model, but have not exposed them via the api. These would be useful for simplifying client-side code and providing a more polished and consistent UX around workflows.

## Solution

Include step groups in the API.

- Update `GET /workflows/:workflow_id` to include step groups
- Add `GET /v1/workflows/:workflow_id/step-groups`
- Add `GET /v1/workflows/:workflow_id/step-groups/:step_group_id`