### PR TITLE
feat: add create flag to sync

### DIFF
--- a/bins/cli/cmd/apps.go
+++ b/bins/cli/cmd/apps.go
@@ -157,6 +157,7 @@ func (c *cli) appsCmd() *cobra.Command {
 	}
 	appsCmd.AddCommand(unsetCurrentAppCmd)
 
+	var syncCreate bool
 	syncCmd := &cobra.Command{
 		Use:               "sync",
 		Short:             "Sync nuon app directory",
@@ -174,9 +175,13 @@ func (c *cli) appsCmd() *cobra.Command {
 			}
 
 			svc := apps.New(c.v, c.apiClient, c.cfg)
+			if syncCreate {
+				return svc.SyncDirWithCreate(cmd.Context(), dirName, version.Version)
+			}
 			return svc.SyncDir(cmd.Context(), dirName, version.Version)
 		}),
 	}
+	syncCmd.Flags().BoolVar(&syncCreate, "create", false, "Create the app if it doesn't exist")
 	appsCmd.AddCommand(syncCmd)
 
 	syncDirCmd := &cobra.Command{

--- a/bins/cli/cmd/sync.go
+++ b/bins/cli/cmd/sync.go
@@ -8,17 +8,21 @@ import (
 )
 
 func (c *cli) syncCmd() *cobra.Command {
+	var create bool
 	syncCmd := &cobra.Command{
 		Use:               "sync",
 		Short:             "Sync local config files to Nuon",
 		PersistentPreRunE: c.persistentPreRunE,
 		Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
-			// Reuse the existing sync functionality from apps
 			svc := apps.New(c.v, c.apiClient, c.cfg)
+			if create {
+				return svc.SyncDirWithCreate(cmd.Context(), ".", version.Version)
+			}
 			return svc.SyncDir(cmd.Context(), ".", version.Version)
 		}),
 		GroupID: CoreGroup.ID,
 	}
+	syncCmd.Flags().BoolVar(&create, "create", false, "Create the app if it doesn't exist")
 
 	return syncCmd
 }

--- a/bins/cli/internal/services/apps/sync_dir.go
+++ b/bins/cli/internal/services/apps/sync_dir.go
@@ -39,6 +39,14 @@ func (s *Service) DeprecatedSyncDir(ctx context.Context, dir string, version str
 }
 
 func (s *Service) SyncDir(ctx context.Context, dir string, version string) error {
+	return s.syncDir(ctx, dir, version, false)
+}
+
+func (s *Service) SyncDirWithCreate(ctx context.Context, dir string, version string) error {
+	return s.syncDir(ctx, dir, version, true)
+}
+
+func (s *Service) syncDir(ctx context.Context, dir string, version string, create bool) error {
 	ui.PrintLn("syncing directory from " + dir)
 	appName, err := parse.AppNameFromDirName(dir)
 	if err != nil {
@@ -48,8 +56,21 @@ func (s *Service) SyncDir(ctx context.Context, dir string, version string) error
 
 	appID, err := lookup.AppID(ctx, s.api, appName)
 	if err != nil {
-		err = errs.WithUserFacing(err, "error looking up app id")
-		return ui.PrintError(err)
+		if !create {
+			err = errs.WithUserFacing(err, "error looking up app id")
+			return ui.PrintError(err)
+		}
+
+		ui.PrintLn(fmt.Sprintf("app %q not found, creating it", appName))
+		if err := s.Create(ctx, appName, false, true); err != nil {
+			return ui.PrintError(err)
+		}
+
+		appID, err = lookup.AppID(ctx, s.api, appName)
+		if err != nil {
+			err = errs.WithUserFacing(err, "error looking up app id after creation")
+			return ui.PrintError(err)
+		}
 	}
 
 	cfg, err := parse.ParseDir(ctx, parse.ParseConfig{


### PR DESCRIPTION
There's currently a UX friction where we have to wait for app creation to finish and then sync an app config. This PR addresses that by making a create flag. 
 