### PR TITLE
feat: (ctl-api) typed step-error directives via stderr.ErrUser

### DIFF
--- a/services/ctl-api/internal/app/installs/signals/v2/componentdeploysyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentdeploysyncandplan/signal.go
@@ -16,7 +16,9 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/workflowstepapprovalrequest"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/plan"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
@@ -103,6 +105,32 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 	_, err := activities.AwaitGetInstallForInstallComponentByInstallComponentID(ctx, s.InstallComponentID)
 	if err != nil {
 		return fmt.Errorf("unable to get install: %w", err)
+	}
+
+	// Fail fast (no auto-retry) when the component has no usable build —
+	// a missing or errored build will not resolve mid-run; the user must
+	// trigger a new build.
+	if s.ComponentID != "" {
+		bld, err := activities.AwaitGetComponentLatestBuildByComponentID(ctx, s.ComponentID)
+		if err != nil {
+			if generics.IsGormErrRecordNotFound(err) {
+				return stderr.NewStopError(
+					"no_component_build",
+					fmt.Sprintf("No active build found for component %s. Trigger a build before retrying.", s.ComponentID),
+					map[string]string{"component_id": s.ComponentID},
+					nil,
+				)
+			}
+			return fmt.Errorf("unable to get component build: %w", err)
+		}
+		if bld.Status == app.ComponentBuildStatusError {
+			return stderr.NewStopError(
+				"component_build_errored",
+				fmt.Sprintf("Component build %s for component %s is in an error state. Trigger a new build before retrying.", bld.ID, s.ComponentID),
+				map[string]string{"component_id": s.ComponentID, "build_id": bld.ID},
+				nil,
+			)
+		}
 	}
 	return nil
 }

