### PR TITLE
fix: compute runner IRSA role ARN inline

### DIFF
--- a/services/ctl-api/internal/app/runners/worker/kuberunner/values.go
+++ b/services/ctl-api/internal/app/runners/worker/kuberunner/values.go
@@ -76,15 +76,12 @@ func (a *Activities) getValues(req *InstallOrUpgradeRequest) helmValues {
 			Name:  "default",
 		}
 	default:
-		roleARN := req.RunnerIAMRole
-		if roleARN == "" {
-			orgID := strings.TrimPrefix(req.RunnerServiceAccountName, "runner-")
-			if orgID != "" && a.config.ManagementAccountID != "" {
-				roleARN = fmt.Sprintf("arn:aws:iam::%s:role/orgs/%s/runner-%s", a.config.ManagementAccountID, orgID, orgID)
-			}
-		}
-		if roleARN != "" {
-			annotations["eks.amazonaws.com/role-arn"] = roleARN
+		orgID := strings.TrimPrefix(req.RunnerServiceAccountName, "runner-")
+		if orgID != "" && a.config.ManagementAccountID != "" {
+			annotations["eks.amazonaws.com/role-arn"] = fmt.Sprintf(
+				"arn:aws:iam::%s:role/orgs/%s/runner-%s",
+				a.config.ManagementAccountID, orgID, orgID,
+			)
 		}
 	}
 

--- a/services/ctl-api/internal/app/runners/worker/kuberunner/values.go
+++ b/services/ctl-api/internal/app/runners/worker/kuberunner/values.go
@@ -1,5 +1,10 @@
 package runner
 
+import (
+	"fmt"
+	"strings"
+)
+
 // NOTE(jm): this struct must match the yaml expected in the helm chart to install the runner.
 type helmValuesImage struct {
 	Tag        string `mapstructure:"tag"`
@@ -71,8 +76,15 @@ func (a *Activities) getValues(req *InstallOrUpgradeRequest) helmValues {
 			Name:  "default",
 		}
 	default:
-		if req.RunnerIAMRole != "" {
-			annotations["eks.amazonaws.com/role-arn"] = req.RunnerIAMRole
+		roleARN := req.RunnerIAMRole
+		if roleARN == "" {
+			orgID := strings.TrimPrefix(req.RunnerServiceAccountName, "runner-")
+			if orgID != "" && a.config.ManagementAccountID != "" {
+				roleARN = fmt.Sprintf("arn:aws:iam::%s:role/orgs/%s/runner-%s", a.config.ManagementAccountID, orgID, orgID)
+			}
+		}
+		if roleARN != "" {
+			annotations["eks.amazonaws.com/role-arn"] = roleARN
 		}
 	}
 


### PR DESCRIPTION
Build runner SAs were missing IRSA annotation because the AWS branch read `req.RunnerIAMRole` from the DB, which is empty for ~48% of org runners. Compute it inline from orgID + management account ID. Same as the May 2025 → Mar 2026 behavior.