### PR TITLE
feat: admin-dashboard dark-mode + shared styles refactor

### DIFF
--- a/services/ctl-api/internal/app/admin-dashboard/client/components/common/Badge.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/components/common/Badge.tsx
@@ -8,28 +8,28 @@ interface IBadge {
 }
 
 function statusColor(status: string | undefined): string {
-  if (!status) return 'bg-gray-100 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700'
+  if (!status) return 'bg-gray-100 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700'
   const s = status.toLowerCase()
   if (s.includes('running') || s.includes('active') || s.includes('online') || s.includes('healthy') || s.includes('completed') || s.includes('success') || s === 'yes' || s === 'true') {
-    return 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
+    return 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800'
   }
   if (s.includes('failed') || s.includes('error') || s.includes('offline') || s.includes('unhealthy') || s === 'no' || s === 'false') {
-    return 'bg-red-50 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800'
+    return 'bg-red-50 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800'
   }
   if (s.includes('pending') || s.includes('queued') || s.includes('waiting')) {
-    return 'bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:border-orange-800'
+    return 'bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-900/30 dark:text-orange-300 dark:border-orange-800'
   }
   if (s.includes('cancel')) {
-    return 'bg-orange-50 text-orange-600 border-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:border-orange-800'
+    return 'bg-orange-50 text-orange-600 border-orange-200 dark:bg-orange-900/30 dark:text-orange-300 dark:border-orange-800'
   }
-  return 'bg-gray-100 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700'
+  return 'bg-gray-100 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700'
 }
 
 export const Badge = ({ children, variant = 'default', status, className }: IBadge) => {
   const base = 'inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium leading-4'
   const color = variant === 'status' && status
     ? statusColor(status)
-    : 'bg-primary-50 text-primary-700 border-primary-200 dark:bg-primary-950 dark:text-primary-400 dark:border-primary-800'
+    : 'bg-primary-50 text-primary-700 border-primary-200 dark:bg-primary-950 dark:text-primary-300 dark:border-primary-900'
 
   return <span className={cn(base, color, className)}>{children}</span>
 }

