### PR TITLE
docs(ecr-access): document gcp_principals and fix output name

### DIFF
--- a/docs/guides/container-image-components.mdx
+++ b/docs/guides/container-image-components.mdx
@@ -182,16 +182,23 @@ If you are having trouble finding the repository ARN in the AWS console, you can
 
 ### AWS ECR from a Self-Hosted-on-GCP Customer
 
-If your customer is running a self-hosted Nuon deployment on GCP, the IAM role's trust policy needs to accept their
-ctl-api service account's OIDC token (via `accounts.google.com`) in addition to (or instead of) the Nuon-hosted AWS
-principal.
+If your customer is running a self-hosted Nuon deployment on GCP, the IAM role's trust policy needs to accept the OIDC
+token (via `accounts.google.com`) of the GCP service accounts that actually call AWS, in addition to (or instead of) the
+Nuon-hosted AWS principal.
+
+Two service accounts in the customer's GCP project hit `sts:AssumeRoleWithWebIdentity` against this role:
+
+- **Org runner SA** — the GKE runner pod is Workload-Identity-bound to a GCP SA named after the org ID. This is the SA
+  that pulls source for builds (the typical failure path). Display name: `Nuon org runner <org_id>`.
+- **ctl-api SA** — fetches image metadata when evaluating external image policies. Display name: `ctl-api for <install_id>`.
+
+Both must be present in `gcp_principals` for the build path to succeed end-to-end.
 
 <Note>
-The `gcp_principals` input requires `nuonco/ecr-access/aws` version `0.1.7` or later. Pin the version explicitly if you
-were previously using an older release.
+The `gcp_principals` input requires `nuonco/ecr-access/aws` version `0.1.8` or later. Earlier releases either lacked
+the input (`<= 0.1.6`) or shipped a trust policy that AWS silently rejects for non-Google-OAuth audiences (`0.1.7`).
+Pin the version explicitly if you were previously using an older release.
 </Note>
-
-Pass each self-hosted customer's GCP service account unique ID via `gcp_principals`:
 
 ```hcl
 module "nuon_ecr_access" {
@@ -201,24 +208,30 @@ module "nuon_ecr_access" {
 
   gcp_principals = [
     {
-      service_account_unique_id = "123456789012345678901"  # numeric uid of the customer's ctl-api SA
-      service_account_email     = "ctl-api-<install>@<customer-project>.iam.gserviceaccount.com"
+      service_account_unique_id = "123456789012345678901"  # org runner SA UID
+      service_account_email     = "<org-id-truncated>@<customer-project>.iam.gserviceaccount.com"
+    },
+    {
+      service_account_unique_id = "987654321098765432109"  # ctl-api SA UID
+      service_account_email     = "ctl-api-<install-id-truncated>@<customer-project>.iam.gserviceaccount.com"
     },
   ]
 }
 ```
 
-The customer can find their ctl-api service account email in their self-hosted Nuon's GCP project. The install creator
-truncates the install ID to fit GCP's 30-character service account `account_id` limit, so the email is
-`ctl-api-<first-12-chars-of-install-id>@<project>.iam.gserviceaccount.com` — not the full install ID. The full install
-ID appears in the SA's display name (`ctl-api for <full-install-id>`).
+<Note>
+The install creator truncates the org/install ID to fit GCP's 30-character service account `account_id` limit. The
+amount truncated depends on the prefix/suffix the SA uses, so don't try to construct emails by hand — the simplest path
+is to list the SAs in the customer's project and copy the values directly. The full org/install ID is preserved in the
+SA's display name (`Nuon org runner <full-org-id>`, `ctl-api for <full-install-id>`).
+</Note>
 
-The simplest way to find both the email and unique ID is:
+The simplest way to find both emails and unique IDs is:
 
 ```bash
 gcloud iam service-accounts list \
   --project=<customer-project> \
-  --filter='email~ctl-api' \
+  --filter='displayName~"Nuon org runner" OR displayName~"ctl-api for"' \
   --format='table(email,uniqueId,displayName)'
 ```
 

--- a/docs/guides/container-image-components.mdx
+++ b/docs/guides/container-image-components.mdx
@@ -170,8 +170,8 @@ module "nuon_ecr_access" {
   repository_arns = ["<repository-arn>"]
 }
 
