### PR TITLE
fix: pulumi update plans

### DIFF
--- a/bins/runner/internal/jobs/deploy/pulumi/exec.go
+++ b/bins/runner/internal/jobs/deploy/pulumi/exec.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
@@ -22,6 +23,8 @@ import (
 	"github.com/nuonco/nuon/pkg/kube/config"
 	pulumiworkspace "github.com/nuonco/nuon/pkg/pulumi/workspace"
 )
+
+const updatePlanFilename = ".pulumi-update-plan.json"
 
 func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecution *models.AppRunnerJobExecution) error {
 	l, err := pkgctx.Logger(ctx)
@@ -108,15 +111,24 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 
 	switch job.Operation {
 	case models.AppRunnerJobOperationTypeCreateDashApplyDashPlan:
-		l.Info("executing pulumi preview")
-		result, err := ws.Preview(ctx)
+		planOutPath := filepath.Join(h.state.arch.BasePath(), updatePlanFilename)
+		l.Info("executing pulumi preview", zap.String("plan_out", planOutPath))
+		result, err := ws.Preview(ctx, &pulumiworkspace.PreviewOpts{PlanOutPath: planOutPath})
 		if err != nil {
 			l.Error("pulumi preview errored", zap.Error(err))
 			h.writeErrorResult(ctx, "pulumi preview", err)
 			return fmt.Errorf("unable to execute pulumi preview: %w", err)
 		}
 
-		if err := h.writePlanResult(ctx, result); err != nil {
+		// Read the saved update plan; missing/empty just means a no-op preview,
+		// in which case the apply step will fall back to a fresh diff.
+		planFileBytes, readErr := os.ReadFile(planOutPath)
+		if readErr != nil && !os.IsNotExist(readErr) {
+			l.Warn("unable to read saved pulumi plan", zap.Error(readErr))
+		}
+		l.Info("saved pulumi update plan", zap.Int("plan_bytes", len(planFileBytes)))
+
+		if err := h.writePlanResult(ctx, result, planFileBytes); err != nil {
 			h.errRecorder.Record("write job execution result", err)
 		}
 
@@ -129,7 +141,8 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 			return fmt.Errorf("unable to execute pulumi destroy preview: %w", err)
 		}
 
-		if err := h.writePlanResult(ctx, result); err != nil {
+		// DestroyPreview is synthetic — no real update plan to persist.
+		if err := h.writePlanResult(ctx, result, nil); err != nil {
 			h.errRecorder.Record("write job execution result", err)
 		}
 
@@ -153,8 +166,21 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 
 			l.Info("pulumi destroy completed")
 		} else {
+			upOpts := &pulumiworkspace.UpOpts{}
+			if h.state.plan.ApplyPlanContents != "" {
+				planPath, err := h.materializeUpdatePlan(h.state.plan.ApplyPlanContents)
+				if err != nil {
+					l.Warn("unable to materialize saved pulumi plan, falling back to fresh diff", zap.Error(err))
+				} else {
+					upOpts.PlanInPath = planPath
+					l.Info("applying saved pulumi update plan", zap.String("plan_path", planPath))
+				}
+			} else {
+				l.Info("no saved pulumi update plan provided, computing fresh diff")
+			}
+
 			l.Info("executing pulumi up")
-			result, err := ws.Up(ctx)
+			result, err := ws.Up(ctx, upOpts)
 			if err != nil {
 				l.Error("pulumi up errored", zap.Error(err))
 				h.writeErrorResult(ctx, "pulumi up", err)
@@ -181,33 +207,82 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 	return nil
 }
 
-func (h *handler) writePlanResult(ctx context.Context, result *pulumiworkspace.PreviewResult) error {
-	resultJSON, err := json.Marshal(result)
+// writePlanResult uploads two payloads on the job execution result:
+//   - ContentsCompressed: the Pulumi update plan file (gzip+b64), used by the
+//     subsequent apply job to skip its own preview and enforce drift safety.
+//   - ContentsDisplayCompressed: the structured PreviewResult JSON (gzip+b64),
+//     used by the dashboard to render the per-resource diff.
+//
+// planFileBytes may be empty for synthetic previews (e.g. destroy) — in that
+// case the apply step computes a fresh diff like before.
+func (h *handler) writePlanResult(ctx context.Context, result *pulumiworkspace.PreviewResult, planFileBytes []byte) error {
+	displayJSON, err := json.Marshal(result)
 	if err != nil {
 		return fmt.Errorf("unable to marshal preview result: %w", err)
 	}
-	resultB64 := base64.URLEncoding.EncodeToString(resultJSON)
-
-	// ContentsDisplayCompressed must be gzip-compressed then base64-encoded
-	var gzBuf bytes.Buffer
-	gzw := gzip.NewWriter(&gzBuf)
-	if _, err := gzw.Write(resultJSON); err != nil {
+	displayB64, err := gzipBase64URL(displayJSON)
+	if err != nil {
 		return fmt.Errorf("unable to gzip preview result: %w", err)
 	}
-	if err := gzw.Close(); err != nil {
-		return fmt.Errorf("unable to close gzip writer: %w", err)
+
+	var contentsB64 string
+	if len(planFileBytes) > 0 {
+		contentsB64, err = gzipBase64URL(planFileBytes)
+		if err != nil {
+			return fmt.Errorf("unable to gzip update plan: %w", err)
+		}
 	}
-	displayB64 := base64.URLEncoding.EncodeToString(gzBuf.Bytes())
 
 	if _, err := h.apiClient.CreateJobExecutionResult(ctx, h.state.jobID, h.state.jobExecutionID, &models.ServiceCreateRunnerJobExecutionResultRequest{
 		Success:                   true,
-		ContentsCompressed:        resultB64,
+		ContentsCompressed:        contentsB64,
 		ContentsDisplayCompressed: displayB64,
 	}); err != nil {
 		return fmt.Errorf("unable to create job execution result: %w", err)
 	}
 
 	return nil
+}
+
+func gzipBase64URL(raw []byte) (string, error) {
+	var gzBuf bytes.Buffer
+	gzw := gzip.NewWriter(&gzBuf)
+	if _, err := gzw.Write(raw); err != nil {
+		return "", err
+	}
+	if err := gzw.Close(); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(gzBuf.Bytes()), nil
+}
+
+// materializeUpdatePlan reverses what writePlanResult+the orchestrator do:
+// the plan job's ContentsGzip (raw gzipped plan JSON) is re-encoded with
+// StdEncoding by the API server (see RunnerJobExecutionResult.GetContentsB64String)
+// before landing in DeployPlan.ApplyPlanContents. So here we StdEncoding-decode,
+// gunzip, and write the JSON to a temp file Pulumi can consume via --plan.
+func (h *handler) materializeUpdatePlan(b64Contents string) (string, error) {
+	gzBytes, err := base64.StdEncoding.DecodeString(b64Contents)
+	if err != nil {
+		return "", fmt.Errorf("unable to base64-decode plan: %w", err)
+	}
+
+	gzReader, err := gzip.NewReader(bytes.NewReader(gzBytes))
+	if err != nil {
+		return "", fmt.Errorf("unable to open gzip reader for plan: %w", err)
+	}
+	defer gzReader.Close()
+
+	planJSON, err := io.ReadAll(gzReader)
+	if err != nil {
+		return "", fmt.Errorf("unable to read decompressed plan: %w", err)
+	}
+
+	planPath := filepath.Join(h.state.arch.BasePath(), updatePlanFilename)
+	if err := os.WriteFile(planPath, planJSON, 0o600); err != nil {
+		return "", fmt.Errorf("unable to write plan file: %w", err)
+	}
+	return planPath, nil
 }
 
 // downloadState fetches the current pulumi state from the control plane.

--- a/bins/runner/internal/jobs/sandbox/pulumi/exec.go
+++ b/bins/runner/internal/jobs/sandbox/pulumi/exec.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 
 	"go.uber.org/zap"
@@ -23,6 +24,8 @@ import (
 	"github.com/nuonco/nuon/pkg/kube/config"
 	pulumiworkspace "github.com/nuonco/nuon/pkg/pulumi/workspace"
 )
+
+const updatePlanFilename = ".pulumi-update-plan.json"
 
 func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecution *models.AppRunnerJobExecution) error {
 	l, err := pkgctx.Logger(ctx)
@@ -105,15 +108,22 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 
 	switch job.Operation {
 	case models.AppRunnerJobOperationTypeCreateDashApplyDashPlan:
-		l.Info("executing pulumi preview")
-		result, err := ws.Preview(ctx)
+		planOutPath := filepath.Join(h.state.arch.BasePath(), updatePlanFilename)
+		l.Info("executing pulumi preview", zap.String("plan_out", planOutPath))
+		result, err := ws.Preview(ctx, &pulumiworkspace.PreviewOpts{PlanOutPath: planOutPath})
 		if err != nil {
 			l.Error("pulumi preview errored", zap.Error(err))
 			h.writeErrorResult(ctx, "pulumi preview", err)
 			return fmt.Errorf("unable to execute pulumi preview: %w", err)
 		}
 
-		if err := h.writePlanResult(ctx, result); err != nil {
+		planFileBytes, readErr := os.ReadFile(planOutPath)
+		if readErr != nil && !os.IsNotExist(readErr) {
+			l.Warn("unable to read saved pulumi plan", zap.Error(readErr))
+		}
+		l.Info("saved pulumi update plan", zap.Int("plan_bytes", len(planFileBytes)))
+
+		if err := h.writePlanResult(ctx, result, planFileBytes); err != nil {
 			h.errRecorder.Record("write job execution result", err)
 		}
 
@@ -126,7 +136,7 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 			return fmt.Errorf("unable to execute pulumi destroy preview: %w", err)
 		}
 
-		if err := h.writePlanResult(ctx, result); err != nil {
+		if err := h.writePlanResult(ctx, result, nil); err != nil {
 			h.errRecorder.Record("write job execution result", err)
 		}
 
@@ -148,8 +158,21 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 
 			l.Info("pulumi destroy completed")
 		} else {
+			upOpts := &pulumiworkspace.UpOpts{}
+			if h.state.plan.ApplyPlanContents != "" {
+				planPath, err := h.materializeUpdatePlan(h.state.plan.ApplyPlanContents)
+				if err != nil {
+					l.Warn("unable to materialize saved pulumi plan, falling back to fresh diff", zap.Error(err))
+				} else {
+					upOpts.PlanInPath = planPath
+					l.Info("applying saved pulumi update plan", zap.String("plan_path", planPath))
+				}
+			} else {
+				l.Info("no saved pulumi update plan provided, computing fresh diff")
+			}
+
 			l.Info("executing pulumi up")
-			result, err := ws.Up(ctx)
+			result, err := ws.Up(ctx, upOpts)
 			if err != nil {
 				l.Error("pulumi up errored", zap.Error(err))
 				h.writeErrorResult(ctx, "pulumi up", err)
@@ -174,32 +197,77 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 	return nil
 }
 
-func (h *handler) writePlanResult(ctx context.Context, result *pulumiworkspace.PreviewResult) error {
-	resultJSON, err := json.Marshal(result)
+// writePlanResult uploads two payloads on the job execution result:
+//   - ContentsCompressed: the Pulumi update plan file (gzip+b64), used by the
+//     subsequent apply job to skip its own preview and enforce drift safety.
+//   - ContentsDisplayCompressed: the structured PreviewResult JSON (gzip+b64),
+//     used by the dashboard to render the per-resource diff.
+func (h *handler) writePlanResult(ctx context.Context, result *pulumiworkspace.PreviewResult, planFileBytes []byte) error {
+	displayJSON, err := json.Marshal(result)
 	if err != nil {
 		return fmt.Errorf("unable to marshal preview result: %w", err)
 	}
-	resultB64 := base64.URLEncoding.EncodeToString(resultJSON)
-
-	var gzBuf bytes.Buffer
-	gzw := gzip.NewWriter(&gzBuf)
-	if _, err := gzw.Write(resultJSON); err != nil {
+	displayB64, err := gzipBase64URL(displayJSON)
+	if err != nil {
 		return fmt.Errorf("unable to gzip preview result: %w", err)
 	}
-	if err := gzw.Close(); err != nil {
-		return fmt.Errorf("unable to close gzip writer: %w", err)
+
+	var contentsB64 string
+	if len(planFileBytes) > 0 {
+		contentsB64, err = gzipBase64URL(planFileBytes)
+		if err != nil {
+			return fmt.Errorf("unable to gzip update plan: %w", err)
+		}
 	}
-	displayB64 := base64.URLEncoding.EncodeToString(gzBuf.Bytes())
 
 	if _, err := h.apiClient.CreateJobExecutionResult(ctx, h.state.jobID, h.state.jobExecutionID, &models.ServiceCreateRunnerJobExecutionResultRequest{
 		Success:                   true,
-		ContentsCompressed:        resultB64,
+		ContentsCompressed:        contentsB64,
 		ContentsDisplayCompressed: displayB64,
 	}); err != nil {
 		return fmt.Errorf("unable to create job execution result: %w", err)
 	}
 
 	return nil
+}
+
+func gzipBase64URL(raw []byte) (string, error) {
+	var gzBuf bytes.Buffer
+	gzw := gzip.NewWriter(&gzBuf)
+	if _, err := gzw.Write(raw); err != nil {
+		return "", err
+	}
+	if err := gzw.Close(); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(gzBuf.Bytes()), nil
+}
+
+// materializeUpdatePlan reverses the gzip+base64 round-trip the plan job and
+// API server perform: ApplyPlanContents arrives StdEncoded around gzipped JSON;
+// we decode, decompress, and write the JSON to a file Pulumi can consume.
+func (h *handler) materializeUpdatePlan(b64Contents string) (string, error) {
+	gzBytes, err := base64.StdEncoding.DecodeString(b64Contents)
+	if err != nil {
+		return "", fmt.Errorf("unable to base64-decode plan: %w", err)
+	}
+
+	gzReader, err := gzip.NewReader(bytes.NewReader(gzBytes))
+	if err != nil {
+		return "", fmt.Errorf("unable to open gzip reader for plan: %w", err)
+	}
+	defer gzReader.Close()
+
+	planJSON, err := io.ReadAll(gzReader)
+	if err != nil {
+		return "", fmt.Errorf("unable to read decompressed plan: %w", err)
+	}
+
+	planPath := filepath.Join(h.state.arch.BasePath(), updatePlanFilename)
+	if err := os.WriteFile(planPath, planJSON, 0o600); err != nil {
+		return "", fmt.Errorf("unable to write plan file: %w", err)
+	}
+	return planPath, nil
 }
 
 func (h *handler) downloadState(ctx context.Context, l *zap.Logger, ws *pulumiworkspace.Workspace, workspaceID string) error {

--- a/pkg/pulumi/workspace/workspace.go
+++ b/pkg/pulumi/workspace/workspace.go
@@ -68,6 +68,21 @@ type UpResult struct {
 	Outputs map[string]any `json:"outputs"`
 }
 
+// PreviewOpts are optional knobs for Preview.
+type PreviewOpts struct {
+	// PlanOutPath, if set, makes Pulumi save an update plan to this path so
+	// a subsequent Up can replay it deterministically.
+	PlanOutPath string
+}
+
+// UpOpts are optional knobs for Up.
+type UpOpts struct {
+	// PlanInPath, if set, makes Pulumi apply this previously-saved update
+	// plan instead of computing a new diff. Up will fail if reality has
+	// drifted from what the plan expected.
+	PlanInPath string
+}
+
 // Workspace wraps the Pulumi Automation API for programmatic Pulumi operations.
 type Workspace struct {
 	stack   auto.Stack
@@ -90,6 +105,8 @@ func New(ctx context.Context, opts *Options) (*Workspace, error) {
 	hash := sha256.Sum256([]byte("nuon-pulumi:" + opts.StackName))
 	envVars["PULUMI_CONFIG_PASSPHRASE"] = hex.EncodeToString(hash[:])
 	envVars["PULUMI_SKIP_UPDATE_CHECK"] = "true"
+	// Required by the Pulumi CLI to accept --save-plan / --plan in this version.
+	envVars["PULUMI_EXPERIMENTAL"] = "true"
 	// Isolate Go build cache per workspace to prevent stale cache entries
 	// from referencing cleaned-up temp directories of previous jobs.
 	envVars["GOCACHE"] = filepath.Join(opts.WorkDir, ".go-cache")
@@ -149,7 +166,10 @@ func extractResourceName(urn string) string {
 
 // Preview runs `pulumi preview` with event streaming to capture structured
 // per-resource changes, producing output comparable to terraform plan JSON.
-func (w *Workspace) Preview(ctx context.Context) (*PreviewResult, error) {
+// When opts.PlanOutPath is set, a Pulumi update plan is also written to that
+// path; pass it back via UpOpts.PlanInPath on a subsequent Up to skip the
+// implicit re-preview and guard against drift between plan and apply.
+func (w *Workspace) Preview(ctx context.Context, opts *PreviewOpts) (*PreviewResult, error) {
 	eventCh := make(chan events.EngineEvent, 100)
 
 	// Drain events concurrently to prevent deadlock — Preview() writes
@@ -195,10 +215,14 @@ func (w *Workspace) Preview(ctx context.Context) (*PreviewResult, error) {
 		}
 	}()
 
-	result, err := w.stack.Preview(ctx,
+	previewOpts := []optpreview.Option{
 		optpreview.Message("Nuon preview"),
 		optpreview.EventStreams(eventCh),
-	)
+	}
+	if opts != nil && opts.PlanOutPath != "" {
+		previewOpts = append(previewOpts, optpreview.Plan(opts.PlanOutPath))
+	}
+	result, err := w.stack.Preview(ctx, previewOpts...)
 
 	// Wait for all events to be processed
 	<-done
@@ -223,11 +247,17 @@ func (w *Workspace) Preview(ctx context.Context) (*PreviewResult, error) {
 	}, nil
 }
 
-// Up runs `pulumi up` and returns the result.
-func (w *Workspace) Up(ctx context.Context) (*UpResult, error) {
-	result, err := w.stack.Up(ctx,
+// Up runs `pulumi up` and returns the result. When opts.PlanInPath is set,
+// Pulumi applies that previously-saved update plan instead of computing a
+// fresh diff — faster, and refuses to apply if reality has drifted.
+func (w *Workspace) Up(ctx context.Context, opts *UpOpts) (*UpResult, error) {
+	upOpts := []optup.Option{
 		optup.Message("Nuon deploy"),
-	)
+	}
+	if opts != nil && opts.PlanInPath != "" {
+		upOpts = append(upOpts, optup.Plan(opts.PlanInPath))
+	}
+	result, err := w.stack.Up(ctx, upOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("pulumi up failed: %w", err)
 	}

--- a/services/ctl-api/internal/app/components/service/create_pulumi_component_config.go
+++ b/services/ctl-api/internal/app/components/service/create_pulumi_component_config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/robfig/cron"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
@@ -146,14 +145,11 @@ func (s *service) CreatePulumiComponentConfig(ctx *gin.Context) {
 		return
 	}
 
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type: signals.OperationConfigCreated,
-	})
+	if err := s.onConfigCreated(ctx, cmpID, app.ComponentTypePulumi); err != nil {
+		ctx.Error(err)
+		return
+	}
 
-	s.evClient.Send(ctx, cmpID, &signals.Signal{
-		Type:          signals.OperationUpdateComponentType,
-		ComponentType: app.ComponentTypePulumi,
-	})
 	ctx.JSON(http.StatusCreated, cfg)
 }
 

--- a/services/ctl-api/internal/app/components/service/create_pulumi_component_config_test.go
+++ b/services/ctl-api/internal/app/components/service/create_pulumi_component_config_test.go
@@ -1,0 +1,196 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
+)
+
+// ---------------------------------------------------------------------------
+// Success cases
+// ---------------------------------------------------------------------------
+
+func (s *ComponentsServiceTestSuite) TestCreateAppPulumiConfigSuccess() {
+	s.Run("creates config with public git VCS", func() {
+		comp := s.deps.Seeder.CreateComponent(s.ctx, s.T(), s.testApp.ID, app.ComponentTypePulumi)
+
+		cfgVal := "bar"
+		envVal := "baz"
+		path := fmt.Sprintf("/v1/apps/%s/components/%s/configs/pulumi", s.testApp.ID, comp.ID)
+		rr := s.makeRequest(http.MethodPost, path, CreatePulumiComponentConfigRequest{
+			AppConfigID: s.testAppConfig.ID,
+			Runtime:     "nodejs",
+			Config:      map[string]*string{"foo": &cfgVal},
+			EnvVars:     map[string]*string{"ENV": &envVal},
+			basicVCSConfigRequest: basicVCSConfigRequest{
+				PublicGitVCSConfig: &PublicGitVCSConfigRequest{
+					Repo:      "owner/repo",
+					Directory: ".",
+					Branch:    "main",
+				},
+			},
+		})
+
+		if rr.Code != http.StatusCreated {
+			s.T().Logf("Status: %d, Body: %s", rr.Code, rr.Body.String())
+		}
+		require.Equal(s.T(), http.StatusCreated, rr.Code)
+
+		var response app.PulumiComponentConfig
+		err := json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(s.T(), err)
+
+		assert.NotNil(s.T(), response.PublicGitVCSConfig)
+		assert.Equal(s.T(), "nodejs", response.Runtime)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Validation error cases
+// ---------------------------------------------------------------------------
+
+func (s *ComponentsServiceTestSuite) TestCreateAppPulumiConfigValidationErrors() {
+	comp := s.deps.Seeder.CreateComponent(s.ctx, s.T(), s.testApp.ID, app.ComponentTypePulumi)
+	path := fmt.Sprintf("/v1/apps/%s/components/%s/configs/pulumi", s.testApp.ID, comp.ID)
+
+	cfgVal := "bar"
+	envVal := "baz"
+
+	testCases := []struct {
+		name    string
+		body    interface{}
+		rawBody string
+	}{
+		{
+			name: "missing runtime",
+			body: map[string]interface{}{
+				"app_config_id": s.testAppConfig.ID,
+				"config":        map[string]*string{"foo": &cfgVal},
+				"env_vars":      map[string]*string{"ENV": &envVal},
+				"public_git_vcs_config": map[string]interface{}{
+					"repo":      "owner/repo",
+					"directory": ".",
+					"branch":    "main",
+				},
+			},
+		},
+		{
+			name: "invalid runtime",
+			body: map[string]interface{}{
+				"app_config_id": s.testAppConfig.ID,
+				"runtime":       "ruby",
+				"config":        map[string]*string{"foo": &cfgVal},
+				"env_vars":      map[string]*string{"ENV": &envVal},
+				"public_git_vcs_config": map[string]interface{}{
+					"repo":      "owner/repo",
+					"directory": ".",
+					"branch":    "main",
+				},
+			},
+		},
+		{
+			name: "missing config",
+			body: map[string]interface{}{
+				"app_config_id": s.testAppConfig.ID,
+				"runtime":       "nodejs",
+				"env_vars":      map[string]*string{"ENV": &envVal},
+				"public_git_vcs_config": map[string]interface{}{
+					"repo":      "owner/repo",
+					"directory": ".",
+					"branch":    "main",
+				},
+			},
+		},
+		{
+			name: "missing env_vars",
+			body: map[string]interface{}{
+				"app_config_id": s.testAppConfig.ID,
+				"runtime":       "nodejs",
+				"config":        map[string]*string{"foo": &cfgVal},
+				"public_git_vcs_config": map[string]interface{}{
+					"repo":      "owner/repo",
+					"directory": ".",
+					"branch":    "main",
+				},
+			},
+		},
+		{
+			name: "no VCS config",
+			body: map[string]interface{}{
+				"app_config_id": s.testAppConfig.ID,
+				"runtime":       "nodejs",
+				"config":        map[string]*string{"foo": &cfgVal},
+				"env_vars":      map[string]*string{"ENV": &envVal},
+			},
+		},
+		{
+			name:    "invalid JSON",
+			rawBody: "{invalid json",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			var rr *httptest.ResponseRecorder
+			if tc.rawBody != "" {
+				rr = s.makeRawRequest(http.MethodPost, path, tc.rawBody)
+			} else {
+				rr = s.makeRequest(http.MethodPost, path, tc.body)
+			}
+
+			if rr.Code != http.StatusBadRequest {
+				s.T().Logf("Status: %d, Body: %s", rr.Code, rr.Body.String())
+			}
+			require.Equal(s.T(), http.StatusBadRequest, rr.Code)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Signals
+// ---------------------------------------------------------------------------
+
+func (s *ComponentsServiceTestSuite) TestCreateAppPulumiConfigSignals() {
+	s.Run("sends OperationConfigCreated and OperationUpdateComponentType signals", func() {
+		s.mockEvClient.Reset()
+
+		comp := s.deps.Seeder.CreateComponent(s.ctx, s.T(), s.testApp.ID, app.ComponentTypePulumi)
+
+		cfgVal := "bar"
+		envVal := "baz"
+		path := fmt.Sprintf("/v1/apps/%s/components/%s/configs/pulumi", s.testApp.ID, comp.ID)
+		rr := s.makeRequest(http.MethodPost, path, CreatePulumiComponentConfigRequest{
+			AppConfigID: s.testAppConfig.ID,
+			Runtime:     "nodejs",
+			Config:      map[string]*string{"foo": &cfgVal},
+			EnvVars:     map[string]*string{"ENV": &envVal},
+			basicVCSConfigRequest: basicVCSConfigRequest{
+				PublicGitVCSConfig: &PublicGitVCSConfigRequest{
+					Repo:      "owner/repo",
+					Directory: ".",
+					Branch:    "main",
+				},
+			},
+		})
+		require.Equal(s.T(), http.StatusCreated, rr.Code)
+
+		capturedSignals := s.mockEvClient.GetSignals()
+		require.Len(s.T(), capturedSignals, 2, "expected 2 signals")
+
+		sig0, ok := capturedSignals[0].Signal.(*signals.Signal)
+		require.True(s.T(), ok)
+		assert.Equal(s.T(), signals.OperationConfigCreated, sig0.Type)
+
+		sig1, ok := capturedSignals[1].Signal.(*signals.Signal)
+		require.True(s.T(), ok)
+		assert.Equal(s.T(), signals.OperationUpdateComponentType, sig1.Type)
+		assert.Equal(s.T(), app.ComponentTypePulumi, sig1.ComponentType)
+	})
+}


### PR DESCRIPTION
Wire Pulumi update plans through the plan → apply flow.

- `create-apply-plan` saves the update plan via `--save-plan` and ships it on the job result.
- `apply-plan` consumes it via `--plan`, skipping pulumi's implicit re-preview and refusing to apply if state drifted between plan and apply.

Falls back to a fresh diff if no saved plan is present (older plans, NOOP deploys). Destroy paths unchanged. Same wiring as terraform's existing `ApplyPlanContents` flow.