### PR TITLE
refactor(ui): smarter step banners

### DIFF
--- a/services/dashboard-ui/client/components/workflows/WorkflowDetails/WorkflowDetails.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/WorkflowDetails/WorkflowDetails.stories.tsx
@@ -1,3 +1,212 @@
 export default {
   title: 'Workflows/WorkflowDetails',
 }
+
+import type { ReactNode } from 'react'
+import { WorkflowDetails } from './WorkflowDetails'
+import { WorkflowContext } from '@/providers/workflow-provider'
+import { OrgContext } from '@/providers/org-provider'
+import { InstallContext } from '@/providers/install-provider'
+import type { TWorkflow, TWorkflowStep } from '@/types'
+
+const mockOrg = { id: 'org-1', name: 'Acme Corp' } as any
+const mockInstall = { id: 'inst-1', name: 'production', app_id: 'app-1' } as any
+
+const baseWorkflow = {
+  id: 'wf-123',
+  name: 'deploy',
+  type: 'deploy_components',
+  created_at: '2026-05-01T10:00:00Z',
+  updated_at: '2026-05-01T10:05:00Z',
+  status: {
+    status: 'success',
+    status_human_description: 'Succeeded',
+    metadata: {},
+  },
+  steps: [],
+} as TWorkflow
+
+const makeStep = (
+  id: string,
+  name: string,
+  status: string,
+  statusDescription?: string
+) =>
+  ({
+    id,
+    name,
+    execution_type: 'system',
+    status: {
+      status,
+      status_human_description: statusDescription ?? status,
+      history: [],
+    },
+  }) as TWorkflowStep
+
+const Wrapper = ({
+  children,
+  workflow,
+}: {
+  children: ReactNode
+  workflow: TWorkflow
+}) => (
+  <OrgContext.Provider value={{ org: mockOrg, refresh: () => {} }}>
+    <InstallContext.Provider value={{ install: mockInstall, refresh: () => {} }}>
+      <WorkflowContext.Provider
+        value={{
+          workflow,
+          stopPolling: () => {},
+          workflowSteps: workflow.steps ?? [],
+          hasApprovals: false,
+          failedSteps: [],
+          pendingApprovals: [],
+          discardedSteps: [],
+          completedSteps: [],
+          stepsWithPolicyViolations: [],
+          totalSteps: workflow.steps?.length ?? 0,
+          pendingApprovalsCount: 0,
+          discardedStepsCount: 0,
+          completedStepsCount: 0,
+          failedStepsCount: 0,
+          policyViolationsCount: 0,
+        }}
+      >
+        {children}
+      </WorkflowContext.Provider>
+    </InstallContext.Provider>
+  </OrgContext.Provider>
+)
+
+export const Default = () => (
+  <Wrapper workflow={baseWorkflow}>
+    <WorkflowDetails workflow={baseWorkflow} failedSteps={[]} />
+  </Wrapper>
+)
+
+export const RetriesExhausted = () => {
+  const workflow = {
+    ...baseWorkflow,
+    status: {
+      ...baseWorkflow.status,
+      status: 'error',
+      status_human_description: 'Failed',
+      metadata: { retries_exhausted: true, max_retries: 3 },
+    },
+  } as TWorkflow
+
+  return (
+    <Wrapper workflow={workflow}>
+      <WorkflowDetails workflow={workflow} failedSteps={[]} />
+    </Wrapper>
+  )
+}
+
+export const WorkflowStopped = () => {
+  const workflow = {
+    ...baseWorkflow,
+    status: {
+      ...baseWorkflow.status,
+      status: 'error',
+      status_human_description: 'Stopped',
+      metadata: {
+        stopped: true,
+        error_message: 'Workflow was cancelled by user before completion.',
+      },
+    },
+  } as TWorkflow
+
+  return (
+    <Wrapper workflow={workflow}>
+      <WorkflowDetails workflow={workflow} failedSteps={[]} />
+    </Wrapper>
+  )
+}
+
+export const SingleFailedStep = () => {
+  const workflow = {
+    ...baseWorkflow,
+    status: {
+      ...baseWorkflow.status,
+      status: 'error',
+      status_human_description: 'Failed',
+      metadata: {},
+    },
+  } as TWorkflow
+
+  return (
+    <Wrapper workflow={workflow}>
+      <WorkflowDetails
+        workflow={workflow}
+        failedSteps={[
+          makeStep(
+            'step-1',
+            'deploy api-server',
+            'error',
+            'Terraform apply failed: resource limit exceeded'
+          ),
+        ]}
+      />
+    </Wrapper>
+  )
+}
+
+export const MultipleFailedSteps = () => {
+  const workflow = {
+    ...baseWorkflow,
+    status: {
+      ...baseWorkflow.status,
+      status: 'error',
+      status_human_description: 'Failed',
+      metadata: {},
+    },
+  } as TWorkflow
+
+  return (
+    <Wrapper workflow={workflow}>
+      <WorkflowDetails
+        workflow={workflow}
+        failedSteps={[
+          makeStep('step-1', 'deploy database', 'error', 'Connection timeout after 300s'),
+          makeStep('step-2', 'deploy cache', 'error', 'Helm release failed: image pull backoff'),
+          makeStep(
+            'step-3',
+            'deploy api-server',
+            'error',
+            'Terraform apply failed: resource limit exceeded'
+          ),
+        ]}
+      />
+    </Wrapper>
+  )
+}
+
+export const StoppedWithFailedSteps = () => {
+  const workflow = {
+    ...baseWorkflow,
+    status: {
+      ...baseWorkflow.status,
+      status: 'error',
+      status_human_description: 'Stopped',
+      metadata: {
+        stopped: true,
+        error_message: 'Workflow stopped due to step failure.',
+      },
+    },
+  } as TWorkflow
+
+  return (
+    <Wrapper workflow={workflow}>
+      <WorkflowDetails
+        workflow={workflow}
+        failedSteps={[
+          makeStep(
+            'step-1',
+            'deploy api-server',
+            'error',
+            'Terraform plan failed: invalid provider configuration'
+          ),
+        ]}
+      />
+    </Wrapper>
+  )
+}

