### PR TITLE
feat(dashboard): install details page

### DIFF
--- a/services/dashboard-ui/client/components/actions/InstallActionsTable/InstallActionsTableContainer.tsx
+++ b/services/dashboard-ui/client/components/actions/InstallActionsTable/InstallActionsTableContainer.tsx
@@ -2,7 +2,6 @@ import { useSearchParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import { AdminDashboardLink } from '@/components/admin/AdminDashboardLink'
 import { LabelFilterDropdown } from '@/components/common/LabelFilterDropdown'
-import { RunAdhocActionButton } from '@/components/installs/management/RunAdhocAction'
 import { useInstall } from '@/hooks/use-install'
 import { useOrg } from '@/hooks/use-org'
 import { getInstallActionsLatestRuns, getActionLabelKeys } from '@/lib'
@@ -67,7 +66,6 @@ export const InstallActionsTableContainer = ({
             queryFn={() => getActionLabelKeys({ orgId: org.id, appId: install.app_id })}
           />
           <AdminDashboardLink path={`/queues?owner_id=${install.id}`} label="View queues" />
-          <RunAdhocActionButton />
           <TriggeredByFilter />
         </div>
       }

--- a/services/dashboard-ui/client/components/actions/TriggeredByFilter/TriggeredByFilter.tsx
+++ b/services/dashboard-ui/client/components/actions/TriggeredByFilter/TriggeredByFilter.tsx
@@ -58,8 +58,8 @@ export const TriggeredByFilter = ({
       alignment="right"
       buttonText={
         <>
-          <Icon variant="SlidersIcon" />
-          Trigger filter
+          <Icon variant="FunnelIcon" size="14" />
+          Trigger
         </>
       }
       id="install-filter"

--- a/services/dashboard-ui/client/components/admin/AdminDashboardLink/AdminDashboardLink.tsx
+++ b/services/dashboard-ui/client/components/admin/AdminDashboardLink/AdminDashboardLink.tsx
@@ -20,8 +20,8 @@ export const AdminDashboardLink = ({
   const href = `${config.adminDashboardUrl}${path}`
 
   return (
-    <Link className="text-xs" href={href} target="_blank">
-      {label} <Icon variant="ArrowSquareOutIcon" />
+    <Link className="text-xs inline-flex items-center gap-1" href={href} target="_blank">
+      {label} <Icon variant="ArrowSquareOutIcon" size="14" />
     </Link>
   )
 }

--- a/services/dashboard-ui/client/components/admin/sections/AdminInstallSection/AdminInstallSection.tsx
+++ b/services/dashboard-ui/client/components/admin/sections/AdminInstallSection/AdminInstallSection.tsx
@@ -51,7 +51,7 @@ export const AdminInstallSection = ({
         />
         <AdminDashboardLink
           path={`/installs/${installId}`}
-          label="View in admin dashboard"
+          label="Admin panel"
         />
       </div>
     </AdminMetadataPanel>

--- a/services/dashboard-ui/client/components/approvals/plan-diffs/DiffFilter.tsx
+++ b/services/dashboard-ui/client/components/approvals/plan-diffs/DiffFilter.tsx
@@ -115,7 +115,7 @@ export function DiffFilter({
         buttonClassName="!p-1"
         buttonText={`Filter ${title} (${selectedActions.size})`}
         className="ml-auto"
-        icon={<Icon variant="FadersHorizontal" />}
+        icon={<Icon variant="FunnelIcon" size="14" />}
         id={`${title}-fitler`}
         alignment="right"
         variant="ghost"

--- a/services/dashboard-ui/client/components/common/Button.tsx
+++ b/services/dashboard-ui/client/components/common/Button.tsx
@@ -110,8 +110,10 @@ export const Button = forwardRef<
       {
         '!border-primary-600 !hover:!border-primary-600':
           isActive && variant === 'tab',
-        '!p-2 text-sm !leading-none h-8 w-full flex justify-between !rounded-md !text-cool-grey-800 dark:!text-white/70':
-          isMenuButton,
+        '!p-2 text-sm !leading-none h-8 w-full flex justify-between !rounded-md !bg-transparent !border-0 !shadow-none !text-cool-grey-800 dark:!text-white/70':
+          isMenuButton && variant !== 'danger',
+        '!p-2 text-sm !leading-none h-8 w-full flex justify-between !rounded-md !bg-transparent !border-0 !shadow-none !text-red-800 dark:!text-red-500 hover:!bg-red-50 dark:hover:!bg-[#1D0D10]':
+          isMenuButton && variant === 'danger',
       },
       className
     )

--- a/services/dashboard-ui/client/components/common/LabelFilterDropdown.tsx
+++ b/services/dashboard-ui/client/components/common/LabelFilterDropdown.tsx
@@ -72,13 +72,11 @@ export const LabelFilterDropdown = ({
   return (
     <Dropdown
       alignment="right"
-      className="!p-2"
       closeOnBlur={false}
       id="labels-filter"
-      buttonClassName="!p-1"
       buttonText={
         <>
-          <Icon variant="TagIcon" size="14" />
+          <Icon variant="FunnelIcon" size="14" />
           Labels{selectedLabels.length > 0 ? ` (${selectedLabels.length})` : ''}
         </>
       }

--- a/services/dashboard-ui/client/components/common/form/Toggle.stories.tsx
+++ b/services/dashboard-ui/client/components/common/form/Toggle.stories.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+import { Toggle } from './Toggle'
+
+export default {
+  title: 'Common/Form/Toggle',
+}
+
+export const Default = () => {
+  const [checked, setChecked] = useState(false)
+  return <Toggle checked={checked} onChange={setChecked} />
+}
+
+export const WithLabel = () => {
+  const [checked, setChecked] = useState(false)
+  return <Toggle checked={checked} onChange={setChecked} label="Auto approval" />
+}
+
+export const Checked = () => {
+  const [checked, setChecked] = useState(true)
+  return <Toggle checked={checked} onChange={setChecked} label="Auto approval" />
+}
+
+export const WithDescription = () => {
+  const [checked, setChecked] = useState(false)
+  return (
+    <Toggle
+      checked={checked}
+      onChange={setChecked}
+      label="Auto approval"
+      description="Automatically approve all workflows"
+    />
+  )
+}
+
+export const Disabled = () => (
+  <div className="flex flex-col gap-4">
+    <Toggle checked={false} onChange={() => {}} label="Disabled off" disabled />
+    <Toggle checked={true} onChange={() => {}} label="Disabled on" disabled />
+  </div>
+)

--- a/services/dashboard-ui/client/components/common/form/Toggle.tsx
+++ b/services/dashboard-ui/client/components/common/form/Toggle.tsx
@@ -1,0 +1,72 @@
+import type { ButtonHTMLAttributes } from 'react'
+import { Text } from '@/components/common/Text'
+import { cn } from '@/utils/classnames'
+
+export interface IToggle
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
+  checked: boolean
+  onChange: (checked: boolean) => void
+  label?: string
+  description?: string
+}
+
+export const Toggle = ({
+  checked,
+  onChange,
+  label,
+  description,
+  className,
+  disabled,
+  ...props
+}: IToggle) => {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      className={cn(
+        'flex gap-2 cursor-pointer text-left items-center',
+        disabled && 'opacity-50 cursor-not-allowed',
+        className
+      )}
+      onClick={() => !disabled && onChange(!checked)}
+      {...props}
+    >
+      <span className="relative shrink-0 h-[20px] w-[24px]">
+        <span
+          className={cn(
+            'absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2',
+            'h-[14px] w-[24px] rounded-full overflow-hidden transition-colors duration-200',
+            checked
+              ? 'bg-primary-600 dark:bg-primary-500'
+              : 'bg-neutral-200 dark:bg-neutral-600'
+          )}
+        >
+          <span
+            className={cn(
+              'absolute top-1/2 -translate-y-1/2 h-[10px] w-[10px] rounded-full bg-white',
+              'shadow-[0px_1px_2px_0px_rgba(0,0,0,0.08)] transition-all duration-200',
+              checked ? 'right-[2px]' : 'right-[12px]'
+            )}
+          />
+        </span>
+      </span>
+      {(label || description) && (
+        <span className="flex flex-col gap-[2px]">
+          {label && (
+            <Text variant="body" weight="strong">
+              {label}
+            </Text>
+          )}
+          {description && (
+            <Text variant="subtext" theme="neutral">
+              {description}
+            </Text>
+          )}
+        </span>
+      )}
+    </button>
+  )
+}

--- a/services/dashboard-ui/client/components/components/ComponentTypeFilter.tsx
+++ b/services/dashboard-ui/client/components/components/ComponentTypeFilter.tsx
@@ -184,10 +184,8 @@ export const ComponentTypeFilterDropdown: React.FC<
   ) : (
     <Dropdown
       alignment="right"
-      className="!p-2"
       closeOnBlur={false}
       id="logs-filter"
-      buttonClassName="!p-1"
       buttonText={
         <>
           <Icon variant="FunnelIcon" size="14" /> Filter ({selectedTypes.length}

--- a/services/dashboard-ui/client/components/deploys/management/ManagementDropdown/ManagementDropdown.tsx
+++ b/services/dashboard-ui/client/components/deploys/management/ManagementDropdown/ManagementDropdown.tsx
@@ -24,10 +24,10 @@ export const ManagementDropdown = ({
   return (
     <Dropdown
       id={`component-${component.id}-mgmt`}
-      variant="primary"
+      variant="secondary"
       buttonText={
         <>
-          <Icon variant="SlidersHorizontalIcon" /> Manage
+          <Icon variant="SlidersHorizontalIcon" /> Deploy controls
         </>
       }
       alignment="right"
@@ -67,7 +67,7 @@ export const ManagementDropdown = ({
         workflow &&
         !workflow?.finished ? (
           <CancelWorkflowButton
-            className="!text-red-600 dark:!text-red-400"
+            variant="danger"
             isMenuButton
             workflow={workflow}
           />

--- a/services/dashboard-ui/client/components/install-components/InstallComponentsTable/InstallComponentsTableContainer.tsx
+++ b/services/dashboard-ui/client/components/install-components/InstallComponentsTable/InstallComponentsTableContainer.tsx
@@ -2,7 +2,6 @@ import { useSearchParams } from 'react-router'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { LabelFilterDropdown } from '@/components/common/LabelFilterDropdown'
 import { ComponentTypeFilterDropdown } from '@/components/components/ComponentTypeFilter'
-import { ManageAllDropdown } from '@/components/install-components/management/ManageAllDropdown'
 import { useInstall } from '@/hooks/use-install'
 import { useOrg } from '@/hooks/use-org'
 import { getInstallComponents, getAppConfig, getComponentLabelKeys } from '@/lib'
@@ -95,7 +94,6 @@ export const InstallComponentsTableContainer = ({
             queryFn={() => getComponentLabelKeys({ orgId: org.id, appId: install.app_id })}
           />
           <ComponentTypeFilterDropdown />
-          <ManageAllDropdown />
         </div>
       }
       pagination={pagination}

--- a/services/dashboard-ui/client/components/install-components/management/ManageAllDropdown/ManageAllDropdown.tsx
+++ b/services/dashboard-ui/client/components/install-components/management/ManageAllDropdown/ManageAllDropdown.tsx
@@ -15,10 +15,10 @@ export const ManageAllDropdown = ({ appId, appConfigId }: IManageAllDropdown) =>
   return (
     <Dropdown
       id="install-components-mgmt"
-      variant="ghost"
+      variant="secondary"
       buttonText={
         <>
-          <Icon variant="SlidersHorizontalIcon" /> Manage
+          Component controls
         </>
       }
       alignment="right"

--- a/services/dashboard-ui/client/components/install-components/management/ManagementDropdown.tsx
+++ b/services/dashboard-ui/client/components/install-components/management/ManagementDropdown.tsx
@@ -25,10 +25,10 @@ export const ManagementDropdown = ({
   return (
     <Dropdown
       id={`component-${component.id}-mgmt`}
-      variant="primary"
+      variant="secondary"
       buttonText={
         <>
-          <Icon variant="SlidersHorizontalIcon" /> Manage
+          <Icon variant="SlidersHorizontalIcon" /> Component controls
         </>
       }
       alignment="right"

--- a/services/dashboard-ui/client/components/install-components/management/TeardownAllComponents/TeardownAllComponentsContainer.tsx
+++ b/services/dashboard-ui/client/components/install-components/management/TeardownAllComponents/TeardownAllComponentsContainer.tsx
@@ -99,7 +99,7 @@ export const TeardownAllComponentsButton = ({ ...props }: IButtonAsButton) => {
         addModal(modal)
       }}
       {...props}
-      className="!text-red-600 dark:!text-red-400"
+      variant="danger"
     >
       Teardown components <Icon variant="CloudArrowDownIcon" />
     </Button>

--- a/services/dashboard-ui/client/components/installs/management/EditInputs/EditInputsContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditInputs/EditInputsContainer.tsx
@@ -256,13 +256,11 @@ export const EditInputsButton = ({
 
   return (
     <Button
-      className="text-sm !font-medium !py-2 !px-3 h-[36px] flex items-center gap-3 w-full"
-      variant="ghost"
       onClick={handleClick}
       {...props}
     >
-      {showNameField ? 'Edit install' : 'Edit inputs'}
       <Icon variant="PencilSimpleLine" />
+      {showNameField ? 'Edit install' : 'Edit inputs'}
     </Button>
   )
 }

--- a/services/dashboard-ui/client/components/installs/management/EditStackOverrides/EditStackOverridesContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditStackOverrides/EditStackOverridesContainer.tsx
@@ -165,13 +165,11 @@ export const EditStackOverridesButton = ({
 
   return (
     <Button
-      className="text-sm !font-medium !py-2 !px-3 h-[36px] flex items-center gap-3 w-full"
-      variant="ghost"
       onClick={handleClick}
       {...props}
     >
-      Edit stack overrides
       <Icon variant="StackSimple" />
+      Edit stack overrides
     </Button>
   )
 }

--- a/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/AutoApproveToggle.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/AutoApproveToggle.tsx
@@ -1,0 +1,44 @@
+import { Toggle } from '@/components/common/form/Toggle'
+import { useInstall } from '@/hooks/use-install'
+import { useSurfaces } from '@/hooks/use-surfaces'
+import {
+  ConfirmOverrideModalContainer,
+  EnableAutoApproveModalContainer,
+} from './EnableAutoApproveContainer'
+
+export const AutoApproveToggle = () => {
+  const { addModal } = useSurfaces()
+  const { install } = useInstall()
+
+  const hasInstallConfig = Boolean(install?.install_config)
+  const isApproveAll =
+    hasInstallConfig &&
+    install?.install_config?.approval_option === 'approve-all'
+  const isInstallManagedByConfig =
+    install?.metadata?.managed_by === 'nuon/cli/install-config'
+
+  const handleChange = () => {
+    if (isInstallManagedByConfig) {
+      const overrideModal = (
+        <ConfirmOverrideModalContainer
+          onConfirm={() => {
+            const mainModal = <EnableAutoApproveModalContainer />
+            addModal(mainModal)
+          }}
+        />
+      )
+      addModal(overrideModal)
+    } else {
+      const modal = <EnableAutoApproveModalContainer />
+      addModal(modal)
+    }
+  }
+
+  return (
+    <Toggle
+      checked={isApproveAll}
+      onChange={handleChange}
+      label="Auto approval"
+    />
+  )
+}

--- a/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/EnableAutoApproveContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/EnableAutoApproveContainer.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
@@ -35,6 +35,7 @@ export const ConfirmOverrideModalContainer = ({ onConfirm, ...props }: { onConfi
 }
 
 export const EnableAutoApproveModalContainer = ({ ...props }: IEnableAutoApprove & Omit<IModal, 'onSubmit'>) => {
+  const queryClient = useQueryClient()
   const { removeModal } = useSurfaces()
   const { org } = useOrg()
   const { install } = useInstall()
@@ -69,6 +70,7 @@ export const EnableAutoApproveModalContainer = ({ ...props }: IEnableAutoApprove
       }
     },
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['install', org.id, install.id] })
       addToast(
         <Toast heading={`Auto approve ${isApproveAll ? 'disabled' : 'enabled'}`} theme="success">
           <Text>Auto approve {isApproveAll ? 'disabled' : 'enabled'} for {install.name}.</Text>

--- a/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/index.ts
+++ b/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/index.ts
@@ -7,3 +7,4 @@ export {
   ConfirmOverrideModal as ConfirmOverrideModalComponent,
   EnableAutoApproveModal as EnableAutoApproveModalComponent,
 } from './EnableAutoApprove'
+export { AutoApproveToggle } from './AutoApproveToggle'

--- a/services/dashboard-ui/client/components/installs/management/Forget/ForgetContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/Forget/ForgetContainer.tsx
@@ -60,7 +60,6 @@ export const ForgetModalContainer = ({ ...props }: IForget & Omit<IModal, 'onSub
 }
 
 export const ForgetButton = ({
-  isMenuButton: _isMenuButton,
   ...props
 }: IForget & IButtonAsButton) => {
   const { addModal } = useSurfaces()
@@ -71,9 +70,9 @@ export const ForgetButton = ({
       onClick={() => {
         addModal(modal)
       }}
-      variant="ghost"
-      className="!bg-transparent !border-0 !p-2 text-sm !leading-none h-8 w-full flex justify-between !rounded-md !text-red-800 dark:!text-red-500 hover:!bg-red-50 dark:hover:!bg-[#1D0D10] active:!bg-red-100 dark:active:!bg-[#2E1013]"
+      isMenuButton
       {...props}
+      variant="danger"
     >
       Forget install
       <Icon variant="Trash" />

--- a/services/dashboard-ui/client/components/installs/management/InstallManagementDropdown/InstallManagementDropdown.tsx
+++ b/services/dashboard-ui/client/components/installs/management/InstallManagementDropdown/InstallManagementDropdown.tsx
@@ -2,30 +2,22 @@ import { Dropdown } from '@/components/common/Dropdown'
 import { Icon } from '@/components/common/Icon'
 import { Menu } from '@/components/common/Menu'
 import { Text } from '@/components/common/Text'
-import { RunnerProvider } from '@/providers/runner-provider'
-import { useInstall } from '@/hooks/use-install'
-import { useOrg } from '@/hooks/use-org'
 import { ShutdownRunnerControl } from '@/components/runners/management/ShutdownRunnerControl'
+import { ReprovisionSandboxButton } from '@/components/sandbox/management/ReprovisionSandbox'
+import { useInstall } from '@/hooks/use-install'
+import { RunnerProvider } from '@/providers/runner-provider'
 import { AuditHistoryButton } from '../AuditHistory'
 import { DeprovisionButton } from '../Deprovision'
 import { DeprovisionStackButton } from '../DeprovisionStack'
-import { EditInputsButton } from '../EditInputs'
 import { EditLabelsButton } from '../EditLabels'
-import { ViewCurrentInputsButton } from '../ViewCurrentInputs'
-import { EditStackOverridesButton } from '../EditStackOverrides'
-import { EnableAutoApproveButton } from '../EnableAutoApprove'
 import { EnableConfigSyncButton } from '../EnableConfigSync'
 import { ForgetButton } from '../Forget'
 import { GenerateInstallConfigButton } from '../GenerateInstallConfig'
 import { ReprovisionButton } from '../Reprovision'
-import { ReprovisionSandboxButton } from '@/components/sandbox/management/ReprovisionSandbox'
-import { RunAdhocActionButton } from '../RunAdhocAction'
 import { SyncSecretsButton } from '../SyncSecrets'
 
 const InstallManagementDropdownContent = () => {
   const { install } = useInstall()
-  const { org } = useOrg()
-  const canRenameInstall = !!org?.features?.['install-rename']
   const isMobile = !window.matchMedia('(min-width: 768px)').matches
   return (
     <Dropdown
@@ -43,12 +35,8 @@ const InstallManagementDropdownContent = () => {
         <Text variant="label" theme="neutral">
           Settings
         </Text>
-        <EditInputsButton isMenuButton showNameField={canRenameInstall} />
         <EditLabelsButton isMenuButton />
-        <ViewCurrentInputsButton isMenuButton />
         <AuditHistoryButton isMenuButton />
-        <EnableAutoApproveButton isMenuButton />
-        <EditStackOverridesButton isMenuButton />
         <EnableConfigSyncButton isMenuButton />
         <GenerateInstallConfigButton isMenuButton />
         <hr />
@@ -66,16 +54,13 @@ const InstallManagementDropdownContent = () => {
           />
         ) : null}
         <SyncSecretsButton isMenuButton />
-        <RunAdhocActionButton isMenuButton />
         <hr />
         <Text variant="label" theme="neutral">
           Danger
         </Text>
         <DeprovisionButton isMenuButton />
         <DeprovisionStackButton isMenuButton />
-        <span>
-          <ForgetButton />
-        </span>
+        <ForgetButton />
       </Menu>
     </Dropdown>
   )

--- a/services/dashboard-ui/client/components/installs/management/ViewCurrentInputs/ViewCurrentInputs.tsx
+++ b/services/dashboard-ui/client/components/installs/management/ViewCurrentInputs/ViewCurrentInputs.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import React, { useState, useMemo } from 'react'
 import { Button } from '@/components/common/Button'
 import { Dropdown } from '@/components/common/Dropdown'
 import { EmptyState } from '@/components/common/EmptyState'
@@ -48,12 +48,14 @@ interface IViewCurrentInputsModal extends IModal {
   isLoading: boolean
   redactedValues: Record<string, any>
   inputGroups: TInputGroup[]
+  footerActions?: React.ReactNode
 }
 
 export const ViewCurrentInputsModal = ({
   isLoading,
   redactedValues,
   inputGroups,
+  footerActions,
   ...props
 }: IViewCurrentInputsModal) => {
   const [search, setSearch] = useState('')
@@ -194,6 +196,7 @@ export const ViewCurrentInputsModal = ({
         </Text>
       }
       size="xl"
+      footerActions={footerActions}
       actions={
         !isLoading && (hasConfig || hasInputs) ? (
           <div className="flex items-center gap-2">
@@ -205,10 +208,8 @@ export const ViewCurrentInputsModal = ({
             {hasConfig ? (
               <Dropdown
                 alignment="right"
-                className="!p-2"
                 closeOnBlur={false}
                 id="inputs-filter"
-                buttonClassName="!p-1"
                 buttonText={
                   <>
                     <Icon variant="FunnelIcon" size="14" />

--- a/services/dashboard-ui/client/components/installs/management/ViewCurrentInputs/ViewCurrentInputsContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/ViewCurrentInputs/ViewCurrentInputsContainer.tsx
@@ -7,11 +7,14 @@ import { useOrg } from '@/hooks/use-org'
 import { useSurfaces } from '@/hooks/use-surfaces'
 import { getAppConfig, getInstallCurrentInputs } from '@/lib'
 import { normalizeAppInputGroups } from '@/utils/app-utils'
+import { EditInputsButton } from '../EditInputs'
 import { ViewCurrentInputsModal } from './ViewCurrentInputs'
 
 export const ViewCurrentInputsModalContainer = ({ ...props }: IModal) => {
   const { org } = useOrg()
   const { install } = useInstall()
+
+  const canRenameInstall = !!org?.features?.['install-rename']
 
   const { data: inputs, isLoading: inputsLoading } = useQuery({
     queryKey: ['install-inputs', org?.id, install?.id],
@@ -46,6 +49,9 @@ export const ViewCurrentInputsModalContainer = ({ ...props }: IModal) => {
       isLoading={isLoading}
       redactedValues={redactedValues}
       inputGroups={inputGroups as any}
+      footerActions={
+        <EditInputsButton variant="primary" showNameField={canRenameInstall} />
+      }
       {...props}
     />
   )

--- a/services/dashboard-ui/client/components/log-stream/log-filters/LogFilters.tsx
+++ b/services/dashboard-ui/client/components/log-stream/log-filters/LogFilters.tsx
@@ -18,10 +18,10 @@ export const LogFilters = ({ filters }: LogFiltersProps) => {
       <LogSearch filters={filters} />
 
       <div className="flex items-center justify-end gap-4">
-        <LogSort filters={filters} />
         <LogJobOutputFilter filters={filters} />
-        <LogServiceFilter title="service" filters={filters} />
-        <LogSeverityFilter title="severity" filters={filters} />
+        <LogSort filters={filters} />
+        <LogServiceFilter title="Service" filters={filters} />
+        <LogSeverityFilter title="Severity" filters={filters} />
         {!isStreamOpen && <DownloadLogsButton />}
       </div>
     </div>

--- a/services/dashboard-ui/client/components/log-stream/log-filters/LogServiceFilter.stories.tsx
+++ b/services/dashboard-ui/client/components/log-stream/log-filters/LogServiceFilter.stories.tsx
@@ -6,7 +6,7 @@ import { LogServiceFilter } from './LogServiceFilter'
 
 export const Default = () => (
   <LogServiceFilter
-    title="service"
+    title="Service"
     filters={{
       selectedServices: new Set(['api', 'runner']),
       handleServiceInputToggle: () => {},
@@ -18,7 +18,7 @@ export const Default = () => (
 
 export const NoneSelected = () => (
   <LogServiceFilter
-    title="service"
+    title="Service"
     filters={{
       selectedServices: new Set(),
       handleServiceInputToggle: () => {},

--- a/services/dashboard-ui/client/components/log-stream/log-filters/LogServiceFilter.tsx
+++ b/services/dashboard-ui/client/components/log-stream/log-filters/LogServiceFilter.tsx
@@ -44,9 +44,10 @@ export const LogServiceFilter = ({ title, filters }: ILogServiceFilter) => {
 
   return (
     <Dropdown
-      buttonText={`Filter ${title} (${selectedServices.size})`}
+      buttonText={`${title} (${selectedServices.size})`}
       className="ml-auto"
-      icon={<Icon variant="FadersHorizontal" />}
+      icon={<Icon variant="FunnelIcon" size="14" />}
+      iconAlignment="left"
       id={`${title}-fitler`}
       alignment="right"
       variant="ghost"

--- a/services/dashboard-ui/client/components/log-stream/log-filters/LogSeverityFilter.stories.tsx
+++ b/services/dashboard-ui/client/components/log-stream/log-filters/LogSeverityFilter.stories.tsx
@@ -6,7 +6,7 @@ import { LogSeverityFilter } from './LogSeverityFilter'
 
 export const Default = () => (
   <LogSeverityFilter
-    title="severity"
+    title="Severity"
     filters={{
       selectedSeverities: new Set(['Info', 'Warn', 'Error']),
       handleSeverityInputToggle: () => {},
@@ -18,7 +18,7 @@ export const Default = () => (
 
 export const AllSelected = () => (
   <LogSeverityFilter
-    title="severity"
+    title="Severity"
     filters={{
       selectedSeverities: new Set(['Trace', 'Debug', 'Info', 'Warn', 'Error', 'Fatal']),
       handleSeverityInputToggle: () => {},

--- a/services/dashboard-ui/client/components/log-stream/log-filters/LogSeverityFilter.tsx
+++ b/services/dashboard-ui/client/components/log-stream/log-filters/LogSeverityFilter.tsx
@@ -49,9 +49,10 @@ export const LogSeverityFilter = ({ title, filters }: ILogSeverityFilter) => {
 
   return (
     <Dropdown
-      buttonText={`Filter ${title} (${selectedSeverities.size})`}
+      buttonText={`${title} (${selectedSeverities.size})`}
       className="ml-auto"
-      icon={<Icon variant="FadersHorizontal" />}
+      icon={<Icon variant="FunnelIcon" size="14" />}
+      iconAlignment="left"
       id={`${title}-fitler`}
       alignment="right"
       variant="ghost"

--- a/services/dashboard-ui/client/components/runners/ProcessCard/ProcessCard.tsx
+++ b/services/dashboard-ui/client/components/runners/ProcessCard/ProcessCard.tsx
@@ -128,7 +128,7 @@ export const ProcessCard = ({
           <ID>{process.id}</ID>
           <AdminDashboardLink
             path={`/queues?owner_id=${process.runner_id}&search=runner-process-${process.id}&redirect=true`}
-            label="View in admin panel"
+            label="Admin panel"
           />
         </div>
         <div className="flex items-center gap-2">

--- a/services/dashboard-ui/client/components/runners/RunnerProcessesTable/RunnerProcessesTable.tsx
+++ b/services/dashboard-ui/client/components/runners/RunnerProcessesTable/RunnerProcessesTable.tsx
@@ -101,7 +101,7 @@ export const RunnerProcessesTable = ({
           return (
             <AdminDashboardLink
               path={`/queues?owner_id=${process.runner_id}&search=runner-process-${process.id}&redirect=true`}
-              label="View in admin panel"
+              label="Admin panel"
             />
           )
         },

--- a/services/dashboard-ui/client/components/sandbox/management/DeprovisionSandbox/DeprovisionSandboxContainer.tsx
+++ b/services/dashboard-ui/client/components/sandbox/management/DeprovisionSandbox/DeprovisionSandboxContainer.tsx
@@ -102,7 +102,7 @@ export const DeprovisionSandboxButton = ({
         addModal(modal)
       }}
       {...props}
-      className="!text-red-600 dark:!text-red-400"
+      variant="danger"
     >
       {props?.isMenuButton ? null : <Icon variant="BoxArrowDown" />}
       Deprovision sandbox

--- a/services/dashboard-ui/client/components/sandbox/management/ManageRunDropdown.tsx
+++ b/services/dashboard-ui/client/components/sandbox/management/ManageRunDropdown.tsx
@@ -33,10 +33,10 @@ export const ManageRunDropdown = ({
   return (
     <Dropdown
       id={`sandbox-run-${sandboxRun.id}-mgmt`}
-      variant="primary"
+      variant="secondary"
       buttonText={
         <>
-          <Icon variant="SlidersHorizontalIcon" /> Manage
+          <Icon variant="SlidersHorizontalIcon" /> Run controls
         </>
       }
       alignment={alignment}
@@ -69,7 +69,7 @@ export const ManageRunDropdown = ({
 
         {shouldShowCancel ? (
           <CancelWorkflowButton
-            className="!text-red-600 dark:!text-red-400"
+            variant="danger"
             isMenuButton
             workflow={workflow}
           />

--- a/services/dashboard-ui/client/components/sandbox/management/ManagementDropdown/ManagementDropdown.tsx
+++ b/services/dashboard-ui/client/components/sandbox/management/ManagementDropdown/ManagementDropdown.tsx
@@ -19,9 +19,10 @@ export const ManagementDropdown = ({
   return (
     <Dropdown
       id="sandbox-mgmt"
+      variant="secondary"
       buttonText={
         <>
-          <Icon variant="SlidersHorizontalIcon" /> Manage sandbox
+          Sandbox controls
         </>
       }
       alignment={alignment}

--- a/services/dashboard-ui/client/components/workflows/filters/WorkflowTypeFilter/WorkflowTypeFilter.tsx
+++ b/services/dashboard-ui/client/components/workflows/filters/WorkflowTypeFilter/WorkflowTypeFilter.tsx
@@ -46,15 +46,13 @@ export const WorkflowTypeFilter = ({
   return (
     <Dropdown
       alignment="right"
-      buttonClassName="!p-2"
       buttonText={
         <>
-          <Icon variant="SlidersIcon" />
-          Type filter
+          <Icon variant="FunnelIcon" size="14" />
+          Type
         </>
       }
       id="workflow-type-filter"
-      variant="ghost"
     >
       <Menu className="!p-0 !w-68">
         <form onReset={onClearFilter}>

--- a/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowActionButtons/WorkflowActionButtons.tsx
+++ b/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowActionButtons/WorkflowActionButtons.tsx
@@ -27,7 +27,7 @@ export const WorkflowActionButtons = ({
       {workflow?.id && (
         <AdminDashboardLink
           path={`/workflows/${workflow.id}`}
-          label="View in admin panel"
+          label="Admin panel"
         />
       )}
     </div>

--- a/services/dashboard-ui/client/views/app/branches/BranchRunDetail.tsx
+++ b/services/dashboard-ui/client/views/app/branches/BranchRunDetail.tsx
@@ -360,7 +360,7 @@ export const BranchRunDetail = () => {
                   <div className="flex flex-wrap gap-2">
                     <AdminDashboardLink
                       path={`/workflows/${selectedStep.install_workflow_id}`}
-                      label="View in admin panel"
+                      label="Admin panel"
                     />
                   </div>
                 </div>

--- a/services/dashboard-ui/client/views/install/ActionDetail.tsx
+++ b/services/dashboard-ui/client/views/install/ActionDetail.tsx
@@ -140,7 +140,7 @@ export const ActionDetail = () => {
               {action?.id ? (
                 <AdminDashboardLink
                   path={`/queues?owner_id=${action.id}`}
-                  label="View in admin panel"
+                  label="Admin panel"
                 />
               ) : null}
             </HeadingGroup>

--- a/services/dashboard-ui/client/views/install/Actions.tsx
+++ b/services/dashboard-ui/client/views/install/Actions.tsx
@@ -1,6 +1,7 @@
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Text } from '@/components/common/Text'
 import { InstallActionsTable } from '@/components/actions/InstallActionsTable'
+import { RunAdhocActionButton } from '@/components/installs/management/RunAdhocAction'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
 import { PageTitle } from '@/components/navigation/PageTitle'
@@ -25,14 +26,19 @@ export const Actions = () => {
           },
         ]}
       />
-      <HeadingGroup>
-        <Text variant="base" weight="strong">
-          Actions
-        </Text>
-        <Text theme="neutral">
-          View and manage all actions for this install.
-        </Text>
-      </HeadingGroup>
+      <div className="flex items-start justify-between gap-4">
+        <HeadingGroup>
+          <Text variant="base" weight="strong">
+            Actions
+          </Text>
+          <Text variant="subtext" theme="neutral">
+            View and manage all actions for this install.
+          </Text>
+        </HeadingGroup>
+        <div className="shrink-0">
+          <RunAdhocActionButton variant="primary" />
+        </div>
+      </div>
 
       <InstallActionsTable shouldPoll />
     </PageSection>

--- a/services/dashboard-ui/client/views/install/ComponentDetail.tsx
+++ b/services/dashboard-ui/client/views/install/ComponentDetail.tsx
@@ -108,7 +108,7 @@ export const InstallComponentDetail = () => {
             {component?.id ? <ID>{component.id}</ID> : null}
             <AdminDashboardLink
               path={`/queues?owner_id=${installComponent?.id}`}
-              label="View in admin panel"
+              label="Admin panel"
             />
           </HeadingGroup>
 

--- a/services/dashboard-ui/client/views/install/Components.tsx
+++ b/services/dashboard-ui/client/views/install/Components.tsx
@@ -1,6 +1,7 @@
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Text } from '@/components/common/Text'
 import { InstallComponentsTable } from '@/components/install-components/InstallComponentsTable'
+import { ManageAllDropdown } from '@/components/install-components/management/ManageAllDropdown'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
 import { PageTitle } from '@/components/navigation/PageTitle'
@@ -25,14 +26,19 @@ export const Components = () => {
           },
         ]}
       />
-      <HeadingGroup>
-        <Text variant="base" weight="strong">
-          Install components
-        </Text>
-        <Text theme="neutral">
-          View and manage all components for this install.
-        </Text>
-      </HeadingGroup>
+      <div className="flex items-start justify-between gap-4">
+        <HeadingGroup>
+          <Text variant="base" weight="strong">
+            Install components
+          </Text>
+          <Text variant="subtext" theme="neutral">
+            View and manage all components for this install.
+          </Text>
+        </HeadingGroup>
+        <div className="shrink-0">
+          <ManageAllDropdown />
+        </div>
+      </div>
 
       <InstallComponentsTable shouldPoll />
     </PageSection>

--- a/services/dashboard-ui/client/views/install/CurrentInputs.tsx
+++ b/services/dashboard-ui/client/views/install/CurrentInputs.tsx
@@ -61,7 +61,7 @@ export const CurrentInputs = () => {
           },
         ]}
       />
-      <div className="flex items-start justify-between">
+      <div className="flex items-start justify-between gap-4">
         <HeadingGroup>
           <Text variant="base" weight="strong">
             Current inputs
@@ -70,7 +70,7 @@ export const CurrentInputs = () => {
             The current input values for this install.
           </Text>
         </HeadingGroup>
-        <div className="flex items-center gap-2">
+        <div className="shrink-0">
           <EditInputsButton variant="secondary" />
         </div>
       </div>

--- a/services/dashboard-ui/client/views/install/InstallLayout.tsx
+++ b/services/dashboard-ui/client/views/install/InstallLayout.tsx
@@ -126,8 +126,8 @@ const InstallTemplate = () => {
       ) : (
         <>
           <PageHeader>
-            <div className="@container flex flex-col gap-4 w-full md:flex-row md:justify-between">
-              <HeadingGroup>
+            <div className="@container flex flex-col gap-6 w-full md:flex-row md:justify-between">
+              <HeadingGroup className="gap-1.5">
                 <div className="flex items-center gap-2 flex-wrap">
                   <Text variant="h3" weight="stronger" level={1}>
                     {install.name}
@@ -149,7 +149,7 @@ const InstallTemplate = () => {
                   </Text>
                   <AdminDashboardLink
                     path={`/queues?owner_id=${install.id}`}
-                    label="View in admin panel"
+                    label="Admin panel"
                   />
                 </div>
               </HeadingGroup>

--- a/services/dashboard-ui/client/views/install/Sandbox.tsx
+++ b/services/dashboard-ui/client/views/install/Sandbox.tsx
@@ -69,14 +69,14 @@ export const Sandbox = () => {
       />
 
       <div className="@container flex flex-col flex-auto gap-6">
-        <div className="flex items-start justify-between">
+        <div className="flex items-start justify-between gap-4">
           <HeadingGroup>
             <Text variant="base" weight="strong">
               Sandbox details
             </Text>
             <ID>{install?.sandbox?.id}</ID>
           </HeadingGroup>
-          <div className="flex items-center gap-2">
+          <div className="shrink-0 flex items-center gap-2">
             <div className="@5xl:hidden">
               <Button
                 variant="secondary"
@@ -89,7 +89,7 @@ export const Sandbox = () => {
                 }
               >
                 <Icon variant="ClockCounterClockwiseIcon" size={16} />
-                Sandbox history
+                History
               </Button>
             </div>
             <ManagementDropdown />

--- a/services/dashboard-ui/client/views/install/Stacks.tsx
+++ b/services/dashboard-ui/client/views/install/Stacks.tsx
@@ -7,6 +7,7 @@ import { LabeledValue } from '@/components/common/LabeledValue'
 import { Link } from '@/components/common/Link'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Text } from '@/components/common/Text'
+import { EditStackOverridesButton } from '@/components/installs/management/EditStackOverrides'
 import { InstallStacksTable, InstallStacksTableSkeleton } from '@/components/stacks/InstallStacksTable'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
@@ -79,14 +80,19 @@ export const Stacks = () => {
           },
         ]}
       />
-      <HeadingGroup>
-        <Text variant="base" weight="strong">
-          Install stacks
-        </Text>
-        <Text variant="subtext" theme="neutral">
-          View your install stack config and versions below.
-        </Text>
-      </HeadingGroup>
+      <div className="flex items-start justify-between gap-4">
+        <HeadingGroup>
+          <Text variant="base" weight="strong">
+            Install stacks
+          </Text>
+          <Text variant="subtext" theme="neutral">
+            View your install stack config and versions below.
+          </Text>
+        </HeadingGroup>
+        <div className="shrink-0">
+          <EditStackOverridesButton variant="secondary" />
+        </div>
+      </div>
 
       {stackChanged && (
         <Banner theme="info">

--- a/services/dashboard-ui/client/views/install/Workflows.tsx
+++ b/services/dashboard-ui/client/views/install/Workflows.tsx
@@ -5,6 +5,7 @@ import { Text } from '@/components/common/Text'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
 import { PageTitle } from '@/components/navigation/PageTitle'
+import { AutoApproveToggle } from '@/components/installs/management/EnableAutoApprove'
 import { ActiveWorkflows } from '@/components/workflows/ActiveWorkflows'
 import { WorkflowTimeline } from '@/components/workflows/WorkflowTimeline'
 import { ShowDriftScanContainer as ShowDriftScan } from '@/components/workflows/filters/ShowDriftScans'
@@ -64,17 +65,18 @@ export const Workflows = () => {
         install={install}
       />
 
-      <div className="flex items-center gap-4 justify-between">
+      <div className="flex items-start justify-between gap-4">
         <HeadingGroup>
           <Text variant="base" weight="strong">
             Workflow history
           </Text>
-          <Text theme="neutral">
+          <Text variant="subtext" theme="neutral">
             View past and active workflows for this install.
           </Text>
         </HeadingGroup>
 
-        <div className="flex items-center gap-4">
+        <div className="shrink-0 flex items-center gap-4">
+          <AutoApproveToggle />
           <ShowDriftScan />
           <WorkflowTypeFilter />
         </div>


### PR DESCRIPTION
## Summary

Standardize the UI of dropdowns, buttons, and filters across install sub-pages for visual consistency and alignment with the Stratus design system.

## Changes

### Install sub-page header pattern
All install sub-pages (`Actions`, `Stacks`, `Components`, `Workflows`, `Sandbox`, `CurrentInputs`) now share an identical header layout:
- `flex items-start justify-between gap-4` with `shrink-0` action wrapper
- Description text uses `variant="subtext" theme="neutral"`
- Headline actions placed in the page header, aligned right

### Action button placement
Moved primary actions out of the `InstallManagementDropdown` and onto their respective sub-page headers:
- `RunAdhocActionButton` → Actions page (primary)
- `EditStackOverridesButton` → Stacks page (secondary)
- `ManageAllDropdown` → Components page header
- `EditInputsButton` → wired into `ViewCurrentInputs` modal footer
- `AutoApproveToggle` → Workflows page (new toggle)

### New `Toggle` component
Pixel-accurate to the [Stratus toggle spec](https://www.figma.com/design/K3IcokRSyYRkH2tsr1KMhV/Stratus-Design-System?node-id=2040-1134):
- 24×14px track, 10×10px thumb
- Body label (14px medium) + optional subtext caption
- Used by `AutoApproveToggle` on the Workflows page

### Dropdown variant + naming
Renamed and standardized control dropdowns to `secondary` variant:
- `Manage` (page-level components) → **Component controls**
- `Manage sandbox` → **Sandbox controls**
- `Manage` (deploy detail) → **Deploy controls**
- `Manage` (sandbox run detail) → **Run controls**
- `Manage` (component detail) → **Component controls**

### Danger button cleanup
Replaced ad-hoc `className="!text-red-600..."` overrides with proper `variant="danger"`:
- `DeprovisionSandboxButton`, `TeardownAllComponentsButton`, `ForgetButton`, `CancelWorkflowButton`
- Fixed bug where `Menu` cloning overrode `variant="danger"` to `'ghost'` by reordering attribute placement
- Added `isMenuButton + variant="danger"` styling block to `Button.tsx`

### Filter dropdown standardization
All filter dropdowns in install sub-pages now use a consistent `FunnelIcon` (`size="14"`):
- `LabelFilterDropdown` (was `TagIcon`)
- `TriggeredByFilter` (was `SlidersIcon`)
- `WorkflowTypeFilter` (was `SlidersIcon`)
- `LogServiceFilter`, `LogSeverityFilter` (were `FadersHorizontal`)
- `DiffFilter` (was `FadersHorizontal`)

Removed `!p-1`/`!p-2` `className`/`buttonClassName` overrides for default secondary button sizing.

### Log filter polish
- Removed redundant "Filter" prefix → `Service (N)`, `Severity (N)`
- Moved icon to left of text via `iconAlignment="left"`
- Reordered controls: `Job output` checkbox now precedes `Sort`

### Admin link consistency
- All install-scoped `AdminDashboardLink` labels → "Admin panel"
- `AdminDashboardLink` renders icon inline with `text-xs`

### Other polish
- `InstallLayout`: header `gap-6`, `HeadingGroup` `gap-1.5` for breathing room around install metadata
- `EnableAutoApproveContainer`: added `queryClient.invalidateQueries(['install', orgId, installId])` on success so the toggle state updates live
- Cleaned up orphaned import blocks and removed wrapping `<span>`s no longer needed

## Test plan
- [x] Verify install sub-page headers (Actions, Stacks, Components, Workflows, Sandbox, CurrentInputs) all align consistently
- [x] Verify primary/secondary buttons match design (RunAdhocAction, EditStackOverrides, ManageAll, EditInputs)
- [x] Verify auto-approval toggle on Workflows page reflects current state and updates on toggle
- [x] Verify all danger menu items (Deprovision sandbox, Teardown components, Forget install, Cancel workflow) render in red
- [x] Verify all filter dropdowns show the funnel icon and consistent styling
- [x] Verify log filter buttons (Service / Severity) show count, icon on left, "Job output" precedes sort
- [x] Verify "Admin panel" links work and show in install-scoped pages