### PR TITLE
feat: add new state workflow for installs

### DIFF
--- a/services/ctl-api/internal/fxmodules/infrastructure.go
+++ b/services/ctl-api/internal/fxmodules/infrastructure.go
@@ -27,6 +27,7 @@ import (
 	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks/arm"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks/cloudformation"
+	stateclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/temporal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/temporal/dataconverter"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/temporal/dataconverter/gzip"
@@ -80,4 +81,5 @@ var InfrastructureModule = fx.Module("infrastructure",
 	fx.Provide(queueclient.New),
 	fx.Provide(emitterclient.New),
 	fx.Provide(flowclient.New),
+	fx.Provide(stateclient.New),
 )

--- a/services/ctl-api/internal/fxmodules/workers_shared.go
+++ b/services/ctl-api/internal/fxmodules/workers_shared.go
@@ -15,6 +15,8 @@ import (
 	handleractivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	signalhooks "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/hooks"
+	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
+	stateactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
@@ -63,6 +65,10 @@ var SharedWorkflowsModule = fx.Module("shared-workflows",
 	fx.Provide(statusactivities.New),
 	fx.Provide(activities.New),
 	fx.Provide(onboardingactivities.New),
+
+	// state-manager
+	fx.Provide(stateactivities.New),
+	fx.Provide(statemanager.NewWorkflows),
 
 	// workflows
 	fx.Provide(job.New),

--- a/services/ctl-api/internal/pkg/state/activities/activities.go
+++ b/services/ctl-api/internal/pkg/state/activities/activities.go
@@ -1,0 +1,129 @@
+package activities
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+type Params struct {
+	fx.In
+
+	DB *gorm.DB `name:"psql"`
+	L  *zap.Logger
+}
+
+type Activities struct {
+	db *gorm.DB
+	l  *zap.Logger
+}
+
+func New(params Params) *Activities {
+	return &Activities{
+		db: params.DB,
+		l:  params.L,
+	}
+}
+
+func (a *Activities) All() []any {
+	return []any{
+		a.CheckModified,
+	}
+}
+
+type CheckModifiedRequest struct {
+	InstallID   string
+	PartialName string
+	LastKnownAt time.Time
+}
+
+type CheckModifiedResponse struct {
+	Changed          bool
+	LatestModifiedAt time.Time
+}
+
+// CheckModified checks if a partial has been modified since the last known time.
+// Each partial maps to a cheap SELECT MAX(updated_at) query.
+//
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 10s
+func (a *Activities) CheckModified(ctx context.Context, req *CheckModifiedRequest) (*CheckModifiedResponse, error) {
+	var latestAt time.Time
+	var err error
+
+	switch req.PartialName {
+	case "org":
+		err = a.db.WithContext(ctx).
+			Raw("SELECT o.updated_at FROM orgs o JOIN installs i ON i.org_id = o.id WHERE i.id = ? AND i.deleted_at IS NULL", req.InstallID).
+			Scan(&latestAt).Error
+	case "app":
+		err = a.db.WithContext(ctx).
+			Raw(`SELECT GREATEST(
+				(SELECT a.updated_at FROM apps a JOIN installs i ON i.app_id = a.id WHERE i.id = ? AND i.deleted_at IS NULL),
+				COALESCE((SELECT MAX(s.updated_at) FROM app_secrets s JOIN installs i ON i.app_id = s.app_id WHERE i.id = ? AND i.deleted_at IS NULL), '1970-01-01'::timestamptz)
+			)`, req.InstallID, req.InstallID).
+			Scan(&latestAt).Error
+	case "domain", "sandbox":
+		err = a.db.WithContext(ctx).
+			Raw("SELECT COALESCE(MAX(updated_at), '1970-01-01'::timestamptz) FROM install_sandbox_runs WHERE install_id = ?", req.InstallID).
+			Scan(&latestAt).Error
+	case "runner":
+		err = a.db.WithContext(ctx).
+			Raw(`SELECT r.updated_at FROM runners r
+				JOIN runner_groups rg ON r.runner_group_id = rg.id
+				JOIN installs i ON i.runner_group_id = rg.id
+				WHERE i.id = ? AND i.deleted_at IS NULL
+				ORDER BY r.created_at DESC LIMIT 1`, req.InstallID).
+			Scan(&latestAt).Error
+	case "cloud":
+		err = a.db.WithContext(ctx).
+			Raw("SELECT updated_at FROM installs WHERE id = ? AND deleted_at IS NULL", req.InstallID).
+			Scan(&latestAt).Error
+	case "actions":
+		err = a.db.WithContext(ctx).
+			Raw("SELECT COALESCE(MAX(updated_at), '1970-01-01'::timestamptz) FROM install_action_workflows WHERE install_id = ?", req.InstallID).
+			Scan(&latestAt).Error
+	case "inputs":
+		err = a.db.WithContext(ctx).
+			Raw("SELECT COALESCE(MAX(updated_at), '1970-01-01'::timestamptz) FROM install_inputs WHERE install_id = ?", req.InstallID).
+			Scan(&latestAt).Error
+	case "components":
+		err = a.db.WithContext(ctx).
+			Raw(`SELECT GREATEST(
+				COALESCE((SELECT MAX(updated_at) FROM install_components WHERE install_id = ?), '1970-01-01'::timestamptz),
+				COALESCE((SELECT MAX(id.updated_at) FROM install_deploys id JOIN install_components ic ON id.install_component_id = ic.id WHERE ic.install_id = ?), '1970-01-01'::timestamptz)
+			)`, req.InstallID, req.InstallID).
+			Scan(&latestAt).Error
+	case "stack":
+		err = a.db.WithContext(ctx).
+			Raw(`SELECT COALESCE(MAX(isv.created_at), '1970-01-01'::timestamptz)
+				FROM install_stack_versions isv
+				JOIN install_stacks ist ON isv.install_stack_id = ist.id
+				WHERE ist.install_id = ?`, req.InstallID).
+			Scan(&latestAt).Error
+	case "secrets":
+		err = a.db.WithContext(ctx).
+			Raw(`SELECT COALESCE(MAX(updated_at), '1970-01-01'::timestamptz)
+				FROM runner_jobs
+				WHERE install_id = ? AND type = 'sync-secrets'`, req.InstallID).
+			Scan(&latestAt).Error
+	default:
+		return &CheckModifiedResponse{Changed: true, LatestModifiedAt: time.Now()}, nil
+	}
+
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return &CheckModifiedResponse{Changed: false}, nil
+		}
+		return nil, err
+	}
+
+	changed := latestAt.After(req.LastKnownAt)
+	return &CheckModifiedResponse{
+		Changed:          changed,
+		LatestModifiedAt: latestAt,
+	}, nil
+}

--- a/services/ctl-api/internal/pkg/state/client/client.go
+++ b/services/ctl-api/internal/pkg/state/client/client.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"fmt"
+
+	enumsv1 "go.temporal.io/api/enums/v1"
+	tclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	temporalclient "github.com/nuonco/nuon/pkg/temporal/client"
+	"github.com/nuonco/nuon/pkg/workflows"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
+)
+
+const (
+	workflowIDTemplate = "state-manager-%s"
+	workflowNamespace  = "installs"
+)
+
+type Client struct {
+	db      *gorm.DB
+	cfg     *internal.Config
+	tClient temporalclient.Client
+	l       *zap.Logger
+}
+
+type Params struct {
+	fx.In
+
+	DB      *gorm.DB `name:"psql"`
+	Cfg     *internal.Config
+	TClient temporalclient.Client
+	L       *zap.Logger
+}
+
+func New(params Params) *Client {
+	return &Client{
+		db:      params.DB,
+		cfg:     params.Cfg,
+		tClient: params.TClient,
+		l:       params.L,
+	}
+}
+
+func workflowID(installID string) string {
+	return fmt.Sprintf(workflowIDTemplate, installID)
+}
+
+// stateManagerStartOperation builds a WithStartWorkflowOperation for the state-manager workflow.
+func (c *Client) stateManagerStartOperation(installID string) tclient.WithStartWorkflowOperation {
+	req := statemanager.StateManagerRequest{
+		InstallID: installID,
+	}
+	startOpts := tclient.StartWorkflowOptions{
+		ID:        workflowID(installID),
+		TaskQueue: workflows.APITaskQueue,
+		Memo: map[string]any{
+			"type":       "state-manager",
+			"install-id": installID,
+		},
+		WorkflowIDConflictPolicy: enumsv1.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 0,
+		},
+	}
+	return c.tClient.NewWithStartWorkflowOperation(startOpts, "StateManager", req)
+}