--- a/services/dashboard-ui/client/components/workflows/WorkflowDetails/WorkflowDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/WorkflowDetails/WorkflowDetails.tsx
@@ -2,7 +2,13 @@ import { useState } from 'react'
 import { Banner } from '@/components/common/Banner'
 import { Button } from '@/components/common/Button'
 import { Text } from '@/components/common/Text'
+import { useSurfaces } from '@/hooks/use-surfaces'
 import { StepBanner } from '../step-details/StepBanner'
+import {
+  StepDetailPanel,
+  getStepPanelSize,
+  getStepPanelDetails,
+} from '../step-details/StepDetailPanel'
 import { WorkflowHeaderContainer } from '../workflow-details/WorkflowHeader'
 import { WorkflowMetricsContainer } from '../workflow-details/WorkflowMetrics'
 import { WorkflowStatusSectionContainer } from '../workflow-details/WorkflowStatusSection'
@@ -20,7 +26,7 @@ export const WorkflowDetails = ({ workflow, failedSteps }: IWorkflowDetails) => 
   const stopped = metadata?.stopped === true
 
   return (
-    <>
+    <div className="flex flex-col gap-2">
       {retriesExhausted && (
         <Banner theme="error">
           <div className="flex flex-col gap-1">
@@ -60,30 +66,63 @@ export const WorkflowDetails = ({ workflow, failedSteps }: IWorkflowDetails) => 
       {failedSteps?.length > 0 && (
         <FailedStepBanners steps={failedSteps} />
       )}
-    </>
+    </div>
   )
 }
 
 const FailedStepBanners = ({ steps }: { steps: TWorkflowStep[] }) => {
   const [expanded, setExpanded] = useState(false)
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set())
+  const { addPanel } = useSurfaces()
 
-  if (steps.length === 0) return null
+  const visibleSteps = steps.filter((s) => !dismissed.has(s.id))
 
-  if (steps.length === 1) {
+  if (visibleSteps.length === 0) return null
+
+  const isRetried = (step: TWorkflowStep) =>
+    step?.status?.metadata?.auto_retried || step?.status?.metadata?.retried
+
+  const openPanel = (step: TWorkflowStep) => {
+    const panel = (
+      <StepDetailPanel
+        panelKey={step.id}
+        initStep={step}
+        size={getStepPanelSize(step)}
+        shouldPoll
+        planOnly
+      >
+        {getStepPanelDetails(step)}
+      </StepDetailPanel>
+    )
+    addPanel(panel, step.id)
+  }
+
+  if (visibleSteps.length === 1) {
+    const step = visibleSteps[0]
     return (
       <div className="flex flex-col gap-4 mt-2">
-        <StepBanner step={steps[0]} planOnly />
+        <StepBanner
+          step={step}
+          planOnly
+          onDismiss={isRetried(step) ? () => setDismissed((prev) => new Set(prev).add(step.id)) : undefined}
+          onViewDetails={() => openPanel(step)}
+        />
       </div>
     )
   }
 
-  const mostRecent = steps[steps.length - 1]
-  const olderSteps = steps.slice(0, -1)
+  const mostRecent = visibleSteps[visibleSteps.length - 1]
+  const olderSteps = visibleSteps.slice(0, -1)
 
   return (
     <div className="flex flex-col gap-2 mt-2">
       <div className="flex flex-col gap-4">
-        <StepBanner step={mostRecent} planOnly />
+        <StepBanner
+          step={mostRecent}
+          planOnly
+          onDismiss={isRetried(mostRecent) ? () => setDismissed((prev) => new Set(prev).add(mostRecent.id)) : undefined}
+          onViewDetails={() => openPanel(mostRecent)}
+        />
       </div>
 
       {olderSteps.length > 0 && (
@@ -102,7 +141,12 @@ const FailedStepBanners = ({ steps }: { steps: TWorkflowStep[] }) => {
       {expanded &&
         olderSteps.map((step) => (
           <div key={step?.id} className="flex flex-col gap-4">
-            <StepBanner step={step} planOnly />
+            <StepBanner
+              step={step}
+              planOnly
+              onDismiss={isRetried(step) ? () => setDismissed((prev) => new Set(prev).add(step.id)) : undefined}
+              onViewDetails={() => openPanel(step)}
+            />
           </div>
         ))}
     </div>

--- a/services/dashboard-ui/client/components/workflows/step-details/StepBanner.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/StepBanner.stories.tsx
@@ -29,3 +29,30 @@ export const ErrorState = () => <StepBanner step={errorStep} />
 export const WithApproval = () => <StepBanner step={approvalStep} />
 
 export const PlanOnly = () => <StepBanner step={approvalStep} planOnly />
+
+const autoRetriedStep = {
+  ...baseStep,
+  status: {
+    status: 'error',
+    status_human_description: 'failed to poll for build: component build is in an error state',
+    history: [],
+    metadata: { auto_retried: true, retry_idx: 1, max_retries: 15 },
+  },
+} as TWorkflowStep
+
+export const AutoRetriedDismissable = () => (
+  <StepBanner
+    step={autoRetriedStep}
+    planOnly
+    onDismiss={() => alert('dismissed')}
+    onViewDetails={() => alert('view details')}
+  />
+)
+
+export const ErrorWithViewDetails = () => (
+  <StepBanner
+    step={errorStep}
+    planOnly
+    onViewDetails={() => alert('view details')}
+  />
+)

--- a/services/dashboard-ui/client/components/workflows/step-details/StepBanner.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/StepBanner.tsx
@@ -1,5 +1,7 @@
 import { ApprovalBanner } from '@/components/approvals/ApprovalBanner'
 import { Banner } from '@/components/common/Banner'
+import { Button } from '@/components/common/Button'
+import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
 import type { TWorkflowStep } from '@/types'
 import { getPolicyViolationCounts, getStepBanner } from '@/utils/workflow-utils'
@@ -9,9 +11,13 @@ import { PolicyViolations } from './PolicyViolations'
 export const StepBanner = ({
   step,
   planOnly = false,
+  onDismiss,
+  onViewDetails,
 }: {
   step: TWorkflowStep
   planOnly?: boolean
+  onDismiss?: () => void
+  onViewDetails?: () => void
 }) => {
   const hasApproval = Boolean(step?.approval)
   const bannerCfg = getStepBanner(step)
@@ -32,8 +38,8 @@ export const StepBanner = ({
       {hasApproval && !planOnly && !isTerminal ? (
         <ApprovalBanner step={step} />
       ) : bannerCfg ? (
-        <Banner theme={bannerCfg.theme}>
-          <div className="flex items-center justify-between gap-4">
+        <Banner theme={bannerCfg.theme} onDismiss={onDismiss}>
+          <div className="flex items-end justify-between gap-4">
             <div className="flex flex-col">
               <Text weight="strong">{bannerCfg.title}</Text>
               <Text variant="subtext" theme="neutral">
@@ -46,7 +52,12 @@ export const StepBanner = ({
               ) : null}
             </div>
 
-            <div className="flex gap-4">
+            <div className="flex items-end gap-4">
+              {onViewDetails ? (
+                <Button variant="ghost" size="md" onClick={onViewDetails}>
+                  View details <Icon variant="CaretRight" />
+                </Button>
+              ) : null}
               {bannerCfg.theme === 'error' ? (
                 <StepButtons buttonSize="md" step={step} />
               ) : null}

--- a/services/dashboard-ui/client/components/workflows/step-details/StepDetailPanel/StepDetailPanelContainer.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/StepDetailPanel/StepDetailPanelContainer.tsx
@@ -19,7 +19,7 @@ import { StepDetailPanel } from './StepDetailPanel'
 
 type TPanelSize = IPanel['size']
 
-function getStepPanelSize(step: TWorkflowStep): TPanelSize {
+export function getStepPanelSize(step: TWorkflowStep): TPanelSize {
   if (
     step?.step_target_type === 'install_deploys' ||
     step?.step_target_type === 'install_sandbox_runs' ||
@@ -31,7 +31,7 @@ function getStepPanelSize(step: TWorkflowStep): TPanelSize {
   return 'half'
 }
 
-function getStepPanelDetails(step: TWorkflowStep): ReactNode {
+export function getStepPanelDetails(step: TWorkflowStep): ReactNode {
   if (step.step_target_type === 'install_action_workflow_runs') return <ActionRunStepDetails />
   if (step.step_target_type === 'install_deploys') return <DeployStepDetails />
   if (step.step_target_type === 'install_sandbox_runs') return <SandboxRunStepDetails />

--- a/services/dashboard-ui/client/components/workflows/step-details/StepDetailPanel/index.ts
+++ b/services/dashboard-ui/client/components/workflows/step-details/StepDetailPanel/index.ts
@@ -1,6 +1,8 @@
 export {
   StepDetailPanelContainer as StepDetailPanel,
   StepDetailPanelButton,
+  getStepPanelSize,
+  getStepPanelDetails,
 } from './StepDetailPanelContainer'
 export { StepDetailPanel as StepDetailPanelComponent } from './StepDetailPanel'
 export type { IStepDetailPanel } from './StepDetailPanel'

--- a/services/dashboard-ui/client/utils/workflow-utils.ts
+++ b/services/dashboard-ui/client/utils/workflow-utils.ts
@@ -113,9 +113,10 @@ export function getStepBanner(step: TWorkflowStep): TStepBannerCfg | undefined {
       }
     }
     if (metadata?.auto_retried) {
+      const attempt = typeof metadata.retry_idx === 'number' ? metadata.retry_idx + 1 : '?'
       return {
-        copy: `Step encountered an error and was automatically retried (attempt ${metadata.retry_idx ?? '?'} of ${metadata.max_retries ?? '?'}).`,
-        theme: 'info',
+        copy: `Step encountered an error and was automatically retried (attempt ${attempt} of ${metadata.max_retries ?? '?'}).`,
+        theme: 'warn',
         title: `Step ${step?.name} — auto-retried`,
       }
     }


### PR DESCRIPTION
- Added ladle stories for the workflow details
- Added view details button to step error banners
- Made step error / warning banners dismissable if the retry completes
- Fixed step retry count 