### PR TITLE
feat(ctl-api): add labels to workflow step groups

### DIFF
--- a/services/ctl-api/internal/app/installs/workflows/v2/provision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/provision.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/awaitinstallstackversionrun"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/awaitrunnerhealthy"
@@ -27,7 +28,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 
 	sg := newStepGroup()
 
-	sg.nextGroup() // generate install state
+	sg.nextGroupLabeled(labels.Labels{"name": "generate-install-state", "display_name": "Generate install state", "type": "hidden"})
 	step, err := sg.installSignalStep(ctx, installID, "generate install state", pgtype.Hstore{}, &generatestate.Signal{
 		InstallID: installID,
 	}, flw.PlanOnly, WithSkippable(false))
@@ -36,7 +37,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 	}
 	steps = append(steps, step)
 
-	sg.nextGroup() // provision service account
+	sg.nextGroupLabeled(labels.Labels{"name": "provision-runner-service-account", "display_name": "Provision runner service account", "type": "system"})
 
 	step, err = sg.installSignalStep(ctx, installID, "provision runner service account", pgtype.Hstore{}, &provisionrunner.Signal{
 		InstallID: installID,
@@ -53,7 +54,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 	}
 	stackID := stack.ID
 
-	sg.nextGroup() // install stack
+	sg.nextGroupLabeled(labels.Labels{"name": "provision-install-stack", "display_name": "Provision install stack", "type": "user"})
 
 	step, err = sg.installSignalStep(ctx, installID, "generate install stack", pgtype.Hstore{}, &generateinstallstackversion.Signal{
 		InstallStackID: stackID,
@@ -80,7 +81,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 	}
 	steps = append(steps, step)
 
-	sg.nextGroup() // runner health
+	sg.nextGroupLabeled(labels.Labels{"name": "await-runner-health", "display_name": "Await runner health", "type": "system"})
 	step, err = sg.installSignalStep(ctx, installID, "await runner health", pgtype.Hstore{}, &awaitrunnerhealthy.Signal{
 		InstallID: installID,
 	}, flw.PlanOnly)
@@ -119,7 +120,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 	}
 	sandboxID := sandbox.ID
 
-	sg.nextGroup() // provision sandbox plan + apply
+	sg.nextGroupLabeled(labels.Labels{"name": "provision-sandbox", "display_name": "Provision sandbox", "type": "approval"})
 	step, err = sg.installSignalStep(ctx, installID, "provision sandbox plan", pgtype.Hstore{}, &provisionsandboxplan.Signal{
 		InstallSandboxID: sandboxID,
 		Role:             flw.Role,
@@ -145,7 +146,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 		}
 		steps = append(steps, lifecycleSteps...)
 
-		sg.nextGroup() // sync secrets
+		sg.nextGroupLabeled(labels.Labels{"name": "sync-secrets", "display_name": "Sync secrets", "type": "system"})
 		step, err = sg.installSignalStep(ctx, installID, "sync secrets", pgtype.Hstore{}, &syncsecrets.Signal{
 			InstallID: installID,
 		}, flw.PlanOnly, WithSkippable(false))
@@ -160,7 +161,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 		}
 		steps = append(steps, lifecycleSteps...)
 
-		sg.nextGroup() // provision sandbox dns
+		sg.nextGroupLabeled(labels.Labels{"name": "provision-sandbox-dns", "display_name": "Provision sandbox DNS", "type": "system"})
 		step, err = sg.installSignalStep(ctx, installID, "provision sandbox dns if enabled", pgtype.Hstore{}, &provisiondns.Signal{
 			InstallID: installID,
 		}, flw.PlanOnly)

--- a/services/ctl-api/internal/app/installs/workflows/v2/provision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/provision.go
@@ -28,7 +28,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 
 	sg := newStepGroup()
 
-	sg.nextGroupLabeled(labels.Labels{"name": "generate-install-state", "display_name": "Generate install state", "type": "hidden"})
+	sg.nextGroupLabeled(labels.Labels{"name": "generate-install-state", "display_name": "Generate install state", "type": "hidden", "domain": "system"})
 	step, err := sg.installSignalStep(ctx, installID, "generate install state", pgtype.Hstore{}, &generatestate.Signal{
 		InstallID: installID,
 	}, flw.PlanOnly, WithSkippable(false))
@@ -37,7 +37,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 	}
 	steps = append(steps, step)
 
