### PR TITLE
feat: add property based tests 

### DIFF
--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/properties_test.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/properties_test.go
@@ -1,0 +1,230 @@
+package executeflow
+
+import (
+	"fmt"
+	"testing"
+
+	"hegel.dev/go/hegel"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// ============================================================================
+// Property: collectGroupIndices preserves first-occurrence order and dedupes
+// ============================================================================
+
+func TestCollectGroupIndicesProperties(t *testing.T) {
+	t.Run("each group appears exactly once", hegel.Case(func(ht *hegel.T) {
+		n := hegel.Draw(ht, hegel.Integers(1, 25))
+		steps := make([]app.WorkflowStep, n)
+		for j := range steps {
+			steps[j] = app.WorkflowStep{
+				ID:       fmt.Sprintf("step-%d", j),
+				Idx:      j,
+				GroupIdx: hegel.Draw(ht, hegel.Integers(0, 5)),
+			}
+		}
+
+		result := collectGroupIndices(steps)
+
+		// Must be deduplicated.
+		seen := make(map[int]bool)
+		for _, g := range result {
+			if seen[g] {
+				ht.Fatalf("group %d appears more than once in %v", g, result)
+			}
+			seen[g] = true
+		}
+
+		// Must contain every GroupIdx present in steps.
+		expected := make(map[int]bool)
+		for _, step := range steps {
+			expected[step.GroupIdx] = true
+		}
+		for g := range expected {
+			if !seen[g] {
+				ht.Fatalf("group %d present in steps but missing from result %v", g, result)
+			}
+		}
+	}, hegel.WithTestCases(500)))
+
+	t.Run("order matches first occurrence in step list", hegel.Case(func(ht *hegel.T) {
+		nGroups := hegel.Draw(ht, hegel.Integers(1, 6))
+		groupIdxs := make([]int, nGroups)
+		for j := range groupIdxs {
+			groupIdxs[j] = hegel.Draw(ht, hegel.Integers(0, 20))
+		}
+		// Dedupe to get the expected order (first occurrence of each).
+		var expectedOrder []int
+		seen := make(map[int]bool)
+		for _, g := range groupIdxs {
+			if !seen[g] {
+				seen[g] = true
+				expectedOrder = append(expectedOrder, g)
+			}
+		}
+
+		// Build steps: each group has 1-3 steps, in groupIdxs order.
+		var steps []app.WorkflowStep
+		idx := 0
+		for _, gIdx := range groupIdxs {
+			nSteps := hegel.Draw(ht, hegel.Integers(1, 3))
+			for s := 0; s < nSteps; s++ {
+				steps = append(steps, app.WorkflowStep{
+					ID:       fmt.Sprintf("step-%d", idx),
+					Idx:      idx,
+					GroupIdx: gIdx,
+				})
+				idx++
+			}
+		}
+
+		result := collectGroupIndices(steps)
+
+		if len(result) != len(expectedOrder) {
+			ht.Fatalf("got %d groups %v, want %d groups %v",
+				len(result), result, len(expectedOrder), expectedOrder)
+		}
+		for i := range result {
+			if result[i] != expectedOrder[i] {
+				ht.Fatalf("result[%d]=%d, want %d (result=%v, expected=%v)",
+					i, result[i], expectedOrder[i], result, expectedOrder)
+			}
+		}
+	}, hegel.WithTestCases(300)))
+
+	t.Run("retry clones do not corrupt order", hegel.Case(func(ht *hegel.T) {
+		nGroups := hegel.Draw(ht, hegel.Integers(2, 5))
+		var steps []app.WorkflowStep
+		idx := 0
+		for g := 0; g < nGroups; g++ {
+			gIdx := (g + 1) * 100
+			nSteps := hegel.Draw(ht, hegel.Integers(1, 3))
+			for s := 0; s < nSteps; s++ {
+				steps = append(steps, app.WorkflowStep{
+					ID:       fmt.Sprintf("step-%d", idx),
+					Idx:      idx,
+					GroupIdx: gIdx,
+				})
+				idx++
+			}
+		}
+
+		baseline := collectGroupIndices(steps)
+
+		// Append retry clones for a random group.
+		cloneGroupPos := hegel.Draw(ht, hegel.Integers(0, len(baseline)-1))
+		retryGroupIdx := baseline[cloneGroupPos]
+		nClones := hegel.Draw(ht, hegel.Integers(1, 3))
+		for s := 0; s < nClones; s++ {
+			steps = append(steps, app.WorkflowStep{
+				ID:       fmt.Sprintf("retry-%d", idx),
+				Idx:      idx,
+				GroupIdx: retryGroupIdx,
+			})
+			idx++
+		}
+
+		withRetry := collectGroupIndices(steps)
+
+		if len(withRetry) != len(baseline) {
+			ht.Fatalf("retry clones changed group count: %v -> %v", baseline, withRetry)
+		}
+		for i := range baseline {
+			if withRetry[i] != baseline[i] {
+				ht.Fatalf("retry clones changed group order at [%d]: %v -> %v", i, baseline, withRetry)
+			}
+		}
+	}, hegel.WithTestCases(300)))
+}
+
+// ============================================================================
+// Property: isGroupParallel depends only on steps in that group
+// ============================================================================
+
+func TestIsGroupParallelProperties(t *testing.T) {
+	t.Run("other groups cannot affect result", hegel.Case(func(ht *hegel.T) {
+		targetGroup := 1
+		n := hegel.Draw(ht, hegel.Integers(1, 5))
+		steps := make([]app.WorkflowStep, n)
+		for j := range steps {
+			steps[j] = app.WorkflowStep{
+				ID:            fmt.Sprintf("target-%d", j),
+				GroupIdx:      targetGroup,
+				GroupParallel: false,
+			}
+		}
+
+		baseResult := isGroupParallel(steps, targetGroup)
+
+		// Add parallel steps in OTHER groups.
+		nOther := hegel.Draw(ht, hegel.Integers(1, 5))
+		for j := 0; j < nOther; j++ {
+			otherGroup := hegel.Draw(ht, hegel.Integers(2, 10))
+			steps = append(steps, app.WorkflowStep{
+				ID:            fmt.Sprintf("other-%d", j),
+				GroupIdx:      otherGroup,
+				GroupParallel: true,
+			})
+		}
+
+		withOthers := isGroupParallel(steps, targetGroup)
+		if baseResult != withOthers {
+			ht.Fatalf("adding parallel steps in other groups changed result: %v -> %v", baseResult, withOthers)
+		}
+	}, hegel.WithTestCases(300)))
+
+	t.Run("any parallel step in target group flips true", hegel.Case(func(ht *hegel.T) {
+		targetGroup := 1
+		n := hegel.Draw(ht, hegel.Integers(2, 8))
+		steps := make([]app.WorkflowStep, n)
+		for j := range steps {
+			steps[j] = app.WorkflowStep{
+				ID:            fmt.Sprintf("step-%d", j),
+				GroupIdx:      targetGroup,
+				GroupParallel: false,
+			}
+		}
+
+		if isGroupParallel(steps, targetGroup) {
+			ht.Fatalf("all GroupParallel=false but isGroupParallel returned true")
+		}
+
+		// Set one random step to parallel.
+		flipIdx := hegel.Draw(ht, hegel.Integers(0, n-1))
+		steps[flipIdx].GroupParallel = true
+
+		if !isGroupParallel(steps, targetGroup) {
+			ht.Fatalf("set step[%d].GroupParallel=true but isGroupParallel returned false", flipIdx)
+		}
+	}, hegel.WithTestCases(300)))
+}
+
+// ============================================================================
+// Property: isStepTerminal exhaustiveness
+// ============================================================================
+
+func TestIsStepTerminalExhaustive(t *testing.T) {
+	terminal := []app.Status{
+		app.StatusSuccess, app.StatusAutoSkipped, app.StatusUserSkipped,
+		app.StatusDiscarded, app.StatusCancelled, app.StatusError,
+		app.StatusNotAttempted,
+		app.WorkflowStepApprovalStatusApproved, app.WorkflowStepApprovalStatusApprovalDenied,
+		app.WorkflowStepNoDrift, app.WorkflowStepDrifted,
+	}
+	for _, s := range terminal {
+		if !isStepTerminal(s) {
+			t.Errorf("status %q should be terminal", s)
+		}
+	}
+
+	nonTerminal := []app.Status{
+		app.StatusPending, app.StatusQueued,
+		app.StatusInProgress, app.StatusRetrying,
+	}
+	for _, s := range nonTerminal {
+		if isStepTerminal(s) {
+			t.Errorf("status %q should not be terminal", s)
+		}
+	}
+}

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/properties_test.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/properties_test.go
@@ -1,0 +1,306 @@
+package executeworkflowstepgroup
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+	"hegel.dev/go/hegel"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
+)
+
+// ============================================================================
+// Property: nextExecutableStep always returns the first executable step
+// ============================================================================
+
+// allStatuses is every step status the system can produce.
+var allStatuses = []app.Status{
+	app.StatusPending,
+	app.StatusNotAttempted,
+	app.StatusQueued,
+	app.StatusSuccess,
+	app.StatusError,
+	app.StatusInProgress,
+	app.StatusDiscarded,
+	app.StatusCancelled,
+	app.StatusAutoSkipped,
+	app.StatusUserSkipped,
+	app.WorkflowStepApprovalStatusApproved,
+	app.WorkflowStepNoDrift,
+	app.WorkflowStepDrifted,
+}
+
+// executableStatuses is the set nextExecutableStep considers "executable".
+var executableStatuses = map[app.Status]bool{
+	app.StatusPending:      true,
+	app.StatusNotAttempted: true,
+	app.StatusQueued:       true,
+}
+
+func TestNextExecutableStepProperties(t *testing.T) {
+	s := &Signal{}
+
+	t.Run("always picks the first executable step", hegel.Case(func(ht *hegel.T) {
+		n := hegel.Draw(ht, hegel.Integers(1, 15))
+		steps := make([]app.WorkflowStep, n)
+		for i := range steps {
+			status := hegel.Draw(ht, hegel.SampledFrom(allStatuses))
+			steps[i] = app.WorkflowStep{
+				ID:     fmt.Sprintf("step-%d", i),
+				Idx:    i * 100,
+				Status: app.CompositeStatus{Status: status},
+			}
+		}
+
+		picked, found := s.nextExecutableStep(steps)
+
+		// Find expected first executable step independently.
+		expectedIdx := -1
+		for j, step := range steps {
+			if executableStatuses[step.Status.Status] {
+				expectedIdx = j
+				break
+			}
+		}
+
+		if expectedIdx == -1 {
+			if found {
+				ht.Fatalf("no executable step exists but found=true, picked %s", picked.ID)
+			}
+		} else {
+			if !found {
+				ht.Fatalf("executable step exists at index %d but found=false", expectedIdx)
+			}
+			if picked.ID != steps[expectedIdx].ID {
+				ht.Fatalf("picked %s but expected first executable at index %d (%s)",
+					picked.ID, expectedIdx, steps[expectedIdx].ID)
+			}
+		}
+	}, hegel.WithTestCases(500)))
+
+	t.Run("terminal steps are never picked", hegel.Case(func(ht *hegel.T) {
+		n := hegel.Draw(ht, hegel.Integers(1, 15))
+		steps := make([]app.WorkflowStep, n)
+		for i := range steps {
+			status := hegel.Draw(ht, hegel.SampledFrom(allStatuses))
+			steps[i] = app.WorkflowStep{
+				ID:     fmt.Sprintf("step-%d", i),
+				Idx:    i * 100,
+				Status: app.CompositeStatus{Status: status},
+			}
+		}
+
+		picked, found := s.nextExecutableStep(steps)
+		if found {
+			if !executableStatuses[picked.Status.Status] {
+				ht.Fatalf("picked step %s with non-executable status %q",
+					picked.ID, picked.Status.Status)
+			}
+		}
+	}, hegel.WithTestCases(500)))
+}
+
+// ============================================================================
+// Property: nextExecutableStep respects Idx ordering
+// ============================================================================
+
+func TestNextExecutableStep_PicksLowestIdx(t *testing.T) {
+	s := &Signal{}
+
+	t.Run("picked step has lowest Idx among executables", hegel.Case(func(ht *hegel.T) {
+		n := hegel.Draw(ht, hegel.Integers(1, 15))
+		steps := make([]app.WorkflowStep, n)
+		for i := range steps {
+			status := hegel.Draw(ht, hegel.SampledFrom(allStatuses))
+			idx := hegel.Draw(ht, hegel.Integers(0, 1000))
+			steps[i] = app.WorkflowStep{
+				ID:     fmt.Sprintf("step-%d", i),
+				Idx:    idx,
+				Status: app.CompositeStatus{Status: status},
+			}
+		}
+
+		// Sort by Idx (simulating DB ORDER BY idx ASC).
+		sort.Slice(steps, func(a, b int) bool {
+			return steps[a].Idx < steps[b].Idx
+		})
+
+		picked, found := s.nextExecutableStep(steps)
+
+		// Find the executable step with the lowest Idx independently.
+		lowestIdx := -1
+		lowestID := ""
+		for _, step := range steps {
+			if executableStatuses[step.Status.Status] {
+				if lowestIdx == -1 || step.Idx < lowestIdx {
+					lowestIdx = step.Idx
+					lowestID = step.ID
+				}
+			}
+		}
+
+		if lowestIdx == -1 {
+			if found {
+				ht.Fatalf("no executable step exists but found=true")
+			}
+		} else {
+			if !found {
+				ht.Fatalf("executable step exists (Idx=%d) but found=false", lowestIdx)
+			}
+			if picked.Idx != lowestIdx {
+				ht.Fatalf("picked step %s (Idx=%d) but lowest executable Idx is %d (%s)",
+					picked.ID, picked.Idx, lowestIdx, lowestID)
+			}
+		}
+	}, hegel.WithTestCases(500)))
+}
+
+// ============================================================================
+// Property: groupMaxRetriesForSteps is the min across all signals
+// ============================================================================
+
+type testMaxRetriesSignal struct {
+	maxRetries int
+}
+
+func (s *testMaxRetriesSignal) Type() signal.SignalType         { return "test-max-retries" }
+func (s *testMaxRetriesSignal) Validate(workflow.Context) error { return nil }
+func (s *testMaxRetriesSignal) Execute(workflow.Context) error  { return nil }
+func (s *testMaxRetriesSignal) MaxRetries() int                 { return s.maxRetries }
+func (s *testMaxRetriesSignal) SleepAfter() time.Duration       { return 0 }
+
+type testNoMaxRetriesSignal struct{}
+
+func (s *testNoMaxRetriesSignal) Type() signal.SignalType         { return "test-no-max" }
+func (s *testNoMaxRetriesSignal) Validate(workflow.Context) error { return nil }
+func (s *testNoMaxRetriesSignal) Execute(workflow.Context) error  { return nil }
+func (s *testNoMaxRetriesSignal) SleepAfter() time.Duration       { return 0 }
+
+type testCloneMaxRetriesSignal struct {
+	maxRetries      int
+	cloneMaxRetries int
+}
+
+func (s *testCloneMaxRetriesSignal) Type() signal.SignalType         { return "test-clone-max" }
+func (s *testCloneMaxRetriesSignal) Validate(workflow.Context) error { return nil }
+func (s *testCloneMaxRetriesSignal) Execute(workflow.Context) error  { return nil }
+func (s *testCloneMaxRetriesSignal) MaxRetries() int                 { return s.maxRetries }
+func (s *testCloneMaxRetriesSignal) SleepAfter() time.Duration       { return 0 }
+
+func (s *testCloneMaxRetriesSignal) CloneSteps(originalStepName string) []signal.CloneStepDef {
+	return []signal.CloneStepDef{
+		{Name: originalStepName + "-plan", Signal: &testMaxRetriesSignal{maxRetries: s.cloneMaxRetries}},
+		{Name: originalStepName + "-apply", Signal: &testMaxRetriesSignal{maxRetries: s.maxRetries}},
+	}
+}
+
+func TestGroupMaxRetriesForStepsProperties(t *testing.T) {
+	t.Run("result equals min of all MaxRetries values", hegel.Case(func(ht *hegel.T) {
+		n := hegel.Draw(ht, hegel.Integers(1, 6))
+		steps := make([]app.WorkflowStep, n)
+		expectedMin := signal.DefaultMaxRetries
+
+		for j := range steps {
+			mr := hegel.Draw(ht, hegel.Integers(1, 20))
+			if mr < expectedMin {
+				expectedMin = mr
+			}
+			steps[j] = app.WorkflowStep{
+				ID:   fmt.Sprintf("step-%d", j),
+				Name: fmt.Sprintf("step-%d", j),
+				QueueSignal: &signaldb.SignalData{
+					Signal: &testMaxRetriesSignal{maxRetries: mr},
+				},
+			}
+		}
+
+		result := groupMaxRetriesForSteps(steps)
+		if result != expectedMin {
+			ht.Fatalf("got %d, want min=%d", result, expectedMin)
+		}
+	}, hegel.WithTestCases(500)))
+
+	t.Run("adding a stricter step can only decrease or preserve", hegel.Case(func(ht *hegel.T) {
+		n := hegel.Draw(ht, hegel.Integers(1, 5))
+		steps := make([]app.WorkflowStep, n)
+		for j := range steps {
+			mr := hegel.Draw(ht, hegel.Integers(5, 15))
+			steps[j] = app.WorkflowStep{
+				ID:   fmt.Sprintf("step-%d", j),
+				Name: fmt.Sprintf("step-%d", j),
+				QueueSignal: &signaldb.SignalData{
+					Signal: &testMaxRetriesSignal{maxRetries: mr},
+				},
+			}
+		}
+
+		baseline := groupMaxRetriesForSteps(steps)
+
+		stricter := hegel.Draw(ht, hegel.Integers(1, 4))
+		steps = append(steps, app.WorkflowStep{
+			ID:   "stricter",
+			Name: "stricter",
+			QueueSignal: &signaldb.SignalData{
+				Signal: &testMaxRetriesSignal{maxRetries: stricter},
+			},
+		})
+
+		withStricter := groupMaxRetriesForSteps(steps)
+		if withStricter > baseline {
+			ht.Fatalf("adding stricter step (max=%d) increased group max: %d -> %d",
+				stricter, baseline, withStricter)
+		}
+	}, hegel.WithTestCases(300)))
+
+	t.Run("clone step signals participate in min", func(t *testing.T) {
+		// Primary has maxRetries=10, but clone step has maxRetries=3.
+		steps := []app.WorkflowStep{{
+			ID:   "step-1",
+			Name: "step-1",
+			QueueSignal: &signaldb.SignalData{
+				Signal: &testCloneMaxRetriesSignal{maxRetries: 10, cloneMaxRetries: 3},
+			},
+		}}
+
+		result := groupMaxRetriesForSteps(steps)
+		if result != 3 {
+			t.Fatalf("got %d, want 3 (clone step min)", result)
+		}
+	})
+
+	t.Run("nil signals are skipped", func(t *testing.T) {
+		steps := []app.WorkflowStep{
+			{ID: "a", QueueSignal: nil},
+			{ID: "b", QueueSignal: &signaldb.SignalData{Signal: nil}},
+			{ID: "c", QueueSignal: &signaldb.SignalData{Signal: &testMaxRetriesSignal{maxRetries: 5}}},
+		}
+		result := groupMaxRetriesForSteps(steps)
+		if result != 5 {
+			t.Fatalf("got %d, want 5", result)
+		}
+	})
+
+	t.Run("empty steps returns default", func(t *testing.T) {
+		result := groupMaxRetriesForSteps(nil)
+		if result != signal.DefaultMaxRetries {
+			t.Fatalf("got %d, want %d", result, signal.DefaultMaxRetries)
+		}
+	})
+
+	t.Run("signals without MaxRetries use default", func(t *testing.T) {
+		steps := []app.WorkflowStep{{
+			ID:          "a",
+			Name:        "a",
+			QueueSignal: &signaldb.SignalData{Signal: &testNoMaxRetriesSignal{}},
+		}}
+		result := groupMaxRetriesForSteps(steps)
+		if result != signal.DefaultMaxRetries {
+			t.Fatalf("got %d, want %d", result, signal.DefaultMaxRetries)
+		}
+	})
+}


### PR DESCRIPTION
Introduces hegel.dev/go/hegel as our property-based testing library and
adds tests for pure helper functions in the v2 flow/queue signal system.

## Properties tested 

* executeworkflowstepgroup:
- nextExecutableStep: terminal steps are never picked; among
  Idx-sorted steps, always picks the lowest-Idx executable step
- groupMaxRetriesForSteps: equals min(MaxRetries) across all signals
  including SignalWithCloneSteps; stricter steps can only decrease the
  result; nil signals and empty input handled correctly

* executeflow:
- collectGroupIndices: each GroupIdx appears exactly once; preserves
  first-occurrence order; retry clones do not corrupt order
- isGroupParallel: depends only on steps in the target group; any
  parallel step in the target group flips the result to true
- isStepTerminal: exhaustive check of all known statuses (terminal vs
  non-terminal sets)

