### PR TITLE
refactor(ui): layout headers

### DIFF
--- a/services/dashboard-ui/client/components/builds/BuildHeader/BuildHeader.tsx
+++ b/services/dashboard-ui/client/components/builds/BuildHeader/BuildHeader.tsx
@@ -1,5 +1,4 @@
 import { BackLink } from '@/components/common/BackLink'
-import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Duration } from '@/components/common/Duration'
 import { Icon } from '@/components/common/Icon'
 import { ID } from '@/components/common/ID'
@@ -25,36 +24,10 @@ interface IBuildHeader {
 
 export const BuildHeader = ({ component, build, app }: IBuildHeader) => {
   return (
-    <header className="p-6 border-b flex justify-between">
-      <HeadingGroup>
-        <BackLink className="mb-6" />
-        <div className="flex flex-col gap-1">
-          <span className="flex items-center gap-2">
-            <ComponentType type={component?.type} displayVariant="icon-only" />
-            <Text variant="base" weight="strong">
-              {component?.name} build
-            </Text>
-          </span>
-          <ID>{build?.id}</ID>
-        </div>
-        <div className="flex gap-8 items-center justify-start mt-2">
-          <Text theme="info" flex className="gap-1">
-            <Icon variant="CalendarBlankIcon" />
-            <Time variant="subtext" time={build.created_at} />
-          </Text>
-          <Text theme="info" flex className="gap-1">
-            <Icon variant="TimerIcon" />
-            <Duration
-              variant="subtext"
-              beginTime={build.created_at}
-              endTime={build.updated_at}
-            />
-          </Text>
-        </div>
-      </HeadingGroup>
-
-      <div className="flex flex-col gap-6">
-        <div className="flex gap-6 items-start justify-start">
+    <header className="p-6 border-b flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <BackLink />
+        <div className="flex items-center gap-6">
           <LabeledStatus
             label="Status"
             statusProps={{
@@ -67,7 +40,7 @@ export const BuildHeader = ({ component, build, app }: IBuildHeader) => {
                   {toSentenceCase(build?.status_v2?.status_human_description)}
                 </Text>
               ),
-              position: 'left',
+              position: 'bottom',
             }}
           />
           <LabeledValue label="App">
@@ -95,29 +68,54 @@ export const BuildHeader = ({ component, build, app }: IBuildHeader) => {
               <CommitDetails commit={build?.vcs_connection_commit} />
             </LabeledValue>
           ) : null}
+        </div>
+      </div>
 
-          {build?.runner_job ? (
-            <RunnerJobPlanButton
-              buttonText="Build plan"
-              runnerJobId={build?.runner_job?.id}
-            />
-          ) : null}
-
-          {build?.runner_job &&
-          build?.status_v2?.status !== 'active' &&
-          build?.status_v2?.status !== 'error' ? (
-            <CancelRunnerJobButton
-              jobType="build"
-              runnerJob={build?.runner_job}
-            />
-          ) : null}
-
-          {build?.queue_signal ? (
-            <AdminDashboardLink
-              path={`/queue-signals?search=${build.id}`}
-              label="View signal"
-            />
-          ) : null}
+      <div className="flex flex-col gap-1">
+        <span className="flex items-center gap-2">
+          <ComponentType type={component?.type} displayVariant="icon-only" />
+          <Text variant="base" weight="strong">
+            {component?.name} build
+          </Text>
+        </span>
+        <ID>{build?.id}</ID>
+        <div className="flex items-center justify-between mt-1">
+          <div className="flex gap-8 items-center">
+            <Text theme="info" flex className="gap-1">
+              <Icon variant="CalendarBlankIcon" />
+              <Time variant="subtext" time={build.created_at} />
+            </Text>
+            <Text theme="info" flex className="gap-1">
+              <Icon variant="TimerIcon" />
+              <Duration
+                variant="subtext"
+                beginTime={build.created_at}
+                endTime={build.updated_at}
+              />
+            </Text>
+          </div>
+          <div className="flex items-center gap-4">
+            {build?.runner_job &&
+            build?.status_v2?.status !== 'active' &&
+            build?.status_v2?.status !== 'error' ? (
+              <CancelRunnerJobButton
+                jobType="build"
+                runnerJob={build?.runner_job}
+              />
+            ) : null}
+            {build?.queue_signal ? (
+              <AdminDashboardLink
+                path={`/queue-signals?search=${build.id}`}
+                label="View signal"
+              />
+            ) : null}
+            {build?.runner_job ? (
+              <RunnerJobPlanButton
+                buttonText="Build plan"
+                runnerJobId={build?.runner_job?.id}
+              />
+            ) : null}
+          </div>
         </div>
       </div>
     </header>

--- a/services/dashboard-ui/client/components/common/ContextTooltip.tsx
+++ b/services/dashboard-ui/client/components/common/ContextTooltip.tsx
@@ -9,7 +9,7 @@ export type TContextTooltipItem = {
   id: string
   href?: string
   leftContent?: ReactNode
-  title: string
+  title: string | ReactNode
   subtitle?: string | ReactNode
   rightContent?: ReactNode
   onClick?: () => void

--- a/services/dashboard-ui/client/components/deploys/DeployHeader/DeployHeader.tsx
+++ b/services/dashboard-ui/client/components/deploys/DeployHeader/DeployHeader.tsx
@@ -2,7 +2,6 @@ import { BackLink } from '@/components/common/BackLink'
 import { Button } from '@/components/common/Button'
 import { CommitDetails } from '@/components/common/CommitDetails'
 import { Duration } from '@/components/common/Duration'
-import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Icon } from '@/components/common/Icon'
 import { ID } from '@/components/common/ID'
 import { LabeledValue } from '@/components/common/LabeledValue'
@@ -34,60 +33,10 @@ export const DeployHeader = ({
   install,
 }: IDeployHeader) => {
   return (
-    <header className="p-6 border-b flex justify-between">
-      <HeadingGroup>
-        <BackLink className="mb-6" />
-        <div className="flex flex-col gap-1">
-          <span className="flex items-cenert gap-2">
-            <ComponentType type={component?.type} displayVariant="icon-only" />
-            <Text variant="base" weight="strong">
-              {deploy?.component_name}{' '}
-              {deploy?.install_deploy_type === 'teardown'
-                ? 'teardown'
-                : 'deploy'}
-            </Text>
-          </span>
-          <ID>{deploy?.id}</ID>
-        </div>
-        <div className="flex gap-8 items-center justify-start my-2">
-          <Text theme="info" flex className="gap-1">
-            <Icon variant="CalendarBlankIcon" />
-            <Time variant="subtext" time={deploy?.created_at} />
-          </Text>
-          <Text theme="info" flex className="gap-1">
-            <Icon variant="TimerIcon" />
-            <Duration
-              variant="subtext"
-              beginTime={deploy?.created_at}
-              endTime={deploy?.updated_at}
-            />
-          </Text>
-          {deploy?.runner_jobs?.at(0)?.install_role_usage?.role_name ? (
-            <Text theme="info" flex className="gap-1">
-              <Icon variant="FileLockIcon" />
-              <Text variant="subtext">{deploy.runner_jobs.at(0).install_role_usage.role_name}</Text>
-            </Text>
-          ) : null}
-          <ID>
-            <Link
-              href={`/${deploy?.org_id}/apps/${install?.app_id}/components/${deploy?.component_id}/builds/${deploy?.build_id}`}
-            >
-              {deploy?.build_id}
-            </Link>
-          </ID>
-        </div>
-        {deploy?.install_workflow_id ? (
-          <Button
-            href={`/${deploy?.org_id}/installs/${deploy?.install_id}/workflows/${workflow?.id}?panel=${stepId}`}
-          >
-            View workflow
-            <Icon variant="CaretRightIcon" />
-          </Button>
-        ) : null}
-      </HeadingGroup>
-
-      <div className="flex flex-col gap-6">
-        <div className="flex gap-6 items-start justify-start">
+    <header className="p-6 border-b flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <BackLink />
+        <div className="flex gap-6 items-center">
           <LabeledStatus
             label="Status"
             statusProps={{
@@ -103,7 +52,6 @@ export const DeployHeader = ({
               position: 'bottom',
             }}
           />
-
           <LabeledValue label="Install">
             <Text variant="subtext">
               <Link href={`/${deploy?.org_id}/installs/${deploy?.install_id}`}>
@@ -133,7 +81,6 @@ export const DeployHeader = ({
               />
             </LabeledValue>
           ) : null}
-
           {deploy?.oci_artifact ? (
             <LabeledValue label="OCI Artifact">
               <OCIArtifactCard ociArtifact={deploy?.oci_artifact}>
@@ -148,12 +95,77 @@ export const DeployHeader = ({
               </OCIArtifactCard>
             </LabeledValue>
           ) : null}
+        </div>
+      </div>
 
+      <div className="flex flex-col gap-1">
+        <span className="flex items-center gap-2">
+          <ComponentType type={component?.type} displayVariant="icon-only" />
+          <Text variant="base" weight="strong">
+            {deploy?.component_name}{' '}
+            {deploy?.install_deploy_type === 'teardown'
+              ? 'teardown'
+              : 'deploy'}
+          </Text>
+        </span>
+        <span className="flex items-center gap-4">
+          <ID>{deploy?.id}</ID>
+          <Text
+            className="!flex gap-2"
+            variant="subtext"
+            theme="neutral"
+            family="mono"
+          >
+            Build:
+            <ID>
+              <Link
+                href={`/${deploy?.org_id}/apps/${install?.app_id}/components/${deploy?.component_id}/builds/${deploy?.build_id}`}
+              >
+                {deploy?.build_id}
+              </Link>
+            </ID>
+          </Text>
+        </span>
+        <div className="flex gap-8 items-center mt-1">
+          <Text theme="info" flex className="gap-1">
+            <Icon variant="CalendarBlankIcon" />
+            <Time variant="subtext" time={deploy?.created_at} />
+          </Text>
+          <Text theme="info" flex className="gap-1">
+            <Icon variant="TimerIcon" />
+            <Duration
+              variant="subtext"
+              beginTime={deploy?.created_at}
+              endTime={deploy?.updated_at}
+            />
+          </Text>
+          {deploy?.runner_jobs?.at(0)?.install_role_usage?.role_name ? (
+            <Text theme="info" flex className="gap-1">
+              <Icon variant="FileLockIcon" />
+              <Text variant="subtext">
+                {deploy.runner_jobs.at(0).install_role_usage.role_name}
+              </Text>
+            </Text>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        {deploy?.install_workflow_id ? (
+          <Button
+            href={`/${deploy?.org_id}/installs/${deploy?.install_id}/workflows/${workflow?.id}?panel=${stepId}`}
+          >
+            View workflow
+            <Icon variant="CaretRightIcon" />
+          </Button>
+        ) : (
+          <div />
+        )}
+        <div className="flex gap-4 items-center">
           <DeploySwitcher
             componentId={deploy?.component_id}
             deployId={deploy?.id}
           />
-
           <ManagementDropdown
             component={component}
             currentBuildId={deploy?.build_id}

--- a/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.stories.tsx
+++ b/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.stories.tsx
@@ -17,6 +17,21 @@ const mockInstall = {
   install_sandbox_runs: [],
 } as any
 
+const mockInstallMixed = {
+  ...mockInstall,
+  runner_status: 'failed',
+  sandbox_status: 'executing',
+  composite_component_status: 'active',
+  drifted_objects: [
+    {
+      target_id: 'deploy-1',
+      target_type: 'install_deploy',
+      component_name: 'web-server',
+      install_workflow_id: 'wf-1',
+    },
+  ],
+} as any
+
 export const BadgeVariant = () => (
   <InstallStatuses install={mockInstall} variant="badge" />
 )
@@ -27,6 +42,24 @@ export const IconVariant = () => (
 
 export const LabelHidden = () => (
   <InstallStatuses install={mockInstall} isLabelHidden />
+)
+
+export const WideContainer = () => (
+  <div className="w-[600px] border border-dashed p-2">
+    <InstallStatuses install={mockInstall} variant="badge" />
+  </div>
+)
+
+export const NarrowContainer = () => (
+  <div className="w-64 border border-dashed p-2">
+    <InstallStatuses install={mockInstall} variant="badge" />
+  </div>
+)
+
+export const NarrowMixedStatuses = () => (
+  <div className="w-64 border border-dashed p-2">
+    <InstallStatuses install={mockInstallMixed} variant="badge" />
+  </div>
 )
 
 export const Simple = () => (

--- a/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.tsx
+++ b/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.tsx
@@ -21,6 +21,7 @@ import { toSentenceCase } from '@/utils/string-utils'
 
 export interface IInstallStatuses
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+  collapsible?: boolean
   isLabelHidden?: boolean
   tooltipPosition?: ITooltip['position']
   variant?: 'badge' | 'icon'
@@ -84,6 +85,7 @@ function getTooltip({
 
 export const InstallStatuses = ({
   className,
+  collapsible = false,
   install,
   isLabelHidden = false,
   tooltipPosition = 'bottom',
@@ -405,29 +407,36 @@ export const InstallStatuses = ({
     },
   ]
 
+  const expandedContent = (
+    <div className={cn('flex items-center flex-wrap gap-2', { 'hidden @5xl:flex': collapsible })}>
+      {install?.drifted_objects ? wrap('Drift detection', driftContent) : null}
+      {stackContent ? wrap('Stack', stackContent) : null}
+      {wrap('Runner', runnerContent)}
+      {wrap('Sandbox', sandboxContent)}
+      {wrap('Components', componentsContent)}
+    </div>
+  )
+
+  const collapsedContent = collapsible ? (
+    <div className="flex @5xl:hidden">
+      <LabeledValue label="Status">
+        <ContextTooltip
+          title="Install status"
+          items={compositeItems}
+          position={tooltipPosition}
+        >
+          <Status status={worstStatus} variant="badge">
+            {worstStatus}
+          </Status>
+        </ContextTooltip>
+      </LabeledValue>
+    </div>
+  ) : null
+
   return (
     <div className={cn(className)} {...props}>
-      <div className="hidden @5xl:flex items-center flex-wrap gap-2">
-        {install?.drifted_objects ? wrap('Drift detection', driftContent) : null}
-        {stackContent ? wrap('Stack', stackContent) : null}
-        {wrap('Runner', runnerContent)}
-        {wrap('Sandbox', sandboxContent)}
-        {wrap('Components', componentsContent)}
-      </div>
-
-      <div className="flex @5xl:hidden">
-        <LabeledValue label="Status">
-          <ContextTooltip
-            title="Install status"
-            items={compositeItems}
-            position={tooltipPosition}
-          >
-            <Status status={worstStatus} variant="badge">
-              {worstStatus}
-            </Status>
-          </ContextTooltip>
-        </LabeledValue>
-      </div>
+      {expandedContent}
+      {collapsedContent}
     </div>
   )
 }

--- a/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.tsx
+++ b/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.tsx
@@ -16,7 +16,7 @@ import type { TInstall, TInstallComponent, TInstallStack } from '@/types'
 import { cn } from '@/utils/classnames'
 import { Time } from '@/components/common/Time'
 import { getInstallStatusTitle } from '@/utils/install-utils'
-import { getStatusTheme } from '@/utils/status-utils'
+import { getStatusTheme, getWorstStatusTheme } from '@/utils/status-utils'
 import { toSentenceCase } from '@/utils/string-utils'
 
 export interface IInstallStatuses
@@ -305,13 +305,129 @@ export const InstallStatuses = ({
       <LabeledValue label={label}>{content}</LabeledValue>
     )
 
+  const allStatuses = [
+    install?.drifted_objects?.length ? 'warn' : 'active',
+    stackStatus,
+    install?.runner_status,
+    install?.sandbox_status,
+    install?.composite_component_status,
+  ]
+  const { worstStatus } = getWorstStatusTheme(allStatuses)
+
+  const compositeItems = [
+    ...(install?.drifted_objects
+      ? [
+          {
+            id: 'drift',
+            title: 'Drift detection',
+            subtitle: install.drifted_objects.length
+              ? 'Drift detected'
+              : 'No drift',
+            href: install.drifted_objects.length
+              ? `/${install.org_id}/installs/${install.id}/workflows`
+              : undefined,
+            leftContent: (
+              <Status
+                status={install.drifted_objects.length ? 'warn' : 'active'}
+                isWithoutText
+                variant="timeline"
+                iconSize={16}
+              />
+            ),
+          },
+        ]
+      : []),
+    ...(stackStatus
+      ? [
+          {
+            id: 'stack',
+            title: 'Stack',
+            subtitle: toSentenceCase(stackStatus),
+            href: `/${install.org_id}/installs/${install.id}/stacks`,
+            leftContent: (
+              <Status
+                status={stackStatus}
+                isWithoutText
+                variant="timeline"
+                iconSize={16}
+              />
+            ),
+          },
+        ]
+      : []),
+    {
+      id: 'runner',
+      title: 'Runner',
+      subtitle: getInstallStatusTitle('runner_status', install?.runner_status),
+      href: `/${install.org_id}/installs/${install.id}/runner`,
+      leftContent: (
+        <Status
+          status={install?.runner_status}
+          isWithoutText
+          variant="timeline"
+          iconSize={16}
+        />
+      ),
+    },
+    {
+      id: 'sandbox',
+      title: 'Sandbox',
+      subtitle: getInstallStatusTitle(
+        'sandbox_status',
+        install?.sandbox_status
+      ),
+      href: `/${install.org_id}/installs/${install.id}/sandbox`,
+      leftContent: (
+        <Status
+          status={install?.sandbox_status}
+          isWithoutText
+          variant="timeline"
+          iconSize={16}
+        />
+      ),
+    },
+    {
+      id: 'components',
+      title: 'Components',
+      subtitle: getInstallStatusTitle(
+        'composite_component_status',
+        install?.composite_component_status
+      ),
+      href: `/${install.org_id}/installs/${install.id}/components`,
+      leftContent: (
+        <Status
+          status={install?.composite_component_status}
+          isWithoutText
+          variant="timeline"
+          iconSize={16}
+        />
+      ),
+    },
+  ]
+
   return (
-    <div className={cn('flex items-center flex-wrap gap-2', className)} {...props}>
-      {install?.drifted_objects ? wrap('Drift detection', driftContent) : null}
-      {stackContent ? wrap('Stack', stackContent) : null}
-      {wrap('Runner', runnerContent)}
-      {wrap('Sandbox', sandboxContent)}
-      {wrap('Components', componentsContent)}
+    <div className={cn(className)} {...props}>
+      <div className="hidden @5xl:flex items-center flex-wrap gap-2">
+        {install?.drifted_objects ? wrap('Drift detection', driftContent) : null}
+        {stackContent ? wrap('Stack', stackContent) : null}
+        {wrap('Runner', runnerContent)}
+        {wrap('Sandbox', sandboxContent)}
+        {wrap('Components', componentsContent)}
+      </div>
+
+      <div className="flex @5xl:hidden">
+        <LabeledValue label="Status">
+          <ContextTooltip
+            title="Install status"
+            items={compositeItems}
+            position={tooltipPosition}
+          >
+            <Status status={worstStatus} variant="badge">
+              {worstStatus}
+            </Status>
+          </ContextTooltip>
+        </LabeledValue>
+      </div>
     </div>
   )
 }

--- a/services/dashboard-ui/client/components/layout/MainSidebar.tsx
+++ b/services/dashboard-ui/client/components/layout/MainSidebar.tsx
@@ -47,7 +47,7 @@ export const MainSidebar = ({
           </>
         )}
 
-        <div className="flex flex-auto items-end md:hidden">
+        <div className="flex flex-auto items-end lg:hidden">
           <UserDropdown
             alignment="left"
             className="!w-full"

--- a/services/dashboard-ui/client/components/layout/MainTopbar.tsx
+++ b/services/dashboard-ui/client/components/layout/MainTopbar.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { UserDropdown } from '@/components/users/UserDropdown'
 import { SpotlightTrigger } from '@/components/spotlight/SpotlightTrigger'
 import { Badge } from '@/components/common/Badge'
+import { Icon } from '@/components/common/Icon'
 import { Tooltip } from '@/components/common/Tooltip'
 import { Text } from '@/components/common/Text'
 import { useOrg } from '@/hooks/use-org'
@@ -43,9 +44,10 @@ export const MainTopbar = ({
         )}
         {children}
 
-        <div className="hidden md:flex items-center gap-4 ml-auto">
+        <div className="hidden lg:flex items-center gap-4 ml-auto shrink-0">
           {org?.sandbox_mode && (
             <Tooltip
+              tipContentClassName="max-w-64"
               tipContent={
                 <Text variant="subtext">
                   This organization is running in sandbox mode. Installs are simulated instead of deploying to a real cloud account.
@@ -53,8 +55,9 @@ export const MainTopbar = ({
               }
               position="bottom"
             >
-              <Badge variant="code" theme="neutral">
-                Sandbox mode
+              <Badge variant="code" theme="neutral" size="sm" className="shrink-0">
+                <Icon variant="TestTube" size={14} className="xl:hidden" />
+                <span className="hidden xl:inline whitespace-nowrap">Sandbox mode</span>
               </Badge>
             </Tooltip>
           )}

--- a/services/dashboard-ui/client/components/navigation/Breadcrumb.tsx
+++ b/services/dashboard-ui/client/components/navigation/Breadcrumb.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { ContextTooltip } from '@/components/common/ContextTooltip'
 import { Icon } from '@/components/common/Icon'
 import { Link } from '@/components/common/Link'
 import { Skeleton } from '@/components/common/Skeleton'
@@ -6,33 +7,167 @@ import { Text } from '@/components/common/Text'
 import { useBreadcrumb } from '@/hooks/use-breadcrumb'
 import type { TNavLink } from '@/types'
 
+const Separator = () => <Icon variant="CaretRight" className="muted" />
+
+const BreadcrumbItem = ({
+  crumb,
+  isLast,
+  isLoading,
+}: {
+  crumb: TNavLink
+  isLast: boolean
+  isLoading: boolean
+}) => (
+  <Text weight="strong">
+    {isLoading ? (
+      <Skeleton
+        height="17px"
+        width={`${crumb?.text?.length * 16 * 0.6}px`}
+        maxWidth="200px"
+      />
+    ) : (
+      <Link
+        href={crumb.path}
+        isActive={isLast}
+        variant="breadcrumb"
+        className="truncate max-w-48 inline-block align-bottom"
+      >
+        {crumb.text}
+      </Link>
+    )}
+  </Text>
+)
+
+const GAP = 8 // gap-2
+const ELLIPSIS_ITEM_WIDTH = 40
+
+function computeCollapseCount(
+  availableWidth: number,
+  itemWidths: number[]
+): number {
+  if (itemWidths.length <= 2) return 0
+
+  const totalWidth = itemWidths.reduce(
+    (sum, w, i) => sum + w + (i > 0 ? GAP : 0),
+    0
+  )
+  if (totalWidth <= availableWidth) return 0
+
+  let hideCount = 0
+  let currentWidth = totalWidth
+
+  for (let i = 1; i < itemWidths.length - 1; i++) {
+    if (currentWidth <= availableWidth) break
+    currentWidth -= itemWidths[i] + GAP
+    if (hideCount === 0) currentWidth += ELLIPSIS_ITEM_WIDTH + GAP
+    hideCount++
+  }
+
+  return Math.min(hideCount, itemWidths.length - 2)
+}
+
+function useCollapsedCount(
+  navRef: React.RefObject<HTMLElement | null>,
+  listRef: React.RefObject<HTMLOListElement | null>,
+  totalItems: number
+) {
+  const [collapsedCount, setCollapsedCount] = useState(0)
+  const itemWidthsRef = useRef<number[]>([])
+  const prevTotalRef = useRef(totalItems)
+
+  // When breadcrumb items change, clear cached widths and show all for measurement
+  if (prevTotalRef.current !== totalItems) {
+    prevTotalRef.current = totalItems
+    itemWidthsRef.current = []
+    setCollapsedCount(0)
+  }
+
+  useEffect(() => {
+    const nav = navRef.current
+    const list = listRef.current
+    if (!nav || !list) return
+
+    const ro = new ResizeObserver(() => {
+      // If no cached widths yet, we're in measurement mode (all items visible)
+      if (itemWidthsRef.current.length === 0) {
+        const items = Array.from(list.children) as HTMLElement[]
+        if (items.length === 0) return
+        itemWidthsRef.current = items.map(
+          (el) => el.getBoundingClientRect().width
+        )
+      }
+
+      const count = computeCollapseCount(
+        nav.clientWidth,
+        itemWidthsRef.current
+      )
+      setCollapsedCount(count)
+    })
+    ro.observe(nav)
+    return () => ro.disconnect()
+  }, [navRef, listRef, totalItems])
+
+  return collapsedCount
+}
+
 export const BreadcrumbNav = () => {
   const { breadcrumbLinks, isLoading } = useBreadcrumb()
-  const Separator = () => <Icon variant="CaretRight" className="muted" />
+  const navRef = useRef<HTMLElement>(null)
+  const listRef = useRef<HTMLOListElement>(null)
+  const collapsedCount = useCollapsedCount(
+    navRef,
+    listRef,
+    breadcrumbLinks.length
+  )
+
+  const firstCrumb = breadcrumbLinks[0]
+  if (!firstCrumb) return null
+
+  const shouldCollapse = collapsedCount > 0
+  const collapsedCrumbs = shouldCollapse
+    ? breadcrumbLinks.slice(1, 1 + collapsedCount)
+    : []
+  const visibleTail = shouldCollapse
+    ? breadcrumbLinks.slice(1 + collapsedCount)
+    : breadcrumbLinks.slice(1)
 
   return (
-    <nav aria-label="Breadcrumb" className="max-w-[1000px] truncate">
-      <ol className="flex gap-2">
-        {breadcrumbLinks.map((crumb, idx) => (
-          <li key={`${crumb.path}-${idx}`} className="flex items-center gap-2">
-            {idx > 0 && <Separator />}
-            <Text weight="strong">
-              {isLoading ? (
-                <Skeleton
-                  height="17px"
-                  width={`${crumb?.text?.length * 16 * 0.6}px`}
-                  maxWidth="200px"
-                />
-              ) : (
-                <Link
-                  href={crumb.path}
-                  isActive={idx === breadcrumbLinks?.length - 1}
-                  variant="breadcrumb"
-                >
-                  {crumb.text}
-                </Link>
-              )}
-            </Text>
+    <nav ref={navRef} aria-label="Breadcrumb" className="flex-1 min-w-0 overflow-hidden">
+      <ol ref={listRef} className="flex items-center gap-2 w-max">
+        <li className="flex items-center gap-2">
+          <BreadcrumbItem
+            crumb={firstCrumb}
+            isLast={breadcrumbLinks.length === 1}
+            isLoading={isLoading}
+          />
+        </li>
+
+        {shouldCollapse && (
+          <li className="flex items-center gap-2">
+            <Separator />
+            <ContextTooltip
+              items={collapsedCrumbs.map((crumb) => ({
+                id: crumb.path,
+                title: <Text weight="strong">{crumb.text}</Text>,
+                href: crumb.path,
+              }))}
+              position="bottom"
+            >
+              <Text weight="strong" className="cursor-default">
+                …
+              </Text>
+            </ContextTooltip>
+          </li>
+        )}
+
+        {visibleTail.map((crumb, idx) => (
+          <li key={crumb.path} className="flex items-center gap-2">
+            <Separator />
+            <BreadcrumbItem
+              crumb={crumb}
+              isLast={idx === visibleTail.length - 1}
+              isLoading={isLoading}
+            />
           </li>
         ))}
       </ol>

--- a/services/dashboard-ui/client/components/sandbox/SandboxHeader/SandboxHeader.tsx
+++ b/services/dashboard-ui/client/components/sandbox/SandboxHeader/SandboxHeader.tsx
@@ -1,7 +1,6 @@
 import { BackLink } from '@/components/common/BackLink'
 import { Button } from '@/components/common/Button'
 import { Duration } from '@/components/common/Duration'
-import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Icon } from '@/components/common/Icon'
 import { ID } from '@/components/common/ID'
 import { LabeledValue } from '@/components/common/LabeledValue'
@@ -33,9 +32,9 @@ export const SandboxHeader = ({
 }: ISandboxHeader) => {
   return (
     <header className="flex flex-col p-6 border-b gap-4">
-      <div className="flex items-start justify-between">
+      <div className="flex items-center justify-between">
         <BackLink />
-        <div className="flex items-start gap-6">
+        <div className="flex items-center gap-6">
           <LabeledStatus
             label="Status"
             statusProps={{
@@ -50,10 +49,9 @@ export const SandboxHeader = ({
                   )}
                 </Text>
               ),
-              position: 'left',
+              position: 'bottom',
             }}
           />
-
           <LabeledValue label="Install">
             <Text variant="subtext">
               <Link href={`/${orgId}/installs/${install?.id}`}>
@@ -73,35 +71,22 @@ export const SandboxHeader = ({
               </Text>
             </SandboxConfigContextTooltip>
           </LabeledValue>
-          <SandboxRunSwitcher sandboxRunId={sandboxRun?.id} />
-          <ManageRunDropdown
-            workflow={workflow}
-            variant="primary"
-          />
         </div>
       </div>
 
-      <HeadingGroup>
-        <div className="flex flex-col gap-1">
-          <span className="flex items-center gap-2">
-            <CloudPlatform
-              platform={install.cloud_platform as TCloudPlatform}
-              variant="subtext"
-              displayVariant="icon-only"
-            />
-            <Text
-              flex
-              className="gap-4"
-              variant="h3"
-              weight="strong"
-            >
-              Sandbox {sandboxRun?.run_type}
-            </Text>
-          </span>
-          <ID>{sandboxRun?.id}</ID>
-        </div>
-
-        <div className="flex flex-wrap gap-x-8 gap-y-1 items-center justify-start my-2">
+      <div className="flex flex-col gap-1">
+        <span className="flex items-center gap-2">
+          <CloudPlatform
+            platform={install.cloud_platform as TCloudPlatform}
+            variant="subtext"
+            displayVariant="icon-only"
+          />
+          <Text variant="base" weight="strong">
+            Sandbox {sandboxRun?.run_type}
+          </Text>
+        </span>
+        <ID>{sandboxRun?.id}</ID>
+        <div className="flex flex-wrap gap-x-8 gap-y-1 items-center mt-1">
           <Text theme="info" flex className="gap-1">
             <Icon variant="CalendarBlankIcon" />
             <Time variant="subtext" time={sandboxRun?.created_at} />
@@ -121,7 +106,9 @@ export const SandboxHeader = ({
             </Text>
           ) : null}
         </div>
+      </div>
 
+      <div className="flex items-center justify-between">
         {sandboxRun?.install_workflow_id ? (
           <Button
             href={`/${orgId}/installs/${install?.id}/workflows/${workflow?.id}?panel=${stepId}`}
@@ -129,8 +116,17 @@ export const SandboxHeader = ({
             View workflow
             <Icon variant="CaretRightIcon" />
           </Button>
-        ) : null}
-      </HeadingGroup>
+        ) : (
+          <div />
+        )}
+        <div className="flex gap-4 items-center">
+          <SandboxRunSwitcher sandboxRunId={sandboxRun?.id} />
+          <ManageRunDropdown
+            workflow={workflow}
+            variant="primary"
+          />
+        </div>
+      </div>
     </header>
   )
 }

--- a/services/dashboard-ui/client/utils/status-utils.ts
+++ b/services/dashboard-ui/client/utils/status-utils.ts
@@ -153,3 +153,35 @@ export function getStatusTheme(status: string): TStatusTheme {
 export function getStatusIconVariant(status: string): TIconVariant {
   return STATUS_ICON_MAP[status] ?? 'ClockCountdown'
 }
+
+const THEME_PRIORITY: TStatusTheme[] = [
+  'error',
+  'warn',
+  'info',
+  'neutral',
+  'success',
+]
+
+export function getWorstStatusTheme(
+  statuses: (string | undefined)[]
+): { theme: TStatusTheme; worstStatus: string } {
+  const defined = statuses.filter((s): s is string => s !== undefined)
+  if (defined.length === 0) return { theme: 'neutral', worstStatus: 'unknown' }
+
+  let worstIdx = THEME_PRIORITY.length
+  let worstStatus = defined[0]
+
+  for (const status of defined) {
+    const theme = getStatusTheme(status)
+    const idx = THEME_PRIORITY.indexOf(theme)
+    if (idx < worstIdx) {
+      worstIdx = idx
+      worstStatus = status
+    }
+  }
+
+  return {
+    theme: THEME_PRIORITY[worstIdx] ?? 'neutral',
+    worstStatus,
+  }
+}

--- a/services/dashboard-ui/client/views/install/ActionDetail.tsx
+++ b/services/dashboard-ui/client/views/install/ActionDetail.tsx
@@ -57,7 +57,7 @@ export const ActionDetail = () => {
     action?.action_workflow?.configs?.[0]?.enable_kube_config
 
   return (
-    <PageSection flush>
+    <PageSection flush className="flex-1">
       <PageTitle
         title={`${action?.action_workflow?.name ?? 'Action'} | ${install?.name}`}
       />
@@ -144,7 +144,7 @@ export const ActionDetail = () => {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-12 flex-auto divide-x">
+      <div className="grid grid-cols-1 md:grid-cols-12 flex-1 divide-x">
         <PageSection className="md:col-span-8">
           <Text variant="base" weight="strong">
             Run history

--- a/services/dashboard-ui/client/views/install/DeployDetail.tsx
+++ b/services/dashboard-ui/client/views/install/DeployDetail.tsx
@@ -57,10 +57,14 @@ const DeployDetailContent = ({ componentId }: { componentId: string }) => {
   const logStream = deploy?.log_stream
   const stepStatus = step?.status?.status
   const isTerminal = stepStatus === 'error' || stepStatus === 'cancelled' || stepStatus === 'discarded'
+  const isAutoApprove =
+    step?.approval?.type === 'approve-all' ||
+    step?.approval?.response?.type === 'auto-approve'
   const pendingApproval =
     step?.approval && !step?.approval?.response && !responded && !isTerminal && stepStatus !== 'auto-skipped'
   const completedApproval =
     step?.approval && (!!step?.approval?.response || responded) && !isTerminal && stepStatus !== 'auto-skipped'
+  const showPlanBelow = completedApproval || isAutoApprove
 
   return (
     <PageSection flush>
@@ -86,7 +90,7 @@ const DeployDetailContent = ({ componentId }: { componentId: string }) => {
 
       <PageSection className="!pb-12">
         <div className="flex flex-col gap-6">
-          {pendingApproval ? (
+          {pendingApproval && !isAutoApprove ? (
             <div className="flex flex-col gap-4">
               <ApprovalBanner step={step} />
               <Plan step={step} />
@@ -105,9 +109,9 @@ const DeployDetailContent = ({ componentId }: { componentId: string }) => {
             <LogsSkeleton />
           )}
 
-          {completedApproval ? (
+          {showPlanBelow && step ? (
             <div className="flex flex-col gap-4">
-              <ApprovalBanner step={step} />
+              {!isAutoApprove && <ApprovalBanner step={step} />}
               <Plan step={step} />
             </div>
           ) : null}

--- a/services/dashboard-ui/client/views/install/InstallLayout.tsx
+++ b/services/dashboard-ui/client/views/install/InstallLayout.tsx
@@ -157,7 +157,7 @@ const InstallTemplate = () => {
                     </Link>
                   </Text>
                 </LabeledValue>
-                <InstallStatusesContainer />
+                <InstallStatusesContainer collapsible />
                 <InstallManagementDropdown />
               </div>
             </div>

--- a/services/dashboard-ui/client/views/install/InstallLayout.tsx
+++ b/services/dashboard-ui/client/views/install/InstallLayout.tsx
@@ -112,7 +112,7 @@ const InstallTemplate = () => {
       ) : (
         <>
           <PageHeader>
-            <div className="flex flex-col gap-4 w-full md:flex-row md:justify-between">
+            <div className="@container flex flex-col gap-4 w-full md:flex-row md:justify-between">
               <HeadingGroup>
                 <div className="flex items-center gap-2 flex-wrap">
                   <Text variant="h3" weight="stronger" level={1}>

--- a/services/dashboard-ui/client/views/install/Overview.tsx
+++ b/services/dashboard-ui/client/views/install/Overview.tsx
@@ -30,7 +30,6 @@ export const Overview = () => {
           { path: `/${org?.id}`, text: org?.name },
           { path: `/${org?.id}/installs`, text: 'Installs' },
           { path: `/${org?.id}/installs/${install?.id}`, text: install?.name },
-          { path: `/${org?.id}/installs/${install?.id}`, text: install?.name },
         ]}
       />
 

--- a/services/dashboard-ui/client/views/install/SandboxRunDetail.tsx
+++ b/services/dashboard-ui/client/views/install/SandboxRunDetail.tsx
@@ -49,10 +49,14 @@ const SandboxRunDetailContent = () => {
   const logStream = sandboxRun?.log_stream
   const stepStatus = step?.status?.status
   const isTerminal = stepStatus === 'error' || stepStatus === 'cancelled' || stepStatus === 'discarded'
+  const isAutoApprove =
+    step?.approval?.type === 'approve-all' ||
+    step?.approval?.response?.type === 'auto-approve'
   const pendingApproval =
     step?.approval && !step?.approval?.response && !responded && !isTerminal && stepStatus !== 'auto-skipped'
   const completedApproval =
     step?.approval && (!!step?.approval?.response || responded) && !isTerminal && stepStatus !== 'auto-skipped'
+  const showPlanBelow = completedApproval || isAutoApprove
 
   return (
     <PageSection flush>
@@ -74,7 +78,7 @@ const SandboxRunDetailContent = () => {
 
       <PageSection className="!pb-12">
         <div className="flex flex-col gap-6">
-          {pendingApproval ? (
+          {pendingApproval && !isAutoApprove ? (
             <div className="flex flex-col gap-4">
               <ApprovalBanner step={step} />
               <Plan step={step} />
@@ -93,9 +97,9 @@ const SandboxRunDetailContent = () => {
             <LogsSkeleton />
           )}
 
-          {completedApproval ? (
+          {showPlanBelow && step ? (
             <div className="flex flex-col gap-4">
-              <ApprovalBanner step={step} />
+              {!isAutoApprove && <ApprovalBanner step={step} />}
               <Plan step={step} />
             </div>
           ) : null}


### PR DESCRIPTION
- Improves the install layout header by collapsing the install statuses on smaller screens
- Improves the main topbar by collapsing the sandbox mode badge on smaller screens
- Breadcrumbs will collapse when they become too large
- Improved the header layout of build, deploy & sandbox run pages
- Fix issue where we hide the user dropdown on small screens but didn't show it in the sidebar.
- More small layout adjustments