### PR TITLE
fix: make queue and runner process shutdown more robust

### DIFF
--- a/bins/runner/Dockerfile
+++ b/bins/runner/Dockerfile
@@ -253,8 +253,8 @@ ENV GIT_REF=$tag
 ENTRYPOINT ["/bin/runner"]
 
 FROM scratch AS artifacts-build
-#COPY --from=build-darwin-arm64 /out/ /
-#COPY --from=build-darwin-amd64 /out/ /
+COPY --from=build-darwin-arm64 /out/ /
+COPY --from=build-darwin-amd64 /out/ /
 COPY --from=build-linux-arm /out/ /
 COPY --from=build-linux-arm64 /out/ /
 COPY --from=build-linux-386 /out/ /

--- a/sdks/nuon-go/models/app_queue_signal.go
+++ b/sdks/nuon-go/models/app_queue_signal.go
@@ -28,6 +28,9 @@ type AppQueueSignal struct {
 	// Optional: if this signal was emitted by an emitter
 	EmitterID string `json:"emitter_id,omitempty"`
 
+	// enqueued
+	Enqueued bool `json:"enqueued,omitempty"`
+
 	// execution count
 	ExecutionCount int64 `json:"execution_count,omitempty"`
 

--- a/sdks/nuon-runner-go/models/app_queue_signal.go
+++ b/sdks/nuon-runner-go/models/app_queue_signal.go
@@ -28,6 +28,9 @@ type AppQueueSignal struct {
 	// Optional: if this signal was emitted by an emitter
 	EmitterID string `json:"emitter_id,omitempty"`
 
+	// enqueued
+	Enqueued bool `json:"enqueued,omitempty"`
+
 	// execution count
 	ExecutionCount int64 `json:"execution_count,omitempty"`
 

--- a/services/ctl-api/internal/app/general/helpers/ensure_general_queue.go
+++ b/services/ctl-api/internal/app/general/helpers/ensure_general_queue.go
@@ -1,0 +1,28 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+)
+
+const GeneralSignalsQueueName = "general-signals"
+
+// EnsureGeneralQueue creates the general-signals queue if it doesn't already exist.
+// Safe to call multiple times — queueClient.Create is idempotent.
+func (h *Helpers) EnsureGeneralQueue(ctx context.Context) (*app.Queue, error) {
+	q, err := h.queueClient.Create(ctx, &queueclient.CreateQueueRequest{
+		OwnerID:     "general",
+		OwnerType:   "general",
+		Namespace:   "general",
+		Name:        GeneralSignalsQueueName,
+		MaxInFlight: 5,
+		MaxDepth:    50,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to ensure general-signals queue: %w", err)
+	}
+	return q, nil
+}

--- a/services/ctl-api/internal/app/general/helpers/helpers.go
+++ b/services/ctl-api/internal/app/general/helpers/helpers.go
@@ -1,0 +1,27 @@
+package helpers
+
+import (
+	"go.uber.org/fx"
+	"gorm.io/gorm"
+
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+)
+
+type Params struct {
+	fx.In
+
+	DB          *gorm.DB `name:"psql"`
+	QueueClient *queueclient.Client
+}
+
+type Helpers struct {
+	db          *gorm.DB
+	queueClient *queueclient.Client
+}
+
+func New(params Params) *Helpers {
+	return &Helpers{
+		db:          params.DB,
+		queueClient: params.QueueClient,
+	}
+}

--- a/services/ctl-api/internal/app/general/service/admin_promotion.go
+++ b/services/ctl-api/internal/app/general/service/admin_promotion.go
@@ -1,16 +1,15 @@
 package service
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	generalsig "github.com/nuonco/nuon/services/ctl-api/internal/app/general/signals"
-	installsig "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/general/signals/v2/promotion"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
 
 type AdminPromotionRequest struct {
@@ -34,53 +33,19 @@ func (s *service) AdminPromotion(ctx *gin.Context) {
 		return
 	}
 
-	s.evClient.Send(ctx, "general", &generalsig.Signal{
-		Type: generalsig.OperationRestart,
-		Tag:  req.Tag,
-	})
-	s.evClient.Send(ctx, "general", &generalsig.Signal{
-		Type: generalsig.OperationPromotion,
-		Tag:  req.Tag,
-	})
-
-	// TODO: remove this when the install state initialization has already ran in the promotion workflow
-	s.initializeInstallStates(ctx)
-	ctx.JSON(http.StatusOK, app.EmptyResponse{})
-}
-
-func (s *service) initializeInstallStates(ctx *gin.Context) {
-	batchSize := 20
-	offset := 0
-	hasMore := true
-
-	for hasMore {
-		var installs []app.Install
-
-		res := s.db.
-			Scopes(scopes.WithDisableViews).
-			Model(&app.Install{}).
-			Select("installs.id").
-			Joins("LEFT JOIN install_states ON installs.id = install_states.install_id").
-			Where("install_states.install_id IS NULL").
-			Limit(batchSize).
-			Offset(offset).
-			Find(&installs)
-
-		if res.Error != nil {
-			ctx.Error(errors.Wrap(res.Error, "unable to get installs without state"))
-			return
-		}
-
-		if len(installs) < batchSize {
-			hasMore = false
-		}
-
-		for _, install := range installs {
-			s.evClient.Send(ctx, install.ID, &installsig.Signal{
-				Type: installsig.OperationGenerateState,
-			})
-		}
-		offset += batchSize
-
+	q, err := s.generalHelpers.EnsureGeneralQueue(ctx)
+	if err != nil {
+		ctx.Error(fmt.Errorf("unable to ensure general queue: %w", err))
+		return
 	}
+
+	if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+		QueueID: q.ID,
+		Signal:  &promotion.Signal{Tag: req.Tag},
+	}); err != nil {
+		ctx.Error(fmt.Errorf("unable to enqueue promotion signal: %w", err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, app.EmptyResponse{})
 }

--- a/services/ctl-api/internal/app/general/service/service.go
+++ b/services/ctl-api/internal/app/general/service/service.go
@@ -11,10 +11,12 @@ import (
 	"github.com/nuonco/nuon/pkg/metrics"
 	temporal "github.com/nuonco/nuon/pkg/temporal/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
+	generalhelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/general/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
 	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/authz"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/eventloop"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
 
 type service struct {
@@ -28,6 +30,8 @@ type service struct {
 	authzClient    *authz.Client
 	acctClient     *account.Client
 	evClient       eventloop.Client
+	queueClient    *queueclient.Client
+	generalHelpers *generalhelpers.Helpers
 	codecs         []converter.PayloadCodec
 }
 
@@ -115,6 +119,8 @@ type Params struct {
 	AuthzClient    *authz.Client
 	AcctClient     *account.Client
 	EvClient       eventloop.Client
+	QueueClient    *queueclient.Client
+	GeneralHelpers *generalhelpers.Helpers
 	DB             *gorm.DB `name:"psql"`
 	MW             metrics.Writer
 
@@ -137,6 +143,8 @@ func New(params Params) *service {
 		authzClient:    params.AuthzClient,
 		acctClient:     params.AcctClient,
 		evClient:       params.EvClient,
+		queueClient:    params.QueueClient,
+		generalHelpers: params.GeneralHelpers,
 		codecs: []converter.PayloadCodec{
 			params.TemporalCodecGzip,
 			params.TemporalCodecLargePayload,

--- a/services/ctl-api/internal/app/general/signals/v2/promotion/init.go
+++ b/services/ctl-api/internal/app/general/signals/v2/promotion/init.go
@@ -1,0 +1,12 @@
+package promotion
+
+import (
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/catalog"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+func init() {
+	catalog.Register(SignalType, func() signal.Signal {
+		return &Signal{}
+	})
+}

--- a/services/ctl-api/internal/app/general/signals/v2/promotion/signal.go
+++ b/services/ctl-api/internal/app/general/signals/v2/promotion/signal.go
@@ -1,0 +1,52 @@
+package promotion
+
+import (
+	"fmt"
+
+	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
+
+	generalactivities "github.com/nuonco/nuon/services/ctl-api/internal/app/general/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+const SignalType signal.SignalType = "general-promotion"
+
+var _ signal.Signal = (*Signal)(nil)
+
+type Signal struct {
+	Tag string `json:"tag"`
+}
+
+func (s *Signal) Type() signal.SignalType { return SignalType }
+
+func (s *Signal) Validate(_ workflow.Context) error {
+	return nil
+}
+
+func (s *Signal) Execute(ctx workflow.Context) error {
+	l, _ := log.WorkflowLogger(ctx)
+
+	// Mark all active runner processes for shutdown in a single query.
+	processResp, err := generalactivities.AwaitMarkActiveProcessesForShutdown(ctx, generalactivities.MarkActiveProcessesForShutdownRequest{})
+	if err != nil {
+		return fmt.Errorf("unable to mark processes for shutdown: %w", err)
+	}
+	if l != nil {
+		l.Info("marked processes for shutdown", zap.Int64("rows_affected", processResp.RowsAffected))
+	}
+
+	// Request continue-as-new on all queues so they restart with the new
+	// code version.
+	queueResp, err := queueclient.AwaitRequestCANAll(ctx, &queueclient.RequestCANAllRequest{})
+	if err != nil {
+		return fmt.Errorf("unable to request CAN on all queues: %w", err)
+	}
+	if l != nil {
+		l.Info("requested CAN on queues", zap.Int64("rows_affected", queueResp.RowsAffected))
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/app/general/worker/activities/get_queue_signal_enqueue_metrics.go
+++ b/services/ctl-api/internal/app/general/worker/activities/get_queue_signal_enqueue_metrics.go
@@ -29,15 +29,11 @@ func (a *Activities) getQueueSignalEnqueueMetrics(ctx context.Context, db *gorm.
 		return nil, fmt.Errorf("unable to count total queue signals: %w", res.Error)
 	}
 
-	// Count queue signals missing enqueue_finished_at in their status metadata.
-	// These are signals where the background enqueue goroutine either hasn't
-	// completed yet or failed silently.
+	// Count queue signals that have not been enqueued yet.
 	if res := db.WithContext(ctx).
-		Raw(`SELECT count(*) FROM queue_signals
-WHERE deleted_at = 0
-AND NOT (status::jsonb -> 'metadata' ? 'enqueue_finished_at')`).
+		Raw(`SELECT count(*) FROM queue_signals WHERE deleted_at = 0 AND enqueued = false`).
 		Scan(&m.MissingEnqueueFinish); res.Error != nil {
-		return nil, fmt.Errorf("unable to count signals missing enqueue_finished_at: %w", res.Error)
+		return nil, fmt.Errorf("unable to count signals not yet enqueued: %w", res.Error)
 	}
 
 	return &m, nil

--- a/services/ctl-api/internal/app/general/worker/activities/mark_active_processes_for_shutdown.go
+++ b/services/ctl-api/internal/app/general/worker/activities/mark_active_processes_for_shutdown.go
@@ -1,0 +1,40 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+)
+
+type MarkActiveProcessesForShutdownRequest struct{}
+
+type MarkActiveProcessesForShutdownResponse struct {
+	RowsAffected int64 `json:"rows_affected"`
+}
+
+// MarkActiveProcessesForShutdown sets shutdown_requested in the composite_status
+// metadata of all active/offline runner processes in a single query. The
+// per-process health check cron will pick this up and create shutdown jobs.
+//
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 1m
+func (a *Activities) MarkActiveProcessesForShutdown(ctx context.Context, req MarkActiveProcessesForShutdownRequest) (*MarkActiveProcessesForShutdownResponse, error) {
+	res := a.db.WithContext(ctx).Exec(`
+		UPDATE runner_processes
+		SET composite_status = jsonb_set(
+			jsonb_set(
+				COALESCE(composite_status::jsonb, '{}'::jsonb),
+				'{metadata}',
+				COALESCE(composite_status::jsonb -> 'metadata', '{}'::jsonb)
+			),
+			'{metadata,shutdown_requested}',
+			'true'::jsonb
+		)
+		WHERE deleted_at = 0
+		AND composite_status::jsonb ->> 'status' IN ('active', 'offline')
+	`)
+	if res.Error != nil {
+		return nil, fmt.Errorf("unable to mark active processes for shutdown: %w", res.Error)
+	}
+
+	return &MarkActiveProcessesForShutdownResponse{RowsAffected: res.RowsAffected}, nil
+}

--- a/services/ctl-api/internal/app/runners/signals/v2/processhealthcheck/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/v2/processhealthcheck/signal.go
@@ -74,6 +74,42 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return nil
 	}
 
+	// If a promotion requested shutdown, create the shutdown record and clear
+	// the flag. The runner's shutdown poller will pick it up. Because health
+	// check emitters run per-process on a 1-minute cron, shutdowns are
+	// staggered naturally across all runners.
+	if val, ok := process.CompositeStatus.Metadata["shutdown_requested"]; ok && val != nil {
+		l.Info("shutdown requested via metadata, creating shutdown record",
+			zap.String("runner_id", s.RunnerID),
+			zap.String("process_id", s.ProcessID),
+		)
+
+		_, err := activities.AwaitCreateRunnerProcessShutdown(ctx, activities.CreateRunnerProcessShutdownRequest{
+			RunnerProcessID: s.ProcessID,
+			Type:            app.RunnerProcessShutdownTypeGraceful,
+			CompositeStatus: app.CompositeStatus{
+				Status:                 app.Status(app.RunnerProcessShutdownStatusRequested),
+				StatusHumanDescription: "shutdown requested via promotion",
+				CreatedAtTS:            workflow.Now(ctx).Unix(),
+			},
+		})
+		if err != nil {
+			return errors.Wrap(err, "unable to create shutdown for process")
+		}
+
+		// Clear the flag so we don't create duplicate shutdowns on the next health check.
+		if clearErr := activities.AwaitClearProcessShutdownRequested(ctx, activities.ClearProcessShutdownRequestedRequest{
+			ProcessID: s.ProcessID,
+		}); clearErr != nil {
+			l.Warn("unable to clear shutdown_requested metadata",
+				zap.String("process_id", s.ProcessID),
+				zap.Error(clearErr),
+			)
+		}
+
+		return nil
+	}
+
 	heartbeat, err := activities.AwaitGetMostRecentHeartBeatByProcess(ctx, activities.GetMostRecentHeartBeatByProcessRequest{
 		RunnerID:  s.RunnerID,
 		ProcessID: s.ProcessID,

--- a/services/ctl-api/internal/app/runners/worker/activities/clear_process_shutdown_requested.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/clear_process_shutdown_requested.go
@@ -1,0 +1,33 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+)
+
+type ClearProcessShutdownRequestedRequest struct {
+	ProcessID string `validate:"required"`
+}
+
+// ClearProcessShutdownRequested removes the shutdown_requested key from a
+// runner process's CompositeStatus metadata. Called after a shutdown record
+// has been created to prevent duplicate shutdowns.
+//
+// @temporal-gen-v2 activity
+func (a *Activities) ClearProcessShutdownRequested(ctx context.Context, req ClearProcessShutdownRequestedRequest) error {
+	// Set shutdown_requested to null to effectively remove it.
+	if err := generics.MergeJSONBMetadata(
+		a.db.WithContext(ctx),
+		&app.RunnerProcess{},
+		req.ProcessID,
+		"composite_status",
+		map[string]any{"shutdown_requested": nil},
+	); err != nil {
+		return fmt.Errorf("unable to clear shutdown_requested: %w", err)
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/app/runners/worker/activities/update_runner_process_status.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/update_runner_process_status.go
@@ -17,7 +17,6 @@ type UpdateRunnerProcessStatusRequest struct {
 // @temporal-gen-v2 activity
 // @by-field ProcessID
 func (a *Activities) UpdateRunnerProcessStatus(ctx context.Context, req UpdateRunnerProcessStatusRequest) (*app.RunnerProcess, error) {
-	// get current process for composite status
 	var current app.RunnerProcess
 	if res := a.db.WithContext(ctx).First(&current, "id = ?", req.ProcessID); res.Error != nil {
 		return nil, fmt.Errorf("unable to get runner process: %w", res.Error)
@@ -25,7 +24,6 @@ func (a *Activities) UpdateRunnerProcessStatus(ctx context.Context, req UpdateRu
 
 	newComposite := app.NewCompositeStatus(ctx, app.Status(req.Status))
 	newComposite.StatusHumanDescription = req.StatusDescription
-	// Carry forward metadata from the previous status, then overlay any new metadata
 	for k, v := range current.CompositeStatus.Metadata {
 		newComposite.Metadata[k] = v
 	}

--- a/services/ctl-api/internal/fxmodules/helpers.go
+++ b/services/ctl-api/internal/fxmodules/helpers.go
@@ -7,6 +7,7 @@ import (
 	actionshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/actions/helpers"
 	appshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/helpers"
 	componentshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
+	generalhelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/general/helpers"
 	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	orgshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/helpers"
 	runnershelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
@@ -24,4 +25,5 @@ var HelpersModule = fx.Module("helpers",
 	fx.Provide(appshelpers.New),
 	fx.Provide(installshelpers.New),
 	fx.Provide(runnershelpers.New),
+	fx.Provide(generalhelpers.New),
 )

--- a/services/ctl-api/internal/pkg/db/generics/json.go
+++ b/services/ctl-api/internal/pkg/db/generics/json.go
@@ -70,8 +70,11 @@ func (jq *JSONBQuerier) WhereJSONPath(field string, path []string, operator stri
 // GORM model (e.g. &app.QueueSignal{}).
 func MergeJSONBMetadata(db *gorm.DB, model any, id string, field string, metadata map[string]any) error {
 	// Build a jsonb_set chain that merges each key into the metadata sub-object.
-	// Start from the existing column value, defaulting to '{}'.
-	expr := fmt.Sprintf("COALESCE(%s::jsonb, '{}'::jsonb)", field)
+	// First ensure the metadata key exists as an object, then set each key.
+	expr := fmt.Sprintf(
+		"jsonb_set(COALESCE(%s::jsonb, '{}'::jsonb), '{metadata}', COALESCE(%s::jsonb -> 'metadata', '{}'::jsonb))",
+		field, field,
+	)
 
 	args := make([]any, 0, len(metadata))
 	for k, v := range metadata {
@@ -83,7 +86,6 @@ func MergeJSONBMetadata(db *gorm.DB, model any, id string, field string, metadat
 		args = append(args, string(valJSON))
 	}
 
-	args = append(args, id)
 	if res := db.
 		Model(model).
 		Where("id = ?", id).
@@ -92,6 +94,41 @@ func MergeJSONBMetadata(db *gorm.DB, model any, id string, field string, metadat
 	}
 
 	return nil
+}
+
+// WhereJSONBStatusIn returns a GORM scope that filters rows where the "status"
+// key inside a JSONB column matches one of the provided values.
+//
+// Example:
+//
+//	db.Model(&app.RunnerProcess{}).
+//	    Scopes(generics.WhereJSONBStatusIn("composite_status", "active", "offline")).
+//	    Find(&results)
+func WhereJSONBStatusIn(field string, statuses ...string) func(*gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Where(fmt.Sprintf("%s::jsonb ->> 'status' IN ?", field), statuses)
+	}
+}
+
+// SetJSONBMetadataKey returns a GORM scope that atomically sets a single key
+// inside the metadata sub-object of a JSONB column via jsonb_set. Executes the
+// update as part of the scope — chain .Where() calls before .Scopes().
+//
+// Example:
+//
+//	db.Model(&app.RunnerProcess{}).
+//	    Where("composite_status::jsonb ->> 'status' = ?", "active").
+//	    Scopes(generics.SetJSONBMetadataKey("composite_status", "shutdown_requested", true))
+func SetJSONBMetadataKey(field, key string, value any) func(*gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		valJSON, err := json.Marshal(value)
+		if err != nil {
+			_ = db.AddError(fmt.Errorf("unable to marshal value for key %s: %w", key, err))
+			return db
+		}
+		expr := fmt.Sprintf("jsonb_set(COALESCE(%s::jsonb, '{}'::jsonb), '{metadata,%s}', ?::jsonb)", field, key)
+		return db.UpdateColumn(field, gorm.Expr(expr, string(valJSON)))
+	}
 }
 
 // Helper function to join strings

--- a/services/ctl-api/internal/pkg/queue/activities/check_can_requested.go
+++ b/services/ctl-api/internal/pkg/queue/activities/check_can_requested.go
@@ -1,0 +1,30 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+)
+
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 1m
+// @as-wrapper
+// @wrapper-prefix QueueInternal
+func (a *Activities) checkCANRequested(ctx context.Context, queueID string) (bool, error) {
+	var queue app.Queue
+	if res := a.db.WithContext(ctx).Where(app.Queue{ID: queueID}).First(&queue); res.Error != nil {
+		return false, generics.TemporalGormError(res.Error, "unable to get queue for CAN check")
+	}
+
+	if queue.StatusV2.Metadata == nil {
+		return false, nil
+	}
+
+	val, ok := queue.StatusV2.Metadata["restart_hint"]
+	if !ok || val == nil {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/services/ctl-api/internal/pkg/queue/activities/check_restart_hint.go
+++ b/services/ctl-api/internal/pkg/queue/activities/check_restart_hint.go
@@ -17,12 +17,12 @@ func (a *Activities) checkRestartHint(ctx context.Context, queueID string) (bool
 		return false, generics.TemporalGormError(res.Error, "unable to get queue for restart hint check")
 	}
 
-	if queue.Metadata == nil {
+	if queue.StatusV2.Metadata == nil {
 		return false, nil
 	}
 
-	hint, ok := queue.Metadata["restart_hint"]
-	if !ok || hint == nil {
+	val, ok := queue.StatusV2.Metadata["restart_hint"]
+	if !ok || val == nil {
 		return false, nil
 	}
 
@@ -34,23 +34,10 @@ func (a *Activities) checkRestartHint(ctx context.Context, queueID string) (bool
 // @as-wrapper
 // @wrapper-prefix QueueInternal
 func (a *Activities) clearRestartHint(ctx context.Context, queueID string) error {
-	var queue app.Queue
-	if res := a.db.WithContext(ctx).Where(app.Queue{ID: queueID}).First(&queue); res.Error != nil {
-		return generics.TemporalGormError(res.Error, "unable to get queue for restart hint clear")
-	}
-
-	if queue.Metadata == nil {
-		return nil
-	}
-
-	if _, ok := queue.Metadata["restart_hint"]; !ok {
-		return nil
-	}
-
-	delete(queue.Metadata, "restart_hint")
-
-	if res := a.db.WithContext(ctx).Model(&app.Queue{}).Where(app.Queue{ID: queueID}).Update("metadata", queue.Metadata); res.Error != nil {
-		return generics.TemporalGormError(res.Error, "unable to clear restart hint")
+	if err := generics.MergeJSONBMetadata(a.db.WithContext(ctx), &app.Queue{}, queueID, "status_v2", map[string]any{
+		"restart_hint": nil,
+	}); err != nil {
+		return generics.TemporalGormError(err, "unable to clear restart hint")
 	}
 
 	return nil

--- a/services/ctl-api/internal/pkg/queue/can_listener.go
+++ b/services/ctl-api/internal/pkg/queue/can_listener.go
@@ -1,0 +1,67 @@
+package queue
+
+import (
+	"math/rand"
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
+)
+
+const (
+	canMinInterval = 2 * time.Minute
+	canMaxJitter   = 3 * time.Minute // interval is 2-5 minutes
+	canStartJitter = 60              // seconds of initial jitter
+	canHistoryMax  = 10000
+)
+
+func (q *queue) startCANListener(ctx workflow.Context) {
+	workflow.Go(ctx, func(gCtx workflow.Context) {
+		l, _ := log.WorkflowLogger(gCtx)
+
+		// Stagger startup across queues to avoid thundering herd.
+		jitter := time.Duration(rand.Intn(canStartJitter)) * time.Second
+		if err := workflow.Sleep(gCtx, jitter); err != nil {
+			return
+		}
+
+		for {
+			interval := canMinInterval + time.Duration(rand.Intn(int(canMaxJitter.Seconds())))*time.Second
+			if err := workflow.Sleep(gCtx, interval); err != nil {
+				return
+			}
+
+			// Check 1: Temporal suggests CAN due to large history.
+			if workflow.GetInfo(gCtx).GetCurrentHistoryLength() > canHistoryMax {
+				if l != nil {
+					l.Info("history length exceeded threshold, triggering continue-as-new",
+						zap.Int("history_length", workflow.GetInfo(gCtx).GetCurrentHistoryLength()))
+				}
+				q.restarted = true
+				return
+			}
+
+			// Check 2: continue_as_new_requested set in queue metadata.
+			requested, err := activities.AwaitCheckCANRequested(gCtx, activities.CheckCANRequestedRequest{
+				QueueID: q.queueID,
+			})
+			if err != nil {
+				if l != nil {
+					l.Warn("unable to check CAN requested", zap.Error(err))
+				}
+				continue
+			}
+
+			if requested {
+				if l != nil {
+					l.Info("continue-as-new requested via metadata")
+				}
+				q.restarted = true
+				return
+			}
+		}
+	})
+}

--- a/services/ctl-api/internal/pkg/queue/catalog/allsignals/allsignals.go
+++ b/services/ctl-api/internal/pkg/queue/catalog/allsignals/allsignals.go
@@ -19,6 +19,9 @@ import (
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/signals/v2/sandboxbuild"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/signals/v2/updatesandbox"
 
+	// general signals
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/general/signals/v2/promotion"
+
 	// components signals
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/v2/build"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/v2/configcreated"

--- a/services/ctl-api/internal/pkg/queue/client/hint_restart.go
+++ b/services/ctl-api/internal/pkg/queue/client/hint_restart.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
-	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
 
 // @temporal-gen-v2 activity
@@ -17,10 +15,19 @@ func (c *Client) HintRestart(ctx context.Context, queueIDs []string) error {
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	if res := c.db.WithContext(ctx).
-		Model(&app.Queue{}).
-		Where("id IN ?", queueIDs).
-		Update("metadata", c.db.Raw("COALESCE(metadata, ''::hstore) || hstore('restart_hint', ?)", now)); res.Error != nil {
+	if res := c.db.WithContext(ctx).Exec(`
+		UPDATE queues
+		SET status_v2 = jsonb_set(
+			jsonb_set(
+				COALESCE(status_v2::jsonb, '{}'::jsonb),
+				'{metadata}',
+				COALESCE(status_v2::jsonb -> 'metadata', '{}'::jsonb)
+			),
+			'{metadata,restart_hint}',
+			to_jsonb(?::text)
+		)
+		WHERE id IN ? AND deleted_at = 0
+	`, now, queueIDs); res.Error != nil {
 		return errors.Wrap(res.Error, "unable to set restart hints")
 	}
 
@@ -31,12 +38,52 @@ func (c *Client) HintRestart(ctx context.Context, queueIDs []string) error {
 // @start-to-close-timeout 1m
 func (c *Client) HintRestartByOrg(ctx context.Context, orgID string) error {
 	now := time.Now().UTC().Format(time.RFC3339)
-	if res := c.db.WithContext(ctx).
-		Model(&app.Queue{}).
-		Where("org_id = ?", orgID).
-		Update("metadata", c.db.Raw("COALESCE(metadata, ''::hstore) || hstore('restart_hint', ?)", now)); res.Error != nil {
+	if res := c.db.WithContext(ctx).Exec(`
+		UPDATE queues
+		SET status_v2 = jsonb_set(
+			jsonb_set(
+				COALESCE(status_v2::jsonb, '{}'::jsonb),
+				'{metadata}',
+				COALESCE(status_v2::jsonb -> 'metadata', '{}'::jsonb)
+			),
+			'{metadata,restart_hint}',
+			to_jsonb(?::text)
+		)
+		WHERE org_id = ? AND deleted_at = 0
+	`, now, orgID); res.Error != nil {
 		return errors.Wrap(res.Error, "unable to set restart hints for org")
 	}
 
 	return nil
+}
+
+type RequestCANAllRequest struct{}
+
+type RequestCANAllResponse struct {
+	RowsAffected int64 `json:"rows_affected"`
+}
+
+// RequestCANAll sets restart_hint on all queues via status_v2 metadata.
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 1m
+func (c *Client) RequestCANAll(ctx context.Context, _ *RequestCANAllRequest) (*RequestCANAllResponse, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	res := c.db.WithContext(ctx).Exec(`
+		UPDATE queues
+		SET status_v2 = jsonb_set(
+			jsonb_set(
+				COALESCE(status_v2::jsonb, '{}'::jsonb),
+				'{metadata}',
+				COALESCE(status_v2::jsonb -> 'metadata', '{}'::jsonb)
+			),
+			'{metadata,restart_hint}',
+			to_jsonb(?::text)
+		)
+		WHERE deleted_at = 0
+	`, now)
+	if res.Error != nil {
+		return nil, errors.Wrap(res.Error, "unable to set restart hint on all queues")
+	}
+
+	return &RequestCANAllResponse{RowsAffected: res.RowsAffected}, nil
 }

--- a/services/ctl-api/internal/pkg/queue/run.go
+++ b/services/ctl-api/internal/pkg/queue/run.go
@@ -76,6 +76,9 @@ func (q *queue) run(ctx workflow.Context) (bool, error) {
 	l.Info("starting hint listener")
 	q.startHintListener(ctx)
 
+	l.Info("starting continue-as-new listener")
+	q.startCANListener(ctx)
+
 	q.setStatus(ctx, l, QueueStatusReady)
 	q.ready = true
 

--- a/services/ctl-api/internal/pkg/workflows/status/activities/update.go
+++ b/services/ctl-api/internal/pkg/workflows/status/activities/update.go
@@ -111,11 +111,18 @@ func (a *Activities) updateStatusCommon(ctx context.Context, obj any, status app
 	existingStatus.History = nil
 	status.History = append(history, existingStatus)
 
-	// Separate out metadata for atomic merge — the status column write carries
-	// everything except metadata so that concurrent MergeJSONBMetadata calls
-	// (e.g. from the background enqueuer) are not clobbered.
+	// Carry forward existing metadata into the new status so it's not lost.
 	newMetadata := status.Metadata
-	status.Metadata = nil
+	if newMetadata == nil {
+		newMetadata = make(map[string]any, 0)
+	}
+	for k, v := range existingStatus.Metadata {
+		if _, ok := newMetadata[k]; ok {
+			continue
+		}
+		newMetadata[k] = v
+	}
+	status.Metadata = newMetadata
 
 	res := a.db.WithContext(ctx).Model(obj).Updates(
 		map[string]any{
@@ -128,11 +135,12 @@ func (a *Activities) updateStatusCommon(ctx context.Context, obj any, status app
 		return errors.New("no object found to update")
 	}
 
-	// Atomically merge metadata keys using jsonb_set so we never overwrite
-	// metadata written by other writers between our read and write.
-	if len(newMetadata) > 0 {
+	// Also atomically merge new metadata keys via jsonb_set so that any
+	// metadata written concurrently (e.g. by the background enqueuer)
+	// between our read and this write is not lost.
+	if len(status.Metadata) > 0 {
 		id := reflectID(obj)
-		if err := generics.MergeJSONBMetadata(a.db.WithContext(ctx), obj, id, statusField, newMetadata); err != nil {
+		if err := generics.MergeJSONBMetadata(a.db.WithContext(ctx), obj, id, statusField, status.Metadata); err != nil {
 			return errors.Wrap(err, "unable to merge metadata")
 		}
 	}

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -4280,6 +4280,7 @@ export interface components {
       created_by_id?: string;
       /** @description Optional: if this signal was emitted by an emitter */
       emitter_id?: string;
+      enqueued?: boolean;
       execution_count?: number;
       id?: string;
       org_id?: string;
@@ -5520,6 +5521,24 @@ export interface components {
       labels?: {
         [key: string]: string;
       };
+      /**
+       * @description TerraformVersion is the version of the terraform CLI the build runner
+       * should install in order to vendor providers via
+       * `terraform providers mirror`. When empty the build runner falls back
+       * to a sane default. Should mirror the version configured for the
+       * component's deploy plan so init resolves the same provider bytes the
+       * build vendored. Only consulted when VendorProviders is true.
+       */
+      terraform_version?: string;
+      /**
+       * @description VendorProviders enables build-time vendoring of terraform providers
+       * via `terraform providers mirror`. Gated by the
+       * `terraform-provider-mirror` org feature flag in ctl-api so we can
+       * roll the change out gradually without coupling install-runner
+       * behaviour to the flag (the install runner auto-detects whether a
+       * mirror is present in the OCI artifact).
+       */
+      vendor_providers?: boolean;
     };
     "plantypes.TerraformDeployHooks": {
       enabled?: boolean;


### PR DESCRIPTION
This PR updates the way we handle shut downs to now use a more independent approach. Previously, when we pushed an 
update, we would run a background workflow that updates each event loop one by one. This was expensive, and hard to add 
backoff and jitter into.

This update makes it so we use a "request_continue_as_new" model. This means, we update the object to say it should CAN, 
and then, the queue is responsible for fetching that state and handling it + clearing the update. This should improve 
reliability of this, and at the same time, allow us to more easily scale these types of updates out.
