### PR TITLE
fix: do not continue-as-new each minute

### DIFF
--- a/services/ctl-api/internal/pkg/queue/run.go
+++ b/services/ctl-api/internal/pkg/queue/run.go
@@ -19,6 +19,8 @@ var statusTimestampKeys = []string{
 	"finished_at",
 }
 
+var maxAliveTime time.Duration = time.Hour * 24 * 7
+
 func (q *queue) run(ctx workflow.Context) (bool, error) {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
@@ -62,7 +64,7 @@ func (q *queue) run(ctx workflow.Context) (bool, error) {
 
 	q.ready = true
 
-	if _, err := workflow.AwaitWithTimeout(ctx, queueReceiveTimeout, func() bool {
+	if _, err := workflow.AwaitWithTimeout(ctx, maxAliveTime, func() bool {
 		return (q.restarted || q.stopped || q.isIdle(ctx)) && q.activeWorkers == 0
 	}); err != nil {
 		return false, err

--- a/services/ctl-api/internal/pkg/queue/worker.go
+++ b/services/ctl-api/internal/pkg/queue/worker.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	queueReceiveTimeout     time.Duration = time.Minute * 1
+	queueReceiveTimeout     time.Duration = time.Minute * 5
 	defaultQueueIdleTimeout time.Duration = time.Minute * 10
 )
 


### PR DESCRIPTION
This fixes an issue where all queues could restart each minute, even mid execution causing the child signals to be 
reprocessed endlessly.
