### PR TITLE
fix(pkg): workflow cancel duration

### DIFF
--- a/docs/config-ref/install.mdx
+++ b/docs/config-ref/install.mdx
@@ -16,6 +16,7 @@ title: 'Install'
 | **`labels`**<br/>object | - | **Optional** | - |
 | **`aws_account`**<br/>[AWSAccount](#aws_account) | AWS account configuration AWS-specific settings for this install, including region and other account details | **Optional** | - |
 | **`gcp_account`**<br/>[GCPAccount](#gcp_account) | GCP account configuration GCP-specific settings for this install, including project ID and region | **Optional** | - |
+| **`azure_account`**<br/>[AzureAccount](#azure_account) | Azure account configuration Azure-specific settings for this install, including the deployment location | **Optional** | - |
 | **`inputs`**<br/>array | input values Array of input groups with key-value pairs for customer inputs provided during installation | **Optional** | - |
 | **`stack_overrides`**<br/>[InstallStackOverrides](#stack_overrides) | Stack template overrides Per-install overrides for the app-level stack template configuration. Overrides take precedence over app-level defaults. | **Optional** | - |
 
@@ -31,6 +32,12 @@ title: 'Install'
 |----------|----------|----------|----------|
 | **`project_id`**<br/>string | GCP project ID GCP project where the infrastructure will be deployed | **Optional** | `"my-gcp-project"` |
 | **`region`**<br/>string | GCP region GCP region where the infrastructure will be deployed | **Optional** | `"us-central1"`, `"europe-west1"` |
+
+### `azure_account`
+
+| Property | Description | Values | Example |
+|----------|----------|----------|----------|
+| **`location`**<br/>string | Azure location Azure location/region where the infrastructure will be deployed | **✅ Required** | `"eastus"`, `"westus2"`, `"westeurope"` |
 
 ### `stack_overrides`
 

--- a/pkg/generics/get_time_duration.go
+++ b/pkg/generics/get_time_duration.go
@@ -3,9 +3,9 @@ package generics
 import "time"
 
 func GetTimeDuration(startedAt time.Time, finishedAt time.Time) time.Duration {
-	if finishedAt.IsZero() && startedAt.IsZero() {
+	if startedAt.IsZero() {
 		return time.Duration(0)
-	} else if !startedAt.IsZero() && finishedAt.IsZero() {
+	} else if finishedAt.IsZero() {
 		return time.Since(startedAt)
 	}
 	return finishedAt.Sub(startedAt)

--- a/sdks/nuon-go/models/app_workflow_step.go
+++ b/sdks/nuon-go/models/app_workflow_step.go
@@ -107,6 +107,10 @@ type AppWorkflowStep struct {
 	// status
 	Status *AppCompositeStatus `json:"status,omitempty"`
 
+	// StepQueueID is the queue where the execute-workflow-step signal runs.
+	// When empty, the group's default step queue is used.
+	StepQueueID string `json:"step_queue_id,omitempty"`
+
 	// the following fields are set _once_ a step is in flight, and are orchestrated via the step's signal.
 	//
 	// this is a polymorphic gorm relationship to one of the following objects:
@@ -120,6 +124,10 @@ type AppWorkflowStep struct {
 
 	// step target type
 	StepTargetType string `json:"step_target_type,omitempty"`
+
+	// TargetQueueID is the queue where the inner signal (the actual work)
+	// gets dispatched. When empty, the step signal's TargetQueueName is used.
+	TargetQueueID string `json:"target_queue_id,omitempty"`
 
 	// updated at
 	UpdatedAt string `json:"updated_at,omitempty"`

--- a/sdks/nuon-runner-go/models/app_workflow_step.go
+++ b/sdks/nuon-runner-go/models/app_workflow_step.go
@@ -107,6 +107,10 @@ type AppWorkflowStep struct {
 	// status
 	Status *AppCompositeStatus `json:"status,omitempty"`
 
+	// StepQueueID is the queue where the execute-workflow-step signal runs.
+	// When empty, the group's default step queue is used.
+	StepQueueID string `json:"step_queue_id,omitempty"`
+
 	// the following fields are set _once_ a step is in flight, and are orchestrated via the step's signal.
 	//
 	// this is a polymorphic gorm relationship to one of the following objects:
@@ -120,6 +124,10 @@ type AppWorkflowStep struct {
 
 	// step target type
 	StepTargetType string `json:"step_target_type,omitempty"`
+
+	// TargetQueueID is the queue where the inner signal (the actual work)
+	// gets dispatched. When empty, the step signal's TargetQueueName is used.
+	TargetQueueID string `json:"target_queue_id,omitempty"`
 
 	// updated at
 	UpdatedAt string `json:"updated_at,omitempty"`

--- a/services/dashboard-ui/client/components/common/Duration.stories.tsx
+++ b/services/dashboard-ui/client/components/common/Duration.stories.tsx
@@ -230,6 +230,46 @@ export const TimeRanges = () => (
   </div>
 )
 
+export const EdgeCases = () => (
+  <div className="space-y-6">
+    <div className="space-y-3">
+      <h3 className="text-lg font-semibold">Edge cases</h3>
+    </div>
+
+    <div className="space-y-4">
+      <div className="space-y-3 p-4 border rounded">
+        <div className="flex items-center gap-3">
+          <Duration nanoseconds={0} />
+          <Text variant="subtext" theme="neutral">
+            Zero nanoseconds (cancelled before start)
+          </Text>
+        </div>
+        <div className="flex items-center gap-3">
+          <Duration nanoseconds={undefined} />
+          <Text variant="subtext" theme="neutral">
+            Undefined nanoseconds
+          </Text>
+        </div>
+        <div className="flex items-center gap-3">
+          <Duration beginTime={undefined} />
+          <Text variant="subtext" theme="neutral">
+            No beginTime or endTime
+          </Text>
+        </div>
+        <div className="flex items-center gap-3">
+          <Duration
+            beginTime="0001-01-01T00:00:00Z"
+            endTime="2026-04-29T13:39:53Z"
+          />
+          <Text variant="subtext" theme="neutral">
+            Go zero-value startedAt with real endTime (the bug: shows 317y)
+          </Text>
+        </div>
+      </div>
+    </div>
+  </div>
+)
+
 export const UsageExamples = () => (
   <div className="space-y-6">
     <div className="space-y-3">

--- a/services/dashboard-ui/client/components/common/Duration.tsx
+++ b/services/dashboard-ui/client/components/common/Duration.tsx
@@ -44,8 +44,10 @@ export const Duration = ({
     duration = LuxonDuration.fromMillis(milliseconds)
   } else if (beginTime) {
     const bt = DateTime.fromISO(beginTime)
-    const et = endTime ? DateTime.fromISO(endTime) : DateTime.now()
-    duration = et.diff(bt, durationUnits)
+    if (bt.isValid && bt.year > 1) {
+      const et = endTime ? DateTime.fromISO(endTime) : DateTime.now()
+      duration = et.diff(bt, durationUnits)
+    }
   }
 
   return (

--- a/services/dashboard-ui/client/components/workflows/WorkflowTimeline/WorkflowTimeline.tsx
+++ b/services/dashboard-ui/client/components/workflows/WorkflowTimeline/WorkflowTimeline.tsx
@@ -123,7 +123,7 @@ export const WorkflowTimeline = ({
                     format="relative"
                   />
                 </Text>
-                {workflow?.finished ? (
+                {workflow?.finished && workflow?.execution_time ? (
                   <Text
                     flex
                     className="gap-1"


### PR DESCRIPTION
When a workflow is canceled before it actually starts the `GetTimeDuration` helper would calculate a invalid duration and the UI would render this as 317 years. This handles the situation where the startedAt time is 0 instead of trying to calculate a duration from the startedAt + finishedAt. This also adds some defenses against invalid duration. 