### PR TITLE
fix: sdk changes when running reset-generated-code

### DIFF
--- a/scripts/reset-generated-code
+++ b/scripts/reset-generated-code
@@ -24,10 +24,10 @@ REPO_DIR="$(resolve_repo_dir)"
 
 ensure_codegen_tools() {
   echo >&2 "Ensuring tool binaries are installed..."
-  go run github.com/swaggo/swag/cmd/swag@latest --version >/dev/null
-  go run github.com/go-swagger/go-swagger/cmd/swagger@v0.33.0 version >/dev/null
-  go run github.com/golang/mock/mockgen@latest -version >/dev/null
-  go run github.com/a-h/templ/cmd/templ@latest version >/dev/null
+  (cd "$REPO_DIR" && go run github.com/swaggo/swag/cmd/swag --version) >/dev/null
+  (cd "$REPO_DIR" && go run github.com/go-swagger/go-swagger/cmd/swagger version) >/dev/null
+  (cd "$REPO_DIR" && go run github.com/golang/mock/mockgen -version) >/dev/null
+  (cd "$REPO_DIR" && go run github.com/a-h/templ/cmd/templ version) >/dev/null
 }
 
 if [[ "$#" == 1 && "$1" == "--help" ]]; then

--- a/sdks/nuon-go/generate.sh
+++ b/sdks/nuon-go/generate.sh
@@ -39,7 +39,7 @@ else
 fi
 
 echo >&2 "generating mocks"
-go run github.com/golang/mock/mockgen@latest \
+go run github.com/golang/mock/mockgen \
   -destination=mock.go \
   -source=client.go \
   -package=nuon

--- a/sdks/nuon-runner-go/generate.sh
+++ b/sdks/nuon-runner-go/generate.sh
@@ -40,7 +40,7 @@ else
 fi
 
 echo >&2 "generating mocks"
-go run github.com/golang/mock/mockgen@latest \
+go run github.com/golang/mock/mockgen \
   -destination=mock.go \
   -source=client.go \
   -package=nuonrunner