--- a/services/ctl-api/internal/pkg/state/client/ensure.go
+++ b/services/ctl-api/internal/pkg/state/client/ensure.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	tclient "go.temporal.io/sdk/client"
+	"go.uber.org/zap"
+
+	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
+)
+
+// EnsureStateManager starts the state-manager workflow for an install, or restarts it if already running.
+func (c *Client) EnsureStateManager(ctx context.Context, installID string) error {
+	wfID := workflowID(installID)
+	c.l.Debug("ensuring state-manager workflow", zap.String("install_id", installID), zap.String("workflow_id", wfID))
+
+	_, err := c.tClient.UpdateWithStartWorkflowInNamespace(ctx, workflowNamespace, tclient.UpdateWithStartWorkflowOptions{
+		UpdateOptions: tclient.UpdateWorkflowOptions{
+			WorkflowID:   wfID,
+			UpdateName:   statemanager.RestartUpdateName,
+			WaitForStage: tclient.WorkflowUpdateStageAccepted,
+			Args: []any{
+				statemanager.RestartRequest{},
+			},
+		},
+		StartWorkflowOperation: c.stateManagerStartOperation(installID),
+	})
+	if err != nil {
+		return errors.Wrap(err, "unable to ensure state-manager workflow")
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/state/client/fetch_state.go
+++ b/services/ctl-api/internal/pkg/state/client/fetch_state.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	tclient "go.temporal.io/sdk/client"
+
+	pkgstate "github.com/nuonco/nuon/pkg/types/state"
+	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
+)
+
+// FetchState returns the current cached state from the state-manager workflow.
+// If the workflow isn't running, it's auto-started. If no cached state exists, the
+// workflow performs a full regeneration before returning.
+// This is the primary way to get state from within other Temporal workflows.
+func (c *Client) FetchState(ctx context.Context, installID string) (*pkgstate.State, error) {
+	wfID := workflowID(installID)
+	handle, err := c.tClient.UpdateWithStartWorkflowInNamespace(ctx, workflowNamespace, tclient.UpdateWithStartWorkflowOptions{
+		UpdateOptions: tclient.UpdateWorkflowOptions{
+			WorkflowID:   wfID,
+			UpdateName:   statemanager.FetchStateUpdateName,
+			WaitForStage: tclient.WorkflowUpdateStageCompleted,
+			Args: []any{
+				statemanager.FetchStateRequest{},
+			},
+		},
+		StartWorkflowOperation: c.stateManagerStartOperation(installID),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to send fetch-state to state-manager")
+	}
+
+	var resp statemanager.FetchStateResponse
+	if err := handle.Get(ctx, &resp); err != nil {
+		return nil, errors.Wrap(err, "unable to get fetch-state response")
+	}
+	return resp.State, nil
+}

--- a/services/ctl-api/internal/pkg/state/client/force_regenerate.go
+++ b/services/ctl-api/internal/pkg/state/client/force_regenerate.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	tclient "go.temporal.io/sdk/client"
+
+	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
+)
+
+// ForceRegenerate triggers a full rebuild of all state partials.
+func (c *Client) ForceRegenerate(ctx context.Context, installID string) (*statemanager.ForceRegenerateResponse, error) {
+	wfID := workflowID(installID)
+	handle, err := c.tClient.UpdateWithStartWorkflowInNamespace(ctx, workflowNamespace, tclient.UpdateWithStartWorkflowOptions{
+		UpdateOptions: tclient.UpdateWorkflowOptions{
+			WorkflowID:   wfID,
+			UpdateName:   statemanager.ForceRegenerateUpdateName,
+			WaitForStage: tclient.WorkflowUpdateStageCompleted,
+			Args: []any{
+				statemanager.ForceRegenerateRequest{},
+			},
+		},
+		StartWorkflowOperation: c.stateManagerStartOperation(installID),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to send force-regenerate to state-manager")
+	}
+
+	var resp statemanager.ForceRegenerateResponse
+	if err := handle.Get(ctx, &resp); err != nil {
+		return nil, errors.Wrap(err, "unable to get force-regenerate response")
+	}
+	return &resp, nil
+}

--- a/services/ctl-api/internal/pkg/state/client/get_state.go
+++ b/services/ctl-api/internal/pkg/state/client/get_state.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	pkgstate "github.com/nuonco/nuon/pkg/types/state"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// GetState reads the latest cached state from the install_states table.
+// This is a pure DB read, not a Temporal operation.
+// Use this for HTTP handlers and non-workflow contexts where last-persisted state is fine.
+func (c *Client) GetState(ctx context.Context, installID string) (*pkgstate.State, error) {
+	var is app.InstallState
+	res := c.db.WithContext(ctx).
+		Where(app.InstallState{InstallID: installID}).
+		Order("created_at DESC").
+		First(&is)
+	if res.Error != nil {
+		return nil, errors.Wrap(res.Error, "unable to find install state")
+	}
+
+	if !is.StaleAt.Empty() {
+		is.State.StaleAt = &is.StaleAt.Time
+	}
+
+	// Hydrate labels fresh — they are mutable and not persisted in the state snapshot.
+	if err := c.hydrateLabels(ctx, installID, is.State); err != nil {
+		return nil, errors.Wrap(err, "unable to hydrate labels")
+	}
+
+	return is.State, nil
+}
+
+func (c *Client) hydrateLabels(ctx context.Context, installID string, is *pkgstate.State) error {
+	var install app.Install
+	if err := c.db.WithContext(ctx).Select("id", "labels").First(&install, "id = ?", installID).Error; err != nil {
+		return errors.Wrap(err, "unable to get install labels")
+	}
+	is.Labels = map[string]string(install.Labels)
+	return nil
+}

--- a/services/ctl-api/internal/pkg/state/client/hint.go
+++ b/services/ctl-api/internal/pkg/state/client/hint.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	tclient "go.temporal.io/sdk/client"
+
+	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
+)
+
+// Hint sends a hint to the state-manager workflow for an install, triggering
+// regeneration of the affected partials. If the workflow isn't running, it's auto-started.
+func (c *Client) Hint(ctx context.Context, installID string, hint statemanager.HintType) (*statemanager.HintResponse, error) {
+	wfID := workflowID(installID)
+	handle, err := c.tClient.UpdateWithStartWorkflowInNamespace(ctx, workflowNamespace, tclient.UpdateWithStartWorkflowOptions{
+		UpdateOptions: tclient.UpdateWorkflowOptions{
+			WorkflowID:   wfID,
+			UpdateName:   statemanager.HintUpdateName,
+			WaitForStage: tclient.WorkflowUpdateStageCompleted,
+			Args: []any{
+				statemanager.HintRequest{HintType: hint},
+			},
+		},
+		StartWorkflowOperation: c.stateManagerStartOperation(installID),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to send hint to state-manager")
+	}
+
+	var resp statemanager.HintResponse
+	if err := handle.Get(ctx, &resp); err != nil {
+		return nil, errors.Wrap(err, "unable to get hint response")
+	}
+	return &resp, nil
+}

--- a/services/ctl-api/internal/pkg/state/client/regenerate.go
+++ b/services/ctl-api/internal/pkg/state/client/regenerate.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	tclient "go.temporal.io/sdk/client"
+
+	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
+)
+
+// Regenerate checks all partials for changes and updates stale ones.
+func (c *Client) Regenerate(ctx context.Context, installID string) (*statemanager.RegenerateResponse, error) {
+	wfID := workflowID(installID)
+	handle, err := c.tClient.UpdateWithStartWorkflowInNamespace(ctx, workflowNamespace, tclient.UpdateWithStartWorkflowOptions{
+		UpdateOptions: tclient.UpdateWorkflowOptions{
+			WorkflowID:   wfID,
+			UpdateName:   statemanager.RegenerateUpdateName,
+			WaitForStage: tclient.WorkflowUpdateStageCompleted,
+			Args: []any{
+				statemanager.RegenerateRequest{},
+			},
+		},
+		StartWorkflowOperation: c.stateManagerStartOperation(installID),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to send regenerate to state-manager")
+	}
+
+	var resp statemanager.RegenerateResponse
+	if err := handle.Get(ctx, &resp); err != nil {
+		return nil, errors.Wrap(err, "unable to get regenerate response")
+	}
+	return &resp, nil
+}

--- a/services/ctl-api/internal/pkg/state/client/status.go
+++ b/services/ctl-api/internal/pkg/state/client/status.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
+	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
+)
+
+// Status queries the state-manager workflow for its current metadata.
+func (c *Client) Status(ctx context.Context, installID string) (*statemanager.StatusResponse, error) {
+	wfID := workflowID(installID)
+	val, err := c.tClient.QueryWorkflowInNamespace(ctx, workflowNamespace, wfID, "", statemanager.StatusQueryName)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to query state-manager status")
+	}
+
+	var resp statemanager.StatusResponse
+	if err := val.Get(&resp); err != nil {
+		// Try json decode as fallback.
+		var raw json.RawMessage
+		if err2 := val.Get(&raw); err2 != nil {
+			return nil, errors.Wrap(err, "unable to decode status response")
+		}
+		if err2 := json.Unmarshal(raw, &resp); err2 != nil {
+			return nil, errors.Wrap(err, "unable to decode status response")
+		}
+	}
+	return &resp, nil
+}

