### PR TITLE
chore: feature flag management

### DIFF
--- a/services/ctl-api/internal/app/general/worker/activities/get_feature_flag_ratios.go
+++ b/services/ctl-api/internal/app/general/worker/activities/get_feature_flag_ratios.go
@@ -1,0 +1,41 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+)
+
+type GetFeatureFlagRatiosRequest struct{}
+
+// FeatureFlagRatio is a single (feature, enabled-ratio) row aggregated across
+// all non-deleted orgs. ratio is the fraction of orgs with the feature enabled
+// (0.0..1.0).
+type FeatureFlagRatio struct {
+	Feature string  `gorm:"column:feature"`
+	Ratio   float64 `gorm:"column:ratio"`
+}
+
+// GetFeatureFlagRatios returns the fraction of non-deleted orgs that have each
+// feature flag enabled. Used by the general metrics workflow to surface flag
+// lifecycle (fully rolled out, fully off, or actively split) to Datadog.
+//
+// @temporal-gen-v2 activity
+func (a *Activities) GetFeatureFlagRatios(ctx context.Context, req GetFeatureFlagRatiosRequest) ([]FeatureFlagRatio, error) {
+	var rows []FeatureFlagRatio
+
+	res := a.db.WithContext(ctx).
+		Raw(`
+			SELECT
+				f.key AS feature,
+				AVG(CASE WHEN f.value = 'true' THEN 1.0 ELSE 0.0 END) AS ratio
+			FROM orgs o, jsonb_each_text(COALESCE(o.features, '{}'::jsonb)) f
+			WHERE o.deleted_at = 0
+			GROUP BY f.key
+		`).
+		Scan(&rows)
+	if res.Error != nil {
+		return nil, fmt.Errorf("unable to query feature flag ratios: %w", res.Error)
+	}
+
+	return rows, nil
+}

--- a/services/ctl-api/internal/app/general/worker/metrics_workflow.go
+++ b/services/ctl-api/internal/app/general/worker/metrics_workflow.go
@@ -80,6 +80,9 @@ func (w *Workflows) Metrics(ctx workflow.Context) error {
 		"temporal_runners": func(ctx workflow.Context) error {
 			return w.temporalNamespaceMetrics(ctx, "runners")
 		},
+		"feature_flags": func(ctx workflow.Context) error {
+			return w.writeFeatureFlagMetrics(ctx)
+		},
 	}
 
 	for name, method := range methods {
@@ -198,6 +201,24 @@ func (w *Workflows) writePSQLTableMetrics(ctx workflow.Context) error {
 			"db_type":    "psql",
 			"table_name": table.TableName,
 		}, defaultTags))...)
