### PR TITLE
fix: optimixations-admin-dashboard

### DIFF
--- a/services/ctl-api/internal/app/admin-dashboard/client/lib/admin-api/runners.ts
+++ b/services/ctl-api/internal/app/admin-dashboard/client/lib/admin-api/runners.ts
@@ -4,7 +4,7 @@ import type { TRunnersResponse, TRunnerDetailView, TAllRunnersResponse } from '@
 export const getRunners = () =>
   api<TRunnersResponse>({ path: 'runners' })
 
-export const getAllRunners = (params?: { org_id?: string }) =>
+export const getAllRunners = (params?: { org_id?: string; page?: number }) =>
   api<TAllRunnersResponse>({ path: 'runners/all', params })
 
 export const getRunnerDetail = (id: string) =>

--- a/services/ctl-api/internal/app/admin-dashboard/client/types/admin.types.ts
+++ b/services/ctl-api/internal/app/admin-dashboard/client/types/admin.types.ts
@@ -469,6 +469,7 @@ export type TLabelsResponse = {
   orgs: TOrgOption[]
   page: number
   total_pages: number
+  total_count: number
 }
 
 export type TLogStreamLogsResponse = {
@@ -564,9 +565,24 @@ export type TAllRunnerView = {
   install_name: string
 }
 
+export type TRunnerStatBucket = {
+  label: string
+  value: number
+}
+
+export type TAllRunnerStats = {
+  group_type: TRunnerStatBucket[]
+  version: TRunnerStatBucket[]
+  process_type: TRunnerStatBucket[]
+}
+
 export type TAllRunnersResponse = {
   runners: TAllRunnerView[]
   orgs: TOrgOption[]
+  stats: TAllRunnerStats
+  page: number
+  total_pages: number
+  total_count: number
 }
 
 export type TInstallActivityResponse = {

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/labels/Labels.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/labels/Labels.tsx
@@ -36,12 +36,12 @@ export const Labels = () => {
   if (isLoading) return <LoadingSpinner />
   if (error) return <ErrorMessage message={(error as Error).message || 'Failed to load labels'} />
 
-  const { results = [], all_keys = [], orgs = [], total_pages = 1 } = data || {}
+  const { results = [], all_keys = [], orgs = [], total_pages = 1, total_count = 0 } = data || {}
 
   return (
     <div>
       <h1 className="page-heading">Labels</h1>
-      <p className="mt-1 text-sm text-gray-500">{results.length} results{all_keys.length > 0 && ` across ${all_keys.length} label keys`}</p>
+      <p className="mt-1 text-sm text-gray-500">{total_count} results{all_keys.length > 0 && ` across ${all_keys.length} label keys`}</p>
 
       <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:flex-wrap">
         <div className="w-full sm:w-64">

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/runners/AllRunners.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/runners/AllRunners.tsx
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
-import { useState, useMemo } from 'react'
+import { useState } from 'react'
 import { Link } from 'react-router'
 import { getAllRunners } from '@/lib/admin-api'
 import { Badge } from '@/components/common/Badge'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { ErrorMessage } from '@/components/common/ErrorMessage'
+import { Pagination } from '@/components/common/Pagination'
 import { truncateId } from '@/utils/format'
 import type { TAllRunnerView } from '@/types/admin.types'
 
@@ -71,38 +72,23 @@ const PieChart = ({ data, title }: { data: { label: string; value: number }[]; t
 
 export const AllRunners = () => {
   const [orgId, setOrgId] = useState('')
+  const [page, setPage] = useState(1)
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['all-runners', orgId],
-    queryFn: () => getAllRunners({ org_id: orgId || undefined }),
+    queryKey: ['all-runners', orgId, page],
+    queryFn: () => getAllRunners({ org_id: orgId || undefined, page }),
     refetchInterval: 30000,
   })
 
   const runners = data?.runners || []
   const orgs = data?.orgs || []
-
-  const stats = useMemo(() => {
-    const groupTypeCounts: Record<string, number> = {}
-    const versionCounts: Record<string, number> = {}
-    const processTypeCounts: Record<string, number> = {}
-
-    for (const rv of runners) {
-      const gt = rv.group_type || 'unknown'
-      groupTypeCounts[gt] = (groupTypeCounts[gt] || 0) + 1
-
-      const v = rv.version || 'unknown'
-      versionCounts[v] = (versionCounts[v] || 0) + 1
-
-      const pt = rv.process_type || 'none'
-      processTypeCounts[pt] = (processTypeCounts[pt] || 0) + 1
-    }
-
-    return {
-      groupType: Object.entries(groupTypeCounts).map(([label, value]) => ({ label, value })),
-      version: Object.entries(versionCounts).map(([label, value]) => ({ label, value })),
-      processType: Object.entries(processTypeCounts).map(([label, value]) => ({ label, value })),
-    }
-  }, [runners])
+  const totalCount = data?.total_count ?? 0
+  const totalPages = data?.total_pages ?? 1
+  const stats = {
+    groupType: data?.stats?.group_type || [],
+    version: data?.stats?.version || [],
+    processType: data?.stats?.process_type || [],
+  }
 
   if (isLoading) return <LoadingSpinner />
   if (error) return <ErrorMessage message={(error as Error).message || 'Failed to load runners'} />
@@ -111,13 +97,16 @@ export const AllRunners = () => {
     <div>
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold text-gray-900">All runners</h1>
-        <span className="text-sm text-gray-500">{runners.length} runners</span>
+        <span className="text-sm text-gray-500">{totalCount} runners</span>
       </div>
 
       <div className="mt-4">
         <select
           value={orgId}
-          onChange={(e) => setOrgId(e.target.value)}
+          onChange={(e) => {
+            setOrgId(e.target.value)
+            setPage(1)
+          }}
           className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
         >
           <option value="">All organizations</option>
@@ -127,7 +116,7 @@ export const AllRunners = () => {
         </select>
       </div>
 
-      {runners.length > 0 && (
+      {totalCount > 0 && (
         <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-3">
           <PieChart data={stats.groupType} title="Install vs org runners" />
           <PieChart data={stats.version} title="Versions" />
@@ -159,6 +148,10 @@ export const AllRunners = () => {
             )}
           </tbody>
         </table>
+      </div>
+
+      <div className="mt-4">
+        <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
       </div>
     </div>
   )

--- a/services/ctl-api/internal/app/admin-dashboard/service/all_runners.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/all_runners.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"math"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -11,15 +12,35 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/admin-dashboard/service/views"
 )
 
+const allRunnersPerPage = 50
+
+type runnerCategoryCount struct {
+	Label string `json:"label" gorm:"column:label"`
+	Value int    `json:"value" gorm:"column:value"`
+}
+
+type runnerStats struct {
+	GroupType   []runnerCategoryCount `json:"group_type"`
+	Version     []runnerCategoryCount `json:"version"`
+	ProcessType []runnerCategoryCount `json:"process_type"`
+}
+
 func (s *service) AllRunners(c *gin.Context) {
 	ctx := c.Request.Context()
 	orgID := c.Query("org_id")
+	page := getPageFromQuery(c)
 
-	runners, err := s.getAllRunnerViews(ctx, orgID)
+	runners, totalCount, err := s.getAllRunnerViews(ctx, orgID, page)
 	if err != nil {
 		s.l.Error("failed to get all runners", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch runners"})
 		return
+	}
+
+	stats, err := s.getAllRunnerStats(ctx, orgID)
+	if err != nil {
+		s.l.Warn("failed to get runner stats", zap.Error(err))
+		stats = runnerStats{}
 	}
 
 	orgs := s.getOrgOptions(ctx)
@@ -27,24 +48,42 @@ func (s *service) AllRunners(c *gin.Context) {
 		orgs = []views.OrgOption{}
 	}
 
+	totalPages := int(math.Ceil(float64(totalCount) / float64(allRunnersPerPage)))
+	if totalPages == 0 {
+		totalPages = 1
+	}
+
 	c.JSON(http.StatusOK, gin.H{
-		"runners": runners,
-		"orgs":    orgs,
+		"runners":     runners,
+		"orgs":        orgs,
+		"stats":       stats,
+		"page":        page,
+		"total_pages": totalPages,
+		"total_count": totalCount,
 	})
 }
 
-func (s *service) getAllRunnerViews(ctx context.Context, orgID string) ([]views.AllRunnerView, error) {
-	query := s.db.WithContext(ctx).
-		Preload("RunnerGroup").
-		Order("created_at DESC")
-
+func (s *service) getAllRunnerViews(ctx context.Context, orgID string, page int) ([]views.AllRunnerView, int64, error) {
+	query := s.db.WithContext(ctx).Model(&app.Runner{})
 	if orgID != "" {
 		query = query.Where(app.Runner{OrgID: orgID})
 	}
 
+	var totalCount int64
+	if err := query.Count(&totalCount).Error; err != nil {
+		return nil, 0, err
+	}
+
+	offset := (page - 1) * allRunnersPerPage
+
 	var runners []app.Runner
-	if res := query.Find(&runners); res.Error != nil {
-		return nil, res.Error
+	if res := query.
+		Preload("RunnerGroup").
+		Order("created_at DESC").
+		Limit(allRunnersPerPage).
+		Offset(offset).
+		Find(&runners); res.Error != nil {
+		return nil, 0, res.Error
 	}
 
 	// batch-collect org IDs and install owner IDs for lookups
@@ -130,7 +169,70 @@ func (s *service) getAllRunnerViews(ctx context.Context, orgID string) ([]views.
 		result = append(result, view)
 	}
 
-	return result, nil
+	return result, totalCount, nil
+}
+
+// getAllRunnerStats returns cluster-wide runner aggregations for the pie charts.
+// Each query returns one row per category, so memory cost is bounded by the
+// number of distinct group types / versions / process types.
+func (s *service) getAllRunnerStats(ctx context.Context, orgID string) (runnerStats, error) {
+	var stats runnerStats
+
+	// group_type: counts by runner_groups.type
+	groupTypeQuery := s.db.WithContext(ctx).
+		Table("runners").
+		Select("COALESCE(NULLIF(runner_groups.type, ''), 'unknown') AS label, COUNT(*) AS value").
+		Joins("JOIN runner_groups ON runner_groups.id = runners.runner_group_id").
+		Where("runners.deleted_at = 0").
+		Group("runner_groups.type")
+	if orgID != "" {
+		groupTypeQuery = groupTypeQuery.Where("runners.org_id = ?", orgID)
+	}
+	if err := groupTypeQuery.Scan(&stats.GroupType).Error; err != nil {
+		return stats, err
+	}
+
+	// version + process_type: counts over the latest runner_process per runner.
+	// Runners with no process row count as 'unknown'/'none' to match the prior
+	// per-runner behavior.
+	latestProcessSQL := `
+		WITH latest AS (
+			SELECT DISTINCT ON (runner_id) runner_id, version, type
+			FROM runner_processes
+			WHERE deleted_at = 0
+			ORDER BY runner_id, created_at DESC
+		)
+	`
+	args := []any{}
+	scope := "WHERE r.deleted_at = 0"
+	if orgID != "" {
+		scope += " AND r.org_id = ?"
+		args = append(args, orgID)
+	}
+
+	versionSQL := latestProcessSQL + `
+		SELECT COALESCE(NULLIF(latest.version, ''), 'unknown') AS label, COUNT(*) AS value
+		FROM runners r
+		LEFT JOIN latest ON latest.runner_id = r.id
+		` + scope + `
+		GROUP BY 1
+	`
+	if err := s.db.WithContext(ctx).Raw(versionSQL, args...).Scan(&stats.Version).Error; err != nil {
+		return stats, err
+	}
+
+	processTypeSQL := latestProcessSQL + `
+		SELECT COALESCE(NULLIF(latest.type, ''), 'none') AS label, COUNT(*) AS value
+		FROM runners r
+		LEFT JOIN latest ON latest.runner_id = r.id
+		` + scope + `
+		GROUP BY 1
+	`
+	if err := s.db.WithContext(ctx).Raw(processTypeSQL, args...).Scan(&stats.ProcessType).Error; err != nil {
+		return stats, err
+	}
+
+	return stats, nil
 }
 
 func mapKeys(m map[string]bool) []string {

--- a/services/ctl-api/internal/app/admin-dashboard/service/labels_page.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/labels_page.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"math"
 	"net/http"
 	"sort"
@@ -9,7 +11,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
-	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -26,7 +27,7 @@ func (s *service) LabelsPage(c *gin.Context) {
 	orgID := c.Query("org_id")
 	page := getPageFromQuery(c)
 
-	results, allKeys, totalPages, err := s.getLabelsData(ctx, search, entityType, orgID, page)
+	results, allKeys, totalPages, totalCount, err := s.getLabelsData(ctx, search, entityType, orgID, page)
 	if err != nil {
 		s.l.Error("failed to get labels data", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch labels data"})
@@ -51,6 +52,7 @@ func (s *service) LabelsPage(c *gin.Context) {
 		"orgs":        orgs,
 		"page":        page,
 		"total_pages": totalPages,
+		"total_count": totalCount,
 	})
 }
 
@@ -62,7 +64,7 @@ func (s *service) LabelsTable(c *gin.Context) {
 	orgID := c.Query("org_id")
 	page := getPageFromQuery(c)
 
-	results, _, totalPages, err := s.getLabelsData(ctx, search, entityType, orgID, page)
+	results, _, totalPages, totalCount, err := s.getLabelsData(ctx, search, entityType, orgID, page)
 	if err != nil {
 		s.l.Error("failed to get labels data", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch labels data"})
@@ -73,59 +75,170 @@ func (s *service) LabelsTable(c *gin.Context) {
 		"results":     results,
 		"page":        page,
 		"total_pages": totalPages,
+		"total_count": totalCount,
 	})
 }
 
 // LabelSearchResult represents a single entity with labels for the browse page.
 type LabelSearchResult = views.LabelSearchResult
 
-func (s *service) getLabelsData(ctx context.Context, search, entityType, orgID string, page int) ([]views.LabelSearchResult, []string, int, error) {
-	// 1. Get all distinct label keys across all entity types
+// labelTable describes one of the labelled tables that the labels-browse query
+// unions over. Per-table org filtering varies because components are scoped via
+// their parent app, not directly by org.
+type labelTable struct {
+	table         string
+	entityType    string
+	detailURLExpr string
+	orgClause     string
+}
+
+var allLabelTables = []labelTable{
+	{
+		table:         "installs",
+		entityType:    "install",
+		detailURLExpr: "'/installs/' || id",
+		orgClause:     "org_id = ?",
+	},
+	{
+		table:         "components",
+		entityType:    "component",
+		detailURLExpr: "''",
+		orgClause:     "app_id IN (SELECT id FROM apps WHERE org_id = ? AND deleted_at = 0)",
+	},
+	{
+		table:         "action_workflows",
+		entityType:    "action",
+		detailURLExpr: "''",
+		orgClause:     "org_id = ?",
+	},
+}
+
+func labelTablesFor(entityType string) []labelTable {
+	if entityType == "" {
+		return allLabelTables
+	}
+	for _, t := range allLabelTables {
+		if t.entityType == entityType {
+			return []labelTable{t}
+		}
+	}
+	return nil
+}
+
+// buildLabelFilterClauses turns a search string ("key:value", "key=value",
+// "k1:v1,k2:*", or a bare key) into SQL clause fragments and args that match
+// the same semantics as labels.WithLabels.
+func buildLabelFilterClauses(search string) ([]string, []any) {
+	search = strings.TrimSpace(search)
+	if search == "" {
+		return nil, nil
+	}
+
+	lbls := labels.ParseLabelsQuery(search)
+	if lbls == nil {
+		return []string{"jsonb_exists(labels, ?)"}, []any{search}
+	}
+
+	var clauses []string
+	var args []any
+
+	exact := make(labels.Labels)
+	var wildcardKeys []string
+	for k, v := range lbls {
+		if v == "*" {
+			wildcardKeys = append(wildcardKeys, k)
+		} else {
+			exact[k] = v
+		}
+	}
+
+	if len(exact) > 0 {
+		jsonBytes, err := json.Marshal(exact)
+		if err == nil {
+			clauses = append(clauses, "labels @> ?::jsonb")
+			args = append(args, string(jsonBytes))
+		}
+	}
+
+	sort.Strings(wildcardKeys)
+	for _, key := range wildcardKeys {
+		clauses = append(clauses, "jsonb_exists(labels, ?)")
+		args = append(args, key)
+	}
+
+	return clauses, args
+}
+
+func (s *service) getLabelsData(ctx context.Context, search, entityType, orgID string, page int) ([]views.LabelSearchResult, []string, int, int64, error) {
 	allKeys := s.getAllLabelKeys(ctx)
 
-	// 2. Query entities matching the search/filter
-	var results []views.LabelSearchResult
-
-	type queryFunc func(context.Context, string, string) ([]views.LabelSearchResult, error)
-	tables := []struct {
-		entityType string
-		query      queryFunc
-	}{
-		{"install", s.getInstallLabelResults},
-		{"component", s.getComponentLabelResults},
-		{"action", s.getActionLabelResults},
+	tables := labelTablesFor(entityType)
+	if len(tables) == 0 {
+		return []views.LabelSearchResult{}, allKeys, 1, 0, nil
 	}
+
+	labelClauses, labelArgs := buildLabelFilterClauses(search)
+
+	var dataSubqueries []string
+	var countSubqueries []string
+	var dataArgs []any
+	var countArgs []any
 
 	for _, t := range tables {
-		if entityType != "" && entityType != t.entityType {
-			continue
+		clauses := []string{
+			"deleted_at = 0",
+			"labels IS NOT NULL",
+			"labels != '{}'::jsonb",
 		}
-		rows, err := t.query(ctx, search, orgID)
-		if err != nil {
-			s.l.Warn("failed to get label results for "+t.entityType, zap.Error(err))
-			continue
+		var args []any
+		if orgID != "" {
+			clauses = append(clauses, t.orgClause)
+			args = append(args, orgID)
 		}
-		results = append(results, rows...)
+		clauses = append(clauses, labelClauses...)
+		args = append(args, labelArgs...)
+
+		where := strings.Join(clauses, " AND ")
+
+		dataSubqueries = append(dataSubqueries, fmt.Sprintf(
+			"SELECT '%s' AS entity_type, id AS entity_id, name AS entity_name, labels, created_at, %s AS detail_url FROM %s WHERE %s",
+			t.entityType, t.detailURLExpr, t.table, where,
+		))
+		countSubqueries = append(countSubqueries, fmt.Sprintf(
+			"SELECT 1 FROM %s WHERE %s", t.table, where,
+		))
+
+		dataArgs = append(dataArgs, args...)
+		countArgs = append(countArgs, args...)
 	}
 
-	// 3. Paginate
-	totalCount := len(results)
+	countSQL := "SELECT COUNT(*) FROM (" + strings.Join(countSubqueries, " UNION ALL ") + ") c"
+	var totalCount int64
+	if err := s.db.WithContext(ctx).Raw(countSQL, countArgs...).Scan(&totalCount).Error; err != nil {
+		return nil, allKeys, 1, 0, fmt.Errorf("unable to count labels: %w", err)
+	}
+
 	totalPages := int(math.Ceil(float64(totalCount) / float64(labelsPerPage)))
 	if totalPages == 0 {
 		totalPages = 1
 	}
 
 	offset := (page - 1) * labelsPerPage
-	if offset > len(results) {
-		offset = len(results)
-	}
-	end := offset + labelsPerPage
-	if end > len(results) {
-		end = len(results)
-	}
-	results = results[offset:end]
+	dataSQL := "SELECT entity_type, entity_id, entity_name, labels, detail_url FROM (" +
+		strings.Join(dataSubqueries, " UNION ALL ") +
+		") u ORDER BY u.created_at DESC LIMIT ? OFFSET ?"
+	dataArgs = append(dataArgs, labelsPerPage, offset)
 
-	return results, allKeys, totalPages, nil
+	var results []views.LabelSearchResult
+	if err := s.db.WithContext(ctx).Raw(dataSQL, dataArgs...).Scan(&results).Error; err != nil {
+		return nil, allKeys, 1, 0, fmt.Errorf("unable to query labels: %w", err)
+	}
+
+	if results == nil {
+		results = []views.LabelSearchResult{}
+	}
+
+	return results, allKeys, totalPages, totalCount, nil
 }
 
 func (s *service) getAllLabelKeys(ctx context.Context) []string {
@@ -169,100 +282,4 @@ func (s *service) getOrgOptions(ctx context.Context) []views.OrgOption {
 		opts = append(opts, views.OrgOption{ID: o.ID, Name: o.Name})
 	}
 	return opts
-}
-
-func (s *service) getInstallLabelResults(ctx context.Context, search, orgID string) ([]views.LabelSearchResult, error) {
-	var installs []app.Install
-	tx := s.db.WithContext(ctx).
-		Where("labels IS NOT NULL AND labels != '{}'::jsonb")
-
-	if orgID != "" {
-		tx = tx.Where("org_id = ?", orgID)
-	}
-	tx = applyLabelSearch(tx, search)
-
-	if err := tx.Find(&installs).Error; err != nil {
-		return nil, err
-	}
-
-	results := make([]views.LabelSearchResult, 0, len(installs))
-	for _, i := range installs {
-		results = append(results, views.LabelSearchResult{
-			EntityType: "install",
-			EntityID:   i.ID,
-			EntityName: i.Name,
-			Labels:     i.Labels,
-			DetailURL:  "/installs/" + i.ID,
-		})
-	}
-	return results, nil
-}
-
-func (s *service) getComponentLabelResults(ctx context.Context, search, orgID string) ([]views.LabelSearchResult, error) {
-	var components []app.Component
-	tx := s.db.WithContext(ctx).
-		Where("labels IS NOT NULL AND labels != '{}'::jsonb")
-
-	if orgID != "" {
-		tx = tx.Where("app_id IN (SELECT id FROM apps WHERE org_id = ?)", orgID)
-	}
-	tx = applyLabelSearch(tx, search)
-
-	if err := tx.Find(&components).Error; err != nil {
-		return nil, err
-	}
-
-	results := make([]views.LabelSearchResult, 0, len(components))
-	for _, c := range components {
-		results = append(results, views.LabelSearchResult{
-			EntityType: "component",
-			EntityID:   c.ID,
-			EntityName: c.Name,
-			Labels:     c.Labels,
-		})
-	}
-	return results, nil
-}
-
-func (s *service) getActionLabelResults(ctx context.Context, search, orgID string) ([]views.LabelSearchResult, error) {
-	var actions []app.ActionWorkflow
-	tx := s.db.WithContext(ctx).
-		Where("labels IS NOT NULL AND labels != '{}'::jsonb")
-
-	if orgID != "" {
-		tx = tx.Where("org_id = ?", orgID)
-	}
-	tx = applyLabelSearch(tx, search)
-
-	if err := tx.Find(&actions).Error; err != nil {
-		return nil, err
-	}
-
-	results := make([]views.LabelSearchResult, 0, len(actions))
-	for _, a := range actions {
-		results = append(results, views.LabelSearchResult{
-			EntityType: "action",
-			EntityID:   a.ID,
-			EntityName: a.Name,
-			Labels:     a.Labels,
-		})
-	}
-	return results, nil
-}
-
-// applyLabelSearch adds WHERE clauses for label search.
-// Supports "key:value" (exact match) or just "key" (key existence).
-func applyLabelSearch(tx *gorm.DB, search string) *gorm.DB {
-	search = strings.TrimSpace(search)
-	if search == "" {
-		return tx
-	}
-
-	lbls := labels.ParseLabelsQuery(search)
-	if lbls != nil {
-		return tx.Scopes(labels.WithLabels("labels", lbls))
-	}
-
-	// Treat as key-only search (check if key exists in JSONB)
-	return tx.Where("jsonb_exists(labels, ?)", search)
 }

--- a/services/ctl-api/internal/app/admin-dashboard/service/queue_emitters_table.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/queue_emitters_table.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"math"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -9,24 +10,46 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
 
+const queueEmittersPerPage = 20
+
 func (s *service) QueueEmittersTable(c *gin.Context) {
+	ctx := c.Request.Context()
 	queueID := c.Param("id")
+	page := getPageFromQuery(c)
+
+	query := s.db.WithContext(ctx).
+		Model(&app.QueueEmitter{}).
+		Where("queue_id = ?", queueID)
+
+	var totalCount int64
+	if err := query.Count(&totalCount).Error; err != nil {
+		s.l.Error("failed to count emitters", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch emitters"})
+		return
+	}
+
+	totalPages := int(math.Ceil(float64(totalCount) / float64(queueEmittersPerPage)))
+	if totalPages == 0 {
+		totalPages = 1
+	}
+
+	offset := (page - 1) * queueEmittersPerPage
 
 	var emitters []app.QueueEmitter
-
-	res := s.db.WithContext(c.Request.Context()).
-		Where("queue_id = ?", queueID).
+	if err := query.
 		Order("created_at desc").
-		Find(&emitters)
-
-	if res.Error != nil {
-		s.l.Error("failed to fetch emitters", zap.Error(res.Error))
+		Limit(queueEmittersPerPage).
+		Offset(offset).
+		Find(&emitters).Error; err != nil {
+		s.l.Error("failed to fetch emitters", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch emitters"})
 		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"emitters": emitters,
-		"queue_id": queueID,
+		"emitters":    emitters,
+		"queue_id":    queueID,
+		"page":        page,
+		"total_pages": totalPages,
 	})
 }

--- a/services/ctl-api/internal/app/admin-dashboard/service/runners.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/runners.go
@@ -54,43 +54,82 @@ func (s *service) getSandboxRunnerViews(ctx context.Context) ([]views.SandboxRun
 		return nil, fmt.Errorf("unable to find sandbox runners: %w", res.Error)
 	}
 
+	// Sandbox job configs are global (no per-runner filter), so fetch once.
+	var configs []app.SandboxModeJobConfig
+	if err := s.db.WithContext(ctx).
+		Where("job_type != ''").
+		Order("job_type").
+		Find(&configs).Error; err != nil {
+		s.l.Warn("failed to load sandbox job configs", zap.Error(err))
+	}
+
+	// Batch-resolve install names for any install-owned runner groups.
+	installIDs := make(map[string]struct{})
+	for _, runner := range runners {
+		if runner.RunnerGroup.OwnerType == "installs" && runner.RunnerGroup.OwnerID != "" {
+			installIDs[runner.RunnerGroup.OwnerID] = struct{}{}
+		}
+	}
+	installNames := make(map[string]string, len(installIDs))
+	if len(installIDs) > 0 {
+		ids := make([]string, 0, len(installIDs))
+		for id := range installIDs {
+			ids = append(ids, id)
+		}
+		var installs []app.Install
+		if err := s.db.WithContext(ctx).
+			Select("id", "name").
+			Where("id IN ?", ids).
+			Find(&installs).Error; err == nil {
+			for _, i := range installs {
+				installNames[i.ID] = i.Name
+			}
+		}
+	}
+
+	// Batch-resolve latest process per runner (one query, DISTINCT ON).
+	type processInfo struct {
+		Online  bool
+		Version string
+	}
+	processMap := make(map[string]processInfo, len(runners))
+	if len(runners) > 0 {
+		runnerIDs := make([]string, len(runners))
+		for i, r := range runners {
+			runnerIDs[i] = r.ID
+		}
+		var processes []app.RunnerProcess
+		if err := s.db.WithContext(ctx).
+			Raw(`SELECT DISTINCT ON (runner_id) * FROM runner_processes
+				 WHERE runner_id IN ? AND deleted_at = 0
+				 ORDER BY runner_id, created_at DESC`, runnerIDs).
+			Scan(&processes).Error; err == nil {
+			for _, p := range processes {
+				processMap[p.RunnerID] = processInfo{
+					Online:  p.ProcessStatus() == app.RunnerProcessStatusActive,
+					Version: p.Version,
+				}
+			}
+		}
+	}
+
 	result := make([]views.SandboxRunnerView, 0, len(runners))
 	for _, runner := range runners {
 		view := views.SandboxRunnerView{
-			Runner: runner,
+			Runner:  runner,
+			Configs: configs,
 		}
 
-		// Resolve the install name if the runner group owner is an install
 		if runner.RunnerGroup.OwnerType == "installs" {
-			var install app.Install
-			if res := s.db.WithContext(ctx).
-				Select("id", "name").
-				Where("id = ?", runner.RunnerGroup.OwnerID).
-				First(&install); res.Error == nil {
-				view.InstallID = install.ID
-				view.InstallName = install.Name
-			}
+			view.InstallID = runner.RunnerGroup.OwnerID
+			view.InstallName = installNames[runner.RunnerGroup.OwnerID]
 		}
 
-		// Get latest process for online status
-		var process app.RunnerProcess
-		if res := s.db.WithContext(ctx).
-			Where("runner_id = ?", runner.ID).
-			Order("created_at desc").
-			First(&process); res.Error == nil {
-			view.ProcessOnline = process.ProcessStatus() == app.RunnerProcessStatusActive
-			if process.Version != "" {
-				view.Version = process.Version
+		if pi, ok := processMap[runner.ID]; ok {
+			view.ProcessOnline = pi.Online
+			if pi.Version != "" {
+				view.Version = pi.Version
 			}
-		}
-
-		// Get sandbox configs for this runner
-		var configs []app.SandboxModeJobConfig
-		if res := s.db.WithContext(ctx).
-			Where("job_type != ''").
-			Order("job_type").
-			Find(&configs); res.Error == nil {
-			view.Configs = configs
 		}
 
 		result = append(result, view)


### PR DESCRIPTION
Fix unbounded SQL queries in admin-dashboard handlers — pages were either pulling
  entire tables into API memory or running per-row queries inside loops.

  ### Changes

  **`queue_emitters_table.go`** — Added SQL pagination (`LIMIT 20`).
  Frontend (`QueueDetail.tsx`) already sent `?page=N` and rendered a `<Pagination>`
  control, but the backend was returning the full unpaginated list. Backend now
  honors the existing contract (`{emitters, page, total_pages, queue_id}`).

  **`all_runners.go`** — Added SQL pagination (`LIMIT 50`) and replaced the
  in-memory pie-chart computation with three SQL aggregation queries
  (`GROUP BY runner_groups.type`, and `DISTINCT ON (runner_id)` over
  `runner_processes` for version/process_type). The page no longer loads every
  runner into Go memory, but the pie charts still reflect cluster-wide totals.
  Frontend wires `?page=` and the `<Pagination>` control.

  **`labels_page.go`** — Replaced in-memory pagination over three unbounded
  `Find()` calls (`installs_view_v7`, `components`, `action_workflows`) with a
  single `UNION ALL` query paginated at the SQL layer (`LIMIT 20 OFFSET ?`).
  Total count comes from a parallel `COUNT(*)` over the same `UNION ALL`. Search
  filter (`labels @> ?::jsonb` / `jsonb_exists(labels, ?)`) preserved exactly.
  Added `total_count` to response.

  **`runners.go`** (sandbox runners view) — Fixed N+1: per-render query count
  went from `3N+2` to `5` (constant in N).
  - Hoisted global `sandbox_mode_job_configs` fetch out of the runner loop
    (was being re-fetched once per runner with identical results)
  - Batched install lookups via `WHERE id IN (...)`
  - Batched latest-process lookups via `SELECT DISTINCT ON (runner_id) ...`