-output "ecr_access_iam_role" {
-  value = module.nuon_ecr_access.ecr_access_iam_role
+output "iam_role_arn" {
+  value = module.nuon_ecr_access.iam_role_arn
 }
 ```
 
@@ -185,6 +185,11 @@ If you are having trouble finding the repository ARN in the AWS console, you can
 If your customer is running a self-hosted Nuon deployment on GCP, the IAM role's trust policy needs to accept their
 ctl-api service account's OIDC token (via `accounts.google.com`) in addition to (or instead of) the Nuon-hosted AWS
 principal.
+
+<Note>
+The `gcp_principals` input requires `nuonco/ecr-access/aws` version `0.1.7` or later. Pin the version explicitly if you
+were previously using an older release.
+</Note>
 
 Pass each self-hosted customer's GCP service account unique ID via `gcp_principals`:
 
@@ -203,8 +208,25 @@ module "nuon_ecr_access" {
 }
 ```
 
-The customer can find their ctl-api service account email in their self-hosted Nuon's GCP project. Run
-`gcloud iam service-accounts describe <email> --format='value(uniqueId)'` to get the numeric ID for the trust condition.
+The customer can find their ctl-api service account email in their self-hosted Nuon's GCP project. The install creator
+truncates the install ID to fit GCP's 30-character service account `account_id` limit, so the email is
+`ctl-api-<first-12-chars-of-install-id>@<project>.iam.gserviceaccount.com` — not the full install ID. The full install
+ID appears in the SA's display name (`ctl-api for <full-install-id>`).
+
+The simplest way to find both the email and unique ID is:
+
+```bash
+gcloud iam service-accounts list \
+  --project=<customer-project> \
+  --filter='email~ctl-api' \
+  --format='table(email,uniqueId,displayName)'
+```
+
+Or, given a known email, fetch just the numeric UID:
+
+```bash
+gcloud iam service-accounts describe <email> --format='value(uniqueId)'
+```
 
 <Note>
 The default Nuon-hosted (AWS) trust principal stays in place — adding `gcp_principals` is additive, so the same role

--- a/docs/guides/container-image-components.mdx
+++ b/docs/guides/container-image-components.mdx
@@ -189,7 +189,7 @@ via `gcp_principals` so they can assume the role via Workload Identity Federatio
 - The ctl-api SA (display name `ctl-api for <install_id>`) — fetches image metadata for `external_image` components.
 
 <Note>
-Requires `nuonco/ecr-access/aws` version `0.1.8` or later.
+Requires `nuonco/ecr-access/aws` version `0.1.9` or later.
 </Note>
 
 ```hcl

--- a/docs/guides/container-image-components.mdx
+++ b/docs/guides/container-image-components.mdx
@@ -182,22 +182,14 @@ If you are having trouble finding the repository ARN in the AWS console, you can
 
 ### AWS ECR from a Self-Hosted-on-GCP Customer
 
-If your customer is running a self-hosted Nuon deployment on GCP, the IAM role's trust policy needs to accept the OIDC
-token (via `accounts.google.com`) of the GCP service accounts that actually call AWS, in addition to (or instead of) the
-Nuon-hosted AWS principal.
+If your customer is running a self-hosted Nuon deployment on GCP, pass the customer's GCP service account unique IDs
+via `gcp_principals` so they can assume the role via Workload Identity Federation. Two SAs need to be listed:
 
-Two service accounts in the customer's GCP project hit `sts:AssumeRoleWithWebIdentity` against this role:
-
-- **Org runner SA** — the GKE runner pod is Workload-Identity-bound to a GCP SA named after the org ID. This is the SA
-  that pulls source for builds (the typical failure path). Display name: `Nuon org runner <org_id>`.
-- **ctl-api SA** — fetches image metadata when evaluating external image policies. Display name: `ctl-api for <install_id>`.
-
-Both must be present in `gcp_principals` for the build path to succeed end-to-end.
+- The org runner SA (display name `Nuon org runner <org_id>`) — pulls source for builds.
+- The ctl-api SA (display name `ctl-api for <install_id>`) — fetches image metadata for `external_image` components.
 
 <Note>
-The `gcp_principals` input requires `nuonco/ecr-access/aws` version `0.1.8` or later. Earlier releases either lacked
-the input (`<= 0.1.6`) or shipped a trust policy that AWS silently rejects for non-Google-OAuth audiences (`0.1.7`).
-Pin the version explicitly if you were previously using an older release.
+Requires `nuonco/ecr-access/aws` version `0.1.8` or later.
 </Note>
 
 ```hcl
@@ -220,25 +212,18 @@ module "nuon_ecr_access" {
 ```
 
 <Note>
-The install creator truncates the org/install ID to fit GCP's 30-character service account `account_id` limit. The
-amount truncated depends on the prefix/suffix the SA uses, so don't try to construct emails by hand — the simplest path
-is to list the SAs in the customer's project and copy the values directly. The full org/install ID is preserved in the
-SA's display name (`Nuon org runner <full-org-id>`, `ctl-api for <full-install-id>`).
+Don't construct the SA emails by hand — Nuon truncates the org/install ID to fit GCP's 30-character SA name limit, and
+the truncation length varies. Look the SAs up directly in the customer's project; the full org/install ID is preserved
+in each SA's display name.
 </Note>
 
-The simplest way to find both emails and unique IDs is:
+Look them up with:
 
 ```bash
 gcloud iam service-accounts list \
   --project=<customer-project> \
   --filter='displayName~"Nuon org runner" OR displayName~"ctl-api for"' \
   --format='table(email,uniqueId,displayName)'
-```
-
-Or, given a known email, fetch just the numeric UID:
-
-```bash
-gcloud iam service-accounts describe <email> --format='value(uniqueId)'
 ```
 
 <Note>


### PR DESCRIPTION
## Summary

- Note that `gcp_principals` requires `nuonco/ecr-access/aws` >= **0.1.7** (just published).
- Explain the 12-char install ID truncation in the ctl-api SA email pattern, and point readers at `gcloud iam service-accounts list` to look up the email and numeric unique ID in one shot — rather than asking them to construct the email by hand.
- Fix the output example to reference the module's actual output `iam_role_arn` (the docs previously had `ecr_access_iam_role`, which doesn't exist on the module — verified by running the example end-to-end against `nuonco/ecr-access/aws@0.1.7` in account 431927561584 and confirming the role plans + applies cleanly).

## Test plan

- [x] Render `docs/guides/container-image-components.mdx` and confirm the new `<Note>` and the truncation explanation read correctly
- [x] Verify `gcloud iam service-accounts list ... --filter='email~ctl-api'` returns email + uniqueId for a self-hosted-on-GCP install
- [x] Confirm the docs example block now matches the actual module outputs in `nuonco/ecr-access/aws` >= 0.1.7