### PR TITLE
fix(api): prevent adhoc action timeout from getting ignored

### DIFF
--- a/bins/runner/internal/jobs/actions/workflow/exec.go
+++ b/bins/runner/internal/jobs/actions/workflow/exec.go
@@ -56,9 +56,10 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 		return err
 	}
 
-	// For adhoc runs, workflowCfg is nil - use a default timeout
-	timeout := 5 * time.Minute // default timeout
-	if h.state.workflowCfg != nil {
+	timeout := 5 * time.Minute
+	if h.state.plan.Timeout > 0 {
+		timeout = h.state.plan.Timeout
+	} else if h.state.workflowCfg != nil && h.state.workflowCfg.Timeout > 0 {
 		timeout = time.Duration(h.state.workflowCfg.Timeout)
 	}
 	execCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/pkg/plans/types/action_workflow_run.go
+++ b/pkg/plans/types/action_workflow_run.go
@@ -1,6 +1,8 @@
 package plantypes
 
 import (
+	"time"
+
 	awscredentials "github.com/nuonco/nuon/pkg/aws/credentials"
 	azurecredentials "github.com/nuonco/nuon/pkg/azure/credentials"
 	gcpcredentials "github.com/nuonco/nuon/pkg/gcp/credentials"
@@ -16,6 +18,7 @@ type ActionWorkflowRunPlan struct {
 	Steps           []*ActionWorkflowRunStepPlan `json:"steps"`
 	BuiltinEnvVars  map[string]string            `json:"builtin_env_vars"`
 	OverrideEnvVars map[string]string            `json:"override_env_vars"`
+	Timeout         time.Duration                `json:"timeout,omitempty"`
 
 	// optional fields based on the configuration
 	ClusterInfo *kube.ClusterInfo        `json:"cluster_info,block"`

--- a/services/ctl-api/internal/app/actions/service/create_adhoc_action.go
+++ b/services/ctl-api/internal/app/actions/service/create_adhoc_action.go
@@ -234,6 +234,7 @@ func (s *service) createAdHocActionRun(
 		StatusDescription: "Queued for execution",
 		Steps:             []app.InstallActionWorkflowRunStep{runStep},
 		RunEnvVars:        dbgenerics.ToHstore(req.EnvVars),
+		Timeout:           time.Duration(req.Timeout) * time.Second,
 		Role:              req.Role,
 		EnableKubeConfig:  enableKubeConfig,
 	}

--- a/services/ctl-api/internal/app/install_action_workflow_run.go
+++ b/services/ctl-api/internal/app/install_action_workflow_run.go
@@ -72,6 +72,8 @@ type InstallActionWorkflowRun struct {
 
 	RunEnvVars pgtype.Hstore `json:"run_env_vars,omitzero" gorm:"type:hstore" swaggertype:"object,string" temporaljson:"run_env_vars,omitzero,omitempty"`
 
+	Timeout time.Duration `json:"timeout,omitzero" gorm:"default:0;not null" swaggertype:"primitive,integer" temporaljson:"timeout,omitzero,omitempty"`
+
 	InstallWorkflowID *string   `json:"install_workflow_id" gorm:"default null" temporaljson:"install_sandbox_id,omitzero,omitempty"`
 	InstallWorkflow   *Workflow `swaggerignore:"true" json:"-" temporaljson:"install_workflow,omitzero,omitempty"`
 

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
@@ -106,6 +106,9 @@ func (p *Planner) createActionWorkflowRunPlan(ctx workflow.Context, runID string
 	}
 
 	if !run.ActionWorkflowConfigID.Empty() {
+		if run.ActionWorkflowConfig.Timeout > 0 {
+			plan.Timeout = run.ActionWorkflowConfig.Timeout
+		}
 		for idx, stepCfg := range run.Steps {
 			l.Debug(fmt.Sprintf("creating plan for step %d", idx))
 			stepPlan, err := p.createStepPlan(ctx, &stepCfg, stateMap, run.InstallID)
@@ -116,6 +119,9 @@ func (p *Planner) createActionWorkflowRunPlan(ctx workflow.Context, runID string
 			plan.Steps = append(plan.Steps, stepPlan)
 		}
 	} else {
+		if run.Timeout > 0 {
+			plan.Timeout = run.Timeout
+		}
 		stepPlan, err := p.createAdhocStepPlan(ctx, &run.Steps[0], stateMap, run.InstallID)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, fmt.Sprintf("unable to create adhoc step plan"))


### PR DESCRIPTION
 1. User sets timeout (e.g. 600s) → API validates it                                                                           
 2. Stored on InstallActionWorkflowRun.Timeout as time.Duration (nanoseconds)
 3. Planner copies it to ActionWorkflowRunPlan.Timeout                                                                         
 4. Runner reads plan.Timeout and uses it for the execution context deadline
                                                                                                                                
The fix also populates plan.Timeout for non-adhoc runs from ActionWorkflowConfig.Timeout, so both paths go through the plan now. The runner falls back to workflowCfg.Timeout then 5 minutes for backwards compatibility with old plans that don't have  the field.   