-	sg.nextGroupLabeled(labels.Labels{"name": "provision-runner-service-account", "display_name": "Provision runner service account", "type": "system"})
+	sg.nextGroupLabeled(labels.Labels{"name": "provision-runner-service-account", "display_name": "Provision runner service account", "type": "system", "domain": "install-stack"})
 
 	step, err = sg.installSignalStep(ctx, installID, "provision runner service account", pgtype.Hstore{}, &provisionrunner.Signal{
 		InstallID: installID,
@@ -54,7 +54,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 	}
 	stackID := stack.ID
 
-	sg.nextGroupLabeled(labels.Labels{"name": "provision-install-stack", "display_name": "Provision install stack", "type": "user"})
+	sg.nextGroupLabeled(labels.Labels{"name": "provision-install-stack", "display_name": "Provision install stack", "type": "user", "domain": "install-stack"})
 
 	step, err = sg.installSignalStep(ctx, installID, "generate install stack", pgtype.Hstore{}, &generateinstallstackversion.Signal{
 		InstallStackID: stackID,
@@ -81,7 +81,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 	}
 	steps = append(steps, step)
 
-	sg.nextGroupLabeled(labels.Labels{"name": "await-runner-health", "display_name": "Await runner health", "type": "system"})
+	sg.nextGroupLabeled(labels.Labels{"name": "await-runner-health", "display_name": "Await runner health", "type": "system", "domain": "system"})
 	step, err = sg.installSignalStep(ctx, installID, "await runner health", pgtype.Hstore{}, &awaitrunnerhealthy.Signal{
 		InstallID: installID,
 	}, flw.PlanOnly)
@@ -120,7 +120,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 	}
 	sandboxID := sandbox.ID
 
-	sg.nextGroupLabeled(labels.Labels{"name": "provision-sandbox", "display_name": "Provision sandbox", "type": "approval"})
+	sg.nextGroupLabeled(labels.Labels{"name": "provision-sandbox", "display_name": "Provision sandbox", "type": "approval", "domain": "sandbox"})
 	step, err = sg.installSignalStep(ctx, installID, "provision sandbox plan", pgtype.Hstore{}, &provisionsandboxplan.Signal{
 		InstallSandboxID: sandboxID,
 		Role:             flw.Role,
@@ -146,7 +146,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 		}
 		steps = append(steps, lifecycleSteps...)
 
-		sg.nextGroupLabeled(labels.Labels{"name": "sync-secrets", "display_name": "Sync secrets", "type": "system"})
+		sg.nextGroupLabeled(labels.Labels{"name": "sync-secrets", "display_name": "Sync secrets", "type": "system", "domain": "sandbox"})
 		step, err = sg.installSignalStep(ctx, installID, "sync secrets", pgtype.Hstore{}, &syncsecrets.Signal{
 			InstallID: installID,
 		}, flw.PlanOnly, WithSkippable(false))
@@ -161,7 +161,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 		}
 		steps = append(steps, lifecycleSteps...)
 
-		sg.nextGroupLabeled(labels.Labels{"name": "provision-sandbox-dns", "display_name": "Provision sandbox DNS", "type": "system"})
+		sg.nextGroupLabeled(labels.Labels{"name": "provision-sandbox-dns", "display_name": "Provision sandbox DNS", "type": "system", "domain": "sandbox"})
 		step, err = sg.installSignalStep(ctx, installID, "provision sandbox dns if enabled", pgtype.Hstore{}, &provisiondns.Signal{
 			InstallID: installID,
 		}, flw.PlanOnly)

--- a/services/ctl-api/internal/app/installs/workflows/v2/shared_component_deploy.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/shared_component_deploy.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"go.temporal.io/sdk/workflow"
 
+	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 )
@@ -31,12 +32,23 @@ func (s *stepGroup) nextGroupNamed(name string) {
 }
 
 func (s *stepGroup) nextGroupWithOpts(name string, parallel bool) {
+	s.nextGroupFull(name, parallel, nil)
+}
+
+func (s *stepGroup) nextGroupLabeled(lbls labels.Labels) {
+	s.nextGroupFull("", false, lbls)
+}
+
+func (s *stepGroup) nextGroupFull(name string, parallel bool, lbls labels.Labels) {
 	s.idx++
 	g := &app.WorkflowStepGroup{
 		GroupIdx: s.idx,
 		Parallel: parallel,
 		Name:     name,
 		Status:   app.CompositeStatus{Status: app.StatusPending},
+	}
+	if lbls != nil {
+		g.Labels = lbls
 	}
 	s.groups = append(s.groups, g)
 	s.currentGroup = g

--- a/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
@@ -114,7 +114,7 @@ func getLifecycleActionsSteps(ctx workflow.Context, installID string, flw *app.W
 	}
 
 	triggerName := string(triggerTyp)
-	sg.nextGroupLabeled(labels.Labels{"name": triggerName, "display_name": strings.ToUpper(triggerName[:1]) + triggerName[1:], "type": "system"})
+	sg.nextGroupLabeled(labels.Labels{"name": triggerName, "display_name": strings.ToUpper(triggerName[:1]) + triggerName[1:], "type": "system", "domain": "action"})
 
 	for _, installAction := range installActions {
 		sig := &executeactionworkflow.Signal{
@@ -172,7 +172,7 @@ func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Wo
 		if comp.Type.IsImage() {
 			groupType = "system"
 		}
-		sg.nextGroupLabeled(labels.Labels{"name": "deploy-" + comp.Name, "display_name": "Deploy " + comp.Name, "type": groupType})
+		sg.nextGroupLabeled(labels.Labels{"name": "deploy-" + comp.Name, "display_name": "Deploy " + comp.Name, "type": groupType, "domain": "component"})
 
 		// Resolve install component ID
 		installComp, err := activities.AwaitGetInstallComponent(ctx, activities.GetInstallComponentRequest{
@@ -257,7 +257,7 @@ func deployAllComponents(ctx workflow.Context, installID string, flw *app.Workfl
 
 	steps := make([]*app.WorkflowStep, 0)
 
-	sg.nextGroupLabeled(labels.Labels{"name": "await-runner-health", "display_name": "Await runner health", "type": "system"})
+	sg.nextGroupLabeled(labels.Labels{"name": "await-runner-health", "display_name": "Await runner health", "type": "system", "domain": "system"})
 
 	step, err := sg.installSignalStep(ctx, installID, "await runner healthy", pgtype.Hstore{}, &awaitrunnerhealthy.Signal{
 		InstallID: installID,

--- a/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
@@ -3,12 +3,14 @@ package v2
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
+	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/actionworkflowrun"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/awaitrunnerhealthy"
@@ -111,7 +113,8 @@ func getLifecycleActionsSteps(ctx workflow.Context, installID string, flw *app.W
 		return steps, nil
 	}
 
-	sg.nextGroup() // lifecycleSteps
+	triggerName := string(triggerTyp)
+	sg.nextGroupLabeled(labels.Labels{"name": triggerName, "display_name": strings.ToUpper(triggerName[:1]) + triggerName[1:], "type": "system"})
 
 	for _, installAction := range installActions {
 		sig := &executeactionworkflow.Signal{
@@ -160,11 +163,16 @@ func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Wo
 			_ = workflow.Sleep(ctx, time.Millisecond)
 		}
 
-		sg.nextGroup()
 		comp, has := components[compID]
 		if !has {
 			return nil, errors.Errorf("component %s not found in app config", compID)
 		}
+
+		groupType := "approval"
+		if comp.Type.IsImage() {
+			groupType = "system"
+		}
+		sg.nextGroupLabeled(labels.Labels{"name": "deploy-" + comp.Name, "display_name": "Deploy " + comp.Name, "type": groupType})
 
 		// Resolve install component ID
 		installComp, err := activities.AwaitGetInstallComponent(ctx, activities.GetInstallComponentRequest{
@@ -249,7 +257,7 @@ func deployAllComponents(ctx workflow.Context, installID string, flw *app.Workfl
 
 	steps := make([]*app.WorkflowStep, 0)
 
-	sg.nextGroup() // runner health
+	sg.nextGroupLabeled(labels.Labels{"name": "await-runner-health", "display_name": "Await runner health", "type": "system"})
 
 	step, err := sg.installSignalStep(ctx, installID, "await runner healthy", pgtype.Hstore{}, &awaitrunnerhealthy.Signal{
 		InstallID: installID,

--- a/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
@@ -172,7 +172,7 @@ func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Wo
 		if comp.Type.IsImage() {
 			groupType = "system"
 		}
-		sg.nextGroupLabeled(labels.Labels{"name": "deploy-" + comp.Name, "display_name": "Deploy " + comp.Name, "type": groupType, "domain": "component"})
+		sg.nextGroupLabeled(labels.Labels{"name": "deploy-" + comp.Name, "display_name": "Deploy " + comp.Name, "type": groupType, "domain": "component", "component_name": comp.Name})
 
 		// Resolve install component ID
 		installComp, err := activities.AwaitGetInstallComponent(ctx, activities.GetInstallComponentRequest{

--- a/services/ctl-api/internal/app/workflow.go
+++ b/services/ctl-api/internal/app/workflow.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/pkg/shortid/domains"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/indexes"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
@@ -158,6 +159,8 @@ type GenerateStepsResult struct {
 //
 // We start with this to make it easier to iterate on them, for now.
 type Workflow struct {
+	labels.Labeled
+
 	ID          string                `gorm:"primary_key;check:id_checker,char_length(id)=26" json:"id,omitzero" temporaljson:"id,omitzero,omitempty"`
 	CreatedByID string                `json:"created_by_id,omitzero" gorm:"not null;default:null" temporaljson:"created_by_id,omitzero,omitempty"`
 	CreatedBy   Account               `json:"created_by" temporaljson:"created_by,omitzero,omitempty"`

--- a/services/ctl-api/internal/app/workflow_step.go
+++ b/services/ctl-api/internal/app/workflow_step.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/pkg/shortid/domains"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/indexes"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
@@ -49,6 +50,8 @@ const (
 )
 
 type WorkflowStep struct {
+	labels.Labeled
+
 	ID          string                `gorm:"primary_key;check:id_checker,char_length(id)=26" json:"id,omitzero" temporaljson:"id,omitzero,omitempty"`
 	CreatedByID string                `json:"created_by_id,omitzero" gorm:"not null;default:null" temporaljson:"created_by_id,omitzero,omitempty"`
 	CreatedBy   Account               `json:"created_by" temporaljson:"created_by,omitzero,omitempty"`

--- a/services/ctl-api/internal/app/workflow_step_group.go
+++ b/services/ctl-api/internal/app/workflow_step_group.go
@@ -6,12 +6,15 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/plugin/soft_delete"
 
+	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/pkg/shortid/domains"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/indexes"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
 )
 
 type WorkflowStepGroup struct {
+	labels.Labeled
+
 	ID          string                `gorm:"primary_key;check:id_checker,char_length(id)=26" json:"id,omitzero" temporaljson:"id,omitzero,omitempty"`
 	CreatedByID string                `json:"created_by_id,omitzero" gorm:"not null;default:null" temporaljson:"created_by_id,omitzero,omitempty"`
 	CreatedAt   time.Time             `json:"created_at,omitzero" gorm:"notnull" temporaljson:"created_at,omitzero,omitempty"`

--- a/services/ctl-api/internal/pkg/flow/step_generate_signal.go
+++ b/services/ctl-api/internal/pkg/flow/step_generate_signal.go
@@ -88,6 +88,7 @@ func generateStepsViaSignal(ctx workflow.Context, cfg StepConfig, flw *app.Workf
 				Parallel:   g.Parallel,
 				Name:       g.Name,
 				Status:     g.Status,
+				Labels:     g.Labels,
 			})
 		}
 		if _, err := activities.AwaitPkgWorkflowsFlowCreateFlowStepGroups(ctx, groupsReq); err != nil {

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/create_flow_step_groups.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/create_flow_step_groups.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
 
@@ -15,6 +16,7 @@ type CreateFlowStepGroup struct {
 	Parallel   bool                `json:"parallel"`
 	Name       string              `json:"name"`
 	Status     app.CompositeStatus `json:"status"`
+	Labels     labels.Labels       `json:"labels"`
 }
 
 type CreateFlowStepGroupsRequest struct {
@@ -37,6 +39,7 @@ func (a *Activities) PkgWorkflowsFlowCreateFlowStepGroups(ctx context.Context, r
 			Name:       req.Name,
 			Status:     req.Status,
 		}
+		g.Labels = req.Labels
 		groups = append(groups, &g)
 	}
 

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -4755,6 +4755,7 @@ export interface components {
       install_action_workflow_runs?: components["schemas"]["app.InstallActionWorkflowRun"][];
       install_deploys?: components["schemas"]["app.InstallDeploy"][];
       install_sandbox_runs?: components["schemas"]["app.InstallSandboxRun"][];
+      labels?: components["schemas"]["github_com_nuonco_nuon_pkg_labels.Labels"];
       links?: {
         [key: string]: unknown;
       };
@@ -4823,6 +4824,7 @@ export interface components {
       idx?: number;
       /** @description DEPRECATED: this is the install workflow ID, which is now the workflow ID. */
       install_workflow_id?: string;
+      labels?: components["schemas"]["github_com_nuonco_nuon_pkg_labels.Labels"];
       links?: {
         [key: string]: unknown;
       };
@@ -4896,6 +4898,7 @@ export interface components {
       created_by_id?: string;
       group_idx?: number;
       id?: string;
+      labels?: components["schemas"]["github_com_nuonco_nuon_pkg_labels.Labels"];
       name?: string;
       parallel?: boolean;
       queue_signal?: components["schemas"]["app.QueueSignal"];


### PR DESCRIPTION
## Problem

I want to work with step groups more, especially in the customer portal, but they are lacking useful metadata. Now that we have labels, instead of adding more attributes to step groups, we can set labels on step groups as they are created that we can use in the UI.

## Solution

Addthe following labels to step groups:
- `name`: a name for the group, like `provision-install-stack`
- `display_name`: a display name for the group, like `Provision install stack`
- `type`: the execution type of the group, like `user`, `approval` or `system`
- `domain`: the domain the group belongs to, `install-stack`, `sandbox`, `component`, `action`, or `system`

Adding label support to step groups, but not steps and workflows was inconsistent, so added labels to them in the data model. I'm not using them yet, but I think there will be use-cases soon.