--- a/services/ctl-api/internal/middlewares/stderr/errors.go
+++ b/services/ctl-api/internal/middlewares/stderr/errors.go
@@ -39,8 +39,13 @@ type ErrUser struct {
 	Err         error
 	Description string
 	Code        string
-	Fields      map[string]string
-	Directive   StepDirective
+	// Fields may be nil when the producer supplied no structured context.
+	// Consumers MUST treat nil as equivalent to an empty map and MUST NOT
+	// write into Fields without first nil-checking and allocating — the
+	// map is shared across the error's lifetime (HTTP response, Temporal
+	// payload, DB metadata) and producers do not deep-copy it.
+	Fields    map[string]string
+	Directive StepDirective
 }
 
 func (u ErrUser) Error() string {

--- a/services/ctl-api/internal/middlewares/stderr/errors.go
+++ b/services/ctl-api/internal/middlewares/stderr/errors.go
@@ -26,11 +26,21 @@ func (e ErrAuthorization) Unwrap() error {
 	return e.Err
 }
 
-// A user error is a standard user error that denotes something about the user input was not valid
+// A user error is a standard user error that denotes something about the user input was not valid.
+//
+// ErrUser is also the canonical error type returned by signal Validate/Execute
+// and by activities they call, so the same well-formed user-facing error
+// travels both the HTTP path and the workflow path. The HTTP middleware
+// renders Description/Code only; the workflow path additionally honors
+// Directive (see step.go) to decide whether to stop, skip, or fall through
+// to normal auto-retry policy. Fields carry small structured context
+// (component_id, install_id, …) that the dashboard can render.
 type ErrUser struct {
 	Err         error
 	Description string
 	Code        string
+	Fields      map[string]string
+	Directive   StepDirective
 }
 
 func (u ErrUser) Error() string {

--- a/services/ctl-api/internal/middlewares/stderr/payload.go
+++ b/services/ctl-api/internal/middlewares/stderr/payload.go
@@ -1,0 +1,139 @@
+package stderr
+
+import (
+	"errors"
+)
+
+// StepErrorPayload is the structured side-channel attached to a Temporal
+// NonRetryableApplicationError so the workflow side can recover the typed
+// ErrUser fields after the activity → workflow boundary strips Go error
+// types.
+//
+// It is also serialized into the QueueSignal status Metadata under the
+// MetadataKey* keys, which is the durable source of truth; the payload is
+// the in-flight transport copy.
+//
+// Keep this struct flat and JSON-encodable (the default Temporal data
+// converter is JSON).
+type StepErrorPayload struct {
+	Code      string            `json:"code,omitempty"`
+	Fields    map[string]string `json:"fields,omitempty"`
+	Directive string            `json:"directive,omitempty"`
+}
+
+// IsZero reports whether the payload carries no useful data and can be
+// omitted from a Temporal ApplicationError.
+func (p StepErrorPayload) IsZero() bool {
+	return p.Code == "" && p.Directive == "" && len(p.Fields) == 0
+}
+
+// Metadata keys used to persist StepErrorPayload fields on a QueueSignal
+// status Metadata map. Read by AwaitSignal when reconstructing the
+// payload from the DB.
+const (
+	MetadataKeyErrorCode     = "error_code"
+	MetadataKeyErrorFields   = "error_fields"
+	MetadataKeyStepDirective = "step_directive"
+)
+
+// PayloadFromErrUser builds a StepErrorPayload from an ErrUser. The two
+// types share the same shape on the wire — this is the canonical converter.
+func PayloadFromErrUser(u ErrUser) StepErrorPayload {
+	return StepErrorPayload{
+		Code:      u.Code,
+		Fields:    u.Fields,
+		Directive: string(u.Directive),
+	}
+}
+
+// MetadataFromPayload converts a StepErrorPayload to a metadata map
+// suitable for merging into a QueueSignal status Metadata. Empty fields
+// are omitted so the metadata map stays minimal. Returns nil when the
+// payload is zero.
+func MetadataFromPayload(p StepErrorPayload) map[string]any {
+	if p.IsZero() {
+		return nil
+	}
+	meta := map[string]any{}
+	if p.Code != "" {
+		meta[MetadataKeyErrorCode] = p.Code
+	}
+	if len(p.Fields) > 0 {
+		meta[MetadataKeyErrorFields] = p.Fields
+	}
+	if p.Directive != "" {
+		meta[MetadataKeyStepDirective] = p.Directive
+	}
+	return meta
+}
+
+// MetadataFromErrUser is a convenience wrapper combining PayloadFromErrUser
+// and MetadataFromPayload. Returns nil when the ErrUser has no
+// payload-relevant fields.
+func MetadataFromErrUser(u ErrUser) map[string]any {
+	return MetadataFromPayload(PayloadFromErrUser(u))
+}
+
+// PayloadFromMeta extracts a StepErrorPayload from a QueueSignal status
+// Metadata map, tolerating the JSON round-trip — when metadata comes from
+// the DB JSONB column, nested values come back as map[string]any.
+func PayloadFromMeta(meta map[string]any) StepErrorPayload {
+	var p StepErrorPayload
+	if meta == nil {
+		return p
+	}
+	if v, ok := meta[MetadataKeyErrorCode].(string); ok {
+		p.Code = v
+	}
+	if v, ok := meta[MetadataKeyStepDirective].(string); ok {
+		p.Directive = v
+	}
+	p.Fields = coerceStringMap(meta[MetadataKeyErrorFields])
+	return p
+}
+
+// ErrUserFromPayload reconstructs an ErrUser from a StepErrorPayload.
+// msg is used as both the underlying error message and the user-facing
+// description.
+func ErrUserFromPayload(p StepErrorPayload, msg string) ErrUser {
+	return ErrUser{
+		Err:         errors.New(msg),
+		Description: msg,
+		Code:        p.Code,
+		Fields:      p.Fields,
+		Directive:   StepDirective(p.Directive),
+	}
+}
+
+// ErrUserFromMeta is a convenience wrapper combining PayloadFromMeta and
+// ErrUserFromPayload. Returns the zero value and false when meta has no
+// payload-relevant fields.
+func ErrUserFromMeta(meta map[string]any, msg string) (ErrUser, bool) {
+	p := PayloadFromMeta(meta)
+	if p.IsZero() {
+		return ErrUser{}, false
+	}
+	return ErrUserFromPayload(p, msg), true
+}
+
+// coerceStringMap converts a map-typed any into a map[string]string,
+// handling both the direct map[string]string case and the JSON-decoded
+// map[string]any case.
+func coerceStringMap(v any) map[string]string {
+	switch f := v.(type) {
+	case map[string]string:
+		return f
+	case map[string]any:
+		out := make(map[string]string, len(f))
+		for k, vv := range f {
+			if s, ok := vv.(string); ok {
+				out[k] = s
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	}
+	return nil
+}

--- a/services/ctl-api/internal/middlewares/stderr/payload.go
+++ b/services/ctl-api/internal/middlewares/stderr/payload.go
@@ -2,6 +2,8 @@ package stderr
 
 import (
 	"errors"
+
+	"go.temporal.io/sdk/temporal"
 )
 
 // StepErrorPayload is the structured side-channel attached to a Temporal
@@ -114,6 +116,28 @@ func ErrUserFromMeta(meta map[string]any, msg string) (ErrUser, bool) {
 		return ErrUser{}, false
 	}
 	return ErrUserFromPayload(p, msg), true
+}
+
+// ExtractUserError recovers a typed ErrUser from err, walking both Go's
+// Unwrap chain (for direct ErrUser wraps) and Temporal's
+// ApplicationError.Details side-channel (used to ferry the typed payload
+// across the activity → workflow boundary). Returns the zero value and
+// false when err carries no user-error metadata.
+//
+// This is the single entry point conductor / step-handling code should
+// use; callers should not reach into temporal.ApplicationError directly.
+func ExtractUserError(err error) (ErrUser, bool) {
+	if u, ok := IsUserError(err); ok {
+		return u, true
+	}
+	var appErr *temporal.ApplicationError
+	if errors.As(err, &appErr) && appErr.HasDetails() {
+		var p StepErrorPayload
+		if dErr := appErr.Details(&p); dErr == nil && !p.IsZero() {
+			return ErrUserFromPayload(p, appErr.Message()), true
+		}
+	}
+	return ErrUser{}, false
 }
 
 // coerceStringMap converts a map-typed any into a map[string]string,

--- a/services/ctl-api/internal/middlewares/stderr/step.go
+++ b/services/ctl-api/internal/middlewares/stderr/step.go
@@ -1,0 +1,93 @@
+package stderr
+
+import (
+	"errors"
+	"fmt"
+)
+
+// StepDirective tells the workflow step framework what to do when an
+// ErrUser of this kind reaches handleStepError. The empty value means
+// "use the signal's normal auto-retry policy" — the historical default.
+//
+// v1 ships with Stop and Skip; the type is intentionally extensible so
+// future directives (e.g. SkipDependents, RetryGroup) can be added without
+// touching producer call sites.
+type StepDirective string
+
+const (
+	// StepDirectiveDefault leaves the existing auto-retry policy in charge.
+	// Producers that just want a normal failure should leave Directive unset.
+	StepDirectiveDefault StepDirective = ""
+
+	// StepDirectiveStop marks the step as errored without consuming the
+	// auto-retry budget — retrying without external action will not change
+	// the outcome (e.g., missing component build, plan superseded).
+	StepDirectiveStop StepDirective = "stop"
+
+	// StepDirectiveSkip marks the step as skipped (not errored) and
+	// continues group execution — the failure represents "nothing to do
+	// here" rather than a problem (e.g., teardown of an already-empty
+	// component).
+	StepDirectiveSkip StepDirective = "skip"
+)
+
+// NewStopError returns an ErrUser whose Directive instructs the step
+// framework to stop without auto-retry. code must be lowercase snake_case.
+// description is the user-facing copy rendered in the dashboard / CLI.
+// fields and cause may be nil.
+func NewStopError(code, description string, fields map[string]string, cause error) ErrUser {
+	return newDirectiveError(StepDirectiveStop, code, description, fields, cause)
+}
+
+// NewSkipError returns an ErrUser whose Directive instructs the step
+// framework to mark the step as skipped (StatusSkipped) and continue.
+// Use this for "no work to do" outcomes (e.g., teardown of an already
+// empty resource).
+func NewSkipError(code, description string, fields map[string]string, cause error) ErrUser {
+	return newDirectiveError(StepDirectiveSkip, code, description, fields, cause)
+}
+
+func newDirectiveError(d StepDirective, code, description string, fields map[string]string, cause error) ErrUser {
+	if cause == nil {
+		// Build a sensible underlying message from the code and description so
+		// .Error() is meaningful even when the producer didn't supply a cause.
+		msg := description
+		if msg == "" {
+			msg = string(d)
+		}
+		if code != "" {
+			cause = fmt.Errorf("[%s] %s", code, msg)
+		} else {
+			cause = errors.New(msg)
+		}
+	}
+	return ErrUser{
+		Err:         cause,
+		Description: description,
+		Code:        code,
+		Fields:      fields,
+		Directive:   d,
+	}
+}
+
+// IsUserError unwraps err looking for an ErrUser and returns it by value.
+// Returns the zero value and false if err does not contain an ErrUser.
+//
+// This is a convenience over errors.As to avoid the address-of-zero-value
+// boilerplate at every call site.
+func IsUserError(err error) (ErrUser, bool) {
+	var u ErrUser
+	if errors.As(err, &u) {
+		return u, true
+	}
+	return ErrUser{}, false
+}
+
+// DirectiveOf returns the StepDirective on the wrapped ErrUser, or
+// StepDirectiveDefault when err does not carry an ErrUser.
+func DirectiveOf(err error) StepDirective {
+	if u, ok := IsUserError(err); ok {
+		return u.Directive
+	}
+	return StepDirectiveDefault
+}

--- a/services/ctl-api/internal/middlewares/stderr/step_test.go
+++ b/services/ctl-api/internal/middlewares/stderr/step_test.go
@@ -1,0 +1,78 @@
+package stderr_test
+
+import (
+	stderrs "errors"
+	"testing"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+)
+
+func TestNewStopError_FieldsPropagated(t *testing.T) {
+	cause := stderrs.New("underlying boom")
+	u := stderr.NewStopError("no_component_build", "no build for component", map[string]string{
+		"component_id": "comp_123",
+	}, cause)
+
+	assert.Equal(t, stderr.StepDirectiveStop, u.Directive)
+	assert.Equal(t, "no_component_build", u.Code)
+	assert.Equal(t, "no build for component", u.Description)
+	assert.Equal(t, "comp_123", u.Fields["component_id"])
+	assert.Same(t, cause, u.Unwrap())
+}
+
+func TestNewSkipError_NoCauseSyntheticMessage(t *testing.T) {
+	u := stderr.NewSkipError("already_torn_down", "nothing to do", nil, nil)
+
+	assert.Equal(t, stderr.StepDirectiveSkip, u.Directive)
+	require.NotNil(t, u.Unwrap())
+	assert.Contains(t, u.Error(), "already_torn_down")
+	assert.Contains(t, u.Error(), "nothing to do")
+}
+
+func TestIsUserError_UnwrapsThroughPkgErrors(t *testing.T) {
+	u := stderr.NewStopError("plan_superseded", "plan superseded", nil, nil)
+	wrapped := pkgerrors.Wrap(u, "while running validate")
+
+	got, ok := stderr.IsUserError(wrapped)
+	require.True(t, ok)
+	assert.Equal(t, "plan_superseded", got.Code)
+	assert.Equal(t, stderr.StepDirectiveStop, got.Directive)
+}
+
+func TestIsUserError_NotUserError(t *testing.T) {
+	_, ok := stderr.IsUserError(stderrs.New("plain error"))
+	assert.False(t, ok)
+}
+
+func TestIsUserError_NilError(t *testing.T) {
+	_, ok := stderr.IsUserError(nil)
+	assert.False(t, ok)
+}
+
+func TestDirectiveOf(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want stderr.StepDirective
+	}{
+		{"nil", nil, stderr.StepDirectiveDefault},
+		{"plain", stderrs.New("x"), stderr.StepDirectiveDefault},
+		{"stop", stderr.NewStopError("c", "d", nil, nil), stderr.StepDirectiveStop},
+		{"skip", stderr.NewSkipError("c", "d", nil, nil), stderr.StepDirectiveSkip},
+		{"wrapped stop", pkgerrors.Wrap(stderr.NewStopError("c", "d", nil, nil), "ctx"), stderr.StepDirectiveStop},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stderr.DirectiveOf(tt.err))
+		})
+	}
+}
+
+func TestErrUser_DefaultDirectiveZeroValue(t *testing.T) {
+	u := stderr.ErrUser{Err: stderrs.New("x"), Description: "d"}
+	assert.Equal(t, stderr.StepDirectiveDefault, u.Directive)
+}

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
@@ -1,10 +1,7 @@
 package executeworkflowstep
 
 import (
-	stderrors "errors"
-
 	"github.com/pkg/errors"
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
@@ -31,7 +28,7 @@ import (
 //
 //  3. Otherwise, mark the step failed and return the error.
 func (s *Signal) handleStepError(ctx workflow.Context, l *zap.Logger, step *app.WorkflowStep, flw *app.Workflow, stepErr error) error {
-	if u, ok := extractUserError(stepErr); ok {
+	if u, ok := stderr.ExtractUserError(stepErr); ok {
 		switch u.Directive {
 		case stderr.StepDirectiveStop:
 			return s.markStepStopped(ctx, l, step, u, stepErr)
@@ -183,13 +180,10 @@ func (s *Signal) markStepStopped(ctx workflow.Context, l *zap.Logger, step *app.
 		desc = stepHumanDescription(stepErr)
 	}
 
-	meta := map[string]any{
+	meta := mergeUserMetadata(map[string]any{
 		"reason":   stepErr.Error(),
 		"terminal": true,
-	}
-	for k, v := range stderr.MetadataFromErrUser(u) {
-		meta[k] = v
-	}
+	}, u)
 
 	if err := statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
 		ID: step.ID,
@@ -220,27 +214,21 @@ func (s *Signal) markStepSkippedFromUserError(ctx workflow.Context, l *zap.Logge
 	if u.Description != "" {
 		extra["description"] = u.Description
 	}
-	for k, v := range stderr.MetadataFromErrUser(u) {
-		extra[k] = v
-	}
+	extra = mergeUserMetadata(extra, u)
 
 	return writeDirective(ctx, step.ID, DirectiveContinue, extra)
 }
 
-// extractUserError recovers a typed stderr.ErrUser from stepErr, walking
-// both Go's Unwrap chain and the Temporal ApplicationError details set by
-// AwaitSignal. Returns the zero value and false when stepErr is not a user
-// error.
-func extractUserError(stepErr error) (stderr.ErrUser, bool) {
-	if u, ok := stderr.IsUserError(stepErr); ok {
-		return u, true
-	}
-	var appErr *temporal.ApplicationError
-	if stderrors.As(stepErr, &appErr) && appErr.HasDetails() {
-		var p stderr.StepErrorPayload
-		if err := appErr.Details(&p); err == nil && !p.IsZero() {
-			return stderr.ErrUserFromPayload(p, appErr.Message()), true
+// mergeUserMetadata copies the StepErrorPayload-derived metadata
+// (error_code / error_fields / step_directive) from u into base in place
+// and returns it. base must be non-nil. Existing keys in base are
+// preserved on collision (the caller's seed takes precedence).
+func mergeUserMetadata(base map[string]any, u stderr.ErrUser) map[string]any {
+	for k, v := range stderr.MetadataFromErrUser(u) {
+		if _, exists := base[k]; exists {
+			continue
 		}
+		base[k] = v
 	}
-	return stderr.ErrUser{}, false
+	return base
 }

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
@@ -1,20 +1,47 @@
 package executeworkflowstep
 
 import (
+	stderrors "errors"
+
 	"github.com/pkg/errors"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
 // handleStepError marks the step as errored and checks for auto-retry.
-// If the inner signal implements SignalWithAutoRetry and the retry budget
-// hasn't been exhausted, it writes a directive ("retry" or "retry-group")
-// and returns nil. The group reads the directive and handles cloning.
+//
+// Step-error processing happens in three layers:
+//
+//  1. If the underlying error carries an stderr.ErrUser (either as a direct
+//     wrap or via the stderr.StepErrorPayload attached as ApplicationError
+//     details by AwaitSignal), and that ErrUser has a non-default Directive,
+//     the directive determines the outcome:
+//     - StepDirectiveStop → mark error, no auto-retry, surface user copy.
+//     - StepDirectiveSkip → mark step as skipped (Success+continue), advance.
+//
+//  2. Otherwise, if the signal implements SignalWithAutoRetry and the retry
+//     budget hasn't been exhausted, write a "retry" / "retry-group"
+//     directive and return nil. The group reads the directive and clones.
+//
+//  3. Otherwise, mark the step failed and return the error.
 func (s *Signal) handleStepError(ctx workflow.Context, l *zap.Logger, step *app.WorkflowStep, flw *app.Workflow, stepErr error) error {
+	if u, ok := extractUserError(stepErr); ok {
+		switch u.Directive {
+		case stderr.StepDirectiveStop:
+			return s.markStepStopped(ctx, l, step, u, stepErr)
+		case stderr.StepDirectiveSkip:
+			return s.markStepSkippedFromUserError(ctx, l, step, u)
+		}
+		// StepDirectiveDefault and any future directive falls through to
+		// the existing auto-retry policy below.
+	}
+
 	sig := stepSignal(step)
 
 	// Check auto-retry on inner signal.
@@ -136,4 +163,84 @@ func (s *Signal) markStepFailed(ctx workflow.Context, step *app.WorkflowStep, st
 		return errors.Wrap(err, "unable to mark step as error")
 	}
 	return stepErr
+}
+
+// markStepStopped marks the step as errored with directive=Stop, skipping
+// the auto-retry path entirely. The user-facing copy on the step status is
+// taken from u.Description so the dashboard renders the curated message
+// rather than the raw cause.
+func (s *Signal) markStepStopped(ctx workflow.Context, l *zap.Logger, step *app.WorkflowStep, u stderr.ErrUser, stepErr error) error {
+	l.Info("step error has Stop directive — skipping auto-retry",
+		zap.String("step_id", step.ID),
+		zap.String("reason_code", u.Code))
+
+	if err := setResultDirective(ctx, step.ID, DirectiveStop); err != nil {
+		return errors.Wrap(err, "unable to set stop directive")
+	}
+
+	desc := u.Description
+	if desc == "" {
+		desc = stepHumanDescription(stepErr)
+	}
+
+	meta := map[string]any{
+		"reason":   stepErr.Error(),
+		"terminal": true,
+	}
+	for k, v := range stderr.MetadataFromErrUser(u) {
+		meta[k] = v
+	}
+
+	if err := statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
+		ID: step.ID,
+		Status: app.CompositeStatus{
+			Status:                 app.StatusError,
+			StatusHumanDescription: desc,
+			Metadata:               meta,
+		},
+	}); err != nil {
+		return errors.Wrap(err, "unable to mark step as stopped")
+	}
+	return stepErr
+}
+
+// markStepSkippedFromUserError marks the step as skipped with directive=Continue,
+// matching the existing single-step skip semantics used by approval_skip.go:
+// the step status is StatusSuccess with metadata.status="skipped". Returns
+// nil so the group continues to the next step.
+func (s *Signal) markStepSkippedFromUserError(ctx workflow.Context, l *zap.Logger, step *app.WorkflowStep, u stderr.ErrUser) error {
+	l.Info("step error has Skip directive — marking step skipped",
+		zap.String("step_id", step.ID),
+		zap.String("reason_code", u.Code))
+
+	extra := map[string]any{
+		"step_idx": step.Idx,
+		"status":   "skipped",
+	}
+	if u.Description != "" {
+		extra["description"] = u.Description
+	}
+	for k, v := range stderr.MetadataFromErrUser(u) {
+		extra[k] = v
+	}
+
+	return writeDirective(ctx, step.ID, DirectiveContinue, extra)
+}
+
+// extractUserError recovers a typed stderr.ErrUser from stepErr, walking
+// both Go's Unwrap chain and the Temporal ApplicationError details set by
+// AwaitSignal. Returns the zero value and false when stepErr is not a user
+// error.
+func extractUserError(stepErr error) (stderr.ErrUser, bool) {
+	if u, ok := stderr.IsUserError(stepErr); ok {
+		return u, true
+	}
+	var appErr *temporal.ApplicationError
+	if stderrors.As(stepErr, &appErr) && appErr.HasDetails() {
+		var p stderr.StepErrorPayload
+		if err := appErr.Details(&p); err == nil && !p.IsZero() {
+			return stderr.ErrUserFromPayload(p, appErr.Message()), true
+		}
+	}
+	return stderr.ErrUser{}, false
 }

--- a/services/ctl-api/internal/pkg/queue/client/await_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/await_signal.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nuonco/nuon/pkg/temporal/heartbeat"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	dbgenerics "github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler"
 )
@@ -28,7 +29,7 @@ func (c *Client) AwaitSignal(ctx context.Context, queueSignalID string) (*handle
 
 	// If the DB status already indicates completion, return immediately.
 	if isTerminalStatus(q.Status.Status) {
-		return terminalResponse(q.Status.Status, q.Status.StatusHumanDescription)
+		return terminalResponseFromMeta(q.Status.Status, q.Status.StatusHumanDescription, q.Status.Metadata)
 	}
 
 	return heartbeat.WithHeartbeat(ctx, 30*time.Second, func(ctx context.Context) (*handler.FinishedResponse, error) {
@@ -50,7 +51,7 @@ func (c *Client) AwaitSignal(ctx context.Context, queueSignalID string) (*handle
 				return nil, errors.Wrap(dbErr, "unable to get queue signal from db")
 			}
 			if isTerminalStatus(fresh.Status.Status) {
-				return terminalResponse(fresh.Status.Status, fresh.Status.StatusHumanDescription)
+				return terminalResponseFromMeta(fresh.Status.Status, fresh.Status.StatusHumanDescription, fresh.Status.Metadata)
 			}
 			return nil, errors.Wrap(err, "unable to call finished handler")
 		}
@@ -63,32 +64,49 @@ func (c *Client) AwaitSignal(ctx context.Context, queueSignalID string) (*handle
 				return nil, errors.Wrap(dbErr, "unable to get queue signal from db")
 			}
 			if isTerminalStatus(fresh.Status.Status) {
-				return terminalResponse(fresh.Status.Status, fresh.Status.StatusHumanDescription)
+				return terminalResponseFromMeta(fresh.Status.Status, fresh.Status.StatusHumanDescription, fresh.Status.Metadata)
 			}
 			return nil, errors.Wrap(err, "unable get response")
 		}
 
 		// The handler returned a terminal status directly - use it.
 		if resp.Status == app.StatusError {
-			return nil, temporal.NewNonRetryableApplicationError(
-				resp.StatusDescription,
-				"SIGNAL_FAILED", nil)
+			return nil, signalFailedError(resp.StatusDescription, resp.Metadata)
 		}
 
 		return &resp, nil
 	})
 }
 
-// terminalResponse converts a terminal DB status into the appropriate return value.
-func terminalResponse(status app.Status, description string) (*handler.FinishedResponse, error) {
+// terminalResponseFromMeta converts a terminal DB status into the appropriate return value.
+//
+// On error, the returned temporal NonRetryableApplicationError carries a
+// stderr.StepErrorPayload as ApplicationError details when the original
+// failure was an stderr.ErrUser (the metadata map carries the
+// MetadataKeyErrorCode / MetadataKeyErrorFields / MetadataKeyStepDirective
+// fields). Conductor code can recover the typed error via errors.As + the
+// ApplicationError.Details API.
+func terminalResponseFromMeta(status app.Status, description string, meta map[string]any) (*handler.FinishedResponse, error) {
 	if status == app.StatusError {
 		msg := description
 		if msg == "" {
 			msg = fmt.Sprintf("signal execution failed with status: %s", status)
 		}
-		return nil, temporal.NewNonRetryableApplicationError(msg, "SIGNAL_FAILED", nil)
+		return nil, signalFailedError(msg, meta)
 	}
-	return &handler.FinishedResponse{Status: status, StatusDescription: description}, nil
+	return &handler.FinishedResponse{Status: status, StatusDescription: description, Metadata: meta}, nil
+}
+
+// signalFailedError builds the canonical SIGNAL_FAILED non-retryable
+// ApplicationError. When meta carries StepErrorPayload-shaped fields, they
+// are attached as details so the workflow side can recover code/fields/
+// directive without re-reading the QueueSignal.
+func signalFailedError(msg string, meta map[string]any) error {
+	payload := stderr.PayloadFromMeta(meta)
+	if payload.IsZero() {
+		return temporal.NewNonRetryableApplicationError(msg, "SIGNAL_FAILED", nil)
+	}
+	return temporal.NewNonRetryableApplicationError(msg, "SIGNAL_FAILED", nil, payload)
 }
 
 func (c *Client) getQueueSignal(ctx context.Context, id string) (*app.QueueSignal, error) {

--- a/services/ctl-api/internal/pkg/queue/handler/execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/execute.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -93,20 +92,7 @@ func (h *handler) executeHandler(ctx workflow.Context) (*ExecuteResponse, error)
 		}
 
 		execErr := &signal.SignalErrExecute{Err: err}
-		humanDesc := signal.HumanError(err)
-		_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
-			QueueSignalID:     h.queueSignalID,
-			Status:            app.StatusError,
-			StatusDescription: humanDesc,
-			Metadata: map[string]any{
-				"execute_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
-			},
-		})
-		h.setFinished(app.StatusError, humanDesc)
-		return nil, temporal.NewNonRetryableApplicationError(
-			"signal failure",
-			humanDesc,
-			execErr)
+		return nil, h.failPhase(ctx, "execute_finished_at", execErr, err)
 	}
 
 	// persist success status to DB

--- a/services/ctl-api/internal/pkg/queue/handler/fail_phase.go
+++ b/services/ctl-api/internal/pkg/queue/handler/fail_phase.go
@@ -46,7 +46,11 @@ func (h *handler) failPhase(ctx workflow.Context, finishedAtKey string, wrapErr,
 		StatusDescription: humanDesc,
 		Metadata:          meta,
 	})
-	h.setFinishedWithMeta(app.StatusError, humanDesc, userMeta)
+	// Pass the full merged meta (including the finishedAt timestamp) so
+	// FinishedResponse.Metadata stays consistent with what we just
+	// persisted to the DB; AwaitSignal's fast path relies on that
+	// equivalence.
+	h.setFinishedWithMeta(app.StatusError, humanDesc, meta)
 
 	if payload.IsZero() {
 		return temporal.NewNonRetryableApplicationError("signal failure", humanDesc, wrapErr)

--- a/services/ctl-api/internal/pkg/queue/handler/fail_phase.go
+++ b/services/ctl-api/internal/pkg/queue/handler/fail_phase.go
@@ -1,0 +1,55 @@
+package handler
+
+import (
+	"time"
+
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
+)
+
+// failPhase persists a failure of a signal phase (Validate or Execute) to
+// the QueueSignal status, captures the StepErrorPayload-shaped metadata for
+// the finishedHandler fast path, and returns a non-retryable
+// ApplicationError that AwaitSignal will surface to the workflow caller.
+//
+// finishedAtKey is the Metadata key recording the phase completion
+// timestamp ("validate_finished_at" or "execute_finished_at"). wrapErr is
+// the phase-specific wrapper error (e.g. *signal.SignalErrValidate)
+// passed as the cause on the returned ApplicationError.
+//
+// When err carries an stderr.ErrUser, its Description overrides the
+// human-facing message and its code/fields/directive are persisted into
+// the QueueSignal status metadata + attached as ApplicationError details
+// so the workflow side can recover the typed error via
+// extractUserError.
+func (h *handler) failPhase(ctx workflow.Context, finishedAtKey string, wrapErr, err error) error {
+	humanDesc := signal.HumanError(err)
+	userDesc, userMeta, payload := extractStepDirective(err)
+	if userDesc != "" {
+		humanDesc = userDesc
+	}
+
+	meta := map[string]any{
+		finishedAtKey: workflow.Now(ctx).UTC().Format(time.RFC3339),
+	}
+	for k, v := range userMeta {
+		meta[k] = v
+	}
+
+	_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+		QueueSignalID:     h.queueSignalID,
+		Status:            app.StatusError,
+		StatusDescription: humanDesc,
+		Metadata:          meta,
+	})
+	h.setFinishedWithMeta(app.StatusError, humanDesc, userMeta)
+
+	if payload.IsZero() {
+		return temporal.NewNonRetryableApplicationError("signal failure", humanDesc, wrapErr)
+	}
+	return temporal.NewNonRetryableApplicationError("signal failure", humanDesc, wrapErr, payload)
+}

--- a/services/ctl-api/internal/pkg/queue/handler/finished.go
+++ b/services/ctl-api/internal/pkg/queue/handler/finished.go
@@ -17,6 +17,11 @@ type FinishedRequest struct{}
 type FinishedResponse struct {
 	Status            app.Status `json:"status"`
 	StatusDescription string     `json:"status_description,omitempty"`
+	// Metadata mirrors the StepErrorPayload-shaped fields persisted on the
+	// QueueSignal status Metadata (error_code, error_fields, step_directive).
+	// AwaitSignal uses it to reconstruct the typed stderr.StepErrorPayload
+	// without re-reading the QueueSignal from the database on the fast path.
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
 func (h *handler) finishedHandler(ctx workflow.Context, req *FinishedRequest) (*FinishedResponse, error) {
@@ -29,5 +34,6 @@ func (h *handler) finishedHandler(ctx workflow.Context, req *FinishedRequest) (*
 	return &FinishedResponse{
 		Status:            h.finishedStatus,
 		StatusDescription: h.finishedErr,
+		Metadata:          h.finishedMeta,
 	}, nil
 }

--- a/services/ctl-api/internal/pkg/queue/handler/handler.go
+++ b/services/ctl-api/internal/pkg/queue/handler/handler.go
@@ -67,10 +67,13 @@ type handler struct {
 	finished  bool
 	canceled  bool
 
-	// finishedStatus and finishedErr capture the terminal outcome so the
+	// finishedStatus, finishedErr, finishedMeta capture the terminal outcome so the
 	// finishedHandler can return it to AwaitSignal callers without a DB round-trip.
+	// finishedMeta carries the StepErrorPayload-shaped metadata (error code,
+	// fields, step directive) when the failure originated from an stderr.ErrUser.
 	finishedStatus app.Status
 	finishedErr    string
+	finishedMeta   map[string]any
 
 	// cancelable context for execution
 	executingCtx    workflow.Context
@@ -83,7 +86,15 @@ type handler struct {
 
 // setFinished marks the handler as finished with a terminal status and optional error description.
 func (h *handler) setFinished(status app.Status, errDesc string) {
+	h.setFinishedWithMeta(status, errDesc, nil)
+}
+
+// setFinishedWithMeta is like setFinished but also captures the
+// StepErrorPayload-shaped metadata produced by extractStepDirective so it
+// can be returned to AwaitSignal callers via FinishedResponse.Metadata.
+func (h *handler) setFinishedWithMeta(status app.Status, errDesc string, meta map[string]any) {
 	h.finished = true
 	h.finishedStatus = status
 	h.finishedErr = errDesc
+	h.finishedMeta = meta
 }

--- a/services/ctl-api/internal/pkg/queue/handler/step_directive.go
+++ b/services/ctl-api/internal/pkg/queue/handler/step_directive.go
@@ -1,0 +1,25 @@
+package handler
+
+import (
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+)
+
+// extractStepDirective inspects err for an stderr.ErrUser and returns the
+// pieces the queue handler needs to persist a typed step failure:
+//
+//   - humanDesc: ErrUser.Description when present (else "" — caller keeps
+//     its existing fallback to signal.HumanError).
+//   - meta: the metadata fields to merge into the QueueSignal status
+//     metadata so the directive/code/fields persist across the DB boundary.
+//   - payload: the StepErrorPayload to attach as ApplicationError details
+//     on the temporal NonRetryableApplicationError. Caller should check
+//     payload.IsZero() before attaching.
+//
+// When err is not an stderr.ErrUser, all return values are zero / empty.
+func extractStepDirective(err error) (humanDesc string, meta map[string]any, payload stderr.StepErrorPayload) {
+	u, ok := stderr.IsUserError(err)
+	if !ok {
+		return "", nil, stderr.StepErrorPayload{}
+	}
+	return u.Description, stderr.MetadataFromErrUser(u), stderr.PayloadFromErrUser(u)
+}

--- a/services/ctl-api/internal/pkg/queue/handler/validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/validate.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -82,20 +81,7 @@ func (h *handler) validateHandler(ctx workflow.Context) (*ValidateResponse, erro
 		}
 
 		validateErr := &signal.SignalErrValidate{Err: err}
-		humanDesc := signal.HumanError(err)
-		_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
-			QueueSignalID:     h.queueSignalID,
-			Status:            app.StatusError,
-			StatusDescription: humanDesc,
-			Metadata: map[string]any{
-				"validate_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
-			},
-		})
-		h.setFinished(app.StatusError, humanDesc)
-		return nil, temporal.NewNonRetryableApplicationError(
-			"signal failure",
-			humanDesc,
-			validateErr)
+		return nil, h.failPhase(ctx, "validate_finished_at", validateErr, err)
 	}
 
 	// record validate completion timestamp


### PR DESCRIPTION
Introduces a typed step-outcome error system on top of `stderr.ErrUser` so signal Validate/Execute can express what the workflow step framework should do on failure instead of always running the auto-retry policy.

Starting with
- Stop (skip auto-retry, surface user copy),
- or Skip (mark step skipped, continue)

The `ErrUser` now carries a `StepDirective` enum, a stable Code, structured Fields, and the existing user-facing Description. The same well-formed error travels both the HTTP path (middleware ignores Directive) and the workflow path (the conductor honors it).

As a first step, the `Validate()` method for Component Sync+Plan signal now fails fast if there's no active build of an component.

Here, you can see a errored build triggered a fail-fast (the plan step is not auto retried) with a detailed error message to the user.

<img width="1376" height="615" alt="Screenshot 2026-05-05 at 11 00 09 PM" src="https://github.com/user-attachments/assets/795d6e20-deca-46ea-b453-3d5e650f5144" />



### Notes for reviewers:

Plumbing across the three lossy boundaries:

  * Activity -> workflow: the queue handler attaches a `stderr.StepErrorPayload` as `ApplicationError` details on the temporal `NonRetryableApplicationError` so the receiver can recover Code/Fields/Directive after the activity hop.
  * QueueSignal status -> DB: code/fields/directive are persisted as JSONB metadata under MetadataKeyErrorCode / Fields / StepDirective.
  * AwaitSignal -> conductor: the typed payload is rebuilt from either the fast-path `FinishedResponse.Metadata` or the DB metadata fallback, then re-attached as `ApplicationError` details so `process_errors.handleStepError` can dispatch on Directive (Stop, Skip, or fall through to existing auto-retry).