### PR TITLE
refactor(ui): better empty state for log viewer

### DIFF
--- a/services/dashboard-ui/client/components/log-stream/SSELogs/SSELogs.tsx
+++ b/services/dashboard-ui/client/components/log-stream/SSELogs/SSELogs.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, memo } from 'react'
 import { Button } from '@/components/common/Button'
+import { EmptyState } from '@/components/common/EmptyState'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
@@ -80,6 +81,33 @@ export const SSELogs = ({
             </Text>
           </div>
         </div>
+
+        {!filteredLogs?.length && filters.filterStats.totalCount > 0 ? (
+          <EmptyState
+            variant="search"
+            emptyTitle="Filters are hiding logs"
+            emptyMessage={`${filters.filterStats.totalCount} log(s) are hidden by the current filters.`}
+            action={
+              <Button size="sm" onClick={filters.handleResetAll}>
+                Reset filters
+              </Button>
+            }
+          />
+        ) : null}
+
+        {!filteredLogs?.length && !filters.filterStats.totalCount && !isLoading && isStreamOpen ? (
+          <EmptyState
+            emptyTitle="Waiting for logs"
+            emptyMessage="Logs will appear here once they start coming in."
+          />
+        ) : null}
+
+        {!filteredLogs?.length && !filters.filterStats.totalCount && !isLoading && !isStreamOpen ? (
+          <EmptyState
+            emptyTitle="No logs available"
+            emptyMessage=""
+          />
+        ) : null}
 
         <div className="flex flex-col divide-y">
           {!filteredLogs?.length && isLoading ? (

--- a/services/dashboard-ui/client/components/log-stream/log-filters/LogFilters.stories.tsx
+++ b/services/dashboard-ui/client/components/log-stream/log-filters/LogFilters.stories.tsx
@@ -32,6 +32,8 @@ const mockFilters: TLogFiltersProps = {
   sortStats: { direction: 'desc', isNewestFirst: true, isOldestFirst: false },
   severityStats: { selectedCount: 4, totalCount: 4 },
   serviceStats: { selectedCount: 2, totalCount: 2, isAllSelected: false },
+  isFiltered: false,
+  handleResetAll: noop,
 }
 
 const mockContextLive = {

--- a/services/dashboard-ui/client/hooks/use-log-filters.ts
+++ b/services/dashboard-ui/client/hooks/use-log-filters.ts
@@ -212,6 +212,20 @@ export const useLogFilters = <T extends TOTELLog>(logs: T[] | null) => {
     setJobOutputOnly((prev) => !prev)
   }
 
+  const isFiltered =
+    jobOutputOnly ||
+    searchQuery.trim() !== '' ||
+    selectedSeverities.size !== DEFAULT_SELECTED_SEVERITIES.size ||
+    [...DEFAULT_SELECTED_SEVERITIES].some(s => !selectedSeverities.has(s)) ||
+    selectedServices.size !== availableServices.size
+
+  const handleResetAll = () => {
+    setSelectedSeverities(new Set(DEFAULT_SELECTED_SEVERITIES))
+    setSelectedServices(new Set(DEFAULT_SELECTED_SERVICES))
+    setJobOutputOnly(false)
+    setSearchQuery('')
+  }
+
   return {
     // Severity filter
     selectedSeverities,
@@ -237,6 +251,10 @@ export const useLogFilters = <T extends TOTELLog>(logs: T[] | null) => {
     handleSearchChange,
     handleSortToggle,
     handleSortChange,
+
+    // Reset
+    isFiltered,
+    handleResetAll,
 
     // Stats
     filterStats: {


### PR DESCRIPTION
 Shows better empty states for log views. If the log viewer is empty but has logs show a reset filters button