### PR TITLE
fix: race condition between enqueue and reueue systems on a newly created queue and signal

### DIFF
--- a/services/ctl-api/internal/pkg/queue/enqueue.go
+++ b/services/ctl-api/internal/pkg/queue/enqueue.go
@@ -46,11 +46,21 @@ func (w *queue) enqueueHandler(ctx workflow.Context, input EnqueueHandlerInput) 
 		return nil, errors.Errorf("unable to queue item, depth of %d reached", w.maxDepth)
 	}
 
+	if w.inFlightSignals[input.QueueSignalID] {
+		l.Info("signal already in-flight via requeueSignals, skipping re-dispatch",
+			zap.String("queue-signal-id", input.QueueSignalID))
+		return &EnqueueResponse{
+			ID:         input.QueueSignalID,
+			WorkflowID: input.WorkflowID,
+		}, nil
+	}
+
 	handlerworkflow.StartHandler(ctx, input.WorkflowID, handlerworkflow.HandlerRequest{
 		QueueID:       w.queueID,
 		QueueSignalID: input.QueueSignalID,
 	})
 
+	w.inFlightSignals[input.QueueSignalID] = true
 	l.Info("queueing signal for processing", zap.String("workflow-id", input.WorkflowID))
 	if !w.ch.SendAsync(QueueRef{
 		WorkflowID: input.WorkflowID,

--- a/services/ctl-api/internal/pkg/queue/queue.go
+++ b/services/ctl-api/internal/pkg/queue/queue.go
@@ -38,11 +38,12 @@ type QueueState struct {
 // @memo type queue
 func (w *Workflows) Queue(ctx workflow.Context, req QueueWorkflowRequest) error {
 	q := &queue{
-		cfg:           w.cfg,
-		v:             w.v,
-		queueID:       req.QueueID,
-		state:         req.State,
-		releaseWindow: req.ReleaseWindow,
+		cfg:             w.cfg,
+		v:               w.v,
+		queueID:         req.QueueID,
+		state:           req.State,
+		releaseWindow:   req.ReleaseWindow,
+		inFlightSignals: make(map[string]bool),
 	}
 	if q.state == nil {
 		q.state = &QueueState{
@@ -103,6 +104,11 @@ type queue struct {
 	// activeWorkers tracks the number of workers currently processing a signal.
 	// Used to prevent continue-as-new while workers are mid-processing.
 	activeWorkers int
+
+	// inFlightSignals tracks signals currently in the dispatcher channel or being
+	// processed. Used to prevent double-dispatch when requeueSignals and enqueueHandler
+	// both try to dispatch the same signal.
+	inFlightSignals map[string]bool
 
 	// state is used to store state that will continue between continue-as-news
 	state *QueueState

--- a/services/ctl-api/internal/pkg/queue/requeue.go
+++ b/services/ctl-api/internal/pkg/queue/requeue.go
@@ -22,7 +22,12 @@ func (w *queue) requeueSignals(ctx workflow.Context) error {
 		return errors.Wrap(err, "unable to get queue signals")
 	}
 	for _, queueSignal := range queueSignals {
+		if w.inFlightSignals[queueSignal.ID] {
+			l.Info("skipping already in-flight signal", zap.String("queue-signal-id", queueSignal.ID))
+			continue
+		}
 		l.Info("requeuing signal", zap.String("queue-signal-id", queueSignal.ID), zap.Any("type", queueSignal.Type))
+		w.inFlightSignals[queueSignal.ID] = true
 		w.ch.Send(ctx, QueueRef{
 			WorkflowID: queueSignal.Workflow.ID,
 			ID:         queueSignal.ID,

--- a/services/ctl-api/internal/pkg/queue/worker.go
+++ b/services/ctl-api/internal/pkg/queue/worker.go
@@ -106,6 +106,7 @@ func (q *queue) dispatcher(ctx workflow.Context) error {
 				q.sem.Release(1)
 				q.activeWorkers--
 				q.lastActivityTime = workflow.Now(gCtx)
+				delete(q.inFlightSignals, ref.ID)
 			}()
 
 			if err := q.handleQueueSignal(gCtx, ref); err != nil {


### PR DESCRIPTION
Enqueue, and requeue were racing to handle newly created signal causing multiple attempts of same signal back to back. This has a downstream side-effect of queue hanging in dead state because the abandon queue cleanup marks the queue signal as error-ed. This causes those signals to never get processed. 

Steps to reproduce: first saw on main while syncing byoc app where for each component we create a queue, and then immediately send signals to those queue.
Can occur in other places where such race is possible.

