### PR TITLE
fix: set await stack to 180 days

### DIFF
--- a/services/ctl-api/internal/app/admin-dashboard/client/lib/admin-api/signals.ts
+++ b/services/ctl-api/internal/app/admin-dashboard/client/lib/admin-api/signals.ts
@@ -8,6 +8,7 @@ export const getQueueSignalsGlobal = (params: {
   owner_id?: string
   namespace?: string
   status?: string
+  enqueued?: string
   page?: number
 }) =>
   api<{ signals: TQueueSignal[]; page: number; total_pages: number; namespaces?: string[] }>({

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/queue-signals/QueueSignals.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/queue-signals/QueueSignals.tsx
@@ -16,6 +16,7 @@ export const QueueSignals = () => {
   const [search, setSearch] = useState('')
   const [signalType, setSignalType] = useState('')
   const [namespace, setNamespace] = useState('')
+  const [enqueued, setEnqueued] = useState('')
   const [page, setPage] = useState(1)
 
   const { data: typeOptions } = useQuery({
@@ -24,11 +25,12 @@ export const QueueSignals = () => {
   })
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['queue-signals-global', search, signalType, namespace, ownerID, page],
+    queryKey: ['queue-signals-global', search, signalType, namespace, enqueued, ownerID, page],
     queryFn: () => getQueueSignalsGlobal({
       search,
       signal_type: signalType || undefined,
       namespace: namespace || undefined,
+      enqueued: enqueued || undefined,
       owner_id: ownerID,
       page,
     }),
@@ -59,6 +61,15 @@ export const QueueSignals = () => {
           {signalTypes.map((t) => (
             <option key={t} value={t}>{t}</option>
           ))}
+        </select>
+        <select
+          value={enqueued}
+          onChange={(e) => { setEnqueued(e.target.value); setPage(1) }}
+          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300"
+        >
+          <option value="">All signals</option>
+          <option value="false">Not enqueued</option>
+          <option value="true">Enqueued</option>
         </select>
       </div>
 

--- a/services/ctl-api/internal/app/admin-dashboard/service/queue_signals.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/queue_signals.go
@@ -23,8 +23,9 @@ func (s *service) QueueSignals(c *gin.Context) {
 	signalType := c.Query("signal_type")
 	status := c.Query("status")
 	namespace := c.Query("namespace")
+	enqueued := c.Query("enqueued")
 
-	signals, totalPages, err := s.getQueueSignals(ctx, search, ownerID, signalType, status, namespace, page)
+	signals, totalPages, err := s.getQueueSignals(ctx, search, ownerID, signalType, status, namespace, enqueued, page)
 	if err != nil {
 		s.l.Error("failed to get queue signals", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch queue signals"})
@@ -58,8 +59,9 @@ func (s *service) QueueSignalsGlobalTable(c *gin.Context) {
 	signalType := c.Query("signal_type")
 	status := c.Query("status")
 	namespace := c.Query("namespace")
+	enqueued := c.Query("enqueued")
 
-	signals, totalPages, err := s.getQueueSignals(ctx, search, ownerID, signalType, status, namespace, page)
+	signals, totalPages, err := s.getQueueSignals(ctx, search, ownerID, signalType, status, namespace, enqueued, page)
 	if err != nil {
 		s.l.Error("failed to get queue signals", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch queue signals"})
@@ -88,7 +90,7 @@ func (s *service) QueueSignalTypeOptions(c *gin.Context) {
 	})
 }
 
-func (s *service) getQueueSignals(ctx context.Context, search, ownerID, signalType, status, namespace string, page int) ([]app.QueueSignal, int, error) {
+func (s *service) getQueueSignals(ctx context.Context, search, ownerID, signalType, status, namespace, enqueued string, page int) ([]app.QueueSignal, int, error) {
 	var signals []app.QueueSignal
 	var totalCount int64
 
@@ -108,6 +110,11 @@ func (s *service) getQueueSignals(ctx context.Context, search, ownerID, signalTy
 	}
 	if namespace != "" {
 		query = query.Where("workflow->>'namespace' = ?", namespace)
+	}
+	if enqueued == "true" {
+		query = query.Where("enqueued = ?", true)
+	} else if enqueued == "false" {
+		query = query.Where("enqueued = ?", false)
 	}
 
 	if err := query.Count(&totalCount).Error; err != nil {

--- a/services/ctl-api/internal/app/installs/signals/v2/awaitinstallstackversionrun/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/awaitinstallstackversionrun/signal.go
@@ -31,12 +31,17 @@ type Signal struct {
 	versionID string
 }
 
+const maxTimeout = 180 * 24 * time.Hour // 180 days
+
 var _ signal.Signal = &Signal{}
 var _ signal.SignalWithStepContext = (*Signal)(nil)
 var _ signal.SignalWithAutoRetry = (*Signal)(nil)
 var _ signal.SignalWithCancel = (*Signal)(nil)
+var _ signal.SignalWithTimeout = (*Signal)(nil)
 
 func (s *Signal) AutoRetry() bool { return true }
+
+func (s *Signal) Timeout() time.Duration { return maxTimeout }
 
 func (s *Signal) Cancel(ctx workflow.Context) error {
 	cancelCtx, cancel := workflow.NewDisconnectedContext(ctx)
@@ -138,7 +143,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	v := validator.New()
 	var run *app.InstallStackVersionRun
 	if err := poll.Poll(ctx, v, poll.PollOpts{
-		MaxTS:           workflow.Now(ctx).Add(time.Hour * 24),
+		MaxTS:           workflow.Now(ctx).Add(maxTimeout),
 		InitialInterval: time.Second * 15,
 		MaxInterval:     time.Minute * 15,
 		BackoffFactor:   1.15,
@@ -156,7 +161,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 			statusactivities.AwaitPkgStatusUpdateInstallStackVersionStatus(ctx, statusactivities.UpdateStatusRequest{
 				ID: version.ID,
 				Status: app.NewCompositeTemporalStatus(ctx, app.InstallStackVersionStatusExpired, map[string]any{
-					"err_message": "cloudformation stack was not applied before expiring",
+					"err_message": "cloudformation stack was not applied within 180 days and expired",
 				}),
 			})
 
@@ -166,7 +171,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 					Status: app.CompositeStatus{
 						Status: app.StatusError,
 						Metadata: map[string]any{
-							"err_step_message": "Stack was not applied within 24hrs and expired. Please reprovision install.",
+							"err_step_message": "Stack was not applied within 180 days and expired. Please reprovision install.",
 						},
 					},
 				}); statusErr != nil {

--- a/services/ctl-api/internal/pkg/flow/group_dispatch.go
+++ b/services/ctl-api/internal/pkg/flow/group_dispatch.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	workflowactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow/activities"
 )
@@ -57,6 +58,13 @@ func DispatchGroupSignal(ctx workflow.Context, cfg StepConfig, group *app.Workfl
 		return "", errors.Wrapf(err, "unable to enqueue group signal for group %d", group.GroupIdx)
 	}
 
+	var awaitOpts []*workflow.ActivityOptions
+	if t, ok := signal.Signal(sig).(signal.SignalWithTimeout); ok && t.Timeout() > 0 {
+		awaitOpts = append(awaitOpts, &workflow.ActivityOptions{
+			ScheduleToCloseTimeout: t.Timeout(),
+		})
+	}
+
 	// Wait for the group to finish via the group-finished update handler.
 	// If the group has a StepGroupID, use ForwardGroupFinished for resilient
 	// completion tracking. Fall back to AwaitAwaitSignal for backward compat
@@ -64,7 +72,7 @@ func DispatchGroupSignal(ctx workflow.Context, cfg StepConfig, group *app.Workfl
 	if group.ID != "" {
 		resp, err := workflowactivities.AwaitForwardGroupFinished(ctx, workflowactivities.ForwardGroupFinishedRequest{
 			StepGroupID: group.ID,
-		})
+		}, awaitOpts...)
 		if err != nil {
 			if ctx.Err() != nil {
 				cancelCtx, cancelCtxCancel := workflow.NewDisconnectedContext(ctx)
@@ -77,7 +85,7 @@ func DispatchGroupSignal(ctx workflow.Context, cfg StepConfig, group *app.Workfl
 	}
 
 	// Legacy fallback: no StepGroupID, use framework-level finished handler.
-	_, err = client.AwaitAwaitSignal(ctx, enqueueResp.QueueSignalID)
+	_, err = client.AwaitAwaitSignal(ctx, enqueueResp.QueueSignalID, awaitOpts...)
 	if err != nil {
 		if ctx.Err() != nil {
 			cancelCtx, cancelCtxCancel := workflow.NewDisconnectedContext(ctx)

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/execute_group.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/execute_group.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	workflowactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow/activities"
 )
@@ -70,7 +71,14 @@ func (s *Signal) executeGroup(ctx workflow.Context, group *app.WorkflowStepGroup
 	// Wait for the group signal to finish using the framework's built-in
 	// finished handler. This avoids the custom group-finished handler which
 	// may not be registered yet when the update arrives.
-	_, err = client.AwaitAwaitSignal(ctx, enqueueResp.QueueSignalID)
+	var awaitOpts []*workflow.ActivityOptions
+	if t, ok := signal.Signal(sig).(signal.SignalWithTimeout); ok && t.Timeout() > 0 {
+		awaitOpts = append(awaitOpts, &workflow.ActivityOptions{
+			ScheduleToCloseTimeout: t.Timeout(),
+		})
+	}
+
+	_, err = client.AwaitAwaitSignal(ctx, enqueueResp.QueueSignalID, awaitOpts...)
 	if err != nil {
 		if ctx.Err() != nil {
 			cancelCtx, cancelCtxCancel := workflow.NewDisconnectedContext(ctx)

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
@@ -61,6 +61,9 @@ type Signal struct {
 var _ qsignal.Signal = (*Signal)(nil)
 var _ qsignal.SignalWithUpdateHandlers = (*Signal)(nil)
 var _ qsignal.SignalWithLifecycleContext = (*Signal)(nil)
+var _ qsignal.SignalWithTimeout = (*Signal)(nil)
+
+func (s *Signal) Timeout() time.Duration { return 180 * 24 * time.Hour }
 
 func (s *Signal) Type() qsignal.SignalType  { return SignalType }
 func (s *Signal) SleepAfter() time.Duration { return time.Second }

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/execute_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/execute_step.go
@@ -198,7 +198,14 @@ func (s *Signal) executeInnerSignal(ctx workflow.Context, step *app.WorkflowStep
 		"queue_signal_id", enqueueResp.QueueSignalID,
 	)
 
-	_, err = client.AwaitAwaitSignal(ctx, enqueueResp.QueueSignalID)
+	var awaitOpts []*workflow.ActivityOptions
+	if t, ok := sig.(signal.SignalWithTimeout); ok && t.Timeout() > 0 {
+		awaitOpts = append(awaitOpts, &workflow.ActivityOptions{
+			ScheduleToCloseTimeout: t.Timeout(),
+		})
+	}
+
+	_, err = client.AwaitAwaitSignal(ctx, enqueueResp.QueueSignalID, awaitOpts...)
 	if err != nil {
 		return errors.Wrapf(err, "queue signal execution failed for step %s", step.Name)
 	}

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/signal.go
@@ -96,7 +96,10 @@ var (
 	_ signal.SignalWithCancel           = (*Signal)(nil)
 	_ signal.SignalWithUpdateHandlers   = (*Signal)(nil)
 	_ signal.SignalWithLifecycleContext = (*Signal)(nil)
+	_ signal.SignalWithTimeout          = (*Signal)(nil)
 )
+
+func (s *Signal) Timeout() time.Duration { return 180 * 24 * time.Hour }
 
 // LifecycleContext exposes the step + workflow identity to lifecycle hooks so
 // they can emit workflow_step.lifecycle.* webhook events without leaking the

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/signal.go
@@ -81,6 +81,9 @@ type Signal struct {
 var _ signal.Signal = (*Signal)(nil)
 var _ signal.SignalWithCancel = (*Signal)(nil)
 var _ signal.SignalWithUpdateHandlers = (*Signal)(nil)
+var _ signal.SignalWithTimeout = (*Signal)(nil)
+
+func (s *Signal) Timeout() time.Duration { return 180 * 24 * time.Hour }
 
 func (s *Signal) Type() signal.SignalType   { return SignalType }
 func (s *Signal) SleepAfter() time.Duration { return time.Second }

--- a/services/ctl-api/internal/pkg/flow/step_dispatch.go
+++ b/services/ctl-api/internal/pkg/flow/step_dispatch.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
@@ -73,7 +74,14 @@ func DispatchStepSignal(ctx workflow.Context, cfg StepConfig, step *app.Workflow
 		return errors.Wrapf(err, "unable to enqueue execute-workflow-step signal for step %s", step.Name)
 	}
 
-	_, err = client.AwaitAwaitSignal(ctx, enqueueResp.QueueSignalID)
+	var awaitOpts []*workflow.ActivityOptions
+	if t, ok := signal.Signal(sig).(signal.SignalWithTimeout); ok && t.Timeout() > 0 {
+		awaitOpts = append(awaitOpts, &workflow.ActivityOptions{
+			ScheduleToCloseTimeout: t.Timeout(),
+		})
+	}
+
+	_, err = client.AwaitAwaitSignal(ctx, enqueueResp.QueueSignalID, awaitOpts...)
 	if err != nil {
 		// If the parent workflow was cancelled, propagate cancellation to the step signal
 		if ctx.Err() != nil {

--- a/services/ctl-api/internal/pkg/queue/activities/get_queue_signals.go
+++ b/services/ctl-api/internal/pkg/queue/activities/get_queue_signals.go
@@ -22,7 +22,8 @@ func (a *Activities) getQueueSignals(ctx context.Context, queueID string) ([]*ap
 		Path:     "status",
 		Value:    []string{string(app.StatusQueued), string(app.StatusInProgress)},
 	}).Where(app.QueueSignal{
-		QueueID: queueID,
+		QueueID:  queueID,
+		Enqueued: true,
 	}).Order("created_at asc").
 		Find(&queueSignals); res.Error != nil {
 		return nil, generics.TemporalGormError(res.Error, "unable to get queue signals")

--- a/services/ctl-api/internal/pkg/queue/handle_signal.go
+++ b/services/ctl-api/internal/pkg/queue/handle_signal.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
 	handleractivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
@@ -111,10 +112,15 @@ func (q *queue) processQueueSignal(ctx workflow.Context, l *zap.Logger, queueSig
 	}
 
 	executeOpts := longRunningActivityOptions
-	if timeoutNs, ok := queueSignal.Status.Metadata["timeout_ns"]; ok {
-		if ns, ok := timeoutNs.(float64); ok {
+
+	// Fetch the deserialized signal to check for a custom timeout.
+	// The queueSignal from the DB activity has Signal excluded (temporaljson:"-"),
+	// so we fetch it separately via the signal-specific activity.
+	sig, sigErr := activities.AwaitGetQueueSignalSignalByQueueSignalID(ctx, queueSignal.ID)
+	if sigErr == nil {
+		if t, ok := sig.(signal.SignalWithTimeout); ok && t.Timeout() > 0 {
 			custom := *longRunningActivityOptions
-			custom.ScheduleToCloseTimeout = time.Duration(int64(ns))
+			custom.ScheduleToCloseTimeout = t.Timeout()
 			executeOpts = &custom
 		}
 	}


### PR DESCRIPTION
We recently added more robust timeouts into signals and workflows.

This adds a timeout for stack runs to allow them to be applied up to 180 days later. In practice, this _only_ works for 
installs with IID enabled.