--- a/services/ctl-api/internal/app/admin-dashboard/client/components/common/DotGraph.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/components/common/DotGraph.tsx
@@ -161,7 +161,7 @@ export const DotGraph = ({ dot, height = '24rem' }: IDotGraph) => {
   if (!dot) return null
   if (nodes.length === 0) {
     return (
-      <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-500">
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400">
         <p>No graph nodes found. Raw DOT:</p>
         <pre className="mt-2 text-xs font-mono overflow-x-auto max-h-32">{dot}</pre>
       </div>
@@ -169,7 +169,7 @@ export const DotGraph = ({ dot, height = '24rem' }: IDotGraph) => {
   }
 
   return (
-    <div className="w-full border border-gray-200 rounded-lg overflow-hidden" style={{ height }}>
+    <div className="w-full border border-gray-200 rounded-lg overflow-hidden dark:border-gray-800" style={{ height }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}

--- a/services/ctl-api/internal/app/admin-dashboard/client/components/common/ErrorMessage.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/components/common/ErrorMessage.tsx
@@ -1,7 +1,7 @@
 export const ErrorMessage = ({ message }: { message: string }) => (
-  <div className="rounded-md bg-red-50 p-4">
+  <div className="rounded-md bg-red-50 p-4 dark:bg-red-900/30">
     <div className="flex">
-      <div className="text-sm text-red-700">{message}</div>
+      <div className="text-sm text-red-700 dark:text-red-300">{message}</div>
     </div>
   </div>
 )

--- a/services/ctl-api/internal/app/admin-dashboard/client/components/common/JsonViewer.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/components/common/JsonViewer.tsx
@@ -14,7 +14,7 @@ export const JsonViewer = ({ data, collapsed = false }: IJsonViewer) => {
     return (
       <button
         onClick={() => setIsCollapsed(false)}
-        className="text-xs text-primary-600 hover:text-primary-800"
+        className="text-xs text-primary-600 hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300"
       >
         Show JSON ({typeof data === 'object' ? Object.keys(data || {}).length : 0} keys)
       </button>
@@ -26,12 +26,12 @@ export const JsonViewer = ({ data, collapsed = false }: IJsonViewer) => {
       {collapsed && (
         <button
           onClick={() => setIsCollapsed(true)}
-          className="absolute right-2 top-2 text-xs text-gray-500 hover:text-gray-700"
+          className="absolute right-2 top-2 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
         >
           Collapse
         </button>
       )}
-      <pre className="overflow-x-auto rounded-md bg-gray-900 p-4 text-xs text-gray-100">
+      <pre className="overflow-x-auto rounded-md bg-gray-900 p-4 text-xs text-gray-100 dark:bg-black dark:text-gray-200">
         <code>{formatted}</code>
       </pre>
     </div>

--- a/services/ctl-api/internal/app/admin-dashboard/client/components/common/LoadingSpinner.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/components/common/LoadingSpinner.tsx
@@ -1,5 +1,5 @@
 export const LoadingSpinner = ({ className = '' }: { className?: string }) => (
   <div className={`flex items-center justify-center py-12 ${className}`}>
-    <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-primary-600" />
+    <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-primary-600 dark:border-gray-800 dark:border-t-primary-400" />
   </div>
 )

--- a/services/ctl-api/internal/app/admin-dashboard/client/components/common/Pagination.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/components/common/Pagination.tsx
@@ -8,25 +8,25 @@ export const Pagination = ({ page, totalPages, onPageChange }: IPagination) => {
   if (totalPages <= 1) return null
 
   return (
-    <div className="flex items-center justify-between border-t border-gray-200 px-4 py-3 sm:px-6">
+    <div className="flex items-center justify-between border-t border-gray-200 px-4 py-3 sm:px-6 dark:border-gray-800">
       <div className="flex flex-1 justify-between sm:hidden">
         <button
           onClick={() => onPageChange(page - 1)}
           disabled={page <= 1}
-          className="relative inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          className="relative inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800"
         >
           Previous
         </button>
         <button
           onClick={() => onPageChange(page + 1)}
           disabled={page >= totalPages}
-          className="relative ml-3 inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          className="relative ml-3 inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800"
         >
           Next
         </button>
       </div>
       <div className="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
-        <p className="text-sm text-gray-700">
+        <p className="text-sm text-gray-700 dark:text-gray-300">
           Page <span className="font-medium">{page}</span> of{' '}
           <span className="font-medium">{totalPages}</span>
         </p>
@@ -34,7 +34,7 @@ export const Pagination = ({ page, totalPages, onPageChange }: IPagination) => {
           <button
             onClick={() => onPageChange(page - 1)}
             disabled={page <= 1}
-            className="relative inline-flex items-center rounded-l-md px-2 py-2 text-gray-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:opacity-50"
+            className="relative inline-flex items-center rounded-l-md px-2 py-2 text-gray-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:opacity-50 dark:text-gray-400 dark:ring-gray-700 dark:hover:bg-gray-800"
           >
             &larr;
           </button>
@@ -53,10 +53,10 @@ export const Pagination = ({ page, totalPages, onPageChange }: IPagination) => {
               <button
                 key={pageNum}
                 onClick={() => onPageChange(pageNum)}
-                className={`relative inline-flex items-center px-4 py-2 text-sm font-semibold ring-1 ring-inset ring-gray-300 ${
+                className={`relative inline-flex items-center px-4 py-2 text-sm font-semibold ring-1 ring-inset ${
                   pageNum === page
-                    ? 'z-10 bg-primary-600 text-white focus-visible:outline-primary-600'
-                    : 'text-gray-900 hover:bg-gray-50'
+                    ? 'z-10 bg-primary-600 text-white ring-primary-600 focus-visible:outline-primary-600 dark:bg-primary-500 dark:ring-primary-500'
+                    : 'text-gray-900 ring-gray-300 hover:bg-gray-50 dark:text-gray-200 dark:ring-gray-700 dark:hover:bg-gray-800'
                 }`}
               >
                 {pageNum}
@@ -66,7 +66,7 @@ export const Pagination = ({ page, totalPages, onPageChange }: IPagination) => {
           <button
             onClick={() => onPageChange(page + 1)}
             disabled={page >= totalPages}
-            className="relative inline-flex items-center rounded-r-md px-2 py-2 text-gray-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:opacity-50"
+            className="relative inline-flex items-center rounded-r-md px-2 py-2 text-gray-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:opacity-50 dark:text-gray-400 dark:ring-gray-700 dark:hover:bg-gray-800"
           >
             &rarr;
           </button>

--- a/services/ctl-api/internal/app/admin-dashboard/client/components/common/SearchInput.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/components/common/SearchInput.tsx
@@ -27,7 +27,7 @@ export const SearchInput = ({ value, onChange, placeholder = 'Search...', classN
       onBlur={() => onChange(local)}
       onKeyDown={handleKeyDown}
       placeholder={placeholder}
-      className={`block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-primary-600 sm:text-sm sm:leading-6 dark:bg-gray-800 dark:text-gray-200 dark:ring-gray-600 dark:placeholder:text-gray-500 ${className}`}
+      className={`block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-primary-600 sm:text-sm sm:leading-6 dark:bg-gray-900 dark:text-gray-100 dark:ring-gray-700 dark:placeholder:text-gray-500 dark:focus:ring-primary-500 ${className}`}
     />
   )
 }

--- a/services/ctl-api/internal/app/admin-dashboard/client/components/common/SignalFlowGraph.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/components/common/SignalFlowGraph.tsx
@@ -355,7 +355,7 @@ export const SignalFlowGraph = ({ graphData, height = '36rem' }: ISignalFlowGrap
   if (!graphData || nodes.length === 0) return null
 
   return (
-    <div className="w-full border border-gray-200 rounded-lg overflow-hidden relative" style={{ height }}>
+    <div className="w-full border border-gray-200 rounded-lg overflow-hidden relative dark:border-gray-800" style={{ height }}>
       {loading && (
         <div className="absolute top-2 left-2 z-10 bg-gray-900 text-white text-xs px-3 py-1.5 rounded shadow-lg animate-pulse">
           Expanding signal...

--- a/services/ctl-api/internal/app/admin-dashboard/client/components/common/SignalLink.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/components/common/SignalLink.tsx
@@ -10,13 +10,13 @@ interface ISignalLink {
 
 export const SignalLink = ({ signalId, queueId, showGraph = true, children }: ISignalLink) => (
   <span className="inline-flex items-center gap-1.5">
-    <Link to={`/queues/${queueId}/signals/${signalId}`} className="font-mono text-xs text-primary-600 hover:text-primary-700">
+    <Link to={`/queues/${queueId}/signals/${signalId}`} className="font-mono text-xs text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300">
       {children || truncateId(signalId)}
     </Link>
     {showGraph && (
       <Link
         to={`/queues/${queueId}/signals/${signalId}/graph`}
-        className="inline-flex items-center rounded bg-primary-50 border border-primary-200 px-1 py-0.5 text-[9px] font-medium text-primary-600 hover:bg-primary-100"
+        className="inline-flex items-center rounded bg-primary-50 border border-primary-200 px-1 py-0.5 text-[9px] font-medium text-primary-600 hover:bg-primary-100 dark:bg-primary-950 dark:border-primary-900 dark:text-primary-300 dark:hover:bg-primary-900"
         title="View signal graph"
       >
         graph

--- a/services/ctl-api/internal/app/admin-dashboard/client/components/common/StatusHistory.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/components/common/StatusHistory.tsx
@@ -32,23 +32,23 @@ export const StatusHistory = ({ status, defaultExpanded = false, maxCollapsed = 
       {visibleEntries.map((h: any, i: number) => {
         const s = getStatus(h)
         return (
-          <div key={i} className="flex items-start gap-2 text-xs border-b border-gray-100 pb-1.5 last:border-0">
+          <div key={i} className="flex items-start gap-2 text-xs border-b border-gray-100 pb-1.5 last:border-0 dark:border-gray-800">
             <Badge variant="status" status={s}>{s}</Badge>
             <div className="flex-1 space-y-0.5 min-w-0">
               <div className="flex items-center gap-1 flex-wrap">
                 <span>{s}</span>
-                {h._isCurrent && <span className="text-primary-600 font-medium">(current)</span>}
-                {h.status_human_description && <span className="text-gray-500">— {h.status_human_description}</span>}
+                {h._isCurrent && <span className="text-primary-600 font-medium dark:text-primary-400">(current)</span>}
+                {h.status_human_description && <span className="text-gray-500 dark:text-gray-400">— {h.status_human_description}</span>}
               </div>
               {h.created_at_ts > 0 && (
-                <div className="text-gray-400 font-mono text-[10px]">
+                <div className="text-gray-400 font-mono text-[10px] dark:text-gray-500">
                   {new Date(h.created_at_ts / 1000000).toISOString().replace('T', ' ').slice(0, 19)} UTC
                 </div>
               )}
               {h.metadata && Object.keys(h.metadata).length > 0 && (
-                <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-gray-400">
+                <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-gray-400 dark:text-gray-500">
                   {Object.entries(h.metadata).map(([k, v]) => (
-                    <span key={k}><span className="text-gray-500">{k}:</span> {String(v)}</span>
+                    <span key={k}><span className="text-gray-500 dark:text-gray-400">{k}:</span> {String(v)}</span>
                   ))}
                 </div>
               )}
@@ -59,7 +59,7 @@ export const StatusHistory = ({ status, defaultExpanded = false, maxCollapsed = 
       {hasMore && (
         <button
           onClick={() => setExpanded(!expanded)}
-          className="text-xs text-primary-600 hover:text-primary-700 font-medium"
+          className="text-xs text-primary-600 hover:text-primary-700 font-medium dark:text-primary-400 dark:hover:text-primary-300"
         >
           {expanded ? `Show less` : `Show ${allEntries.length - maxCollapsed} more...`}
         </button>

--- a/services/ctl-api/internal/app/admin-dashboard/client/components/layout/AppLayout.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/components/layout/AppLayout.tsx
@@ -77,7 +77,7 @@ export const AppLayout = () => {
   return (
     <div className="flex min-h-screen bg-gray-50 dark:bg-gray-950">
       {/* Sidebar */}
-      <aside className="w-56 flex-shrink-0 border-r border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+      <aside className="w-56 flex-shrink-0 border-r border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950">
         <div className="sticky top-0 flex h-screen flex-col overflow-y-auto">
           <div className="flex h-12 items-center justify-between px-4 border-b border-gray-200 dark:border-gray-800">
             <Link to="/" className="text-sm font-semibold tracking-tight text-primary-700 dark:text-primary-400">
@@ -112,8 +112,8 @@ export const AppLayout = () => {
                     const className = cn(
                       'block rounded-md px-2 py-1.5 text-[13px] font-medium transition-colors duration-100',
                       isActive(item)
-                        ? 'bg-primary-50 text-primary-700 dark:bg-primary-950 dark:text-primary-400'
-                        : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200',
+                        ? 'bg-primary-50 text-primary-700 dark:bg-primary-950 dark:text-primary-300'
+                        : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-gray-100',
                     )
                     if (item.external) {
                       return (

--- a/services/ctl-api/internal/app/admin-dashboard/client/index.html
+++ b/services/ctl-api/internal/app/admin-dashboard/client/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/services/ctl-api/internal/app/admin-dashboard/client/styles.css
+++ b/services/ctl-api/internal/app/admin-dashboard/client/styles.css
@@ -76,14 +76,9 @@ body {
   color: #272E35;
 }
 
-/* ---- Dark mode ---- */
-.dark body, body.dark {
-  background-color: #0f1117;
-  color: #d1d5db;
-}
-
-.dark {
-  color-scheme: dark;
+.dark body {
+  background-color: #0B0F14;
+  color: #E5E7EB;
 }
 
 #root {
@@ -94,15 +89,15 @@ body {
 
 /* Card-style tables */
 .table-card {
-  @apply overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800;
+  @apply overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900;
 }
 
 .table-card table {
-  @apply min-w-full divide-y divide-gray-200 dark:divide-gray-700;
+  @apply min-w-full divide-y divide-gray-200 dark:divide-gray-800;
 }
 
 .table-card thead {
-  @apply bg-gray-50/80 dark:bg-gray-800/80;
+  @apply bg-gray-50/80 dark:bg-gray-800/60;
 }
 
 .table-card th {
@@ -114,7 +109,7 @@ body {
 }
 
 .table-card tbody tr {
-  @apply transition-colors duration-100 hover:bg-gray-50/50 dark:hover:bg-gray-700/50;
+  @apply transition-colors duration-100 hover:bg-gray-50/50 dark:hover:bg-gray-800/40;
 }
 
 /* Better focus rings */
@@ -124,7 +119,7 @@ input:focus, select:focus, textarea:focus {
 }
 
 .dark input:focus, .dark select:focus, .dark textarea:focus {
-  box-shadow: 0 0 0 1px #1f2937, 0 0 0 3px rgba(173, 113, 234, 0.4);
+  box-shadow: 0 0 0 1px #0B0F14, 0 0 0 3px rgba(196, 148, 244, 0.5);
 }
 
 /* Link styles */
@@ -140,136 +135,3 @@ a.link {
 .page-subheading {
   @apply mt-1 text-sm text-gray-500 dark:text-gray-400;
 }
-
-/* Dark mode overrides for common patterns */
-.dark input, .dark select, .dark textarea {
-  background-color: #1f2937;
-  color: #d1d5db;
-  border-color: #374151;
-  --tw-ring-color: #374151;
-  --tw-shadow-color: transparent;
-}
-
-.dark input::placeholder, .dark select::placeholder, .dark textarea::placeholder {
-  color: #6b7280;
-}
-
-/* Dark mode tables (non-.table-card) */
-.dark table thead {
-  @apply bg-gray-800;
-}
-
-.dark table tbody {
-  @apply divide-gray-700;
-}
-
-.dark table th {
-  @apply text-gray-400;
-}
-
-.dark table td {
-  @apply text-gray-300;
-}
-
-.dark table tbody tr:hover {
-  @apply bg-gray-800/50;
-}
-
-/* ---- Dark mode global overrides ---- */
-
-/* Text */
-.dark .text-gray-900 { color: #f9fafb; }
-.dark .text-gray-800 { color: #e5e7eb; }
-.dark .text-gray-700 { color: #d1d5db; }
-.dark .text-gray-600 { color: #9ca3af; }
-.dark .text-gray-500 { color: #9ca3af; }
-.dark .text-gray-400 { color: #6b7280; }
-
-/* Backgrounds */
-.dark .bg-white { background-color: #111827; }
-.dark .bg-gray-50 { background-color: #1a2332; }
-.dark .bg-gray-100 { background-color: #1f2937; }
-.dark .bg-gray-50\/80 { background-color: rgba(26, 35, 50, 0.8); }
-.dark .bg-gray-50\/50 { background-color: rgba(26, 35, 50, 0.5); }
-.dark .bg-gray-50\/30 { background-color: rgba(26, 35, 50, 0.3); }
-
-/* Borders & dividers */
-.dark .border-gray-200 { border-color: #2d3748; }
-.dark .border-gray-100 { border-color: #1f2937; }
-.dark .divide-gray-200 > :not(:last-child) { border-color: #2d3748; }
-.dark .divide-gray-50 > :not(:last-child) { border-color: #1f2937; }
-.dark .ring-gray-300 { --tw-ring-color: #374151; }
-
-/* Hover states */
-.dark [class*="hover:bg-gray-50"]:hover {
-  background-color: rgba(31, 41, 55, 0.6) !important;
-}
-
-/* Blue (labels, links) */
-.dark .bg-blue-50 { background-color: rgba(30, 80, 192, 0.2); }
-.dark .bg-blue-50\/30 { background-color: rgba(30, 80, 192, 0.15); }
-.dark .border-blue-200 { border-color: #2759cd; }
-.dark .border-blue-100 { border-color: #1e50c0; }
-.dark .text-blue-700 { color: #8db0fb; }
-.dark .text-blue-600 { color: #8db0fb; }
-.dark .text-blue-400 { color: #6792f4; }
-
-/* Purple (primary, mng panels) */
-.dark .bg-primary-50 { background-color: rgba(128, 64, 191, 0.15); }
-.dark .bg-primary-100 { background-color: rgba(128, 64, 191, 0.2); }
-.dark .bg-primary-600 { background-color: #7339ac; }
-.dark .bg-primary-600:hover { background-color: #8040bf; }
-.dark .border-primary-200 { border-color: #662f9d; }
-.dark .border-primary-300 { border-color: #7339ac; }
-.dark .text-primary-700 { color: #c494f4; }
-.dark .text-primary-600 { color: #c494f4; }
-.dark .bg-purple-50\/30 { background-color: rgba(128, 64, 191, 0.1); }
-.dark .border-purple-100 { border-color: #4c2277; }
-
-/* Green */
-.dark .bg-green-50 { background-color: rgba(30, 113, 74, 0.2); }
-.dark .bg-green-100 { background-color: rgba(30, 113, 74, 0.25); }
-.dark .text-green-700 { color: #75cc9e; }
-.dark .text-green-600 { color: #75cc9e; }
-
-/* Orange / Yellow */
-.dark .bg-orange-50 { background-color: rgba(180, 97, 14, 0.2); }
-.dark .bg-orange-100 { background-color: rgba(180, 97, 14, 0.25); }
-.dark .text-orange-700 { color: #feb872; }
-.dark .text-orange-600 { color: #feb872; }
-.dark .text-orange-500 { color: #feb872; }
-.dark .bg-yellow-50 { background-color: rgba(180, 97, 14, 0.15); }
-.dark .border-yellow-200 { border-color: #7a4510; }
-.dark .text-yellow-700, .dark .text-yellow-800 { color: #feb872; }
-
-/* Red */
-.dark .bg-red-50 { background-color: rgba(185, 28, 28, 0.2); }
-.dark .bg-red-100 { background-color: rgba(185, 28, 28, 0.25); }
-.dark .text-red-700 { color: #f87171; }
-.dark .text-red-600 { color: #f87171; }
-.dark .text-red-500 { color: #f87171; }
-
-/* SVG pie chart text */
-.dark svg text.fill-gray-700 { fill: #d1d5db; }
-.dark svg text { fill: #d1d5db; }
-.dark svg circle[stroke="#e5e7eb"] { stroke: #374151; }
-
-/* Code blocks */
-.dark pre, .dark code {
-  background-color: #1a2332;
-  color: #d1d5db;
-}
-
-/* Job bars */
-.dark .bg-gray-400 { background-color: #4b5563; }
-.dark .bg-blue-300 { background-color: #3062d4; }
-
-/* Pill toggle buttons (org labels) */
-.dark .bg-gray-50.border-gray-200 {
-  background-color: #1f2937;
-  border-color: #374151;
-}
-
-/* Scrollbar */
-.dark ::-webkit-scrollbar { background: #0f1117; }
-.dark ::-webkit-scrollbar-thumb { background: #374151; border-radius: 4px; }

--- a/services/ctl-api/internal/app/admin-dashboard/client/utils/format.ts
+++ b/services/ctl-api/internal/app/admin-dashboard/client/utils/format.ts
@@ -28,19 +28,19 @@ export function truncateId(id: string, len = 12): string {
 }
 
 export function statusColor(status: string | undefined): string {
-  if (!status) return 'bg-gray-100 text-gray-700'
+  if (!status) return 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300'
   const s = status.toLowerCase()
   if (s.includes('running') || s.includes('active') || s.includes('online') || s.includes('healthy') || s.includes('completed') || s.includes('success')) {
-    return 'bg-green-100 text-green-800'
+    return 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-200'
   }
   if (s.includes('failed') || s.includes('error') || s.includes('offline') || s.includes('unhealthy')) {
-    return 'bg-red-100 text-red-800'
+    return 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200'
   }
   if (s.includes('pending') || s.includes('queued') || s.includes('waiting')) {
-    return 'bg-yellow-100 text-yellow-800'
+    return 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-200'
   }
   if (s.includes('cancel')) {
-    return 'bg-orange-100 text-orange-800'
+    return 'bg-orange-100 dark:bg-orange-900/40 text-orange-800 dark:text-orange-200'
   }
-  return 'bg-gray-100 text-gray-700'
+  return 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300'
 }

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/Home.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/Home.tsx
@@ -28,8 +28,8 @@ export const Home = () => {
       <h1 className="page-heading">Admin dashboard</h1>
       <p className="page-subheading">Internal operations dashboard for the Nuon platform</p>
 
-      <div className="mt-6 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
-        <h2 className="text-sm font-semibold text-gray-900">Global actions</h2>
+      <div className="mt-6 rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4 shadow-sm">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Global actions</h2>
         <div className="mt-3 flex items-center gap-3">
           <button
             onClick={() => {
@@ -38,7 +38,7 @@ export const Home = () => {
               }
             }}
             disabled={promoteMutation.isPending}
-            className="rounded-md bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+            className="rounded-md bg-primary-600 dark:bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 dark:hover:bg-primary-600 disabled:opacity-50"
           >
             {promoteMutation.isPending ? 'Promoting...' : 'Promote'}
           </button>
@@ -49,23 +49,23 @@ export const Home = () => {
               }
             }}
             disabled={seedMutation.isPending}
-            className="rounded-md bg-yellow-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-yellow-700 disabled:opacity-50"
+            className="rounded-md bg-yellow-600 dark:bg-yellow-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-yellow-700 dark:hover:bg-yellow-600 disabled:opacity-50"
           >
             {seedMutation.isPending ? 'Seeding...' : 'Seed'}
           </button>
           {promoteMutation.isSuccess && (
-            <span className="text-sm text-green-600">
+            <span className="text-sm text-green-600 dark:text-green-400">
               Promoted with tag: {promoteMutation.data.tag}
             </span>
           )}
           {promoteMutation.isError && (
-            <span className="text-sm text-red-600">Failed to promote</span>
+            <span className="text-sm text-red-600 dark:text-red-400">Failed to promote</span>
           )}
           {seedMutation.isSuccess && (
-            <span className="text-sm text-green-600">Seed triggered</span>
+            <span className="text-sm text-green-600 dark:text-green-400">Seed triggered</span>
           )}
           {seedMutation.isError && (
-            <span className="text-sm text-red-600">Failed to seed</span>
+            <span className="text-sm text-red-600 dark:text-red-400">Failed to seed</span>
           )}
         </div>
       </div>
@@ -75,10 +75,10 @@ export const Home = () => {
           <Link
             key={s.path}
             to={s.path}
-            className="group rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition-all duration-150 hover:border-primary-200 hover:shadow-md"
+            className="group rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4 shadow-sm transition-all duration-150 hover:border-primary-200 dark:hover:border-primary-800 hover:shadow-md"
           >
-            <h3 className="text-sm font-semibold text-gray-900 group-hover:text-primary-700">{s.title}</h3>
-            <p className="mt-1 text-xs text-gray-500 leading-relaxed">{s.description}</p>
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 group-hover:text-primary-700 dark:group-hover:text-primary-300">{s.title}</h3>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 leading-relaxed">{s.description}</p>
           </Link>
         ))}
       </div>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/accounts/AccountDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/accounts/AccountDetail.tsx
@@ -70,23 +70,23 @@ export const AccountDetail = () => {
   return (
     <div className="space-y-6">
       {/* Breadcrumb */}
-      <nav className="flex items-center gap-2 text-sm text-gray-500">
-        <Link to="/accounts" className="text-primary-600 hover:text-primary-800">Accounts</Link>
+      <nav className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+        <Link to="/accounts" className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">Accounts</Link>
         <span>/</span>
-        <span className="text-gray-900">{account.email}</span>
+        <span className="text-gray-900 dark:text-gray-100">{account.email}</span>
       </nav>
 
       {/* Page Heading */}
       <div className="page-heading">
-        <h1 className="text-xl font-bold text-gray-900">{account.email}</h1>
-        <p className="mt-1 text-sm text-gray-500 font-mono">{account.id}</p>
+        <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">{account.email}</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400 font-mono">{account.id}</p>
         {account.subject && (
-          <p className="mt-0.5 text-xs text-gray-400 font-mono">Subject: {account.subject}</p>
+          <p className="mt-0.5 text-xs text-gray-400 dark:text-gray-500 font-mono">Subject: {account.subject}</p>
         )}
         <div className="mt-2 flex items-center gap-2">
           <Badge>{account.account_type}</Badge>
         </div>
-        <div className="mt-1 flex items-center gap-4 text-xs text-gray-400">
+        <div className="mt-1 flex items-center gap-4 text-xs text-gray-400 dark:text-gray-500">
           <span>Created {formatDate(account.created_at)}</span>
           <span>Updated {formatDate(account.updated_at)}</span>
         </div>
@@ -94,9 +94,9 @@ export const AccountDetail = () => {
 
       {/* User Journey */}
       {Array.isArray(account.user_journeys) && account.user_journeys.length > 0 && (
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900">User Journey</h2>
-          <p className="mt-0.5 text-xs text-gray-500">Onboarding progress and completion tracking</p>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">User Journey</h2>
+          <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">Onboarding progress and completion tracking</p>
           <div className="mt-3 space-y-4">
             {account.user_journeys.map((journey: any, ji: number) => {
               const steps: any[] = journey.steps || []
@@ -104,12 +104,12 @@ export const AccountDetail = () => {
               const total = steps.length
               const pct = total > 0 ? Math.round((completed / total) * 100) : 0
               return (
-                <div key={ji} className={ji > 0 ? 'border-t border-gray-100 pt-3' : ''}>
+                <div key={ji} className={ji > 0 ? 'border-t border-gray-100 dark:border-gray-800 pt-3' : ''}>
                   <div className="flex items-center justify-between gap-3">
-                    <h3 className="text-xs font-semibold text-gray-700">{journey.title || journey.name}</h3>
-                    <span className="text-xs text-gray-500 font-mono">{completed} / {total}</span>
+                    <h3 className="text-xs font-semibold text-gray-700 dark:text-gray-300">{journey.title || journey.name}</h3>
+                    <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">{completed} / {total}</span>
                   </div>
-                  <div className="mt-1.5 h-1.5 w-full rounded bg-gray-100">
+                  <div className="mt-1.5 h-1.5 w-full rounded bg-gray-100 dark:bg-gray-800">
                     <div
                       className="h-1.5 rounded bg-primary-500"
                       style={{ width: `${pct}%` }}
@@ -122,26 +122,26 @@ export const AccountDetail = () => {
                           className={`mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold ${
                             step.complete
                               ? 'bg-primary-500 text-white'
-                              : 'bg-gray-100 text-gray-400'
+                              : 'bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500'
                           }`}
                         >
                           {step.complete ? '✓' : '○'}
                         </span>
                         <div className="flex-1">
-                          <div className={step.complete ? 'text-gray-900' : 'text-gray-500'}>
+                          <div className={step.complete ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'}>
                             {step.title || step.name}
                           </div>
                           {step.complete && step.completed_at && (
-                            <div className="text-[11px] text-gray-400">
+                            <div className="text-[11px] text-gray-400 dark:text-gray-500">
                               Completed {formatDate(step.completed_at)}
                               {step.completion_method && <> · via {step.completion_method}</>}
                             </div>
                           )}
                           {step.metadata && Object.keys(step.metadata).length > 0 && (
-                            <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-gray-500">
+                            <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-gray-500 dark:text-gray-400">
                               {Object.entries(step.metadata).map(([k, v]) => (
                                 <span key={k} className="font-mono">
-                                  <span className="text-gray-400">{k}:</span> {String(v)}
+                                  <span className="text-gray-400 dark:text-gray-500">{k}:</span> {String(v)}
                                 </span>
                               ))}
                             </div>
@@ -159,33 +159,33 @@ export const AccountDetail = () => {
 
       {/* Organizations */}
       <div className="table-card p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Organizations</h2>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Organizations</h2>
         <div className="mt-2 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Org Name</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Role Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Org Name</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Role Type</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
               {orgsList.map((o) => (
                 <tr key={o.org_id}>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
-                    <Link to={`/orgs/${o.org_id}`} className="text-primary-600 hover:text-primary-800 font-medium">
+                    <Link to={`/orgs/${o.org_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-medium">
                       {o.org_name}
                     </Link>
                   </td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
                     <Badge>{o.role_type}</Badge>
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(o.created_at)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(o.created_at)}</td>
                 </tr>
               ))}
               {orgsList.length === 0 && (
                 <tr>
-                  <td colSpan={3} className="px-4 py-8 text-center text-sm text-gray-500">No organizations</td>
+                  <td colSpan={3} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No organizations</td>
                 </tr>
               )}
             </tbody>
@@ -195,33 +195,33 @@ export const AccountDetail = () => {
 
       {/* Roles */}
       <div className="table-card p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Roles</h2>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Roles</h2>
         <div className="mt-2 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Role Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Org</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Role Type</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Org</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
               {(account.roles || []).map((role: any) => (
                 <tr key={role.id}>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
                     <Badge>{role.role_type}</Badge>
                   </td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
-                    <Link to={`/orgs/${role.org_id}`} className="text-primary-600 hover:text-primary-800">
+                    <Link to={`/orgs/${role.org_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">
                       {role.org?.name || truncateId(role.org_id)}
                     </Link>
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(role.created_at)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(role.created_at)}</td>
                 </tr>
               ))}
               {(!account.roles || account.roles.length === 0) && (
                 <tr>
-                  <td colSpan={3} className="px-4 py-8 text-center text-sm text-gray-500">No roles</td>
+                  <td colSpan={3} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No roles</td>
                 </tr>
               )}
             </tbody>
@@ -231,27 +231,27 @@ export const AccountDetail = () => {
 
       {/* Apps */}
       <div className="table-card p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Apps</h2>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Apps</h2>
         <div className="mt-2 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Organization</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Configs</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Organization</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Configs</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
               {apps.map((app: any) => (
                 <tr key={app.id}>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">{app.name}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 font-mono">{truncateId(app.id)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{app.name}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400 font-mono">{truncateId(app.id)}</td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
                     {app.org_id ? (
-                      <Link to={`/orgs/${app.org_id}`} className="text-primary-600 hover:text-primary-800">
+                      <Link to={`/orgs/${app.org_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">
                         {app.org?.name || truncateId(app.org_id)}
                       </Link>
                     ) : '-'}
@@ -261,13 +261,13 @@ export const AccountDetail = () => {
                       <Badge variant="status" status={getStatus(app.status)}>{getStatus(app.status)}</Badge>
                     ) : '-'}
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{app.config_count ?? '-'}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(app.created_at)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{app.config_count ?? '-'}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(app.created_at)}</td>
                 </tr>
               ))}
               {apps.length === 0 && (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500">No apps</td>
+                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No apps</td>
                 </tr>
               )}
             </tbody>
@@ -277,29 +277,29 @@ export const AccountDetail = () => {
 
       {/* Installs */}
       <div className="table-card p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Installs</h2>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Installs</h2>
         <div className="mt-2 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Organization</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">App</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Runner</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Sandbox</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Component</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Organization</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">App</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Runner</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Sandbox</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Component</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
               {(installsData?.installs || accountInstalls).map((install: any) => {
                 const isDeleted = install.deleted_at && install.deleted_at > 0
                 return (
                   <tr key={install.id} className={isDeleted ? 'opacity-50' : ''}>
                     <td className="whitespace-nowrap px-4 py-3 text-sm">
                       <div className="flex items-center gap-1">
-                        <Link to={`/installs/${install.id}`} className="text-primary-600 hover:text-primary-800 font-medium">
+                        <Link to={`/installs/${install.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-medium">
                           {install.name || truncateId(install.id)}
                         </Link>
                         {isDeleted && <Badge variant="status" status="error">Deleted</Badge>}
@@ -307,12 +307,12 @@ export const AccountDetail = () => {
                     </td>
                     <td className="whitespace-nowrap px-4 py-3 text-sm">
                       {install.org_id ? (
-                        <Link to={`/orgs/${install.org_id}`} className="text-primary-600 hover:text-primary-800">
+                        <Link to={`/orgs/${install.org_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">
                           {install.org?.name || truncateId(install.org_id)}
                         </Link>
                       ) : '-'}
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
                       {install.app?.name || truncateId(install.app_id)}
                     </td>
                     <td className="whitespace-nowrap px-4 py-3 text-sm">
@@ -333,13 +333,13 @@ export const AccountDetail = () => {
                         <Badge variant="status" status={getStatus(install.composite_component_status)}>{getStatus(install.composite_component_status)}</Badge>
                       ) : '-'}
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(install.created_at)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(install.created_at)}</td>
                   </tr>
                 )
               })}
               {(installsData?.installs || accountInstalls).length === 0 && (
                 <tr>
-                  <td colSpan={8} className="px-4 py-8 text-center text-sm text-gray-500">No installs</td>
+                  <td colSpan={8} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No installs</td>
                 </tr>
               )}
             </tbody>
@@ -352,12 +352,12 @@ export const AccountDetail = () => {
 
       {/* Audit Logs */}
       <div className="table-card p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Audit Logs</h2>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Audit Logs</h2>
         <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
           <select
             value={auditEntityType}
             onChange={(e) => { setAuditEntityType(e.target.value); setAuditPage(1) }}
-            className="block w-48 rounded-md border-0 py-1 px-2 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+            className="block w-48 rounded-md border-0 py-1 px-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
           >
             <option value="">All types</option>
             <option value="app">App</option>
@@ -370,28 +370,28 @@ export const AccountDetail = () => {
             type="date"
             value={startDate}
             onChange={(e) => { setStartDate(e.target.value); setAuditPage(1) }}
-            className="block rounded-md border-0 py-1 px-2 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+            className="block rounded-md border-0 py-1 px-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
           />
           <input
             type="date"
             value={endDate}
             onChange={(e) => { setEndDate(e.target.value); setAuditPage(1) }}
-            className="block rounded-md border-0 py-1 px-2 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+            className="block rounded-md border-0 py-1 px-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
           />
         </div>
         <div className="mt-2 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Entity Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Entity ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Org</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Entity Type</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Entity ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Org</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Description</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
               {(auditData?.audit_logs || []).map((entry: any, idx: number) => {
                 const entityLink = entry.entity_type === 'workflow'
                   ? `/workflows/${entry.entity_id}`
@@ -403,33 +403,33 @@ export const AccountDetail = () => {
                     <td className="whitespace-nowrap px-4 py-3 text-sm">
                       <Badge>{entry.entity_type}</Badge>
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{entry.entity_name || '-'}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{entry.entity_name || '-'}</td>
                     <td className="whitespace-nowrap px-4 py-3 text-sm font-mono">
                       {entityLink ? (
-                        <Link to={entityLink} className="text-primary-600 hover:text-primary-800">
+                        <Link to={entityLink} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">
                           {truncateId(entry.entity_id)}
                         </Link>
                       ) : (
-                        <span className="text-gray-500">{truncateId(entry.entity_id)}</span>
+                        <span className="text-gray-500 dark:text-gray-400">{truncateId(entry.entity_id)}</span>
                       )}
                     </td>
                     <td className="whitespace-nowrap px-4 py-3 text-sm">
                       {entry.org_id ? (
-                        <Link to={`/orgs/${entry.org_id}`} className="text-primary-600 hover:text-primary-800">
+                        <Link to={`/orgs/${entry.org_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">
                           {entry.org_name || truncateId(entry.org_id)}
                         </Link>
                       ) : '-'}
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 max-w-xs truncate" title={entry.description || ''}>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400 max-w-xs truncate" title={entry.description || ''}>
                       {entry.description || '-'}
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(entry.created_at)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(entry.created_at)}</td>
                   </tr>
                 )
               })}
               {(!auditData?.audit_logs || auditData.audit_logs.length === 0) && (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500">No audit logs</td>
+                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No audit logs</td>
                 </tr>
               )}
             </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/accounts/AccountsList.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/accounts/AccountsList.tsx
@@ -32,7 +32,7 @@ export const AccountsList = () => {
 
   return (
     <div>
-      <h1 className="text-xl font-bold text-gray-900">Accounts</h1>
+      <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">Accounts</h1>
 
       <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center">
         <div className="w-full sm:w-64">
@@ -45,8 +45,8 @@ export const AccountsList = () => {
               onClick={() => { setAccountType(opt.value); setPage(1) }}
               className={`rounded-md px-3 py-1.5 text-sm font-medium ${
                 accountType === opt.value
-                  ? 'bg-primary-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  ? 'bg-primary-600 dark:bg-primary-500 text-white'
+                  : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
               }`}
             >
               {opt.label}
@@ -56,35 +56,35 @@ export const AccountsList = () => {
       </div>
 
       <div className="mt-4 overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+          <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Roles</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Email</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">ID</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Type</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Roles</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200 bg-white">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
             {accounts.map((account) => (
-              <tr key={account.id} className="hover:bg-gray-50">
+              <tr key={account.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
                 <td className="whitespace-nowrap px-4 py-3 text-sm">
-                  <Link to={`/accounts/${account.id}`} className="text-primary-600 hover:text-primary-800 font-medium">
+                  <Link to={`/accounts/${account.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-medium">
                     {account.email}
                   </Link>
                 </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 font-mono">{truncateId(account.id)}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400 font-mono">{truncateId(account.id)}</td>
                 <td className="whitespace-nowrap px-4 py-3 text-sm">
                   <Badge>{account.account_type}</Badge>
                 </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{account.roles?.length ?? 0}</td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(account.created_at)}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{account.roles?.length ?? 0}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(account.created_at)}</td>
               </tr>
             ))}
             {accounts.length === 0 && (
               <tr>
-                <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500">No accounts found</td>
+                <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No accounts found</td>
               </tr>
             )}
           </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/in-flight-signals/InFlightSignals.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/in-flight-signals/InFlightSignals.tsx
@@ -39,13 +39,13 @@ export const InFlightSignals = () => {
   return (
     <div>
       <h1 className="page-heading">In-flight signals</h1>
-      <p className="mt-1 text-sm text-gray-500">{signals.length} active signals (auto-refreshing)</p>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{signals.length} active signals (auto-refreshing)</p>
 
       <div className="mt-3">
         <select
           value={namespace}
           onChange={(e) => setNamespace(e.target.value)}
-          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300"
+          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700"
         >
           <option value="">All namespaces</option>
           {namespaces.map((n) => (
@@ -67,7 +67,7 @@ export const InFlightSignals = () => {
               <th>Updated</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
             {signals.map((signal) => (
               <tr key={signal.id}>
                 <td>
@@ -76,27 +76,27 @@ export const InFlightSignals = () => {
                 <td className="whitespace-nowrap text-sm">
                   <Badge>{signal.type}</Badge>
                 </td>
-                <td className="whitespace-nowrap text-sm text-gray-500">
+                <td className="whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                   <span className="font-mono text-xs">{truncateId(signal.owner_id)}</span>
-                  <span className="ml-1 text-xs text-gray-400">({signal.owner_type})</span>
+                  <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">({signal.owner_type})</span>
                 </td>
-                <td className="whitespace-nowrap text-sm text-gray-500 font-mono">
-                  <Link to={`/queues/${signal.queue_id}`} className="text-primary-600 hover:text-primary-700">
+                <td className="whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 font-mono">
+                  <Link to={`/queues/${signal.queue_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">
                     {truncateId(signal.queue_id)}
                   </Link>
                 </td>
                 <td className="whitespace-nowrap text-sm">
                   <Badge variant="status" status={String(signal.status?.status || signal.status)}>{String(signal.status?.status || signal.status)}</Badge>
                 </td>
-                <td className="whitespace-nowrap text-sm text-gray-500 font-mono">
+                <td className="whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 font-mono">
                   {getElapsed(signal.updated_at)}
                 </td>
-                <td className="whitespace-nowrap text-sm text-gray-500">{formatDate(signal.updated_at)}</td>
+                <td className="whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{formatDate(signal.updated_at)}</td>
               </tr>
             ))}
             {signals.length === 0 && (
               <tr>
-                <td colSpan={7} className="text-center text-gray-500 py-6">No in-flight signals</td>
+                <td colSpan={7} className="text-center text-gray-500 dark:text-gray-400 py-6">No in-flight signals</td>
               </tr>
             )}
           </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/installs/InstallDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/installs/InstallDetail.tsx
@@ -126,54 +126,54 @@ export const InstallDetail = () => {
   return (
     <div className="space-y-6">
       {/* Breadcrumb */}
-      <nav className="flex items-center gap-2 text-sm text-gray-500">
-        <Link to="/installs" className="text-primary-600 hover:text-primary-800">Installs</Link>
+      <nav className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+        <Link to="/installs" className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">Installs</Link>
         <span>/</span>
-        <span className="text-gray-900">{install.name || truncateId(install.id)}</span>
+        <span className="text-gray-900 dark:text-gray-100">{install.name || truncateId(install.id)}</span>
       </nav>
 
       {/* Page Heading */}
       <div className="page-heading">
         <div className="flex items-center gap-3">
-          <h1 className="text-xl font-bold text-gray-900">{install.name || truncateId(install.id)}</h1>
+          <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">{install.name || truncateId(install.id)}</h1>
           <Badge variant="status" status={install.status}>{install.status}</Badge>
           {install.status_description && (
-            <span className="text-xs text-gray-500" title={install.status_description}>{install.status_description}</span>
+            <span className="text-xs text-gray-500 dark:text-gray-400" title={install.status_description}>{install.status_description}</span>
           )}
         </div>
-        <p className="mt-1 text-sm text-gray-500 font-mono">{install.id}</p>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400 font-mono">{install.id}</p>
         <div className="mt-2 flex flex-wrap items-center gap-3 text-sm">
-          <span className="text-gray-500">
-            Org: <Link to={`/orgs/${install.org_id}`} className="text-primary-600 hover:text-primary-800">{install.org?.name || truncateId(install.org_id)}</Link>
+          <span className="text-gray-500 dark:text-gray-400">
+            Org: <Link to={`/orgs/${install.org_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">{install.org?.name || truncateId(install.org_id)}</Link>
           </span>
-          <span className="text-gray-500">
+          <span className="text-gray-500 dark:text-gray-400">
             App: {install.app?.name || truncateId(install.app_id)}
           </span>
           {install.cloud_platform && (
-            <span className="text-gray-500">
+            <span className="text-gray-500 dark:text-gray-400">
               Cloud: <Badge>{install.cloud_platform}</Badge>
             </span>
           )}
           {install.runner_type && (
-            <span className="text-gray-500">
+            <span className="text-gray-500 dark:text-gray-400">
               Runner Type: <Badge>{install.runner_type}</Badge>
             </span>
           )}
           {install.app_config?.version ? (
-            <span className="text-gray-500">Config v{install.app_config.version}</span>
+            <span className="text-gray-500 dark:text-gray-400">Config v{install.app_config.version}</span>
           ) : null}
         </div>
-        <div className="mt-1 flex items-center gap-4 text-xs text-gray-400">
+        <div className="mt-1 flex items-center gap-4 text-xs text-gray-400 dark:text-gray-500">
           <span>Created {formatDate(install.created_at)}</span>
           <span>Updated {formatDate(install.updated_at)}</span>
         </div>
         <div className="mt-2 flex items-center gap-3">
           {dashboardUrl && (
-            <a href={dashboardUrl} target="_blank" rel="noopener noreferrer" className="text-sm text-primary-600 hover:text-primary-800 underline">
+            <a href={dashboardUrl} target="_blank" rel="noopener noreferrer" className="text-sm text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 underline">
               View Dashboard
             </a>
           )}
-          <Link to={`/queues?search=${install.id}`} className="text-sm text-primary-600 hover:text-primary-800 underline">
+          <Link to={`/queues?search=${install.id}`} className="text-sm text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 underline">
             View Queues
           </Link>
         </div>
@@ -181,14 +181,14 @@ export const InstallDetail = () => {
 
       {/* Labels */}
       <div className="table-card p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Labels</h2>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Labels</h2>
         <div className="mt-2 flex flex-wrap gap-2">
           {Object.entries(install.labels || {}).map(([key, value]) => (
-            <span key={key} className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700">
+            <span key={key} className="inline-flex items-center gap-1 rounded-full bg-gray-100 dark:bg-gray-800 px-2.5 py-0.5 text-xs font-medium text-gray-700 dark:text-gray-300">
               {key}={value}
               <button
                 onClick={() => removeLabelMutation.mutate(key)}
-                className="ml-1 text-gray-400 hover:text-red-500"
+                className="ml-1 text-gray-400 dark:text-gray-500 hover:text-red-500"
                 disabled={removeLabelMutation.isPending}
               >
                 x
@@ -202,19 +202,19 @@ export const InstallDetail = () => {
             value={newLabelKey}
             onChange={(e) => setNewLabelKey(e.target.value)}
             placeholder="Key"
-            className="block w-32 rounded-md border-0 py-1 px-2 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+            className="block w-32 rounded-md border-0 py-1 px-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
           />
           <input
             type="text"
             value={newLabelValue}
             onChange={(e) => setNewLabelValue(e.target.value)}
             placeholder="Value"
-            className="block w-32 rounded-md border-0 py-1 px-2 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+            className="block w-32 rounded-md border-0 py-1 px-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
           />
           <button
             onClick={() => newLabelKey.trim() && addLabelMutation.mutate()}
             disabled={addLabelMutation.isPending || !newLabelKey.trim()}
-            className="rounded-md bg-primary-600 px-3 py-1 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+            className="rounded-md bg-primary-600 dark:bg-primary-500 px-3 py-1 text-sm font-medium text-white hover:bg-primary-700 dark:hover:bg-primary-600 disabled:opacity-50"
           >
             Add
           </button>
@@ -223,58 +223,58 @@ export const InstallDetail = () => {
 
       {/* Status Badges */}
       <div className="table-card p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Status</h2>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Status</h2>
         <div className="mt-2 grid grid-cols-2 gap-4 sm:grid-cols-4">
           <div>
-            <p className="text-xs text-gray-500">Runner</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Runner</p>
             {runnerStatus ? (
               <div className="flex items-center gap-1">
                 <Badge variant="status" status={runnerStatus.status}>{runnerStatus.status}</Badge>
                 {runnerStatus.description && (
-                  <span className="text-xs text-gray-400" title={runnerStatus.description}>{runnerStatus.description}</span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500" title={runnerStatus.description}>{runnerStatus.description}</span>
                 )}
               </div>
             ) : (
-              <span className="text-xs text-gray-400">Loading...</span>
+              <span className="text-xs text-gray-400 dark:text-gray-500">Loading...</span>
             )}
           </div>
           <div>
-            <p className="text-xs text-gray-500">Sandbox</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Sandbox</p>
             {sandboxStatus ? (
               <div className="flex items-center gap-1">
                 <Badge variant="status" status={sandboxStatus.status}>{sandboxStatus.status}</Badge>
                 {sandboxStatus.description && (
-                  <span className="text-xs text-gray-400" title={sandboxStatus.description}>{sandboxStatus.description}</span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500" title={sandboxStatus.description}>{sandboxStatus.description}</span>
                 )}
               </div>
             ) : (
-              <span className="text-xs text-gray-400">Loading...</span>
+              <span className="text-xs text-gray-400 dark:text-gray-500">Loading...</span>
             )}
           </div>
           <div>
-            <p className="text-xs text-gray-500">Component</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Component</p>
             {componentStatus ? (
               <div className="flex items-center gap-1">
                 <Badge variant="status" status={componentStatus.status}>{componentStatus.status}</Badge>
                 {componentStatus.description && (
-                  <span className="text-xs text-gray-400" title={componentStatus.description}>{componentStatus.description}</span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500" title={componentStatus.description}>{componentStatus.description}</span>
                 )}
               </div>
             ) : (
-              <span className="text-xs text-gray-400">Loading...</span>
+              <span className="text-xs text-gray-400 dark:text-gray-500">Loading...</span>
             )}
           </div>
           <div>
-            <p className="text-xs text-gray-500">Drift</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Drift</p>
             {driftStatus ? (
               <div className="flex items-center gap-1">
                 <Badge variant="status" status={driftStatus.status}>{driftStatus.status}</Badge>
                 {driftStatus.description && (
-                  <span className="text-xs text-gray-400" title={driftStatus.description}>{driftStatus.description}</span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500" title={driftStatus.description}>{driftStatus.description}</span>
                 )}
               </div>
             ) : (
-              <span className="text-xs text-gray-400">Loading...</span>
+              <span className="text-xs text-gray-400 dark:text-gray-500">Loading...</span>
             )}
           </div>
         </div>
@@ -282,40 +282,40 @@ export const InstallDetail = () => {
 
       {/* Active Deployments */}
       <div className="table-card p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Active Deployments</h2>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Active Deployments</h2>
         <div className="mt-2 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Component</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Build ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Component</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Type</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Build ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
               {(deploymentsData?.deployments || []).map((dep: any) => (
                 <tr key={dep.id}>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 font-mono">{truncateId(dep.id)}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{dep.component_name || '-'}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{dep.install_deploy_type || '-'}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 font-mono">{dep.build_id ? truncateId(dep.build_id) : '-'}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400 font-mono">{truncateId(dep.id)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{dep.component_name || '-'}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{dep.install_deploy_type || '-'}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400 font-mono">{dep.build_id ? truncateId(dep.build_id) : '-'}</td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
                     <div className="flex items-center gap-1">
                       <Badge variant="status" status={dep.status}>{dep.status}</Badge>
                       {dep.status_description && (
-                        <span className="text-xs text-gray-400" title={dep.status_description}>{dep.status_description}</span>
+                        <span className="text-xs text-gray-400 dark:text-gray-500" title={dep.status_description}>{dep.status_description}</span>
                       )}
                     </div>
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(dep.created_at)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(dep.created_at)}</td>
                 </tr>
               ))}
               {(!deploymentsData?.deployments || deploymentsData.deployments.length === 0) && (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500">No active deployments</td>
+                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No active deployments</td>
                 </tr>
               )}
             </tbody>
@@ -325,46 +325,46 @@ export const InstallDetail = () => {
 
       {/* Workflows */}
       <div className="table-card p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Workflows</h2>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Workflows</h2>
         <div className="mt-2 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Duration</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Type</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Duration</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
               {(workflowsData?.workflows || []).map((wf: any) => {
                 const wfStatus = getStatus(wf.status)
                 const wfStatusDesc = getStatusDescription(wf.status)
                 return (
-                  <tr key={wf.id} className="hover:bg-gray-50">
+                  <tr key={wf.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
                     <td className="whitespace-nowrap px-4 py-3 text-sm">
-                      <Link to={`/workflows/${wf.id}`} className="text-primary-600 hover:text-primary-800 font-mono">
+                      <Link to={`/workflows/${wf.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-mono">
                         {truncateId(wf.id)}
                       </Link>
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{wf.type}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{wf.type}</td>
                     <td className="whitespace-nowrap px-4 py-3 text-sm">
                       <div className="flex items-center gap-1">
                         <Badge variant="status" status={wfStatus}>{wfStatus}</Badge>
                         {wfStatusDesc && (
-                          <span className="text-xs text-gray-400" title={wfStatusDesc}>{wfStatusDesc}</span>
+                          <span className="text-xs text-gray-400 dark:text-gray-500" title={wfStatusDesc}>{wfStatusDesc}</span>
                         )}
                       </div>
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDuration(wf.execution_time)}</td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(wf.created_at)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDuration(wf.execution_time)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(wf.created_at)}</td>
                   </tr>
                 )
               })}
               {(!workflowsData?.workflows || workflowsData.workflows.length === 0) && (
                 <tr>
-                  <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500">No workflows</td>
+                  <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No workflows</td>
                 </tr>
               )}
             </tbody>
@@ -377,12 +377,12 @@ export const InstallDetail = () => {
 
       {/* Activity */}
       <div className="table-card p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Activity</h2>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Activity</h2>
         <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
           <select
             value={activityEntityType}
             onChange={(e) => { setActivityEntityType(e.target.value); setActivityPage(1) }}
-            className="block w-48 rounded-md border-0 py-1 px-2 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+            className="block w-48 rounded-md border-0 py-1 px-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
           >
             <option value="">All types</option>
             <option value="runner_job">Runner Job</option>
@@ -392,49 +392,49 @@ export const InstallDetail = () => {
             type="date"
             value={activityStartDate}
             onChange={(e) => { setActivityStartDate(e.target.value); setActivityPage(1) }}
-            className="block rounded-md border-0 py-1 px-2 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+            className="block rounded-md border-0 py-1 px-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
           />
           <input
             type="date"
             value={activityEndDate}
             onChange={(e) => { setActivityEndDate(e.target.value); setActivityPage(1) }}
-            className="block rounded-md border-0 py-1 px-2 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+            className="block rounded-md border-0 py-1 px-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
           />
         </div>
         <div className="mt-2 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Entity Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Entity ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Entity Type</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Entity ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Description</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
               {(activityData?.activity_logs || []).map((entry: any, idx: number) => (
                 <tr key={entry.entity_id + '-' + idx}>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
                     <Badge>{entry.entity_type}</Badge>
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{entry.entity_name || '-'}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{entry.entity_name || '-'}</td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm font-mono">
                     {entry.entity_type === 'workflow' ? (
-                      <Link to={`/workflows/${entry.entity_id}`} className="text-primary-600 hover:text-primary-800">
+                      <Link to={`/workflows/${entry.entity_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">
                         {truncateId(entry.entity_id)}
                       </Link>
                     ) : (
-                      <span className="text-gray-500">{truncateId(entry.entity_id)}</span>
+                      <span className="text-gray-500 dark:text-gray-400">{truncateId(entry.entity_id)}</span>
                     )}
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{entry.description || '-'}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(entry.created_at)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{entry.description || '-'}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(entry.created_at)}</td>
                 </tr>
               ))}
               {(!activityData?.activity_logs || activityData.activity_logs.length === 0) && (
                 <tr>
-                  <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500">No activity</td>
+                  <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No activity</td>
                 </tr>
               )}
             </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/installs/InstallsList.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/installs/InstallsList.tsx
@@ -54,7 +54,7 @@ export const InstallsList = () => {
 
   return (
     <div>
-      <h1 className="text-xl font-bold text-gray-900">Installs</h1>
+      <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">Installs</h1>
 
       <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:flex-wrap">
         <div className="w-full sm:w-64">
@@ -67,8 +67,8 @@ export const InstallsList = () => {
               onClick={() => { setCreatorType(opt.value); setPage(1) }}
               className={`rounded-md px-3 py-1.5 text-sm font-medium ${
                 creatorType === opt.value
-                  ? 'bg-primary-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  ? 'bg-primary-600 dark:bg-primary-500 text-white'
+                  : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
               }`}
             >
               {opt.label}
@@ -78,60 +78,60 @@ export const InstallsList = () => {
         <select
           value={sort}
           onChange={(e) => { setSort(e.target.value); setPage(1) }}
-          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
         >
           {SORT_OPTIONS.map((opt) => (
             <option key={opt.value} value={opt.value}>{opt.label}</option>
           ))}
         </select>
-        <label className="flex items-center gap-1 text-sm text-gray-700 cursor-pointer">
+        <label className="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
           <input
             type="checkbox"
             checked={showDeleted}
             onChange={(e) => { setShowDeleted(e.target.checked); setPage(1) }}
-            className="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+            className="rounded border-gray-300 dark:border-gray-700 text-primary-600 dark:text-primary-400 focus:ring-primary-500"
           />
           Show deleted
         </label>
       </div>
 
       <div className="mt-4 overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+          <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Org</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">App</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Runner</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Sandbox</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Components</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">ID</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Org</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">App</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Runner</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Sandbox</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Components</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200 bg-white">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
             {installs.map((install) => {
               const isDeleted = !!install.deleted_at
               const runnerStatus = getStatus(install.runner_status)
               const sandboxStatus = getStatus(install.sandbox_status)
               const componentStatus = getStatus(install.composite_component_status)
               return (
-                <tr key={install.id} className={`hover:bg-gray-50 ${isDeleted ? 'opacity-50' : ''}`}>
+                <tr key={install.id} className={`hover:bg-gray-50 dark:hover:bg-gray-800 ${isDeleted ? 'opacity-50' : ''}`}>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
                     <div className="flex items-center gap-2">
-                      <Link to={`/installs/${install.id}`} className="text-primary-600 hover:text-primary-800 font-medium">
+                      <Link to={`/installs/${install.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-medium">
                         {install.name || truncateId(install.id)}
                       </Link>
                       {isDeleted && <Badge variant="status" status="error">Deleted</Badge>}
                     </div>
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 font-mono">{truncateId(install.id)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400 font-mono">{truncateId(install.id)}</td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
-                    <Link to={`/orgs/${install.org_id}`} className="text-primary-600 hover:text-primary-800">
+                    <Link to={`/orgs/${install.org_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">
                       {install.org?.name || truncateId(install.org_id)}
                     </Link>
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
                     {install.app?.name || truncateId(install.app_id)}
                   </td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
@@ -143,13 +143,13 @@ export const InstallsList = () => {
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
                     {componentStatus && <Badge variant="status" status={componentStatus}>{componentStatus}</Badge>}
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(install.created_at)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(install.created_at)}</td>
                 </tr>
               )
             })}
             {installs.length === 0 && (
               <tr>
-                <td colSpan={8} className="px-4 py-8 text-center text-sm text-gray-500">No installs found</td>
+                <td colSpan={8} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No installs found</td>
               </tr>
             )}
           </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/labels/Labels.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/labels/Labels.tsx
@@ -41,7 +41,7 @@ export const Labels = () => {
   return (
     <div>
       <h1 className="page-heading">Labels</h1>
-      <p className="mt-1 text-sm text-gray-500">{total_count} results{all_keys.length > 0 && ` across ${all_keys.length} label keys`}</p>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{total_count} results{all_keys.length > 0 && ` across ${all_keys.length} label keys`}</p>
 
       <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:flex-wrap">
         <div className="w-full sm:w-64">
@@ -59,8 +59,8 @@ export const Labels = () => {
               onClick={() => { setEntityType(opt.value); setPage(1) }}
               className={`rounded-md px-3 py-1.5 text-sm font-medium ${
                 entityType === opt.value
-                  ? 'bg-primary-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  ? 'bg-primary-600 dark:bg-primary-500 text-white'
+                  : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
               }`}
             >
               {opt.label}
@@ -72,7 +72,7 @@ export const Labels = () => {
           <select
             value={orgId}
             onChange={(e) => { setOrgId(e.target.value); setPage(1) }}
-            className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+            className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
           >
             <option value="">All organizations</option>
             {orgs.map((org) => (
@@ -88,7 +88,7 @@ export const Labels = () => {
             <button
               key={key}
               onClick={() => { setSearch(key); setPage(1) }}
-              className="rounded-md bg-gray-100 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-200"
+              className="rounded-md bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
             >
               {key}
             </button>
@@ -106,7 +106,7 @@ export const Labels = () => {
               <th>Labels</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
             {results.map((result) => (
               <tr key={`${result.entity_type}-${result.entity_id}`}>
                 <td>
@@ -114,21 +114,21 @@ export const Labels = () => {
                 </td>
                 <td>
                   {result.detail_url ? (
-                    <Link to={result.detail_url} className="text-primary-600 hover:text-primary-700 font-medium">
+                    <Link to={result.detail_url} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium">
                       {result.entity_name || truncateId(result.entity_id)}
                     </Link>
                   ) : (
-                    <span className="text-sm text-gray-900">{result.entity_name || truncateId(result.entity_id)}</span>
+                    <span className="text-sm text-gray-900 dark:text-gray-100">{result.entity_name || truncateId(result.entity_id)}</span>
                   )}
                 </td>
-                <td className="text-gray-500 font-mono text-xs">{truncateId(result.entity_id)}</td>
+                <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">{truncateId(result.entity_id)}</td>
                 <td>
                   <div className="flex flex-wrap gap-1">
                     {Object.entries(result.labels || {}).map(([key, value]) => (
-                      <span key={key} className="inline-flex items-center gap-0.5 rounded-md bg-blue-50 border border-blue-200 px-2 py-0.5 text-xs font-mono">
-                        <span className="text-blue-700">{key}</span>
+                      <span key={key} className="inline-flex items-center gap-0.5 rounded-md bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 px-2 py-0.5 text-xs font-mono">
+                        <span className="text-blue-700 dark:text-blue-300">{key}</span>
                         <span className="text-blue-400">=</span>
-                        <span className="text-blue-600">{String(value)}</span>
+                        <span className="text-blue-600 dark:text-blue-400">{String(value)}</span>
                       </span>
                     ))}
                   </div>
@@ -137,7 +137,7 @@ export const Labels = () => {
             ))}
             {results.length === 0 && (
               <tr>
-                <td colSpan={4} className="text-center text-gray-500 py-6">No labeled entities found</td>
+                <td colSpan={4} className="text-center text-gray-500 dark:text-gray-400 py-6">No labeled entities found</td>
               </tr>
             )}
           </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/log-streams/LogStreamDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/log-streams/LogStreamDetail.tsx
@@ -12,17 +12,17 @@ function severityColor(severity: string): string {
   switch (severity?.toUpperCase()) {
     case 'ERROR':
     case 'FATAL':
-      return 'text-red-600'
+      return 'text-red-600 dark:text-red-400'
     case 'WARN':
     case 'WARNING':
       return 'text-orange-500'
     case 'INFO':
-      return 'text-blue-600'
+      return 'text-blue-600 dark:text-blue-400'
     case 'DEBUG':
     case 'TRACE':
-      return 'text-gray-400'
+      return 'text-gray-400 dark:text-gray-500'
     default:
-      return 'text-gray-600'
+      return 'text-gray-600 dark:text-gray-400'
   }
 }
 
@@ -48,20 +48,20 @@ function AttributeTable({ title, attrs }: { title: string; attrs: Record<string,
   if (!attrs || Object.keys(attrs).length === 0) return null
   return (
     <div>
-      <h4 className="text-xs font-semibold text-gray-500 uppercase mb-1">{title}</h4>
-      <div className="rounded border border-gray-200 overflow-hidden">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+      <h4 className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1">{title}</h4>
+      <div className="rounded border border-gray-200 dark:border-gray-800 overflow-hidden">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+          <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th className="px-3 py-1.5 text-left text-xs font-medium text-gray-500">Key</th>
-              <th className="px-3 py-1.5 text-left text-xs font-medium text-gray-500">Value</th>
+              <th className="px-3 py-1.5 text-left text-xs font-medium text-gray-500 dark:text-gray-400">Key</th>
+              <th className="px-3 py-1.5 text-left text-xs font-medium text-gray-500 dark:text-gray-400">Value</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100">
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
             {Object.entries(attrs).map(([key, value]) => (
               <tr key={key}>
-                <td className="px-3 py-1.5 text-xs font-mono text-gray-700 whitespace-nowrap">{key}</td>
-                <td className="px-3 py-1.5 text-xs font-mono text-gray-900 break-all">{value}</td>
+                <td className="px-3 py-1.5 text-xs font-mono text-gray-700 dark:text-gray-300 whitespace-nowrap">{key}</td>
+                <td className="px-3 py-1.5 text-xs font-mono text-gray-900 dark:text-gray-100 break-all">{value}</td>
               </tr>
             ))}
           </tbody>
@@ -112,19 +112,19 @@ export const LogStreamDetail = () => {
   return (
     <div className="space-y-6">
       {/* Breadcrumb */}
-      <nav className="text-sm text-gray-500">
-        <Link to="/log-streams" className="text-primary-600 hover:text-primary-800">Log Streams</Link>
+      <nav className="text-sm text-gray-500 dark:text-gray-400">
+        <Link to="/log-streams" className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">Log Streams</Link>
         <span className="mx-1">/</span>
         <span className="font-mono">{truncateId(log_stream.id)}</span>
       </nav>
 
       {/* Header */}
       <div>
-        <h1 className="text-xl font-bold text-gray-900">Log Stream</h1>
-        <p className="mt-1 text-sm text-gray-500 font-mono">{log_stream.id}</p>
-        <div className="mt-2 grid grid-cols-1 gap-1 sm:grid-cols-2 lg:grid-cols-4 text-sm text-gray-500">
+        <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">Log Stream</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400 font-mono">{log_stream.id}</p>
+        <div className="mt-2 grid grid-cols-1 gap-1 sm:grid-cols-2 lg:grid-cols-4 text-sm text-gray-500 dark:text-gray-400">
           <div>
-            Org: <Link to={`/orgs/${log_stream.org_id}`} className="text-primary-600 hover:text-primary-800 font-mono">{truncateId(log_stream.org_id)}</Link>
+            Org: <Link to={`/orgs/${log_stream.org_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-mono">{truncateId(log_stream.org_id)}</Link>
           </div>
           <div>
             Owner: <span className="font-mono text-xs">{truncateId(log_stream.owner_id)}</span>{' '}
@@ -135,40 +135,40 @@ export const LogStreamDetail = () => {
       </div>
 
       {/* Logs */}
-      <div className="table-card rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">
+      <div className="table-card rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
           Logs
           {logs.length > 0 && (
-            <span className="ml-2 text-xs font-normal text-gray-500">
+            <span className="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">
               (page {logsData?.page || data?.page || logsPage} of {totalPages})
             </span>
           )}
         </h2>
         <div className="mt-2 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
                 <th className="w-8 px-2 py-3"></th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Timestamp</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Severity</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Service</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Body</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Timestamp</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Severity</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Service</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Body</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
               {logs.map((log: any, i: number) => {
                 const isExpanded = expandedRows.has(i)
                 return (
                   <>
                     <tr
                       key={`row-${i}`}
-                      className="hover:bg-gray-50 cursor-pointer"
+                      className="hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer"
                       onClick={() => toggleRow(i)}
                     >
-                      <td className="px-2 py-3 text-xs text-gray-400">
+                      <td className="px-2 py-3 text-xs text-gray-400 dark:text-gray-500">
                         {isExpanded ? '\u25BC' : '\u25B6'}
                       </td>
-                      <td className="whitespace-nowrap px-4 py-3 text-xs text-gray-500 font-mono">
+                      <td className="whitespace-nowrap px-4 py-3 text-xs text-gray-500 dark:text-gray-400 font-mono">
                         {formatDate(log.timestamp)}
                       </td>
                       <td className="whitespace-nowrap px-4 py-3 text-xs">
@@ -176,16 +176,16 @@ export const LogStreamDetail = () => {
                           {log.severity_text || '-'}
                         </span>
                       </td>
-                      <td className="whitespace-nowrap px-4 py-3 text-xs text-gray-700">
+                      <td className="whitespace-nowrap px-4 py-3 text-xs text-gray-700 dark:text-gray-300">
                         {log.service_name || '-'}
                       </td>
-                      <td className="px-4 py-3 text-xs text-gray-900 max-w-lg truncate">
+                      <td className="px-4 py-3 text-xs text-gray-900 dark:text-gray-100 max-w-lg truncate">
                         {log.body}
                       </td>
                     </tr>
                     {isExpanded && (
                       <tr key={`detail-${i}`}>
-                        <td colSpan={5} className="px-4 py-4 bg-gray-50">
+                        <td colSpan={5} className="px-4 py-4 bg-gray-50 dark:bg-gray-900">
                           <div className="space-y-4">
                             {/* Core details */}
                             <div className="grid grid-cols-2 gap-x-8 gap-y-2 sm:grid-cols-3 lg:grid-cols-4">
@@ -202,8 +202,8 @@ export const LogStreamDetail = () => {
                                 .filter(({ value }) => value)
                                 .map(({ label, value }) => (
                                   <div key={label}>
-                                    <div className="text-xs text-gray-500">{label}</div>
-                                    <div className="text-xs font-mono text-gray-900 break-all">{value}</div>
+                                    <div className="text-xs text-gray-500 dark:text-gray-400">{label}</div>
+                                    <div className="text-xs font-mono text-gray-900 dark:text-gray-100 break-all">{value}</div>
                                   </div>
                                 ))}
                             </div>
@@ -211,8 +211,8 @@ export const LogStreamDetail = () => {
                             {/* Full body */}
                             {log.body && log.body.length > 80 && (
                               <div>
-                                <h4 className="text-xs font-semibold text-gray-500 uppercase mb-1">Full Body</h4>
-                                <pre className="text-xs font-mono text-gray-900 bg-white border border-gray-200 rounded p-3 overflow-x-auto whitespace-pre-wrap break-all">
+                                <h4 className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-1">Full Body</h4>
+                                <pre className="text-xs font-mono text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded p-3 overflow-x-auto whitespace-pre-wrap break-all">
                                   {log.body}
                                 </pre>
                               </div>
@@ -231,7 +231,7 @@ export const LogStreamDetail = () => {
               })}
               {logs.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500">No logs</td>
+                  <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No logs</td>
                 </tr>
               )}
             </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/log-streams/LogStreams.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/log-streams/LogStreams.tsx
@@ -22,45 +22,45 @@ export const LogStreams = () => {
 
   return (
     <div>
-      <h1 className="text-xl font-bold text-gray-900">Log Streams</h1>
+      <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">Log Streams</h1>
 
       <div className="mt-4 w-full sm:w-64">
         <SearchInput value={search} onChange={setSearch} placeholder="Search log streams..." />
       </div>
 
       <div className="mt-4 overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+          <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Org ID</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Owner</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">ID</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Org ID</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Owner</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200 bg-white">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
             {logStreams.map((ls) => (
-              <tr key={ls.id} className="hover:bg-gray-50">
+              <tr key={ls.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
                 <td className="whitespace-nowrap px-4 py-3 text-sm">
-                  <Link to={`/log-streams/${ls.id}`} className="text-primary-600 hover:text-primary-800 font-mono">
+                  <Link to={`/log-streams/${ls.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-mono">
                     {truncateId(ls.id)}
                   </Link>
                 </td>
                 <td className="whitespace-nowrap px-4 py-3 text-sm">
-                  <Link to={`/orgs/${ls.org_id}`} className="text-primary-600 hover:text-primary-800 font-mono">
+                  <Link to={`/orgs/${ls.org_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-mono">
                     {truncateId(ls.org_id)}
                   </Link>
                 </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
                   <span className="font-mono text-xs">{truncateId(ls.owner_id)}</span>
-                  <span className="ml-1 text-xs text-gray-400">({ls.owner_type})</span>
+                  <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">({ls.owner_type})</span>
                 </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(ls.created_at)}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(ls.created_at)}</td>
               </tr>
             ))}
             {logStreams.length === 0 && (
               <tr>
-                <td colSpan={4} className="px-4 py-8 text-center text-sm text-gray-500">No log streams found</td>
+                <td colSpan={4} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No log streams found</td>
               </tr>
             )}
           </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/orgs/OrgDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/orgs/OrgDetail.tsx
@@ -69,10 +69,10 @@ export const OrgDetail = () => {
   return (
     <div className="space-y-6">
       {/* Breadcrumb */}
-      <nav className="flex items-center gap-1 text-sm text-gray-500">
-        <Link to="/orgs" className="text-primary-600 hover:text-primary-700">Orgs</Link>
+      <nav className="flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400">
+        <Link to="/orgs" className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">Orgs</Link>
         <span>/</span>
-        <span className="text-gray-900 font-medium">{org.name}</span>
+        <span className="text-gray-900 dark:text-gray-100 font-medium">{org.name}</span>
       </nav>
 
       {/* Header */}
@@ -84,30 +84,30 @@ export const OrgDetail = () => {
               href={`${app_url}/${org.id}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 rounded-md bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700"
+              className="inline-flex items-center gap-1 rounded-md bg-primary-600 dark:bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 dark:hover:bg-primary-600"
             >
               View Dashboard
             </a>
           )}
         </div>
-        <p className="mt-1 text-sm text-gray-500 font-mono">{org.id}</p>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400 font-mono">{org.id}</p>
         <div className="mt-2 flex items-center gap-2">
           {org.status && (
             <Badge variant="status" status={getStatus(org.status)}>{getStatus(org.status)}</Badge>
           )}
           {org.status_description && (
-            <span className="text-xs text-gray-500">{org.status_description}</span>
+            <span className="text-xs text-gray-500 dark:text-gray-400">{org.status_description}</span>
           )}
         </div>
-        <div className="mt-2 text-xs text-gray-500 flex gap-4">
+        <div className="mt-2 text-xs text-gray-500 dark:text-gray-400 flex gap-4">
           <span>Created: {formatDate(org.created_at)}</span>
           <span>Updated: {formatDate(org.updated_at)}</span>
         </div>
       </div>
 
       {/* Labels */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Labels</h2>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Labels</h2>
         <div className="mt-2 flex flex-wrap gap-1.5">
           {[
             { key: 'demo', label: 'Demo' },
@@ -130,8 +130,8 @@ export const OrgDetail = () => {
                 disabled={addLabelMutation.isPending || removeLabelMutation.isPending}
                 className={`rounded-full px-3 py-1 text-xs font-medium border transition-colors ${
                   isSet
-                    ? 'bg-primary-100 border-primary-300 text-primary-700'
-                    : 'bg-gray-50 border-gray-200 text-gray-500 hover:border-gray-300'
+                    ? 'bg-primary-100 dark:bg-primary-900/40 border-primary-300 dark:border-primary-700 text-primary-700 dark:text-primary-300'
+                    : 'bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600'
                 }`}
               >
                 {label}
@@ -142,10 +142,10 @@ export const OrgDetail = () => {
         {Object.keys(orgLabels).length > 0 ? (
           <div className="mt-2 flex flex-wrap gap-2">
             {Object.entries(orgLabels).map(([key, value]) => (
-              <span key={key} className="inline-flex items-center gap-1 rounded-md bg-blue-50 border border-blue-200 px-2 py-0.5 text-xs font-mono">
-                <span className="text-blue-700">{key}</span>
+              <span key={key} className="inline-flex items-center gap-1 rounded-md bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 px-2 py-0.5 text-xs font-mono">
+                <span className="text-blue-700 dark:text-blue-300">{key}</span>
                 <span className="text-blue-400">=</span>
-                <span className="text-blue-600">{String(value)}</span>
+                <span className="text-blue-600 dark:text-blue-400">{String(value)}</span>
                 <button
                   onClick={() => removeLabelMutation.mutate(key)}
                   disabled={removeLabelMutation.isPending}
@@ -157,7 +157,7 @@ export const OrgDetail = () => {
             ))}
           </div>
         ) : (
-          <p className="mt-2 text-sm text-gray-500">No labels</p>
+          <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">No labels</p>
         )}
         <div className="mt-2 flex gap-2">
           <input
@@ -165,7 +165,7 @@ export const OrgDetail = () => {
             value={labelKey}
             onChange={(e) => setLabelKey(e.target.value)}
             placeholder="Key"
-            className="block w-32 rounded-md border-0 py-1.5 px-2.5 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400"
+            className="block w-32 rounded-md border-0 py-1.5 px-2.5 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 placeholder:text-gray-400"
           />
           <input
             type="text"
@@ -173,12 +173,12 @@ export const OrgDetail = () => {
             onChange={(e) => setLabelValue(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && handleAddLabel()}
             placeholder="Value"
-            className="block w-40 rounded-md border-0 py-1.5 px-2.5 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400"
+            className="block w-40 rounded-md border-0 py-1.5 px-2.5 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 placeholder:text-gray-400"
           />
           <button
             onClick={handleAddLabel}
             disabled={addLabelMutation.isPending}
-            className="rounded-md bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+            className="rounded-md bg-primary-600 dark:bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 dark:hover:bg-primary-600 disabled:opacity-50"
           >
             Add
           </button>
@@ -187,11 +187,11 @@ export const OrgDetail = () => {
 
       {/* Most Recent App */}
       {recent_app && (
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900">Most Recent App</h2>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Most Recent App</h2>
           <div className="mt-2 space-y-1">
-            <p className="text-sm text-gray-900 font-medium">{recent_app.name}</p>
-            <p className="text-xs text-gray-500 font-mono">{recent_app.id}</p>
+            <p className="text-sm text-gray-900 dark:text-gray-100 font-medium">{recent_app.name}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 font-mono">{recent_app.id}</p>
             {recent_app.status && (
               <Badge variant="status" status={getStatus(recent_app.status)}>{getStatus(recent_app.status)}</Badge>
             )}
@@ -201,8 +201,8 @@ export const OrgDetail = () => {
 
       {/* Component Graph */}
       {graph_dot && (
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900">Component dependency graph</h2>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Component dependency graph</h2>
           <div className="mt-2">
             <DotGraph dot={graph_dot} height="28rem" />
           </div>
@@ -210,37 +210,37 @@ export const OrgDetail = () => {
       )}
 
       {/* Actions */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Actions</h2>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Actions</h2>
         <div className="mt-2 flex gap-3">
           <div>
             <button
               onClick={() => supportMutation.mutate()}
               disabled={supportMutation.isPending}
-              className="rounded-md bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+              className="rounded-md bg-primary-600 dark:bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 dark:hover:bg-primary-600 disabled:opacity-50"
             >
               {supportMutation.isPending ? 'Adding...' : 'Add support users'}
             </button>
-            {supportMutation.isSuccess && <span className="ml-2 text-sm text-green-600">Done</span>}
-            {supportMutation.isError && <span className="ml-2 text-sm text-red-600">Failed</span>}
+            {supportMutation.isSuccess && <span className="ml-2 text-sm text-green-600 dark:text-green-400">Done</span>}
+            {supportMutation.isError && <span className="ml-2 text-sm text-red-600 dark:text-red-400">Failed</span>}
           </div>
           <div>
             <button
               onClick={() => migrateMutation.mutate()}
               disabled={migrateMutation.isPending}
-              className="rounded-md bg-orange-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-orange-700 disabled:opacity-50"
+              className="rounded-md bg-orange-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-orange-700 dark:hover:bg-orange-600 disabled:opacity-50"
             >
               {migrateMutation.isPending ? 'Migrating...' : 'Migrate queues'}
             </button>
-            {migrateMutation.isSuccess && <span className="ml-2 text-sm text-green-600">Migration started</span>}
-            {migrateMutation.isError && <span className="ml-2 text-sm text-red-600">Failed</span>}
+            {migrateMutation.isSuccess && <span className="ml-2 text-sm text-green-600 dark:text-green-400">Migration started</span>}
+            {migrateMutation.isError && <span className="ml-2 text-sm text-red-600 dark:text-red-400">Failed</span>}
           </div>
         </div>
       </div>
 
       {/* Installs */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Installs</h2>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Installs</h2>
         <div className="mt-2 table-card">
           <table>
             <thead>
@@ -254,7 +254,7 @@ export const OrgDetail = () => {
                 <th>Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
               {installs.map((install: any) => {
                 const isDeleted = !!install.deleted_at
                 const runnerStatus = getStatus(install.runner_status)
@@ -264,14 +264,14 @@ export const OrgDetail = () => {
                   <tr key={install.id} className={isDeleted ? 'opacity-50' : ''}>
                     <td>
                       <div className="flex items-center gap-2">
-                        <Link to={`/installs/${install.id}`} className="text-primary-600 hover:text-primary-700 font-medium">
+                        <Link to={`/installs/${install.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium">
                           {install.name || truncateId(install.id)}
                         </Link>
                         {isDeleted && <Badge variant="status" status="error">Deleted</Badge>}
                       </div>
                     </td>
-                    <td className="text-gray-500 font-mono text-xs">{truncateId(install.id)}</td>
-                    <td className="text-sm text-gray-700">
+                    <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">{truncateId(install.id)}</td>
+                    <td className="text-sm text-gray-700 dark:text-gray-300">
                       {install.app?.name || truncateId(install.app_id || '')}
                     </td>
                     <td>
@@ -289,12 +289,12 @@ export const OrgDetail = () => {
                         <Badge variant="status" status={componentStatus}>{componentStatus}</Badge>
                       )}
                     </td>
-                    <td className="text-gray-500">{formatDate(install.created_at)}</td>
+                    <td className="text-gray-500 dark:text-gray-400">{formatDate(install.created_at)}</td>
                   </tr>
                 )
               })}
               {installs.length === 0 && (
-                <tr><td colSpan={7} className="text-center text-gray-500 py-6">No installs found</td></tr>
+                <tr><td colSpan={7} className="text-center text-gray-500 dark:text-gray-400 py-6">No installs found</td></tr>
               )}
             </tbody>
           </table>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/orgs/OrgsList.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/orgs/OrgsList.tsx
@@ -40,60 +40,60 @@ export const OrgsList = () => {
 
   return (
     <div>
-      <h1 className="text-xl font-bold text-gray-900">Organizations</h1>
+      <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">Organizations</h1>
 
       <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:flex-wrap">
         <div className="w-full sm:w-64">
           <SearchInput value={search} onChange={(v) => { setSearch(v); setPage(1) }} placeholder="Search orgs..." />
         </div>
-        <select
-          value={labelKey}
-          onChange={(e) => { setLabelKey(e.target.value); setLabelValue(''); setPage(1) }}
-          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300"
-        >
-          <option value="">All labels</option>
-          {label_options.map((l) => (
-            <option key={l.key} value={l.key}>{l.key}</option>
-          ))}
-        </select>
-        {labelKey && selectedLabelOption && selectedLabelOption.values.length > 0 && (
-          <select
-            value={labelValue}
-            onChange={(e) => { setLabelValue(e.target.value); setPage(1) }}
-            className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300"
-          >
-            <option value="">Any value</option>
-            {selectedLabelOption.values.map((v) => (
-              <option key={v} value={v}>{v}</option>
-            ))}
-          </select>
-        )}
-      </div>
+<select
+  value={labelKey}
+  onChange={(e) => { setLabelKey(e.target.value); setLabelValue(''); setPage(1) }}
+  className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 dark:bg-gray-900"
+>
+  <option value="">All labels</option>
+  {label_options.map((l) => (
+    <option key={l.key} value={l.key}>{l.key}</option>
+  ))}
+</select>
+{labelKey && selectedLabelOption && selectedLabelOption.values.length > 0 && (
+  <select
+    value={labelValue}
+    onChange={(e) => { setLabelValue(e.target.value); setPage(1) }}
+    className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 dark:bg-gray-900"
+  >
+    <option value="">Any value</option>
+    {selectedLabelOption.values.map((v) => (
+      <option key={v} value={v}>{v}</option>
+    ))}
+  </select>
+)}
+</div>
 
       <div className="mt-4 overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+          <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Labels</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Apps</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Installs</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+<th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+<th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">ID</th>
+<th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+<th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Labels</th>
+<th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Apps</th>
+<th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Installs</th>
+<th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200 bg-white">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
             {orgs.map((org) => {
               const orgLabels = org.labels || {}
               return (
-                <tr key={org.id} className="hover:bg-gray-50">
+                <tr key={org.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
-                    <Link to={`/orgs/${org.id}`} className="text-primary-600 hover:text-primary-800 font-medium">
+                    <Link to={`/orgs/${org.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-medium">
                       {org.name}
                     </Link>
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 font-mono">{truncateId(org.id)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400 font-mono">{truncateId(org.id)}</td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
                     {org.status && (
                       <Badge variant="status" status={getStatus(org.status)}>{getStatus(org.status)}</Badge>
@@ -102,23 +102,23 @@ export const OrgsList = () => {
                   <td className="px-4 py-3 text-sm">
                     <div className="flex flex-wrap gap-1">
                       {Object.entries(orgLabels).map(([k, v]) => (
-                        <span key={k} className="inline-flex items-center rounded bg-blue-50 border border-blue-200 px-1.5 py-0.5 text-[10px] font-mono">
-                          <span className="text-blue-700">{k}</span>
+                        <span key={k} className="inline-flex items-center rounded bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 px-1.5 py-0.5 text-[10px] font-mono">
+                          <span className="text-blue-700 dark:text-blue-300">{k}</span>
                           <span className="text-blue-400">=</span>
-                          <span className="text-blue-600">{String(v)}</span>
+                          <span className="text-blue-600 dark:text-blue-400">{String(v)}</span>
                         </span>
                       ))}
                     </div>
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{org.app_count ?? '-'}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{org.install_count ?? '-'}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(org.created_at)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{org.app_count ?? '-'}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{org.install_count ?? '-'}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(org.created_at)}</td>
                 </tr>
               )
             })}
             {orgs.length === 0 && (
               <tr>
-                <td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-500">No organizations found</td>
+                <td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No organizations found</td>
               </tr>
             )}
           </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/queue-signals/QueueSignals.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/queue-signals/QueueSignals.tsx
@@ -55,7 +55,7 @@ export const QueueSignals = () => {
         <select
           value={signalType}
           onChange={(e) => { setSignalType(e.target.value); setPage(1) }}
-          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300"
+          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700"
         >
           <option value="">All types</option>
           {signalTypes.map((t) => (
@@ -85,27 +85,27 @@ export const QueueSignals = () => {
               <th>Created</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
             {signals.map((signal) => (
               <tr key={signal.id}>
                 <td>
                   <SignalLink signalId={signal.id} queueId={signal.queue_id} />
                 </td>
                 <td><Badge>{signal.type}</Badge></td>
-                <td className="text-gray-500">
+                <td className="text-gray-500 dark:text-gray-400">
                   <span className="font-mono text-xs">{truncateId(signal.owner_id)}</span>
-                  <span className="ml-1 text-xs text-gray-400">({signal.owner_type})</span>
+                  <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">({signal.owner_type})</span>
                 </td>
-                <td className="text-gray-500 font-mono text-xs">{truncateId(signal.queue_id)}</td>
+                <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">{truncateId(signal.queue_id)}</td>
                 <td>
                   <Badge variant="status" status={String(signal.status?.status || signal.status)}>{String(signal.status?.status || signal.status)}</Badge>
                 </td>
-                <td className="text-gray-500">{formatDate(signal.created_at)}</td>
+                <td className="text-gray-500 dark:text-gray-400">{formatDate(signal.created_at)}</td>
               </tr>
             ))}
             {signals.length === 0 && (
               <tr>
-                <td colSpan={6} className="text-center text-gray-500 py-6">No signals found</td>
+                <td colSpan={6} className="text-center text-gray-500 dark:text-gray-400 py-6">No signals found</td>
               </tr>
             )}
           </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/queues/QueueDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/queues/QueueDetail.tsx
@@ -81,8 +81,8 @@ export const QueueDetail = () => {
   return (
     <div className="space-y-6">
       {/* Breadcrumb */}
-      <nav className="text-sm text-gray-500">
-        <Link to="/queues" className="text-primary-600 hover:text-primary-800">Queues</Link>
+      <nav className="text-sm text-gray-500 dark:text-gray-400">
+        <Link to="/queues" className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">Queues</Link>
         <span className="mx-1">/</span>
         <span className="font-mono">{truncateId(queue.id)}</span>
       </nav>
@@ -91,7 +91,7 @@ export const QueueDetail = () => {
       <div className="flex items-start justify-between">
         <div>
           <div className="flex items-center gap-3 flex-wrap">
-            <h1 className="text-xl font-bold text-gray-900">{queue.name}</h1>
+            <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">{queue.name}</h1>
             {queue.status_v2?.status && (
               <Badge variant="status" status={getStatus(queue.status_v2)}>
                 {getStatus(queue.status_v2)}
@@ -101,8 +101,8 @@ export const QueueDetail = () => {
               {queueStatusLabel(status)}
             </Badge>
           </div>
-          <p className="mt-1 text-sm text-gray-500 font-mono">{queue.id}</p>
-          <div className="mt-1 flex items-center gap-2 text-sm text-gray-500">
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400 font-mono">{queue.id}</p>
+          <div className="mt-1 flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
             <span>Owner:</span>
             <span className="font-mono text-xs">{truncateId(queue.owner_id)}</span>
             <Badge variant="default">{queue.owner_type}</Badge>
@@ -113,7 +113,7 @@ export const QueueDetail = () => {
             href={`${temporal_ui_url}/namespaces/components/workflows/${queue.workflow.id}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200"
+            className="rounded-md bg-gray-100 dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700"
           >
             View in Temporal
           </a>
@@ -122,28 +122,28 @@ export const QueueDetail = () => {
 
       {/* Stats Cards */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <div className="text-xs font-medium text-gray-500 uppercase">Max Depth</div>
-          <div className="mt-1 text-2xl font-semibold text-gray-900">{queue.max_depth}</div>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Max Depth</div>
+          <div className="mt-1 text-2xl font-semibold text-gray-900 dark:text-gray-100">{queue.max_depth}</div>
         </div>
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <div className="text-xs font-medium text-gray-500 uppercase">Max In-Flight</div>
-          <div className="mt-1 text-2xl font-semibold text-gray-900">{queue.max_in_flight}</div>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Max In-Flight</div>
+          <div className="mt-1 text-2xl font-semibold text-gray-900 dark:text-gray-100">{queue.max_in_flight}</div>
         </div>
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <div className="text-xs font-medium text-gray-500 uppercase">Queue Depth</div>
-          <div className="mt-1 text-2xl font-semibold text-gray-900">{status?.QueueDepthCount ?? '-'}</div>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Queue Depth</div>
+          <div className="mt-1 text-2xl font-semibold text-gray-900 dark:text-gray-100">{status?.QueueDepthCount ?? '-'}</div>
         </div>
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <div className="text-xs font-medium text-gray-500 uppercase">In-Flight</div>
-          <div className="mt-1 text-2xl font-semibold text-gray-900">{status?.InFlightCount ?? '-'}</div>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">In-Flight</div>
+          <div className="mt-1 text-2xl font-semibold text-gray-900 dark:text-gray-100">{status?.InFlightCount ?? '-'}</div>
         </div>
       </div>
 
       {/* Status Timestamps */}
       {queue.metadata && (
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900">Status Timestamps</h2>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Status Timestamps</h2>
           <div className="mt-2 grid grid-cols-2 gap-x-8 gap-y-2 sm:grid-cols-3 lg:grid-cols-5">
             {[
               { label: 'Ready At', key: 'ready_at' },
@@ -153,8 +153,8 @@ export const QueueDetail = () => {
               { label: 'Finished At', key: 'finished_at' },
             ].map(({ label, key }) => (
               <div key={key}>
-                <div className="text-xs text-gray-500">{label}</div>
-                <div className="text-sm text-gray-900 font-mono">
+                <div className="text-xs text-gray-500 dark:text-gray-400">{label}</div>
+                <div className="text-sm text-gray-900 dark:text-gray-100 font-mono">
                   {queue.metadata?.[key] ? formatRelativeDate(queue.metadata[key]) : '-'}
                 </div>
               </div>
@@ -168,7 +168,7 @@ export const QueueDetail = () => {
         <button
           onClick={() => restartMutation.mutate()}
           disabled={restartMutation.isPending}
-          className="rounded-md bg-yellow-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-yellow-700 disabled:opacity-50"
+          className="rounded-md bg-yellow-600 dark:bg-yellow-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-yellow-700 dark:hover:bg-yellow-600 disabled:opacity-50"
         >
           {restartMutation.isPending ? 'Restarting...' : 'Restart Queue'}
         </button>
@@ -179,7 +179,7 @@ export const QueueDetail = () => {
             }
           }}
           disabled={forceRestartMutation.isPending}
-          className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+          className="rounded-md bg-red-600 dark:bg-red-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50"
         >
           {forceRestartMutation.isPending ? 'Force restarting...' : 'Force Restart'}
         </button>
@@ -190,7 +190,7 @@ export const QueueDetail = () => {
             }
           }}
           disabled={clearMutation.isPending}
-          className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+          className="rounded-md bg-red-600 dark:bg-red-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50"
         >
           {clearMutation.isPending ? 'Clearing...' : 'Clear Queue'}
         </button>
@@ -198,9 +198,9 @@ export const QueueDetail = () => {
 
       {/* Queue Status (StatusV2) */}
       {queue.status_v2?.status && (
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900">Queue Status</h2>
-          <p className="mt-0.5 text-xs text-gray-500">Current status and history</p>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Queue Status</h2>
+          <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">Current status and history</p>
           <div className="mt-3">
             <StatusHistory status={queue.status_v2} defaultExpanded maxCollapsed={5} />
           </div>
@@ -208,51 +208,51 @@ export const QueueDetail = () => {
       )}
 
       {/* Emitters */}
-      <div className="table-card rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Emitters</h2>
+      <div className="table-card rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Emitters</h2>
         <div className="mt-2 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Mode</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Schedule</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Signal type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Emit count</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last emitted</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Owner</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Mode</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Schedule</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Signal type</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Emit count</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Last emitted</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Owner</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
               {(queue.emitters || emittersData?.emitters || []).map((emitter: any) => (
-                <tr key={emitter.id} className="hover:bg-gray-50">
+                <tr key={emitter.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
-                    <Link to={`/queues/${id}/emitters/${emitter.id}`} className="text-primary-600 hover:text-primary-800 font-mono">
+                    <Link to={`/queues/${id}/emitters/${emitter.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-mono">
                       {truncateId(emitter.id)}
                     </Link>
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{emitter.name}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{emitter.mode || '-'}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 font-mono">{emitter.cron_schedule || '-'}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{emitter.signal_type || '-'}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{emitter.name}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{emitter.mode || '-'}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400 font-mono">{emitter.cron_schedule || '-'}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{emitter.signal_type || '-'}</td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
-                    {emitter.status?.status ? <Badge variant="status" status={getStatus(emitter.status)}>{getStatus(emitter.status)}</Badge> : <span className="text-gray-400">-</span>}
+                    {emitter.status?.status ? <Badge variant="status" status={getStatus(emitter.status)}>{getStatus(emitter.status)}</Badge> : <span className="text-gray-400 dark:text-gray-500">-</span>}
                   </td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm font-mono">{emitter.emit_count ?? 0}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{emitter.last_emitted_at ? formatRelativeDate(emitter.last_emitted_at) : '-'}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{emitter.last_emitted_at ? formatRelativeDate(emitter.last_emitted_at) : '-'}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
                     <span className="font-mono text-xs">{truncateId(emitter.owner_id)}</span>
-                    <span className="ml-1 text-xs text-gray-400">({emitter.owner_type})</span>
+                    <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">({emitter.owner_type})</span>
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(emitter.created_at)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(emitter.created_at)}</td>
                 </tr>
               ))}
               {(!(queue.emitters || emittersData?.emitters) || (queue.emitters || emittersData?.emitters || []).length === 0) && (
                 <tr>
-                  <td colSpan={10} className="px-4 py-8 text-center text-sm text-gray-500">No emitters</td>
+                  <td colSpan={10} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No emitters</td>
                 </tr>
               )}
             </tbody>
@@ -264,44 +264,44 @@ export const QueueDetail = () => {
       </div>
 
       {/* Recent Signals */}
-      <div className="table-card rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Recent Signals</h2>
+      <div className="table-card rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Recent Signals</h2>
         <div className="mt-2 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Owner Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Owner ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Type</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Owner Type</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Owner ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
               {(signals || []).map((signal: any) => (
-                <tr key={signal.id} className="hover:bg-gray-50">
+                <tr key={signal.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
-                    <Link to={`/queues/${id}/signals/${signal.id}`} className="text-primary-600 hover:text-primary-800 font-mono">
+                    <Link to={`/queues/${id}/signals/${signal.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-mono">
                       {truncateId(signal.id)}
                     </Link>
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{signal.type}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{signal.type}</td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
                     <Badge variant="status" status={getStatus(signal.status)}>{getStatus(signal.status)}</Badge>
                   </td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
                     <Badge variant="default">{signal.owner_type}</Badge>
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm font-mono text-gray-500">
+                  <td className="whitespace-nowrap px-4 py-3 text-sm font-mono text-gray-500 dark:text-gray-400">
                     {truncateId(signal.owner_id)}
                   </td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(signal.created_at)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(signal.created_at)}</td>
                 </tr>
               ))}
               {(!signals || signals.length === 0) && (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500">No signals</td>
+                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No signals</td>
                 </tr>
               )}
             </tbody>
@@ -310,29 +310,29 @@ export const QueueDetail = () => {
       </div>
 
       {/* In-Flight Signals */}
-      <div className="table-card rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">
+      <div className="table-card rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
           In-Flight Signals
           {(in_flight_signals || inFlightData?.signals || []).length > 0 && (
-            <span className="ml-2 text-xs font-normal text-gray-500">
+            <span className="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">
               ({(in_flight_signals || inFlightData?.signals || []).length})
             </span>
           )}
         </h2>
         <div className="mt-2 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Owner Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Owner ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Updated</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Duration</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Type</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Owner Type</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Owner ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Updated</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Duration</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
               {(in_flight_signals || inFlightData?.signals || []).map((signal: any) => {
                 const createdMs = signal.created_at ? new Date(signal.created_at).getTime() : 0
                 const nowMs = Date.now()
@@ -345,26 +345,26 @@ export const QueueDetail = () => {
                       : `${Math.floor(durationMs / 3600000)}h ${Math.floor((durationMs % 3600000) / 60000)}m`
                   : '-'
                 return (
-                  <tr key={signal.id} className="hover:bg-gray-50">
+                  <tr key={signal.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
                     <td className="whitespace-nowrap px-4 py-3 text-sm">
-                      <Link to={`/queues/${id}/signals/${signal.id}`} className="text-primary-600 hover:text-primary-800 font-mono">
+                      <Link to={`/queues/${id}/signals/${signal.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-mono">
                         {truncateId(signal.id)}
                       </Link>
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{signal.type}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{signal.type}</td>
                     <td className="whitespace-nowrap px-4 py-3 text-sm">
                       <Badge variant="status" status={getStatus(signal.status)}>{getStatus(signal.status)}</Badge>
                     </td>
                     <td className="whitespace-nowrap px-4 py-3 text-sm">
                       <Badge variant="default">{signal.owner_type}</Badge>
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm font-mono text-gray-500">
+                    <td className="whitespace-nowrap px-4 py-3 text-sm font-mono text-gray-500 dark:text-gray-400">
                       {truncateId(signal.owner_id)}
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
                       {formatRelativeDate(signal.updated_at)}
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 font-mono">
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400 font-mono">
                       {durationStr}
                     </td>
                   </tr>
@@ -372,7 +372,7 @@ export const QueueDetail = () => {
               })}
               {(!(in_flight_signals || inFlightData?.signals) || (in_flight_signals || inFlightData?.signals || []).length === 0) && (
                 <tr>
-                  <td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-500">No in-flight signals</td>
+                  <td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No in-flight signals</td>
                 </tr>
               )}
             </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/queues/QueueEmitterDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/queues/QueueEmitterDetail.tsx
@@ -34,16 +34,16 @@ export const QueueEmitterDetail = () => {
   return (
     <div className="space-y-6">
       {/* Breadcrumb */}
-      <div className="flex gap-2 text-xs text-gray-500">
-        <Link to="/queues" className="text-primary-600 hover:text-primary-700">Queues</Link>
+      <div className="flex gap-2 text-xs text-gray-500 dark:text-gray-400">
+        <Link to="/queues" className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">Queues</Link>
         <span>&rarr;</span>
-        <Link to={`/queues/${queue?.id}`} className="text-primary-600 hover:text-primary-700">{truncateId(queue?.id)}</Link>
+        <Link to={`/queues/${queue?.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">{truncateId(queue?.id)}</Link>
         <span>&rarr;</span>
         <span>Emitter</span>
       </div>
 
       {/* Header */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
         <div className="flex flex-wrap items-center gap-2 mb-2">
           <h1 className="text-lg font-semibold">{emitter.name || 'Emitter'}</h1>
           <Badge>{emitter.mode}</Badge>
@@ -53,23 +53,23 @@ export const QueueEmitterDetail = () => {
               href={`${temporalUIUrl}/namespaces/${emitter.workflow.namespace}/workflows/${emitter.workflow.id}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-xs text-primary-600 hover:text-primary-700"
+              className="text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
             >
               View in Temporal &rarr;
             </a>
           )}
         </div>
         <div className="space-y-1 text-xs">
-          <div><span className="text-gray-500 uppercase">Emitter ID:</span> <span className="font-mono select-all">{emitter.id}</span></div>
-          <div><span className="text-gray-500 uppercase">Queue ID:</span> <Link to={`/queues/${emitter.queue_id}`} className="font-mono text-primary-600 hover:text-primary-700">{emitter.queue_id}</Link></div>
+          <div><span className="text-gray-500 dark:text-gray-400 uppercase">Emitter ID:</span> <span className="font-mono select-all">{emitter.id}</span></div>
+          <div><span className="text-gray-500 dark:text-gray-400 uppercase">Queue ID:</span> <Link to={`/queues/${emitter.queue_id}`} className="font-mono text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">{emitter.queue_id}</Link></div>
         </div>
       </div>
 
       {/* Configuration + Runtime state */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {/* Configuration */}
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900 mb-2">Configuration</h2>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">Configuration</h2>
           <div className="space-y-2 text-xs">
             <InfoRow label="Signal type" value={emitter.signal_type} />
             <InfoRow label="Mode" value={emitter.mode} />
@@ -88,11 +88,11 @@ export const QueueEmitterDetail = () => {
         </div>
 
         {/* Runtime state */}
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900 mb-2">Runtime State</h2>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">Runtime State</h2>
           <div className="space-y-2 text-xs">
             <div className="flex items-start gap-3">
-              <span className="text-gray-500 uppercase w-28 shrink-0">Status</span>
+              <span className="text-gray-500 dark:text-gray-400 uppercase w-28 shrink-0">Status</span>
               <Badge variant="status" status={status}>{status || 'unknown'}</Badge>
             </div>
             {emitter.status?.status_human_description && (
@@ -103,7 +103,7 @@ export const QueueEmitterDetail = () => {
             <InfoRow label="Next emit" value={formatDate(emitter.next_emit_at)} />
             {isFireOnce && (
               <div className="flex items-start gap-3">
-                <span className="text-gray-500 uppercase w-28 shrink-0">Fired</span>
+                <span className="text-gray-500 dark:text-gray-400 uppercase w-28 shrink-0">Fired</span>
                 <Badge variant="status" status={emitter.fired ? 'yes' : 'no'}>{emitter.fired ? 'Yes' : 'No'}</Badge>
               </div>
             )}
@@ -113,15 +113,15 @@ export const QueueEmitterDetail = () => {
 
       {/* Signal template */}
       {emitter.signal_template && (
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900 mb-2">Signal Template</h2>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">Signal Template</h2>
           <JsonViewer data={emitter.signal_template} />
         </div>
       )}
 
       {/* Emitted signals */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Emitted Signals ({signals.length})</h2>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Emitted Signals ({signals.length})</h2>
         {signals.length > 0 ? (
           <div className="mt-2 table-card">
             <table>
@@ -134,31 +134,31 @@ export const QueueEmitterDetail = () => {
                   <th>Created</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200">
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
                 {signals.map((sig: any) => (
                   <tr key={sig.id}>
                     <td className="font-mono text-xs">
                       <Link
                         to={`/queues/${queueId}/signals/${sig.id}`}
-                        className="text-primary-600 hover:text-primary-700"
+                        className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
                       >
                         {truncateId(sig.id)}
                       </Link>
                     </td>
                     <td className="text-xs"><Badge>{sig.type}</Badge></td>
                     <td><Badge variant="status" status={getStatus(sig.status)}>{getStatus(sig.status)}</Badge></td>
-                    <td className="text-xs text-gray-500">
+                    <td className="text-xs text-gray-500 dark:text-gray-400">
                       <span className="font-mono">{truncateId(sig.owner_id)}</span>
-                      {sig.owner_type && <span className="text-gray-400 ml-1">({sig.owner_type})</span>}
+                      {sig.owner_type && <span className="text-gray-400 dark:text-gray-500 ml-1">({sig.owner_type})</span>}
                     </td>
-                    <td className="text-xs text-gray-500 whitespace-nowrap">{formatDate(sig.created_at)}</td>
+                    <td className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">{formatDate(sig.created_at)}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
         ) : (
-          <p className="mt-2 text-sm text-gray-500">No signals emitted yet</p>
+          <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">No signals emitted yet</p>
         )}
       </div>
     </div>
@@ -168,7 +168,7 @@ export const QueueEmitterDetail = () => {
 function InfoRow({ label, value }: { label: string; value?: string }) {
   return (
     <div className="flex items-start gap-3">
-      <span className="text-gray-500 uppercase w-28 shrink-0">{label}</span>
+      <span className="text-gray-500 dark:text-gray-400 uppercase w-28 shrink-0">{label}</span>
       <span className="font-mono break-all">{value || '-'}</span>
     </div>
   )

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/queues/QueueSignalDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/queues/QueueSignalDetail.tsx
@@ -80,29 +80,29 @@ export const QueueSignalDetail = () => {
   return (
     <div className="space-y-6">
       {/* Breadcrumb */}
-      <div className="flex gap-2 text-xs text-gray-500">
-        <Link to="/queues" className="text-primary-600 hover:text-primary-700">Queues</Link>
+      <div className="flex gap-2 text-xs text-gray-500 dark:text-gray-400">
+        <Link to="/queues" className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">Queues</Link>
         <span>&rarr;</span>
-        <Link to={`/queues/${queue?.id}`} className="text-primary-600 hover:text-primary-700">{truncateId(queue?.id)}</Link>
+        <Link to={`/queues/${queue?.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">{truncateId(queue?.id)}</Link>
         <span>&rarr;</span>
         <span>Signal</span>
       </div>
 
       {/* Header */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
         <div className="flex flex-wrap items-center gap-2 mb-2">
           <h1 className="text-lg font-semibold">Signal</h1>
           <Badge>{signal?.type}</Badge>
           <Badge variant="status" status={status}>{status}</Badge>
           {temporalUIUrl && signal?.workflow?.id && signal?.workflow?.namespace && (
-            <a href={`${temporalUIUrl}/namespaces/${signal.workflow.namespace}/workflows/${signal.workflow.id}`} target="_blank" rel="noopener noreferrer" className="text-xs text-primary-600 hover:text-primary-700">
+            <a href={`${temporalUIUrl}/namespaces/${signal.workflow.namespace}/workflows/${signal.workflow.id}`} target="_blank" rel="noopener noreferrer" className="text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">
               View in Temporal &rarr;
             </a>
           )}
-          <Link to={`/queues/${queueId}/signals/${signalId}/graph`} className="inline-flex items-center rounded-md bg-primary-50 border border-primary-200 px-2 py-1 text-xs font-medium text-primary-700 hover:bg-primary-100">
+          <Link to={`/queues/${queueId}/signals/${signalId}/graph`} className="inline-flex items-center rounded-md bg-primary-50 dark:bg-primary-950 border border-primary-200 dark:border-primary-800 px-2 py-1 text-xs font-medium text-primary-700 dark:text-primary-300 hover:bg-primary-100 dark:hover:bg-primary-900">
             View as graph
           </Link>
-          <Link to="/signal-catalog" className="text-xs text-primary-600 hover:text-primary-700">View catalog &rarr;</Link>
+          <Link to="/signal-catalog" className="text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">View catalog &rarr;</Link>
           <button
             onClick={() => {
               if (confirm('Are you sure you want to directly execute this signal?')) {
@@ -110,21 +110,21 @@ export const QueueSignalDetail = () => {
               }
             }}
             disabled={directExecuteMutation.isPending}
-            className="ml-auto rounded-md bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50"
+            className="ml-auto rounded-md bg-red-600 dark:bg-red-500 px-2 py-1 text-xs font-medium text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50"
           >
             {directExecuteMutation.isPending ? 'Executing...' : 'Direct Execute'}
           </button>
         </div>
         <div className="space-y-1 text-xs">
-          <div><span className="text-gray-500 uppercase">Signal ID:</span> <span className="font-mono">{signal?.id}</span></div>
-          <div><span className="text-gray-500 uppercase">Queue ID:</span> <Link to={`/queues/${signal?.queue_id}`} className="font-mono text-primary-600 hover:text-primary-700">{signal?.queue_id}</Link></div>
+          <div><span className="text-gray-500 dark:text-gray-400 uppercase">Signal ID:</span> <span className="font-mono">{signal?.id}</span></div>
+          <div><span className="text-gray-500 dark:text-gray-400 uppercase">Queue ID:</span> <Link to={`/queues/${signal?.queue_id}`} className="font-mono text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">{signal?.queue_id}</Link></div>
         </div>
       </div>
 
       {/* Signal attributes */}
       {attrs && (
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900">Signal attributes</h2>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Signal attributes</h2>
           <div className="mt-2 flex flex-wrap gap-2 text-xs">
             {attrs.Namespace && <Badge>ns: {attrs.Namespace}</Badge>}
             {attrs.AutoRetry && <Badge variant="status" status="online">auto-retry</Badge>}
@@ -144,8 +144,8 @@ export const QueueSignalDetail = () => {
       )}
 
       {/* Timeline */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900 mb-3">Timeline</h2>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Timeline</h2>
         <div className="flex items-start justify-between">
           <TimelineStep label="Enqueued" value={enqueuedAt} active />
           <TimelineConnector duration={timeBetween(enqueueStartedAt, enqueueFinishedAt)} />
@@ -162,50 +162,50 @@ export const QueueSignalDetail = () => {
           <TimelineStep label="Execute finished" value={executeFinishedAt} active={!!executeFinishedAt} />
         </div>
         {enqueueTimingMissing && (
-          <div className="mt-3 text-xs text-gray-500">
+          <div className="mt-3 text-xs text-gray-500 dark:text-gray-400">
             Enqueue timing metadata not available (signal created before tracking was added).
           </div>
         )}
       </div>
 
       {/* Signals ahead */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Signals ahead</h2>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Signals ahead</h2>
         {signalsAhead.length > 0 ? (
           <div className="mt-2 space-y-1">
             {signalsAhead.map((sig: any) => (
-              <div key={sig.id} className="flex items-center gap-3 p-2 border border-gray-100 rounded text-xs">
-                <Link to={`/queues/${queue?.id}/signals/${sig.id}`} className="font-mono text-primary-600 hover:text-primary-700 truncate flex-1">{sig.id}</Link>
+              <div key={sig.id} className="flex items-center gap-3 p-2 border border-gray-100 dark:border-gray-800 rounded text-xs">
+                <Link to={`/queues/${queue?.id}/signals/${sig.id}`} className="font-mono text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 truncate flex-1">{sig.id}</Link>
                 <Badge>{sig.type}</Badge>
                 <Badge variant="status" status={getStatus(sig.status)}>{getStatus(sig.status)}</Badge>
-                <span className="text-gray-400 whitespace-nowrap">{formatDate(sig.created_at)}</span>
+                <span className="text-gray-400 dark:text-gray-500 whitespace-nowrap">{formatDate(sig.created_at)}</span>
               </div>
             ))}
           </div>
         ) : (
-          <p className="mt-2 text-sm text-gray-500">No signals ahead</p>
+          <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">No signals ahead</p>
         )}
       </div>
 
       {/* Executions */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Executions</h2>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Executions</h2>
         <div className="mt-2 flex items-center gap-4">
           <div>
-            <p className="text-xs text-gray-500 uppercase">Execution count</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 uppercase">Execution count</p>
             <p className={`text-2xl font-bold font-mono ${signal?.execution_count > 1 ? 'text-orange-500' : ''}`}>
               {signal?.execution_count ?? 0}
             </p>
           </div>
         </div>
         {wfInfo && (
-          <div className="mt-3 border-t border-gray-200 pt-3 space-y-2 text-xs">
-            <div><span className="text-gray-500 uppercase w-32 inline-block">Status</span> <Badge variant="status" status={wfInfo.status}>{wfInfo.status}</Badge></div>
+          <div className="mt-3 border-t border-gray-200 dark:border-gray-800 pt-3 space-y-2 text-xs">
+            <div><span className="text-gray-500 dark:text-gray-400 uppercase w-32 inline-block">Status</span> <Badge variant="status" status={wfInfo.status}>{wfInfo.status}</Badge></div>
             {wfInfo.update_executions?.length > 0 && (
-              <div><span className="text-gray-500 uppercase w-32 inline-block">Updates</span> <span className="font-mono">{wfInfo.update_executions.length}</span></div>
+              <div><span className="text-gray-500 dark:text-gray-400 uppercase w-32 inline-block">Updates</span> <span className="font-mono">{wfInfo.update_executions.length}</span></div>
             )}
             {wfInfo.activities?.length > 0 && (
-              <div><span className="text-gray-500 uppercase w-32 inline-block">Activities</span> <span className="font-mono">{wfInfo.activities.length}</span></div>
+              <div><span className="text-gray-500 dark:text-gray-400 uppercase w-32 inline-block">Activities</span> <span className="font-mono">{wfInfo.activities.length}</span></div>
             )}
             {/* Failures */}
             {(wfInfo.status === 'Failed' || wfInfo.status === 'Timed Out') && (
@@ -213,13 +213,13 @@ export const QueueSignalDetail = () => {
                 {wfInfo.update_executions?.filter((ue: any) => ue.failure).map((ue: any, i: number) => (
                   <div key={i} className="mt-1">
                     <Badge variant="status" status="failed">{ue.name}</Badge>
-                    <pre className="mt-1 text-xs text-red-600 font-mono whitespace-pre-wrap bg-red-50 border border-red-200 rounded p-2">{ue.failure}</pre>
+                    <pre className="mt-1 text-xs text-red-600 dark:text-red-400 font-mono whitespace-pre-wrap bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded p-2">{ue.failure}</pre>
                   </div>
                 ))}
                 {wfInfo.orphan_activities?.filter((a: any) => a.failure).map((a: any, i: number) => (
                   <div key={i} className="mt-1">
                     <Badge variant="status" status="failed">{a.name}</Badge>
-                    <pre className="mt-1 text-xs text-red-600 font-mono whitespace-pre-wrap bg-red-50 border border-red-200 rounded p-2">{a.failure}</pre>
+                    <pre className="mt-1 text-xs text-red-600 dark:text-red-400 font-mono whitespace-pre-wrap bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded p-2">{a.failure}</pre>
                   </div>
                 ))}
               </>
@@ -229,12 +229,12 @@ export const QueueSignalDetail = () => {
       </div>
 
       {/* Signal flow graph */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
         <div className="flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-gray-900">Signal flow graph</h2>
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Signal flow graph</h2>
           <button
             onClick={() => setShowGraph(!showGraph)}
-            className={`rounded-md px-3 py-1.5 text-xs font-medium ${showGraph ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
+            className={`rounded-md px-3 py-1.5 text-xs font-medium ${showGraph ? 'bg-primary-600 dark:bg-primary-500 text-white' : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'}`}
           >
             {showGraph ? 'Hide graph' : 'Load graph'}
           </button>
@@ -245,7 +245,7 @@ export const QueueSignalDetail = () => {
           </div>
         )}
         {showGraph && !graphData?.graph && (
-          <p className="mt-2 text-xs text-gray-500">Loading graph...</p>
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">Loading graph...</p>
         )}
       </div>
 
@@ -256,8 +256,8 @@ export const QueueSignalDetail = () => {
 
       {/* Update handlers */}
       {wfInfo?.update_handlers?.length > 0 && (
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900">Update handlers</h2>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Update handlers</h2>
           <div className="mt-2 flex flex-wrap gap-2">
             {wfInfo.update_handlers.map((h: string) => <Badge key={h}>{h}</Badge>)}
           </div>
@@ -266,8 +266,8 @@ export const QueueSignalDetail = () => {
 
       {/* Signal info + Handler */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900 mb-2">Signal info</h2>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">Signal info</h2>
           <div className="space-y-2 text-xs">
             <InfoRow label="Type" value={signal?.type} />
             <InfoRow label="Status" value={status} />
@@ -280,58 +280,58 @@ export const QueueSignalDetail = () => {
             ))}
           </div>
         </div>
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900 mb-2">Handler</h2>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">Handler</h2>
           <div className="space-y-2 text-xs">
             <InfoRow label="Owner type" value={signal?.owner_type} />
             <div className="flex items-start gap-3">
-              <span className="text-gray-500 uppercase w-28 shrink-0">Owner ID</span>
+              <span className="text-gray-500 dark:text-gray-400 uppercase w-28 shrink-0">Owner ID</span>
               <span className="font-mono break-all">{signal?.owner_id}</span>
             </div>
             {signal?.emitter_id && (
               <div className="flex items-start gap-3">
-                <span className="text-gray-500 uppercase w-28 shrink-0">Emitter</span>
-                <Link to={`/queues/${queue?.id}/emitters/${signal.emitter_id}`} className="font-mono text-primary-600 hover:text-primary-700">{signal.emitter_id}</Link>
+                <span className="text-gray-500 dark:text-gray-400 uppercase w-28 shrink-0">Emitter</span>
+                <Link to={`/queues/${queue?.id}/emitters/${signal.emitter_id}`} className="font-mono text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">{signal.emitter_id}</Link>
               </div>
             )}
             {signal?.workflow?.id && <InfoRow label="Workflow ID" value={signal.workflow.id} />}
             {signal?.workflow?.namespace && <InfoRow label="Namespace" value={signal.workflow.namespace} />}
           </div>
-          <div className="mt-3 pt-3 border-t border-gray-200 flex flex-wrap gap-3 text-xs">
+          <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-800 flex flex-wrap gap-3 text-xs">
             {signal?.workflow?.id && signal?.workflow?.namespace && (
-              <Link to={`/temporal-workflows?namespace=${signal.workflow.namespace}&workflow_id=${signal.workflow.id}`} className="text-primary-600 hover:text-primary-700">
+              <Link to={`/temporal-workflows?namespace=${signal.workflow.namespace}&workflow_id=${signal.workflow.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">
                 View handler workflow &rarr;
               </Link>
             )}
             {temporalUIUrl && signal?.workflow?.id && signal?.workflow?.namespace && (
-              <a href={`${temporalUIUrl}/namespaces/${signal.workflow.namespace}/workflows/${signal.workflow.id}`} target="_blank" rel="noopener noreferrer" className="text-primary-600 hover:text-primary-700">
+              <a href={`${temporalUIUrl}/namespaces/${signal.workflow.namespace}/workflows/${signal.workflow.id}`} target="_blank" rel="noopener noreferrer" className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">
                 View in Temporal UI &rarr;
               </a>
             )}
-            <Link to={`/queue-signals?search=${signal?.owner_id}`} className="text-primary-600 hover:text-primary-700">
+            <Link to={`/queue-signals?search=${signal?.owner_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">
               Owner signals &rarr;
             </Link>
             {signal?.owner_type === 'install_workflow_steps' && (
-              <Link to={`/workflows?search=${signal?.owner_id}`} className="text-primary-600 hover:text-primary-700">Step's workflow &rarr;</Link>
+              <Link to={`/workflows?search=${signal?.owner_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">Step's workflow &rarr;</Link>
             )}
             {signal?.owner_type === 'install_workflows' && (
-              <Link to={`/workflows?search=${signal?.owner_id}`} className="text-primary-600 hover:text-primary-700">Install workflow &rarr;</Link>
+              <Link to={`/workflows?search=${signal?.owner_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">Install workflow &rarr;</Link>
             )}
           </div>
         </div>
       </div>
 
       {/* Signal data */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Signal data</h2>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Signal data</h2>
         <div className="mt-2">
           <JsonViewer data={signal?.signal || signal} />
         </div>
       </div>
 
       {/* Status history */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Status history</h2>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Status history</h2>
         <div className="mt-2">
           <StatusHistory status={signal?.status} maxCollapsed={5} />
         </div>
@@ -343,12 +343,12 @@ export const QueueSignalDetail = () => {
 function TimelineStep({ label, value, active }: { label: string; value?: string; active: boolean }) {
   return (
     <div className="flex flex-col items-center text-center min-w-0 shrink-0">
-      <div className={`w-3 h-3 rounded-full mb-2 ${active ? 'bg-primary-500' : 'bg-gray-300'}`} />
-      <p className="text-[10px] text-gray-500 uppercase font-medium">{label}</p>
+      <div className={`w-3 h-3 rounded-full mb-2 ${active ? 'bg-primary-500' : 'bg-gray-300 dark:bg-gray-600'}`} />
+      <p className="text-[10px] text-gray-500 dark:text-gray-400 uppercase font-medium">{label}</p>
       {value ? (
         <p className="text-[10px] font-mono mt-0.5 max-w-[140px] break-all">{formatDate(value)}</p>
       ) : (
-        <p className="text-[10px] font-mono mt-0.5 text-gray-300">&mdash;</p>
+        <p className="text-[10px] font-mono mt-0.5 text-gray-300 dark:text-gray-400">&mdash;</p>
       )}
     </div>
   )
@@ -357,7 +357,7 @@ function TimelineStep({ label, value, active }: { label: string; value?: string;
 function TimelineConnector({ duration }: { duration: string }) {
   return (
     <div className="flex flex-col items-center flex-1 min-w-[40px] pt-1">
-      <div className="h-px w-full bg-gray-200 mt-1" />
+      <div className="h-px w-full bg-gray-200 dark:bg-gray-700 mt-1" />
       {duration && <p className="text-[10px] font-mono text-primary-500 mt-1">{duration}</p>}
     </div>
   )
@@ -366,7 +366,7 @@ function TimelineConnector({ duration }: { duration: string }) {
 function InfoRow({ label, value, highlight }: { label: string; value?: string; highlight?: boolean }) {
   return (
     <div className="flex items-start gap-3">
-      <span className="text-gray-500 uppercase w-28 shrink-0">{label}</span>
+      <span className="text-gray-500 dark:text-gray-400 uppercase w-28 shrink-0">{label}</span>
       <span className={`font-mono break-all ${highlight ? 'text-orange-500 font-bold' : ''}`}>{value || '-'}</span>
     </div>
   )
@@ -376,21 +376,21 @@ function StatusHistoryEntry({ h, isCurrent }: { h: any; isCurrent?: boolean }) {
   if (!h) return null
   const status = getStatus(h)
   return (
-    <div className="flex items-start gap-3 text-xs border-b border-gray-100 pb-2 last:border-0">
+    <div className="flex items-start gap-3 text-xs border-b border-gray-100 dark:border-gray-800 pb-2 last:border-0">
       <Badge variant="status" status={status}>{status}</Badge>
       <div className="flex-1 space-y-0.5">
         <div>
           {status}
-          {isCurrent && <span className="text-primary-600 font-medium ml-1">(current)</span>}
-          {h.status_human_description && <span className="text-gray-500 ml-1">— {h.status_human_description}</span>}
+          {isCurrent && <span className="text-primary-600 dark:text-primary-400 font-medium ml-1">(current)</span>}
+          {h.status_human_description && <span className="text-gray-500 dark:text-gray-400 ml-1">— {h.status_human_description}</span>}
         </div>
         {h.created_at_ts > 0 && (
-          <div className="text-gray-400 font-mono">{new Date(h.created_at_ts / 1000000).toISOString().replace('T', ' ').slice(0, 19)} UTC</div>
+          <div className="text-gray-400 dark:text-gray-500 font-mono">{new Date(h.created_at_ts / 1000000).toISOString().replace('T', ' ').slice(0, 19)} UTC</div>
         )}
         {h.metadata && Object.keys(h.metadata).length > 0 && (
-          <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-gray-400">
+          <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-gray-400 dark:text-gray-500">
             {Object.entries(h.metadata).map(([k, v]) => (
-              <span key={k}><span className="text-gray-500">{k}:</span> {String(v)}</span>
+              <span key={k}><span className="text-gray-500 dark:text-gray-400">{k}:</span> {String(v)}</span>
             ))}
           </div>
         )}
@@ -426,20 +426,20 @@ function ExecutionWaterfall({ wfInfo, temporalUIUrl, hideReady, setHideReady, so
   if (totalItems === 0) return null
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-4">
+    <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
       <div className="flex items-center justify-between flex-wrap gap-2">
         <div>
-          <h2 className="text-sm font-semibold text-gray-900">Execution waterfall</h2>
-          <p className="mt-0.5 text-xs text-gray-500">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Execution waterfall</h2>
+          <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
             {updates.length}/{allUpdates.length} update{allUpdates.length !== 1 ? 's' : ''}, {childWfs.length} child workflow{childWfs.length !== 1 ? 's' : ''}, {awaited.length} awaited signal{awaited.length !== 1 ? 's' : ''}
           </p>
         </div>
         <div className="flex items-center gap-2 text-xs">
-          <label className="flex items-center gap-1 text-gray-600">
+          <label className="flex items-center gap-1 text-gray-600 dark:text-gray-400">
             <input type="checkbox" checked={hideReady} onChange={(e) => setHideReady(e.target.checked)} />
             Hide "ready" updates
           </label>
-          <select value={sortOrder} onChange={(e) => setSortOrder(e.target.value as any)} className="rounded border-gray-300 text-xs py-1 px-2">
+          <select value={sortOrder} onChange={(e) => setSortOrder(e.target.value as any)} className="rounded border-gray-300 dark:border-gray-700 text-xs py-1 px-2">
             <option value="newest">Newest first</option>
             <option value="oldest">Oldest first</option>
           </select>
@@ -448,7 +448,7 @@ function ExecutionWaterfall({ wfInfo, temporalUIUrl, hideReady, setHideReady, so
 
       <div className="mt-3 relative">
         {/* Vertical line */}
-        <div className="absolute left-3 top-0 bottom-0 w-px bg-gray-200" />
+        <div className="absolute left-3 top-0 bottom-0 w-px bg-gray-200 dark:bg-gray-700" />
 
         <div className="space-y-1">
           {/* Update executions */}
@@ -504,55 +504,55 @@ function WaterfallUpdateNode({ ue, awaited, childWfs, temporalUIUrl }: { ue: any
     return cwStart >= ueStart && cwStart <= ueEnd
   })
 
-  const statusColor = ue.status === 'Completed' ? 'bg-green-500' : ue.status === 'Failed' ? 'bg-red-500' : ue.status === 'Running' ? 'bg-primary-500 animate-pulse' : 'bg-gray-400'
+  const statusColor = ue.status === 'Completed' ? 'bg-green-500' : ue.status === 'Failed' ? 'bg-red-500' : ue.status === 'Running' ? 'bg-primary-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-500'
 
   return (
     <div className="relative pl-7">
       {/* Dot on the vertical line */}
-      <div className={`absolute left-1.5 top-2.5 w-3 h-3 rounded-full ${statusColor} ring-2 ring-white`} />
+      <div className={`absolute left-1.5 top-2.5 w-3 h-3 rounded-full ${statusColor} ring-2 ring-white dark:ring-gray-950`} />
 
-      <div className="border border-gray-200 rounded-lg overflow-hidden">
+      <div className="border border-gray-200 dark:border-gray-800 rounded-lg overflow-hidden">
         <button
           onClick={() => setExpanded(!expanded)}
-          className="w-full flex items-center justify-between px-3 py-2 bg-gray-50 hover:bg-gray-100 text-left"
+          className="w-full flex items-center justify-between px-3 py-2 bg-gray-50 dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 text-left"
         >
           <div className="flex items-center gap-2 text-xs flex-wrap">
             <Badge variant="status" status={ue.status}>{ue.status}</Badge>
             <span className="font-mono font-semibold">{ue.name}</span>
-            <span className="text-gray-400">{formatDuration(ue.duration)}</span>
-            <span className="text-gray-400">{activities.length} activit{activities.length !== 1 ? 'ies' : 'y'}</span>
+            <span className="text-gray-400 dark:text-gray-500">{formatDuration(ue.duration)}</span>
+            <span className="text-gray-400 dark:text-gray-500">{activities.length} activit{activities.length !== 1 ? 'ies' : 'y'}</span>
             {relatedAwaited.length > 0 && <span className="text-orange-500">{relatedAwaited.length} awaited</span>}
             {relatedChildWfs.length > 0 && <span className="text-blue-500">{relatedChildWfs.length} child wf</span>}
-            <span className="text-gray-300 font-mono ml-auto">{ue.started_at ? formatDate(ue.started_at) : ''}</span>
+            <span className="text-gray-300 dark:text-gray-400 font-mono ml-auto">{ue.started_at ? formatDate(ue.started_at) : ''}</span>
           </div>
-          <span className="text-gray-400 text-xs">{expanded ? '▾' : '▸'}</span>
+          <span className="text-gray-400 dark:text-gray-500 text-xs">{expanded ? '▾' : '▸'}</span>
         </button>
 
         {expanded && (
-          <div className="border-t border-gray-200">
+          <div className="border-t border-gray-200 dark:border-gray-800">
             {/* Update metadata */}
             {(ue.input || ue.result || ue.failure) && (
-              <div className="px-3 py-2 border-b border-gray-100 text-xs space-y-1 bg-gray-50/50">
+              <div className="px-3 py-2 border-b border-gray-100 dark:border-gray-800 text-xs space-y-1 bg-gray-50/50 dark:bg-gray-900/50">
                 {ue.failure && (
-                  <pre className="font-mono text-red-600 bg-red-50 border border-red-200 rounded p-2 overflow-x-auto max-h-24 whitespace-pre-wrap">{ue.failure}</pre>
+                  <pre className="font-mono text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded p-2 overflow-x-auto max-h-24 whitespace-pre-wrap">{ue.failure}</pre>
                 )}
                 {ue.input && (
                   <details className="group">
-                    <summary className="text-gray-500 cursor-pointer hover:text-gray-700">Input</summary>
-                    <pre className="mt-1 font-mono bg-gray-50 rounded p-2 overflow-x-auto max-h-24 text-[10px]">{ue.input}</pre>
+                    <summary className="text-gray-500 dark:text-gray-400 cursor-pointer hover:text-gray-700 dark:hover:text-gray-200">Input</summary>
+                    <pre className="mt-1 font-mono bg-gray-50 dark:bg-gray-900 rounded p-2 overflow-x-auto max-h-24 text-[10px]">{ue.input}</pre>
                   </details>
                 )}
                 {ue.result && (
                   <details className="group">
-                    <summary className="text-gray-500 cursor-pointer hover:text-gray-700">Result</summary>
-                    <pre className="mt-1 font-mono bg-gray-50 rounded p-2 overflow-x-auto max-h-24 text-[10px]">{ue.result}</pre>
+                    <summary className="text-gray-500 dark:text-gray-400 cursor-pointer hover:text-gray-700 dark:hover:text-gray-200">Result</summary>
+                    <pre className="mt-1 font-mono bg-gray-50 dark:bg-gray-900 rounded p-2 overflow-x-auto max-h-24 text-[10px]">{ue.result}</pre>
                   </details>
                 )}
               </div>
             )}
 
             {/* Activities + awaited signals + child workflows as waterfall items */}
-            <div className="divide-y divide-gray-100">
+            <div className="divide-y divide-gray-100 dark:divide-gray-800">
               {activities.map((act: any, i: number) => (
                 <WaterfallActivityRow key={`act-${i}`} act={act} />
               ))}
@@ -572,22 +572,22 @@ function WaterfallUpdateNode({ ue, awaited, childWfs, temporalUIUrl }: { ue: any
 
 function WaterfallActivityRow({ act }: { act: any }) {
   const [showDetail, setShowDetail] = useState(false)
-  const dot = act.status === 'Completed' ? 'text-green-500' : act.status === 'Failed' ? 'text-red-500' : act.status === 'Running' ? 'text-primary-500' : 'text-gray-400'
+  const dot = act.status === 'Completed' ? 'text-green-500' : act.status === 'Failed' ? 'text-red-500' : act.status === 'Running' ? 'text-primary-500' : 'text-gray-400 dark:text-gray-500'
 
   return (
     <>
-      <div className="flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-gray-50 cursor-pointer" onClick={() => setShowDetail(!showDetail)}>
+      <div className="flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer" onClick={() => setShowDetail(!showDetail)}>
         <span className={`${dot} text-[8px]`}>●</span>
-        <span className="font-mono text-gray-900 flex-1 truncate">{act.name}</span>
+        <span className="font-mono text-gray-900 dark:text-gray-100 flex-1 truncate">{act.name}</span>
         <Badge variant="status" status={act.status}>{act.status}</Badge>
-        <span className="text-gray-400 font-mono w-16 text-right">{formatDuration(act.duration)}</span>
+        <span className="text-gray-400 dark:text-gray-500 font-mono w-16 text-right">{formatDuration(act.duration)}</span>
         {act.attempt > 1 && <span className="text-orange-500">×{act.attempt}</span>}
       </div>
       {showDetail && (
-        <div className="px-3 py-2 bg-gray-50 text-[10px] space-y-1 border-t border-gray-100">
-          {act.failure && <pre className="font-mono text-red-600 bg-red-50 rounded p-1.5 whitespace-pre-wrap">{act.failure}</pre>}
-          {act.input && <details><summary className="text-gray-500 cursor-pointer">Input</summary><pre className="mt-0.5 font-mono bg-white rounded p-1.5 overflow-x-auto max-h-20">{act.input}</pre></details>}
-          {act.result && <details><summary className="text-gray-500 cursor-pointer">Result</summary><pre className="mt-0.5 font-mono bg-white rounded p-1.5 overflow-x-auto max-h-20">{act.result}</pre></details>}
+        <div className="px-3 py-2 bg-gray-50 dark:bg-gray-900 text-[10px] space-y-1 border-t border-gray-100 dark:border-gray-800">
+          {act.failure && <pre className="font-mono text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/30 rounded p-1.5 whitespace-pre-wrap">{act.failure}</pre>}
+          {act.input && <details><summary className="text-gray-500 dark:text-gray-400 cursor-pointer">Input</summary><pre className="mt-0.5 font-mono bg-white dark:bg-gray-900 rounded p-1.5 overflow-x-auto max-h-20">{act.input}</pre></details>}
+          {act.result && <details><summary className="text-gray-500 dark:text-gray-400 cursor-pointer">Result</summary><pre className="mt-0.5 font-mono bg-white dark:bg-gray-900 rounded p-1.5 overflow-x-auto max-h-20">{act.result}</pre></details>}
         </div>
       )}
     </>
@@ -600,26 +600,26 @@ function WaterfallAwaitedSignal({ as: asig }: { as: any }) {
 
   return (
     <>
-      <div className="flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-orange-50 cursor-pointer" onClick={() => setShowDetail(!showDetail)}>
+      <div className="flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-orange-50 dark:hover:bg-orange-900/30 cursor-pointer" onClick={() => setShowDetail(!showDetail)}>
         <span className="text-orange-500 text-[8px]">◇</span>
-        <span className="text-orange-700 font-medium">await signal</span>
+        <span className="text-orange-700 dark:text-orange-300 font-medium">await signal</span>
         {asig.queue_signal_id && (
-          <Link to={`/queue-signals?search=${asig.queue_signal_id}`} className="font-mono text-primary-600 hover:text-primary-700" onClick={(e) => e.stopPropagation()}>
+          <Link to={`/queue-signals?search=${asig.queue_signal_id}`} className="font-mono text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300" onClick={(e) => e.stopPropagation()}>
             {truncateId(asig.queue_signal_id)}
           </Link>
         )}
         <Badge variant="status" status={asig.status}>{asig.status}</Badge>
-        <span className="text-gray-400 font-mono ml-auto w-16 text-right">{formatDuration(asig.duration)}</span>
+        <span className="text-gray-400 dark:text-gray-500 font-mono ml-auto w-16 text-right">{formatDuration(asig.duration)}</span>
       </div>
       {showDetail && asig.signal && (
-        <div className="px-3 py-2 bg-orange-50/50 text-[10px] space-y-1 border-t border-orange-100">
+        <div className="px-3 py-2 bg-orange-50/50 dark:bg-orange-900/30 text-[10px] space-y-1 border-t border-orange-100 dark:border-orange-900">
           <div className="grid grid-cols-2 gap-1 sm:grid-cols-4">
-            <div><span className="text-gray-500">Type:</span> <span className="font-mono">{asig.signal.type}</span></div>
-            <div><span className="text-gray-500">Signal status:</span> <Badge variant="status" status={signalStatus}>{signalStatus}</Badge></div>
-            <div><span className="text-gray-500">Queue:</span> <Link to={`/queues/${asig.signal.queue_id}`} className="font-mono text-primary-600">{truncateId(asig.signal.queue_id)}</Link></div>
-            <div><span className="text-gray-500">Owner:</span> <span className="font-mono">{truncateId(asig.signal.owner_id)}</span></div>
+            <div><span className="text-gray-500 dark:text-gray-400">Type:</span> <span className="font-mono">{asig.signal.type}</span></div>
+            <div><span className="text-gray-500 dark:text-gray-400">Signal status:</span> <Badge variant="status" status={signalStatus}>{signalStatus}</Badge></div>
+            <div><span className="text-gray-500 dark:text-gray-400">Queue:</span> <Link to={`/queues/${asig.signal.queue_id}`} className="font-mono text-primary-600 dark:text-primary-400">{truncateId(asig.signal.queue_id)}</Link></div>
+            <div><span className="text-gray-500 dark:text-gray-400">Owner:</span> <span className="font-mono">{truncateId(asig.signal.owner_id)}</span></div>
           </div>
-          {asig.failure && <pre className="font-mono text-red-600 bg-red-50 rounded p-1.5 whitespace-pre-wrap">{asig.failure}</pre>}
+          {asig.failure && <pre className="font-mono text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/30 rounded p-1.5 whitespace-pre-wrap">{asig.failure}</pre>}
         </div>
       )}
     </>
@@ -631,28 +631,28 @@ function WaterfallChildWorkflow({ cw, temporalUIUrl }: { cw: any; temporalUIUrl:
 
   return (
     <>
-      <div className="flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-blue-50 cursor-pointer" onClick={() => setShowDetail(!showDetail)}>
+      <div className="flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-blue-50 dark:hover:bg-blue-900/30 cursor-pointer" onClick={() => setShowDetail(!showDetail)}>
         <span className="text-blue-500 text-[8px]">⑂</span>
-        <span className="text-blue-700 font-medium">child workflow</span>
-        <span className="font-mono text-gray-900">{cw.workflow_type}</span>
+        <span className="text-blue-700 dark:text-blue-300 font-medium">child workflow</span>
+        <span className="font-mono text-gray-900 dark:text-gray-100">{cw.workflow_type}</span>
         <Badge variant="status" status={cw.status}>{cw.status}</Badge>
-        <span className="text-gray-400 font-mono ml-auto w-16 text-right">{formatDuration(cw.duration)}</span>
+        <span className="text-gray-400 dark:text-gray-500 font-mono ml-auto w-16 text-right">{formatDuration(cw.duration)}</span>
       </div>
       {showDetail && (
-        <div className="px-3 py-2 bg-blue-50/50 text-[10px] space-y-1 border-t border-blue-100">
+        <div className="px-3 py-2 bg-blue-50/50 dark:bg-blue-900/30 text-[10px] space-y-1 border-t border-blue-100 dark:border-blue-900">
           <div className="grid grid-cols-2 gap-1 sm:grid-cols-4">
-            <div><span className="text-gray-500">Namespace:</span> {cw.namespace}</div>
-            <div><span className="text-gray-500">Workflow ID:</span> <span className="font-mono">{cw.workflow_id}</span></div>
-            <div><span className="text-gray-500">Run ID:</span> <span className="font-mono">{truncateId(cw.run_id)}</span></div>
+            <div><span className="text-gray-500 dark:text-gray-400">Namespace:</span> {cw.namespace}</div>
+            <div><span className="text-gray-500 dark:text-gray-400">Workflow ID:</span> <span className="font-mono">{cw.workflow_id}</span></div>
+            <div><span className="text-gray-500 dark:text-gray-400">Run ID:</span> <span className="font-mono">{truncateId(cw.run_id)}</span></div>
             {temporalUIUrl && (
               <div>
-                <a href={`${temporalUIUrl}/namespaces/${cw.namespace}/workflows/${cw.workflow_id}`} target="_blank" rel="noopener noreferrer" className="text-primary-600 hover:text-primary-700">
+                <a href={`${temporalUIUrl}/namespaces/${cw.namespace}/workflows/${cw.workflow_id}`} target="_blank" rel="noopener noreferrer" className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">
                   View in Temporal &rarr;
                 </a>
               </div>
             )}
           </div>
-          {cw.failure && <pre className="font-mono text-red-600 bg-red-50 rounded p-1.5 whitespace-pre-wrap">{cw.failure}</pre>}
+          {cw.failure && <pre className="font-mono text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/30 rounded p-1.5 whitespace-pre-wrap">{cw.failure}</pre>}
         </div>
       )}
     </>
@@ -663,17 +663,17 @@ function WaterfallSection({ icon, label, status, children }: { icon: string; lab
   const [expanded, setExpanded] = useState(true)
   return (
     <div className="relative pl-7">
-      <div className="absolute left-1.5 top-2.5 w-3 h-3 rounded-full bg-gray-300 ring-2 ring-white" />
-      <div className="border border-gray-200 rounded-lg overflow-hidden">
-        <button onClick={() => setExpanded(!expanded)} className="w-full flex items-center justify-between px-3 py-2 bg-gray-50 hover:bg-gray-100 text-left">
+      <div className="absolute left-1.5 top-2.5 w-3 h-3 rounded-full bg-gray-300 dark:bg-gray-600 ring-2 ring-white dark:ring-gray-950" />
+      <div className="border border-gray-200 dark:border-gray-800 rounded-lg overflow-hidden">
+        <button onClick={() => setExpanded(!expanded)} className="w-full flex items-center justify-between px-3 py-2 bg-gray-50 dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 text-left">
           <div className="flex items-center gap-2 text-xs">
             <span>{icon}</span>
-            <span className="font-medium text-gray-700">{label}</span>
+            <span className="font-medium text-gray-700 dark:text-gray-300">{label}</span>
             {status && <Badge variant="status" status={status}>{status}</Badge>}
           </div>
-          <span className="text-gray-400 text-xs">{expanded ? '▾' : '▸'}</span>
+          <span className="text-gray-400 dark:text-gray-500 text-xs">{expanded ? '▾' : '▸'}</span>
         </button>
-        {expanded && <div className="border-t border-gray-200 divide-y divide-gray-100">{children}</div>}
+        {expanded && <div className="border-t border-gray-200 dark:border-gray-800 divide-y divide-gray-100 dark:divide-gray-800">{children}</div>}
       </div>
     </div>
   )

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/queues/QueuesList.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/queues/QueuesList.tsx
@@ -37,7 +37,7 @@ export const QueuesList = () => {
 
   return (
     <div>
-      <h1 className="text-xl font-bold text-gray-900">Queues</h1>
+      <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">Queues</h1>
 
       <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center">
         <div className="w-full sm:w-64">
@@ -48,48 +48,48 @@ export const QueuesList = () => {
           value={name}
           onChange={(e) => { setName(e.target.value); setPage(1) }}
           placeholder="Filter by name..."
-          className="block w-48 rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+          className="block w-48 rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
         />
         <input
           type="text"
           value={namespace}
           onChange={(e) => { setNamespace(e.target.value); setPage(1) }}
           placeholder="Filter by namespace..."
-          className="block w-48 rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+          className="block w-48 rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
         />
       </div>
 
       <div className="mt-4 overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+          <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Owner</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Emitters</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">ID</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Owner</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Emitters</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200 bg-white">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
             {queues.map((queue) => (
-              <tr key={queue.id} className="hover:bg-gray-50">
+              <tr key={queue.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
                 <td className="whitespace-nowrap px-4 py-3 text-sm">
-                  <Link to={`/queues/${queue.id}`} className="text-primary-600 hover:text-primary-800 font-mono">
+                  <Link to={`/queues/${queue.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-mono">
                     {truncateId(queue.id)}
                   </Link>
                 </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{queue.name}</td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{queue.name}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
                   <span className="font-mono text-xs">{truncateId(queue.owner_id)}</span>
-                  <span className="ml-1 text-xs text-gray-400">({queue.owner_type})</span>
+                  <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">({queue.owner_type})</span>
                 </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{queue.emitters?.length ?? 0}</td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{formatDate(queue.created_at)}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{queue.emitters?.length ?? 0}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{formatDate(queue.created_at)}</td>
               </tr>
             ))}
             {queues.length === 0 && (
               <tr>
-                <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500">No queues found</td>
+                <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No queues found</td>
               </tr>
             )}
           </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/queues/SignalGraphView.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/queues/SignalGraphView.tsx
@@ -21,18 +21,18 @@ export const SignalGraphView = () => {
   return (
     <div className="-m-6 lg:-m-8 flex flex-col" style={{ height: 'calc(100vh - 3rem)' }}>
       {/* Compact toolbar */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 bg-white shrink-0">
-        <div className="flex items-center gap-2 text-xs text-gray-500">
-          <Link to={`/queues/${queueId}/signals/${signalId}`} className="text-primary-600 hover:text-primary-700">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shrink-0">
+        <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+          <Link to={`/queues/${queueId}/signals/${signalId}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">
             &larr; Signal {truncateId(signalId || '')}
           </Link>
-          <span className="text-gray-300">|</span>
-          <span className="font-medium text-gray-900">Signal graph</span>
+          <span className="text-gray-300 dark:text-gray-400">|</span>
+          <span className="font-medium text-gray-900 dark:text-gray-100">Signal graph</span>
         </div>
         <div className="flex items-center gap-2">
           <Link
             to={`/queues/${queueId}/signals/${signalId}`}
-            className="rounded-md bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-200"
+            className="rounded-md bg-gray-100 dark:bg-gray-800 px-2.5 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700"
           >
             Back to detail
           </Link>
@@ -44,7 +44,7 @@ export const SignalGraphView = () => {
         {data?.graph ? (
           <SignalFlowGraph graphData={data.graph} height="100%" />
         ) : (
-          <div className="flex items-center justify-center h-full text-sm text-gray-500">No graph data available</div>
+          <div className="flex items-center justify-center h-full text-sm text-gray-500 dark:text-gray-400">No graph data available</div>
         )}
       </div>
     </div>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/runner-uptime/RunnerUptime.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/runner-uptime/RunnerUptime.tsx
@@ -49,10 +49,10 @@ const PieChart = ({ value, max, label, color }: { value: number; max: number; la
 
 const statusColor = (s: string) => {
   switch (s) {
-    case 'active': return 'bg-green-100 text-green-700'
-    case 'inactive': case 'offline': return 'bg-gray-100 text-gray-600'
-    case 'error': return 'bg-red-100 text-red-700'
-    default: return 'bg-yellow-100 text-yellow-700'
+    case 'active': return 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300'
+    case 'inactive': case 'offline': return 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'
+    case 'error': return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+    default: return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300'
   }
 }
 
@@ -65,7 +65,7 @@ const processTypeLabel = (t: string) => {
 }
 
 const JobBar = ({ jobs }: { jobs: TJobSummary }) => {
-  if (jobs.total === 0) return <span className="text-xs text-gray-400">No jobs</span>
+  if (jobs.total === 0) return <span className="text-xs text-gray-400 dark:text-gray-500">No jobs</span>
   const segments = [
     { count: jobs.finished, color: 'bg-green-500', label: 'finished' },
     { count: jobs.failed, color: 'bg-red-500', label: 'failed' },
@@ -75,7 +75,7 @@ const JobBar = ({ jobs }: { jobs: TJobSummary }) => {
   ]
   return (
     <div>
-      <div className="flex h-2 w-full rounded-full overflow-hidden bg-gray-100">
+      <div className="flex h-2 w-full rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800">
         {segments.map((seg) =>
           seg.count > 0 ? (
             <div
@@ -87,11 +87,11 @@ const JobBar = ({ jobs }: { jobs: TJobSummary }) => {
           ) : null
         )}
       </div>
-      <div className="mt-1 flex gap-3 text-[10px] text-gray-500">
+      <div className="mt-1 flex gap-3 text-[10px] text-gray-500 dark:text-gray-400">
         <span>{jobs.total} total</span>
-        <span className="text-green-600">{jobs.finished} ok</span>
-        {jobs.failed > 0 && <span className="text-red-600">{jobs.failed} fail</span>}
-        {jobs.timed_out > 0 && <span className="text-yellow-600">{jobs.timed_out} timeout</span>}
+        <span className="text-green-600 dark:text-green-400">{jobs.finished} ok</span>
+        {jobs.failed > 0 && <span className="text-red-600 dark:text-red-400">{jobs.failed} fail</span>}
+        {jobs.timed_out > 0 && <span className="text-yellow-600 dark:text-yellow-400">{jobs.timed_out} timeout</span>}
       </div>
     </div>
   )
@@ -122,8 +122,8 @@ const MetricsPies = ({ m }: { m: TUptimeMetrics }) => {
           />
           {m.total_health_checks > 0 && (
             <div className="flex gap-1.5 text-[9px]">
-              <span className="text-green-600">{m.healthy_checks} ok</span>
-              {m.unhealthy_checks > 0 && <span className="text-red-600">{m.unhealthy_checks} bad</span>}
+              <span className="text-green-600 dark:text-green-400">{m.healthy_checks} ok</span>
+              {m.unhealthy_checks > 0 && <span className="text-red-600 dark:text-red-400">{m.unhealthy_checks} bad</span>}
             </div>
           )}
         </div>
@@ -140,37 +140,37 @@ const ProcessBlock = ({ procs, metrics, label, color }: {
 }) => {
   return (
     <div className={`rounded-md border p-3 ${color}`}>
-      <h4 className="text-xs font-semibold text-gray-700 mb-2">{label}</h4>
+      <h4 className="text-xs font-semibold text-gray-700 dark:text-gray-200 mb-2">{label}</h4>
       <MetricsPies m={metrics} />
       <div className="mt-2">
-        <h5 className="text-[10px] font-semibold text-gray-500 mb-1">Processes</h5>
+        <h5 className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 mb-1">Processes</h5>
         {procs.length > 0 ? (
-          <div className="divide-y divide-gray-50">
+          <div className="divide-y divide-gray-50 dark:divide-gray-800">
             {procs.map((p) => (
               <div key={p.process_id} className="flex items-center gap-3 py-1.5 text-xs">
                 <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${statusColor(p.status)}`}>
                   {p.status}
                 </span>
                 <Badge>{processTypeLabel(p.type)}</Badge>
-                <span className="font-mono text-gray-500 w-20" title="Process uptime">{p.uptime_str || '—'}</span>
-                {p.heartbeats > 0 && <span className="text-gray-400" title="Heartbeats">{p.heartbeats} hb</span>}
+                <span className="font-mono text-gray-500 dark:text-gray-400 w-20" title="Process uptime">{p.uptime_str || '—'}</span>
+                {p.heartbeats > 0 && <span className="text-gray-400 dark:text-gray-500" title="Heartbeats">{p.heartbeats} hb</span>}
                 {p.health_checks > 0 && (
-                  <span className="text-gray-400" title={`${p.healthy_checks} ok / ${p.unhealthy_checks} bad`}>
+                  <span className="text-gray-400 dark:text-gray-500" title={`${p.healthy_checks} ok / ${p.unhealthy_checks} bad`}>
                     {p.health_checks} hc
-                    {p.unhealthy_checks > 0 && <span className="text-red-500 ml-0.5">({p.unhealthy_checks} bad)</span>}
+                    {p.unhealthy_checks > 0 && <span className="text-red-500 dark:text-red-400 ml-0.5">({p.unhealthy_checks} bad)</span>}
                   </span>
                 )}
                 {p.last_heartbeat && (
-                  <span className="text-[10px] text-gray-400" title="Last heartbeat">
+                  <span className="text-[10px] text-gray-400 dark:text-gray-500" title="Last heartbeat">
                     last hb {new Date(p.last_heartbeat).toLocaleTimeString()}
                   </span>
                 )}
-                <span className="text-gray-400 font-mono text-[10px] ml-auto">{p.version}</span>
+                <span className="text-gray-400 dark:text-gray-500 font-mono text-[10px] ml-auto">{p.version}</span>
               </div>
             ))}
           </div>
         ) : (
-          <span className="text-xs text-gray-400">No processes</span>
+          <span className="text-xs text-gray-400 dark:text-gray-500">No processes</span>
         )}
       </div>
     </div>
@@ -218,7 +218,7 @@ export const RunnerUptime = () => {
       <div className="flex items-center justify-between">
         <h1 className="page-heading">Runner uptime</h1>
         {since && (
-          <span className="text-xs text-gray-400">Since {new Date(since).toLocaleString()}</span>
+          <span className="text-xs text-gray-400 dark:text-gray-500">Since {new Date(since).toLocaleString()}</span>
         )}
       </div>
 
@@ -226,7 +226,7 @@ export const RunnerUptime = () => {
         <select
           value={orgId}
           onChange={(e) => setOrgId(e.target.value)}
-          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300"
+          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 dark:bg-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
         >
           <option value="">All orgs</option>
           {orgs.map((o) => (
@@ -239,7 +239,7 @@ export const RunnerUptime = () => {
         <select
           value={labelKey}
           onChange={(e) => { setLabelKey(e.target.value); setLabelValue('') }}
-          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300"
+          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 dark:bg-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
         >
           <option value="">All labels</option>
           {labelOptions.map((l) => (
@@ -250,7 +250,7 @@ export const RunnerUptime = () => {
           <select
             value={labelValue}
             onChange={(e) => setLabelValue(e.target.value)}
-            className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300"
+            className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 dark:bg-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
           >
             <option value="">Any value</option>
             {selectedLabelOption.values.map((v) => (
@@ -261,7 +261,7 @@ export const RunnerUptime = () => {
         <select
           value={window}
           onChange={(e) => setWindow(e.target.value)}
-          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300"
+          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 dark:bg-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
         >
           {WINDOWS.map((w) => (
             <option key={w.value} value={w.value}>{w.label}</option>
@@ -279,44 +279,44 @@ export const RunnerUptime = () => {
           const successRate = totalJobs > 0 ? ((finishedJobs / totalJobs) * 100).toFixed(1) : null
 
           return (
-            <div key={entry.install_id} className="rounded-md border border-gray-200 bg-white">
+            <div key={entry.install_id} className="rounded-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
               <button
                 onClick={() => setExpanded(isExpanded ? null : entry.install_id)}
-                className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm hover:bg-gray-50"
+                className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-800"
               >
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
-                    <span className="font-medium text-gray-900">{entry.install_name || '(unnamed)'}</span>
+                    <span className="font-medium text-gray-900 dark:text-gray-100">{entry.install_name || '(unnamed)'}</span>
                   </div>
-                  <div className="text-xs text-gray-400 mt-0.5">{entry.org_name}</div>
+                  <div className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{entry.org_name}</div>
                 </div>
                 <div className="flex items-center gap-5 flex-shrink-0 text-xs">
                   <div className="text-center">
-                    <div className="font-semibold text-blue-600">{activeInstall}</div>
-                    <div className="text-[10px] text-gray-400">install</div>
+                    <div className="font-semibold text-blue-600 dark:text-blue-400">{activeInstall}</div>
+                    <div className="text-[10px] text-gray-400 dark:text-gray-500">install</div>
                   </div>
                   <div className="text-center">
-                    <div className="font-semibold text-purple-600">{activeMng}</div>
-                    <div className="text-[10px] text-gray-400">mng</div>
+                    <div className="font-semibold text-purple-600 dark:text-purple-400">{activeMng}</div>
+                    <div className="text-[10px] text-gray-400 dark:text-gray-500">mng</div>
                   </div>
                   <div className="text-center">
-                    <div className="font-semibold text-gray-700">{totalJobs}</div>
-                    <div className="text-[10px] text-gray-400">jobs</div>
+                    <div className="font-semibold text-gray-700 dark:text-gray-200">{totalJobs}</div>
+                    <div className="text-[10px] text-gray-400 dark:text-gray-500">jobs</div>
                   </div>
                   {successRate && (
                     <div className="text-center">
-                      <div className={`font-semibold ${Number(successRate) >= 95 ? 'text-green-600' : Number(successRate) >= 80 ? 'text-yellow-600' : 'text-red-600'}`}>
+                      <div className={`font-semibold ${Number(successRate) >= 95 ? 'text-green-600 dark:text-green-400' : Number(successRate) >= 80 ? 'text-yellow-600 dark:text-yellow-400' : 'text-red-600 dark:text-red-400'}`}>
                         {successRate}%
                       </div>
-                      <div className="text-[10px] text-gray-400">success</div>
+                      <div className="text-[10px] text-gray-400 dark:text-gray-500">success</div>
                     </div>
                   )}
                 </div>
               </button>
               {isExpanded && (
-                <div className="border-t border-gray-100 px-4 py-3 space-y-4">
+                <div className="border-t border-gray-100 dark:border-gray-800 px-4 py-3 space-y-4">
                   {entry.runner_created_at && since && new Date(entry.runner_created_at).getTime() > new Date(since).getTime() && (
-                    <div className="rounded bg-yellow-50 border border-yellow-200 px-3 py-1.5 text-xs text-yellow-700">
+                    <div className="rounded bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800 px-3 py-1.5 text-xs text-yellow-700 dark:text-yellow-300">
                       Runner created after window began ({new Date(entry.runner_created_at).toLocaleString()}) — stats reflect partial coverage
                     </div>
                   )}
@@ -325,20 +325,20 @@ export const RunnerUptime = () => {
                       procs={entry.install_processes}
                       metrics={entry.install_metrics}
                       label="Install process"
-                      color="border-blue-100 bg-blue-50/30"
+                      color="border-blue-100 bg-blue-50/30 dark:border-blue-900/50 dark:bg-blue-950/30"
                     />
                     <ProcessBlock
                       procs={entry.mng_processes}
                       metrics={entry.mng_metrics}
                       label="Management process (mng)"
-                      color="border-purple-100 bg-purple-50/30"
+                      color="border-purple-100 bg-purple-50/30 dark:border-purple-900/50 dark:bg-purple-950/30"
                     />
                   </div>
                   <div>
-                    <h4 className="text-xs font-semibold text-gray-700 mb-1">Runner jobs (combined)</h4>
+                    <h4 className="text-xs font-semibold text-gray-700 dark:text-gray-200 mb-1">Runner jobs (combined)</h4>
                     <JobBar jobs={entry.jobs} />
                   </div>
-                  <div className="text-[10px] text-gray-400 font-mono">
+                  <div className="text-[10px] text-gray-400 dark:text-gray-500 font-mono">
                     install: {entry.install_id} | org: {entry.org_id}
                   </div>
                 </div>
@@ -347,7 +347,7 @@ export const RunnerUptime = () => {
           )
         })}
         {installs.length === 0 && (
-          <div className="text-center text-gray-500 py-8 text-sm">No installs found</div>
+          <div className="text-center text-gray-500 dark:text-gray-400 py-8 text-sm">No installs found</div>
         )}
       </div>
     </div>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/runners/AllRunners.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/runners/AllRunners.tsx
@@ -34,7 +34,7 @@ const PieChart = ({ data, title }: { data: { label: string; value: number }[]; t
 
   return (
     <div className="flex flex-col items-center gap-2">
-      <h3 className="text-sm font-medium text-gray-700">{title}</h3>
+      <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">{title}</h3>
       <div className="flex items-center gap-4">
         <svg width={140} height={140} viewBox="0 0 140 140">
           {slices.map((s, i) => {
@@ -61,7 +61,7 @@ const PieChart = ({ data, title }: { data: { label: string; value: number }[]; t
           {slices.map((s, i) => (
             <div key={i} className="flex items-center gap-2 text-xs">
               <div className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: s.color }} />
-              <span className="text-gray-600">{s.label}: {s.value}</span>
+              <span className="text-gray-600 dark:text-gray-400">{s.label}: {s.value}</span>
             </div>
           ))}
         </div>
@@ -96,8 +96,8 @@ export const AllRunners = () => {
   return (
     <div>
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-bold text-gray-900">All runners</h1>
-        <span className="text-sm text-gray-500">{totalCount} runners</span>
+        <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">All runners</h1>
+        <span className="text-sm text-gray-500 dark:text-gray-400">{totalCount} runners</span>
       </div>
 
       <div className="mt-4">
@@ -107,7 +107,7 @@ export const AllRunners = () => {
             setOrgId(e.target.value)
             setPage(1)
           }}
-          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
         >
           <option value="">All organizations</option>
           {orgs.map((org) => (
@@ -125,25 +125,25 @@ export const AllRunners = () => {
       )}
 
       <div className="mt-6 overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+          <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
-              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Org</th>
-              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Type</th>
-              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
-              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Version</th>
-              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Process</th>
-              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Owner</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Name</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Org</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Type</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Status</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Version</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Process</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Owner</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200 bg-white">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
             {runners.map((rv) => (
               <RunnerRow key={rv.runner.id} rv={rv} />
             ))}
             {runners.length === 0 && (
               <tr>
-                <td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-500">No runners found</td>
+                <td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No runners found</td>
               </tr>
             )}
           </tbody>
@@ -158,13 +158,13 @@ export const AllRunners = () => {
 }
 
 const RunnerRow = ({ rv }: { rv: TAllRunnerView }) => (
-  <tr className="hover:bg-gray-50">
+  <tr className="hover:bg-gray-50 dark:hover:bg-gray-800">
     <td className="whitespace-nowrap px-4 py-3 text-sm">
-      <Link to={`/runners/${rv.runner.id}`} className="font-medium text-primary-600 hover:text-primary-800">
+      <Link to={`/runners/${rv.runner.id}`} className="font-medium text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">
         {rv.runner.name || truncateId(rv.runner.id)}
       </Link>
     </td>
-    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{rv.org_name || '-'}</td>
+    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{rv.org_name || '-'}</td>
     <td className="whitespace-nowrap px-4 py-3 text-sm">
       <Badge variant="status" status={rv.group_type === 'install' ? 'info' : 'neutral'}>
         {rv.group_type || '-'}
@@ -175,15 +175,15 @@ const RunnerRow = ({ rv }: { rv: TAllRunnerView }) => (
         {rv.process_online ? 'Online' : 'Offline'}
       </Badge>
     </td>
-    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{rv.version || '-'}</td>
-    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{rv.process_type || '-'}</td>
+    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{rv.version || '-'}</td>
+    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{rv.process_type || '-'}</td>
     <td className="whitespace-nowrap px-4 py-3 text-sm">
       {rv.install_id ? (
-        <Link to={`/installs/${rv.install_id}`} className="text-primary-600 hover:text-primary-800">
+        <Link to={`/installs/${rv.install_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">
           {rv.install_name || truncateId(rv.install_id)}
         </Link>
       ) : (
-        <span className="text-gray-500">org</span>
+        <span className="text-gray-500 dark:text-gray-400">org</span>
       )}
     </td>
   </tr>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/runners/RunnerDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/runners/RunnerDetail.tsx
@@ -83,71 +83,71 @@ export const RunnerDetail = () => {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-xl font-bold text-gray-900">{runner.name || truncateId(runner.id)}</h1>
-        <p className="mt-1 text-sm text-gray-500 font-mono">{runner.id}</p>
+        <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">{runner.name || truncateId(runner.id)}</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400 font-mono">{runner.id}</p>
         <div className="mt-2 flex items-center gap-3 text-sm">
           <Badge variant="status" status={process_online ? 'online' : 'offline'}>
             {process_online ? 'Online' : 'Offline'}
           </Badge>
-          <span className="text-gray-500">
-            Install: <Link to={`/installs/${install_id}`} className="text-primary-600 hover:text-primary-800">{install_name || truncateId(install_id)}</Link>
+          <span className="text-gray-500 dark:text-gray-400">
+            Install: <Link to={`/installs/${install_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">{install_name || truncateId(install_id)}</Link>
           </span>
         </div>
       </div>
 
       {/* Process Info */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Process</h2>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Process</h2>
         {process ? (
           <dl className="mt-2 grid grid-cols-2 gap-2 text-sm">
             <div>
-              <dt className="text-gray-500">Version</dt>
-              <dd className="text-gray-900">{process.version}</dd>
+              <dt className="text-gray-500 dark:text-gray-400">Version</dt>
+              <dd className="text-gray-900 dark:text-gray-100">{process.version}</dd>
             </div>
             <div>
-              <dt className="text-gray-500">Status</dt>
+              <dt className="text-gray-500 dark:text-gray-400">Status</dt>
               <dd><Badge variant="status" status={process.status}>{process.status}</Badge></dd>
             </div>
             <div>
-              <dt className="text-gray-500">Created</dt>
-              <dd className="text-gray-900">{formatDate(process.created_at)}</dd>
+              <dt className="text-gray-500 dark:text-gray-400">Created</dt>
+              <dd className="text-gray-900 dark:text-gray-100">{formatDate(process.created_at)}</dd>
             </div>
           </dl>
         ) : (
-          <p className="mt-2 text-sm text-gray-500">No process info available</p>
+          <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">No process info available</p>
         )}
       </div>
 
       {/* Configs */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
         <div className="flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-gray-900">Configs</h2>
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Configs</h2>
           <button
             onClick={() => resetMutation.mutate()}
             disabled={resetMutation.isPending}
-            className="rounded-md bg-red-600 px-3 py-1 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+            className="rounded-md bg-red-600 dark:bg-red-500 px-3 py-1 text-sm font-medium text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50"
           >
             {resetMutation.isPending ? 'Resetting...' : 'Reset All'}
           </button>
         </div>
 
         <div className="mt-3 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Job Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Duration</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Error</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Panic</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Shutdown</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Job Type</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Duration</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Error</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Panic</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Shutdown</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Actions</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
               {Object.entries(configs || {}).map(([jobType, config]) => (
                 <tr key={jobType}>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{jobType}</td>
-                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{Math.round((config.duration ?? 0) / NS_PER_MS)}ms</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{jobType}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{Math.round((config.duration ?? 0) / NS_PER_MS)}ms</td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm">
                     <Badge variant="status" status={config.should_error ? 'error' : 'healthy'}>
                       {config.should_error ? 'Yes' : 'No'}
@@ -167,7 +167,7 @@ export const RunnerDetail = () => {
                     <button
                       onClick={() => deleteMutation.mutate(jobType)}
                       disabled={deleteMutation.isPending}
-                      className="text-red-600 hover:text-red-800 text-xs font-medium"
+                      className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-200 text-xs font-medium"
                     >
                       Delete
                     </button>
@@ -176,7 +176,7 @@ export const RunnerDetail = () => {
               ))}
               {Object.keys(configs || {}).length === 0 && (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500">No configs</td>
+                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No configs</td>
                 </tr>
               )}
             </tbody>
@@ -184,8 +184,8 @@ export const RunnerDetail = () => {
         </div>
 
         {/* Upsert Form */}
-        <div className="mt-4 rounded-md border border-gray-200 p-3">
-          <h3 className="text-xs font-semibold text-gray-700 mb-2">Add/Update Config</h3>
+        <div className="mt-4 rounded-md border border-gray-200 dark:border-gray-800 p-3">
+          <h3 className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Add/Update Config</h3>
           <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:flex-wrap">
             <input
               type="text"
@@ -193,7 +193,7 @@ export const RunnerDetail = () => {
               value={configForm.job_type}
               onChange={(e) => setConfigForm((f) => ({ ...f, job_type: e.target.value }))}
               placeholder="Job type"
-              className="block w-56 rounded-md border-0 py-1 px-2 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600 font-mono"
+              className="block w-56 rounded-md border-0 py-1 px-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500 font-mono"
             />
             <datalist id="sandbox-job-types">
               {SANDBOX_JOB_TYPES.map((t) => (
@@ -205,24 +205,24 @@ export const RunnerDetail = () => {
               value={configForm.duration_ms}
               onChange={(e) => setConfigForm((f) => ({ ...f, duration_ms: Number(e.target.value) }))}
               placeholder="Duration (ms)"
-              className="block w-32 rounded-md border-0 py-1 px-2 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+              className="block w-32 rounded-md border-0 py-1 px-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
             />
-            <label className="flex items-center gap-1 text-xs text-gray-700">
-              <input type="checkbox" checked={configForm.should_error} onChange={(e) => setConfigForm((f) => ({ ...f, should_error: e.target.checked }))} className="rounded border-gray-300" />
+            <label className="flex items-center gap-1 text-xs text-gray-700 dark:text-gray-300">
+              <input type="checkbox" checked={configForm.should_error} onChange={(e) => setConfigForm((f) => ({ ...f, should_error: e.target.checked }))} className="rounded border-gray-300 dark:border-gray-700" />
               Error
             </label>
-            <label className="flex items-center gap-1 text-xs text-gray-700">
-              <input type="checkbox" checked={configForm.panic} onChange={(e) => setConfigForm((f) => ({ ...f, panic: e.target.checked }))} className="rounded border-gray-300" />
+            <label className="flex items-center gap-1 text-xs text-gray-700 dark:text-gray-300">
+              <input type="checkbox" checked={configForm.panic} onChange={(e) => setConfigForm((f) => ({ ...f, panic: e.target.checked }))} className="rounded border-gray-300 dark:border-gray-700" />
               Panic
             </label>
-            <label className="flex items-center gap-1 text-xs text-gray-700">
-              <input type="checkbox" checked={configForm.trigger_shutdown} onChange={(e) => setConfigForm((f) => ({ ...f, trigger_shutdown: e.target.checked }))} className="rounded border-gray-300" />
+            <label className="flex items-center gap-1 text-xs text-gray-700 dark:text-gray-300">
+              <input type="checkbox" checked={configForm.trigger_shutdown} onChange={(e) => setConfigForm((f) => ({ ...f, trigger_shutdown: e.target.checked }))} className="rounded border-gray-300 dark:border-gray-700" />
               Shutdown
             </label>
             <button
               onClick={() => configForm.job_type.trim() && upsertMutation.mutate()}
               disabled={upsertMutation.isPending || !configForm.job_type.trim()}
-              className="rounded-md bg-primary-600 px-3 py-1 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+              className="rounded-md bg-primary-600 dark:bg-primary-500 px-3 py-1 text-sm font-medium text-white hover:bg-primary-700 dark:hover:bg-primary-600 disabled:opacity-50"
             >
               Save
             </button>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/runners/RunnersList.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/runners/RunnersList.tsx
@@ -19,46 +19,46 @@ export const RunnersList = () => {
 
   return (
     <div>
-      <h1 className="text-xl font-bold text-gray-900">Runners</h1>
+      <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">Runners</h1>
 
       <div className="mt-4 overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+          <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Display Name</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Install</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Version</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Configs</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Name</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Display Name</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Install</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Version</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Configs</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200 bg-white">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
             {runners.map((rv) => (
-              <tr key={rv.runner.id} className="hover:bg-gray-50">
+              <tr key={rv.runner.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
                 <td className="whitespace-nowrap px-4 py-3 text-sm">
-                  <Link to={`/runners/${rv.runner.id}`} className="text-primary-600 hover:text-primary-800 font-medium">
+                  <Link to={`/runners/${rv.runner.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-medium">
                     {rv.runner.name || truncateId(rv.runner.id)}
                   </Link>
                 </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{rv.runner.display_name || '-'}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{rv.runner.display_name || '-'}</td>
                 <td className="whitespace-nowrap px-4 py-3 text-sm">
                   <Badge variant="status" status={rv.process_online ? 'online' : 'offline'}>
                     {rv.process_online ? 'Online' : 'Offline'}
                   </Badge>
                 </td>
                 <td className="whitespace-nowrap px-4 py-3 text-sm">
-                  <Link to={`/installs/${rv.install_id}`} className="text-primary-600 hover:text-primary-800">
+                  <Link to={`/installs/${rv.install_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200">
                     {rv.install_name || truncateId(rv.install_id)}
                   </Link>
                 </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">{rv.version || '-'}</td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">{rv.configs?.length ?? 0}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{rv.version || '-'}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{rv.configs?.length ?? 0}</td>
               </tr>
             ))}
             {runners.length === 0 && (
               <tr>
-                <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500">No runners found</td>
+                <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">No runners found</td>
               </tr>
             )}
           </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/sandbox-mode/SandboxMode.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/sandbox-mode/SandboxMode.tsx
@@ -161,7 +161,7 @@ export const SandboxMode = () => {
     <div>
       <h1 className="page-heading">Sandbox mode</h1>
 
-      <div className="mt-4 border-b border-gray-200">
+      <div className="mt-4 border-b border-gray-200 dark:border-gray-800">
         <nav className="flex -mb-px space-x-8">
           {tabs.map((tab) => (
             <button
@@ -169,8 +169,8 @@ export const SandboxMode = () => {
               onClick={() => setActiveTab(tab.key)}
               className={`whitespace-nowrap border-b-2 py-3 px-1 text-sm font-medium ${
                 activeTab === tab.key
-                  ? 'border-primary-500 text-primary-600'
-                  : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+                  ? 'border-primary-500 text-primary-600 dark:text-primary-400'
+                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200'
               }`}
             >
               {tab.label}
@@ -184,13 +184,13 @@ export const SandboxMode = () => {
         {activeTab === 'runner-jobs' && (
           <div>
             <div className="mb-3 flex gap-2">
-              <button onClick={openNewJob} className="rounded-md bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700">
+              <button onClick={openNewJob} className="rounded-md bg-primary-600 dark:bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 dark:hover:bg-primary-600">
                 New override
               </button>
               <button
                 onClick={() => disableJobsMutation.mutate()}
                 disabled={disableJobsMutation.isPending}
-                className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                className="rounded-md bg-red-600 dark:bg-red-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50"
               >
                 Disable all
               </button>
@@ -227,23 +227,23 @@ export const SandboxMode = () => {
                     <th>Actions</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-200">
+                <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
                   {runnerJobConfigs.map((config: any) => (
-                    <tr key={config.id || config.job_type} className={editingJobType === config.job_type ? 'bg-primary-50' : ''}>
-                      <td className="font-mono text-xs text-gray-900">{config.job_type}{config.operation ? ` (${config.operation})` : ''}</td>
+                    <tr key={config.id || config.job_type} className={editingJobType === config.job_type ? 'bg-primary-50 dark:bg-primary-950' : ''}>
+                      <td className="font-mono text-xs text-gray-900 dark:text-gray-100">{config.job_type}{config.operation ? ` (${config.operation})` : ''}</td>
                       <td><Badge variant="status" status={config.enabled ? 'online' : 'offline'}>{config.enabled ? 'Yes' : 'No'}</Badge></td>
-                      <td className="font-mono text-xs text-gray-500">{config.duration ? `${config.duration / 1_000_000}ms` : '-'}</td>
-                      <td className="font-mono text-xs text-gray-500">{config.sleep_duration ? `${config.sleep_duration / 1_000_000}ms` : '-'}</td>
+                      <td className="font-mono text-xs text-gray-500 dark:text-gray-400">{config.duration ? `${config.duration / 1_000_000}ms` : '-'}</td>
+                      <td className="font-mono text-xs text-gray-500 dark:text-gray-400">{config.sleep_duration ? `${config.sleep_duration / 1_000_000}ms` : '-'}</td>
                       <td className="text-xs">{config.should_error ? '✓' : '-'}</td>
                       <td className="text-xs">{config.panic ? '✓' : '-'}</td>
                       <td className="text-xs">{config.trigger_shutdown ? '✓' : '-'}</td>
-                      <td className="text-xs text-gray-500">
+                      <td className="text-xs text-gray-500 dark:text-gray-400">
                         {[config.log_template, config.plan_template, config.state_template, config.output_template].filter(Boolean).join(', ') || '-'}
                       </td>
                       <td>
                         <button
                           onClick={() => openEditJob(config)}
-                          className="text-xs text-primary-600 hover:text-primary-800 font-medium"
+                          className="text-xs text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-medium"
                         >
                           Edit
                         </button>
@@ -251,7 +251,7 @@ export const SandboxMode = () => {
                     </tr>
                   ))}
                   {runnerJobConfigs.length === 0 && (
-                    <tr><td colSpan={9} className="text-center text-gray-500 py-6">No runner job overrides</td></tr>
+                    <tr><td colSpan={9} className="text-center text-gray-500 dark:text-gray-400 py-6">No runner job overrides</td></tr>
                   )}
                 </tbody>
               </table>
@@ -263,13 +263,13 @@ export const SandboxMode = () => {
         {activeTab === 'signals' && (
           <div>
             <div className="mb-3 flex gap-2">
-              <button onClick={openNewSignal} className="rounded-md bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700">
+              <button onClick={openNewSignal} className="rounded-md bg-primary-600 dark:bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 dark:hover:bg-primary-600">
                 New override
               </button>
               <button
                 onClick={() => disableSignalsMutation.mutate()}
                 disabled={disableSignalsMutation.isPending}
-                className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                className="rounded-md bg-red-600 dark:bg-red-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50"
               >
                 Disable all
               </button>
@@ -304,20 +304,20 @@ export const SandboxMode = () => {
                     <th>Actions</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-200">
+                <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
                   {signalConfigs.map((config: any) => (
-                    <tr key={config.id || config.signal_type} className={editingSignalType === config.signal_type ? 'bg-primary-50' : ''}>
-                      <td className="font-mono text-xs text-gray-900">{config.signal_type}</td>
+                    <tr key={config.id || config.signal_type} className={editingSignalType === config.signal_type ? 'bg-primary-50 dark:bg-primary-950' : ''}>
+                      <td className="font-mono text-xs text-gray-900 dark:text-gray-100">{config.signal_type}</td>
                       <td><Badge variant="status" status={config.enabled ? 'online' : 'offline'}>{config.enabled ? 'Yes' : 'No'}</Badge></td>
-                      <td className="font-mono text-xs text-gray-500">{config.deadlock_sleep ? `${config.deadlock_sleep / 1_000_000_000}s` : '-'}</td>
-                      <td className="font-mono text-xs text-gray-500">{config.workflow_sleep ? `${config.workflow_sleep / 1_000_000_000}s` : '-'}</td>
+                      <td className="font-mono text-xs text-gray-500 dark:text-gray-400">{config.deadlock_sleep ? `${config.deadlock_sleep / 1_000_000_000}s` : '-'}</td>
+                      <td className="font-mono text-xs text-gray-500 dark:text-gray-400">{config.workflow_sleep ? `${config.workflow_sleep / 1_000_000_000}s` : '-'}</td>
                       <td className="text-xs">{config.panic ? '✓' : '-'}</td>
-                      <td className="text-xs text-gray-500 max-w-[120px] truncate">{config.error || '-'}</td>
-                      <td className="text-xs text-gray-500 max-w-[120px] truncate">{config.validate_error || '-'}</td>
+                      <td className="text-xs text-gray-500 dark:text-gray-400 max-w-[120px] truncate">{config.error || '-'}</td>
+                      <td className="text-xs text-gray-500 dark:text-gray-400 max-w-[120px] truncate">{config.validate_error || '-'}</td>
                       <td>
                         <button
                           onClick={() => openEditSignal(config)}
-                          className="text-xs text-primary-600 hover:text-primary-800 font-medium"
+                          className="text-xs text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-medium"
                         >
                           Edit
                         </button>
@@ -325,7 +325,7 @@ export const SandboxMode = () => {
                     </tr>
                   ))}
                   {signalConfigs.length === 0 && (
-                    <tr><td colSpan={8} className="text-center text-gray-500 py-6">No signal overrides</td></tr>
+                    <tr><td colSpan={8} className="text-center text-gray-500 dark:text-gray-400 py-6">No signal overrides</td></tr>
                   )}
                 </tbody>
               </table>
@@ -337,17 +337,17 @@ export const SandboxMode = () => {
         {activeTab === 'stacks' && (
           <div>
             {stackConfig ? (
-              <div className="rounded-lg border border-gray-200 bg-white p-4">
-                <h3 className="text-sm font-medium text-gray-900">Sandbox terraform config</h3>
+              <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+                <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">Sandbox terraform config</h3>
                 <dl className="mt-3 grid grid-cols-2 gap-3 text-sm">
-                  <div><dt className="text-gray-500">Job type</dt><dd className="font-mono">{stackConfig.job_type}</dd></div>
-                  <div><dt className="text-gray-500">Enabled</dt><dd><Badge variant="status" status={stackConfig.enabled ? 'online' : 'offline'}>{stackConfig.enabled ? 'Yes' : 'No'}</Badge></dd></div>
-                  <div><dt className="text-gray-500">Duration</dt><dd className="font-mono">{stackConfig.duration ? `${stackConfig.duration / 1_000_000}ms` : '-'}</dd></div>
-                  <div><dt className="text-gray-500">Should error</dt><dd>{stackConfig.should_error ? 'Yes' : 'No'}</dd></div>
+                  <div><dt className="text-gray-500 dark:text-gray-400">Job type</dt><dd className="font-mono">{stackConfig.job_type}</dd></div>
+                  <div><dt className="text-gray-500 dark:text-gray-400">Enabled</dt><dd><Badge variant="status" status={stackConfig.enabled ? 'online' : 'offline'}>{stackConfig.enabled ? 'Yes' : 'No'}</Badge></dd></div>
+                  <div><dt className="text-gray-500 dark:text-gray-400">Duration</dt><dd className="font-mono">{stackConfig.duration ? `${stackConfig.duration / 1_000_000}ms` : '-'}</dd></div>
+                  <div><dt className="text-gray-500 dark:text-gray-400">Should error</dt><dd>{stackConfig.should_error ? 'Yes' : 'No'}</dd></div>
                 </dl>
               </div>
             ) : (
-              <p className="text-sm text-gray-500">No stack config</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">No stack config</p>
             )}
           </div>
         )}
@@ -358,17 +358,17 @@ export const SandboxMode = () => {
             {flowTemplates.length > 0 ? (
               <div className="space-y-2">
                 {flowTemplates.map((template: any, i: number) => (
-                  <div key={template.key || template.Key || i} className="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-4">
+                  <div key={template.key || template.Key || i} className="flex items-center justify-between rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
                     <div>
-                      <p className="text-sm font-medium text-gray-900">{template.name || template.Name || template.key || template.Key}</p>
+                      <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{template.name || template.Name || template.key || template.Key}</p>
                       {(template.description || template.Description) && (
-                        <p className="mt-0.5 text-xs text-gray-500">{template.description || template.Description}</p>
+                        <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">{template.description || template.Description}</p>
                       )}
                     </div>
                     <button
                       onClick={() => applyTemplateMutation.mutate(template.key || template.Key)}
                       disabled={applyTemplateMutation.isPending}
-                      className="rounded-md bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+                      className="rounded-md bg-primary-600 dark:bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 dark:hover:bg-primary-600 disabled:opacity-50"
                     >
                       Apply
                     </button>
@@ -376,7 +376,7 @@ export const SandboxMode = () => {
                 ))}
               </div>
             ) : (
-              <p className="text-sm text-gray-500">No flow templates</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">No flow templates</p>
             )}
           </div>
         )}
@@ -411,8 +411,8 @@ function JobFormPanel({
   isPending: boolean
 }) {
   return (
-    <div className="mb-4 rounded-lg border border-primary-200 bg-primary-50/50 p-4">
-      <h3 className="text-sm font-semibold text-gray-900 mb-3">
+    <div className="mb-4 rounded-lg border border-primary-200 dark:border-primary-800 bg-primary-50/50 dark:bg-primary-900/30 p-4">
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
         {isNew ? 'New runner job override' : `Edit: ${jobType}`}
       </h3>
       <div className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
@@ -442,7 +442,7 @@ function JobFormPanel({
           <input type="checkbox" checked={form.trigger_shutdown} onChange={(e) => setForm((f) => ({ ...f, trigger_shutdown: e.target.checked }))} className="mt-1" />
         </Field>
         <Field label="Operation">
-          <input type="text" value={form.operation} onChange={(e) => setForm((f) => ({ ...f, operation: e.target.value }))} placeholder="optional" className="w-full rounded-md border-gray-300 text-sm py-1.5 px-2" />
+          <input type="text" value={form.operation} onChange={(e) => setForm((f) => ({ ...f, operation: e.target.value }))} placeholder="optional" className="w-full rounded-md border-gray-300 dark:border-gray-700 text-sm py-1.5 px-2" />
         </Field>
         <Field label="Log template">
           <TemplateSelect value={form.log_template} onChange={(v) => setForm((f) => ({ ...f, log_template: v }))} options={templateOptions} />
@@ -461,10 +461,10 @@ function JobFormPanel({
         </Field>
       </div>
       <div className="mt-3 flex gap-2">
-        <button onClick={onSave} disabled={isPending || (isNew && !jobType)} className="rounded-md bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+        <button onClick={onSave} disabled={isPending || (isNew && !jobType)} className="rounded-md bg-primary-600 dark:bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 dark:hover:bg-primary-600 disabled:opacity-50">
           {isPending ? 'Saving...' : 'Save'}
         </button>
-        <button onClick={onCancel} className="rounded-md px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100">Cancel</button>
+        <button onClick={onCancel} className="rounded-md px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800">Cancel</button>
       </div>
     </div>
   )
@@ -492,8 +492,8 @@ function SignalFormPanel({
   isPending: boolean
 }) {
   return (
-    <div className="mb-4 rounded-lg border border-primary-200 bg-primary-50/50 p-4">
-      <h3 className="text-sm font-semibold text-gray-900 mb-3">
+    <div className="mb-4 rounded-lg border border-primary-200 dark:border-primary-800 bg-primary-50/50 dark:bg-primary-900/30 p-4">
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
         {isNew ? 'New signal override' : `Edit: ${signalType}`}
       </h3>
       <div className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
@@ -517,17 +517,17 @@ function SignalFormPanel({
           <input type="checkbox" checked={form.panic} onChange={(e) => setForm((f) => ({ ...f, panic: e.target.checked }))} className="mt-1" />
         </Field>
         <Field label="Error message">
-          <input type="text" value={form.error} onChange={(e) => setForm((f) => ({ ...f, error: e.target.value }))} placeholder="Execute error" className="w-full rounded-md border-gray-300 text-sm py-1.5 px-2" />
+          <input type="text" value={form.error} onChange={(e) => setForm((f) => ({ ...f, error: e.target.value }))} placeholder="Execute error" className="w-full rounded-md border-gray-300 dark:border-gray-700 text-sm py-1.5 px-2" />
         </Field>
         <Field label="Validate error">
-          <input type="text" value={form.validate_error} onChange={(e) => setForm((f) => ({ ...f, validate_error: e.target.value }))} placeholder="Validate error" className="w-full rounded-md border-gray-300 text-sm py-1.5 px-2" />
+          <input type="text" value={form.validate_error} onChange={(e) => setForm((f) => ({ ...f, validate_error: e.target.value }))} placeholder="Validate error" className="w-full rounded-md border-gray-300 dark:border-gray-700 text-sm py-1.5 px-2" />
         </Field>
       </div>
       <div className="mt-3 flex gap-2">
-        <button onClick={onSave} disabled={isPending || (isNew && !signalType)} className="rounded-md bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+        <button onClick={onSave} disabled={isPending || (isNew && !signalType)} className="rounded-md bg-primary-600 dark:bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 dark:hover:bg-primary-600 disabled:opacity-50">
           {isPending ? 'Saving...' : 'Save'}
         </button>
-        <button onClick={onCancel} className="rounded-md px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100">Cancel</button>
+        <button onClick={onCancel} className="rounded-md px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800">Cancel</button>
       </div>
     </div>
   )
@@ -538,7 +538,7 @@ function SignalFormPanel({
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div>
-      <label className="block text-xs font-medium text-gray-700 mb-1">{label}</label>
+      <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">{label}</label>
       {children}
     </div>
   )
@@ -546,7 +546,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 
 function TemplateSelect({ value, onChange, options }: { value: string; onChange: (v: string) => void; options: string[] }) {
   return (
-    <select value={value} onChange={(e) => onChange(e.target.value)} className="w-full rounded-md border-gray-300 text-sm py-1.5 px-2">
+    <select value={value} onChange={(e) => onChange(e.target.value)} className="w-full rounded-md border-gray-300 dark:border-gray-700 text-sm py-1.5 px-2">
       <option value="">None</option>
       {options.map((t) => <option key={t} value={t}>{t}</option>)}
     </select>
@@ -570,16 +570,16 @@ function TypeCombobox({ value, onChange, options, placeholder }: { value: string
         onChange={(e) => { setFilter(e.target.value); setOpen(true) }}
         onFocus={() => setOpen(true)}
         placeholder={placeholder}
-        className="w-full rounded-md border-gray-300 text-sm py-1.5 px-2 font-mono"
+        className="w-full rounded-md border-gray-300 dark:border-gray-700 text-sm py-1.5 px-2 font-mono"
       />
       {open && filtered.length > 0 && (
-        <div className="absolute z-10 mt-1 max-h-48 w-full overflow-y-auto rounded-md border border-gray-200 bg-white shadow-lg">
+        <div className="absolute z-10 mt-1 max-h-48 w-full overflow-y-auto rounded-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-lg">
           {filtered.map((opt) => (
             <button
               key={opt}
               type="button"
               onClick={() => { onChange(opt); setFilter(opt); setOpen(false) }}
-              className={`block w-full text-left px-2 py-1.5 text-xs font-mono hover:bg-primary-50 ${opt === value ? 'bg-primary-50 text-primary-700 font-medium' : 'text-gray-700'}`}
+              className={`block w-full text-left px-2 py-1.5 text-xs font-mono hover:bg-primary-50 dark:hover:bg-primary-900/30 ${opt === value ? 'bg-primary-50 dark:bg-primary-950 text-primary-700 dark:text-primary-300 font-medium' : 'text-gray-700 dark:text-gray-300'}`}
             >
               {opt}
             </button>
@@ -613,14 +613,14 @@ const secPresets = [
 function DurationMsInput({ value, onChange }: { value: number; onChange: (v: number) => void }) {
   return (
     <div>
-      <input type="number" value={value} onChange={(e) => onChange(Number(e.target.value))} className="w-full rounded-md border-gray-300 text-sm py-1.5 px-2" />
+      <input type="number" value={value} onChange={(e) => onChange(Number(e.target.value))} className="w-full rounded-md border-gray-300 dark:border-gray-700 text-sm py-1.5 px-2" />
       <div className="mt-1 flex gap-1">
         {msPresets.map((p) => (
           <button
             key={p.label}
             type="button"
             onClick={() => onChange(p.value)}
-            className={`rounded px-1.5 py-0.5 text-[10px] font-medium border transition-colors ${value === p.value ? 'bg-primary-100 border-primary-300 text-primary-700' : 'bg-gray-50 border-gray-200 text-gray-500 hover:bg-gray-100'}`}
+            className={`rounded px-1.5 py-0.5 text-[10px] font-medium border transition-colors ${value === p.value ? 'bg-primary-100 dark:bg-primary-900/50 border-primary-300 dark:border-primary-700 text-primary-700 dark:text-primary-300' : 'bg-gray-50 dark:bg-gray-900 border-gray-200 dark:border-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
           >
             {p.label}
           </button>
@@ -634,14 +634,14 @@ function DurationMsInput({ value, onChange }: { value: number; onChange: (v: num
 function DurationSecInput({ value, onChange }: { value: number; onChange: (v: number) => void }) {
   return (
     <div>
-      <input type="number" step="0.1" value={value} onChange={(e) => onChange(Number(e.target.value))} className="w-full rounded-md border-gray-300 text-sm py-1.5 px-2" />
+      <input type="number" step="0.1" value={value} onChange={(e) => onChange(Number(e.target.value))} className="w-full rounded-md border-gray-300 dark:border-gray-700 text-sm py-1.5 px-2" />
       <div className="mt-1 flex gap-1">
         {secPresets.map((p) => (
           <button
             key={p.label}
             type="button"
             onClick={() => onChange(p.value)}
-            className={`rounded px-1.5 py-0.5 text-[10px] font-medium border transition-colors ${value === p.value ? 'bg-primary-100 border-primary-300 text-primary-700' : 'bg-gray-50 border-gray-200 text-gray-500 hover:bg-gray-100'}`}
+            className={`rounded px-1.5 py-0.5 text-[10px] font-medium border transition-colors ${value === p.value ? 'bg-primary-100 dark:bg-primary-900/50 border-primary-300 dark:border-primary-700 text-primary-700 dark:text-primary-300' : 'bg-gray-50 dark:bg-gray-900 border-gray-200 dark:border-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
           >
             {p.label}
           </button>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/signal-catalog/SignalCatalog.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/signal-catalog/SignalCatalog.tsx
@@ -52,7 +52,7 @@ function CapabilityBadges({ info }: { info: SignalInfo }) {
         <Badge key={c}>{c}</Badge>
       ))}
       {info.HasQueue && info.Queue && <Badge>queue: {info.Queue}</Badge>}
-      {caps.length === 0 && !info.HasQueue && <span className="text-xs text-gray-400">—</span>}
+      {caps.length === 0 && !info.HasQueue && <span className="text-xs text-gray-400 dark:text-gray-500">—</span>}
     </div>
   )
 }
@@ -96,40 +96,40 @@ export const SignalCatalog = () => {
       <div className="mt-4 space-y-8">
         {visibleNamespaces.map(({ ns, signals }) => (
           <div key={ns}>
-            <h2 className="border-b border-gray-200 pb-2 mb-3 text-sm font-semibold uppercase tracking-wider text-primary-600">
+            <h2 className="border-b border-gray-200 dark:border-gray-800 pb-2 mb-3 text-sm font-semibold uppercase tracking-wider text-primary-600 dark:text-primary-400">
               {ns}
-              <span className="ml-2 font-normal text-gray-400">({signals.length})</span>
+              <span className="ml-2 font-normal text-gray-400 dark:text-gray-500">({signals.length})</span>
             </h2>
-            <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
+            <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
+              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+                <thead className="bg-gray-50 dark:bg-gray-900">
                   <tr>
-                    <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Type</th>
-                    <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Operation</th>
-                    <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Auto-retry</th>
-                    <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Max retries</th>
-                    <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Capabilities</th>
+                    <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Type</th>
+                    <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Operation</th>
+                    <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Auto-retry</th>
+                    <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Max retries</th>
+                    <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Capabilities</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-200">
+                <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
                   {signals.map((info) => (
-                    <tr key={String(info.Type)} className="hover:bg-gray-50">
+                    <tr key={String(info.Type)} className="hover:bg-gray-50 dark:hover:bg-gray-800">
                       <td className="whitespace-nowrap px-4 py-2 text-xs font-mono">
                         <Link
                           to={`/signal-catalog/${encodeURIComponent(String(info.Type))}`}
-                          className="text-primary-600 hover:underline"
+                          className="text-primary-600 dark:text-primary-400 hover:underline"
                         >
                           {String(info.Type)}
                         </Link>
                       </td>
-                      <td className="whitespace-nowrap px-4 py-2 text-xs font-mono text-gray-700">
-                        {info.Operation || <span className="text-gray-400">—</span>}
+                      <td className="whitespace-nowrap px-4 py-2 text-xs font-mono text-gray-700 dark:text-gray-300">
+                        {info.Operation || <span className="text-gray-400 dark:text-gray-500">—</span>}
                       </td>
                       <td className="whitespace-nowrap px-4 py-2 text-xs">
                         {info.AutoRetry ? (
                           <Badge variant="status" status="online">Yes</Badge>
                         ) : (
-                          <span className="text-gray-400">No</span>
+                          <span className="text-gray-400 dark:text-gray-500">No</span>
                         )}
                       </td>
                       <td className="whitespace-nowrap px-4 py-2 text-xs font-mono">{info.MaxRetries ?? 0}</td>
@@ -144,7 +144,7 @@ export const SignalCatalog = () => {
           </div>
         ))}
         {visibleNamespaces.length === 0 && (
-          <p className="text-sm text-gray-500">No signal types found</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">No signal types found</p>
         )}
       </div>
     </div>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/signal-catalog/SignalCatalogDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/signal-catalog/SignalCatalogDetail.tsx
@@ -26,15 +26,15 @@ export const SignalCatalogDetail = () => {
       <div>
         <h1 className="page-heading font-mono">{signalType}</h1>
         {info && (
-          <div className="mt-2 flex flex-wrap gap-3 text-xs text-gray-500">
+          <div className="mt-2 flex flex-wrap gap-3 text-xs text-gray-500 dark:text-gray-400">
             {info.Namespace && <span>Namespace: <strong>{info.Namespace}</strong></span>}
             {info.Operation && <span>Operation: <strong>{info.Operation}</strong></span>}
           </div>
         )}
       </div>
 
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Recent signals ({recent_signals.length})</h2>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Recent signals ({recent_signals.length})</h2>
         <div className="mt-2 table-card">
           <table>
             <thead>
@@ -46,24 +46,24 @@ export const SignalCatalogDetail = () => {
                 <th>Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
               {recent_signals.map((signal) => (
                 <tr key={signal.id}>
-                  <td className="text-gray-500 font-mono text-xs">{truncateId(signal.id)}</td>
-                  <td className="text-gray-500">
+                  <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">{truncateId(signal.id)}</td>
+                  <td className="text-gray-500 dark:text-gray-400">
                     <span className="font-mono text-xs">{truncateId(signal.owner_id)}</span>
-                    <span className="ml-1 text-xs text-gray-400">({signal.owner_type})</span>
+                    <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">({signal.owner_type})</span>
                   </td>
-                  <td className="text-gray-500 font-mono text-xs">{truncateId(signal.queue_id)}</td>
+                  <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">{truncateId(signal.queue_id)}</td>
                   <td>
                     <Badge variant="status" status={String(signal.status?.status || signal.status)}>{String(signal.status?.status || signal.status)}</Badge>
                   </td>
-                  <td className="text-gray-500">{formatDate(signal.created_at)}</td>
+                  <td className="text-gray-500 dark:text-gray-400">{formatDate(signal.created_at)}</td>
                 </tr>
               ))}
               {recent_signals.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="text-center text-gray-500 py-6">No recent signals</td>
+                  <td colSpan={5} className="text-center text-gray-500 dark:text-gray-400 py-6">No recent signals</td>
                 </tr>
               )}
             </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/temporal-workers/TemporalWorkerDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/temporal-workers/TemporalWorkerDetail.tsx
@@ -35,22 +35,22 @@ export const TemporalWorkerDetail = () => {
           <Badge variant="status" status={isHealthy ? 'healthy' : 'unhealthy'}>
             {isHealthy ? 'Healthy' : 'Unhealthy'}
           </Badge>
-          <span className="text-gray-500">Task queue: <span className="font-mono">{info.task_queue}</span></span>
-          <span className="text-gray-500">Pollers: {wfPollerCount + actPollerCount}</span>
+          <span className="text-gray-500 dark:text-gray-400">Task queue: <span className="font-mono">{info.task_queue}</span></span>
+          <span className="text-gray-500 dark:text-gray-400">Pollers: {wfPollerCount + actPollerCount}</span>
           {temporalUIUrl && (
-            <a href={`${temporalUIUrl}/namespaces/${namespace}`} target="_blank" rel="noopener noreferrer" className="text-primary-600 hover:text-primary-700 text-xs">
+            <a href={`${temporalUIUrl}/namespaces/${namespace}`} target="_blank" rel="noopener noreferrer" className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 text-xs">
               Open in Temporal UI &rarr;
             </a>
           )}
         </div>
         {info.error && (
-          <div className="mt-2 rounded-md bg-red-50 border border-red-200 p-3 text-sm text-red-700">{info.error}</div>
+          <div className="mt-2 rounded-md bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 p-3 text-sm text-red-700 dark:text-red-300">{info.error}</div>
         )}
       </div>
 
       {/* Workflow Pollers */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Workflow pollers ({wfPollerCount})</h2>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Workflow pollers ({wfPollerCount})</h2>
         <div className="mt-2 table-card">
           <table>
             <thead>
@@ -60,16 +60,16 @@ export const TemporalWorkerDetail = () => {
                 <th>Rate/s</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
               {(info.workflow_pollers || []).map((poller, i) => (
                 <tr key={i}>
-                  <td className="text-gray-900 break-all text-xs font-mono">{poller.identity}</td>
-                  <td className="text-gray-500">{formatDate(poller.last_access_time)}</td>
-                  <td className="text-gray-500 font-mono">{poller.rate_per_second?.toFixed(2)}</td>
+                  <td className="text-gray-900 dark:text-gray-100 break-all text-xs font-mono">{poller.identity}</td>
+                  <td className="text-gray-500 dark:text-gray-400">{formatDate(poller.last_access_time)}</td>
+                  <td className="text-gray-500 dark:text-gray-400 font-mono">{poller.rate_per_second?.toFixed(2)}</td>
                 </tr>
               ))}
               {wfPollerCount === 0 && (
-                <tr><td colSpan={3} className="text-center text-gray-500 py-4">No workflow pollers</td></tr>
+                <tr><td colSpan={3} className="text-center text-gray-500 dark:text-gray-400 py-4">No workflow pollers</td></tr>
               )}
             </tbody>
           </table>
@@ -77,8 +77,8 @@ export const TemporalWorkerDetail = () => {
       </div>
 
       {/* Activity Pollers */}
-      <div className="rounded-lg border border-gray-200 bg-white p-4">
-        <h2 className="text-sm font-semibold text-gray-900">Activity pollers ({actPollerCount})</h2>
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Activity pollers ({actPollerCount})</h2>
         <div className="mt-2 table-card">
           <table>
             <thead>
@@ -88,16 +88,16 @@ export const TemporalWorkerDetail = () => {
                 <th>Rate/s</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200">
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
               {(info.activity_pollers || []).map((poller, i) => (
                 <tr key={i}>
-                  <td className="text-gray-900 break-all text-xs font-mono">{poller.identity}</td>
-                  <td className="text-gray-500">{formatDate(poller.last_access_time)}</td>
-                  <td className="text-gray-500 font-mono">{poller.rate_per_second?.toFixed(2)}</td>
+                  <td className="text-gray-900 dark:text-gray-100 break-all text-xs font-mono">{poller.identity}</td>
+                  <td className="text-gray-500 dark:text-gray-400">{formatDate(poller.last_access_time)}</td>
+                  <td className="text-gray-500 dark:text-gray-400 font-mono">{poller.rate_per_second?.toFixed(2)}</td>
                 </tr>
               ))}
               {actPollerCount === 0 && (
-                <tr><td colSpan={3} className="text-center text-gray-500 py-4">No activity pollers</td></tr>
+                <tr><td colSpan={3} className="text-center text-gray-500 dark:text-gray-400 py-4">No activity pollers</td></tr>
               )}
             </tbody>
           </table>
@@ -107,53 +107,53 @@ export const TemporalWorkerDetail = () => {
       {/* Queue Stats */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {info.workflow_stats && (
-          <div className="rounded-lg border border-gray-200 bg-white p-4">
-            <h2 className="text-sm font-semibold text-gray-900">Workflow queue stats</h2>
+          <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+            <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Workflow queue stats</h2>
             <dl className="mt-3 space-y-2 text-sm">
               <div className="flex justify-between">
-                <dt className="text-gray-500">Backlog count</dt>
-                <dd className="font-mono text-gray-900">{info.workflow_stats.approximate_backlog_count}</dd>
+                <dt className="text-gray-500 dark:text-gray-400">Backlog count</dt>
+                <dd className="font-mono text-gray-900 dark:text-gray-100">{info.workflow_stats.approximate_backlog_count}</dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-gray-500">Backlog age</dt>
-                <dd className="font-mono text-gray-900">{info.workflow_stats.approximate_backlog_age ? `${(info.workflow_stats.approximate_backlog_age / 1000000000).toFixed(1)}s` : '-'}</dd>
+                <dt className="text-gray-500 dark:text-gray-400">Backlog age</dt>
+                <dd className="font-mono text-gray-900 dark:text-gray-100">{info.workflow_stats.approximate_backlog_age ? `${(info.workflow_stats.approximate_backlog_age / 1000000000).toFixed(1)}s` : '-'}</dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-gray-500">Tasks add rate</dt>
-                <dd className="font-mono text-gray-900">{info.workflow_stats.tasks_add_rate?.toFixed(2)}/s</dd>
+                <dt className="text-gray-500 dark:text-gray-400">Tasks add rate</dt>
+                <dd className="font-mono text-gray-900 dark:text-gray-100">{info.workflow_stats.tasks_add_rate?.toFixed(2)}/s</dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-gray-500">Tasks dispatch rate</dt>
-                <dd className="font-mono text-gray-900">{info.workflow_stats.tasks_dispatch_rate?.toFixed(2)}/s</dd>
+                <dt className="text-gray-500 dark:text-gray-400">Tasks dispatch rate</dt>
+                <dd className="font-mono text-gray-900 dark:text-gray-100">{info.workflow_stats.tasks_dispatch_rate?.toFixed(2)}/s</dd>
               </div>
             </dl>
           </div>
         )}
         {info.activity_stats && (
-          <div className="rounded-lg border border-gray-200 bg-white p-4">
-            <h2 className="text-sm font-semibold text-gray-900">Activity queue stats</h2>
+          <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+            <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Activity queue stats</h2>
             <dl className="mt-3 space-y-2 text-sm">
               <div className="flex justify-between">
-                <dt className="text-gray-500">Backlog count</dt>
-                <dd className="font-mono text-gray-900">{info.activity_stats.approximate_backlog_count}</dd>
+                <dt className="text-gray-500 dark:text-gray-400">Backlog count</dt>
+                <dd className="font-mono text-gray-900 dark:text-gray-100">{info.activity_stats.approximate_backlog_count}</dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-gray-500">Backlog age</dt>
-                <dd className="font-mono text-gray-900">{info.activity_stats.approximate_backlog_age ? `${(info.activity_stats.approximate_backlog_age / 1000000000).toFixed(1)}s` : '-'}</dd>
+                <dt className="text-gray-500 dark:text-gray-400">Backlog age</dt>
+                <dd className="font-mono text-gray-900 dark:text-gray-100">{info.activity_stats.approximate_backlog_age ? `${(info.activity_stats.approximate_backlog_age / 1000000000).toFixed(1)}s` : '-'}</dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-gray-500">Tasks add rate</dt>
-                <dd className="font-mono text-gray-900">{info.activity_stats.tasks_add_rate?.toFixed(2)}/s</dd>
+                <dt className="text-gray-500 dark:text-gray-400">Tasks add rate</dt>
+                <dd className="font-mono text-gray-900 dark:text-gray-100">{info.activity_stats.tasks_add_rate?.toFixed(2)}/s</dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-gray-500">Tasks dispatch rate</dt>
-                <dd className="font-mono text-gray-900">{info.activity_stats.tasks_dispatch_rate?.toFixed(2)}/s</dd>
+                <dt className="text-gray-500 dark:text-gray-400">Tasks dispatch rate</dt>
+                <dd className="font-mono text-gray-900 dark:text-gray-100">{info.activity_stats.tasks_dispatch_rate?.toFixed(2)}/s</dd>
               </div>
             </dl>
           </div>
         )}
         {!info.workflow_stats && !info.activity_stats && (
-          <p className="text-sm text-gray-500">No queue stats available</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">No queue stats available</p>
         )}
       </div>
     </div>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/temporal-workers/TemporalWorkers.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/temporal-workers/TemporalWorkers.tsx
@@ -37,7 +37,7 @@ export const TemporalWorkers = () => {
               <th>Health</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
             {workers.map((worker) => {
               const wfPollerCount = worker.workflow_pollers?.length ?? 0
               const actPollerCount = worker.activity_pollers?.length ?? 0
@@ -48,18 +48,18 @@ export const TemporalWorkers = () => {
                   <td>
                     <Link
                       to={`/temporal-workers/${encodeURIComponent(worker.namespace)}`}
-                      className="text-primary-600 hover:text-primary-700 font-medium"
+                      className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium"
                     >
                       {worker.namespace}
                     </Link>
                   </td>
-                  <td className="text-gray-500 font-mono text-xs">{worker.task_queue}</td>
-                  <td className="text-gray-900">{wfPollerCount}</td>
-                  <td className="text-gray-900">{actPollerCount}</td>
-                  <td className="text-gray-500 font-mono text-xs">
+                  <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">{worker.task_queue}</td>
+                  <td className="text-gray-900 dark:text-gray-100">{wfPollerCount}</td>
+                  <td className="text-gray-900 dark:text-gray-100">{actPollerCount}</td>
+                  <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">
                     {worker.workflow_stats?.approximate_backlog_count ?? '-'}
                   </td>
-                  <td className="text-gray-500 font-mono text-xs">
+                  <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">
                     {worker.activity_stats?.approximate_backlog_count ?? '-'}
                   </td>
                   <td>
@@ -77,7 +77,7 @@ export const TemporalWorkers = () => {
             })}
             {workers.length === 0 && (
               <tr>
-                <td colSpan={7} className="text-center text-gray-500 py-6">No temporal workers found</td>
+                <td colSpan={7} className="text-center text-gray-500 dark:text-gray-400 py-6">No temporal workers found</td>
               </tr>
             )}
           </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/temporal-workflows/TemporalWorkflows.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/temporal-workflows/TemporalWorkflows.tsx
@@ -34,29 +34,29 @@ export const TemporalWorkflows = () => {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-xl font-bold text-gray-900">Temporal Workflows</h1>
+      <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">Temporal Workflows</h1>
 
       {/* Search form */}
-      <form onSubmit={handleSubmit} className="rounded-lg border border-gray-200 bg-white p-4">
+      <form onSubmit={handleSubmit} className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div>
-            <label className="block text-xs font-medium text-gray-700 mb-1">Workflow ID</label>
+            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Workflow ID</label>
             <input
               type="text"
               value={workflowId}
               onChange={(e) => { setWorkflowId(e.target.value); setSubmitted(false) }}
               placeholder="Workflow ID..."
-              className="block w-full rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+              className="block w-full rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
             />
           </div>
           <div>
-            <label className="block text-xs font-medium text-gray-700 mb-1">Namespace</label>
+            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Namespace</label>
             <input
               type="text"
               value={namespace}
               onChange={(e) => { setNamespace(e.target.value); setSubmitted(false) }}
               placeholder="Namespace..."
-              className="block w-full rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-primary-600"
+              className="block w-full rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 focus:ring-2 focus:ring-primary-600 dark:focus:ring-primary-500"
             />
           </div>
         </div>
@@ -64,7 +64,7 @@ export const TemporalWorkflows = () => {
           <button
             type="submit"
             disabled={!workflowId || !namespace}
-            className="rounded-md bg-primary-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+            className="rounded-md bg-primary-600 dark:bg-primary-500 px-4 py-1.5 text-sm font-medium text-white hover:bg-primary-700 dark:hover:bg-primary-600 disabled:opacity-50"
           >
             Search
           </button>
@@ -77,7 +77,7 @@ export const TemporalWorkflows = () => {
       {/* Workflow header */}
       {submitted && wfInfo && (
         <>
-          <div className="rounded-lg border border-gray-200 bg-white p-4">
+          <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
             <div className="flex flex-wrap items-center gap-2 mb-3">
               <h2 className="text-lg font-semibold">Workflow</h2>
               <Badge variant="status" status={wfInfo.status}>{wfInfo.status}</Badge>
@@ -86,7 +86,7 @@ export const TemporalWorkflows = () => {
                   href={`${temporalUIUrl}/namespaces/${data.namespace}/workflows/${data.workflow_id}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-xs text-primary-600 hover:text-primary-700"
+                  className="text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
                 >
                   View in Temporal &rarr;
                 </a>
@@ -94,30 +94,30 @@ export const TemporalWorkflows = () => {
             </div>
             <div className="space-y-1 text-xs">
               <div className="flex items-center gap-2">
-                <span className="text-gray-500 uppercase w-28">Workflow ID</span>
+                <span className="text-gray-500 dark:text-gray-400 uppercase w-28">Workflow ID</span>
                 <span className="font-mono break-all select-all">{data?.workflow_id}</span>
               </div>
               <div className="flex items-center gap-2">
-                <span className="text-gray-500 uppercase w-28">Namespace</span>
+                <span className="text-gray-500 dark:text-gray-400 uppercase w-28">Namespace</span>
                 <span className="font-mono">{data?.namespace}</span>
               </div>
             </div>
 
             {/* Execution stats */}
-            <div className="mt-4 pt-3 border-t border-gray-200 flex flex-wrap gap-6 text-xs">
+            <div className="mt-4 pt-3 border-t border-gray-200 dark:border-gray-800 flex flex-wrap gap-6 text-xs">
               <div>
-                <p className="text-gray-500 uppercase">Status</p>
+                <p className="text-gray-500 dark:text-gray-400 uppercase">Status</p>
                 <p className="font-mono font-medium mt-0.5">{wfInfo.status}</p>
               </div>
               {wfInfo.update_executions?.length > 0 && (
                 <div>
-                  <p className="text-gray-500 uppercase">Updates</p>
+                  <p className="text-gray-500 dark:text-gray-400 uppercase">Updates</p>
                   <p className="font-mono font-medium mt-0.5">{wfInfo.update_executions.length}</p>
                 </div>
               )}
               {(wfInfo.activities?.length > 0 || wfInfo.orphan_activities?.length > 0) && (
                 <div>
-                  <p className="text-gray-500 uppercase">Activities</p>
+                  <p className="text-gray-500 dark:text-gray-400 uppercase">Activities</p>
                   <p className="font-mono font-medium mt-0.5">
                     {(wfInfo.activities?.length || 0) + (wfInfo.orphan_activities?.length || 0)}
                   </p>
@@ -125,13 +125,13 @@ export const TemporalWorkflows = () => {
               )}
               {wfInfo.child_workflows?.length > 0 && (
                 <div>
-                  <p className="text-gray-500 uppercase">Child Workflows</p>
+                  <p className="text-gray-500 dark:text-gray-400 uppercase">Child Workflows</p>
                   <p className="font-mono font-medium mt-0.5">{wfInfo.child_workflows.length}</p>
                 </div>
               )}
               {wfInfo.awaited_signals?.length > 0 && (
                 <div>
-                  <p className="text-gray-500 uppercase">Awaited Signals</p>
+                  <p className="text-gray-500 dark:text-gray-400 uppercase">Awaited Signals</p>
                   <p className="font-mono font-medium mt-0.5">{wfInfo.awaited_signals.length}</p>
                 </div>
               )}
@@ -140,25 +140,25 @@ export const TemporalWorkflows = () => {
 
           {/* Failures section */}
           {(wfInfo.status === 'Failed' || wfInfo.status === 'Timed Out') && (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-4">
-              <h2 className="text-sm font-semibold text-red-800 mb-2">Failures</h2>
+            <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4">
+              <h2 className="text-sm font-semibold text-red-800 dark:text-red-200 mb-2">Failures</h2>
               <div className="space-y-2">
                 {wfInfo.update_executions?.filter((ue: any) => ue.failure).map((ue: any, i: number) => (
                   <div key={`ue-${i}`}>
                     <Badge variant="status" status="failed">{ue.name}</Badge>
-                    <pre className="mt-1 text-xs text-red-600 font-mono whitespace-pre-wrap bg-white border border-red-200 rounded p-2">{ue.failure}</pre>
+                    <pre className="mt-1 text-xs text-red-600 dark:text-red-400 font-mono whitespace-pre-wrap bg-white dark:bg-gray-900 border border-red-200 dark:border-red-800 rounded p-2">{ue.failure}</pre>
                   </div>
                 ))}
                 {wfInfo.orphan_activities?.filter((a: any) => a.failure).map((a: any, i: number) => (
                   <div key={`oa-${i}`}>
                     <Badge variant="status" status="failed">{a.name}</Badge>
-                    <pre className="mt-1 text-xs text-red-600 font-mono whitespace-pre-wrap bg-white border border-red-200 rounded p-2">{a.failure}</pre>
+                    <pre className="mt-1 text-xs text-red-600 dark:text-red-400 font-mono whitespace-pre-wrap bg-white dark:bg-gray-900 border border-red-200 dark:border-red-800 rounded p-2">{a.failure}</pre>
                   </div>
                 ))}
                 {wfInfo.activities?.filter((a: any) => a.failure).map((a: any, i: number) => (
                   <div key={`a-${i}`}>
                     <Badge variant="status" status="failed">{a.name}</Badge>
-                    <pre className="mt-1 text-xs text-red-600 font-mono whitespace-pre-wrap bg-white border border-red-200 rounded p-2">{a.failure}</pre>
+                    <pre className="mt-1 text-xs text-red-600 dark:text-red-400 font-mono whitespace-pre-wrap bg-white dark:bg-gray-900 border border-red-200 dark:border-red-800 rounded p-2">{a.failure}</pre>
                   </div>
                 ))}
               </div>
@@ -167,8 +167,8 @@ export const TemporalWorkflows = () => {
 
           {/* Activities */}
           {wfInfo.activities?.length > 0 && (
-            <div className="rounded-lg border border-gray-200 bg-white p-4">
-              <h2 className="text-sm font-semibold text-gray-900">Activities ({wfInfo.activities.length})</h2>
+            <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+              <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Activities ({wfInfo.activities.length})</h2>
               <div className="mt-2 table-card">
                 <table>
                   <thead>
@@ -176,13 +176,13 @@ export const TemporalWorkflows = () => {
                       <th>Name</th><th>Status</th><th>Duration</th><th>Attempt</th><th>Failure</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-200">
+                  <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
                     {wfInfo.activities.map((act: any, i: number) => (
                       <tr key={i}>
                         <td className="font-mono text-xs">{act.name}</td>
                         <td><Badge variant="status" status={act.status}>{act.status}</Badge></td>
-                        <td className="font-mono text-xs text-gray-500">{formatDuration(act.duration)}</td>
-                        <td className="text-xs text-gray-500">{act.attempt}</td>
+                        <td className="font-mono text-xs text-gray-500 dark:text-gray-400">{formatDuration(act.duration)}</td>
+                        <td className="text-xs text-gray-500 dark:text-gray-400">{act.attempt}</td>
                         <td className="text-xs text-red-500 max-w-[200px] truncate">{act.failure || '-'}</td>
                       </tr>
                     ))}
@@ -194,9 +194,9 @@ export const TemporalWorkflows = () => {
 
           {/* Orphan activities (main workflow body) */}
           {wfInfo.orphan_activities?.length > 0 && (
-            <div className="rounded-lg border border-gray-200 bg-white p-4">
-              <h2 className="text-sm font-semibold text-gray-900">Orphan Activities ({wfInfo.orphan_activities.length})</h2>
-              <p className="text-xs text-gray-500 mt-1 mb-2">Activities not associated with any update execution (main workflow body)</p>
+            <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+              <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Orphan Activities ({wfInfo.orphan_activities.length})</h2>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 mb-2">Activities not associated with any update execution (main workflow body)</p>
               <div className="table-card">
                 <table>
                   <thead>
@@ -204,13 +204,13 @@ export const TemporalWorkflows = () => {
                       <th>Name</th><th>Status</th><th>Duration</th><th>Attempt</th><th>Failure</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-200">
+                  <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
                     {wfInfo.orphan_activities.map((act: any, i: number) => (
                       <tr key={i}>
                         <td className="font-mono text-xs">{act.name}</td>
                         <td><Badge variant="status" status={act.status}>{act.status}</Badge></td>
-                        <td className="font-mono text-xs text-gray-500">{formatDuration(act.duration)}</td>
-                        <td className="text-xs text-gray-500">{act.attempt}</td>
+                        <td className="font-mono text-xs text-gray-500 dark:text-gray-400">{formatDuration(act.duration)}</td>
+                        <td className="text-xs text-gray-500 dark:text-gray-400">{act.attempt}</td>
                         <td className="text-xs text-red-500 max-w-[200px] truncate">{act.failure || '-'}</td>
                       </tr>
                     ))}
@@ -222,8 +222,8 @@ export const TemporalWorkflows = () => {
 
           {/* Update executions */}
           {wfInfo.update_executions?.length > 0 && (
-            <div className="rounded-lg border border-gray-200 bg-white p-4">
-              <h2 className="text-sm font-semibold text-gray-900">Update Executions ({wfInfo.update_executions.length})</h2>
+            <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+              <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Update Executions ({wfInfo.update_executions.length})</h2>
               <div className="mt-2 space-y-2">
                 {wfInfo.update_executions.map((ue: any, i: number) => (
                   <UpdateExecutionCard key={i} ue={ue} />
@@ -234,8 +234,8 @@ export const TemporalWorkflows = () => {
 
           {/* Child workflows */}
           {wfInfo.child_workflows?.length > 0 && (
-            <div className="rounded-lg border border-gray-200 bg-white p-4">
-              <h2 className="text-sm font-semibold text-gray-900">Child Workflows ({wfInfo.child_workflows.length})</h2>
+            <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+              <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Child Workflows ({wfInfo.child_workflows.length})</h2>
               <div className="mt-2 table-card">
                 <table>
                   <thead>
@@ -243,20 +243,20 @@ export const TemporalWorkflows = () => {
                       <th>Type</th><th>Status</th><th>Namespace</th><th>Duration</th><th>Workflow ID</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-200">
+                  <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
                     {wfInfo.child_workflows.map((cw: any, i: number) => (
                       <tr key={i}>
                         <td className="font-mono text-xs">{cw.workflow_type}</td>
                         <td><Badge variant="status" status={cw.status}>{cw.status}</Badge></td>
-                        <td className="text-xs text-gray-500">{cw.namespace}</td>
-                        <td className="font-mono text-xs text-gray-500">{formatDuration(cw.duration)}</td>
+                        <td className="text-xs text-gray-500 dark:text-gray-400">{cw.namespace}</td>
+                        <td className="font-mono text-xs text-gray-500 dark:text-gray-400">{formatDuration(cw.duration)}</td>
                         <td className="font-mono text-xs">
                           {temporalUIUrl ? (
                             <a
                               href={`${temporalUIUrl}/namespaces/${cw.namespace}/workflows/${cw.workflow_id}`}
                               target="_blank"
                               rel="noopener noreferrer"
-                              className="text-primary-600 hover:text-primary-700"
+                              className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
                             >
                               {truncateId(cw.workflow_id)}
                             </a>
@@ -272,8 +272,8 @@ export const TemporalWorkflows = () => {
 
           {/* Awaited signals */}
           {wfInfo.awaited_signals?.length > 0 && (
-            <div className="rounded-lg border border-gray-200 bg-white p-4">
-              <h2 className="text-sm font-semibold text-gray-900">Awaited Signals ({wfInfo.awaited_signals.length})</h2>
+            <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+              <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Awaited Signals ({wfInfo.awaited_signals.length})</h2>
               <div className="mt-2 table-card">
                 <table>
                   <thead>
@@ -281,21 +281,21 @@ export const TemporalWorkflows = () => {
                       <th>Signal ID</th><th>Status</th><th>Duration</th><th>Failure</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-200">
+                  <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
                     {wfInfo.awaited_signals.map((as: any, i: number) => (
                       <tr key={i}>
                         <td className="font-mono text-xs">
                           {as.queue_signal_id ? (
                             <Link
                               to={`/queue-signals?search=${as.queue_signal_id}`}
-                              className="text-primary-600 hover:text-primary-700"
+                              className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
                             >
                               {truncateId(as.queue_signal_id)}
                             </Link>
                           ) : '-'}
                         </td>
                         <td><Badge variant="status" status={as.status}>{as.status}</Badge></td>
-                        <td className="font-mono text-xs text-gray-500">{formatDuration(as.duration)}</td>
+                        <td className="font-mono text-xs text-gray-500 dark:text-gray-400">{formatDuration(as.duration)}</td>
                         <td className="text-xs text-red-500 max-w-[200px] truncate">{as.failure || '-'}</td>
                       </tr>
                     ))}
@@ -307,8 +307,8 @@ export const TemporalWorkflows = () => {
 
           {/* Update handlers */}
           {wfInfo.update_handlers?.length > 0 && (
-            <div className="rounded-lg border border-gray-200 bg-white p-4">
-              <h2 className="text-sm font-semibold text-gray-900">Update Handlers</h2>
+            <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+              <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Update Handlers</h2>
               <div className="mt-2 flex flex-wrap gap-2">
                 {wfInfo.update_handlers.map((h: string) => <Badge key={h}>{h}</Badge>)}
               </div>
@@ -318,7 +318,7 @@ export const TemporalWorkflows = () => {
       )}
 
       {submitted && !isLoading && !error && !wfInfo && (
-        <p className="text-sm text-gray-500">No workflow found with the given parameters</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">No workflow found with the given parameters</p>
       )}
     </div>
   )
@@ -327,40 +327,40 @@ export const TemporalWorkflows = () => {
 function UpdateExecutionCard({ ue }: { ue: any }) {
   const [expanded, setExpanded] = useState(false)
   return (
-    <div className="border border-gray-200 rounded-md">
-      <button onClick={() => setExpanded(!expanded)} className="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-gray-50">
+    <div className="border border-gray-200 dark:border-gray-800 rounded-md">
+      <button onClick={() => setExpanded(!expanded)} className="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-800">
         <div className="flex items-center gap-2 text-xs">
           <Badge variant="status" status={ue.status}>{ue.status}</Badge>
           <span className="font-mono font-medium">{ue.name}</span>
-          <span className="text-gray-400">{formatDuration(ue.duration)}</span>
+          <span className="text-gray-400 dark:text-gray-500">{formatDuration(ue.duration)}</span>
         </div>
-        <span className="text-gray-400 text-xs">{expanded ? '▾' : '▸'}</span>
+        <span className="text-gray-400 dark:text-gray-500 text-xs">{expanded ? '▾' : '▸'}</span>
       </button>
       {expanded && (
-        <div className="border-t border-gray-200 px-3 py-2 text-xs space-y-2">
-          <div><span className="text-gray-500">Update ID:</span> <span className="font-mono select-all">{ue.update_id}</span></div>
-          <div><span className="text-gray-500">Duration:</span> <span className="font-mono">{formatDuration(ue.duration)}</span></div>
+        <div className="border-t border-gray-200 dark:border-gray-800 px-3 py-2 text-xs space-y-2">
+          <div><span className="text-gray-500 dark:text-gray-400">Update ID:</span> <span className="font-mono select-all">{ue.update_id}</span></div>
+          <div><span className="text-gray-500 dark:text-gray-400">Duration:</span> <span className="font-mono">{formatDuration(ue.duration)}</span></div>
           {ue.input && (
             <div>
-              <span className="text-gray-500">Input:</span>
-              <pre className="mt-0.5 font-mono bg-gray-50 rounded p-2 overflow-x-auto max-h-32">{ue.input}</pre>
+              <span className="text-gray-500 dark:text-gray-400">Input:</span>
+              <pre className="mt-0.5 font-mono bg-gray-50 dark:bg-gray-900 rounded p-2 overflow-x-auto max-h-32">{ue.input}</pre>
             </div>
           )}
           {ue.result && (
             <div>
-              <span className="text-gray-500">Result:</span>
-              <pre className="mt-0.5 font-mono bg-gray-50 rounded p-2 overflow-x-auto max-h-32">{ue.result}</pre>
+              <span className="text-gray-500 dark:text-gray-400">Result:</span>
+              <pre className="mt-0.5 font-mono bg-gray-50 dark:bg-gray-900 rounded p-2 overflow-x-auto max-h-32">{ue.result}</pre>
             </div>
           )}
           {ue.failure && (
             <div>
-              <span className="text-gray-500">Failure:</span>
-              <pre className="mt-0.5 font-mono text-red-600 bg-red-50 rounded p-2 overflow-x-auto max-h-32">{ue.failure}</pre>
+              <span className="text-gray-500 dark:text-gray-400">Failure:</span>
+              <pre className="mt-0.5 font-mono text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/30 rounded p-2 overflow-x-auto max-h-32">{ue.failure}</pre>
             </div>
           )}
           {ue.activities?.length > 0 && (
             <div>
-              <p className="text-gray-500 mb-1">Activities ({ue.activities.length}):</p>
+              <p className="text-gray-500 dark:text-gray-400 mb-1">Activities ({ue.activities.length}):</p>
               <div className="table-card">
                 <table>
                   <thead>
@@ -368,13 +368,13 @@ function UpdateExecutionCard({ ue }: { ue: any }) {
                       <th>Name</th><th>Status</th><th>Duration</th><th>Attempt</th><th>Failure</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-200">
+                  <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
                     {ue.activities.map((a: any, i: number) => (
                       <tr key={i}>
                         <td className="font-mono text-xs">{a.name}</td>
                         <td><Badge variant="status" status={a.status}>{a.status}</Badge></td>
-                        <td className="font-mono text-xs text-gray-500">{formatDuration(a.duration)}</td>
-                        <td className="text-xs text-gray-500">{a.attempt}</td>
+                        <td className="font-mono text-xs text-gray-500 dark:text-gray-400">{formatDuration(a.duration)}</td>
+                        <td className="text-xs text-gray-500 dark:text-gray-400">{a.attempt}</td>
                         <td className="text-xs text-red-500 max-w-[200px] truncate">{a.failure || '-'}</td>
                       </tr>
                     ))}

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/workflows/WorkflowDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/workflows/WorkflowDetail.tsx
@@ -42,42 +42,42 @@ function StepRow({ stepData }: { stepData: any }) {
   const maxAutoRetries = step?.status?.metadata?.max_auto_retries
   return (
     <>
-      <tr className="hover:bg-gray-50 cursor-pointer" onClick={() => setExpanded(!expanded)}>
-        <td className="text-xs text-gray-500">{step?.idx}</td>
-        <td className="text-xs text-gray-900 max-w-[200px] truncate" title={step?.name}>{step?.name || '-'}</td>
+      <tr className="hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer" onClick={() => setExpanded(!expanded)}>
+        <td className="text-xs text-gray-500 dark:text-gray-400">{step?.idx}</td>
+        <td className="text-xs text-gray-900 dark:text-gray-100 max-w-[200px] truncate" title={step?.name}>{step?.name || '-'}</td>
         <td><Badge variant="status" status={status}>{status || '-'}</Badge></td>
-        <td className="text-xs text-gray-500 font-mono">
+        <td className="text-xs text-gray-500 dark:text-gray-400 font-mono">
           <span>{step?.execution_type || '-'}</span>
           {maxAutoRetries !== undefined && maxAutoRetries !== null && (
             <Badge className="ml-1">max retries: {String(maxAutoRetries)}</Badge>
           )}
         </td>
-        <td className="text-xs text-gray-500">{formatTime(step?.started_at)}</td>
-        <td className="text-xs text-gray-500">{formatDur(step?.execution_time)}</td>
+        <td className="text-xs text-gray-500 dark:text-gray-400">{formatTime(step?.started_at)}</td>
+        <td className="text-xs text-gray-500 dark:text-gray-400">{formatDur(step?.execution_time)}</td>
         <td className="text-xs space-x-1">
           {stepData.step_signal_id && stepData.step_signal_queue_id && (
-            <Link to={`/queues/${stepData.step_signal_queue_id}/signals/${stepData.step_signal_id}`} className="text-primary-600 hover:text-primary-700" onClick={(e) => e.stopPropagation()}>
+            <Link to={`/queues/${stepData.step_signal_queue_id}/signals/${stepData.step_signal_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300" onClick={(e) => e.stopPropagation()}>
               signal
             </Link>
           )}
           {!stepData.step_signal_id && (
-            <Link to={`/queue-signals?search=${step?.id}`} className="text-primary-600 hover:text-primary-700" onClick={(e) => e.stopPropagation()}>
+            <Link to={`/queue-signals?search=${step?.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300" onClick={(e) => e.stopPropagation()}>
               search
             </Link>
           )}
         </td>
-        <td className="text-xs text-gray-400">{expanded ? '▾' : '▸'}</td>
+        <td className="text-xs text-gray-400 dark:text-gray-500">{expanded ? '▾' : '▸'}</td>
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={8} className="bg-gray-50 px-4 py-3">
+          <td colSpan={8} className="bg-gray-50 dark:bg-gray-900 px-4 py-3">
             <div className="space-y-3 text-xs">
               {/* IDs */}
               <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                <div><span className="text-gray-500">Step ID:</span> <span className="font-mono">{step?.id}</span></div>
-                <div><span className="text-gray-500">Group:</span> g{step?.group_idx}r{step?.group_retry_idx}</div>
-                <div><span className="text-gray-500">Target type:</span> {step?.step_target_type || '-'}</div>
-                <div><span className="text-gray-500">Target ID:</span> <span className="font-mono">{truncateId(step?.step_target_id) || '-'}</span></div>
+                <div><span className="text-gray-500 dark:text-gray-400">Step ID:</span> <span className="font-mono">{step?.id}</span></div>
+                <div><span className="text-gray-500 dark:text-gray-400">Group:</span> g{step?.group_idx}r{step?.group_retry_idx}</div>
+                <div><span className="text-gray-500 dark:text-gray-400">Target type:</span> {step?.step_target_type || '-'}</div>
+                <div><span className="text-gray-500 dark:text-gray-400">Target ID:</span> <span className="font-mono">{truncateId(step?.step_target_id) || '-'}</span></div>
               </div>
 
               {/* Step flags */}
@@ -91,14 +91,14 @@ function StepRow({ stepData }: { stepData: any }) {
               {/* Step target */}
               {stepData.step_target && (
                 <div>
-                  <p className="font-semibold text-gray-700 mb-1">Step target</p>
+                  <p className="font-semibold text-gray-700 dark:text-gray-300 mb-1">Step target</p>
                   <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                    <div><span className="text-gray-500">Type:</span> {stepData.step_target.type}</div>
-                    <div><span className="text-gray-500">ID:</span> <span className="font-mono">{stepData.step_target.id}</span></div>
-                    <div><span className="text-gray-500">Status:</span> {stepData.step_target.status ? <Badge variant="status" status={stepData.step_target.status}>{stepData.step_target.status}</Badge> : '-'}</div>
+                    <div><span className="text-gray-500 dark:text-gray-400">Type:</span> {stepData.step_target.type}</div>
+                    <div><span className="text-gray-500 dark:text-gray-400">ID:</span> <span className="font-mono">{stepData.step_target.id}</span></div>
+                    <div><span className="text-gray-500 dark:text-gray-400">Status:</span> {stepData.step_target.status ? <Badge variant="status" status={stepData.step_target.status}>{stepData.step_target.status}</Badge> : '-'}</div>
                     {stepData.step_target.log_stream_id && (
                       <div>
-                        <Link to={`/log-streams/${stepData.step_target.log_stream_id}`} className="text-primary-600 hover:text-primary-700">
+                        <Link to={`/log-streams/${stepData.step_target.log_stream_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">
                           View logs &rarr;
                         </Link>
                       </div>
@@ -110,14 +110,14 @@ function StepRow({ stepData }: { stepData: any }) {
               {/* Approval */}
               {step?.approval && (
                 <div>
-                  <p className="font-semibold text-gray-700 mb-1">Approval</p>
+                  <p className="font-semibold text-gray-700 dark:text-gray-300 mb-1">Approval</p>
                   <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                    <div><span className="text-gray-500">Type:</span> {step.approval.type || '-'}</div>
+                    <div><span className="text-gray-500 dark:text-gray-400">Type:</span> {step.approval.type || '-'}</div>
                     {step.approval.response && (
-                      <div><span className="text-gray-500">Response:</span> {step.approval.response.type || step.approval.response.response || '-'}</div>
+                      <div><span className="text-gray-500 dark:text-gray-400">Response:</span> {step.approval.response.type || step.approval.response.response || '-'}</div>
                     )}
                     {step.approval.note && (
-                      <div className="col-span-2"><span className="text-gray-500">Note:</span> {step.approval.note}</div>
+                      <div className="col-span-2"><span className="text-gray-500 dark:text-gray-400">Note:</span> {step.approval.note}</div>
                     )}
                   </div>
                 </div>
@@ -126,7 +126,7 @@ function StepRow({ stepData }: { stepData: any }) {
               {/* Status history */}
               {step?.status && (
                 <div>
-                  <p className="font-semibold text-gray-700 mb-1">Status history</p>
+                  <p className="font-semibold text-gray-700 dark:text-gray-300 mb-1">Status history</p>
                   <StatusHistory status={step.status} maxCollapsed={3} />
                 </div>
               )}
@@ -134,10 +134,10 @@ function StepRow({ stepData }: { stepData: any }) {
               {/* Metadata */}
               {step?.metadata && Object.keys(step.metadata).length > 0 && (
                 <div>
-                  <p className="font-semibold text-gray-700 mb-1">Metadata</p>
+                  <p className="font-semibold text-gray-700 dark:text-gray-300 mb-1">Metadata</p>
                   <div className="grid grid-cols-2 gap-1">
                     {Object.entries(step.metadata).map(([k, v]) => (
-                      <div key={k}><span className="text-gray-500">{k}:</span> <span className="font-mono">{String(v)}</span></div>
+                      <div key={k}><span className="text-gray-500 dark:text-gray-400">{k}:</span> <span className="font-mono">{String(v)}</span></div>
                     ))}
                   </div>
                 </div>
@@ -146,7 +146,7 @@ function StepRow({ stepData }: { stepData: any }) {
               {/* Queue signal JSON */}
               {stepData.queue_signal_json && (
                 <div>
-                  <p className="font-semibold text-gray-700 mb-1">Queue signal data</p>
+                  <p className="font-semibold text-gray-700 dark:text-gray-300 mb-1">Queue signal data</p>
                   <JsonViewer data={stepData.queue_signal_json} collapsed />
                 </div>
               )}
@@ -168,24 +168,24 @@ function StepGroupSection({ group }: { group: any }) {
   const groupSignal = g?.queue_signal
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white">
+    <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-gray-50"
+        className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-800"
       >
         <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-xs font-semibold text-gray-500">g{g?.group_idx}</span>
-          <span className="text-sm font-medium text-gray-900">{g?.name || `Group ${g?.group_idx}`}</span>
+          <span className="text-xs font-semibold text-gray-500 dark:text-gray-400">g{g?.group_idx}</span>
+          <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{g?.name || `Group ${g?.group_idx}`}</span>
           <Badge>{g?.parallel ? 'parallel' : 'sequential'}</Badge>
           {status && <Badge variant="status" status={status}>{status}</Badge>}
           {g?.result_directive && <Badge>{g.result_directive}</Badge>}
-          <span className="text-xs text-gray-400">{steps.length} steps</span>
+          <span className="text-xs text-gray-400 dark:text-gray-500">{steps.length} steps</span>
         </div>
         <div className="flex items-center gap-2">
           {groupSignal && (
             <Link
               to={`/queues/${groupSignal.queue_id}/signals/${groupSignal.id}`}
-              className="text-xs text-primary-600 hover:text-primary-700"
+              className="text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
               onClick={(e) => e.stopPropagation()}
             >
               group signal &rarr;
@@ -194,31 +194,31 @@ function StepGroupSection({ group }: { group: any }) {
           {!groupSignal && g?.id && (
             <Link
               to={`/queue-signals?search=${g.id}`}
-              className="text-xs text-primary-600 hover:text-primary-700"
+              className="text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
               onClick={(e) => e.stopPropagation()}
             >
               search signal
             </Link>
           )}
-          <span className="text-gray-400">{expanded ? '▾' : '▸'}</span>
+          <span className="text-gray-400 dark:text-gray-500">{expanded ? '▾' : '▸'}</span>
         </div>
       </button>
       {expanded && steps.length > 0 && (
-        <div className="border-t border-gray-200 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-100">
-            <thead className="bg-gray-50/50">
+        <div className="border-t border-gray-200 dark:border-gray-800 overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-100 dark:divide-gray-800">
+            <thead className="bg-gray-50/50 dark:bg-gray-900/50">
               <tr>
-                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase w-10">#</th>
-                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase">Name</th>
-                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase">Status</th>
-                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase">Exec type</th>
-                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase">Started</th>
-                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase">Duration</th>
-                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase">Signal</th>
+                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase w-10">#</th>
+                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Name</th>
+                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Status</th>
+                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Exec type</th>
+                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Started</th>
+                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Duration</th>
+                <th className="px-4 py-2 text-left text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase">Signal</th>
                 <th className="px-4 py-2 w-6"></th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100">
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
               {steps.map((sd: any) => (
                 <StepRow key={sd.step?.id} stepData={sd} />
               ))}
@@ -227,7 +227,7 @@ function StepGroupSection({ group }: { group: any }) {
         </div>
       )}
       {expanded && steps.length === 0 && (
-        <div className="border-t border-gray-200 px-4 py-4 text-sm text-gray-500">No steps in this group</div>
+        <div className="border-t border-gray-200 dark:border-gray-800 px-4 py-4 text-sm text-gray-500 dark:text-gray-400">No steps in this group</div>
       )}
     </div>
   )
@@ -267,21 +267,21 @@ export const WorkflowDetail = () => {
           <Badge variant="status" status={wfStatus}>{wfStatus || '-'}</Badge>
           {wf?.result_directive && <Badge>{wf.result_directive}</Badge>}
         </div>
-        <div className="mt-2 text-sm text-gray-500">
-          Owner: <Link to={`/installs/${wf?.owner_id}`} className="font-mono text-xs text-primary-600 hover:text-primary-700">{wf?.owner_id}</Link>
-          <span className="text-gray-400 ml-1">({wf?.owner_type})</span>
+        <div className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          Owner: <Link to={`/installs/${wf?.owner_id}`} className="font-mono text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">{wf?.owner_id}</Link>
+          <span className="text-gray-400 dark:text-gray-500 ml-1">({wf?.owner_type})</span>
           {wf?.created_by?.email && (
-            <span className="ml-3">by <Link to={`/accounts/${wf.created_by_id}`} className="text-primary-600 hover:text-primary-700">{wf.created_by.email}</Link></span>
+            <span className="ml-3">by <Link to={`/accounts/${wf.created_by_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">{wf.created_by.email}</Link></span>
           )}
         </div>
         <div className="mt-1 flex gap-3 text-xs">
           {wfSignal ? (
             <>
-              <Link to={`/queues/${wfSignal.queue_id}/signals/${wfSignal.id}`} className="text-primary-600 hover:text-primary-700">Workflow signal &rarr;</Link>
-              <Link to={`/queues/${wfSignal.queue_id}/signals/${wfSignal.id}/graph`} className="inline-flex items-center rounded bg-primary-50 border border-primary-200 px-1.5 py-0.5 text-[10px] font-medium text-primary-600 hover:bg-primary-100">graph</Link>
+              <Link to={`/queues/${wfSignal.queue_id}/signals/${wfSignal.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">Workflow signal &rarr;</Link>
+              <Link to={`/queues/${wfSignal.queue_id}/signals/${wfSignal.id}/graph`} className="inline-flex items-center rounded bg-primary-50 dark:bg-primary-950 border border-primary-200 dark:border-primary-800 px-1.5 py-0.5 text-[10px] font-medium text-primary-600 dark:text-primary-400 hover:bg-primary-100 dark:hover:bg-primary-900">graph</Link>
             </>
           ) : (
-            <Link to={`/queue-signals?search=${wf?.id}`} className="text-primary-600 hover:text-primary-700">Search workflow signals &rarr;</Link>
+            <Link to={`/queue-signals?search=${wf?.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">Search workflow signals &rarr;</Link>
           )}
         </div>
       </div>
@@ -296,27 +296,27 @@ export const WorkflowDetail = () => {
 
       {/* Generate steps signal */}
       {genSignal && (
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900">Generate steps signal</h2>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Generate steps signal</h2>
           <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4 text-sm">
             <div>
-              <span className="text-gray-500 text-xs">Signal ID:</span>
-              <Link to={`/queues/${genSignal.queue_id}/signals/${genSignal.id}`} className="ml-1 font-mono text-xs text-primary-600 hover:text-primary-700">
+              <span className="text-gray-500 dark:text-gray-400 text-xs">Signal ID:</span>
+              <Link to={`/queues/${genSignal.queue_id}/signals/${genSignal.id}`} className="ml-1 font-mono text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">
                 {truncateId(genSignal.id)}
               </Link>
             </div>
             <div>
-              <span className="text-gray-500 text-xs">Queue:</span>
-              <Link to={`/queues/${genSignal.queue_id}`} className="ml-1 font-mono text-xs text-primary-600 hover:text-primary-700">
+              <span className="text-gray-500 dark:text-gray-400 text-xs">Queue:</span>
+              <Link to={`/queues/${genSignal.queue_id}`} className="ml-1 font-mono text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">
                 {truncateId(genSignal.queue_id)}
               </Link>
             </div>
             <div>
-              <span className="text-gray-500 text-xs">Type:</span>
+              <span className="text-gray-500 dark:text-gray-400 text-xs">Type:</span>
               <span className="ml-1 font-mono text-xs">{genSignal.type}</span>
             </div>
             <div>
-              <span className="text-gray-500 text-xs">Status:</span>
+              <span className="text-gray-500 dark:text-gray-400 text-xs">Status:</span>
               <Badge variant="status" status={getStatus(genSignal.status)} className="ml-1">{getStatus(genSignal.status)}</Badge>
             </div>
           </div>
@@ -325,8 +325,8 @@ export const WorkflowDetail = () => {
 
       {/* Workflow status history */}
       {wf?.status && (
-        <div className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-sm font-semibold text-gray-900">Status history</h2>
+        <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Status history</h2>
           <div className="mt-2">
             <StatusHistory status={wf.status} maxCollapsed={5} />
           </div>
@@ -335,7 +335,7 @@ export const WorkflowDetail = () => {
 
       {/* Step Groups */}
       <div>
-        <h2 className="text-sm font-semibold text-gray-900 mb-2">Step groups ({groups.length})</h2>
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">Step groups ({groups.length})</h2>
         {groups.length > 0 ? (
           <div className="space-y-3">
             {groups.map((group: any, i: number) => (
@@ -343,7 +343,7 @@ export const WorkflowDetail = () => {
             ))}
           </div>
         ) : (
-          <div className="rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-500">
+          <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4 text-sm text-gray-500 dark:text-gray-400">
             No steps recorded
           </div>
         )}
@@ -354,9 +354,9 @@ export const WorkflowDetail = () => {
 
 function TimelineCard({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-3">
-      <p className="text-[11px] text-gray-500 uppercase tracking-wider">{label}</p>
-      <p className="mt-0.5 text-sm font-mono text-gray-900">{value}</p>
+    <div className="rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-3">
+      <p className="text-[11px] text-gray-500 dark:text-gray-400 uppercase tracking-wider">{label}</p>
+      <p className="mt-0.5 text-sm font-mono text-gray-900 dark:text-gray-100">{value}</p>
     </div>
   )
 }

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/workflows/WorkflowsList.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/workflows/WorkflowsList.tsx
@@ -57,7 +57,7 @@ export const WorkflowsList = () => {
         <select
           value={type}
           onChange={(e) => { setType(e.target.value); setPage(1) }}
-          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300"
+          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700"
         >
           <option value="">All types</option>
           {WORKFLOW_TYPES.map((t) => (
@@ -67,7 +67,7 @@ export const WorkflowsList = () => {
         <select
           value={sort}
           onChange={(e) => { setSort(e.target.value as 'newest' | 'oldest'); setPage(1) }}
-          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300"
+          className="rounded-md border-0 py-1.5 px-3 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700"
         >
           <option value="newest">Newest first</option>
           <option value="oldest">Oldest first</option>
@@ -87,41 +87,41 @@ export const WorkflowsList = () => {
               <th>Created</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
             {workflows.map((wf: any) => {
               const status = getStatus(wf.status)
               return (
                 <tr key={wf.id}>
                   <td>
-                    <Link to={`/workflows/${wf.id}`} className="text-primary-600 hover:text-primary-700 font-mono text-xs">
+                    <Link to={`/workflows/${wf.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-mono text-xs">
                       {truncateId(wf.id)}
                     </Link>
                   </td>
-                  <td className="font-mono text-xs text-gray-900">{wf.type}</td>
-                  <td className="text-gray-500">
-                    <Link to={`/installs/${wf.owner_id}`} className="font-mono text-xs text-primary-600 hover:text-primary-700">
+                  <td className="font-mono text-xs text-gray-900 dark:text-gray-100">{wf.type}</td>
+                  <td className="text-gray-500 dark:text-gray-400">
+                    <Link to={`/installs/${wf.owner_id}`} className="font-mono text-xs text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">
                       {truncateId(wf.owner_id)}
                     </Link>
-                    <span className="ml-1 text-[11px] text-gray-400">({wf.owner_type})</span>
+                    <span className="ml-1 text-[11px] text-gray-400 dark:text-gray-500">({wf.owner_type})</span>
                   </td>
-                  <td className="text-gray-500 text-xs">{wf.steps?.length ?? 0}</td>
+                  <td className="text-gray-500 dark:text-gray-400 text-xs">{wf.steps?.length ?? 0}</td>
                   <td>
                     <Badge variant="status" status={status}>{status || '-'}</Badge>
                   </td>
-                  <td className="text-gray-500 text-xs">
+                  <td className="text-gray-500 dark:text-gray-400 text-xs">
                     {wf.created_by?.email ? (
-                      <Link to={`/accounts/${wf.created_by_id}`} className="text-primary-600 hover:text-primary-700">{wf.created_by.email}</Link>
+                      <Link to={`/accounts/${wf.created_by_id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300">{wf.created_by.email}</Link>
                     ) : (
                       <span className="font-mono">{truncateId(wf.created_by_id)}</span>
                     )}
                   </td>
-                  <td className="text-gray-500">{formatDate(wf.created_at)}</td>
+                  <td className="text-gray-500 dark:text-gray-400">{formatDate(wf.created_at)}</td>
                 </tr>
               )
             })}
             {workflows.length === 0 && (
               <tr>
-                <td colSpan={7} className="text-center text-gray-500 py-6">No workflows found</td>
+                <td colSpan={7} className="text-center text-gray-500 dark:text-gray-400 py-6">No workflows found</td>
               </tr>
             )}
           </tbody>

--- a/services/ctl-api/internal/app/admin-dashboard/package-lock.json
+++ b/services/ctl-api/internal/app/admin-dashboard/package-lock.json
@@ -719,9 +719,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -739,9 +736,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -759,9 +753,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -779,9 +770,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1026,6 +1014,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1443,6 +1432,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1843,6 +1833,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3685,9 +3676,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3709,9 +3697,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3733,9 +3718,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3757,9 +3739,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4506,6 +4485,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4719,6 +4699,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4731,6 +4712,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5837,6 +5819,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },


### PR DESCRIPTION
Tightens the admin-dashboard SPA in three coordinated ways:

- **Dark mode** — adds `dark:*` Tailwind variants across every common
  component and view (Badge, DotGraph, JsonViewer, Pagination, SignalLink,
  StatusHistory, AppLayout, and all view pages: accounts, installs, queues,
  workflows, runners, etc.). Pairs with the dark-mode body styles in
  `styles.css`.

- **Shared style classes** — pulls repeated breadcrumb / page-heading /
  card / table chrome out of inline Tailwind salads and onto a small set
  of shared classes in `styles.css`. Net result: -155 LOC across 44 files.

- **Misc cleanup** — drops a few unused log-stream / org / runner / temporal
  detail bits that were dead after upstream refactors.

No backend changes. No new dependencies (only `package-lock.json` churn from
a routine install).