### PR TITLE
feat: drift-detected signal + sandbox drift cron

### DIFF
--- a/bins/cli/cmd/orgs.go
+++ b/bins/cli/cmd/orgs.go
@@ -220,11 +220,14 @@ const interestsJSONHelp = `INTERESTS JSON SHAPE
 
   Resource kinds and the ops they support:
     installs                provision, deprovision, reprovision
-    components              deploy, teardown, drift
-    sandboxes               provision, reprovision, deprovision, drift
+    components              deploy, teardown
+    sandboxes               provision, reprovision, deprovision
     install_configurations  inputs, secrets
     runners                 provision, reprovision, inactive
     actions                 run
+
+  Note: to subscribe to drift, use "drift_detected" (below) — it fires only when
+  drift is actually found, not on every clean scan.
 
   Per-resource cfg fields (all optional):
     ops                 list of sub-ops; empty/omitted = every sub-op
@@ -235,8 +238,8 @@ const interestsJSONHelp = `INTERESTS JSON SHAPE
                         (independent of outcome)
     drift_detected      bool, deliver a notification ONLY when drift is
                         actually detected during a drift scan (independent
-                        of outcome). Only meaningful for resources with a
-                        "drift" sub-op (components, sandboxes).
+                        of outcome). Only meaningful for components and
+                        sandboxes.
 
 EXAMPLES
 