--- a/services/ctl-api/internal/pkg/state/client/stop.go
+++ b/services/ctl-api/internal/pkg/state/client/stop.go
@@ -1,0 +1,30 @@
+package client
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	tclient "go.temporal.io/sdk/client"
+
+	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
+)
+
+// Stop terminates the state-manager workflow for an install.
+func (c *Client) Stop(ctx context.Context, installID string) error {
+	wfID := workflowID(installID)
+	_, err := c.tClient.UpdateWithStartWorkflowInNamespace(ctx, workflowNamespace, tclient.UpdateWithStartWorkflowOptions{
+		UpdateOptions: tclient.UpdateWorkflowOptions{
+			WorkflowID:   wfID,
+			UpdateName:   statemanager.StopUpdateName,
+			WaitForStage: tclient.WorkflowUpdateStageAccepted,
+			Args: []any{
+				statemanager.StopRequest{},
+			},
+		},
+		StartWorkflowOperation: c.stateManagerStartOperation(installID),
+	})
+	if err != nil {
+		return errors.Wrap(err, "unable to stop state-manager")
+	}
+	return nil
+}

--- a/services/ctl-api/internal/pkg/state/partials.go
+++ b/services/ctl-api/internal/pkg/state/partials.go
@@ -1,0 +1,75 @@
+package state
+
+// PartialName identifies a component of install state that can be independently regenerated.
+type PartialName string
+
+const (
+	PartialOrg        PartialName = "org"
+	PartialApp        PartialName = "app"
+	PartialDomain     PartialName = "domain"
+	PartialRunner     PartialName = "runner"
+	PartialCloud      PartialName = "cloud"
+	PartialActions    PartialName = "actions"
+	PartialInputs     PartialName = "inputs"
+	PartialComponents PartialName = "components"
+	PartialSandbox    PartialName = "sandbox"
+	PartialStack      PartialName = "stack"
+	PartialSecrets    PartialName = "secrets"
+)
+
+// AllPartials is the ordered list of all state partials.
+var AllPartials = []PartialName{
+	PartialOrg,
+	PartialApp,
+	PartialDomain,
+	PartialRunner,
+	PartialCloud,
+	PartialActions,
+	PartialInputs,
+	PartialComponents,
+	PartialSandbox,
+	PartialStack,
+	PartialSecrets,
+}
+
+// HintType describes what changed, allowing the workflow to determine which partials to regenerate.
+type HintType string
+
+const (
+	HintDeployCompleted      HintType = "deploy-completed"
+	HintComponentTeardown    HintType = "component-teardown"
+	HintSandboxProvisioned   HintType = "sandbox-provisioned"
+	HintSandboxDeprovisioned HintType = "sandbox-deprovisioned"
+	HintSandboxReprovisioned HintType = "sandbox-reprovisioned"
+	HintActionRan            HintType = "action-ran"
+	HintStackRunCompleted    HintType = "stack-run-completed"
+	HintStackOutputsUpdated  HintType = "stack-outputs-updated"
+	HintInputsUpdated        HintType = "inputs-updated"
+	HintSecretsUpdated       HintType = "secrets-updated"
+	HintRunnerUpdated        HintType = "runner-updated"
+	HintAppConfigUpdated     HintType = "app-config-updated"
+)
+
+// HintToPartials maps a hint type to the set of partials that should be regenerated.
+var HintToPartials = map[HintType][]PartialName{
+	HintDeployCompleted:      {PartialComponents},
+	HintComponentTeardown:    {PartialComponents},
+	HintSandboxProvisioned:   {PartialSandbox, PartialDomain},
+	HintSandboxDeprovisioned: {PartialSandbox, PartialDomain},
+	HintSandboxReprovisioned: {PartialSandbox, PartialDomain},
+	HintActionRan:            {PartialActions},
+	HintStackRunCompleted:    {PartialStack},
+	HintStackOutputsUpdated:  {PartialStack},
+	HintInputsUpdated:        {PartialInputs},
+	HintSecretsUpdated:       {PartialSecrets},
+	HintRunnerUpdated:        {PartialRunner},
+	HintAppConfigUpdated:     {PartialApp, PartialInputs},
+}
+
+func allPartialsSet() map[PartialName]bool {
+	m := make(map[PartialName]bool, len(AllPartials))
+	for _, p := range AllPartials {
+		m[p] = true
+	}
+	return m
+}