--- a/services/ctl-api/cmd/gen/main.go
+++ b/services/ctl-api/cmd/gen/main.go
@@ -37,7 +37,7 @@ func init() {
 
 func generateRunnerSchema(ctx context.Context) error {
 	args := []string{
-		"run", "github.com/swaggo/swag/cmd/swag@latest",
+		"run", "github.com/swaggo/swag/cmd/swag",
 		"init",
 		"--instanceName", "runner",
 		"--output", "docs/runner",
@@ -67,7 +67,7 @@ func generateRunnerSchema(ctx context.Context) error {
 
 func generateAdminSchema(ctx context.Context) error {
 	args := []string{
-		"run", "github.com/swaggo/swag/cmd/swag@latest",
+		"run", "github.com/swaggo/swag/cmd/swag",
 		"init",
 		"--instanceName", "admin",
 		"--output", "docs/admin",
@@ -98,7 +98,7 @@ func generateAdminSchema(ctx context.Context) error {
 
 func generatePublicSchema(ctx context.Context) error {
 	args := []string{
-		"run", "github.com/swaggo/swag/cmd/swag@latest",
+		"run", "github.com/swaggo/swag/cmd/swag",
 		"init",
 		"--parseDependency",
 		"--output", "docs/public",

--- a/tools.go
+++ b/tools.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/go-openapi/strfmt"
 	_ "github.com/go-openapi/errors"
 	_ "github.com/go-openapi/runtime"
+	_ "github.com/a-h/templ/cmd/templ"
 	_ "github.com/go-swagger/go-swagger/cmd/swagger"
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/swaggo/swag/cmd/swag"


### PR DESCRIPTION
## Problem

Tool versions in the codegen pipeline were unpinned (`@latest`), so
SDK output drifted whenever swag/mockgen cut a release that changed
formatting. A clean `git pull origin main && nctl scripts exec
reset-generated-code` would produce SDK diffs (and break the runner
locally, since the regenerated client no longer matched committed
runner code).

## Solution

Drop `@latest` from every codegen invocation so `go run`
resolves the version from the surrounding module's go.mod / tools.go.

## Context

Pinned points:
- scripts/reset-generated-code: swag/mockgen/templ tool checks
- tools.go: added templ so it's module-pinned (v0.3.977)
- sdks/{nuon-go,nuon-runner-go}/generate.sh: mockgen
  (v1.7.0-rc.1 via each SDK module's go.mod)
- services/ctl-api/cmd/gen/main.go: swag in 3 places
  (v1.16.6 via root go.mod) — this is the actual swagger.json
  generator that drives downstream SDK regen

## Call chain reference

```mermaid
flowchart TD
    A["user runs: nctl scripts reset-generated-code"] --> B

    B["nuonctl name resolution<br/>(mono/bins/nuonctl/internal/namespaces/scripts/register.go)<br/><br/>1. Go scripts registered first (higher precedence)<br/>   reset_generated_code.go registers as<br/>   'go-reset-generated-code' — does NOT shadow this command<br/><br/>2. Bash scripts: walk MONO_DIR + NUON_DIR at<br/>   &lt;repo&gt;/bins/nuonctl/scripts/<br/>   • mono/bins/nuonctl/scripts/reset-generated-code  exists<br/>   • nuon/bins/nuonctl/scripts/reset-generated-code  missing<br/>     (the file is at nuon/scripts/, not under bins/nuonctl/scripts/)"] --> C

    C["mono/bins/nuonctl/scripts/reset-generated-code (bash)<br/><br/>generate_repo $MONO_DIR 'mono'<br/>generate_repo $NUON_DIR 'nuon'<br/>each: deletes generated files, go mod download,<br/>parallel 'go generate' on every .go containing<br/>//go:generate (excludes sdks/nuon-go,<br/>sdks/nuon-runner-go, graveyard/)<br/><br/>then explicitly:<br/>cd $NUON_DIR/sdks/nuon-go        → go generate ./...<br/>cd $NUON_DIR/sdks/nuon-runner-go → go generate ./..."]

    C --> D["go generate across nuon/ + mono/ source tree<br/><br/>//go:generate directives run their commands<br/>(templ, mockgen, etc.)<br/>none use @latest in this repo (verified)"]

    C --> E["go generate in sdks/nuon-go + sdks/nuon-runner-go<br/><br/>//go:generate ./generate.sh (in client.go)"]

    E --> F["sdks/nuon-go/generate.sh<br/>sdks/nuon-runner-go/generate.sh<br/><br/>if swagger.json missing:<br/>  cd nuon/services/ctl-api &&<br/>  go run cmd/gen/main.go --targets sdk<br/><br/>if swagger.json hash changed:<br/>  go run go-swagger@v0.33.0 generate client<br/>  (pinned, deterministic ✓)<br/><br/>always:<br/>  go run mockgen<br/>  ⚠ was @latest, now pinned via SDK module's<br/>  go.mod (v1.7.0-rc.1)"]

    F -. "only when swagger.json is missing" .-> G

    G["services/ctl-api/cmd/gen/main.go --targets sdk<br/><br/>generateRunnerSchema<br/>generateAdminSchema<br/>generatePublicSchema<br/>each shells out to:<br/><br/>  go run swaggo/swag init ...<br/>  ⚠ was @latest, now pinned via root go.mod<br/>  (v1.16.6)<br/><br/>writes:<br/>  docs/public/swagger.json<br/>  docs/runner/...<br/>  docs/admin/..."]

    G -. "feeds swagger.json back into SDK generate.sh<br/>on the next run" .-> F

    classDef fixed fill:#fff4cc,stroke:#cc8800,color:#000
    class F,G fixed
```

## Why this caused the bug

1. nuon/scripts/reset-generated-code is never invoked by nctl —
   it's an orphan unless run directly. Its --sdk shortcut calls
   the same cmd/gen + SDK generate.sh pipeline, so the same fix
   applies for direct usage.

2. go-reset-generated-code (the Go reimplementation) exists but
   is registered under a different name, so it doesn't shadow the
   bash command. Worth knowing if anyone migrates.

3. The cycle: swag@latest (in cmd/gen/main.go) regenerated
   swagger.json, the SDK generate.sh saw the hash change and
   regenerated the client, and mockgen@latest regenerated the
   mocks — all transitively triggered by running the bash script.
   Pinning all three points makes the pipeline deterministic.

4. swagger.json is gitignored (per services/ctl-api/AGENTS.md —
   'Generated files (swagger.json, swagger.yaml, docs.go) are not
   tracked in git'). That's why it's regenerated every run, which
   is why a non-deterministic swag was so dangerous: every run
   produced a fresh spec with a different hash, forcing a full
   client regen.