### PR TITLE
feat: org runners terminate their own pods

### DIFF
--- a/bins/runner/bundle/helm/templates/deployment.tpl
+++ b/bins/runner/bundle/helm/templates/deployment.tpl
@@ -50,3 +50,13 @@ spec:
               valueFrom:
                   fieldRef:
                       fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                  fieldRef:
+                      fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                  fieldRef:
+                      fieldPath: metadata.namespace
+            - name: DELETE_POD_ON_SHUTDOWN
+              value: "true"

--- a/bins/runner/bundle/helm/templates/deployment.tpl
+++ b/bins/runner/bundle/helm/templates/deployment.tpl
@@ -58,5 +58,7 @@ spec:
               valueFrom:
                   fieldRef:
                       fieldPath: metadata.namespace
+            - name: DEPLOYMENT_NAME
+              value: {{ include "common.fullname" . }}
             - name: DELETE_POD_ON_SHUTDOWN
               value: "true"

--- a/bins/runner/internal/config.go
+++ b/bins/runner/internal/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	// kubernetes pod identity and self-deletion
 	PodName             string `config:"pod_name"`
 	PodNamespace        string `config:"pod_namespace"`
+	DeploymentName      string `config:"deployment_name"`
 	DeletePodOnShutdown bool   `config:"delete_pod_on_shutdown"`
 
 	// only for enabling local things

