### PR TITLE
docs: add estimated times to sample apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ bins/lsp/lsp
 ws-*/
 agent-day2/
 agent-day2/*
+sdks/nuon-go/models/cctx_signal_context.go
+sdks/nuon-runner-go/models/cctx_signal_context.go

--- a/docs/get-started/create-your-first-app.mdx
+++ b/docs/get-started/create-your-first-app.mdx
@@ -15,8 +15,10 @@ If you are new to Nuon, we recommend understanding the life cycle of packaging y
 
 Choose one of the following example app guides to get started:
 
-- [aws-lambda](/get-started/app-aws-lambda): A Lambda function with DynamoDB and API Gateway
-- [eks-simple](/get-started/app-aws-k8s): An AWS EKS Traefik `whoami` application
+- [eks-simple](/get-started/app-aws-k8s): An AWS EKS (Kubernetes) Traefik `whoami` application (~35 min)
+- [aws-lambda](/get-started/app-aws-lambda): A Lambda function with DynamoDB and API Gateway (~26 min)
+
+Estimated times above include creating the initial VPC, Subnets, Nat Gateway, ASG, EC2 VM, and a healthy Nuon runner (~11 min). For the fastest duration, approve all workflow steps when the app install begins.
 
 ## Other Apps to Explore
 


### PR DESCRIPTION
This is a qualify of life thing to let new users know how long the 2 example apps should take to deploy on AWS