### PR TITLE
fix: tune hearbeat timeouts

### DIFF
--- a/services/ctl-api/internal/pkg/queue/client/await_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/await_signal.go
@@ -19,7 +19,7 @@ import (
 // @temporal-gen-v2 activity
 // @start-to-close-timeout 5m
 // @schedule-to-close-timeout 2h
-// @heartbeat-timeout 10s
+// @heartbeat-timeout 30s
 func (c *Client) AwaitSignal(ctx context.Context, queueSignalID string) (*handler.FinishedResponse, error) {
 	q, err := c.getQueueSignal(ctx, queueSignalID)
 	if err != nil {
@@ -36,7 +36,7 @@ func (c *Client) AwaitSignal(ctx context.Context, queueSignalID string) (*handle
 		return &handler.FinishedResponse{}, nil
 	}
 
-	return heartbeat.WithHeartbeat(ctx, 3*time.Second, func(ctx context.Context) (*handler.FinishedResponse, error) {
+	return heartbeat.WithHeartbeat(ctx, 10*time.Second, func(ctx context.Context) (*handler.FinishedResponse, error) {
 		rawResp, err := c.tClient.UpdateWorkflowInNamespace(ctx, q.Workflow.Namespace, tclient.UpdateWorkflowOptions{
 			UpdateID:     queueSignalID + "-finished",
 			WorkflowID:   q.Workflow.ID,

--- a/services/ctl-api/internal/pkg/queue/client/fetch_steps.go
+++ b/services/ctl-api/internal/pkg/queue/client/fetch_steps.go
@@ -21,7 +21,7 @@ type FetchStepsRequest struct {
 
 // @temporal-gen-v2 activity
 // @start-to-close-timeout 2m
-// @heartbeat-timeout 10s
+// @heartbeat-timeout 30s
 func (c *Client) FetchSteps(ctx context.Context, req FetchStepsRequest) (*app.GenerateStepsResult, error) {
 	q, err := c.getQueueSignal(ctx, req.QueueSignalID)
 	if err != nil {
@@ -46,7 +46,7 @@ func (c *Client) FetchSteps(ctx context.Context, req FetchStepsRequest) (*app.Ge
 		activity.RecordHeartbeat(ctx, runID)
 	}
 
-	return heartbeat.WithHeartbeat(ctx, 3*time.Second, func(ctx context.Context) (*app.GenerateStepsResult, error) {
+	return heartbeat.WithHeartbeat(ctx, 10*time.Second, func(ctx context.Context) (*app.GenerateStepsResult, error) {
 		rawResp, err := c.tClient.UpdateWorkflowInNamespace(ctx, q.Workflow.Namespace, tclient.UpdateWorkflowOptions{
 			WorkflowID:   q.Workflow.ID,
 			RunID:        runID,

--- a/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__execute.go
@@ -17,12 +17,12 @@ import (
 // @temporal-gen-v2 activity
 // @start-to-close-timeout 5m
 // @schedule-to-close-timeout 2h
-// @heartbeat-timeout 10s
+// @heartbeat-timeout 30s
 // @as-wrapper
 // @wrapper-prefix HandlerInternal
 // @by-field WorkflowID
 func (a *Activities) updateWorkflowExecute(ctx context.Context, workflowID string, updateID string, queueID string, runID string) (*handler.ExecuteResponse, error) {
-	return heartbeat.WithHeartbeat(ctx, 3*time.Second, func(ctx context.Context) (*handler.ExecuteResponse, error) {
+	return heartbeat.WithHeartbeat(ctx, 10*time.Second, func(ctx context.Context) (*handler.ExecuteResponse, error) {
 		info := activity.GetInfo(ctx)
 
 		rawResp, err := a.tclient.UpdateWorkflowInNamespace(ctx,

--- a/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/activities/update_workflow__validate.go
@@ -17,12 +17,12 @@ import (
 // @temporal-gen-v2 activity
 // @start-to-close-timeout 5m
 // @schedule-to-close-timeout 2h
-// @heartbeat-timeout 10s
+// @heartbeat-timeout 30s
 // @as-wrapper
 // @wrapper-prefix HandlerInternal
 // @by-field WorkflowID
 func (a *Activities) updateWorkflowValidate(ctx context.Context, workflowID string, updateID string, queueID string, runID string) (*handler.ValidateResponse, error) {
-	return heartbeat.WithHeartbeat(ctx, 3*time.Second, func(ctx context.Context) (*handler.ValidateResponse, error) {
+	return heartbeat.WithHeartbeat(ctx, 10*time.Second, func(ctx context.Context) (*handler.ValidateResponse, error) {
 		info := activity.GetInfo(ctx)
 
 		rawResp, err := a.tclient.UpdateWorkflowInNamespace(ctx,

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_group_finished.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_group_finished.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	enumsv1 "go.temporal.io/api/enums/v1"
 	tclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 
@@ -43,33 +44,6 @@ func (a *Activities) ForwardGroupFinished(ctx context.Context, req ForwardGroupF
 	if res.Error != nil {
 		return nil, fmt.Errorf("unable to find group queue signal for group %s: %w", req.StepGroupID, res.Error)
 	}
-
-	return heartbeat.WithHeartbeat(ctx, 10*time.Second, func(ctx context.Context) (*GroupFinishedResponse, error) {
-		startOp := a.tClient.NewWithStartWorkflowOperation(
-			tclient.StartWorkflowOptions{
- 				ID:                       qs.Workflow.ID,
- 				TaskQueue:                "api",
- 				WorkflowIDConflictPolicy: enumsv1.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
- 				RetryPolicy: &temporal.RetryPolicy{
- 					MaximumAttempts: 0,
- 				},
- 			},
- 			"Handler",
- 			handler.HandlerRequest{
- 				QueueID:       qs.QueueID,
- 				QueueSignalID: qs.ID,
- 			},
- 		)
- 
- 		rawResp, err := a.tClient.UpdateWithStartWorkflowInNamespace(ctx, qs.Workflow.Namespace,
- 			tclient.UpdateWithStartWorkflowOptions{
- 				UpdateOptions: tclient.UpdateWorkflowOptions{
- 					WorkflowID:   qs.Workflow.ID,
- 					UpdateName:   "group-finished",
- 					WaitForStage: tclient.WorkflowUpdateStageCompleted,
- 				},
- 				StartWorkflowOperation: startOp,
- 			})
 
 	return heartbeat.WithHeartbeat(ctx, 10*time.Second, func(ctx context.Context) (*GroupFinishedResponse, error) {
 		startOp := a.tClient.NewWithStartWorkflowOperation(

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_group_finished.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_group_finished.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	enumsv1 "go.temporal.io/api/enums/v1"
 	tclient "go.temporal.io/sdk/client"
-	"go.temporal.io/sdk/temporal"
 
 	"github.com/nuonco/nuon/pkg/temporal/heartbeat"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -46,31 +44,10 @@ func (a *Activities) ForwardGroupFinished(ctx context.Context, req ForwardGroupF
 	}
 
 	return heartbeat.WithHeartbeat(ctx, 10*time.Second, func(ctx context.Context) (*GroupFinishedResponse, error) {
-		startOp := a.tClient.NewWithStartWorkflowOperation(
-			tclient.StartWorkflowOptions{
-				ID:                       qs.Workflow.ID,
-				TaskQueue:                "api",
-				WorkflowIDConflictPolicy: enumsv1.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
-				RetryPolicy: &temporal.RetryPolicy{
-					MaximumAttempts: 0,
-				},
-			},
-			"Handler",
-			handler.HandlerRequest{
-				QueueID:       qs.QueueID,
-				QueueSignalID: qs.ID,
-			},
-		)
-
-		rawResp, err := a.tClient.UpdateWithStartWorkflowInNamespace(ctx, qs.Workflow.Namespace,
-			tclient.UpdateWithStartWorkflowOptions{
-				UpdateOptions: tclient.UpdateWorkflowOptions{
-					WorkflowID:   qs.Workflow.ID,
-					UpdateName:   "group-finished",
-					WaitForStage: tclient.WorkflowUpdateStageCompleted,
-				},
-				StartWorkflowOperation: startOp,
-			})
+		rawResp, err := handler.UpdateWithStart(ctx, a.tClient, &qs, handler.UpdateWithStartOptions{
+			UpdateName:   "group-finished",
+			WaitForStage: tclient.WorkflowUpdateStageCompleted,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("unable to send group-finished update to group %s: %w", req.StepGroupID, err)
 		}

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_group_finished.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_group_finished.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	tclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 
 	"github.com/nuonco/nuon/pkg/temporal/heartbeat"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -28,7 +29,7 @@ type GroupFinishedResponse struct {
 // @temporal-gen-v2 activity
 // @start-to-close-timeout 5m
 // @schedule-to-close-timeout 2h
-// @heartbeat-timeout 10s
+// @heartbeat-timeout 30s
 func (a *Activities) ForwardGroupFinished(ctx context.Context, req ForwardGroupFinishedRequest) (*GroupFinishedResponse, error) {
 	var qs app.QueueSignal
 	res := a.db.WithContext(ctx).
@@ -43,11 +44,59 @@ func (a *Activities) ForwardGroupFinished(ctx context.Context, req ForwardGroupF
 		return nil, fmt.Errorf("unable to find group queue signal for group %s: %w", req.StepGroupID, res.Error)
 	}
 
-	return heartbeat.WithHeartbeat(ctx, 3*time.Second, func(ctx context.Context) (*GroupFinishedResponse, error) {
-		rawResp, err := handler.UpdateWithStart(ctx, a.tClient, &qs, handler.UpdateWithStartOptions{
-			UpdateName:   "group-finished",
-			WaitForStage: tclient.WorkflowUpdateStageCompleted,
-		})
+	return heartbeat.WithHeartbeat(ctx, 10*time.Second, func(ctx context.Context) (*GroupFinishedResponse, error) {
+		startOp := a.tClient.NewWithStartWorkflowOperation(
+			tclient.StartWorkflowOptions{
+ 				ID:                       qs.Workflow.ID,
+ 				TaskQueue:                "api",
+ 				WorkflowIDConflictPolicy: enumsv1.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+ 				RetryPolicy: &temporal.RetryPolicy{
+ 					MaximumAttempts: 0,
+ 				},
+ 			},
+ 			"Handler",
+ 			handler.HandlerRequest{
+ 				QueueID:       qs.QueueID,
+ 				QueueSignalID: qs.ID,
+ 			},
+ 		)
+ 
+ 		rawResp, err := a.tClient.UpdateWithStartWorkflowInNamespace(ctx, qs.Workflow.Namespace,
+ 			tclient.UpdateWithStartWorkflowOptions{
+ 				UpdateOptions: tclient.UpdateWorkflowOptions{
+ 					WorkflowID:   qs.Workflow.ID,
+ 					UpdateName:   "group-finished",
+ 					WaitForStage: tclient.WorkflowUpdateStageCompleted,
+ 				},
+ 				StartWorkflowOperation: startOp,
+ 			})
+
+	return heartbeat.WithHeartbeat(ctx, 10*time.Second, func(ctx context.Context) (*GroupFinishedResponse, error) {
+		startOp := a.tClient.NewWithStartWorkflowOperation(
+			tclient.StartWorkflowOptions{
+				ID:                       qs.Workflow.ID,
+				TaskQueue:                "api",
+				WorkflowIDConflictPolicy: enumsv1.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+				RetryPolicy: &temporal.RetryPolicy{
+					MaximumAttempts: 0,
+				},
+			},
+			"Handler",
+			handler.HandlerRequest{
+				QueueID:       qs.QueueID,
+				QueueSignalID: qs.ID,
+			},
+		)
+
+		rawResp, err := a.tClient.UpdateWithStartWorkflowInNamespace(ctx, qs.Workflow.Namespace,
+			tclient.UpdateWithStartWorkflowOptions{
+				UpdateOptions: tclient.UpdateWorkflowOptions{
+					WorkflowID:   qs.Workflow.ID,
+					UpdateName:   "group-finished",
+					WaitForStage: tclient.WorkflowUpdateStageCompleted,
+				},
+				StartWorkflowOperation: startOp,
+			})
 		if err != nil {
 			return nil, fmt.Errorf("unable to send group-finished update to group %s: %w", req.StepGroupID, err)
 		}

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_step_finished.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_step_finished.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	enumsv1 "go.temporal.io/api/enums/v1"
 	tclient "go.temporal.io/sdk/client"
-	"go.temporal.io/sdk/temporal"
 
 	"github.com/nuonco/nuon/pkg/temporal/heartbeat"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -48,31 +46,10 @@ func (a *Activities) ForwardStepFinished(ctx context.Context, req ForwardStepFin
 	}
 
 	return heartbeat.WithHeartbeat(ctx, 10*time.Second, func(ctx context.Context) (*StepFinishedResponse, error) {
-		startOp := a.tClient.NewWithStartWorkflowOperation(
-			tclient.StartWorkflowOptions{
-				ID:                       qs.Workflow.ID,
-				TaskQueue:                "api",
-				WorkflowIDConflictPolicy: enumsv1.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
-				RetryPolicy: &temporal.RetryPolicy{
-					MaximumAttempts: 0,
-				},
-			},
-			"Handler",
-			handler.HandlerRequest{
-				QueueID:       qs.QueueID,
-				QueueSignalID: qs.ID,
-			},
-		)
-
-		rawResp, err := a.tClient.UpdateWithStartWorkflowInNamespace(ctx, qs.Workflow.Namespace,
-			tclient.UpdateWithStartWorkflowOptions{
-				UpdateOptions: tclient.UpdateWorkflowOptions{
-					WorkflowID:   qs.Workflow.ID,
-					UpdateName:   "step-finished",
-					WaitForStage: tclient.WorkflowUpdateStageCompleted,
-				},
-				StartWorkflowOperation: startOp,
-			})
+		rawResp, err := handler.UpdateWithStart(ctx, a.tClient, &qs, handler.UpdateWithStartOptions{
+			UpdateName:   "step-finished",
+			WaitForStage: tclient.WorkflowUpdateStageCompleted,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("unable to send step-finished update to step %s: %w", req.StepID, err)
 		}

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_step_finished.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_step_finished.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	tclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 
 	"github.com/nuonco/nuon/pkg/temporal/heartbeat"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -30,7 +31,7 @@ type StepFinishedResponse struct {
 // @temporal-gen-v2 activity
 // @start-to-close-timeout 5m
 // @schedule-to-close-timeout 2h
-// @heartbeat-timeout 10s
+// @heartbeat-timeout 30s
 func (a *Activities) ForwardStepFinished(ctx context.Context, req ForwardStepFinishedRequest) (*StepFinishedResponse, error) {
 	var qs app.QueueSignal
 	res := a.db.WithContext(ctx).
@@ -45,11 +46,32 @@ func (a *Activities) ForwardStepFinished(ctx context.Context, req ForwardStepFin
 		return nil, fmt.Errorf("unable to find step queue signal for step %s: %w", req.StepID, res.Error)
 	}
 
-	return heartbeat.WithHeartbeat(ctx, 3*time.Second, func(ctx context.Context) (*StepFinishedResponse, error) {
-		rawResp, err := handler.UpdateWithStart(ctx, a.tClient, &qs, handler.UpdateWithStartOptions{
-			UpdateName:   "step-finished",
-			WaitForStage: tclient.WorkflowUpdateStageCompleted,
-		})
+	return heartbeat.WithHeartbeat(ctx, 10*time.Second, func(ctx context.Context) (*StepFinishedResponse, error) {
+		startOp := a.tClient.NewWithStartWorkflowOperation(
+			tclient.StartWorkflowOptions{
+				ID:                       qs.Workflow.ID,
+				TaskQueue:                "api",
+				WorkflowIDConflictPolicy: enumsv1.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+				RetryPolicy: &temporal.RetryPolicy{
+					MaximumAttempts: 0,
+				},
+			},
+			"Handler",
+			handler.HandlerRequest{
+				QueueID:       qs.QueueID,
+				QueueSignalID: qs.ID,
+			},
+		)
+
+		rawResp, err := a.tClient.UpdateWithStartWorkflowInNamespace(ctx, qs.Workflow.Namespace,
+			tclient.UpdateWithStartWorkflowOptions{
+				UpdateOptions: tclient.UpdateWorkflowOptions{
+					WorkflowID:   qs.Workflow.ID,
+					UpdateName:   "step-finished",
+					WaitForStage: tclient.WorkflowUpdateStageCompleted,
+				},
+				StartWorkflowOperation: startOp,
+			})
 		if err != nil {
 			return nil, fmt.Errorf("unable to send step-finished update to step %s: %w", req.StepID, err)
 		}

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_step_finished.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_step_finished.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	enumsv1 "go.temporal.io/api/enums/v1"
 	tclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 


### PR DESCRIPTION
The SDK throttles outbound heartbeats to min(heartbeat_timeout × 0.8, 60s). So the @heartbeat-timeout annotation directly governs the per-activity outbound RPC rate.

With this change, we get ~3× reduction in heartbeat RPCs per active activity. 30s is Temporal's commonly recommended default for long-running activities. Cost: worker-crash and cancel detection moves from ~10s to ~30s  & is negligible for these blocking-RPC activities.

Why the ticker is 10s (not 3s, not 30s)
heartbeat.WithHeartbeat(ctx, interval, ...) is a local goroutine ticker calling RecordHeartbeat. It does not RPC; the SDK's send loop does, gated by the throttle. Effective RPC rate = max(ticker, throttle).

3s (original): below the 8s throttle — 9 of every 10 ticker calls were silently dropped. Misleading.
30s (interval == timeout): no jitter margin. A GC pause or scheduler delay could push the heartbeat past the server's 30s deadline and trigger spurious timeouts.
10s (chosen): well below the 24s throttle, so it's free in RPC terms, and gives a ~3:1 ticker-to-timeout ratio, which is the standard Temporal recommendation. The SDK always has fresh heartbeat data ready, with ~6s of margin before the server timeout.