--- a/bins/runner/internal/config.go
+++ b/bins/runner/internal/config.go
@@ -39,6 +39,11 @@ type Config struct {
 	RegistryDir  string `config:"registry_dir" validate:"required"`
 	RegistryPort int    `config:"registry_port" validate:"required"`
 
+	// kubernetes pod identity and self-deletion
+	PodName             string `config:"pod_name"`
+	PodNamespace        string `config:"pod_namespace"`
+	DeletePodOnShutdown bool   `config:"delete_pod_on_shutdown"`
+
 	// only for enabling local things
 	IsNuonctl                bool          `config:"is_nuonctl"`
 	SandboxJobDuration       time.Duration `config:"sandbox_job_duration"`

--- a/bins/runner/internal/pkg/process/pod_shutdown.go
+++ b/bins/runner/internal/pkg/process/pod_shutdown.go
@@ -1,0 +1,112 @@
+package process
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/nuonco/nuon/bins/runner/internal"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/k8s"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/settings"
+)
+
+type podShutdown struct {
+	cfg      *internal.Config
+	settings *settings.Settings
+	l        *zap.Logger
+}
+
+func newPodShutdown(cfg *internal.Config, settings *settings.Settings, l *zap.Logger) *podShutdown {
+	if !cfg.DeletePodOnShutdown || cfg.PodName == "" || cfg.PodNamespace == "" {
+		return nil
+	}
+	return &podShutdown{cfg: cfg, settings: settings, l: l}
+}
+
+func (ps *podShutdown) execute(ctx context.Context) error {
+	clientset, _, _, err := k8s.ClientsetInCluster()
+	if err != nil {
+		return fmt.Errorf("unable to create in-cluster k8s client: %w", err)
+	}
+
+	if err := ps.updateDeploymentImage(ctx, clientset); err != nil {
+		return fmt.Errorf("unable to update deployment image: %w", err)
+	}
+
+	if err := ps.deletePod(ctx, clientset); err != nil {
+		return fmt.Errorf("unable to delete own pod: %w", err)
+	}
+
+	return nil
+}
+
+func (ps *podShutdown) deletePod(ctx context.Context, clientset *kubernetes.Clientset) error {
+	ps.l.Info("deleting own pod",
+		zap.String("pod_name", ps.cfg.PodName),
+		zap.String("pod_namespace", ps.cfg.PodNamespace),
+	)
+
+	if err := clientset.CoreV1().Pods(ps.cfg.PodNamespace).Delete(ctx, ps.cfg.PodName, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+
+	ps.l.Info("successfully deleted own pod")
+	return nil
+}
+
+func (ps *podShutdown) updateDeploymentImage(ctx context.Context, clientset *kubernetes.Clientset) error {
+	if ps.cfg.DeploymentName == "" {
+		return nil
+	}
+
+	imageTag := ps.settings.ContainerImageTag
+	imageURL := ps.settings.ContainerImageURL
+	if imageTag == "" || imageURL == "" {
+		return nil
+	}
+
+	image := fmt.Sprintf("%s:%s", imageURL, imageTag)
+	ps.l.Info("updating deployment image",
+		zap.String("deployment", ps.cfg.DeploymentName),
+		zap.String("namespace", ps.cfg.PodNamespace),
+		zap.String("image", image),
+	)
+
+	patch := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []map[string]interface{}{
+						{
+							"name":  ps.cfg.DeploymentName,
+							"image": image,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("unable to marshal deployment patch: %w", err)
+	}
+
+	if _, err := clientset.AppsV1().Deployments(ps.cfg.PodNamespace).Patch(
+		ctx,
+		ps.cfg.DeploymentName,
+		types.StrategicMergePatchType,
+		patchBytes,
+		metav1.PatchOptions{},
+	); err != nil {
+		return err
+	}
+
+	ps.l.Info("successfully updated deployment image", zap.String("image", image))
+	return nil
+}

--- a/bins/runner/internal/pkg/process/shutdown_poller.go
+++ b/bins/runner/internal/pkg/process/shutdown_poller.go
@@ -8,7 +8,10 @@ import (
 	"github.com/sourcegraph/conc"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/nuonco/nuon/bins/runner/internal"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/k8s"
 	nuonrunner "github.com/nuonco/nuon/sdks/nuon-runner-go"
 )
 
@@ -21,6 +24,7 @@ type ShutdownPollerParams struct {
 	fx.In
 
 	APIClient  nuonrunner.Client
+	Cfg        *internal.Config
 	L          *zap.Logger `name:"system"`
 	LC         fx.Lifecycle
 	Registrar  *Registrar
@@ -29,6 +33,7 @@ type ShutdownPollerParams struct {
 
 type ShutdownPoller struct {
 	apiClient  nuonrunner.Client
+	cfg        *internal.Config
 	l          *zap.Logger
 	registrar  *Registrar
 	shutdowner fx.Shutdowner
@@ -43,6 +48,7 @@ func NewShutdownPoller(params ShutdownPollerParams) *ShutdownPoller {
 
 	sp := &ShutdownPoller{
 		apiClient:  params.APIClient,
+		cfg:        params.Cfg,
 		l:          params.L,
 		registrar:  params.Registrar,
 		shutdowner: params.Shutdowner,
@@ -113,6 +119,8 @@ func (sp *ShutdownPoller) check(ctx context.Context) {
 				)
 			}
 
+			sp.deletePod(ctx)
+
 			// Force-kill the process if fx.Shutdown doesn't complete in time.
 			go func() {
 				time.Sleep(forceExitTimeout)
@@ -126,4 +134,33 @@ func (sp *ShutdownPoller) check(ctx context.Context) {
 			return
 		}
 	}
+}
+
+func (sp *ShutdownPoller) deletePod(ctx context.Context) {
+	if !sp.cfg.DeletePodOnShutdown {
+		return
+	}
+
+	if sp.cfg.PodName == "" || sp.cfg.PodNamespace == "" {
+		sp.l.Warn("delete_pod_on_shutdown enabled but pod_name or pod_namespace not set, skipping pod deletion")
+		return
+	}
+
+	sp.l.Info("deleting own pod",
+		zap.String("pod_name", sp.cfg.PodName),
+		zap.String("pod_namespace", sp.cfg.PodNamespace),
+	)
+
+	clientset, _, _, err := k8s.ClientsetInCluster()
+	if err != nil {
+		sp.l.Warn("unable to create in-cluster k8s client for pod deletion", zap.Error(err))
+		return
+	}
+
+	if err := clientset.CoreV1().Pods(sp.cfg.PodNamespace).Delete(ctx, sp.cfg.PodName, metav1.DeleteOptions{}); err != nil {
+		sp.l.Warn("unable to delete own pod", zap.Error(err))
+		return
+	}
+
+	sp.l.Info("successfully deleted own pod")
 }

--- a/bins/runner/internal/pkg/process/shutdown_poller.go
+++ b/bins/runner/internal/pkg/process/shutdown_poller.go
@@ -2,6 +2,8 @@ package process
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"time"
 
@@ -9,9 +11,12 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/nuonco/nuon/bins/runner/internal"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/k8s"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/settings"
 	nuonrunner "github.com/nuonco/nuon/sdks/nuon-runner-go"
 )
 
@@ -28,6 +33,7 @@ type ShutdownPollerParams struct {
 	L          *zap.Logger `name:"system"`
 	LC         fx.Lifecycle
 	Registrar  *Registrar
+	Settings   *settings.Settings
 	Shutdowner fx.Shutdowner
 }
 
@@ -36,6 +42,7 @@ type ShutdownPoller struct {
 	cfg        *internal.Config
 	l          *zap.Logger
 	registrar  *Registrar
+	settings   *settings.Settings
 	shutdowner fx.Shutdowner
 
 	ctx      context.Context
@@ -51,6 +58,7 @@ func NewShutdownPoller(params ShutdownPollerParams) *ShutdownPoller {
 		cfg:        params.Cfg,
 		l:          params.L,
 		registrar:  params.Registrar,
+		settings:   params.Settings,
 		shutdowner: params.Shutdowner,
 		ctx:        ctx,
 		cancelFn:   cancelFn,
@@ -146,16 +154,18 @@ func (sp *ShutdownPoller) deletePod(ctx context.Context) {
 		return
 	}
 
+	clientset, _, _, err := k8s.ClientsetInCluster()
+	if err != nil {
+		sp.l.Warn("unable to create in-cluster k8s client for pod self-deletion", zap.Error(err))
+		return
+	}
+
+	sp.updateDeploymentImage(ctx, clientset)
+
 	sp.l.Info("deleting own pod",
 		zap.String("pod_name", sp.cfg.PodName),
 		zap.String("pod_namespace", sp.cfg.PodNamespace),
 	)
-
-	clientset, _, _, err := k8s.ClientsetInCluster()
-	if err != nil {
-		sp.l.Warn("unable to create in-cluster k8s client for pod deletion", zap.Error(err))
-		return
-	}
 
 	if err := clientset.CoreV1().Pods(sp.cfg.PodNamespace).Delete(ctx, sp.cfg.PodName, metav1.DeleteOptions{}); err != nil {
 		sp.l.Warn("unable to delete own pod", zap.Error(err))
@@ -163,4 +173,62 @@ func (sp *ShutdownPoller) deletePod(ctx context.Context) {
 	}
 
 	sp.l.Info("successfully deleted own pod")
+}
+
+func (sp *ShutdownPoller) updateDeploymentImage(ctx context.Context, clientset *kubernetes.Clientset) {
+	if sp.cfg.DeploymentName == "" {
+		sp.l.Warn("deployment_name not set, skipping deployment image update")
+		return
+	}
+
+	imageTag := sp.settings.ContainerImageTag
+	imageURL := sp.settings.ContainerImageURL
+	if imageTag == "" || imageURL == "" {
+		sp.l.Warn("container image tag or url not set in settings, skipping deployment image update",
+			zap.String("container_image_tag", imageTag),
+			zap.String("container_image_url", imageURL),
+		)
+		return
+	}
+
+	image := fmt.Sprintf("%s:%s", imageURL, imageTag)
+	sp.l.Info("updating deployment image",
+		zap.String("deployment", sp.cfg.DeploymentName),
+		zap.String("namespace", sp.cfg.PodNamespace),
+		zap.String("image", image),
+	)
+
+	patch := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []map[string]interface{}{
+						{
+							"name":  sp.cfg.DeploymentName,
+							"image": image,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		sp.l.Warn("unable to marshal deployment patch", zap.Error(err))
+		return
+	}
+
+	if _, err := clientset.AppsV1().Deployments(sp.cfg.PodNamespace).Patch(
+		ctx,
+		sp.cfg.DeploymentName,
+		types.StrategicMergePatchType,
+		patchBytes,
+		metav1.PatchOptions{},
+	); err != nil {
+		sp.l.Warn("unable to update deployment image", zap.Error(err))
+		return
+	}
+
+	sp.l.Info("successfully updated deployment image", zap.String("image", image))
 }

--- a/bins/runner/internal/pkg/process/shutdown_poller.go
+++ b/bins/runner/internal/pkg/process/shutdown_poller.go
@@ -2,20 +2,14 @@ package process
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"os"
 	"time"
 
 	"github.com/sourcegraph/conc"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/nuonco/nuon/bins/runner/internal"
-	"github.com/nuonco/nuon/bins/runner/internal/pkg/k8s"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/settings"
 	nuonrunner "github.com/nuonco/nuon/sdks/nuon-runner-go"
 )
@@ -39,11 +33,11 @@ type ShutdownPollerParams struct {
 
 type ShutdownPoller struct {
 	apiClient  nuonrunner.Client
-	cfg        *internal.Config
 	l          *zap.Logger
 	registrar  *Registrar
-	settings   *settings.Settings
 	shutdowner fx.Shutdowner
+
+	podShutdown *podShutdown
 
 	ctx      context.Context
 	cancelFn func()
@@ -54,15 +48,14 @@ func NewShutdownPoller(params ShutdownPollerParams) *ShutdownPoller {
 	ctx, cancelFn := context.WithCancel(context.Background())
 
 	sp := &ShutdownPoller{
-		apiClient:  params.APIClient,
-		cfg:        params.Cfg,
-		l:          params.L,
-		registrar:  params.Registrar,
-		settings:   params.Settings,
-		shutdowner: params.Shutdowner,
-		ctx:        ctx,
-		cancelFn:   cancelFn,
-		wg:         conc.NewWaitGroup(),
+		apiClient:   params.APIClient,
+		l:           params.L,
+		registrar:   params.Registrar,
+		shutdowner:  params.Shutdowner,
+		podShutdown: newPodShutdown(params.Cfg, params.Settings, params.L),
+		ctx:         ctx,
+		cancelFn:    cancelFn,
+		wg:          conc.NewWaitGroup(),
 	}
 
 	params.LC.Append(fx.Hook{
@@ -127,7 +120,11 @@ func (sp *ShutdownPoller) check(ctx context.Context) {
 				)
 			}
 
-			sp.deletePod(ctx)
+			if sp.podShutdown != nil {
+				if err := sp.podShutdown.execute(ctx); err != nil {
+					sp.l.Warn("pod shutdown failed", zap.Error(err))
+				}
+			}
 
 			// Force-kill the process if fx.Shutdown doesn't complete in time.
 			go func() {
@@ -142,93 +139,4 @@ func (sp *ShutdownPoller) check(ctx context.Context) {
 			return
 		}
 	}
-}
-
-func (sp *ShutdownPoller) deletePod(ctx context.Context) {
-	if !sp.cfg.DeletePodOnShutdown {
-		return
-	}
-
-	if sp.cfg.PodName == "" || sp.cfg.PodNamespace == "" {
-		sp.l.Warn("delete_pod_on_shutdown enabled but pod_name or pod_namespace not set, skipping pod deletion")
-		return
-	}
-
-	clientset, _, _, err := k8s.ClientsetInCluster()
-	if err != nil {
-		sp.l.Warn("unable to create in-cluster k8s client for pod self-deletion", zap.Error(err))
-		return
-	}
-
-	sp.updateDeploymentImage(ctx, clientset)
-
-	sp.l.Info("deleting own pod",
-		zap.String("pod_name", sp.cfg.PodName),
-		zap.String("pod_namespace", sp.cfg.PodNamespace),
-	)
-
-	if err := clientset.CoreV1().Pods(sp.cfg.PodNamespace).Delete(ctx, sp.cfg.PodName, metav1.DeleteOptions{}); err != nil {
-		sp.l.Warn("unable to delete own pod", zap.Error(err))
-		return
-	}
-
-	sp.l.Info("successfully deleted own pod")
-}
-
-func (sp *ShutdownPoller) updateDeploymentImage(ctx context.Context, clientset *kubernetes.Clientset) {
-	if sp.cfg.DeploymentName == "" {
-		sp.l.Warn("deployment_name not set, skipping deployment image update")
-		return
-	}
-
-	imageTag := sp.settings.ContainerImageTag
-	imageURL := sp.settings.ContainerImageURL
-	if imageTag == "" || imageURL == "" {
-		sp.l.Warn("container image tag or url not set in settings, skipping deployment image update",
-			zap.String("container_image_tag", imageTag),
-			zap.String("container_image_url", imageURL),
-		)
-		return
-	}
-
-	image := fmt.Sprintf("%s:%s", imageURL, imageTag)
-	sp.l.Info("updating deployment image",
-		zap.String("deployment", sp.cfg.DeploymentName),
-		zap.String("namespace", sp.cfg.PodNamespace),
-		zap.String("image", image),
-	)
-
-	patch := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"template": map[string]interface{}{
-				"spec": map[string]interface{}{
-					"containers": []map[string]interface{}{
-						{
-							"name":  sp.cfg.DeploymentName,
-							"image": image,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		sp.l.Warn("unable to marshal deployment patch", zap.Error(err))
-		return
-	}
-
-	if _, err := clientset.AppsV1().Deployments(sp.cfg.PodNamespace).Patch(
-		ctx,
-		sp.cfg.DeploymentName,
-		types.StrategicMergePatchType,
-		patchBytes,
-		metav1.PatchOptions{},
-	); err != nil {
-		sp.l.Warn("unable to update deployment image", zap.Error(err))
-		return
-	}
-
-	sp.l.Info("successfully updated deployment image", zap.String("image", image))
 }


### PR DESCRIPTION
Previously, we relied on org runners being reprovisioned every deploy. This updates the shutdown process so they can updated _without_ being reprovisioned by using their own kubeconfig to modify their access.