--- a/services/ctl-api/internal/pkg/state/state_manager.go
+++ b/services/ctl-api/internal/pkg/state/state_manager.go
@@ -1,0 +1,68 @@
+package state
+
+import (
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+	"go.uber.org/fx"
+
+	"github.com/go-playground/validator/v10"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+type Params struct {
+	fx.In
+
+	Cfg *internal.Config
+	V   *validator.Validate
+}
+
+func NewWorkflows(params Params) (*Workflows, error) {
+	return &Workflows{
+		cfg: params.Cfg,
+		v:   params.V,
+	}, nil
+}
+
+type Workflows struct {
+	cfg *internal.Config
+	v   *validator.Validate
+}
+
+func (w *Workflows) All() []any {
+	return []any{
+		w.StateManager,
+	}
+}
+
+// StateManager is a long-lived per-install workflow that maintains cached state
+// and only regenerates the partials that have changed.
+//
+// @temporal-gen-v2 workflow
+// @id-template state-manager-{{.InstallID}}
+// @memo type state-manager
+func (w *Workflows) StateManager(ctx workflow.Context, req StateManagerRequest) error {
+	sm := &stateManager{
+		installID:       req.InstallID,
+		state:           req.State,
+		workflows:       w,
+		pendingPartials: make(map[PartialName]bool),
+	}
+	if sm.state == nil {
+		sm.state = &StateManagerState{
+			LastModifiedAt: make(map[PartialName]time.Time),
+		}
+	}
+
+	finished, err := sm.run(ctx)
+	if err != nil {
+		return err
+	}
+	if !finished {
+		req.State = sm.state
+		return workflow.NewContinueAsNewError(ctx, w.StateManager, req)
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/state/state_manager_execute.go
+++ b/services/ctl-api/internal/pkg/state/state_manager_execute.go
@@ -1,0 +1,438 @@
+package state
+
+import (
+	"strings"
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+	"gorm.io/gorm"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	pkggenerics "github.com/nuonco/nuon/pkg/generics"
+	pkgstate "github.com/nuonco/nuon/pkg/types/state"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+)
+
+// executeRegeneration regenerates the specified partials, saves to DB, and updates cached state.
+func (sm *stateManager) executeRegeneration(ctx workflow.Context, partials map[PartialName]bool) ([]PartialName, error) {
+	l, err := log.WorkflowLogger(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	is := sm.state.CachedState
+	if is == nil {
+		is = pkgstate.New()
+		// Fetch install for ID/Name.
+		install, err := activities.AwaitGetByInstallID(ctx, sm.installID)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to get install")
+		}
+		is.ID = install.ID
+		is.Name = install.Name
+	}
+
+	var updatedPartials []PartialName
+
+	for _, partial := range AllPartials {
+		if !partials[partial] {
+			continue
+		}
+
+		l.Debug("regenerating partial", zap.String("partial", string(partial)))
+
+		if err := sm.fetchPartial(ctx, partial, is); err != nil {
+			return nil, errors.Wrapf(err, "unable to fetch partial %s", partial)
+		}
+
+		sm.state.LastModifiedAt[partial] = workflow.Now(ctx)
+		updatedPartials = append(updatedPartials, partial)
+	}
+
+	// Always map legacy fields if anything changed.
+	if len(updatedPartials) > 0 {
+		mapLegacyFields(is)
+	}
+
+	sm.state.CachedState = is
+
+	// Persist to DB.
+	if len(updatedPartials) > 0 {
+		if _, err := activities.AwaitSaveState(ctx, &activities.SaveStateRequest{
+			State:           is,
+			InstallID:       sm.installID,
+			TriggeredByID:   sm.installID,
+			TriggeredByType: "state-manager",
+		}); err != nil {
+			return nil, errors.Wrap(err, "unable to save state")
+		}
+
+		if err := activities.AwaitArchiveState(ctx, &activities.ArchiveStateRequest{
+			InstallID: sm.installID,
+		}); err != nil {
+			return nil, errors.Wrap(err, "unable to archive stale state")
+		}
+	}
+
+	sm.state.LastGeneratedAt = workflow.Now(ctx)
+	sm.state.GenerationCount++
+
+	return updatedPartials, nil
+}
+
+// fetchPartial regenerates a single partial and sets it on the state.
+func (sm *stateManager) fetchPartial(ctx workflow.Context, partial PartialName, is *pkgstate.State) error {
+	switch partial {
+	case PartialOrg:
+		return sm.fetchOrgPartial(ctx, is)
+	case PartialApp:
+		return sm.fetchAppPartial(ctx, is)
+	case PartialDomain:
+		return sm.fetchDomainPartial(ctx, is)
+	case PartialRunner:
+		return sm.fetchRunnerPartial(ctx, is)
+	case PartialCloud:
+		return sm.fetchCloudPartial(ctx, is)
+	case PartialActions:
+		return sm.fetchActionsPartial(ctx, is)
+	case PartialInputs:
+		return sm.fetchInputsPartial(ctx, is)
+	case PartialComponents:
+		return sm.fetchComponentsPartial(ctx, is)
+	case PartialSandbox:
+		return sm.fetchSandboxPartial(ctx, is)
+	case PartialStack:
+		return sm.fetchStackPartial(ctx, is)
+	case PartialSecrets:
+		return sm.fetchSecretsPartial(ctx, is)
+	default:
+		return errors.Errorf("unknown partial: %s", partial)
+	}
+}
+
+func (sm *stateManager) fetchOrgPartial(ctx workflow.Context, is *pkgstate.State) error {
+	org, err := activities.AwaitGetOrgByInstallID(ctx, sm.installID)
+	if err != nil {
+		return errors.Wrap(err, "unable to get org")
+	}
+
+	st := pkgstate.NewOrgState()
+	st.Populated = true
+	st.ID = org.ID
+	st.Name = org.Name
+	st.Status = string(org.Status)
+	is.Org = st
+	return nil
+}
+
+func (sm *stateManager) fetchAppPartial(ctx workflow.Context, is *pkgstate.State) error {
+	install, err := activities.AwaitGetByInstallID(ctx, sm.installID)
+	if err != nil {
+		return errors.Wrap(err, "unable to get install")
+	}
+
+	currentApp := install.App
+	st := pkgstate.NewAppState()
+	st.Populated = true
+	st.ID = currentApp.ID
+	st.Name = currentApp.Name
+	st.Status = string(currentApp.Status)
+	for _, secr := range currentApp.AppSecrets {
+		st.Variables[secr.Name] = secr.Value
+	}
+	is.App = st
+	return nil
+}
+
+func (sm *stateManager) fetchDomainPartial(ctx workflow.Context, is *pkgstate.State) error {
+	sandboxRun, err := activities.AwaitGetInstallSandboxRunStateByInstallID(ctx, sm.installID)
+	if err != nil {
+		if strings.Contains(err.Error(), gorm.ErrRecordNotFound.Error()) {
+			is.Domain = &pkgstate.DomainState{}
+			return nil
+		}
+		return errors.Wrap(err, "unable to get domain state")
+	}
+
+	st := pkgstate.NewDomainState()
+	if sandboxRun != nil {
+		if v, ok := sandboxRun.Outputs["public_domain"].(string); ok {
+			st.PublicDomain = v
+		}
+		if v, ok := sandboxRun.Outputs["internal_domain"].(string); ok {
+			st.InternalDomain = v
+		}
+	}
+	is.Domain = st
+	return nil
+}
+
+func (sm *stateManager) fetchRunnerPartial(ctx workflow.Context, is *pkgstate.State) error {
+	install, err := activities.AwaitGetByInstallID(ctx, sm.installID)
+	if err != nil {
+		return errors.Wrap(err, "unable to get install")
+	}
+
+	runner, err := activities.AwaitGetRunnerByID(ctx, install.RunnerID)
+	if err != nil {
+		return errors.Wrap(err, "unable to get runner")
+	}
+
+	st := pkgstate.NewRunnerState()
+	st.Populated = true
+	st.ID = runner.ID
+	st.RunnerGroupID = runner.RunnerGroupID
+	st.Status = string(runner.Status)
+	is.Runner = st
+	return nil
+}
+
+func (sm *stateManager) fetchCloudPartial(ctx workflow.Context, is *pkgstate.State) error {
+	install, err := activities.AwaitGetByInstallID(ctx, sm.installID)
+	if err != nil {
+		return errors.Wrap(err, "unable to get install")
+	}
+
+	st := pkgstate.NewCloudAccount()
+	if install.AWSAccount != nil {
+		st.AWS = &pkgstate.AWSCloudAccount{Region: install.AWSAccount.Region}
+	}
+	if install.AzureAccount != nil {
+		st.Azure = &pkgstate.AzureCloudAccount{Location: install.AzureAccount.Location}
+	}
+	if install.GCPAccount != nil {
+		st.GCP = &pkgstate.GCPCloudAccount{
+			ProjectID: install.GCPAccount.ProjectID,
+			Region:    install.GCPAccount.Region,
+		}
+	}
+	is.Cloud = st
+	return nil
+}
+
+func (sm *stateManager) fetchActionsPartial(ctx workflow.Context, is *pkgstate.State) error {
+	actions, err := activities.AwaitGetActionWorkflowsByInstallID(ctx, sm.installID)
+	if err != nil {
+		return errors.Wrap(err, "unable to get actions")
+	}
+
+	st := pkgstate.NewActionsState()
+	st.Populated = true
+	for _, action := range actions {
+		act, err := activities.AwaitGetInstallActionWorkflowStateByInstallActionWorkflowID(ctx, action.ID)
+		if err != nil {
+			return errors.Wrap(err, "unable to get action workflow state")
+		}
+
+		aws := pkgstate.NewActionWorkflowState()
+		aws.Populated = true
+		aws.Status = string(act.Status)
+		aws.ID = act.ActionWorkflow.ID
+		for _, run := range act.Runs {
+			if run.RunnerJob != nil {
+				aws.Outputs = run.RunnerJob.ParsedOutputs
+				break
+			}
+		}
+		st.Workflows[action.ActionWorkflow.Name] = aws
+	}
+	is.Actions = st
+	return nil
+}
+
+func (sm *stateManager) fetchInputsPartial(ctx workflow.Context, is *pkgstate.State) error {
+	inst, err := activities.AwaitGetByInstallID(ctx, sm.installID)
+	if err != nil {
+		return errors.Wrap(err, "unable to get install")
+	}
+
+	inps, err := activities.AwaitGetInstallInputsStateByInstallID(ctx, sm.installID)
+	if err != nil {
+		if strings.Contains(err.Error(), gorm.ErrRecordNotFound.Error()) {
+			is.Inputs = &pkgstate.InputsState{}
+			return nil
+		}
+		return errors.Wrap(err, "unable to get inputs state")
+	}
+
+	cfg, err := activities.AwaitGetAppConfigByID(ctx, inst.AppConfigID)
+	if err != nil {
+		return errors.Wrap(err, "unable to get app config")
+	}
+
+	is.Inputs = toInputState(inps, cfg, false)
+	return nil
+}
+
+func (sm *stateManager) fetchComponentsPartial(ctx workflow.Context, is *pkgstate.State) error {
+	installComps, err := activities.AwaitGetInstallComponentIDsByInstallID(ctx, sm.installID)
+	if err != nil {
+		return errors.Wrap(err, "unable to get install components")
+	}
+
+	comps := pkgstate.NewComponentsState()
+	comps.Populated = true
+
+	for _, instCmpID := range installComps {
+		installComp, err := activities.AwaitGetInstallComponentStateByInstallComponentID(ctx, instCmpID)
+		if err != nil {
+			return errors.Wrap(err, "unable to get install component state")
+		}
+
+		st := pkgstate.NewComponentState()
+		st.Name = installComp.Component.Name
+		st.Populated = true
+		st.ComponentID = installComp.ComponentID
+		st.InstallComponentID = installComp.ID
+		if len(installComp.InstallDeploys) > 0 {
+			st.Status = string(installComp.InstallDeploys[0].Status)
+			st.BuildID = string(installComp.InstallDeploys[0].ComponentBuildID)
+			st.Outputs = installComp.InstallDeploys[0].Outputs
+		}
+		comps.Components[installComp.Component.Name] = st
+	}
+
+	is.Components = make(map[string]any)
+	for name, c := range comps.Components {
+		cMap, err := pkgstate.AsMap(c)
+		if err != nil {
+			return errors.Wrap(err, "unable to create map")
+		}
+		is.Components[name] = cMap
+	}
+	return nil
+}
+
+func (sm *stateManager) fetchSandboxPartial(ctx workflow.Context, is *pkgstate.State) error {
+	sandboxRun, err := activities.AwaitGetInstallSandboxRunStateByInstallID(ctx, sm.installID)
+	if err != nil {
+		if strings.Contains(err.Error(), gorm.ErrRecordNotFound.Error()) {
+			is.Sandbox = &pkgstate.SandboxState{}
+			return nil
+		}
+		return errors.Wrap(err, "unable to get sandbox run")
+	}
+
+	st := pkgstate.NewSandboxState()
+	st.Populated = true
+	st.Status = string(sandboxRun.Status)
+	st.Outputs = sandboxRun.Outputs
+
+	publicVCSConfig := sandboxRun.AppSandboxConfig.PublicGitVCSConfig
+	connectedVCSConfig := sandboxRun.AppSandboxConfig.ConnectedGithubVCSConfig
+	if publicVCSConfig != nil {
+		st.Type = publicVCSConfig.Directory
+		st.Version = publicVCSConfig.Branch
+	}
+	if connectedVCSConfig != nil {
+		st.Type = connectedVCSConfig.Directory
+		st.Version = connectedVCSConfig.Branch
+	}
+	is.Sandbox = st
+	return nil
+}
+
+func (sm *stateManager) fetchStackPartial(ctx workflow.Context, is *pkgstate.State) error {
+	stack, err := activities.AwaitGetInstallStackStateByInstallID(ctx, sm.installID)
+	if err != nil {
+		return errors.Wrap(err, "unable to get stack")
+	}
+
+	is.InstallStack = toInstallStackState(stack)
+	return nil
+}
+
+func (sm *stateManager) fetchSecretsPartial(ctx workflow.Context, is *pkgstate.State) error {
+	runnerJob, err := activities.AwaitGetSecretsSyncJobByInstallID(ctx, sm.installID)
+	if err != nil {
+		if strings.Contains(err.Error(), gorm.ErrRecordNotFound.Error()) {
+			is.Secrets = &pkgstate.SecretsState{}
+			return nil
+		}
+		return errors.Wrap(err, "unable to get secrets state")
+	}
+
+	var secretsState pkgstate.SecretsState
+	decoderConfig := &mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToSliceHookFunc(","),
+			mapstructure.StringToTimeDurationHookFunc(),
+			mapstructure.StringToTimeHookFunc(time.RFC3339Nano),
+			pkggenerics.StringToMapDecodeHook(),
+		),
+		WeaklyTypedInput: true,
+		Result:           &secretsState,
+	}
+	decoder, err := mapstructure.NewDecoder(decoderConfig)
+	if err != nil {
+		return errors.Wrap(err, "unable to create decoder")
+	}
+	if err := decoder.Decode(runnerJob.ParsedOutputs); err != nil {
+		return errors.Wrap(err, "unable to parse secrets outputs")
+	}
+	is.Secrets = &secretsState
+	return nil
+}
+
+// Helper functions ported from the old state package.
+
+func toInputState(inputs *app.InstallInputs, cfg *app.AppConfig, redacted bool) *pkgstate.InputsState {
+	inputValues := inputs.Values
+	if redacted {
+		inputValues = inputs.ValuesRedacted
+	}
+	if inputs == nil || len(inputValues) < 1 {
+		return nil
+	}
+
+	is := pkgstate.NewInputsState()
+	for _, inp := range cfg.InputConfig.AppInputs {
+		val, ok := inputValues[inp.Name]
+		if !ok {
+			val = &inp.Default
+		}
+		is.Inputs[inp.Name] = pkggenerics.FromPtrStr(val)
+	}
+	return is
+}
+
+func toInstallStackState(stack *app.InstallStack) *pkgstate.InstallStackState {
+	if stack == nil || len(stack.InstallStackVersions) < 1 {
+		return nil
+	}
+
+	is := pkgstate.NewInstallStackState()
+	is.Populated = true
+
+	version := stack.InstallStackVersions[0]
+	is.QuickLinkURL = version.QuickLinkURL
+	is.TemplateURL = version.TemplateURL
+	is.TemplateJSON = string(version.Contents)
+	is.Checksum = version.Checksum
+	is.Status = string(version.Status.Status)
+	is.Outputs = stack.InstallStackOutputs.DataContents
+	return is
+}
+
+func mapLegacyFields(is *pkgstate.State) {
+	is.Install = &pkgstate.InstallState{
+		Populated: true,
+		ID:        is.ID,
+		Name:      is.Name,
+	}
+	if is.Sandbox != nil {
+		is.Install.Sandbox = *is.Sandbox
+	}
+	if is.Domain != nil {
+		is.Install.PublicDomain = is.Domain.PublicDomain
+		is.Install.InternalDomain = is.Domain.InternalDomain
+	}
+	if is.Inputs != nil {
+		is.Install.Inputs = is.Inputs.Inputs
+	}
+}

--- a/services/ctl-api/internal/pkg/state/state_manager_handlers.go
+++ b/services/ctl-api/internal/pkg/state/state_manager_handlers.go
@@ -1,0 +1,180 @@
+package state
+
+import (
+	"fmt"
+
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/pkg/errors"
+
+	stateactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state/activities"
+)
+
+type handlerType string
+
+const (
+	handlerTypeQuery  handlerType = "query"
+	handlerTypeUpdate handlerType = "update"
+)
+
+type handler struct {
+	typ              handlerType
+	handler          any
+	handlerValidator any
+}
+
+func (sm *stateManager) registerHandlers(ctx workflow.Context) error {
+	handlers := map[string]handler{
+		ForceRegenerateUpdateName: {handlerTypeUpdate, sm.forceRegenerateHandler, nil},
+		RegenerateUpdateName:      {handlerTypeUpdate, sm.regenerateHandler, nil},
+		HintUpdateName:            {handlerTypeUpdate, sm.hintHandler, nil},
+		FetchStateUpdateName:      {handlerTypeUpdate, sm.fetchStateHandler, nil},
+		StatusQueryName:           {handlerTypeQuery, sm.statusHandler, nil},
+		StopUpdateName:            {handlerTypeUpdate, sm.stopHandler, nil},
+		RestartUpdateName:         {handlerTypeUpdate, sm.restartHandler, nil},
+	}
+
+	for name, h := range handlers {
+		switch h.typ {
+		case handlerTypeQuery:
+			if err := workflow.SetQueryHandler(ctx, name, h.handler); err != nil {
+				return errors.Wrapf(err, "unable to create query handler %s", name)
+			}
+		case handlerTypeUpdate:
+			opts := workflow.UpdateHandlerOptions{
+				Validator: h.handlerValidator,
+			}
+			if err := workflow.SetUpdateHandlerWithOptions(ctx, name, h.handler, opts); err != nil {
+				return errors.Wrapf(err, "unable to create update handler %s", name)
+			}
+		}
+	}
+
+	return nil
+}
+
+// forceRegenerateHandler rebuilds all partials from scratch.
+func (sm *stateManager) forceRegenerateHandler(ctx workflow.Context, req *ForceRegenerateRequest) (*ForceRegenerateResponse, error) {
+	if err := workflow.Await(ctx, func() bool { return sm.ready }); err != nil {
+		return nil, err
+	}
+
+	updated, err := sm.executeRegeneration(ctx, allPartialsSet())
+	if err != nil {
+		return nil, errors.Wrap(err, "force regeneration failed")
+	}
+	_ = updated
+
+	return &ForceRegenerateResponse{
+		State:       sm.state.CachedState,
+		GeneratedAt: sm.state.LastGeneratedAt,
+	}, nil
+}
+
+// regenerateHandler checks all partials for changes and updates stale ones.
+func (sm *stateManager) regenerateHandler(ctx workflow.Context, req *RegenerateRequest) (*RegenerateResponse, error) {
+	if err := workflow.Await(ctx, func() bool { return sm.ready }); err != nil {
+		return nil, err
+	}
+
+	// Check each partial for modifications.
+	stalePartials := make(map[PartialName]bool)
+	for _, partial := range AllPartials {
+		lastKnown := sm.state.LastModifiedAt[partial]
+		resp, err := stateactivities.AwaitCheckModified(ctx, &stateactivities.CheckModifiedRequest{
+			InstallID:   sm.installID,
+			PartialName: string(partial),
+			LastKnownAt: lastKnown,
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to check modified for %s", partial)
+		}
+		if resp.Changed {
+			stalePartials[partial] = true
+		}
+	}
+
+	var updatedPartials []PartialName
+	if len(stalePartials) > 0 {
+		var err error
+		updatedPartials, err = sm.executeRegeneration(ctx, stalePartials)
+		if err != nil {
+			return nil, errors.Wrap(err, "regeneration failed")
+		}
+	}
+
+	return &RegenerateResponse{
+		State:           sm.state.CachedState,
+		UpdatedPartials: updatedPartials,
+		GeneratedAt:     sm.state.LastGeneratedAt,
+	}, nil
+}
+
+// hintHandler regenerates the partials affected by a specific change.
+func (sm *stateManager) hintHandler(ctx workflow.Context, req *HintRequest) (*HintResponse, error) {
+	if err := workflow.Await(ctx, func() bool { return sm.ready }); err != nil {
+		return nil, err
+	}
+
+	partials, ok := HintToPartials[req.HintType]
+	if !ok {
+		return nil, fmt.Errorf("unknown hint type: %s", req.HintType)
+	}
+
+	partialsToRegen := make(map[PartialName]bool, len(partials))
+	for _, p := range partials {
+		partialsToRegen[p] = true
+	}
+
+	updatedPartials, err := sm.executeRegeneration(ctx, partialsToRegen)
+	if err != nil {
+		return nil, errors.Wrap(err, "hint regeneration failed")
+	}
+
+	return &HintResponse{
+		State:           sm.state.CachedState,
+		UpdatedPartials: updatedPartials,
+		GeneratedAt:     sm.state.LastGeneratedAt,
+	}, nil
+}
+
+// fetchStateHandler returns the current cached state without regenerating.
+// If no cached state exists, triggers a full regeneration first.
+func (sm *stateManager) fetchStateHandler(ctx workflow.Context, req *FetchStateRequest) (*FetchStateResponse, error) {
+	if err := workflow.Await(ctx, func() bool { return sm.ready }); err != nil {
+		return nil, err
+	}
+
+	if sm.state.CachedState == nil {
+		if _, err := sm.executeRegeneration(ctx, allPartialsSet()); err != nil {
+			return nil, errors.Wrap(err, "unable to generate state for fetch")
+		}
+	}
+
+	return &FetchStateResponse{
+		State:       sm.state.CachedState,
+		GeneratedAt: sm.state.LastGeneratedAt,
+	}, nil
+}
+
+// statusHandler returns workflow metadata.
+func (sm *stateManager) statusHandler() (*StatusResponse, error) {
+	return &StatusResponse{
+		Ready:           sm.ready,
+		LastGeneratedAt: sm.state.LastGeneratedAt,
+		GenerationCount: sm.state.GenerationCount,
+		LastModifiedAt:  sm.state.LastModifiedAt,
+	}, nil
+}
+
+// stopHandler terminates the workflow.
+func (sm *stateManager) stopHandler(ctx workflow.Context, req *StopRequest) (*StopResponse, error) {
+	sm.stopped = true
+	return &StopResponse{}, nil
+}
+
+// restartHandler triggers continue-as-new.
+func (sm *stateManager) restartHandler(ctx workflow.Context, req *RestartRequest) (*RestartResponse, error) {
+	sm.restarted = true
+	return &RestartResponse{}, nil
+}

--- a/services/ctl-api/internal/pkg/state/state_manager_run.go
+++ b/services/ctl-api/internal/pkg/state/state_manager_run.go
@@ -1,0 +1,97 @@
+package state
+
+import (
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+)
+
+const stateManagerIdleTimeout = 30 * time.Minute
+
+type stateManager struct {
+	installID string
+	state     *StateManagerState
+	workflows *Workflows
+
+	ready     bool
+	stopped   bool
+	restarted bool
+
+	// pendingPartials accumulates partials that need regeneration from hints.
+	pendingPartials map[PartialName]bool
+
+	// forceRegenerate flags a full rebuild on next cycle.
+	forceRegenerate bool
+}
+
+func (sm *stateManager) run(ctx workflow.Context) (bool, error) {
+	l, err := log.WorkflowLogger(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	l.Info("state-manager: verifying install exists", zap.String("install_id", sm.installID))
+	if _, err := activities.AwaitGetByInstallID(ctx, sm.installID); err != nil {
+		return true, errors.Wrap(err, "install not found, terminating state-manager")
+	}
+
+	l.Info("state-manager: registering handlers")
+	if err := sm.registerHandlers(ctx); err != nil {
+		return false, errors.Wrap(err, "unable to register handlers")
+	}
+
+	// First run: generate full state if no cached state exists.
+	if sm.state.CachedState == nil {
+		l.Info("state-manager: no cached state, performing full generation")
+		if _, err := sm.executeRegeneration(ctx, allPartialsSet()); err != nil {
+			return false, errors.Wrap(err, "unable to perform initial state generation")
+		}
+	}
+
+	sm.ready = true
+	l.Info("state-manager: ready")
+
+	// Wait for work or exit conditions.
+	if _, err := workflow.AwaitWithTimeout(ctx, stateManagerIdleTimeout, func() bool {
+		return sm.restarted || sm.stopped || len(sm.pendingPartials) > 0 || sm.forceRegenerate
+	}); err != nil {
+		return false, err
+	}
+
+	if sm.stopped {
+		l.Info("state-manager: stopped")
+		return true, nil
+	}
+	if sm.restarted {
+		l.Info("state-manager: restarting via continue-as-new")
+		return false, nil
+	}
+
+	// Process pending work.
+	if sm.forceRegenerate || len(sm.pendingPartials) > 0 {
+		partials := sm.drainPendingPartials()
+		if sm.forceRegenerate {
+			partials = allPartialsSet()
+			sm.forceRegenerate = false
+		}
+		if _, err := sm.executeRegeneration(ctx, partials); err != nil {
+			l.Error("state-manager: regeneration failed", zap.Error(err))
+			return false, errors.Wrap(err, "regeneration failed")
+		}
+	}
+
+	// Continue-as-new after processing work (or idle timeout).
+	return false, nil
+}
+
+func (sm *stateManager) drainPendingPartials() map[PartialName]bool {
+	drained := sm.pendingPartials
+	sm.pendingPartials = make(map[PartialName]bool)
+	return drained
+}

--- a/services/ctl-api/internal/pkg/state/types.go
+++ b/services/ctl-api/internal/pkg/state/types.go
@@ -1,0 +1,88 @@
+package state
+
+import (
+	"time"
+
+	pkgstate "github.com/nuonco/nuon/pkg/types/state"
+)
+
+// StateManagerRequest is the input to the StateManager workflow.
+type StateManagerRequest struct {
+	InstallID string
+	State     *StateManagerState
+}
+
+// StateManagerState is carried between continue-as-new cycles.
+type StateManagerState struct {
+	// LastModifiedAt tracks the last-known updated_at per partial.
+	LastModifiedAt map[PartialName]time.Time
+
+	// CachedState holds the last-generated full state.
+	CachedState *pkgstate.State
+
+	// LastGeneratedAt tracks when the state was last persisted.
+	LastGeneratedAt time.Time
+
+	// GenerationCount tracks total generations for diagnostics.
+	GenerationCount int64
+}
+
+// Update handler names.
+const (
+	ForceRegenerateUpdateName = "force-regenerate"
+	RegenerateUpdateName      = "regenerate"
+	HintUpdateName            = "hint"
+	FetchStateUpdateName      = "fetch-state"
+	StatusQueryName           = "status"
+	StopUpdateName            = "stop"
+	RestartUpdateName         = "restart"
+)
+
+// ForceRegenerate — full rebuild of all partials.
+type ForceRegenerateRequest struct{}
+type ForceRegenerateResponse struct {
+	State       *pkgstate.State
+	GeneratedAt time.Time
+}
+
+// Regenerate — check all partials for changes, update stale ones.
+type RegenerateRequest struct{}
+type RegenerateResponse struct {
+	State           *pkgstate.State
+	UpdatedPartials []PartialName
+	GeneratedAt     time.Time
+}
+
+// Hint — targeted regeneration based on what changed.
+type HintRequest struct {
+	HintType HintType
+	EntityID string
+}
+type HintResponse struct {
+	State           *pkgstate.State
+	UpdatedPartials []PartialName
+	GeneratedAt     time.Time
+}
+
+// FetchState — return the current cached state without regenerating.
+type FetchStateRequest struct{}
+type FetchStateResponse struct {
+	State       *pkgstate.State
+	GeneratedAt time.Time
+}
+
+// Status — query workflow metadata (lightweight).
+type StatusResponse struct {
+	Ready           bool
+	LastGeneratedAt time.Time
+	GenerationCount int64
+	LastModifiedAt  map[PartialName]time.Time
+}
+
+// Stop — terminate the workflow.
+type StopRequest struct{}
+type StopResponse struct{}
+
+// Restart — trigger continue-as-new.
+type RestartRequest struct{}
+type RestartResponse struct{}

--- a/services/ctl-api/internal/pkg/workflows/activities.go
+++ b/services/ctl-api/internal/pkg/workflows/activities.go
@@ -8,6 +8,7 @@ import (
 	emitteractivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/emitter/activities"
 	handleractivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+	stateactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	jobactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job/activities"
 	signalsactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/signals/activities"
@@ -33,6 +34,7 @@ type Params struct {
 	HandlerActs               *handleractivities.Activities
 	SignalsActivities         *signalsactivities.Activities
 	SignalLifecycleActivities *signal.SignalLifecycleActivities
+	StateActivities           *stateactivities.Activities
 }
 
 type Activities struct {
@@ -46,6 +48,7 @@ type Activities struct {
 	HandlerActivities         *handleractivities.Activities
 	QueueClient               *queueclient.Client
 	SignalLifecycleActivities *signal.SignalLifecycleActivities
+	StateActivities           *stateactivities.Activities
 }
 
 func (a *Activities) AllActivities() []any {
@@ -60,6 +63,7 @@ func (a *Activities) AllActivities() []any {
 		a.HandlerActivities,
 		a.QueueClient,
 		a.SignalLifecycleActivities,
+		a.StateActivities,
 	}
 }
 
@@ -75,5 +79,6 @@ func NewActivities(params Params) *Activities {
 		HandlerActivities:         params.HandlerActs,
 		QueueClient:               params.QueueClient,
 		SignalLifecycleActivities: params.SignalLifecycleActivities,
+		StateActivities:           params.StateActivities,
 	}
 }

--- a/services/ctl-api/internal/pkg/workflows/workflows.go
+++ b/services/ctl-api/internal/pkg/workflows/workflows.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue"
 	queueemitter "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/emitter"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler"
+	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow"
 )
@@ -18,6 +19,7 @@ type WorkflowParams struct {
 	QueueWorkflows        *queue.Workflows
 	QueueEmitterWorkflows *queueemitter.Workflows
 	HandlerWorkflows      *handler.Workflows
+	StateManagerWorkflows *statemanager.Workflows
 }
 
 type Workflows struct {
@@ -26,6 +28,7 @@ type Workflows struct {
 	queueWorkflows        *queue.Workflows
 	queueemitterWorkflows *queueemitter.Workflows
 	handlerWorkflows      *handler.Workflows
+	stateManagerWorkflows *statemanager.Workflows
 }
 
 func (w *Workflows) AllWorkflows() []interface{} {
@@ -41,6 +44,7 @@ func (w *Workflows) AllWorkflows() []interface{} {
 	wkflows = append(wkflows, w.queueWorkflows.All()...)
 	wkflows = append(wkflows, w.queueemitterWorkflows.All()...)
 	wkflows = append(wkflows, w.handlerWorkflows.All()...)
+	wkflows = append(wkflows, w.stateManagerWorkflows.All()...)
 
 	return wkflows
 }
@@ -52,5 +56,6 @@ func NewWorkflows(params WorkflowParams) *Workflows {
 		queueWorkflows:        params.QueueWorkflows,
 		queueemitterWorkflows: params.QueueEmitterWorkflows,
 		handlerWorkflows:      params.HandlerWorkflows,
+		stateManagerWorkflows: params.StateManagerWorkflows,
 	}
 }


### PR DESCRIPTION
This PR introduces a long-lived state manager workflow for each install. The goal is to power more real-time 
capabilities with the state by a.) making it faster and b.) powering procedural updates.

Currently, whenever we run a workflow we do a full state regeneration at just about every step. The reason for this is 
so that we do _not_ run into situations where the state is ever stale, or for whatever reason not accurate.

This gives us consistency, but does come at a cost - for large installs (think, the Nuon app itself) with dozens of 
components and actions, we may be loading a significant amount of data over and over again, causing slowness in a 
workflow. With this change, we can power install updates procedurally so the state is always guaranteed fresh, but not 
always regenerated.

We do this with a long-lived temporal workflow that we run for each install. Instead of an install needing to regenerate 
the state for each step, we can simply send hints to the workflow engine and then use an update handler to fetch the 
state whenever needed (though, it's still in the database).
