### PR TITLE
refactor(ui): deploy & sandbox plans decoupled form approval status

### DIFF
--- a/services/dashboard-ui/client/views/install/deploy-tabs/DeployManifestTab.tsx
+++ b/services/dashboard-ui/client/views/install/deploy-tabs/DeployManifestTab.tsx
@@ -13,6 +13,8 @@ export const DeployManifestTab = () => {
 
   const planJob = deploy?.runner_jobs?.find(
     (j) => j.operation === 'create-apply-plan'
+  ) ?? deploy?.runner_jobs?.find(
+    (j) => j.operation === 'apply-plan'
   )
 
   const { data: compositePlan, isLoading } = useQuery({

--- a/services/dashboard-ui/client/views/install/deploy-tabs/DeployPlanTab.tsx
+++ b/services/dashboard-ui/client/views/install/deploy-tabs/DeployPlanTab.tsx
@@ -1,20 +1,83 @@
 import { useOutletContext } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
 import { Plan } from '@/components/approvals/Plan'
+import { HelmDiff } from '@/components/approvals/plan-diffs/helm/HelmDiff'
+import { KubernetesDiff } from '@/components/approvals/plan-diffs/kubernetes/KubernetesDiff'
+import { PulumiDiff } from '@/components/approvals/plan-diffs/pulumi/PulumiDiff'
+import { TerraformDiff } from '@/components/approvals/plan-diffs/terraform/TerraformDiff'
 import { EmptyState } from '@/components/common/EmptyState'
+import { Skeleton } from '@/components/common/Skeleton'
+import { useDeploy } from '@/hooks/use-deploy'
+import { useOrg } from '@/hooks/use-org'
+import { getRunnerJobPlan } from '@/lib'
+import type { TComponentType } from '@/types'
 import type { TDeployOutletContext } from './types'
 
-export const DeployPlanTab = () => {
-  const { step } = useOutletContext<TDeployOutletContext>()
+function getDiffForComponentType(componentType: TComponentType, plan: any) {
+  switch (componentType) {
+    case 'terraform_module':
+      return <TerraformDiff plan={plan} />
+    case 'helm_chart':
+      return <HelmDiff plan={plan} />
+    case 'kubernetes_manifest':
+      return <KubernetesDiff plan={plan} />
+    case 'pulumi':
+      return <PulumiDiff plan={plan} />
+    default:
+      return null
+  }
+}
 
-  if (!step?.approval) {
+const DeployPlanFallback = ({ componentType }: { componentType: TComponentType }) => {
+  const { deploy } = useDeploy()
+  const { org } = useOrg()
+
+  const applyJob = deploy?.runner_jobs?.find(
+    (j) => j.operation === 'apply-plan'
+  )
+
+  const { data: compositePlan, isLoading } = useQuery({
+    queryKey: ['runner-job-plan', org?.id, applyJob?.id],
+    queryFn: () =>
+      getRunnerJobPlan({ runnerJobId: applyJob!.id, orgId: org.id }),
+    enabled: !!org?.id && !!applyJob?.id,
+  })
+
+  if (isLoading) return <Skeleton height="350px" width="100%" />
+
+  const planDisplay = compositePlan?.deploy_plan?.apply_plan_display
+  if (!planDisplay) {
     return (
       <EmptyState
         variant="table"
         emptyTitle="No plan available"
-        emptyMessage="No approval plan has been generated for this deploy."
+        emptyMessage="The plan hasn't been generated yet or is not available for this deploy."
       />
     )
   }
 
-  return <Plan step={step} />
+  const parsed = typeof planDisplay === 'string' ? JSON.parse(planDisplay) : planDisplay
+  const diff = getDiffForComponentType(componentType, parsed)
+
+  if (!diff) {
+    return (
+      <EmptyState
+        variant="table"
+        emptyTitle="No plan available"
+        emptyMessage="Plan view is not supported for this component type."
+      />
+    )
+  }
+
+  return diff
+}
+
+export const DeployPlanTab = () => {
+  const { step, component } = useOutletContext<TDeployOutletContext>()
+
+  if (step?.approval) {
+    return <Plan step={step} />
+  }
+
+  return <DeployPlanFallback componentType={component.type!} />
 }

--- a/services/dashboard-ui/client/views/install/deploy-tabs/DeployValuesTab.tsx
+++ b/services/dashboard-ui/client/views/install/deploy-tabs/DeployValuesTab.tsx
@@ -12,6 +12,8 @@ export const DeployValuesTab = () => {
 
   const planJob = deploy?.runner_jobs?.find(
     (j) => j.operation === 'create-apply-plan'
+  ) ?? deploy?.runner_jobs?.find(
+    (j) => j.operation === 'apply-plan'
   )
 
   const { data: compositePlan, isLoading } = useQuery({

--- a/services/dashboard-ui/client/views/install/deploy-tabs/DeployVariablesTab.tsx
+++ b/services/dashboard-ui/client/views/install/deploy-tabs/DeployVariablesTab.tsx
@@ -12,6 +12,8 @@ export const DeployVariablesTab = () => {
 
   const planJob = deploy?.runner_jobs?.find(
     (j) => j.operation === 'create-apply-plan'
+  ) ?? deploy?.runner_jobs?.find(
+    (j) => j.operation === 'apply-plan'
   )
 
   const { data: compositePlan, isLoading } = useQuery({

--- a/services/dashboard-ui/client/views/install/sandbox-tabs/SandboxRunPlanTab.tsx
+++ b/services/dashboard-ui/client/views/install/sandbox-tabs/SandboxRunPlanTab.tsx
@@ -1,20 +1,52 @@
 import { useOutletContext } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
 import { Plan } from '@/components/approvals/Plan'
+import { TerraformDiff } from '@/components/approvals/plan-diffs/terraform/TerraformDiff'
 import { EmptyState } from '@/components/common/EmptyState'
+import { Skeleton } from '@/components/common/Skeleton'
+import { useSandboxRun } from '@/hooks/use-sandbox-run'
+import { useOrg } from '@/hooks/use-org'
+import { getRunnerJobPlan } from '@/lib'
 import type { TSandboxRunOutletContext } from './types'
 
-export const SandboxRunPlanTab = () => {
-  const { step } = useOutletContext<TSandboxRunOutletContext>()
+const SandboxRunPlanFallback = () => {
+  const { sandboxRun } = useSandboxRun()
+  const { org } = useOrg()
 
-  if (!step?.approval) {
+  const applyJob = sandboxRun?.runner_jobs?.find(
+    (j) => j.operation === 'apply-plan'
+  )
+
+  const { data: compositePlan, isLoading } = useQuery({
+    queryKey: ['runner-job-plan', org?.id, applyJob?.id],
+    queryFn: () =>
+      getRunnerJobPlan({ runnerJobId: applyJob!.id, orgId: org.id }),
+    enabled: !!org?.id && !!applyJob?.id,
+  })
+
+  if (isLoading) return <Skeleton height="350px" width="100%" />
+
+  const planDisplay = compositePlan?.sandbox_run_plan?.apply_plan_display
+  if (!planDisplay) {
     return (
       <EmptyState
         variant="table"
         emptyTitle="No plan available"
-        emptyMessage="No approval plan has been generated for this sandbox run."
+        emptyMessage="The plan hasn't been generated yet or is not available for this sandbox run."
       />
     )
   }
 
-  return <Plan step={step} />
+  const parsed = typeof planDisplay === 'string' ? JSON.parse(planDisplay) : planDisplay
+  return <TerraformDiff plan={parsed} />
+}
+
+export const SandboxRunPlanTab = () => {
+  const { step } = useOutletContext<TSandboxRunOutletContext>()
+
+  if (step?.approval) {
+    return <Plan step={step} />
+  }
+
+  return <SandboxRunPlanFallback />
 }

--- a/services/dashboard-ui/client/views/install/sandbox-tabs/SandboxRunVariablesTab.tsx
+++ b/services/dashboard-ui/client/views/install/sandbox-tabs/SandboxRunVariablesTab.tsx
@@ -12,6 +12,8 @@ export const SandboxRunVariablesTab = () => {
 
   const planJob = sandboxRun?.runner_jobs?.find(
     (j) => j.operation === 'create-apply-plan'
+  ) ?? sandboxRun?.runner_jobs?.find(
+    (j) => j.operation === 'apply-plan'
   )
 
   const { data: compositePlan, isLoading } = useQuery({


### PR DESCRIPTION
Fixes issue where deploy and sandbox plan pages wouldn't render the plan if it had been approved