### PR TITLE
feat: add queue-signal callback system

### DIFF
--- a/pkg/shortid/domains/domains.go
+++ b/pkg/shortid/domains/domains.go
@@ -314,6 +314,10 @@ func NewQueueEmitterID() string {
 	return shortid.NewNanoID("qem")
 }
 
+func NewQueueSignalCallbackID() string {
+	return shortid.NewNanoID("qsc")
+}
+
 func NewOCIArtifactID() string {
 	return shortid.NewNanoID("oci")
 }

--- a/services/ctl-api/internal/app/queue_signal_callback.go
+++ b/services/ctl-api/internal/app/queue_signal_callback.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/plugin/soft_delete"
+
+	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/indexes"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
+	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
+)
+
+type QueueSignalCallback struct {
+	ID string `gorm:"primary_key;check:id_checker,char_length(id)=26" json:"id,omitzero" temporaljson:"id,omitzero,omitempty"`
+
+	CreatedAt time.Time             `json:"created_at,omitzero" gorm:"notnull" temporaljson:"created_at,omitzero,omitempty"`
+	UpdatedAt time.Time             `json:"updated_at,omitzero" gorm:"notnull" temporaljson:"updated_at,omitzero,omitempty"`
+	DeletedAt soft_delete.DeletedAt `json:"-" temporaljson:"deleted_at,omitzero,omitempty"`
+
+	OrgID *string `json:"org_id,omitempty" temporaljson:"org_id,omitzero,omitempty"`
+	Org   *Org    `json:"-" temporaljson:"org,omitzero,omitempty"`
+
+	QueueSignalID string      `json:"queue_signal_id,omitzero" gorm:"type:text;not null;index:idx_qsc_queue_signal_id" temporaljson:"queue_signal_id,omitzero,omitempty"`
+	QueueSignal   QueueSignal `json:"-" gorm:"constraint:OnDelete:CASCADE;" temporaljson:"queue_signal,omitzero,omitempty"`
+
+	Event         string                 `json:"event,omitzero" gorm:"type:text;not null" temporaljson:"event,omitzero,omitempty"`
+	UpdateHandler signaldb.UpdateHandler `json:"update_handler" gorm:"type:jsonb;not null" temporaljson:"update_handler,omitzero,omitempty"`
+}
+
+func (r *QueueSignalCallback) Indexes(db *gorm.DB) []migrations.Index {
+	return []migrations.Index{
+		{
+			Name: indexes.Name(db, &QueueSignalCallback{}, "queue_signal_id"),
+			Columns: []string{
+				"queue_signal_id",
+			},
+		},
+	}
+}
+
+func (r *QueueSignalCallback) BeforeCreate(tx *gorm.DB) error {
+	if r.ID == "" {
+		r.ID = domains.NewQueueSignalCallbackID()
+	}
+
+	if r.OrgID == nil {
+		if orgID := orgIDFromContext(tx.Statement.Context); orgID != "" {
+			r.OrgID = &orgID
+		}
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/fxmodules/workers_shared.go
+++ b/services/ctl-api/internal/fxmodules/workers_shared.go
@@ -9,6 +9,7 @@ import (
 	validateinterceptor "github.com/nuonco/nuon/services/ctl-api/internal/interceptors/validate"
 	queue "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue"
 	queueactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/callback"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/emitter"
 	emitteractivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/emitter/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler"
@@ -53,6 +54,7 @@ var WorkerInterceptorsModule = fx.Module("worker-interceptors",
 var SharedWorkflowsModule = fx.Module("shared-workflows",
 	fx.Provide(signal.AsSignalLifecycleHook(signalhooks.NewWebhookSignalLifecycleHook)),
 	fx.Provide(signal.NewSignalLifecycleActivities),
+	fx.Provide(callback.NewActivities),
 
 	fx.Provide(jobactivities.New),
 	fx.Provide(flowactivities.New),

--- a/services/ctl-api/internal/pkg/db/psql/models.go
+++ b/services/ctl-api/internal/pkg/db/psql/models.go
@@ -140,6 +140,7 @@ func AllModels() []any {
 		// queues
 		&app.Queue{},
 		&app.QueueSignal{},
+		&app.QueueSignalCallback{},
 
 		// actions
 		&app.ActionWorkflow{},

--- a/services/ctl-api/internal/pkg/queue/callback/activities.go
+++ b/services/ctl-api/internal/pkg/queue/callback/activities.go
@@ -1,0 +1,97 @@
+package callback
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	tclient "go.temporal.io/sdk/client"
+
+	temporalclient "github.com/nuonco/nuon/pkg/temporal/client"
+	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+type ActivitiesParams struct {
+	fx.In
+
+	DB      *gorm.DB `name:"psql"`
+	TClient temporalclient.Client
+}
+
+type Activities struct {
+	db      *gorm.DB
+	tClient temporalclient.Client
+}
+
+func NewActivities(params ActivitiesParams) *Activities {
+	return &Activities{
+		db:      params.DB,
+		tClient: params.TClient,
+	}
+}
+
+type InvokeCallbacksRequest struct {
+	QueueSignalID string `json:"queue_signal_id" validate:"required"`
+	QueueID       string `json:"queue_id" validate:"required"`
+	Event         Event  `json:"event" validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 30s
+func (a *Activities) InvokeCallbacks(ctx context.Context, req *InvokeCallbacksRequest) error {
+	if req == nil {
+		return fmt.Errorf("invoke callbacks request is nil")
+	}
+
+	l := temporalzap.GetActivityLogger(ctx).With(
+		zap.String("queue_signal_id", req.QueueSignalID),
+		zap.String("queue_id", req.QueueID),
+		zap.String("event", string(req.Event)),
+	)
+
+	var callbacks []app.QueueSignalCallback
+	res := a.db.WithContext(ctx).Where(app.QueueSignalCallback{
+		QueueSignalID: req.QueueSignalID,
+		Event:         string(req.Event),
+	}).Find(&callbacks)
+	if res.Error != nil {
+		return errors.Wrap(res.Error, "unable to query callbacks")
+	}
+
+	if len(callbacks) == 0 {
+		return nil
+	}
+
+	l.Info("invoking callbacks", zap.Int("count", len(callbacks)))
+
+	payload := CallbackPayload{
+		Event:         req.Event,
+		QueueSignalID: req.QueueSignalID,
+		QueueID:       req.QueueID,
+	}
+
+	for _, cb := range callbacks {
+		uh := cb.UpdateHandler
+		_, err := a.tClient.UpdateWorkflowInNamespace(ctx, uh.Namespace, tclient.UpdateWorkflowOptions{
+			WorkflowID:   uh.WorkflowID,
+			UpdateName:   uh.UpdateName,
+			WaitForStage: tclient.WorkflowUpdateStageAccepted,
+			Args:         []any{payload},
+		})
+		if err != nil {
+			l.Warn("callback invocation failed",
+				zap.String("callback_id", cb.ID),
+				zap.String("workflow_id", uh.WorkflowID),
+				zap.String("update_name", uh.UpdateName),
+				zap.Error(err))
+			continue
+		}
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/queue/callback/activities.go
+++ b/services/ctl-api/internal/pkg/queue/callback/activities.go
@@ -39,6 +39,7 @@ type InvokeCallbacksRequest struct {
 	QueueSignalID string `json:"queue_signal_id" validate:"required"`
 	QueueID       string `json:"queue_id" validate:"required"`
 	Event         Event  `json:"event" validate:"required"`
+	ErrMessage    string `json:"err_message,omitempty"`
 }
 
 // @temporal-gen-v2 activity
@@ -73,6 +74,7 @@ func (a *Activities) InvokeCallbacks(ctx context.Context, req *InvokeCallbacksRe
 		Event:         req.Event,
 		QueueSignalID: req.QueueSignalID,
 		QueueID:       req.QueueID,
+		ErrMessage:    req.ErrMessage,
 	}
 
 	for _, cb := range callbacks {

--- a/services/ctl-api/internal/pkg/queue/callback/callback.go
+++ b/services/ctl-api/internal/pkg/queue/callback/callback.go
@@ -1,0 +1,23 @@
+package callback
+
+type Event string
+
+const (
+	OnEnqueue  Event = "on_enqueue"
+	OnValidate Event = "on_validate"
+	OnExecute  Event = "on_execute"
+	OnSuccess  Event = "on_success"
+	OnError    Event = "on_error"
+)
+
+// AllEvents returns all valid callback event types.
+func AllEvents() []Event {
+	return []Event{OnEnqueue, OnValidate, OnExecute, OnSuccess, OnError}
+}
+
+// CallbackPayload is the request payload sent as the update argument when invoking a callback.
+type CallbackPayload struct {
+	Event         Event  `json:"event"`
+	QueueSignalID string `json:"queue_signal_id"`
+	QueueID       string `json:"queue_id"`
+}

--- a/services/ctl-api/internal/pkg/queue/callback/callback.go
+++ b/services/ctl-api/internal/pkg/queue/callback/callback.go
@@ -1,5 +1,9 @@
 package callback
 
+import (
+	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
+)
+
 type Event string
 
 const (
@@ -15,9 +19,16 @@ func AllEvents() []Event {
 	return []Event{OnEnqueue, OnValidate, OnExecute, OnSuccess, OnError}
 }
 
+// CallbackRequest describes a callback to register when enqueuing a signal.
+type CallbackRequest struct {
+	Event         Event                  `validate:"required"`
+	UpdateHandler signaldb.UpdateHandler `validate:"required"`
+}
+
 // CallbackPayload is the request payload sent as the update argument when invoking a callback.
 type CallbackPayload struct {
 	Event         Event  `json:"event"`
 	QueueSignalID string `json:"queue_signal_id"`
 	QueueID       string `json:"queue_id"`
+	ErrMessage    string `json:"err_message,omitempty"`
 }

--- a/services/ctl-api/internal/pkg/queue/callback/handler.go
+++ b/services/ctl-api/internal/pkg/queue/callback/handler.go
@@ -1,0 +1,97 @@
+package callback
+
+import (
+	"fmt"
+
+	"go.temporal.io/sdk/workflow"
+
+	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
+)
+
+// Handler registers a single Temporal update handler on the current workflow.
+// The queue system invokes this update for any registered callback event,
+// delivering a CallbackPayload that includes the event type and optional error.
+//
+// A Handler is tied to a single update name, but can be registered for multiple
+// callback events (e.g. both OnSuccess and OnError). The caller uses Await or
+// AwaitExecute to block until any registered event fires.
+type Handler struct {
+	ref signaldb.UpdateHandler
+	ch  workflow.Channel
+}
+
+// NewHandler registers a Temporal update handler on the current workflow.
+// The updateName should be unique within the workflow (e.g. "deploy-callback").
+func NewHandler(ctx workflow.Context, updateName string) (*Handler, error) {
+	info := workflow.GetInfo(ctx)
+
+	h := &Handler{
+		ref: signaldb.UpdateHandler{
+			Namespace:  info.Namespace,
+			WorkflowID: info.WorkflowExecution.ID,
+			UpdateName: updateName,
+		},
+		ch: workflow.NewChannel(ctx),
+	}
+
+	if err := workflow.SetUpdateHandler(ctx, updateName, h.handleUpdate); err != nil {
+		return nil, fmt.Errorf("unable to register callback handler %q: %w", updateName, err)
+	}
+
+	return h, nil
+}
+
+// Ref returns the UpdateHandler reference for a specific event. Use this when
+// building CallbackRequest entries to pass to EnqueueSignal.
+func (h *Handler) Ref() signaldb.UpdateHandler {
+	return h.ref
+}
+
+// Callbacks returns CallbackRequest entries for the given events, all pointing
+// at this handler's single update endpoint.
+func (h *Handler) Callbacks(events ...Event) []CallbackRequest {
+	out := make([]CallbackRequest, len(events))
+	for i, e := range events {
+		out[i] = CallbackRequest{
+			Event:         e,
+			UpdateHandler: h.ref,
+		}
+	}
+	return out
+}
+
+// Await blocks until any registered callback fires and returns the payload.
+func (h *Handler) Await(ctx workflow.Context) (CallbackPayload, error) {
+	var payload CallbackPayload
+	h.ch.Receive(ctx, &payload)
+	if ctx.Err() != nil {
+		return payload, ctx.Err()
+	}
+	return payload, nil
+}
+
+// AwaitExecute is a convenience method that blocks until an OnSuccess or OnError
+// callback fires. Returns nil on success, or an error containing the error message
+// from the queue signal execution on failure.
+func (h *Handler) AwaitExecute(ctx workflow.Context) error {
+	payload, err := h.Await(ctx)
+	if err != nil {
+		return err
+	}
+
+	if payload.Event == OnError {
+		if payload.ErrMessage != "" {
+			return fmt.Errorf("queue signal failed: %s", payload.ErrMessage)
+		}
+		return fmt.Errorf("queue signal failed")
+	}
+
+	return nil
+}
+
+// handleUpdate is the Temporal update handler that receives the callback payload
+// and sends it to the waiting channel.
+func (h *Handler) handleUpdate(ctx workflow.Context, payload CallbackPayload) error {
+	h.ch.Send(ctx, payload)
+	return nil
+}

--- a/services/ctl-api/internal/pkg/queue/client/enqueue_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/enqueue_signal.go
@@ -16,17 +16,12 @@ import (
 	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
 )
 
-type CallbackRequest struct {
-	Event         callback.Event         `validate:"required"`
-	UpdateHandler signaldb.UpdateHandler `validate:"required"`
-}
-
 type EnqueueSignalRequest struct {
 	QueueID   string        `validate:"required"`
 	Signal    signal.Signal `validate:"required"`
 	OwnerID   string
 	OwnerType string
-	Callbacks []CallbackRequest
+	Callbacks []callback.CallbackRequest
 }
 
 // @temporal-gen-v2 activity

--- a/services/ctl-api/internal/pkg/queue/client/enqueue_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/enqueue_signal.go
@@ -11,15 +11,22 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/callback"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
 )
+
+type CallbackRequest struct {
+	Event         callback.Event         `validate:"required"`
+	UpdateHandler signaldb.UpdateHandler `validate:"required"`
+}
 
 type EnqueueSignalRequest struct {
 	QueueID   string        `validate:"required"`
 	Signal    signal.Signal `validate:"required"`
 	OwnerID   string
 	OwnerType string
+	Callbacks []CallbackRequest
 }
 
 // @temporal-gen-v2 activity
@@ -54,6 +61,18 @@ func (c *Client) EnqueueSignal(ctx context.Context, req *EnqueueSignalRequest) (
 		return nil, errors.Wrap(res.Error, "unable to create queue signal")
 	}
 
+	// Create callback records for the signal.
+	for _, cbReq := range req.Callbacks {
+		cb := app.QueueSignalCallback{
+			QueueSignalID: queueSignal.ID,
+			Event:         string(cbReq.Event),
+			UpdateHandler: cbReq.UpdateHandler,
+		}
+		if res := c.db.WithContext(ctx).Create(&cb); res.Error != nil {
+			return nil, errors.Wrap(res.Error, "unable to create queue signal callback")
+		}
+	}
+
 	// Send the enqueue update to the queue workflow. We only wait for the
 	// "accepted" stage so the caller gets the signal ID back immediately.
 	_, err = c.tClient.UpdateWithStartWorkflowInNamespace(ctx, q.Workflow.Namespace, tclient.UpdateWithStartWorkflowOptions{
@@ -73,6 +92,9 @@ func (c *Client) EnqueueSignal(ctx context.Context, req *EnqueueSignalRequest) (
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to call enqueue handler")
 	}
+
+	// Fire on_enqueue callbacks directly since this runs before the handler workflow.
+	c.fireCallbacks(ctx, queueSignal.ID, req.QueueID, callback.OnEnqueue)
 
 	return &queue.EnqueueResponse{
 		ID:         queueSignal.ID,

--- a/services/ctl-api/internal/pkg/queue/client/fire_callbacks.go
+++ b/services/ctl-api/internal/pkg/queue/client/fire_callbacks.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"context"
+
+	tclient "go.temporal.io/sdk/client"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/callback"
+)
+
+// fireCallbacks loads and invokes all callbacks for the given signal and event.
+// This is best-effort: errors are logged but do not fail the caller.
+func (c *Client) fireCallbacks(ctx context.Context, queueSignalID string, queueID string, event callback.Event) {
+	var callbacks []app.QueueSignalCallback
+	res := c.db.WithContext(ctx).Where(app.QueueSignalCallback{
+		QueueSignalID: queueSignalID,
+		Event:         string(event),
+	}).Find(&callbacks)
+	if res.Error != nil {
+		c.l.Warn("unable to query callbacks",
+			zap.String("queue_signal_id", queueSignalID),
+			zap.String("event", string(event)),
+			zap.Error(res.Error))
+		return
+	}
+
+	if len(callbacks) == 0 {
+		return
+	}
+
+	payload := callback.CallbackPayload{
+		Event:         event,
+		QueueSignalID: queueSignalID,
+		QueueID:       queueID,
+	}
+
+	for _, cb := range callbacks {
+		uh := cb.UpdateHandler
+		_, err := c.tClient.UpdateWorkflowInNamespace(ctx, uh.Namespace, tclient.UpdateWorkflowOptions{
+			WorkflowID:   uh.WorkflowID,
+			UpdateName:   uh.UpdateName,
+			WaitForStage: tclient.WorkflowUpdateStageAccepted,
+			Args:         []any{payload},
+		})
+		if err != nil {
+			c.l.Warn("callback invocation failed",
+				zap.String("callback_id", cb.ID),
+				zap.String("workflow_id", uh.WorkflowID),
+				zap.String("update_name", uh.UpdateName),
+				zap.Error(err))
+			continue
+		}
+	}
+}

--- a/services/ctl-api/internal/pkg/queue/client/register_callback.go
+++ b/services/ctl-api/internal/pkg/queue/client/register_callback.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/callback"
+	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
+)
+
+type RegisterCallbackRequest struct {
+	QueueSignalID string                 `validate:"required"`
+	Event         callback.Event         `validate:"required"`
+	UpdateHandler signaldb.UpdateHandler `validate:"required"`
+}
+
+// RegisterCallback creates a callback for an existing queue signal.
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 1m
+func (c *Client) RegisterCallback(ctx context.Context, req *RegisterCallbackRequest) (*app.QueueSignalCallback, error) {
+	cb := app.QueueSignalCallback{
+		QueueSignalID: req.QueueSignalID,
+		Event:         string(req.Event),
+		UpdateHandler: req.UpdateHandler,
+	}
+
+	if res := c.db.WithContext(ctx).Create(&cb); res.Error != nil {
+		return nil, errors.Wrap(res.Error, "unable to create queue signal callback")
+	}
+
+	return &cb, nil
+}

--- a/services/ctl-api/internal/pkg/queue/handler/execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/execute.go
@@ -64,7 +64,7 @@ func (h *handler) executeHandler(ctx workflow.Context) (*ExecuteResponse, error)
 		},
 	})
 
-	h.fireCallbacks(ctx, callback.OnExecute)
+	h.fireCallbacks(ctx, callback.OnExecute, "")
 
 	err := h.runSignalExecute(execCtx)
 	dur := workflow.Now(ctx).Sub(start)
@@ -84,7 +84,7 @@ func (h *handler) executeHandler(ctx workflow.Context) (*ExecuteResponse, error)
 					"execute_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
 				},
 			})
-			h.fireCallbacks(ctx, callback.OnError)
+			h.fireCallbacks(ctx, callback.OnError, panicErr.Error())
 			return nil, panicErr
 		}
 
@@ -102,7 +102,7 @@ func (h *handler) executeHandler(ctx workflow.Context) (*ExecuteResponse, error)
 				"execute_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
 			},
 		})
-		h.fireCallbacks(ctx, callback.OnError)
+		h.fireCallbacks(ctx, callback.OnError, execErr.Error())
 		return nil, temporal.NewNonRetryableApplicationError(
 			"signal failure",
 			execErr.Error(),
@@ -118,7 +118,7 @@ func (h *handler) executeHandler(ctx workflow.Context) (*ExecuteResponse, error)
 		},
 	})
 
-	h.fireCallbacks(ctx, callback.OnSuccess)
+	h.fireCallbacks(ctx, callback.OnSuccess, "")
 
 	return nil, nil
 }

--- a/services/ctl-api/internal/pkg/queue/handler/execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/execute.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/callback"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
@@ -63,6 +64,8 @@ func (h *handler) executeHandler(ctx workflow.Context) (*ExecuteResponse, error)
 		},
 	})
 
+	h.fireCallbacks(ctx, callback.OnExecute)
+
 	err := h.runSignalExecute(execCtx)
 	dur := workflow.Now(ctx).Sub(start)
 
@@ -81,6 +84,7 @@ func (h *handler) executeHandler(ctx workflow.Context) (*ExecuteResponse, error)
 					"execute_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
 				},
 			})
+			h.fireCallbacks(ctx, callback.OnError)
 			return nil, panicErr
 		}
 
@@ -98,6 +102,7 @@ func (h *handler) executeHandler(ctx workflow.Context) (*ExecuteResponse, error)
 				"execute_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
 			},
 		})
+		h.fireCallbacks(ctx, callback.OnError)
 		return nil, temporal.NewNonRetryableApplicationError(
 			"signal failure",
 			execErr.Error(),
@@ -112,6 +117,8 @@ func (h *handler) executeHandler(ctx workflow.Context) (*ExecuteResponse, error)
 			"execute_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
 		},
 	})
+
+	h.fireCallbacks(ctx, callback.OnSuccess)
 
 	return nil, nil
 }

--- a/services/ctl-api/internal/pkg/queue/handler/lifecycle.go
+++ b/services/ctl-api/internal/pkg/queue/handler/lifecycle.go
@@ -5,6 +5,7 @@ import (
 
 	"go.temporal.io/sdk/workflow"
 
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/callback"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 )
 
@@ -70,6 +71,17 @@ func (h *handler) runBeforePhase(ctx workflow.Context, event signal.SignalPhaseE
 		Reason:   resp.Reason,
 		Metadata: resp.Metadata,
 	}
+}
+
+// fireCallbacks invokes callbacks for the given event as a best-effort operation.
+// Uses a disconnected context so callbacks don't block or fail the signal.
+func (h *handler) fireCallbacks(ctx workflow.Context, event callback.Event) {
+	dctx, _ := workflow.NewDisconnectedContext(ctx)
+	_ = callback.AwaitInvokeCallbacks(dctx, &callback.InvokeCallbacksRequest{
+		QueueSignalID: h.queueSignalID,
+		QueueID:       h.queueID,
+		Event:         event,
+	})
 }
 
 // outcomeFromError builds a SignalPhaseOutcome from an error and duration.

--- a/services/ctl-api/internal/pkg/queue/handler/lifecycle.go
+++ b/services/ctl-api/internal/pkg/queue/handler/lifecycle.go
@@ -75,12 +75,13 @@ func (h *handler) runBeforePhase(ctx workflow.Context, event signal.SignalPhaseE
 
 // fireCallbacks invokes callbacks for the given event as a best-effort operation.
 // Uses a disconnected context so callbacks don't block or fail the signal.
-func (h *handler) fireCallbacks(ctx workflow.Context, event callback.Event) {
+func (h *handler) fireCallbacks(ctx workflow.Context, event callback.Event, errMessage string) {
 	dctx, _ := workflow.NewDisconnectedContext(ctx)
 	_ = callback.AwaitInvokeCallbacks(dctx, &callback.InvokeCallbacksRequest{
 		QueueSignalID: h.queueSignalID,
 		QueueID:       h.queueID,
 		Event:         event,
+		ErrMessage:    errMessage,
 	})
 }
 

--- a/services/ctl-api/internal/pkg/queue/handler/validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/validate.go
@@ -8,6 +8,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/callback"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
@@ -98,6 +99,8 @@ func (h *handler) validateHandler(ctx workflow.Context) (*ValidateResponse, erro
 			"validate_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
 		},
 	})
+
+	h.fireCallbacks(ctx, callback.OnValidate)
 
 	return nil, nil
 }

--- a/services/ctl-api/internal/pkg/queue/handler/validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/validate.go
@@ -100,7 +100,7 @@ func (h *handler) validateHandler(ctx workflow.Context) (*ValidateResponse, erro
 		},
 	})
 
-	h.fireCallbacks(ctx, callback.OnValidate)
+	h.fireCallbacks(ctx, callback.OnValidate, "")
 
 	return nil, nil
 }

--- a/services/ctl-api/internal/pkg/queue/signal/db/update_handler.go
+++ b/services/ctl-api/internal/pkg/queue/signal/db/update_handler.go
@@ -1,0 +1,39 @@
+package signaldb
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+type UpdateHandler struct {
+	Namespace  string `json:"namespace"`
+	WorkflowID string `json:"workflow_id"`
+	UpdateName string `json:"update_name"`
+}
+
+func (u UpdateHandler) Value() (driver.Value, error) {
+	return json.Marshal(u)
+}
+
+func (u *UpdateHandler) Scan(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+
+	bytes, ok := value.([]byte)
+	if !ok {
+		return errors.New("invalid type")
+	}
+
+	if err := json.Unmarshal(bytes, u); err != nil {
+		return errors.Wrap(err, "unable to convert update handler json to ref")
+	}
+
+	return nil
+}
+
+func (UpdateHandler) GormDataType() string {
+	return "jsonb"
+}


### PR DESCRIPTION
Earlier today, @erickyellott proposed a callback based system to improve the latency of the execute-job workflow. https://github.com/nuonco/nuon/pull/1006

For some context, right now we dispatch and await many signals. Within a workflow, a single workflow step can have 3/4 signals minimum just to execute it, and then downstream waiting on others. Currently, we have an `AwaitSignal` activity that calls an update and then awaits it's response. Essentially, it picks a run-id, calls the update like an "api" and keeps backing off until we get a response. There's an idempotency key in there, and heart beats so it does mean that 
we're doing a lot to await a signal.

The thing that's nice about #1006 is that it side-steps all of the waiting, and instead relies on a callback signal. While that's viable, it's only working for the _one_ endpoint. This PR expands upon the idea and makes it generalizable for the entire system. This system uses a callback system, where we register callbacks to await a signal's response. 

So, this means that our await can be event driven, and not require long-lived activities continuously awaiting, heart-beating and backing off. Instead, we have an update handler that we register to await a response from the queue signal we're handling. We add helper methods to make the API interface of this nicer, and make it opt-in.