+	}
+
+	return nil
+}
+
+func (w *Workflows) writeFeatureFlagMetrics(ctx workflow.Context) error {
+	defaultTags := map[string]string{"general": "true"}
+
+	rows, err := activities.AwaitGetFeatureFlagRatios(ctx, activities.GetFeatureFlagRatiosRequest{})
+	if err != nil {
+		return errors.Wrap(err, "unable to get feature flag ratios")
+	}
+
+	for _, r := range rows {
+		w.mw.Gauge(ctx, "feature.enabled_ratio", r.Ratio,
+			metrics.ToTags(generics.MergeMap(map[string]string{
+				"feature": r.Feature,
+			}, defaultTags))...)
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/org.go
+++ b/services/ctl-api/internal/app/org.go
@@ -164,42 +164,94 @@ func (o *Org) AfterQuery(tx *gorm.DB) error {
 	return nil
 }
 
+// prodDefaultFeatures is the canonical "production" default value for each
+// known feature flag. Used both by BeforeCreate (as a defensive fallback
+// when an Org is created without going through orgs/helpers.CreateOrg —
+// e.g., test seeders) and by NewOrgFeatureDefaults below.
+//
+// To change a feature's prod default, edit this map. To enable every
+// non-deny-listed feature in a non-prod environment by default, set
+// internal.Config.DefaultAllFeaturesEnabled=true; that override is applied
+// in NewOrgFeatureDefaults.
+var prodDefaultFeatures = map[OrgFeature]bool{
+	// Disabled by default
+	OrgFeatureInstallBreakGlass:  false,
+	OrgFeatureTerraformInstaller: false,
+	OrgFeatureInstallRename:      false,
+	OrgFeatureDeployOutputs:      false,
+	OrgFeatureSupportRole:        false,
+
+	// Enabled by default
+	OrgFeatureParallelRunnerJobs:      true,
+	OrgFeatureQueues:                  true,
+	OrgFeatureStratusLayout:           true,
+	OrgFeatureStratusWorkflow:         true,
+	OrgFeatureDashboardSSE:            true,
+	OrgFeatureAPIPagination:           true,
+	OrgFeatureOrgDashboard:            true,
+	OrgFeatureOrgRunner:               true,
+	OrgFeatureOrgSettings:             true,
+	OrgFeatureOrgSupport:              true,
+	OrgFeatureInstallDeleteComponents: true,
+	OrgFeatureInstallDelete:           true,
+	OrgFeatureTerraformWorkspace:      true,
+	OrgFeatureDevCommand:              true,
+	OrgFeatureAppBranches:             true,
+}
+
+// NeverDefaultOnFeatures lists features that must remain off-by-default
+// in every environment regardless of DefaultAllFeaturesEnabled, because
+// they grant destructive or escalated capabilities. Tenants who want
+// them on must opt in explicitly via the admin UI.
+var NeverDefaultOnFeatures = map[OrgFeature]struct{}{
+	OrgFeatureInstallBreakGlass: {},
+	OrgFeatureSupportRole:       {},
+}
+
+// NewOrgFeatureDefaults returns the Features map that should be applied
+// to a freshly-constructed Org before it's persisted.
+//
+// When defaultAllEnabled is true, every known feature (except those in
+// NeverDefaultOnFeatures) is enabled. Otherwise the per-feature prod
+// defaults from prodDefaultFeatures are used.
+//
+// Callers that create Orgs (orgs/helpers.CreateOrg, etc.) should invoke
+// this and assign the result to Org.Features. The Org.BeforeCreate hook
+// remains a defensive fallback for code paths that bypass the helper
+// (e.g., test seeders) — it always uses prod defaults regardless of the
+// env knob, which is the right default for tests.
+func NewOrgFeatureDefaults(defaultAllEnabled bool) map[string]bool {
+	out := make(map[string]bool, len(GetFeatures()))
+	for _, f := range GetFeatures() {
+		switch {
+		case isNeverDefaultOn(f):
+			out[string(f)] = false
+		case defaultAllEnabled:
+			out[string(f)] = true
+		default:
+			out[string(f)] = prodDefaultFeatures[f]
+		}
+	}
+	return out
+}
+
+func isNeverDefaultOn(f OrgFeature) bool {
+	_, ok := NeverDefaultOnFeatures[f]
+	return ok
+}
+
 func (o *Org) BeforeCreate(tx *gorm.DB) error {
 	if o.Features == nil {
 		o.Features = make(map[string]bool, 0)
 	}
 
-	// Set default feature flag values - most features enabled by default
-	// except install-break-glass and user-managed-features which remain disabled
-	defaultFeatures := map[OrgFeature]bool{
-		// Disabled by default
-		OrgFeatureInstallBreakGlass:  false,
-		OrgFeatureTerraformInstaller: false,
-		OrgFeatureInstallRename:      false,
-		OrgFeatureDeployOutputs:      false,
-		OrgFeatureSupportRole:        false,
-
-		// Enabled by default
-		OrgFeatureParallelRunnerJobs:      true,
-		OrgFeatureQueues:                  true,
-		OrgFeatureStratusLayout:           true,
-		OrgFeatureStratusWorkflow:         true,
-		OrgFeatureDashboardSSE:            true,
-		OrgFeatureAPIPagination:           true,
-		OrgFeatureOrgDashboard:            true,
-		OrgFeatureOrgRunner:               true,
-		OrgFeatureOrgSettings:             true,
-		OrgFeatureOrgSupport:              true,
-		OrgFeatureInstallDeleteComponents: true,
-		OrgFeatureInstallDelete:           true,
-		OrgFeatureTerraformWorkspace:      true,
-		OrgFeatureDevCommand:              true,
-		OrgFeatureAppBranches:             true,
-	}
-
+	// Defensive fallback for code paths that construct an Org directly
+	// without going through orgs/helpers.CreateOrg (test seeders, etc.).
+	// Production org creation pre-populates Features via
+	// NewOrgFeatureDefaults, so this loop is a no-op there.
 	for _, feature := range GetFeatures() {
 		if _, ok := o.Features[string(feature)]; !ok {
-			o.Features[string(feature)] = defaultFeatures[feature]
+			o.Features[string(feature)] = prodDefaultFeatures[feature]
 		}
 	}
 

--- a/services/ctl-api/internal/app/orgs/helpers/create_org.go
+++ b/services/ctl-api/internal/app/orgs/helpers/create_org.go
@@ -34,6 +34,13 @@ func (h *Helpers) CreateOrg(ctx context.Context, acct *app.Account, params *Crea
 		EnableEmailNotifications: acct.AccountType == app.AccountTypeAuth0,
 		InternalSlackWebhookURL:  h.cfg.InternalSlackWebhookURL,
 	}
+	// Pre-populate Features so Org.BeforeCreate's defensive fallback is a
+	// no-op for orgs created via this helper. NewOrgFeatureDefaults
+	// honours h.cfg.DefaultAllFeaturesEnabled, which non-prod
+	// environments (e.g. stage) set to true so newly-provisioned orgs
+	// get every non-deny-listed feature flag turned on by default.
+	// Tenants can still flip any flag off per-org via the admin UI;
+	// the per-org stored value always wins over this default.
 	org := app.Org{
 		Name:                params.Name,
 		Status:              "queued",
@@ -42,10 +49,7 @@ func (h *Helpers) CreateOrg(ctx context.Context, acct *app.Account, params *Crea
 		OrgType:             orgTyp,
 		NotificationsConfig: notificationsCfg,
 		Tags:                params.Tags,
-		Features: map[string]bool{
-			"queues":               true,
-			"parallel-runner-jobs": true,
-		},
+		Features:            app.NewOrgFeatureDefaults(h.cfg.DefaultAllFeaturesEnabled),
 	}
 	if h.cfg.ForceSandboxMode {
 		org.SandboxMode = true

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -201,6 +201,16 @@ type Config struct {
 	AdminAPIURL   string `config:"admin_api_url" validate:"required"`
 	TemporalUIURL string `config:"temporal_ui_url" validate:"required"`
 
+	// DefaultAllFeaturesEnabled, when true, causes every newly-provisioned
+	// org to have all currently-known feature flags pre-set to true at
+	// creation time (except any listed in app.NeverDefaultOnFeatures).
+	// Intended to be set in non-production environments so new
+	// functionality gets exercised by default. Existing orgs are not
+	// affected — only orgs created after the config takes effect.
+	// Tenants can still opt out per-org via the admin UI; the per-org
+	// stored value always wins over this default.
+	DefaultAllFeaturesEnabled bool `config:"default_all_features_enabled"`
+
 	// flags for controlling the background workers
 	ForceSandboxMode           bool          `config:"force_sandbox_mode"`
 	ForceOnboardingSandboxMode bool          `config:"force_onboarding_sandbox_mode"`


### PR DESCRIPTION
Improves our feature management story by:
* Making it configurable at env level to enable all feature flags for new orgs, so it can be set on dev & stage for aggressive dogfooding. Features can be opt-ed out per org manually and it will be respected over the config set at env level. 
*  Setup metrics to see how many orgs have a feature flag enabled. It will help us decide if a feature is being adopted or needs to be removed. 