### PR TITLE
fix(customer-dashboard): include approvals in step group api responses

### DIFF
--- a/services/ctl-api/internal/app/installs/service/get_workflow.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow.go
@@ -98,6 +98,8 @@ func (s *service) getWorkflow(ctx *gin.Context, orgID, workflowID string) (*app.
 		Preload("StepGroups.Steps", func(db *gorm.DB) *gorm.DB {
 			return db.Order("group_retry_idx, idx, created_at asc")
 		}).
+		Preload("StepGroups.Steps.Approval").
+		Preload("StepGroups.Steps.Approval.Response").
 		Where("id = ? AND org_id = ?", workflowID, orgID).
 		First(&installWorkflow)
 	if res.Error != nil {

--- a/services/ctl-api/internal/app/installs/service/get_workflow_step_group.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow_step_group.go
@@ -54,6 +54,8 @@ func (s *service) getWorkflowStepGroup(ctx *gin.Context, orgID, workflowID, step
 		Preload("Steps", func(db *gorm.DB) *gorm.DB {
 			return db.Order("group_retry_idx, idx, created_at asc")
 		}).
+		Preload("Steps.Approval").
+		Preload("Steps.Approval.Response").
 		First(&group)
 	if res.Error != nil {
 		return nil, errors.Wrap(res.Error, "unable to get workflow step group")

--- a/services/ctl-api/internal/app/installs/service/get_workflow_step_groups.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow_step_groups.go
@@ -56,6 +56,8 @@ func (s *service) getWorkflowStepGroups(ctx *gin.Context, orgID, workflowID stri
 		Preload("Steps", func(db *gorm.DB) *gorm.DB {
 			return db.Order("group_retry_idx, idx, created_at asc")
 		}).
+		Preload("Steps.Approval").
+		Preload("Steps.Approval.Response").
 		Order("group_idx asc").
 		Find(&groups)
 	if res.Error != nil {


### PR DESCRIPTION
It turns out that we do still include approvals in the steps in the `/v1/workflow:workflow_id` api response. We're excluding the contents of the approval, which avoids the OOM issue. This PR includes approvals in the step groups as well for parity.