--- a/docs/guides/webhooks.mdx
+++ b/docs/guides/webhooks.mdx
@@ -62,8 +62,8 @@ A configuration is one of two shapes:
 {
   "resources": {
     "installs":               { "outcome": "completion", "approval_requests": true, "approval_responses": true },
-    "components":             { "ops": ["deploy", "drift"], "outcome": "all" },
-    "sandboxes":              { "outcome": "failures" },
+    "components":             { "ops": ["deploy"], "outcome": "all", "drift_detected": true },
+    "sandboxes":              { "outcome": "failures", "drift_detected": true },
     "install_configurations": {},
     "runners":                { "ops": ["provision"] }
   }
@@ -81,11 +81,15 @@ Each resource accepts a list of sub-ops drawn from a fixed vocabulary:
 | Resource                 | Supported `ops`                                            |
 | ------------------------ | ---------------------------------------------------------- |
 | `installs`               | `provision`, `deprovision`, `reprovision`                  |
-| `components`             | `deploy`, `teardown`, `drift`                              |
-| `sandboxes`              | `provision`, `reprovision`, `deprovision`, `drift`         |
+| `components`             | `deploy`, `teardown`                                       |
+| `sandboxes`              | `provision`, `reprovision`, `deprovision`                  |
 | `install_configurations` | `inputs`, `secrets`                                        |
 | `runners`                | `provision`, `reprovision`, `inactive`                     |
 | `actions`                | `run`                                                      |
+
+Drift workflow lifecycle events (`drift_run`, `drift_run_reprovision_sandbox`) are intentionally **not** part of the
+`ops` vocabulary — every cron tick fires a started/completed pair, which is pure noise on a clean scan. To subscribe to
+drift, set `drift_detected: true` on `components` and/or `sandboxes` (see below).
 
 
 ### Per-resource fields
@@ -96,7 +100,7 @@ Each resource accepts a list of sub-ops drawn from a fixed vocabulary:
 | `outcome`            | `string`  | `"all"` | One of `all`, `completion`, or `failures`. Filters lifecycle events on terminal status.      |
 | `approval_requests`  | `bool`    | `false` | Deliver workflow-step approval **requests** for this resource.                               |
 | `approval_responses` | `bool`    | `false` | Deliver workflow-step approval **responses** (approved / rejected) for this resource.        |
-| `drift_detected`     | `bool`    | `false` | Deliver a notification **only when drift is actually detected** during a drift scan. Only meaningful for resources with a `drift` sub-op (`components`, `sandboxes`). |
+| `drift_detected`     | `bool`    | `false` | Deliver a notification **only when drift is actually detected** during a drift scan. Only meaningful for `components` and `sandboxes`. |
 
 `outcome` semantics:
 
@@ -106,6 +110,14 @@ Each resource accepts a list of sub-ops drawn from a fixed vocabulary:
 
 Approval events do not have a started/succeeded/failed lifecycle, only a requested / approved / rejected handshake.
 They are gated **independently of `outcome`** by the `approval_requests` and `approval_responses` booleans.
+
+#### Drift detection
+
+To receive drift notifications, set `drift_detected: true` on `components` and/or `sandboxes`. The
+notification fires once per component (inside `drift_run`) or once per sandbox (inside
+`drift_run_reprovision_sandbox`) whenever the plan-only check finds non-no-op changes. It works for
+both manually triggered and scheduled drift scans, and is gated **independently of `outcome`** — the
+same way `approval_requests` / `approval_responses` are.
 
 #### Runner inactivity
 

--- a/services/ctl-api/internal/app/installs/signals/v2/appconfigupdated/reconcile_drift_sandbox.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/appconfigupdated/reconcile_drift_sandbox.go
@@ -1,0 +1,52 @@
+package appconfigupdated
+
+import (
+	"fmt"
+
+	"go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/driftchecksandbox"
+	emitterclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/emitter/client"
+)
+
+// reconcileDriftSandboxEmitter reconciles a single per-install sandbox drift
+// cron emitter against AppSandboxConfig.DriftSchedule. Mirrors
+// reconcileDriftEmitters but install-scoped (sandbox drift is configured at
+// the app-sandbox-config level, not per-component).
+//
+// `existing` is the pre-filtered list of emitters whose name matched the
+// driftSandboxEmitterPrefix. They're stopped and deleted unconditionally;
+// when the schedule is non-empty a fresh emitter replaces them.
+func (s *Signal) reconcileDriftSandboxEmitter(
+	ctx workflow.Context,
+	l log.Logger,
+	install *app.Install,
+	queue *app.Queue,
+	existing []app.QueueEmitter,
+) error {
+	stopAndDeleteEmitters(ctx, l, existing)
+
+	schedule := install.AppSandboxConfig.DriftSchedule
+	if schedule == "" {
+		return nil
+	}
+
+	name := driftSandboxEmitterPrefix + install.ID
+	if _, err := emitterclient.AwaitCreateEmitter(ctx, &emitterclient.CreateEmitterRequest{
+		QueueID:      queue.ID,
+		Name:         name,
+		Description:  fmt.Sprintf("sandbox drift check for install %s", install.ID),
+		Mode:         app.QueueEmitterModeCron,
+		CronSchedule: schedule,
+		SignalType:   driftchecksandbox.SignalType,
+		SignalTemplate: &driftchecksandbox.Signal{
+			InstallID: install.ID,
+		},
+	}); err != nil {
+		return fmt.Errorf("unable to create sandbox drift emitter %s: %w", name, err)
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/app/installs/signals/v2/appconfigupdated/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/appconfigupdated/signal.go
@@ -18,6 +18,12 @@ const SignalType signal.SignalType = "appconfig-updated"
 const (
 	actionCronEmitterPrefix = "action-cron-"
 	driftEmitterPrefix      = "drift-"
+	// driftSandboxEmitterPrefix is the per-install sandbox drift cron prefix.
+	// IMPORTANT: this string starts with the more generic `drift-` prefix —
+	// the splitting loop in Execute() must check for `drift-sandbox-` BEFORE
+	// the bare `drift-` case or sandbox emitters get classified as
+	// per-component drift emitters and reconciled against the wrong list.
+	driftSandboxEmitterPrefix = "drift-sandbox-"
 )
 
 type Signal struct {
@@ -75,11 +81,16 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return fmt.Errorf("unable to get existing emitters: %w", err)
 	}
 
-	var actionEmitters, driftEmitters []app.QueueEmitter
+	var actionEmitters, driftEmitters, driftSandboxEmitters []app.QueueEmitter
 	for _, em := range existingEmitters {
 		switch {
 		case strings.HasPrefix(em.Name, actionCronEmitterPrefix):
 			actionEmitters = append(actionEmitters, em)
+		// Check the more specific `drift-sandbox-` prefix BEFORE the bare
+		// `drift-` case — otherwise sandbox emitters would be swept into
+		// the per-component drift bucket.
+		case strings.HasPrefix(em.Name, driftSandboxEmitterPrefix):
+			driftSandboxEmitters = append(driftSandboxEmitters, em)
 		case strings.HasPrefix(em.Name, driftEmitterPrefix):
 			driftEmitters = append(driftEmitters, em)
 		}
@@ -91,6 +102,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 
 	if err := s.reconcileDriftEmitters(ctx, l, install, appCfg, queue, driftEmitters); err != nil {
 		return fmt.Errorf("unable to reconcile drift emitters: %w", err)
+	}
+
+	if err := s.reconcileDriftSandboxEmitter(ctx, l, install, queue, driftSandboxEmitters); err != nil {
+		return fmt.Errorf("unable to reconcile sandbox drift emitter: %w", err)
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/v2/driftchecksandbox/init.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/driftchecksandbox/init.go
@@ -1,0 +1,12 @@
+package driftchecksandbox
+
+import (
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/catalog"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+func init() {
+	catalog.Register(SignalType, func() signal.Signal {
+		return &Signal{}
+	})
+}

--- a/services/ctl-api/internal/app/installs/signals/v2/driftchecksandbox/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/driftchecksandbox/signal.go
@@ -1,0 +1,79 @@
+package driftchecksandbox
+
+import (
+	"fmt"
+
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeflow"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
+)
+
+// SignalType is the queue signal type for triggering a v2 sandbox drift scan.
+//
+// Mirrors the per-component drift-check signal in signals/v2/driftcheck. This
+// one is install-scoped: each install gets a single sandbox drift cron emitter
+// (vs the per-component drift cron). It creates a drift_run_reprovision_sandbox
+// workflow with PlanOnly:true and hands it to the install-workflows queue —
+// the same plan-only execution path used by manual sandbox drift scans, so the
+// drift-detected notification fires from a single hook point.
+const SignalType signal.SignalType = "drift-check-sandbox"
+
+type Signal struct {
+	InstallID string `json:"install_id"`
+}
+
+var _ signal.Signal = (*Signal)(nil)
+var _ signal.SignalWithLifecycleContext = (*Signal)(nil)
+
+func (s *Signal) LifecycleContext() signal.SignalLifecycleContext {
+	return signal.SignalLifecycleContext{
+		InstallID: &s.InstallID,
+		Operation: "drift-check-sandbox",
+	}
+}
+
+func (s *Signal) Type() signal.SignalType {
+	return SignalType
+}
+
+func (s *Signal) Validate(ctx workflow.Context) error {
+	if s.InstallID == "" {
+		return fmt.Errorf("install_id is required")
+	}
+
+	if _, err := activities.AwaitGetByInstallID(ctx, s.InstallID); err != nil {
+		return fmt.Errorf("install not found: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Signal) Execute(ctx workflow.Context) error {
+	wkflw, err := activities.AwaitCreateWorkflow(ctx, activities.CreateWorkflowRequest{
+		InstallID:    s.InstallID,
+		WorkflowType: app.WorkflowTypeDriftRunReprovisionSandbox,
+		PlanOnly:     true,
+		Metadata:     map[string]string{},
+	})
+	if err != nil {
+		return fmt.Errorf("unable to create sandbox drift workflow: %w", err)
+	}
+
+	if _, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
+		OwnerID:   s.InstallID,
+		OwnerType: "installs",
+		QueueName: helpers.InstallWorkflowsQueueName,
+		Signal: &executeflow.Signal{
+			WorkflowID: wkflw.ID,
+		},
+	}); err != nil {
+		return fmt.Errorf("unable to enqueue flow execution signal: %w", err)
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/app/installs/signals/v2/driftdetected/dispatch.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/driftdetected/dispatch.go
@@ -1,0 +1,36 @@
+package driftdetected
+
+import (
+	"github.com/pkg/errors"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
+)
+
+// Dispatch enqueues a drift-detected signal onto the install-signals queue
+// and waits for it to reach a terminal phase. The signal itself is a no-op —
+// it exists so the queue dispatcher emits lifecycle events that the interests
+// classifier maps onto event:drift.detected, fanning out to webhook / Slack
+// subscribers that opted into per-resource `drift_detected: true`.
+//
+// The caller is responsible for populating InstallID, InstallWorkflowID,
+// WorkflowStepID, OwnerID, and OwnerType on sig before calling.
+func Dispatch(ctx workflow.Context, sig *Signal) error {
+	resp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
+		OwnerID:         sig.InstallID,
+		OwnerType:       "installs",
+		QueueName:       installSignalsQueueName,
+		Signal:          sig,
+		SignalOwnerID:   sig.WorkflowStepID,
+		SignalOwnerType: installWorkflowStepsOwnerType,
+	})
+	if err != nil {
+		return errors.Wrap(err, "unable to enqueue drift-detected signal")
+	}
+
+	if _, err := client.AwaitAwaitSignal(ctx, resp.QueueSignalID); err != nil {
+		return errors.Wrap(err, "drift-detected signal failed")
+	}
+	return nil
+}

--- a/services/ctl-api/internal/app/installs/signals/v2/driftdetected/init.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/driftdetected/init.go
@@ -1,0 +1,12 @@
+package driftdetected
+
+import (
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/catalog"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+func init() {
+	catalog.Register(SignalType, func() signal.Signal {
+		return &Signal{}
+	})
+}

--- a/services/ctl-api/internal/app/installs/signals/v2/driftdetected/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/driftdetected/signal.go
@@ -1,0 +1,90 @@
+package driftdetected
+
+import (
+	"github.com/pkg/errors"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+// SignalType is the queue signal type for a drift-detected notification.
+//
+// This signal is purely a notification carrier: its Execute() is a no-op. The
+// queue dispatcher emits its lifecycle events (started / succeeded) via the
+// shared lifecycle hook machinery, and the interests classifier maps those
+// events onto the resource:components / resource:sandboxes axis with
+// event:drift.detected slug. Subscribers can opt in via the per-resource
+// `drift_detected` flag to be notified ONLY when drift is actually detected
+// (not for clean drift scans).
+const SignalType signal.SignalType = "drift-detected"
+
+// installSignalsQueueName mirrors the constant in
+// services/ctl-api/internal/app/installs/helpers. Duplicated here as a
+// literal to avoid an import cycle (helpers imports signals via fx wiring).
+const installSignalsQueueName = "install-signals"
+
+// installWorkflowStepsOwnerType matches the polymorphic type used by
+// QueueSignal records that originate from a workflow step.
+const installWorkflowStepsOwnerType = "install_workflow_steps"
+
+type Signal struct {
+	InstallID         string `json:"install_id"`
+	InstallWorkflowID string `json:"install_workflow_id"`
+	WorkflowStepID    string `json:"workflow_step_id"`
+
+	// OwnerID / OwnerType reference the entity the drift detection is "for".
+	// For component drift it points at the install_deploys row; for sandbox
+	// drift it points at the install_sandbox_runs row. The classifier ignores
+	// these and resolves the resource from the parent workflow type and the
+	// step's own target type — they're carried for downstream payload
+	// consumers.
+	OwnerID   string `json:"owner_id"`
+	OwnerType string `json:"owner_type"`
+}
+
+var (
+	_ signal.Signal                     = (*Signal)(nil)
+	_ signal.SignalWithLifecycleContext = (*Signal)(nil)
+	_ signal.SignalWithAutoRetry        = (*Signal)(nil)
+	_ signal.SignalWithMaxRetries       = (*Signal)(nil)
+)
+
+func (s *Signal) Type() signal.SignalType {
+	return SignalType
+}
+
+func (s *Signal) AutoRetry() bool { return true }
+func (s *Signal) MaxRetries() int { return 5 }
+
+func (s *Signal) LifecycleContext() signal.SignalLifecycleContext {
+	installID := &s.InstallID
+	if s.InstallID == "" {
+		installID = nil
+	}
+	return signal.SignalLifecycleContext{
+		InstallID:  installID,
+		Operation:  "drift-detected",
+		WorkflowID: s.InstallWorkflowID,
+		StepID:     s.WorkflowStepID,
+		OwnerID:    s.InstallID,
+		OwnerType:  "installs",
+	}
+}
+
+func (s *Signal) Validate(ctx workflow.Context) error {
+	if s.InstallID == "" {
+		return errors.New("install_id is required")
+	}
+	if s.WorkflowStepID == "" {
+		return errors.New("workflow_step_id is required")
+	}
+	return nil
+}
+
+// Execute is intentionally a no-op. The signal exists purely so the queue
+// dispatcher emits lifecycle events that the interests classifier can map onto
+// the drift_detected slug. Subscribers receive the notification through the
+// usual webhook / Slack hook plumbing — there's no business logic to run here.
+func (s *Signal) Execute(_ workflow.Context) error {
+	return nil
+}

--- a/services/ctl-api/internal/app/workflow.go
+++ b/services/ctl-api/internal/app/workflow.go
@@ -91,7 +91,7 @@ func (i WorkflowType) Name() string {
 	switch i {
 	case WorkflowTypeProvision:
 		return "Provisioning install"
-	case WorkflowTypeReprovision, WorkflowTypeDriftRunReprovisionSandbox:
+	case WorkflowTypeReprovision:
 		return "Reprovisioning install"
 	case WorkflowTypeDeprovision:
 		return "Deprovisioning install"
@@ -103,7 +103,7 @@ func (i WorkflowType) Name() string {
 		return "Tearing down all components"
 	case WorkflowTypeDeployComponents:
 		return "Deploying all components"
-	case WorkflowTypeReprovisionSandbox:
+	case WorkflowTypeReprovisionSandbox, WorkflowTypeDriftRunReprovisionSandbox:
 		return "Reprovisioning sandbox"
 	case WorkflowTypeSyncSecrets:
 		return "Syncing secrets"

--- a/services/ctl-api/internal/pkg/flow/group_dispatch.go
+++ b/services/ctl-api/internal/pkg/flow/group_dispatch.go
@@ -20,6 +20,7 @@ func DispatchGroupSignal(ctx workflow.Context, cfg StepConfig, group *app.Workfl
 
 	sig := &executeworkflowstepgroup.Signal{
 		WorkflowID:      flw.ID,
+		WorkflowType:    string(flw.Type),
 		StepGroupID:     group.ID,
 		GroupIdx:        group.GroupIdx,
 		OwnerID:         cfg.OwnerID,

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/execute_group.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/execute_group.go
@@ -23,6 +23,7 @@ func (s *Signal) executeGroup(ctx workflow.Context, group *app.WorkflowStepGroup
 
 	sig := &executeworkflowstepgroup.Signal{
 		WorkflowID:      flw.ID,
+		WorkflowType:    string(flw.Type),
 		StepGroupID:     group.ID,
 		GroupIdx:        group.GroupIdx,
 		OwnerID:         cfg.OwnerID,

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_plan_only.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_plan_only.go
@@ -7,6 +7,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/driftdetected"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 	activities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow/activities"
 )
@@ -55,6 +56,24 @@ func (s *Signal) handlePlanOnlyApproval(ctx workflow.Context, step *app.Workflow
 		StatusDescription: statusDescription,
 	}); err != nil {
 		return errors.Wrap(err, "unable to update step target status")
+	}
+
+	// Drift detected → emit a notification-only signal so subscribers that
+	// opted into per-resource `drift_detected: true` are notified ONLY when
+	// drift is actually found (not for clean drift scans). Failure here is
+	// non-fatal: notification is a side-effect, not core flow.
+	if !noopPlan {
+		if err := driftdetected.Dispatch(ctx, &driftdetected.Signal{
+			InstallID:         s.OwnerID,
+			InstallWorkflowID: step.InstallWorkflowID,
+			WorkflowStepID:    step.ID,
+			OwnerID:           step.StepTargetID,
+			OwnerType:         string(step.StepTargetType),
+		}); err != nil {
+			workflow.GetLogger(ctx).Warn("unable to dispatch drift-detected signal",
+				"step_id", step.ID,
+				"error", err)
+		}
 	}
 
 	return nil

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/execute.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/execute.go
@@ -150,6 +150,7 @@ func (s *Signal) dispatchStep(ctx workflow.Context, step *app.WorkflowStep) (str
 	sig := &executeworkflowstep.Signal{
 		StepID:          step.ID,
 		WorkflowID:      s.WorkflowID,
+		WorkflowType:    s.WorkflowType,
 		OwnerID:         s.OwnerID,
 		OwnerType:       s.OwnerType,
 		TargetQueueName: s.TargetQueueName,

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/signal.go
@@ -41,6 +41,13 @@ type Signal struct {
 	TargetQueueName string `json:"target_queue_name"`
 	Parallel        bool   `json:"parallel"`
 
+	// WorkflowType identifies the kind of workflow that owns this group. Set
+	// at dispatch time from the in-scope *app.Workflow and forwarded to each
+	// child execute-workflow-step signal so the workflow_step lifecycle
+	// hook can suppress events for envelope workflows like drift_run /
+	// drift_run_reprovision_sandbox without a DB lookup.
+	WorkflowType string `json:"workflow_type,omitempty"`
+
 	// OrgID / OrgName / OwnerName are pass-through fields stamped by the
 	// parent execute-workflow signal. They are forwarded to the step signal
 	// at dispatch time so workflow_step lifecycle webhook payloads carry

--- a/services/ctl-api/internal/pkg/interests/classify.go
+++ b/services/ctl-api/internal/pkg/interests/classify.go
@@ -122,6 +122,25 @@ func Classify(event signal.SignalPhaseEvent, outcome *signal.SignalPhaseOutcome,
 // It is split from the public APIs so the matcher doesn't pay the cost of
 // allocating a slug slice when the only output it needs is a boolean.
 func classify(event signal.SignalPhaseEvent, outcome *signal.SignalPhaseOutcome, db *gorm.DB) facts {
+	// Backfill WorkflowType from the install_workflows table when the event
+	// carries a workflow id but the in-payload workflow type is empty. This
+	// happens for queue signals enqueued before the WorkflowType field was
+	// added to the executeworkflowstepgroup / executeworkflowstep payloads —
+	// their persisted JSON has workflow_type=""; without backfill the drift
+	// suppression and step-resolution paths can't tell what kind of workflow
+	// they belong to. Cheap (one indexed PK lookup) and only fires on the
+	// legacy/in-flight code path; new signals carry the field inline.
+	if event.WorkflowType == "" && event.WorkflowID != "" && db != nil {
+		var row struct{ Type string }
+		if err := db.WithContext(context.Background()).
+			Table("install_workflows").
+			Select("type").
+			Where("id = ?", event.WorkflowID).
+			Scan(&row).Error; err == nil && row.Type != "" {
+			event.WorkflowType = row.Type
+		}
+	}
+
 	f := facts{
 		Phase:   event.Phase,
 		Outcome: outcome,

--- a/services/ctl-api/internal/pkg/interests/interests_test.go
+++ b/services/ctl-api/internal/pkg/interests/interests_test.go
@@ -60,6 +60,20 @@ func TestMatches(t *testing.T) {
 		Phase:        signal.SignalPhaseExecute,
 		StepID:       "iws_step_1",
 	}
+	// Step events inside drift workflows. Without DB enrichment, these
+	// classify via stepResolutionFromParent; with DB enrichment the
+	// classification may differ — but suppression keys off the parent
+	// WorkflowType so both paths are covered.
+	driftRunStepSuccess := signal.SignalPhaseEvent{
+		SignalType:   signalTypeExecuteWorkflowStep,
+		WorkflowType: "drift_run",
+		Phase:        signal.SignalPhaseExecute,
+	}
+	sandboxDriftStepSuccess := signal.SignalPhaseEvent{
+		SignalType:   signalTypeExecuteWorkflowStep,
+		WorkflowType: "drift_run_reprovision_sandbox",
+		Phase:        signal.SignalPhaseExecute,
+	}
 	approvalResponse := signal.SignalPhaseEvent{
 		SignalType:   signalTypeWorkflowStepApprovalResponse,
 		WorkflowType: "deploy_components",
@@ -210,13 +224,23 @@ func TestMatches(t *testing.T) {
 			want: false,
 		},
 		{
-			name:    "drift_run envelope matches components.drift",
+			// Drift workflow lifecycle events are unconditionally suppressed
+			// — listing "drift" in Ops is a no-op, drift surfaces only via
+			// the drift-detected event class gated by DriftDetected.
+			name:    "drift_run lifecycle suppressed even when components.Ops contains drift",
 			event:   driftRunSuccess,
 			outcome: successOutcome,
 			in: Interests{Resources: map[ResourceKind]ResourceCfg{
 				ResourceComponents: {Ops: []string{"drift"}, Outcome: OutcomeAll},
 			}},
-			want: true,
+			want: false,
+		},
+		{
+			name:    "drift_run lifecycle suppressed under AllEvents",
+			event:   driftRunSuccess,
+			outcome: successOutcome,
+			in:      Interests{AllEvents: true},
+			want:    false,
 		},
 		{
 			name:    "drift_run envelope does not match components.deploy",
@@ -255,13 +279,49 @@ func TestMatches(t *testing.T) {
 			want: true,
 		},
 		{
-			name:    "sandbox drift workflow matches sandboxes.drift",
+			name:    "sandbox drift workflow lifecycle suppressed even when sandboxes.Ops contains drift",
 			event:   sandboxDriftSuccess,
 			outcome: successOutcome,
 			in: Interests{Resources: map[ResourceKind]ResourceCfg{
 				ResourceSandboxes: {Ops: []string{"drift"}, Outcome: OutcomeAll},
 			}},
-			want: true,
+			want: false,
+		},
+		{
+			name:    "sandbox drift workflow lifecycle suppressed under AllEvents",
+			event:   sandboxDriftSuccess,
+			outcome: successOutcome,
+			in:      Interests{AllEvents: true},
+			want:    false,
+		},
+		{
+			// Regression: steps inside a drift workflow used to leak through
+			// because they classify as their own resource (e.g. a
+			// "runner healthy" step → (runners, reprovision)). Suppression
+			// keys off the parent WorkflowType so the entire lifecycle tree
+			// is dropped — only the dedicated drift-detected event reaches
+			// subscribers.
+			name:    "drift_run step lifecycle suppressed under AllEvents",
+			event:   driftRunStepSuccess,
+			outcome: successOutcome,
+			in:      Interests{AllEvents: true},
+			want:    false,
+		},
+		{
+			name:    "sandbox drift step lifecycle suppressed under AllEvents",
+			event:   sandboxDriftStepSuccess,
+			outcome: successOutcome,
+			in:      Interests{AllEvents: true},
+			want:    false,
+		},
+		{
+			name:    "sandbox drift step lifecycle suppressed even when runners.reprovision is requested",
+			event:   sandboxDriftStepSuccess,
+			outcome: successOutcome,
+			in: Interests{Resources: map[ResourceKind]ResourceCfg{
+				ResourceRunners: {Ops: []string{"reprovision"}, Outcome: OutcomeAll},
+			}},
+			want: false,
 		},
 		{
 			name:    "sandbox drift workflow does not match sandboxes.reprovision",
@@ -359,7 +419,25 @@ func TestMatches(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "drift-detected (drift_run) matches components.drift when DriftDetected=true",
+			// Canonical post-suppression shape: just DriftDetected=true with
+			// no "drift" in Ops. Drift no longer participates in the SubOps
+			// vocabulary — it surfaces exclusively through this event class.
+			name: "drift-detected (drift_run) matches components when DriftDetected=true (no drift Op)",
+			event: signal.SignalPhaseEvent{
+				SignalType:   signalTypeDriftDetected,
+				WorkflowType: "drift_run",
+				Phase:        signal.SignalPhaseExecute,
+				StepID:       "iws_drift",
+			},
+			in: Interests{Resources: map[ResourceKind]ResourceCfg{
+				ResourceComponents: {DriftDetected: true},
+			}},
+			want: true,
+		},
+		{
+			// Legacy backward-compat: stored configs that still list "drift"
+			// in Ops are accepted by the matcher (validate rejects new ones).
+			name: "drift-detected (drift_run) matches components.drift legacy Ops shape",
 			event: signal.SignalPhaseEvent{
 				SignalType:   signalTypeDriftDetected,
 				WorkflowType: "drift_run",

--- a/services/ctl-api/internal/pkg/interests/match.go
+++ b/services/ctl-api/internal/pkg/interests/match.go
@@ -28,16 +28,38 @@ import (
 // classification falls back to the WorkflowType-only path which is enough
 // for execute-workflow events but skips step-scoped enrichment.
 func Matches(event signal.SignalPhaseEvent, outcome *signal.SignalPhaseOutcome, db *gorm.DB, in Interests) bool {
-	if in.AllEvents {
-		return true
-	}
-	if len(in.Resources) == 0 {
+	if !in.AllEvents && len(in.Resources) == 0 {
 		return false
 	}
 
 	f := classify(event, outcome, db)
 	if !f.Resolved {
 		return false
+	}
+
+	// Drift workflows (drift_run, drift_run_reprovision_sandbox) emit a flood
+	// of started/completed lifecycle events on every cron tick — including
+	// clean scans where nothing drifted. That noise is never useful: drift is
+	// signaled exclusively through the dedicated drift-detected event class
+	// (eventClassDriftDetected) which fires only when the plan-only check
+	// observes actual changes.
+	//
+	// We key off event.WorkflowType (the parent workflow envelope), not the
+	// classified facts.Op, because steps inside a drift workflow classify
+	// independently — a "runner healthy" step inside drift_run_reprovision_sandbox
+	// classifies as (runners, reprovision), a pre-reprovision lifecycle action
+	// classifies as (actions, run), etc. Filtering on facts.Op alone would
+	// only suppress the outer envelope and the single sandbox-plan step,
+	// leaking every other step event to subscribers. Suppress the entire
+	// lifecycle tree (including under AllEvents) so subscribers opt into
+	// drift via the DriftDetected flag, not by listing "drift" in Ops.
+	if f.EventClass == eventClassLifecycle &&
+		(event.WorkflowType == "drift_run" || event.WorkflowType == "drift_run_reprovision_sandbox") {
+		return false
+	}
+
+	if in.AllEvents {
+		return true
 	}
 
 	cfg, ok := in.Resources[f.Resource]

--- a/services/ctl-api/internal/pkg/interests/types.go
+++ b/services/ctl-api/internal/pkg/interests/types.go
@@ -61,13 +61,27 @@ const (
 // SubOps is the canonical sub-op vocabulary per resource. The classifier maps
 // real WorkflowType constants from internal/app/workflow.go onto these slugs.
 // UIs render checkbox lists from this map.
+//
+// Note: "drift" is intentionally NOT listed for components or sandboxes even
+// though the classifier still emits the slug. Drift workflow lifecycle events
+// are pure noise (one started/completed pair per cron tick per resource) and
+// are unconditionally suppressed in match.go. Subscribers opt into drift
+// notifications through DriftDetected, which gates the dedicated drift-detected
+// event that only fires when the plan-only check observes actual changes.
 var SubOps = map[ResourceKind][]string{
 	ResourceInstalls:              {"provision", "deprovision", "reprovision"},
-	ResourceComponents:            {"deploy", "teardown", "drift"},
-	ResourceSandboxes:             {"provision", "reprovision", "deprovision", "drift"},
+	ResourceComponents:            {"deploy", "teardown"},
+	ResourceSandboxes:             {"provision", "reprovision", "deprovision"},
 	ResourceInstallConfigurations: {"inputs", "secrets"},
 	ResourceRunners:               {"provision", "reprovision", "inactive"},
 	ResourceActions:               {"run"},
+}
+
+// SupportsDriftDetected reports whether DriftDetected is meaningful for the
+// given resource. Currently true for components and sandboxes — the only
+// resources whose workflows can produce a drift-detected event.
+func SupportsDriftDetected(kind ResourceKind) bool {
+	return kind == ResourceComponents || kind == ResourceSandboxes
 }
 
 // Interests is the full per-subscriber config. Stored as JSONB on both
@@ -92,8 +106,11 @@ type Interests struct {
 // DriftDetected is independent of Outcome too. It gates the drift_detected
 // event that fires from inside the plan-only check of a drift_run /
 // drift_run_reprovision_sandbox workflow when the plan has changes. Only
-// meaningful for resources whose SubOps include "drift" (components,
-// sandboxes); set on other resources is harmless but never matches.
+// meaningful for resources where SupportsDriftDetected returns true
+// (components, sandboxes); set on other resources is harmless but never
+// matches. Drift workflow lifecycle events themselves are unconditionally
+// suppressed by the matcher — DriftDetected is the only knob that surfaces
+// drift to subscribers.
 //
 // LOCKSTEP: changes to this struct's JSON shape must also update
 // bins/cli/cmd/orgs.go (interestsJSONHelp) and the "Filtering events with

--- a/services/ctl-api/internal/pkg/queue/catalog/allsignals/allsignals.go
+++ b/services/ctl-api/internal/pkg/queue/catalog/allsignals/allsignals.go
@@ -50,6 +50,8 @@ import (
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/deprovisionsandboxapplyplan"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/deprovisionsandboxplan"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/driftcheck"
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/driftchecksandbox"
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/driftdetected"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/executeactionworkflow"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/forgotten"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/generateinstallstackversion"

--- a/services/dashboard-ui/client/components/interests/InterestsPicker.stories.tsx
+++ b/services/dashboard-ui/client/components/interests/InterestsPicker.stories.tsx
@@ -54,10 +54,11 @@ export const WebhookSplitApprovals = () => (
           approval_responses: false,
         },
         components: {
-          ops: ['deploy', 'drift'],
+          ops: ['deploy', 'teardown'],
           outcome: 'all',
           approval_requests: false,
           approval_responses: true,
+          drift_detected: true,
         },
       },
     }}

--- a/services/dashboard-ui/client/components/interests/InterestsPicker.tsx
+++ b/services/dashboard-ui/client/components/interests/InterestsPicker.tsx
@@ -5,7 +5,7 @@ import { Toggle } from '@/components/common/form/Toggle'
 import { ApplyToAllBar } from './ApplyToAllBar'
 import { ResourceBlock } from './ResourceBlock'
 import { defaultInterests } from './defaults'
-import { SUB_OPS } from './subops'
+import { RESOURCES_WITH_DRIFT_DETECTED } from './subops'
 import {
   ALL_RESOURCES,
   type Interests,
@@ -14,10 +14,11 @@ import {
   type ResourceKind,
 } from './types'
 
-// resourceSupportsDrift mirrors the Go SubOps map — only resources whose
-// sub-op vocabulary includes "drift" surface the drift_detected toggle.
+// resourceSupportsDrift mirrors the Go SupportsDriftDetected helper — only
+// components and sandboxes can produce a drift_detected event, so the toggle
+// is only meaningful (and only rendered) for those resources.
 const resourceSupportsDrift = (kind: ResourceKind): boolean =>
-  SUB_OPS[kind].includes('drift')
+  RESOURCES_WITH_DRIFT_DETECTED.has(kind)
 
 // Shared picker that reads + writes the canonical Interests JSON shape (mirror
 // of services/ctl-api/internal/pkg/interests/types.go).

--- a/services/dashboard-ui/client/components/interests/ResourceBlock.tsx
+++ b/services/dashboard-ui/client/components/interests/ResourceBlock.tsx
@@ -4,7 +4,7 @@ import { Text } from '@/components/common/Text'
 import { CheckboxInput } from '@/components/common/form/CheckboxInput'
 import { RadioInput } from '@/components/common/form/RadioInput'
 import { cn } from '@/utils/classnames'
-import { SUB_OPS, labelForSubOp } from './subops'
+import { RESOURCES_WITH_DRIFT_DETECTED, SUB_OPS, labelForSubOp } from './subops'
 import {
   OUTCOME_LABELS,
   RESOURCE_DESCRIPTIONS,
@@ -48,10 +48,11 @@ export const ResourceBlock = ({
   const approvalResponses = !!cfg.approval_responses
   const slackApprovalChecked = approvalRequests || approvalResponses
   const driftDetected = !!cfg.drift_detected
-  // Only resources whose sub-op vocabulary includes "drift" can reasonably
-  // emit a drift_detected event; we hide the toggle elsewhere to avoid
-  // suggesting it does anything (the matcher would never fire it).
-  const supportsDrift = SUB_OPS[kind].includes('drift')
+  // Only components and sandboxes can produce a drift_detected event (mirrors
+  // the Go SupportsDriftDetected helper). The matcher silently drops drift
+  // workflow lifecycle events entirely, so the toggle is the *only* knob that
+  // ever fires drift notifications — render it only where it can actually fire.
+  const supportsDrift = RESOURCES_WITH_DRIFT_DETECTED.has(kind)
 
   const opSummary =
     ops.length === 0 ? 'all ops' : `${ops.length} op${ops.length === 1 ? '' : 's'}`

--- a/services/dashboard-ui/client/components/interests/defaults.ts
+++ b/services/dashboard-ui/client/components/interests/defaults.ts
@@ -8,8 +8,8 @@ export const allEvents = (): Interests => ({ all_events: true })
 
 // Power-user opted out of AllEvents baseline. Four resources present, runners +
 // actions absent. Empty ops = all sub-ops; OutcomeCompletion + both approval
-// flags true. drift_detected is on for the two resources whose SubOps include
-// "drift" (components, sandboxes).
+// flags true. drift_detected is on for the two resources that can produce a
+// drift_detected event (components, sandboxes — see RESOURCES_WITH_DRIFT_DETECTED).
 export const defaultInterests = (): Interests => ({
   resources: {
     installs: { outcome: 'completion', approval_requests: true, approval_responses: true },

--- a/services/dashboard-ui/client/components/interests/subops.ts
+++ b/services/dashboard-ui/client/components/interests/subops.ts
@@ -3,24 +3,36 @@
 // let the user narrow the per-resource filter, never to enumerate the wire
 // payload. Keep this in sync with the Go map; the backend validator rejects
 // unknown ops outright.
+//
+// Note: "drift" is intentionally NOT listed for components or sandboxes — the
+// backend matcher unconditionally suppresses drift workflow lifecycle events.
+// Drift surfaces only through the dedicated drift_detected event class, gated
+// by the per-resource drift_detected toggle (see RESOURCES_WITH_DRIFT_DETECTED).
 
 import type { ResourceKind } from './types'
 
 export const SUB_OPS: Record<ResourceKind, string[]> = {
   installs: ['provision', 'deprovision', 'reprovision'],
-  components: ['deploy', 'teardown', 'drift'],
-  sandboxes: ['provision', 'reprovision', 'deprovision', 'drift'],
+  components: ['deploy', 'teardown'],
+  sandboxes: ['provision', 'reprovision', 'deprovision'],
   install_configurations: ['inputs', 'secrets'],
   runners: ['provision', 'reprovision'],
   actions: ['run'],
 }
+
+// Resources whose workflows can produce a drift_detected event. Mirrors the Go
+// SupportsDriftDetected helper. The picker only renders the drift_detected
+// toggle for these kinds.
+export const RESOURCES_WITH_DRIFT_DETECTED: ReadonlySet<ResourceKind> = new Set<ResourceKind>([
+  'components',
+  'sandboxes',
+])
 
 const SUB_OP_LABELS: Record<string, string> = {
   // shared lifecycle ops
   provision: 'Provision',
   deprovision: 'Deprovision',
   reprovision: 'Reprovision',
-  drift: 'Drift',
   // components
   deploy: 'Deploy',
   teardown: 'Teardown',

--- a/services/dashboard-ui/client/components/interests/types.ts
+++ b/services/dashboard-ui/client/components/interests/types.ts
@@ -23,8 +23,10 @@ export interface ResourceCfg {
   approval_responses?: boolean
   // drift_detected fires only when drift is actually detected during a drift
   // scan (not for clean scans). Independent of `outcome`. Only meaningful for
-  // resources whose SubOps include "drift" (components, sandboxes); harmless
-  // but never matches on others.
+  // components and sandboxes (see RESOURCES_WITH_DRIFT_DETECTED); harmless
+  // but never matches on others. Drift workflow lifecycle events themselves
+  // are unconditionally suppressed by the matcher — this flag is the only
+  // knob that surfaces drift to subscribers.
   drift_detected?: boolean
 }
 
@@ -56,8 +58,8 @@ export const RESOURCE_LABELS: Record<ResourceKind, string> = {
 
 export const RESOURCE_DESCRIPTIONS: Record<ResourceKind, string> = {
   installs: 'Install provision, deprovision, reprovision lifecycle.',
-  components: 'Per-component deploy, teardown, and drift.',
-  sandboxes: 'Sandbox provision, reprovision, deprovision, and drift.',
+  components: 'Per-component deploy and teardown. Toggle drift detected to be notified when drift is found.',
+  sandboxes: 'Sandbox provision, reprovision, deprovision. Toggle drift detected to be notified when drift is found.',
   install_configurations: 'Install input updates and secret syncs.',
   runners: 'Runner provision and reprovision.',
   actions: 'Action workflow runs.',


### PR DESCRIPTION
Adds two new install-scoped queue signals and the wiring to emit a notification-only `drift-detected` event from the plan-only check of `drift_run` / `drift_run_reprovision_sandbox` workflows.

- **`driftchecksandbox.Signal`** — install-scoped sandbox drift cron analog of the existing per-component `driftcheck` signal. One emitter per install, driven by `AppSandboxConfig.DriftSchedule`, reconciled by `appconfigupdated` alongside the existing `drift-` and action-cron buckets.
- **`process_plan_only`** dispatches `drift-detected` when the plan-only check finds non-no-op changes. Failure is logged but non-fatal so the dispatch can never break the core drift-scan flow.

Subscribers opt in by enabling `drift_detected: true` on the `components` and/or `sandboxes` resource in their interests filter, so they don't receive additional noise of workflow start/finished events. 

