### PR TITLE
fix: properly pass through context

### DIFF
--- a/services/ctl-api/internal/app/queue_signal.go
+++ b/services/ctl-api/internal/app/queue_signal.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nuonco/nuon/pkg/shortid/domains"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/indexes"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
+	queuecctx "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
 )
@@ -43,6 +44,8 @@ type QueueSignal struct {
 	Workflow signaldb.WorkflowRef `json:"workflow"`
 
 	Enqueued bool `json:"enqueued" gorm:"default:false;not null" temporaljson:"enqueued,omitzero,omitempty"`
+
+	SignalContext queuecctx.SignalContext `json:"signal_context" gorm:"type:jsonb;default:null" temporaljson:"signal_context,omitzero,omitempty"`
 
 	ExecutionCount int `json:"execution_count" gorm:"default:0;not null" temporaljson:"execution_count,omitzero,omitempty"`
 }

--- a/services/ctl-api/internal/pkg/queue/activities/create_queue_signal.go
+++ b/services/ctl-api/internal/pkg/queue/activities/create_queue_signal.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/queuecctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
 )
@@ -31,6 +32,7 @@ func (a *Activities) CreateQueueSignal(ctx context.Context, req *CreateQueueSign
 	_, _ = rand.Read(suffix)
 
 	queueSignal := app.QueueSignal{
+		SignalContext: queuecctx.FromContext(ctx),
 		Signal: signaldb.SignalData{
 			Signal: req.Signal,
 		},

--- a/services/ctl-api/internal/pkg/queue/cctx/cctx.go
+++ b/services/ctl-api/internal/pkg/queue/cctx/cctx.go
@@ -1,0 +1,38 @@
+package cctx
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+)
+
+// SignalContext captures the request-scoped context values that must survive
+// asynchronous enqueuing. It is stored as a JSONB column on QueueSignal so that
+// the background enqueuer can restore the full context when processing the
+// signal outside the original request goroutine.
+type SignalContext struct {
+	AccountID   string `json:"account_id,omitempty"`
+	OrgID       string `json:"org_id,omitempty"`
+	TraceID     string `json:"trace_id,omitempty"`
+	LogStreamID string `json:"log_stream_id,omitempty"`
+}
+
+// Scan implements database/sql.Scanner for reading JSONB from PostgreSQL.
+func (sc *SignalContext) Scan(v interface{}) error {
+	switch v := v.(type) {
+	case nil:
+		return nil
+	case []byte:
+		return json.Unmarshal(v, sc)
+	}
+	return nil
+}
+
+// Value implements driver.Valuer for writing JSONB to PostgreSQL.
+func (sc SignalContext) Value() (driver.Value, error) {
+	return json.Marshal(sc)
+}
+
+// GormDataType tells GORM to use the jsonb PostgreSQL type.
+func (SignalContext) GormDataType() string {
+	return "jsonb"
+}

--- a/services/ctl-api/internal/pkg/queue/client/enqueue_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/enqueue_signal.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/queuecctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
 )
@@ -42,6 +43,7 @@ func (c *Client) EnqueueSignal(ctx context.Context, req *EnqueueSignalRequest) (
 	}
 
 	queueSignal := app.QueueSignal{
+		SignalContext: queuecctx.FromContext(ctx),
 		Signal: signaldb.SignalData{
 			Signal: req.Signal,
 		},

--- a/services/ctl-api/internal/pkg/queue/enqueuer/enqueuer.go
+++ b/services/ctl-api/internal/pkg/queue/enqueuer/enqueuer.go
@@ -108,8 +108,6 @@ func (e *Enqueuer) run() {
 			return
 		case id := <-e.ch:
 			e.processOne(id)
-		case <-ticker.C:
-			e.sweep()
 		}
 	}
 }

--- a/services/ctl-api/internal/pkg/queue/enqueuer/enqueuer.go
+++ b/services/ctl-api/internal/pkg/queue/enqueuer/enqueuer.go
@@ -98,8 +98,8 @@ func (e *Enqueuer) Send(queueSignalID string) {
 func (e *Enqueuer) run() {
 	defer close(e.doneCh)
 
-	ticker := time.NewTicker(sweepInterval)
-	defer ticker.Stop()
+	// ticker := time.NewTicker(sweepInterval)
+	// defer ticker.Stop()
 
 	for {
 		select {
@@ -108,6 +108,9 @@ func (e *Enqueuer) run() {
 			return
 		case id := <-e.ch:
 			e.processOne(id)
+			// NOTE(jm): we no longer run the sweep in process
+			// case <-ticker.C:
+			// e.sweep()
 		}
 	}
 }

--- a/services/ctl-api/internal/pkg/queue/enqueuer/process_one.go
+++ b/services/ctl-api/internal/pkg/queue/enqueuer/process_one.go
@@ -8,9 +8,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/queuecctx"
 )
 
 // processOne looks up the queue signal and its parent queue, performs the
@@ -36,8 +36,7 @@ func (e *Enqueuer) processOne(queueSignalID string) {
 		return
 	}
 
-	ctx = cctx.SetOrgIDContext(ctx, *q.OrgID)
-	ctx = cctx.SetAccountIDContext(ctx, q.CreatedByID)
+	ctx = queuecctx.Apply(ctx, qs.SignalContext)
 
 	startOp := e.queueStartOperation(&q)
 	_, err := e.tClient.UpdateWithStartWorkflowInNamespace(ctx, q.Workflow.Namespace, tclient.UpdateWithStartWorkflowOptions{

--- a/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx.go
+++ b/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx.go
@@ -1,0 +1,39 @@
+package queuecctx
+
+import (
+	"context"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	qcctx "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/cctx"
+)
+
+// FromContext reads the common context values and returns a SignalContext
+// suitable for persisting alongside a QueueSignal record.
+func FromContext(ctx cctx.ValueContext) qcctx.SignalContext {
+	sc := qcctx.SignalContext{}
+
+	sc.AccountID, _ = cctx.AccountIDFromContext(ctx)
+	sc.OrgID, _ = cctx.OrgIDFromContext(ctx)
+	sc.TraceID = cctx.TraceIDFromContext(ctx)
+
+	if ls, err := cctx.GetLogStreamContext(ctx); err == nil && ls != nil {
+		sc.LogStreamID = ls.ID
+	}
+
+	return sc
+}
+
+// Apply restores the captured context values onto a context.Context so that
+// downstream consumers (e.g. Temporal propagators) see the original values.
+func Apply(ctx context.Context, sc qcctx.SignalContext) context.Context {
+	if sc.AccountID != "" {
+		ctx = cctx.SetAccountIDContext(ctx, sc.AccountID)
+	}
+	if sc.OrgID != "" {
+		ctx = cctx.SetOrgIDContext(ctx, sc.OrgID)
+	}
+	if sc.TraceID != "" {
+		ctx = cctx.SetTraceIDContext(ctx, sc.TraceID)
+	}
+	return ctx
+}


### PR DESCRIPTION
This PR updates how we pass the context to queue-signals, allowing us to fully decouple the process of enqueuing a signal from it's origin context.

While in here, we also disable the sweep loop, which looks for old queue signals. Will re-add that later.
