### PR TITLE
feat: queue robustness write path

### DIFF
--- a/bins/runner/Dockerfile
+++ b/bins/runner/Dockerfile
@@ -253,8 +253,8 @@ ENV GIT_REF=$tag
 ENTRYPOINT ["/bin/runner"]
 
 FROM scratch AS artifacts-build
-COPY --from=build-darwin-arm64 /out/ /
-COPY --from=build-darwin-amd64 /out/ /
+#COPY --from=build-darwin-arm64 /out/ /
+#COPY --from=build-darwin-amd64 /out/ /
 COPY --from=build-linux-arm /out/ /
 COPY --from=build-linux-arm64 /out/ /
 COPY --from=build-linux-386 /out/ /

--- a/bins/runner/bundle/helm/templates/service_account.tpl
+++ b/bins/runner/bundle/helm/templates/service_account.tpl
@@ -22,7 +22,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: {{ include "common.fullname" . }}
+    name: {{ .Values.serviceAccount.name | default (include "common.fullname" .)}}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -34,7 +34,7 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "common.fullname" . }}
+    name: {{ .Values.serviceAccount.name | default (include "common.fullname" .)}}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/bins/runner/internal/pkg/process/pod_shutdown.go
+++ b/bins/runner/internal/pkg/process/pod_shutdown.go
@@ -25,6 +25,7 @@ func newPodShutdown(cfg *internal.Config, settings *settings.Settings, l *zap.Lo
 	if !cfg.DeletePodOnShutdown || cfg.PodName == "" || cfg.PodNamespace == "" {
 		return nil
 	}
+
 	return &podShutdown{cfg: cfg, settings: settings, l: l}
 }
 

