### PR TITLE
fix(ctl-api): vcs connection lookup

### DIFF
--- a/services/ctl-api/internal/app/vcs/helpers/lookup.go
+++ b/services/ctl-api/internal/app/vcs/helpers/lookup.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
@@ -10,7 +11,8 @@ import (
 )
 
 // LookupVCSConnection: lookup a VCS connection from a list of vcs conns, for the one that has access to the repo
-// provided.
+// provided. Connections are iterated most-recent first so that newly created connections take precedence over
+// older ones that may still grant access to the repo (e.g. when a connection has been re-created).
 func (h *Helpers) LookupVCSConnection(ctx context.Context,
 	owner, name string,
 	vcsConnections []app.VCSConnection) (string, error) {
@@ -21,7 +23,13 @@ func (h *Helpers) LookupVCSConnection(ctx context.Context,
 		}
 	}
 
-	for _, vcsConn := range vcsConnections {
+	// Sort most recent first so we prefer the newest connection with access.
+	sortedConns := slices.Clone(vcsConnections)
+	slices.SortStableFunc(sortedConns, func(a, b app.VCSConnection) int {
+		return b.CreatedAt.Compare(a.CreatedAt)
+	})
+
+	for _, vcsConn := range sortedConns {
 		client, err := h.GetVCSConnectionClient(ctx, &vcsConn)
 		if err != nil {
 			return "", fmt.Errorf("unable to get client: %w", err)


### PR DESCRIPTION
in rare cases mostly related to aggressive testing which involves
heavily re-creating vcs connections, we can have a large number of rows
the query and lookup here is naïve so we're modifying it to prevent using a stale vcs connection.