--- a/bins/runner/internal/pkg/process/shutdown_poller.go
+++ b/bins/runner/internal/pkg/process/shutdown_poller.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -47,6 +48,9 @@ type ShutdownPoller struct {
 func NewShutdownPoller(params ShutdownPollerParams) *ShutdownPoller {
 	ctx, cancelFn := context.WithCancel(context.Background())
 
+	fmt.Println(params.Cfg.PodNamespace)
+	fmt.Println(params.Cfg.DeletePodOnShutdown)
+	fmt.Println(params.Cfg.DeploymentName)
 	sp := &ShutdownPoller{
 		apiClient:   params.APIClient,
 		l:           params.L,
@@ -104,6 +108,7 @@ func (sp *ShutdownPoller) check(ctx context.Context) {
 		if shutdown == nil {
 			continue
 		}
+
 		if shutdown.Status == "requested" {
 			sp.l.Info("shutdown requested, marking as completed and initiating graceful shutdown",
 				zap.String("process_id", processID),
@@ -123,6 +128,7 @@ func (sp *ShutdownPoller) check(ctx context.Context) {
 			if sp.podShutdown != nil {
 				if err := sp.podShutdown.execute(ctx); err != nil {
 					sp.l.Warn("pod shutdown failed", zap.Error(err))
+					fmt.Println("pod shut down failure", err.Error())
 				}
 			}
 

--- a/bins/runner/internal/pkg/process/shutdown_poller.go
+++ b/bins/runner/internal/pkg/process/shutdown_poller.go
@@ -2,7 +2,6 @@ package process
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
@@ -48,9 +47,6 @@ type ShutdownPoller struct {
 func NewShutdownPoller(params ShutdownPollerParams) *ShutdownPoller {
 	ctx, cancelFn := context.WithCancel(context.Background())
 
-	fmt.Println(params.Cfg.PodNamespace)
-	fmt.Println(params.Cfg.DeletePodOnShutdown)
-	fmt.Println(params.Cfg.DeploymentName)
 	sp := &ShutdownPoller{
 		apiClient:   params.APIClient,
 		l:           params.L,
@@ -128,7 +124,6 @@ func (sp *ShutdownPoller) check(ctx context.Context) {
 			if sp.podShutdown != nil {
 				if err := sp.podShutdown.execute(ctx); err != nil {
 					sp.l.Warn("pod shutdown failed", zap.Error(err))
-					fmt.Println("pod shut down failure", err.Error())
 				}
 			}
 

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/queue_detail.templ
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/queue_detail.templ
@@ -87,6 +87,9 @@ templ QueueDetail(q *app.Queue, status *queue.StatusResponse, signals []app.Queu
 					</div>
 					<!-- Status badges -->
 					<div class="flex gap-2">
+						if string(q.StatusV2.Status) != "" {
+							@signalStatusBadge(q.StatusV2)
+						}
 						if status != nil {
 							if status.Ready {
 								@badge.Badge(badge.Props{Variant: badge.VariantDefault}) {

--- a/services/ctl-api/internal/app/admin-dashboard/service/views/queue_signal_detail.templ
+++ b/services/ctl-api/internal/app/admin-dashboard/service/views/queue_signal_detail.templ
@@ -80,6 +80,9 @@ templ QueueSignalDetail(signal *app.QueueSignal, q *app.Queue, temporalUIURL str
 
 			<!-- Timeline -->
 			{{ enqueuedAt := signal.CreatedAt.Format("2006-01-02 15:04:05 MST") }}
+			{{ enqueueStartedAt := getMetadataString(signal.Status, "enqueue_started_at") }}
+			{{ enqueueFinishedAt := getMetadataString(signal.Status, "enqueue_finished_at") }}
+			{{ enqueueError := getMetadataString(signal.Status, "enqueue_error") }}
 			{{ dequeuedAt := getMetadataString(signal.Status, "dequeued_at") }}
 			{{ executeStartedAt := getMetadataString(signal.Status, "execute_started_at") }}
 			{{ executeFinishedAt := getMetadataString(signal.Status, "execute_finished_at") }}
@@ -93,13 +96,24 @@ templ QueueSignalDetail(signal *app.QueueSignal, q *app.Queue, temporalUIURL str
 					@card.Content() {
 						<div class="flex items-start">
 							@timelineStep("Enqueued", enqueuedAt, true)
-							@timelineConnector(computeQueueWait(signal))
+							@timelineConnector(computeEnqueueDuration(signal))
+							if enqueueError != "" {
+								@timelineStep("Enqueue failed", enqueueError, false)
+							} else {
+								@timelineStep("Enqueue finished", enqueueFinishedAt, enqueueFinishedAt != "")
+							}
+							@timelineConnector(computeEnqueueToDequeue(signal))
 							@timelineStep("Dequeued", dequeuedAt, dequeuedAt != "")
 							@timelineConnector(computeDequeuedToExecute(signal))
 							@timelineStep("Execute started", executeStartedAt, executeStartedAt != "")
 							@timelineConnector(computeDuration(signal))
 							@timelineStep("Execute finished", executeFinishedAt, executeFinishedAt != "")
 						</div>
+						if enqueueStartedAt == "" && enqueueFinishedAt == "" {
+							<div class="mt-3 text-xs text-muted-foreground">
+								Enqueue timing metadata not available (signal created before tracking was added).
+							</div>
+						}
 					}
 				}
 			</div>
@@ -498,6 +512,40 @@ func computeDequeuedToExecute(signal *app.QueueSignal) string {
 		return ""
 	}
 	return formatDuration(start.Sub(dequeued))
+}
+
+func computeEnqueueDuration(signal *app.QueueSignal) string {
+	startStr := getMetadataString(signal.Status, "enqueue_started_at")
+	endStr := getMetadataString(signal.Status, "enqueue_finished_at")
+	if startStr == "" || endStr == "" {
+		return ""
+	}
+	start, err := time.Parse(time.RFC3339, startStr)
+	if err != nil {
+		return ""
+	}
+	end, err := time.Parse(time.RFC3339, endStr)
+	if err != nil {
+		return ""
+	}
+	return formatDuration(end.Sub(start))
+}
+
+func computeEnqueueToDequeue(signal *app.QueueSignal) string {
+	enqueueFinishedStr := getMetadataString(signal.Status, "enqueue_finished_at")
+	dequeuedStr := getMetadataString(signal.Status, "dequeued_at")
+	if enqueueFinishedStr == "" || dequeuedStr == "" {
+		return ""
+	}
+	enqueueFinished, err := time.Parse(time.RFC3339, enqueueFinishedStr)
+	if err != nil {
+		return ""
+	}
+	dequeued, err := time.Parse(time.RFC3339, dequeuedStr)
+	if err != nil {
+		return ""
+	}
+	return formatDuration(dequeued.Sub(enqueueFinished))
 }
 
 func computeQueueWait(signal *app.QueueSignal) string {

--- a/services/ctl-api/internal/app/general/worker/activities/get_queue_signal_enqueue_metrics.go
+++ b/services/ctl-api/internal/app/general/worker/activities/get_queue_signal_enqueue_metrics.go
@@ -1,0 +1,44 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+type QueueSignalEnqueueMetrics struct {
+	TotalQueued          int64
+	MissingEnqueueFinish int64
+}
+
+type GetQueueSignalEnqueueMetricsRequest struct{}
+
+// @temporal-gen-v2 activity
+func (a *Activities) GetQueueSignalEnqueueMetrics(ctx context.Context, req GetQueueSignalEnqueueMetricsRequest) (*QueueSignalEnqueueMetrics, error) {
+	return a.getQueueSignalEnqueueMetrics(ctx, a.db)
+}
+
+func (a *Activities) getQueueSignalEnqueueMetrics(ctx context.Context, db *gorm.DB) (*QueueSignalEnqueueMetrics, error) {
+	var m QueueSignalEnqueueMetrics
+
+	// Count total queue signals in non-terminal queued state
+	if res := db.WithContext(ctx).
+		Raw(`SELECT count(*) FROM queue_signals WHERE deleted_at = 0`).
+		Scan(&m.TotalQueued); res.Error != nil {
+		return nil, fmt.Errorf("unable to count total queue signals: %w", res.Error)
+	}
+
+	// Count queue signals missing enqueue_finished_at in their status metadata.
+	// These are signals where the background enqueue goroutine either hasn't
+	// completed yet or failed silently.
+	if res := db.WithContext(ctx).
+		Raw(`SELECT count(*) FROM queue_signals
+WHERE deleted_at = 0
+AND NOT (status::jsonb -> 'metadata' ? 'enqueue_finished_at')`).
+		Scan(&m.MissingEnqueueFinish); res.Error != nil {
+		return nil, fmt.Errorf("unable to count signals missing enqueue_finished_at: %w", res.Error)
+	}
+
+	return &m, nil
+}

--- a/services/ctl-api/internal/app/general/worker/metrics_workflow.go
+++ b/services/ctl-api/internal/app/general/worker/metrics_workflow.go
@@ -80,6 +80,9 @@ func (w *Workflows) Metrics(ctx workflow.Context) error {
 		"temporal_runners": func(ctx workflow.Context) error {
 			return w.temporalNamespaceMetrics(ctx, "runners")
 		},
+		"queue_signal_enqueue": func(ctx workflow.Context) error {
+			return w.writeQueueSignalEnqueueMetrics(ctx)
+		},
 	}
 
 	for name, method := range methods {
@@ -199,6 +202,25 @@ func (w *Workflows) writePSQLTableMetrics(ctx workflow.Context) error {
 			"table_name": table.TableName,
 		}, defaultTags))...)
 	}
+
+	return nil
+}
+
+func (w *Workflows) writeQueueSignalEnqueueMetrics(ctx workflow.Context) error {
+	defaultTags := map[string]string{"general": "true"}
+
+	m, err := activities.AwaitGetQueueSignalEnqueueMetrics(ctx, activities.GetQueueSignalEnqueueMetricsRequest{})
+	if err != nil {
+		return errors.Wrap(err, "unable to get queue signal enqueue metrics")
+	}
+
+	w.mw.Gauge(ctx, "queue_signals.total",
+		float64(m.TotalQueued),
+		metrics.ToTags(defaultTags)...)
+
+	w.mw.Gauge(ctx, "queue_signals.missing_enqueue_finished",
+		float64(m.MissingEnqueueFinish),
+		metrics.ToTags(defaultTags)...)
 
 	return nil
 }

--- a/services/ctl-api/internal/app/queue_signal.go
+++ b/services/ctl-api/internal/app/queue_signal.go
@@ -42,6 +42,8 @@ type QueueSignal struct {
 
 	Workflow signaldb.WorkflowRef `json:"workflow"`
 
+	Enqueued bool `json:"enqueued" gorm:"default:false;not null" temporaljson:"enqueued,omitzero,omitempty"`
+
 	ExecutionCount int `json:"execution_count" gorm:"default:0;not null" temporaljson:"execution_count,omitzero,omitempty"`
 }
 
@@ -51,6 +53,13 @@ func (r *QueueSignal) Indexes(db *gorm.DB) []migrations.Index {
 			Name: indexes.Name(db, &QueueSignal{}, "org_id"),
 			Columns: []string{
 				"org_id",
+			},
+		},
+		{
+			Name: indexes.Name(db, &QueueSignal{}, "enqueued"),
+			Columns: []string{
+				"enqueued",
+				"created_at",
 			},
 		},
 	}

--- a/services/ctl-api/internal/fxmodules/infrastructure.go
+++ b/services/ctl-api/internal/fxmodules/infrastructure.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/notifications"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	emitterclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/emitter/client"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/enqueuer"
 	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks/arm"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks/cloudformation"
@@ -77,6 +78,7 @@ var InfrastructureModule = fx.Module("infrastructure",
 	fx.Provide(analytics.NewTemporal),
 	fx.Provide(cloudformation.NewTemplates),
 	fx.Provide(arm.NewTemplates),
+	fx.Provide(enqueuer.New),
 	fx.Provide(queueclient.New),
 	fx.Provide(emitterclient.New),
 	fx.Provide(flowclient.New),

--- a/services/ctl-api/internal/pkg/db/generics/json.go
+++ b/services/ctl-api/internal/pkg/db/generics/json.go
@@ -1,6 +1,7 @@
 package generics
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"gorm.io/gorm"
@@ -62,6 +63,35 @@ func (jq *JSONBQuerier) WhereJSONPath(field string, path []string, operator stri
 	pathStr := "{" + join(path, ",") + "}"
 	query := fmt.Sprintf("%s#>>? %s ?", field, operator)
 	return jq.Where(query, pathStr, value)
+}
+
+// MergeJSONBMetadata reads a JSONB column's "metadata" key, merges the provided
+// key-value pairs, and writes the column back. The model must be a pointer to a
+// GORM model (e.g. &app.QueueSignal{}).
+func MergeJSONBMetadata(db *gorm.DB, model any, id string, field string, metadata map[string]any) error {
+	// Build a jsonb_set chain that merges each key into the metadata sub-object.
+	// Start from the existing column value, defaulting to '{}'.
+	expr := fmt.Sprintf("COALESCE(%s::jsonb, '{}'::jsonb)", field)
+
+	args := make([]any, 0, len(metadata))
+	for k, v := range metadata {
+		valJSON, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("unable to marshal metadata value for key %s: %w", k, err)
+		}
+		expr = fmt.Sprintf("jsonb_set(%s, '{metadata,%s}', ?::jsonb)", expr, k)
+		args = append(args, string(valJSON))
+	}
+
+	args = append(args, id)
+	if res := db.
+		Model(model).
+		Where("id = ?", id).
+		Update(field, gorm.Expr(expr, args...)); res.Error != nil {
+		return fmt.Errorf("unable to merge metadata: %w", res.Error)
+	}
+
+	return nil
 }
 
 // Helper function to join strings

--- a/services/ctl-api/internal/pkg/db/psql/migrations/098_backfill_queue_signal_enqueue_finished_at.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/098_backfill_queue_signal_enqueue_finished_at.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// Migration098BackfillQueueSignalEnqueueFinishedAt sets enqueue_finished_at on
+// all existing queue signals that don't have it. This ensures the new metric
+// (queue_signals.missing_enqueue_finished) starts from a clean baseline when
+// the background-enqueue change rolls out.
+func (m *Migrations) Migration098BackfillQueueSignalEnqueueFinishedAt(ctx context.Context, db *gorm.DB) error {
+	if res := db.WithContext(ctx).
+		Exec(`UPDATE queue_signals
+SET status = jsonb_set(
+    COALESCE(status::jsonb, '{}'::jsonb),
+    '{metadata,enqueue_finished_at}',
+    to_jsonb(to_char(created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"'))
+)
+WHERE deleted_at = 0
+AND NOT (COALESCE(status::jsonb, '{}'::jsonb) -> 'metadata' ? 'enqueue_finished_at');`); res.Error != nil {
+		return res.Error
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/098_backfill_queue_signal_enqueue_finished_at.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/098_backfill_queue_signal_enqueue_finished_at.go
@@ -7,13 +7,13 @@ import (
 )
 
 // Migration098BackfillQueueSignalEnqueueFinishedAt sets enqueue_finished_at on
-// all existing queue signals that don't have it. This ensures the new metric
-// (queue_signals.missing_enqueue_finished) starts from a clean baseline when
-// the background-enqueue change rolls out.
+// all existing queue signals that don't have it and marks them as enqueued.
+// This ensures a clean baseline when the background-enqueue change rolls out.
 func (m *Migrations) Migration098BackfillQueueSignalEnqueueFinishedAt(ctx context.Context, db *gorm.DB) error {
 	if res := db.WithContext(ctx).
 		Exec(`UPDATE queue_signals
-SET status = jsonb_set(
+SET enqueued = true,
+    status = jsonb_set(
     COALESCE(status::jsonb, '{}'::jsonb),
     '{metadata,enqueue_finished_at}',
     to_jsonb(to_char(created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"'))

--- a/services/ctl-api/internal/pkg/db/psql/migrations/all.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/all.go
@@ -64,5 +64,9 @@ func (m *Migrations) All() []migrations.Migration {
 			Name: "097-backfill-runner-group-owner-name",
 			Fn:   m.Migration097BackfillRunnerGroupOwnerName,
 		},
+		{
+			Name: "098-backfill-queue-signal-enqueue-finished-at",
+			Fn:   m.Migration098BackfillQueueSignalEnqueueFinishedAt,
+		},
 	}
 }

--- a/services/ctl-api/internal/pkg/queue/activities/check_restart_hint.go
+++ b/services/ctl-api/internal/pkg/queue/activities/check_restart_hint.go
@@ -1,0 +1,57 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+)
+
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 1m
+// @as-wrapper
+// @wrapper-prefix QueueInternal
+func (a *Activities) checkRestartHint(ctx context.Context, queueID string) (bool, error) {
+	var queue app.Queue
+	if res := a.db.WithContext(ctx).Where(app.Queue{ID: queueID}).First(&queue); res.Error != nil {
+		return false, generics.TemporalGormError(res.Error, "unable to get queue for restart hint check")
+	}
+
+	if queue.Metadata == nil {
+		return false, nil
+	}
+
+	hint, ok := queue.Metadata["restart_hint"]
+	if !ok || hint == nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 1m
+// @as-wrapper
+// @wrapper-prefix QueueInternal
+func (a *Activities) clearRestartHint(ctx context.Context, queueID string) error {
+	var queue app.Queue
+	if res := a.db.WithContext(ctx).Where(app.Queue{ID: queueID}).First(&queue); res.Error != nil {
+		return generics.TemporalGormError(res.Error, "unable to get queue for restart hint clear")
+	}
+
+	if queue.Metadata == nil {
+		return nil
+	}
+
+	if _, ok := queue.Metadata["restart_hint"]; !ok {
+		return nil
+	}
+
+	delete(queue.Metadata, "restart_hint")
+
+	if res := a.db.WithContext(ctx).Model(&app.Queue{}).Where(app.Queue{ID: queueID}).Update("metadata", queue.Metadata); res.Error != nil {
+		return generics.TemporalGormError(res.Error, "unable to clear restart hint")
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/queue/client/client.go
+++ b/services/ctl-api/internal/pkg/queue/client/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"context"
+	"encoding/json"
 	"time"
 
 	enumsv1 "go.temporal.io/api/enums/v1"
@@ -64,4 +66,42 @@ func (c *Client) queueStartOperation(q *app.Queue) tclient.WithStartWorkflowOper
 		},
 	}
 	return c.tClient.NewWithStartWorkflowOperation(startOpts, "Queue", wkflowReq)
+}
+
+// updateQueueSignalMetadata merges metadata keys into a queue signal's CompositeStatus.
+// This is a best-effort, fire-and-forget operation used from background goroutines.
+func (c *Client) updateQueueSignalMetadata(queueSignalID string, metadata map[string]any) {
+	ctx := context.Background()
+
+	var qs app.QueueSignal
+	if res := c.db.WithContext(ctx).Select("id", "status").First(&qs, "id = ?", queueSignalID); res.Error != nil {
+		c.l.Warn("unable to get queue signal for metadata update",
+			zap.String("queue-signal-id", queueSignalID),
+			zap.Error(res.Error))
+		return
+	}
+
+	if qs.Status.Metadata == nil {
+		qs.Status.Metadata = make(map[string]any)
+	}
+	for k, v := range metadata {
+		qs.Status.Metadata[k] = v
+	}
+
+	statusJSON, err := json.Marshal(qs.Status)
+	if err != nil {
+		c.l.Warn("unable to marshal status for metadata update",
+			zap.String("queue-signal-id", queueSignalID),
+			zap.Error(err))
+		return
+	}
+
+	if res := c.db.WithContext(ctx).
+		Model(&app.QueueSignal{}).
+		Where("id = ?", queueSignalID).
+		Update("status", gorm.Expr("?::jsonb", string(statusJSON))); res.Error != nil {
+		c.l.Warn("unable to update queue signal metadata",
+			zap.String("queue-signal-id", queueSignalID),
+			zap.Error(res.Error))
+	}
 }

--- a/services/ctl-api/internal/pkg/queue/client/client.go
+++ b/services/ctl-api/internal/pkg/queue/client/client.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"context"
-	"encoding/json"
 	"time"
 
 	enumsv1 "go.temporal.io/api/enums/v1"
@@ -17,30 +15,34 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/enqueuer"
 )
 
 type Client struct {
-	db      *gorm.DB
-	cfg     *internal.Config
-	tClient temporalclient.Client
-	l       *zap.Logger
+	db       *gorm.DB
+	cfg      *internal.Config
+	tClient  temporalclient.Client
+	l        *zap.Logger
+	enqueuer *enqueuer.Enqueuer
 }
 
 type Params struct {
 	fx.In
 
-	DB      *gorm.DB `name:"psql"`
-	Cfg     *internal.Config
-	TClient temporalclient.Client
-	L       *zap.Logger
+	DB       *gorm.DB `name:"psql"`
+	Cfg      *internal.Config
+	TClient  temporalclient.Client
+	L        *zap.Logger
+	Enqueuer *enqueuer.Enqueuer
 }
 
 func New(params Params) *Client {
 	return &Client{
-		db:      params.DB,
-		cfg:     params.Cfg,
-		tClient: params.TClient,
-		l:       params.L,
+		db:       params.DB,
+		cfg:      params.Cfg,
+		tClient:  params.TClient,
+		l:        params.L,
+		enqueuer: params.Enqueuer,
 	}
 }
 
@@ -66,42 +68,4 @@ func (c *Client) queueStartOperation(q *app.Queue) tclient.WithStartWorkflowOper
 		},
 	}
 	return c.tClient.NewWithStartWorkflowOperation(startOpts, "Queue", wkflowReq)
-}
-
-// updateQueueSignalMetadata merges metadata keys into a queue signal's CompositeStatus.
-// This is a best-effort, fire-and-forget operation used from background goroutines.
-func (c *Client) updateQueueSignalMetadata(queueSignalID string, metadata map[string]any) {
-	ctx := context.Background()
-
-	var qs app.QueueSignal
-	if res := c.db.WithContext(ctx).Select("id", "status").First(&qs, "id = ?", queueSignalID); res.Error != nil {
-		c.l.Warn("unable to get queue signal for metadata update",
-			zap.String("queue-signal-id", queueSignalID),
-			zap.Error(res.Error))
-		return
-	}
-
-	if qs.Status.Metadata == nil {
-		qs.Status.Metadata = make(map[string]any)
-	}
-	for k, v := range metadata {
-		qs.Status.Metadata[k] = v
-	}
-
-	statusJSON, err := json.Marshal(qs.Status)
-	if err != nil {
-		c.l.Warn("unable to marshal status for metadata update",
-			zap.String("queue-signal-id", queueSignalID),
-			zap.Error(err))
-		return
-	}
-
-	if res := c.db.WithContext(ctx).
-		Model(&app.QueueSignal{}).
-		Where("id = ?", queueSignalID).
-		Update("status", gorm.Expr("?::jsonb", string(statusJSON))); res.Error != nil {
-		c.l.Warn("unable to update queue signal metadata",
-			zap.String("queue-signal-id", queueSignalID),
-			zap.Error(res.Error))
-	}
 }

--- a/services/ctl-api/internal/pkg/queue/client/enqueue_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/enqueue_signal.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"time"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	tclient "go.temporal.io/sdk/client"
 
@@ -35,6 +37,14 @@ func (c *Client) EnqueueSignal(ctx context.Context, req *EnqueueSignalRequest) (
 	suffix := make([]byte, 3)
 	_, _ = rand.Read(suffix)
 
+	status := app.NewCompositeStatus(ctx, app.StatusQueued)
+	if t, ok := req.Signal.(signal.SignalWithTimeout); ok {
+		if status.Metadata == nil {
+			status.Metadata = make(map[string]any)
+		}
+		status.Metadata["timeout_ns"] = t.Timeout().Nanoseconds()
+	}
+
 	queueSignal := app.QueueSignal{
 		Signal: signaldb.SignalData{
 			Signal: req.Signal,
@@ -43,7 +53,7 @@ func (c *Client) EnqueueSignal(ctx context.Context, req *EnqueueSignalRequest) (
 		Type:      req.Signal.Type(),
 		OwnerID:   req.OwnerID,
 		OwnerType: req.OwnerType,
-		Status:    app.NewCompositeStatus(ctx, app.StatusQueued),
+		Status:    status,
 		Workflow: signaldb.WorkflowRef{
 			Namespace:  q.Workflow.Namespace,
 			IDTemplate: q.Workflow.ID + "-handler-%s-" + string(req.Signal.Type()) + "-" + hex.EncodeToString(suffix),
@@ -54,25 +64,44 @@ func (c *Client) EnqueueSignal(ctx context.Context, req *EnqueueSignalRequest) (
 		return nil, errors.Wrap(res.Error, "unable to create queue signal")
 	}
 
-	// Send the enqueue update to the queue workflow. We only wait for the
-	// "accepted" stage so the caller gets the signal ID back immediately.
-	_, err = c.tClient.UpdateWithStartWorkflowInNamespace(ctx, q.Workflow.Namespace, tclient.UpdateWithStartWorkflowOptions{
-		UpdateOptions: tclient.UpdateWorkflowOptions{
-			WorkflowID:   q.Workflow.ID,
-			UpdateName:   queue.EnqueueUpdateName,
-			WaitForStage: tclient.WorkflowUpdateStageAccepted,
-			Args: []any{
-				queue.EnqueueHandlerInput{
-					QueueSignalID: queueSignal.ID,
-					WorkflowID:    queueSignal.Workflow.ID,
+	// Fire off the UpdateWithStart call in a background goroutine so the caller
+	// gets the signal ID back immediately without waiting for the queue workflow.
+	enqueueStartedAt := time.Now().UTC().Format(time.RFC3339)
+	startOp := c.queueStartOperation(q)
+	namespace := q.Workflow.Namespace
+	workflowID := q.Workflow.ID
+	signalID := queueSignal.ID
+	handlerWorkflowID := queueSignal.Workflow.ID
+
+	go func() {
+		bgCtx := context.Background()
+		_, err := c.tClient.UpdateWithStartWorkflowInNamespace(bgCtx, namespace, tclient.UpdateWithStartWorkflowOptions{
+			UpdateOptions: tclient.UpdateWorkflowOptions{
+				WorkflowID:   workflowID,
+				UpdateName:   queue.EnqueueUpdateName,
+				WaitForStage: tclient.WorkflowUpdateStageAccepted,
+				Args: []any{
+					queue.EnqueueHandlerInput{
+						QueueSignalID: signalID,
+						WorkflowID:    handlerWorkflowID,
+					},
 				},
 			},
-		},
-		StartWorkflowOperation: c.queueStartOperation(q),
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to call enqueue handler")
-	}
+			StartWorkflowOperation: startOp,
+		})
+
+		metadata := map[string]any{
+			"enqueue_started_at":  enqueueStartedAt,
+			"enqueue_finished_at": time.Now().UTC().Format(time.RFC3339),
+		}
+		if err != nil {
+			metadata["enqueue_error"] = err.Error()
+			c.l.Warn("background enqueue failed",
+				zap.String("queue-signal-id", signalID),
+				zap.Error(err))
+		}
+		c.updateQueueSignalMetadata(signalID, metadata)
+	}()
 
 	return &queue.EnqueueResponse{
 		ID:         queueSignal.ID,

--- a/services/ctl-api/internal/pkg/queue/client/enqueue_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/enqueue_signal.go
@@ -4,12 +4,8 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"time"
 
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
-
-	tclient "go.temporal.io/sdk/client"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue"
@@ -64,44 +60,9 @@ func (c *Client) EnqueueSignal(ctx context.Context, req *EnqueueSignalRequest) (
 		return nil, errors.Wrap(res.Error, "unable to create queue signal")
 	}
 
-	// Fire off the UpdateWithStart call in a background goroutine so the caller
-	// gets the signal ID back immediately without waiting for the queue workflow.
-	enqueueStartedAt := time.Now().UTC().Format(time.RFC3339)
-	startOp := c.queueStartOperation(q)
-	namespace := q.Workflow.Namespace
-	workflowID := q.Workflow.ID
-	signalID := queueSignal.ID
-	handlerWorkflowID := queueSignal.Workflow.ID
-
-	go func() {
-		bgCtx := context.Background()
-		_, err := c.tClient.UpdateWithStartWorkflowInNamespace(bgCtx, namespace, tclient.UpdateWithStartWorkflowOptions{
-			UpdateOptions: tclient.UpdateWorkflowOptions{
-				WorkflowID:   workflowID,
-				UpdateName:   queue.EnqueueUpdateName,
-				WaitForStage: tclient.WorkflowUpdateStageAccepted,
-				Args: []any{
-					queue.EnqueueHandlerInput{
-						QueueSignalID: signalID,
-						WorkflowID:    handlerWorkflowID,
-					},
-				},
-			},
-			StartWorkflowOperation: startOp,
-		})
-
-		metadata := map[string]any{
-			"enqueue_started_at":  enqueueStartedAt,
-			"enqueue_finished_at": time.Now().UTC().Format(time.RFC3339),
-		}
-		if err != nil {
-			metadata["enqueue_error"] = err.Error()
-			c.l.Warn("background enqueue failed",
-				zap.String("queue-signal-id", signalID),
-				zap.Error(err))
-		}
-		c.updateQueueSignalMetadata(signalID, metadata)
-	}()
+	if c.enqueuer != nil {
+		c.enqueuer.Send(queueSignal.ID)
+	}
 
 	return &queue.EnqueueResponse{
 		ID:         queueSignal.ID,

--- a/services/ctl-api/internal/pkg/queue/client/hint_restart.go
+++ b/services/ctl-api/internal/pkg/queue/client/hint_restart.go
@@ -1,0 +1,42 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 1m
+func (c *Client) HintRestart(ctx context.Context, queueIDs []string) error {
+	if len(queueIDs) == 0 {
+		return nil
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if res := c.db.WithContext(ctx).
+		Model(&app.Queue{}).
+		Where("id IN ?", queueIDs).
+		Update("metadata", c.db.Raw("COALESCE(metadata, ''::hstore) || hstore('restart_hint', ?)", now)); res.Error != nil {
+		return errors.Wrap(res.Error, "unable to set restart hints")
+	}
+
+	return nil
+}
+
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 1m
+func (c *Client) HintRestartByOrg(ctx context.Context, orgID string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	if res := c.db.WithContext(ctx).
+		Model(&app.Queue{}).
+		Where("org_id = ?", orgID).
+		Update("metadata", c.db.Raw("COALESCE(metadata, ''::hstore) || hstore('restart_hint', ?)", now)); res.Error != nil {
+		return errors.Wrap(res.Error, "unable to set restart hints for org")
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/queue/enqueuer/enqueuer.go
+++ b/services/ctl-api/internal/pkg/queue/enqueuer/enqueuer.go
@@ -1,0 +1,127 @@
+package enqueuer
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	temporalclient "github.com/nuonco/nuon/pkg/temporal/client"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+const (
+	enqueueChannelSize = 1000
+	sweepInterval      = 1 * time.Minute
+	sweepBatchSize     = 100
+)
+
+const (
+	sweepTimeout      = 30 * time.Second
+	processOneTimeout = 30 * time.Second
+)
+
+// Enqueuer processes signal enqueue requests in the background. It receives
+// queue signal IDs via a channel and also periodically sweeps for orphaned
+// signals that were never enqueued.
+type Enqueuer struct {
+	db      *gorm.DB
+	cfg     *internal.Config
+	tClient temporalclient.Client
+	l       *zap.Logger
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	ch     chan string
+	stopCh chan struct{}
+	doneCh chan struct{}
+}
+
+type Params struct {
+	fx.In
+
+	DB      *gorm.DB `name:"psql"`
+	Cfg     *internal.Config
+	TClient temporalclient.Client
+	L       *zap.Logger
+	LC      fx.Lifecycle
+}
+
+func New(params Params) *Enqueuer {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	e := &Enqueuer{
+		db:      params.DB,
+		cfg:     params.Cfg,
+		tClient: params.TClient,
+		l:       params.L.Named("queue-enqueuer"),
+		ctx:     ctx,
+		cancel:  cancel,
+		ch:      make(chan string, enqueueChannelSize),
+		stopCh:  make(chan struct{}),
+		doneCh:  make(chan struct{}),
+	}
+
+	params.LC.Append(fx.Hook{
+		OnStart: func(context.Context) error {
+			go e.run()
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			e.cancel()
+			close(e.stopCh)
+			select {
+			case <-e.doneCh:
+			case <-ctx.Done():
+			}
+			return nil
+		},
+	})
+
+	return e
+}
+
+// Send enqueues a queue signal ID for background processing. If the channel
+// is full the ID is dropped with a warning — the periodic sweep will recover it.
+func (e *Enqueuer) Send(queueSignalID string) {
+	select {
+	case e.ch <- queueSignalID:
+	default:
+		e.l.Warn("enqueue channel full, signal will be retried by sweep",
+			zap.String("queue-signal-id", queueSignalID))
+	}
+}
+
+func (e *Enqueuer) run() {
+	defer close(e.doneCh)
+
+	ticker := time.NewTicker(sweepInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-e.stopCh:
+			e.drain()
+			return
+		case id := <-e.ch:
+			e.processOne(id)
+		case <-ticker.C:
+			e.sweep()
+		}
+	}
+}
+
+// drain processes any remaining channel items during shutdown.
+func (e *Enqueuer) drain() {
+	for {
+		select {
+		case id := <-e.ch:
+			e.processOne(id)
+		default:
+			return
+		}
+	}
+}

--- a/services/ctl-api/internal/pkg/queue/enqueuer/process_one.go
+++ b/services/ctl-api/internal/pkg/queue/enqueuer/process_one.go
@@ -1,0 +1,80 @@
+package enqueuer
+
+import (
+	"context"
+	"time"
+
+	tclient "go.temporal.io/sdk/client"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue"
+)
+
+// processOne looks up the queue signal and its parent queue, performs the
+// UpdateWithStart call, and marks the signal as enqueued.
+func (e *Enqueuer) processOne(queueSignalID string) {
+	ctx, cancel := context.WithTimeout(e.ctx, processOneTimeout)
+	defer cancel()
+
+	var qs app.QueueSignal
+	if res := e.db.WithContext(ctx).First(&qs, "id = ?", queueSignalID); res.Error != nil {
+		e.l.Warn("unable to get queue signal for enqueue",
+			zap.String("queue-signal-id", queueSignalID),
+			zap.Error(res.Error))
+		return
+	}
+
+	var q app.Queue
+	if res := e.db.WithContext(ctx).First(&q, "id = ?", qs.QueueID); res.Error != nil {
+		e.l.Warn("unable to get queue for enqueue",
+			zap.String("queue-signal-id", queueSignalID),
+			zap.String("queue-id", qs.QueueID),
+			zap.Error(res.Error))
+		return
+	}
+
+	startOp := e.queueStartOperation(&q)
+
+	_, err := e.tClient.UpdateWithStartWorkflowInNamespace(ctx, q.Workflow.Namespace, tclient.UpdateWithStartWorkflowOptions{
+		UpdateOptions: tclient.UpdateWorkflowOptions{
+			WorkflowID:   q.Workflow.ID,
+			UpdateName:   queue.EnqueueUpdateName,
+			WaitForStage: tclient.WorkflowUpdateStageAccepted,
+			Args: []any{
+				queue.EnqueueHandlerInput{
+					QueueSignalID: qs.ID,
+					WorkflowID:    qs.Workflow.ID,
+				},
+			},
+		},
+		StartWorkflowOperation: startOp,
+	})
+
+	metadata := map[string]any{
+		"enqueue_started_at":  time.Now().UTC().Format(time.RFC3339),
+		"enqueue_finished_at": time.Now().UTC().Format(time.RFC3339),
+	}
+	if err != nil {
+		metadata["enqueue_error"] = err.Error()
+		e.l.Warn("background enqueue failed",
+			zap.String("queue-signal-id", queueSignalID),
+			zap.Error(err))
+	} else {
+		if res := e.db.WithContext(ctx).
+			Model(&app.QueueSignal{}).
+			Where("id = ?", queueSignalID).
+			Update("enqueued", true); res.Error != nil {
+			e.l.Warn("unable to mark signal as enqueued",
+				zap.String("queue-signal-id", queueSignalID),
+				zap.Error(res.Error))
+		}
+	}
+
+	if mergeErr := generics.MergeJSONBMetadata(e.db.WithContext(ctx), &app.QueueSignal{}, queueSignalID, "status", metadata); mergeErr != nil {
+		e.l.Warn("unable to update queue signal metadata",
+			zap.String("queue-signal-id", queueSignalID),
+			zap.Error(mergeErr))
+	}
+}

--- a/services/ctl-api/internal/pkg/queue/enqueuer/start_operation.go
+++ b/services/ctl-api/internal/pkg/queue/enqueuer/start_operation.go
@@ -1,0 +1,35 @@
+package enqueuer
+
+import (
+	"time"
+
+	enumsv1 "go.temporal.io/api/enums/v1"
+	tclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/nuonco/nuon/pkg/workflows"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue"
+)
+
+func (e *Enqueuer) queueStartOperation(q *app.Queue) tclient.WithStartWorkflowOperation {
+	wkflowReq := queue.QueueWorkflowRequest{
+		QueueID: q.ID,
+		Version: e.cfg.Version,
+	}
+	startOpts := tclient.StartWorkflowOptions{
+		ID:        q.Workflow.ID,
+		TaskQueue: workflows.APITaskQueue,
+		Memo: map[string]any{
+			"id":           q.ID,
+			"owner-id":     q.OwnerID,
+			"owner-type":   q.OwnerType,
+			"idle-timeout": time.Duration(q.IdleTimeout).String(),
+		},
+		WorkflowIDConflictPolicy: enumsv1.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 0,
+		},
+	}
+	return e.tClient.NewWithStartWorkflowOperation(startOpts, "Queue", wkflowReq)
+}

--- a/services/ctl-api/internal/pkg/queue/enqueuer/sweep.go
+++ b/services/ctl-api/internal/pkg/queue/enqueuer/sweep.go
@@ -1,0 +1,35 @@
+package enqueuer
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// sweep queries for signals that have not been enqueued and processes them.
+func (e *Enqueuer) sweep() {
+	ctx := context.Background()
+
+	var signals []app.QueueSignal
+	if res := e.db.WithContext(ctx).
+		Select("id").
+		Where("enqueued = ?", false).
+		Where("created_at < ?", time.Now().Add(-30*time.Second)).
+		Order("created_at ASC").
+		Limit(sweepBatchSize).
+		Find(&signals); res.Error != nil {
+		e.l.Warn("sweep query failed", zap.Error(res.Error))
+		return
+	}
+
+	if len(signals) > 0 {
+		e.l.Warn("sweep found orphaned signals", zap.Int("count", len(signals)))
+	}
+
+	for _, s := range signals {
+		e.processOne(s.ID)
+	}
+}

--- a/services/ctl-api/internal/pkg/queue/handle_signal.go
+++ b/services/ctl-api/internal/pkg/queue/handle_signal.go
@@ -103,12 +103,21 @@ func (q *queue) processQueueSignal(ctx workflow.Context, l *zap.Logger, queueSig
 		return errors.Wrap(err, "unable to validate")
 	}
 
+	executeOpts := longRunningActivityOptions
+	if timeoutNs, ok := queueSignal.Status.Metadata["timeout_ns"]; ok {
+		if ns, ok := timeoutNs.(float64); ok {
+			custom := *longRunningActivityOptions
+			custom.ScheduleToCloseTimeout = time.Duration(int64(ns))
+			executeOpts = &custom
+		}
+	}
+
 	if _, err := handleractivities.AwaitUpdateWorkflowExecute(ctx, handleractivities.UpdateWorkflowExecuteRequest{
 		UpdateID:   queueSignal.ID,
 		WorkflowID: queueRef.WorkflowID,
 		QueueID:    queueSignal.QueueID,
 		RunID:      readyResp.RunID,
-	}, longRunningActivityOptions); err != nil {
+	}, executeOpts); err != nil {
 		return errors.Wrap(err, "unable to execute")
 	}
 

--- a/services/ctl-api/internal/pkg/queue/hint.go
+++ b/services/ctl-api/internal/pkg/queue/hint.go
@@ -1,0 +1,40 @@
+package queue
+
+import (
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
+)
+
+func (q *queue) startHintListener(ctx workflow.Context) {
+	workflow.Go(ctx, func(gCtx workflow.Context) {
+		l, _ := log.WorkflowLogger(gCtx)
+		for {
+			if err := workflow.Sleep(gCtx, 30*time.Second); err != nil {
+				return
+			}
+
+			hint, err := activities.AwaitCheckRestartHint(gCtx, activities.CheckRestartHintRequest{
+				QueueID: q.queueID,
+			})
+			if err != nil {
+				if l != nil {
+					l.Warn("unable to check restart hint", zap.Error(err))
+				}
+				continue
+			}
+
+			if hint {
+				if l != nil {
+					l.Info("restart hint detected, triggering continue-as-new")
+				}
+				q.restarted = true
+				return
+			}
+		}
+	})
+}

--- a/services/ctl-api/internal/pkg/queue/run.go
+++ b/services/ctl-api/internal/pkg/queue/run.go
@@ -46,6 +46,13 @@ func (q *queue) run(ctx workflow.Context) (bool, error) {
 		return true, nil
 	}
 
+	// Clear any stale restart hint so this run doesn't immediately restart.
+	if err := activities.AwaitClearRestartHint(ctx, activities.ClearRestartHintRequest{
+		QueueID: q.queueID,
+	}); err != nil {
+		l.Warn("unable to clear restart hint", zap.Error(err))
+	}
+
 	l.Info("registering handlers")
 	if err := q.registerHandlers(ctx); err != nil {
 		return false, errors.Wrap(err, "unable to register handlers")
@@ -65,6 +72,9 @@ func (q *queue) run(ctx workflow.Context) (bool, error) {
 	if err := q.startDispatcher(ctx); err != nil {
 		return false, errors.Wrap(err, "unable to start dispatcher")
 	}
+
+	l.Info("starting hint listener")
+	q.startHintListener(ctx)
 
 	q.setStatus(ctx, l, QueueStatusReady)
 	q.ready = true

--- a/services/ctl-api/internal/pkg/queue/signal/interfaces.go
+++ b/services/ctl-api/internal/pkg/queue/signal/interfaces.go
@@ -1,6 +1,10 @@
 package signal
 
-import "go.temporal.io/sdk/workflow"
+import (
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+)
 
 // This file defines all optional extension interfaces that signals can implement
 // to declare capabilities and attributes. The conductor and step workflow check
@@ -156,6 +160,17 @@ type SignalWithSkipGroup interface {
 type SignalWithFetchSteps interface {
 	Signal
 	SignalWithUpdateHandlers
+}
+
+// ---------------------------------------------------------------------------
+// Timeouts
+// ---------------------------------------------------------------------------
+
+// SignalWithTimeout is implemented by signals that need a custom execution timeout.
+// The returned duration is used as the ScheduleToCloseTimeout for the execute
+// activity in the queue dispatcher. If not implemented, the default (2 hours) is used.
+type SignalWithTimeout interface {
+	Timeout() time.Duration
 }
 
 // ---------------------------------------------------------------------------

--- a/services/ctl-api/internal/pkg/workflows/status/activities/update.go
+++ b/services/ctl-api/internal/pkg/workflows/status/activities/update.go
@@ -3,6 +3,7 @@ package statusactivities
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/pkg/errors"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 )
 
 // NOTE
@@ -109,16 +111,11 @@ func (a *Activities) updateStatusCommon(ctx context.Context, obj any, status app
 	existingStatus.History = nil
 	status.History = append(history, existingStatus)
 
-	if status.Metadata == nil {
-		status.Metadata = make(map[string]any, 0)
-	}
-	for k, v := range existingStatus.Metadata {
-		if _, ok := status.Metadata[k]; ok {
-			continue
-		}
-
-		status.Metadata[k] = v
-	}
+	// Separate out metadata for atomic merge — the status column write carries
+	// everything except metadata so that concurrent MergeJSONBMetadata calls
+	// (e.g. from the background enqueuer) are not clobbered.
+	newMetadata := status.Metadata
+	status.Metadata = nil
 
 	res := a.db.WithContext(ctx).Model(obj).Updates(
 		map[string]any{
@@ -130,7 +127,26 @@ func (a *Activities) updateStatusCommon(ctx context.Context, obj any, status app
 	if res.RowsAffected < 1 {
 		return errors.New("no object found to update")
 	}
+
+	// Atomically merge metadata keys using jsonb_set so we never overwrite
+	// metadata written by other writers between our read and write.
+	if len(newMetadata) > 0 {
+		id := reflectID(obj)
+		if err := generics.MergeJSONBMetadata(a.db.WithContext(ctx), obj, id, statusField, newMetadata); err != nil {
+			return errors.Wrap(err, "unable to merge metadata")
+		}
+	}
+
 	return nil
+}
+
+// reflectID extracts the ID field from a model pointer via reflection.
+func reflectID(obj any) string {
+	v := reflect.ValueOf(obj)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	return v.FieldByName("ID").String()
 }
 
 // @temporal-gen-v2 activity

--- a/services/dashboard-ui/client/components/runners/ProcessCard/ProcessCardContainer.tsx
+++ b/services/dashboard-ui/client/components/runners/ProcessCard/ProcessCardContainer.tsx
@@ -67,7 +67,6 @@ export const ProcessCardContainer = ({
       managementDropdown={
         <ProcessManagementDropdown
           process={process}
-          settings={settings}
         />
       }
     />

--- a/services/dashboard-ui/client/components/runners/ProcessManagementDropdown/ProcessManagementDropdown.stories.tsx
+++ b/services/dashboard-ui/client/components/runners/ProcessManagementDropdown/ProcessManagementDropdown.stories.tsx
@@ -11,14 +11,9 @@ const mockProcess = {
   log_stream_id: 'log-1',
 } as any
 
-const mockSettings = {
-  container_image_tag: '1.2.3',
-} as any
-
 export const Default = () => (
   <ProcessManagementDropdown
     process={mockProcess}
-    settings={mockSettings}
     runnerId="runner-456"
     onViewSystemLogs={() => {}}
   />
@@ -27,7 +22,6 @@ export const Default = () => (
 export const InactiveProcess = () => (
   <ProcessManagementDropdown
     process={{ ...mockProcess, composite_status: { status: 'shut-down' } }}
-    settings={mockSettings}
     runnerId="runner-456"
   />
 )

--- a/services/dashboard-ui/client/components/runners/ProcessManagementDropdown/ProcessManagementDropdown.tsx
+++ b/services/dashboard-ui/client/components/runners/ProcessManagementDropdown/ProcessManagementDropdown.tsx
@@ -3,20 +3,17 @@ import { Dropdown } from '@/components/common/Dropdown'
 import { Icon } from '@/components/common/Icon'
 import { Menu } from '@/components/common/Menu'
 import { Text } from '@/components/common/Text'
-import { UpdateRunnerButton } from '@/components/runners/management/UpdateRunner'
 import { ShutdownRunnerControl } from '@/components/runners/management/ShutdownRunnerControl'
-import type { TRunnerProcess, TRunnerSettings } from '@/types'
+import type { TRunnerProcess } from '@/types'
 
 interface IProcessManagementDropdown {
   process: TRunnerProcess
-  settings?: TRunnerSettings
   runnerId: string
   onViewSystemLogs?: () => void
 }
 
 export const ProcessManagementDropdown = ({
   process,
-  settings,
   runnerId,
   onViewSystemLogs,
 }: IProcessManagementDropdown) => {
@@ -31,10 +28,6 @@ export const ProcessManagementDropdown = ({
     >
       <Menu>
         <Text>Controls</Text>
-        {process.composite_status?.status === 'active' && settings ? (
-          <UpdateRunnerButton settings={settings} isMenuButton />
-        ) : null}
-
         {process.composite_status?.status === 'active' ? (
           <ShutdownRunnerControl isMenuButton isManaged runnerId={runnerId} processId={process.id} />
         ) : null}

--- a/services/dashboard-ui/client/components/runners/ProcessManagementDropdown/ProcessManagementDropdownContainer.tsx
+++ b/services/dashboard-ui/client/components/runners/ProcessManagementDropdown/ProcessManagementDropdownContainer.tsx
@@ -1,15 +1,13 @@
 import { useNavigate } from 'react-router'
 import { useOrg } from '@/hooks/use-org'
 import { useRunner } from '@/hooks/use-runner'
-import type { TRunnerProcess, TRunnerSettings } from '@/types'
+import type { TRunnerProcess } from '@/types'
 import { ProcessManagementDropdown } from './ProcessManagementDropdown'
 
 export const ProcessManagementDropdownContainer = ({
   process,
-  settings,
 }: {
   process: TRunnerProcess
-  settings?: TRunnerSettings
 }) => {
   const { org } = useOrg()
   const { runner } = useRunner()
@@ -20,7 +18,6 @@ export const ProcessManagementDropdownContainer = ({
   return (
     <ProcessManagementDropdown
       process={process}
-      settings={settings}
       runnerId={runner.id}
       onViewSystemLogs={
         process.log_stream_id

--- a/services/dashboard-ui/client/components/runners/management/ManagementDropdown/ManagementDropdown.stories.tsx
+++ b/services/dashboard-ui/client/components/runners/management/ManagementDropdown/ManagementDropdown.stories.tsx
@@ -11,13 +11,14 @@ const mockRunner = {
 
 const mockSettings = {
   id: 'settings-1',
+  container_image_tag: 'v1.2.3',
+  binary_version: 'v0.5.0',
 } as any
 
 export const BuildRunner = () => (
   <div className="p-4">
     <ManagementDropdown
       runner={mockRunner}
-      isManaged={false}
       isInstallRunner={false}
       settings={mockSettings}
     />
@@ -28,7 +29,6 @@ export const InstallRunner = () => (
   <div className="p-4">
     <ManagementDropdown
       runner={mockRunner}
-      isManaged
       isInstallRunner
       settings={mockSettings}
     />

--- a/services/dashboard-ui/client/components/runners/management/ManagementDropdown/ManagementDropdown.tsx
+++ b/services/dashboard-ui/client/components/runners/management/ManagementDropdown/ManagementDropdown.tsx
@@ -1,24 +1,17 @@
 import { Dropdown } from '@/components/common/Dropdown'
 import { Icon } from '@/components/common/Icon'
 import { Menu } from '@/components/common/Menu'
-import { Text } from '@/components/common/Text'
 import { UpdateRunnerButton } from '../UpdateRunner'
-import { ShutdownRunnerControl } from '../ShutdownRunnerControl'
-import { ShutdownInstanceButton } from '../ShutdownInstance'
-import { DeprovisionRunnerButtonContainer as DeprovisionRunnerButton } from '../DeprovisionRunner'
-import { PruneRunnerTokensButton } from '../PruneRunnerTokens'
 import type { TRunnerSettings, TRunner } from '@/types'
 
 interface IManagementDropdown {
   runner: TRunner
-  isManaged: boolean
   isInstallRunner?: boolean
   settings: TRunnerSettings
 }
 
 export const ManagementDropdown = ({
   runner,
-  isManaged,
   isInstallRunner = false,
   settings,
 }: IManagementDropdown) => {
@@ -34,23 +27,41 @@ export const ManagementDropdown = ({
       variant={!isInstallRunner ? 'primary' : 'secondary'}
     >
       <Menu>
-        <Text>Controls</Text>
-        {settings ? (
-          <UpdateRunnerButton settings={settings} isMenuButton />
-        ) : null}
-
-        <ShutdownRunnerControl isMenuButton isManaged={isManaged} runnerId={runner.id} />
-
-        {isInstallRunner && isManaged ? (
-          <ShutdownInstanceButton isMenuButton />
-        ) : null}
-
-        {isInstallRunner ? <PruneRunnerTokensButton isMenuButton /> : null}
-
-        {isInstallRunner && <hr />}
-
-        {isInstallRunner && <Text>Remove</Text>}
-        {isInstallRunner && <DeprovisionRunnerButton isMenuButton />}
+        {!isInstallRunner ? (
+          <UpdateRunnerButton
+            settings={settings}
+            field="container_image_tag"
+            label="Update runner tag"
+            modalHeading="Update runner tag"
+            inputLabel="Enter the runner tag you'd like to update to."
+            inputPlaceholder="runner tag"
+            submitLabel="Update runner tag"
+            isMenuButton
+          />
+        ) : (
+          <>
+            <UpdateRunnerButton
+              settings={settings}
+              field="binary_version"
+              label="Update manager version"
+              modalHeading="Update manager version"
+              inputLabel="Enter the manager version you'd like to update to."
+              inputPlaceholder="manager version"
+              submitLabel="Update manager version"
+              isMenuButton
+            />
+            <UpdateRunnerButton
+              settings={settings}
+              field="container_image_tag"
+              label="Update instance version"
+              modalHeading="Update instance version"
+              inputLabel="Enter the instance version you'd like to update to."
+              inputPlaceholder="instance version"
+              submitLabel="Update instance version"
+              isMenuButton
+            />
+          </>
+        )}
       </Menu>
     </Dropdown>
   )

--- a/services/dashboard-ui/client/components/runners/management/ManagementDropdown/ManagementDropdownContainer.tsx
+++ b/services/dashboard-ui/client/components/runners/management/ManagementDropdown/ManagementDropdownContainer.tsx
@@ -9,13 +9,12 @@ export const ManagementDropdownContainer = ({
   isInstallRunner?: boolean
   settings: TRunnerSettings
 }) => {
-  const { runner, isManaged } = useRunner()
+  const { runner } = useRunner()
   if (!runner) return null
 
   return (
     <ManagementDropdown
       runner={runner}
-      isManaged={isManaged}
       isInstallRunner={isInstallRunner}
       settings={settings}
     />

--- a/services/dashboard-ui/client/components/runners/management/UpdateRunner/UpdateRunner.stories.tsx
+++ b/services/dashboard-ui/client/components/runners/management/UpdateRunner/UpdateRunner.stories.tsx
@@ -18,6 +18,36 @@ export const Default = () => (
   </ModalStory>
 )
 
+export const UpdateManagerVersion = () => (
+  <ModalStory>
+    <UpdateRunnerModal
+      isPending={false}
+      error={null}
+      onSubmit={noop}
+      onClose={noop}
+      modalHeading="Update manager version"
+      inputLabel="Enter the manager version you'd like to update to."
+      inputPlaceholder="manager version"
+      submitLabel="Update manager version"
+    />
+  </ModalStory>
+)
+
+export const UpdateInstanceVersion = () => (
+  <ModalStory>
+    <UpdateRunnerModal
+      isPending={false}
+      error={null}
+      onSubmit={noop}
+      onClose={noop}
+      modalHeading="Update instance version"
+      inputLabel="Enter the instance version you'd like to update to."
+      inputPlaceholder="instance version"
+      submitLabel="Update instance version"
+    />
+  </ModalStory>
+)
+
 export const Pending = () => (
   <ModalStory>
     <UpdateRunnerModal

--- a/services/dashboard-ui/client/components/runners/management/UpdateRunner/UpdateRunner.tsx
+++ b/services/dashboard-ui/client/components/runners/management/UpdateRunner/UpdateRunner.tsx
@@ -12,6 +12,10 @@ interface IUpdateRunnerModal extends Omit<IModal, 'onSubmit'> {
   error: TAPIError | null
   onSubmit: (tag: string) => void
   onClose: () => void
+  modalHeading?: string
+  inputLabel?: string
+  inputPlaceholder?: string
+  submitLabel?: string
 }
 
 export const UpdateRunnerModal = ({
@@ -19,6 +23,10 @@ export const UpdateRunnerModal = ({
   error,
   onSubmit,
   onClose,
+  modalHeading = 'Update runner version',
+  inputLabel = 'Enter the runner tag you\'d like to update to.',
+  inputPlaceholder = 'runner tag',
+  submitLabel = 'Update runner version',
   ...props
 }: IUpdateRunnerModal) => {
   const formRef = useRef<HTMLFormElement>(null)
@@ -54,7 +62,7 @@ export const UpdateRunnerModal = ({
             theme="info"
           >
             <Icon variant="ArrowsCounterClockwise" size="24" />
-            Update runner version
+            {modalHeading}
           </Text>
         </div>
       }
@@ -67,7 +75,7 @@ export const UpdateRunnerModal = ({
         ) : (
           <span className="flex items-center gap-2">
             <Icon variant="ArrowsCounterClockwise" />
-            Update runner version
+            {submitLabel}
           </span>
         ),
         disabled: !canUpdate,
@@ -85,16 +93,13 @@ export const UpdateRunnerModal = ({
         ) : null}
         <form ref={formRef} onSubmit={handleSubmit}>
           <div className="flex flex-col gap-4">
-            <Text variant="base" weight="strong">
-              Update to a different runner version.
-            </Text>
             <div className="flex flex-col gap-2">
               <Text variant="base" weight="stronger">
-                Enter the runner tag you&apos;d like to update to.
+                {inputLabel}
               </Text>
               <Input
                 id="runner-tag"
-                placeholder="runner tag"
+                placeholder={inputPlaceholder}
                 type="text"
                 value={tag}
                 onChange={(e) => setTag(e.target.value)}
@@ -110,10 +115,12 @@ export const UpdateRunnerModal = ({
 
 interface IUpdateRunnerButton extends IButtonAsButton {
   onOpenModal: () => void
+  label?: string
 }
 
 export const UpdateRunnerButton = ({
   onOpenModal,
+  label = 'Update runner version',
   ...props
 }: IUpdateRunnerButton) => {
   return (
@@ -122,7 +129,7 @@ export const UpdateRunnerButton = ({
       {...props}
     >
       {props?.isMenuButton ? null : <Icon variant="ArrowsCounterClockwise" />}
-      Update runner version
+      {label}
       {props?.isMenuButton ? <Icon variant="ArrowsCounterClockwise" /> : null}
     </Button>
   )

--- a/services/dashboard-ui/client/components/runners/management/UpdateRunner/UpdateRunnerContainer.tsx
+++ b/services/dashboard-ui/client/components/runners/management/UpdateRunner/UpdateRunnerContainer.tsx
@@ -17,15 +17,43 @@ import {
   UpdateRunnerButton as UpdateRunnerButtonComponent,
 } from './UpdateRunner'
 
+export type UpdateField = 'container_image_tag' | 'binary_version'
+
+interface IUpdateRunnerButtonProps extends IButtonAsButton {
+  settings: TRunnerSettings
+  field?: UpdateField
+  label?: string
+  modalHeading?: string
+  inputLabel?: string
+  inputPlaceholder?: string
+  submitLabel?: string
+}
+
 export const UpdateRunnerButton = ({
   settings,
+  field = 'container_image_tag',
+  label = 'Update runner version',
+  modalHeading,
+  inputLabel,
+  inputPlaceholder,
+  submitLabel,
   ...props
-}: IButtonAsButton & { settings: TRunnerSettings }) => {
+}: IUpdateRunnerButtonProps) => {
   const { addModal } = useSurfaces()
-  const modal = <UpdateRunnerModal settings={settings} />
+  const modal = (
+    <UpdateRunnerModal
+      settings={settings}
+      field={field}
+      modalHeading={modalHeading}
+      inputLabel={inputLabel}
+      inputPlaceholder={inputPlaceholder}
+      submitLabel={submitLabel}
+    />
+  )
   return (
     <UpdateRunnerButtonComponent
       onOpenModal={() => addModal(modal)}
+      label={label}
       {...props}
     />
   )
@@ -33,8 +61,20 @@ export const UpdateRunnerButton = ({
 
 export const UpdateRunnerModal = ({
   settings,
+  field = 'container_image_tag',
+  modalHeading,
+  inputLabel,
+  inputPlaceholder,
+  submitLabel,
   ...props
-}: Omit<IModal, 'onSubmit'> & { settings: TRunnerSettings }) => {
+}: Omit<IModal, 'onSubmit'> & {
+  settings: TRunnerSettings
+  field?: UpdateField
+  modalHeading?: string
+  inputLabel?: string
+  inputPlaceholder?: string
+  submitLabel?: string
+}) => {
   const { user } = useAuth()
   const { org } = useOrg()
   const { runner } = useRunner()
@@ -47,16 +87,17 @@ export const UpdateRunnerModal = ({
     mutate,
     isPending: isLoading,
   } = useMutation({
-    mutationFn: async (tag: string) => {
+    mutationFn: async (value: string) => {
       await updateRunner({
         runnerId: runner.id,
         orgId: org.id,
         body: {
-          container_image_tag: tag,
+          container_image_tag: field === 'container_image_tag' ? value : settings?.container_image_tag,
           container_image_url: settings?.container_image_url,
           org_awsiam_role_arn: settings?.org_aws_iam_role_arn || '',
           org_k8s_service_account_name: settings?.org_k8s_service_account_name,
           runner_api_url: settings?.runner_api_url,
+          ...(field === 'binary_version' ? { binary_version: value } : {}),
         },
       })
 
@@ -106,6 +147,10 @@ export const UpdateRunnerModal = ({
       error={error}
       onSubmit={(tag) => mutate(tag)}
       onClose={() => removeModal(props.modalId)}
+      modalHeading={modalHeading}
+      inputLabel={inputLabel}
+      inputPlaceholder={inputPlaceholder}
+      submitLabel={submitLabel}
       {...props}
     />
   )

--- a/services/dashboard-ui/client/components/runners/management/UpdateRunner/index.ts
+++ b/services/dashboard-ui/client/components/runners/management/UpdateRunner/index.ts
@@ -1,2 +1,2 @@
-export { UpdateRunnerButton, UpdateRunnerModal } from './UpdateRunnerContainer'
+export { UpdateRunnerButton, UpdateRunnerModal, type UpdateField } from './UpdateRunnerContainer'
 export { UpdateRunnerModal as UpdateRunnerModalComponent, UpdateRunnerButton as UpdateRunnerButtonComponent } from './UpdateRunner'

--- a/services/dashboard-ui/client/lib/ctl-api/runners/update-runner.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/runners/update-runner.ts
@@ -2,6 +2,7 @@ import { api } from '@/lib/api'
 import type { TRunnerJob } from '@/types'
 
 export interface IUpdateRunnerBody {
+  binary_version?: string
   container_image_tag: string
   container_image_url: string
   org_awsiam_role_arn: string

--- a/services/dashboard-ui/client/views/install/Runner.tsx
+++ b/services/dashboard-ui/client/views/install/Runner.tsx
@@ -9,6 +9,7 @@ import {
   ProcessCardSkeleton,
 } from '@/components/runners/ProcessCard'
 import { RunnerRecentActivity } from '@/components/runners/RunnerRecentActivity'
+import { ManagementDropdownContainer } from '@/components/runners/management/ManagementDropdown'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
 import { PageTitle } from '@/components/navigation/PageTitle'
@@ -52,6 +53,18 @@ const RunnerContent = ({
 
   return (
     <>
+      <div className="flex items-center justify-between">
+        <HeadingGroup>
+          <Text variant="base" weight="strong">
+            Install runner
+          </Text>
+          <ID>{runnerId}</ID>
+        </HeadingGroup>
+        {settings && (
+          <ManagementDropdownContainer isInstallRunner settings={settings} />
+        )}
+      </div>
+
       <Text variant="base" weight="strong">
         Processes
       </Text>
@@ -153,12 +166,6 @@ export const Runner = () => {
           ]}
         />
         <PageSection>
-          <HeadingGroup>
-            <Text variant="base" weight="strong">
-              Install runner
-            </Text>
-            <ID>{install?.runner_id}</ID>
-          </HeadingGroup>
           <RunnerContent runnerId={install.runner_id} installId={install.id} />
         </PageSection>
       </SurfacesProvider>

--- a/services/dashboard-ui/client/views/org/BuildRunner.tsx
+++ b/services/dashboard-ui/client/views/org/BuildRunner.tsx
@@ -16,31 +16,38 @@ import {
   ProcessCardSkeleton,
 } from '@/components/runners/ProcessCard'
 import { RunnerRecentActivity } from '@/components/runners/RunnerRecentActivity'
+import { ManagementDropdownContainer } from '@/components/runners/management/ManagementDropdown'
 import { useOrg } from '@/hooks/use-org'
 import { getRunnerSettings, getRunnerProcesses } from '@/lib'
 import { RunnerProvider } from '@/providers/runner-provider'
 import { SurfacesProvider } from '@/providers/surfaces-provider'
+import type { TRunnerSettings } from '@/types'
 
 const RunnerHeading = ({
   runnerId,
+  settings,
 }: {
   runnerId?: string
+  settings?: TRunnerSettings
 }) => (
   <PageHeader>
-    <HeadingGroup>
-      <div className="flex items-center gap-3">
-        <Text variant="h3" weight="strong" level={1}>
-          Build runner
-        </Text>
-        {runnerId ? <ID>{runnerId}</ID> : null}
-      </div>
-      {runnerId && (
-        <AdminDashboardLink
-          path={`/queues?owner_id=${runnerId}`}
-          label="View queues in admin panel"
-        />
-      )}
-    </HeadingGroup>
+    <div className="flex items-center justify-between w-full">
+      <HeadingGroup>
+        <div className="flex items-center gap-3">
+          <Text variant="h3" weight="strong" level={1}>
+            Build runner
+          </Text>
+          {runnerId ? <ID>{runnerId}</ID> : null}
+        </div>
+        {runnerId && (
+          <AdminDashboardLink
+            path={`/queues?owner_id=${runnerId}`}
+            label="View queues in admin panel"
+          />
+        )}
+      </HeadingGroup>
+      {settings && <ManagementDropdownContainer settings={settings} />}
+    </div>
   </PageHeader>
 )
 
@@ -104,7 +111,7 @@ export const BuildRunner = () => {
       <SurfacesProvider>
         <PageLayout className="pb-6">
           {breadcrumbs}
-          <RunnerHeading runnerId={runnerId} />
+          <RunnerHeading runnerId={runnerId} settings={settings} />
 
           <PageContent>
             <PageSection>


### PR DESCRIPTION
This updates our enqueuing logic to use an async based enqueuer. Each worker/api process runs a background process to  enqueue signals with.

Whenever a signal is created, we send it via a channel to the background enqueuer. That then ensures the workflow has been started, and then will update it's enqueued metadata.