### PR TITLE
refactor(ui): workflow step panel updates

### DIFF
--- a/services/dashboard-ui/client/components/log-stream/LogPanel.tsx
+++ b/services/dashboard-ui/client/components/log-stream/LogPanel.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useRef, useState } from 'react'
 import { Badge } from '@/components/common/Badge'
 import { ClickToCopyButton } from '@/components/common/ClickToCopy'
 import { Code } from '@/components/common/Code'
@@ -17,10 +18,109 @@ import { LogMetadata } from './LogMetadata'
 
 interface ILogPanel extends Omit<IPanel, 'heading' | 'children' | 'size'> {
   log: TOTELLog
+  cycleDirection?: 'up' | 'down'
 }
 
-export const LogPanel = ({ className, log, ...props }: ILogPanel) => {
+const LogPanelBody = ({ log, url }: { log: TOTELLog; url: string }) => (
+  <>
+    <div className="flex flex-col gap-2">
+      <span className="flex items-center gap-2 justify-between">
+        <Text weight="strong">Log details</Text>
+
+        <Text variant="subtext" flex className="gap-2">
+          Copy link
+          <ClickToCopyButton textToCopy={url} />
+        </Text>
+      </span>
+      <div className="flex flex-wrap gap-8">
+        <LabeledValue label="Service">
+          <Text>{log.service_name}</Text>
+        </LabeledValue>
+
+        <LabeledValue label="Scope">
+          <Text>{log.scope_name}</Text>
+        </LabeledValue>
+      </div>
+    </div>
+    <div className="flex flex-col gap-2">
+      <span className="flex items-center gap-2 justify-between">
+        <Text weight="strong">Log message</Text>
+
+        <ClickToCopyButton textToCopy={log.body} />
+      </span>
+
+      <Code className="!shadow-none">{log.body}</Code>
+    </div>
+
+    <AttributesTabs log={log} />
+
+    <LogMetadata log={log} />
+  </>
+)
+
+const LogPanelNavHint = () => (
+  <div className="flex w-full mt-auto">
+    <Text flex nowrap className="gap-2">
+      Use
+      <span className="inline-flex items-center gap-1">
+        <Badge variant="code" size="sm">
+          <Icon variant="ArrowUp" />
+        </Badge>
+        /
+        <Badge variant="code" size="sm">
+          <Icon variant="ArrowDown" />
+        </Badge>
+        or
+        <Badge variant="code" size="sm">
+          <Text family="mono" variant="subtext">
+            k
+          </Text>
+        </Badge>
+        /
+        <Badge variant="code" size="sm">
+          <Text family="mono" variant="subtext">
+            j
+          </Text>
+        </Badge>
+      </span>
+      to navigate between logs.
+    </Text>
+  </div>
+)
+
+type TCycleTransition = {
+  prevLog: TOTELLog
+  direction: 'up' | 'down'
+}
+
+export const LogPanel = ({ className, log, cycleDirection, ...props }: ILogPanel) => {
   const url = useFullUrl()
+  const prevLogRef = useRef<TOTELLog>(log)
+  const [transition, setTransition] = useState<TCycleTransition | null>(null)
+
+  useEffect(() => {
+    if (log.id !== prevLogRef.current.id && cycleDirection) {
+      setTransition({ prevLog: prevLogRef.current, direction: cycleDirection })
+      prevLogRef.current = log
+      const timer = setTimeout(() => setTransition(null), 150)
+      return () => clearTimeout(timer)
+    }
+    prevLogRef.current = log
+  }, [log.id, cycleDirection])
+
+  const enterClass =
+    transition?.direction === 'down'
+      ? 'animate-slide-in-from-bottom'
+      : transition?.direction === 'up'
+        ? 'animate-slide-in-from-top'
+        : undefined
+
+  const exitClass =
+    transition?.direction === 'down'
+      ? 'animate-slide-exit-up'
+      : transition?.direction === 'up'
+        ? 'animate-slide-exit-down'
+        : undefined
 
   return (
     <Panel
@@ -29,70 +129,37 @@ export const LogPanel = ({ className, log, ...props }: ILogPanel) => {
         getSeverityBorderClasses(log.severity_number, 't'),
         className
       )}
-      heading={<LogPanelHeading log={log} />}
+      heading={
+        <div className="relative overflow-hidden">
+          {transition && (
+            <div className={cn('absolute inset-0', exitClass)}>
+              <LogPanelHeading log={transition.prevLog} />
+            </div>
+          )}
+          <div className={enterClass}>
+            <LogPanelHeading log={log} />
+          </div>
+        </div>
+      }
       size="half"
       {...props}
     >
-      <div className="flex flex-col gap-2">
-        <span className="flex items-center gap-2 justify-between">
-          <Text weight="strong">Log details</Text>
-
-          <Text variant="subtext" flex className="gap-2">
-            Copy link
-            <ClickToCopyButton textToCopy={url} />
-          </Text>
-        </span>
-        <div className="flex flex-wrap gap-8">
-          <LabeledValue label="Service">
-            <Text>{log.service_name}</Text>
-          </LabeledValue>
-
-          <LabeledValue label="Scope">
-            <Text>{log.scope_name}</Text>
-          </LabeledValue>
+      <div className="relative overflow-hidden flex flex-col flex-auto">
+        {transition && (
+          <div
+            className={cn(
+              'absolute inset-x-0 top-0 flex flex-col gap-4 md:gap-6',
+              exitClass
+            )}
+          >
+            <LogPanelBody log={transition.prevLog} url={url} />
+          </div>
+        )}
+        <div className={cn('flex flex-col flex-auto gap-4 md:gap-6', enterClass)}>
+          <LogPanelBody log={log} url={url} />
         </div>
       </div>
-      <div className="flex flex-col gap-2">
-        <span className="flex items-center gap-2 justify-between">
-          <Text weight="strong">Log message</Text>
-
-          <ClickToCopyButton textToCopy={log.body} />
-        </span>
-
-        <Code className="!shadow-none">{log.body}</Code>
-      </div>
-
-      <AttributesTabs log={log} />
-
-      <LogMetadata log={log} />
-
-      <div className="flex w-full mt-auto">
-        <Text flex nowrap className="gap-2">
-          Use
-          <span className="inline-flex items-center gap-1">
-            <Badge variant="code" size="sm">
-              <Icon variant="ArrowUp" />
-            </Badge>
-            /
-            <Badge variant="code" size="sm">
-              <Icon variant="ArrowDown" />
-            </Badge>
-            or
-            <Badge variant="code" size="sm">
-              <Text family="mono" variant="subtext">
-                k
-              </Text>
-            </Badge>
-            /
-            <Badge variant="code" size="sm">
-              <Text family="mono" variant="subtext">
-                j
-              </Text>
-            </Badge>
-          </span>
-          to navigate between logs.
-        </Text>
-      </div>
+      <LogPanelNavHint />
     </Panel>
   )
 }

--- a/services/dashboard-ui/client/components/log-stream/LogPanel.tsx
+++ b/services/dashboard-ui/client/components/log-stream/LogPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 import { Badge } from '@/components/common/Badge'
 import { ClickToCopyButton } from '@/components/common/ClickToCopy'
 import { Code } from '@/components/common/Code'
@@ -88,32 +88,47 @@ const LogPanelNavHint = () => (
   </div>
 )
 
+const ANIM_DURATION = 100
+
 type TCycleTransition = {
+  phase: 'exiting' | 'entering'
   prevLog: TOTELLog
   direction: 'up' | 'down'
 }
 
+const LOG_PANEL_FULLSCREEN_KEY = 'log-panel-fullscreen'
+
 export const LogPanel = ({ className, log, cycleDirection, ...props }: ILogPanel) => {
   const url = useFullUrl()
   const prevLogRef = useRef<TOTELLog>(log)
+  const isFullscreen = localStorage.getItem(LOG_PANEL_FULLSCREEN_KEY) === 'true'
   const [transition, setTransition] = useState<TCycleTransition | null>(null)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (log.id !== prevLogRef.current.id && cycleDirection) {
-      setTransition({ prevLog: prevLogRef.current, direction: cycleDirection })
+      const prevLog = prevLogRef.current
       prevLogRef.current = log
-      const timer = setTimeout(() => setTransition(null), 150)
-      return () => clearTimeout(timer)
+      setTransition({ phase: 'exiting', prevLog, direction: cycleDirection })
+      const exitTimer = setTimeout(() => {
+        requestAnimationFrame(() => {
+          setTransition({ phase: 'entering', prevLog, direction: cycleDirection })
+        })
+      }, ANIM_DURATION)
+      const enterTimer = setTimeout(() => {
+        requestAnimationFrame(() => {
+          setTransition(null)
+        })
+      }, ANIM_DURATION * 2)
+      return () => {
+        clearTimeout(exitTimer)
+        clearTimeout(enterTimer)
+      }
     }
     prevLogRef.current = log
   }, [log.id, cycleDirection])
 
-  const enterClass =
-    transition?.direction === 'down'
-      ? 'animate-slide-in-from-bottom'
-      : transition?.direction === 'up'
-        ? 'animate-slide-in-from-top'
-        : undefined
+  const isExiting = transition?.phase === 'exiting'
+  const isEntering = transition?.phase === 'entering'
 
   const exitClass =
     transition?.direction === 'down'
@@ -122,41 +137,47 @@ export const LogPanel = ({ className, log, cycleDirection, ...props }: ILogPanel
         ? 'animate-slide-exit-down'
         : undefined
 
+  const enterClass =
+    transition?.direction === 'down'
+      ? 'animate-slide-in-from-bottom'
+      : transition?.direction === 'up'
+        ? 'animate-slide-in-from-top'
+        : undefined
+
+  const displayLog = isExiting ? transition.prevLog : log
+
   return (
     <Panel
       className={cn(
         'border-t-6',
-        getSeverityBorderClasses(log.severity_number, 't'),
+        getSeverityBorderClasses(
+          (isExiting ? transition.prevLog : log).severity_number,
+          't'
+        ),
         className
       )}
       heading={
-        <div className="relative overflow-hidden">
-          {transition && (
-            <div className={cn('absolute inset-0', exitClass)}>
-              <LogPanelHeading log={transition.prevLog} />
-            </div>
-          )}
-          <div className={enterClass}>
-            <LogPanelHeading log={log} />
-          </div>
+        <div className={cn(
+          isExiting && 'animate-heading-exit',
+          isEntering && 'animate-heading-enter'
+        )}>
+          <LogPanelHeading log={displayLog} />
         </div>
       }
       size="half"
+      defaultExpanded={isFullscreen}
+      onSizeChange={(size) => {
+        localStorage.setItem(LOG_PANEL_FULLSCREEN_KEY, size === 'full' ? 'true' : 'false')
+      }}
       {...props}
     >
-      <div className="relative overflow-hidden flex flex-col flex-auto">
-        {transition && (
-          <div
-            className={cn(
-              'absolute inset-x-0 top-0 flex flex-col gap-4 md:gap-6',
-              exitClass
-            )}
-          >
-            <LogPanelBody log={transition.prevLog} url={url} />
-          </div>
-        )}
-        <div className={cn('flex flex-col flex-auto gap-4 md:gap-6', enterClass)}>
-          <LogPanelBody log={log} url={url} />
+      <div className="relative flex flex-col flex-auto">
+        <div className={cn(
+          'flex flex-col flex-auto gap-4 md:gap-6',
+          isExiting && exitClass,
+          isEntering && enterClass
+        )}>
+          <LogPanelBody log={displayLog} url={url} />
         </div>
       </div>
       <LogPanelNavHint />

--- a/services/dashboard-ui/client/components/log-stream/SSELogs/SSELogs.stories.tsx
+++ b/services/dashboard-ui/client/components/log-stream/SSELogs/SSELogs.stories.tsx
@@ -2,9 +2,13 @@ export default {
   title: 'LogStream/SSELogs',
 }
 
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { SSELogs, LogsSkeleton } from './SSELogs'
+import { LogPanel } from '@/components/log-stream/LogPanel'
 import { UnifiedLogsContext } from '@/providers/unified-logs-provider'
 import { LogStreamContext } from '@/providers/log-stream-provider'
+import { useArrowKeys } from '@/hooks/use-arrow-keys'
+import { useSurfaces } from '@/hooks/use-surfaces'
 import type { TOTELLog, TLogStream } from '@/types'
 import type { TLogFiltersProps } from '@/hooks/use-log-filters'
 
@@ -13,58 +17,418 @@ const noop = () => {}
 const mockLogs: TOTELLog[] = [
   {
     id: 'log-1',
-    timestamp: '2024-01-15T10:30:00.000Z',
+    timestamp: '2024-01-15T10:30:00.123Z',
+    timestamp_date: '2024-01-15',
+    timestamp_time: '10:30:00.123',
     severity_number: 9,
     severity_text: 'Info',
-    body: 'Deploying application to cluster...',
+    body: 'Starting OCI sync for component helm-chart: pulling 766121324316.dkr.ecr.us-west-2.amazonaws.com/orgrok933tcyzji01s7us3aeo3/app98e2wpzdxwoey393edtqj45:bldq7fplr1up5atx5zpxotbabm',
     service_name: 'runner',
     scope_name: 'oteljob',
+    log_stream_id: 'lgsf8k2m4npq1rvx3wtz6yba7',
+    org_id: 'orgrok933tcyzji01s7us3aeo3',
+    runner_id: 'rnr4x8gkm2vp7qtw1ycz5nbjh',
+    runner_group_id: 'rgrpnk3m7fvx9qtz2wyc4abj6',
+    runner_job_id: 'jobypfusmjzcer1unneh0jso67',
+    runner_job_execution_id: 'runmwxrdg4jesn8jc1jhdjdyym',
+    runner_job_execution_step: 'oci-sync',
+    trace_id: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6',
+    span_id: 'f1e2d3c4b5a6f7e8',
+    trace_flags: 1,
+    log_attributes: {
+      'log_stream.id': 'lgsf8k2m4npq1rvx3wtz6yba7',
+      'runner_job.id': 'jobypfusmjzcer1unneh0jso67',
+      'runner_job.type': 'oci-sync',
+      'runner_job_execution.id': 'runmwxrdg4jesn8jc1jhdjdyym',
+      'runner_job_execution_step.name': 'oci-sync',
+      step: 'oci-sync',
+    },
+    resource_attributes: {
+      'service.name': 'runner',
+      'service.version': 'v0.14.82',
+      'host.name': 'runner-7b8f4d6c9-xk2m4',
+      'os.type': 'linux',
+      'process.runtime.name': 'go',
+      'process.runtime.version': 'go1.25.0',
+    },
+    scope_attributes: {
+      'otel.scope.name': 'oteljob',
+      'otel.scope.version': 'v1',
+    },
   },
   {
     id: 'log-2',
-    timestamp: '2024-01-15T10:30:01.000Z',
+    timestamp: '2024-01-15T10:30:01.456Z',
+    timestamp_date: '2024-01-15',
+    timestamp_time: '10:30:01.456',
     severity_number: 9,
     severity_text: 'Info',
-    body: 'Pulling image: 123456789.dkr.ecr.us-east-1.amazonaws.com/my-app:latest',
+    body: 'Pulling image: 766121324316.dkr.ecr.us-west-2.amazonaws.com/orgrok933tcyzji01s7us3aeo3/app98e2wpzdxwoey393edtqj45:bldq7fplr1up5atx5zpxotbabm',
     service_name: 'runner',
     scope_name: 'oteljob',
+    log_stream_id: 'lgsf8k2m4npq1rvx3wtz6yba7',
+    org_id: 'orgrok933tcyzji01s7us3aeo3',
+    runner_id: 'rnr4x8gkm2vp7qtw1ycz5nbjh',
+    runner_group_id: 'rgrpnk3m7fvx9qtz2wyc4abj6',
+    runner_job_id: 'jobypfusmjzcer1unneh0jso67',
+    runner_job_execution_id: 'runmwxrdg4jesn8jc1jhdjdyym',
+    runner_job_execution_step: 'oci-sync',
+    trace_id: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6',
+    span_id: 'f1e2d3c4b5a6f7e8',
+    log_attributes: {
+      'log_stream.id': 'lgsf8k2m4npq1rvx3wtz6yba7',
+      'runner_job.id': 'jobypfusmjzcer1unneh0jso67',
+      'runner_job.type': 'oci-sync',
+      'runner_job_execution.id': 'runmwxrdg4jesn8jc1jhdjdyym',
+      'runner_job_execution_step.name': 'oci-sync',
+      step: 'oci-sync',
+    },
+    resource_attributes: {
+      'service.name': 'runner',
+      'service.version': 'v0.14.82',
+      'host.name': 'runner-7b8f4d6c9-xk2m4',
+      'os.type': 'linux',
+    },
+    scope_attributes: {
+      'otel.scope.name': 'oteljob',
+      'otel.scope.version': 'v1',
+    },
   },
   {
     id: 'log-3',
-    timestamp: '2024-01-15T10:30:02.500Z',
+    timestamp: '2024-01-15T10:30:02.789Z',
+    timestamp_date: '2024-01-15',
+    timestamp_time: '10:30:02.789',
     severity_number: 13,
     severity_text: 'Warn',
-    body: 'Retrying connection attempt (2/3)',
-    service_name: 'api',
+    body: 'ECR token refresh: token expires in 4m30s, threshold is 5m — refreshing early',
+    service_name: 'runner',
     scope_name: 'system',
+    log_stream_id: 'lgsf8k2m4npq1rvx3wtz6yba7',
+    org_id: 'orgrok933tcyzji01s7us3aeo3',
+    runner_id: 'rnr4x8gkm2vp7qtw1ycz5nbjh',
+    runner_group_id: 'rgrpnk3m7fvx9qtz2wyc4abj6',
+    runner_job_id: 'jobypfusmjzcer1unneh0jso67',
+    runner_job_execution_id: 'runmwxrdg4jesn8jc1jhdjdyym',
+    runner_job_execution_step: 'initialize',
+    trace_id: 'b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a1',
+    span_id: 'e2d3c4b5a6f7e8f1',
+    log_attributes: {
+      'log_stream.id': 'lgsf8k2m4npq1rvx3wtz6yba7',
+      'runner_job.id': 'jobypfusmjzcer1unneh0jso67',
+      'runner_job.type': 'oci-sync',
+      'runner_job_execution.id': 'runmwxrdg4jesn8jc1jhdjdyym',
+      'runner_job_execution_step.name': 'initialize',
+      step: 'initialize',
+      'ecr.token_ttl_seconds': '270',
+      'ecr.refresh_threshold_seconds': '300',
+    },
+    resource_attributes: {
+      'service.name': 'runner',
+      'service.version': 'v0.14.82',
+      'host.name': 'runner-7b8f4d6c9-xk2m4',
+      'os.type': 'linux',
+    },
+    scope_attributes: {
+      'otel.scope.name': 'system',
+      'otel.scope.version': 'v1',
+    },
   },
   {
     id: 'log-4',
-    timestamp: '2024-01-15T10:30:04.000Z',
+    timestamp: '2024-01-15T10:30:04.012Z',
+    timestamp_date: '2024-01-15',
+    timestamp_time: '10:30:04.012',
     severity_number: 9,
     severity_text: 'Info',
-    body: 'Helm release updated successfully',
+    body: 'Helm release "my-app" upgraded successfully in namespace "default" (revision 7)',
     service_name: 'runner',
     scope_name: 'oteljob',
+    log_stream_id: 'lgsf8k2m4npq1rvx3wtz6yba7',
+    org_id: 'orgrok933tcyzji01s7us3aeo3',
+    runner_id: 'rnr4x8gkm2vp7qtw1ycz5nbjh',
+    runner_group_id: 'rgrpnk3m7fvx9qtz2wyc4abj6',
+    runner_job_id: 'job3m9xkr7fvp2qtw4ycz1nbah',
+    runner_job_execution_id: 'runhx5kcw8fvp3qtm2ycz9nbaj',
+    runner_job_execution_step: 'helm-upgrade',
+    trace_id: 'c3d4e5f6a7b8c9d0e1f2a3b4c5d6a1b2',
+    span_id: 'd3c4b5a6f7e8f1e2',
+    log_attributes: {
+      'log_stream.id': 'lgsf8k2m4npq1rvx3wtz6yba7',
+      'runner_job.id': 'job3m9xkr7fvp2qtw4ycz1nbah',
+      'runner_job.type': 'helm-deploy',
+      'runner_job_execution.id': 'runhx5kcw8fvp3qtm2ycz9nbaj',
+      'runner_job_execution_step.name': 'helm-upgrade',
+      step: 'helm-upgrade',
+      'helm.release': 'my-app',
+      'helm.namespace': 'default',
+      'helm.revision': '7',
+    },
+    resource_attributes: {
+      'service.name': 'runner',
+      'service.version': 'v0.14.82',
+      'host.name': 'runner-7b8f4d6c9-xk2m4',
+      'os.type': 'linux',
+      'k8s.cluster.name': 'install-us-east-1',
+      'k8s.namespace.name': 'default',
+    },
+    scope_attributes: {
+      'otel.scope.name': 'oteljob',
+      'otel.scope.version': 'v1',
+    },
   },
   {
     id: 'log-5',
-    timestamp: '2024-01-15T10:30:05.000Z',
+    timestamp: '2024-01-15T10:30:05.345Z',
+    timestamp_date: '2024-01-15',
+    timestamp_time: '10:30:05.345',
     severity_number: 17,
     severity_text: 'Error',
-    body: 'Failed to connect to database: connection timeout after 30s',
-    service_name: 'api',
+    body: 'Failed to connect to database: connection timeout after 30s — host=db-primary.us-east-1.rds.amazonaws.com port=5432 dbname=app_production sslmode=require',
+    service_name: 'runner',
+    scope_name: 'oteljob',
+    log_stream_id: 'lgsf8k2m4npq1rvx3wtz6yba7',
+    org_id: 'orgrok933tcyzji01s7us3aeo3',
+    runner_id: 'rnr4x8gkm2vp7qtw1ycz5nbjh',
+    runner_group_id: 'rgrpnk3m7fvx9qtz2wyc4abj6',
+    runner_job_id: 'job3m9xkr7fvp2qtw4ycz1nbah',
+    runner_job_execution_id: 'runhx5kcw8fvp3qtm2ycz9nbaj',
+    runner_job_execution_step: 'health-check',
+    trace_id: 'd4e5f6a7b8c9d0e1f2a3b4c5d6a1b2c3',
+    span_id: 'c4b5a6f7e8f1e2d3',
+    log_attributes: {
+      'log_stream.id': 'lgsf8k2m4npq1rvx3wtz6yba7',
+      'runner_job.id': 'job3m9xkr7fvp2qtw4ycz1nbah',
+      'runner_job.type': 'helm-deploy',
+      'runner_job_execution.id': 'runhx5kcw8fvp3qtm2ycz9nbaj',
+      'runner_job_execution_step.name': 'health-check',
+      step: 'health-check',
+      'error.type': 'ConnectionTimeout',
+      'db.system': 'postgresql',
+      'db.name': 'app_production',
+      'net.peer.name': 'db-primary.us-east-1.rds.amazonaws.com',
+      'net.peer.port': '5432',
+    },
+    resource_attributes: {
+      'service.name': 'runner',
+      'service.version': 'v0.14.82',
+      'host.name': 'runner-7b8f4d6c9-xk2m4',
+      'os.type': 'linux',
+      'k8s.cluster.name': 'install-us-east-1',
+      'k8s.namespace.name': 'default',
+    },
+    scope_attributes: {
+      'otel.scope.name': 'oteljob',
+      'otel.scope.version': 'v1',
+    },
+  },
+  {
+    id: 'log-6',
+    timestamp: '2024-01-15T10:30:06.678Z',
+    timestamp_date: '2024-01-15',
+    timestamp_time: '10:30:06.678',
+    severity_number: 5,
+    severity_text: 'Debug',
+    body: 'Resolving terraform providers: hashicorp/aws v5.31.0, hashicorp/kubernetes v2.25.2',
+    service_name: 'runner',
+    scope_name: 'oteljob',
+    log_stream_id: 'lgsf8k2m4npq1rvx3wtz6yba7',
+    org_id: 'orgrok933tcyzji01s7us3aeo3',
+    runner_id: 'rnr4x8gkm2vp7qtw1ycz5nbjh',
+    runner_group_id: 'rgrpnk3m7fvx9qtz2wyc4abj6',
+    runner_job_id: 'jobkz6m4npq8rvx1wts3ybaf2',
+    runner_job_execution_id: 'runtz9m2npq5rvx7wkc4ybaj8',
+    runner_job_execution_step: 'terraform-init',
+    trace_id: 'e5f6a7b8c9d0e1f2a3b4c5d6a1b2c3d4',
+    span_id: 'b5a6f7e8f1e2d3c4',
+    log_attributes: {
+      'log_stream.id': 'lgsf8k2m4npq1rvx3wtz6yba7',
+      'runner_job.id': 'jobkz6m4npq8rvx1wts3ybaf2',
+      'runner_job.type': 'terraform-apply',
+      'runner_job_execution.id': 'runtz9m2npq5rvx7wkc4ybaj8',
+      'runner_job_execution_step.name': 'terraform-init',
+      step: 'terraform-init',
+      'terraform.provider.aws': 'v5.31.0',
+      'terraform.provider.kubernetes': 'v2.25.2',
+    },
+    resource_attributes: {
+      'service.name': 'runner',
+      'service.version': 'v0.14.82',
+      'host.name': 'runner-7b8f4d6c9-xk2m4',
+      'os.type': 'linux',
+    },
+    scope_attributes: {
+      'otel.scope.name': 'oteljob',
+      'otel.scope.version': 'v1',
+    },
+  },
+  {
+    id: 'log-7',
+    timestamp: '2024-01-15T10:30:08.901Z',
+    timestamp_date: '2024-01-15',
+    timestamp_time: '10:30:08.901',
+    severity_number: 9,
+    severity_text: 'Info',
+    body: 'Terraform plan: 3 to add, 1 to change, 0 to destroy',
+    service_name: 'runner',
+    scope_name: 'oteljob',
+    log_stream_id: 'lgsf8k2m4npq1rvx3wtz6yba7',
+    org_id: 'orgrok933tcyzji01s7us3aeo3',
+    runner_id: 'rnr4x8gkm2vp7qtw1ycz5nbjh',
+    runner_group_id: 'rgrpnk3m7fvx9qtz2wyc4abj6',
+    runner_job_id: 'jobkz6m4npq8rvx1wts3ybaf2',
+    runner_job_execution_id: 'runtz9m2npq5rvx7wkc4ybaj8',
+    runner_job_execution_step: 'terraform-plan',
+    trace_id: 'e5f6a7b8c9d0e1f2a3b4c5d6a1b2c3d4',
+    span_id: 'a6f7e8f1e2d3c4b5',
+    log_attributes: {
+      'log_stream.id': 'lgsf8k2m4npq1rvx3wtz6yba7',
+      'runner_job.id': 'jobkz6m4npq8rvx1wts3ybaf2',
+      'runner_job.type': 'terraform-apply',
+      'runner_job_execution.id': 'runtz9m2npq5rvx7wkc4ybaj8',
+      'runner_job_execution_step.name': 'terraform-plan',
+      step: 'terraform-plan',
+      'terraform.plan.add': '3',
+      'terraform.plan.change': '1',
+      'terraform.plan.destroy': '0',
+    },
+    resource_attributes: {
+      'service.name': 'runner',
+      'service.version': 'v0.14.82',
+      'host.name': 'runner-7b8f4d6c9-xk2m4',
+      'os.type': 'linux',
+    },
+    scope_attributes: {
+      'otel.scope.name': 'oteljob',
+      'otel.scope.version': 'v1',
+    },
+  },
+  {
+    id: 'log-8',
+    timestamp: '2024-01-15T10:30:10.234Z',
+    timestamp_date: '2024-01-15',
+    timestamp_time: '10:30:10.234',
+    severity_number: 21,
+    severity_text: 'Fatal',
+    body: 'Runner process crashed: out of memory — container limit 512Mi exceeded, peak usage 623Mi during terraform apply',
+    service_name: 'runner',
     scope_name: 'system',
+    log_stream_id: 'lgsf8k2m4npq1rvx3wtz6yba7',
+    org_id: 'orgrok933tcyzji01s7us3aeo3',
+    runner_id: 'rnr4x8gkm2vp7qtw1ycz5nbjh',
+    runner_group_id: 'rgrpnk3m7fvx9qtz2wyc4abj6',
+    runner_job_id: 'jobkz6m4npq8rvx1wts3ybaf2',
+    runner_job_execution_id: 'runtz9m2npq5rvx7wkc4ybaj8',
+    runner_job_execution_step: 'terraform-apply',
+    trace_id: 'e5f6a7b8c9d0e1f2a3b4c5d6a1b2c3d4',
+    span_id: 'f7e8f1e2d3c4b5a6',
+    log_attributes: {
+      'log_stream.id': 'lgsf8k2m4npq1rvx3wtz6yba7',
+      'runner_job.id': 'jobkz6m4npq8rvx1wts3ybaf2',
+      'runner_job.type': 'terraform-apply',
+      'runner_job_execution.id': 'runtz9m2npq5rvx7wkc4ybaj8',
+      'runner_job_execution_step.name': 'terraform-apply',
+      step: 'terraform-apply',
+      'error.type': 'OOMKilled',
+      'container.memory.limit_bytes': '536870912',
+      'container.memory.peak_bytes': '653262848',
+    },
+    resource_attributes: {
+      'service.name': 'runner',
+      'service.version': 'v0.14.82',
+      'host.name': 'runner-7b8f4d6c9-xk2m4',
+      'os.type': 'linux',
+      'k8s.pod.name': 'runner-7b8f4d6c9-xk2m4',
+      'k8s.container.name': 'runner',
+      'k8s.namespace.name': 'nuon-runner',
+    },
+    scope_attributes: {
+      'otel.scope.name': 'system',
+      'otel.scope.version': 'v1',
+    },
+  },
+  {
+    id: 'log-9',
+    timestamp: '2024-01-15T10:30:11.567Z',
+    timestamp_date: '2024-01-15',
+    timestamp_time: '10:30:11.567',
+    severity_number: 1,
+    severity_text: 'Trace',
+    body: 'HTTP GET /healthz 200 0.8ms',
+    service_name: 'runner',
+    scope_name: 'system',
+    log_stream_id: 'lgsf8k2m4npq1rvx3wtz6yba7',
+    org_id: 'orgrok933tcyzji01s7us3aeo3',
+    runner_id: 'rnr4x8gkm2vp7qtw1ycz5nbjh',
+    runner_group_id: 'rgrpnk3m7fvx9qtz2wyc4abj6',
+    trace_id: 'f6a7b8c9d0e1f2a3b4c5d6a1b2c3d4e5',
+    span_id: 'e8f1e2d3c4b5a6f7',
+    log_attributes: {
+      'http.method': 'GET',
+      'http.route': '/healthz',
+      'http.status_code': '200',
+      'http.duration_ms': '0.8',
+    },
+    resource_attributes: {
+      'service.name': 'runner',
+      'service.version': 'v0.14.82',
+      'host.name': 'runner-7b8f4d6c9-xk2m4',
+      'os.type': 'linux',
+    },
+    scope_attributes: {
+      'otel.scope.name': 'system',
+      'otel.scope.version': 'v1',
+    },
+  },
+  {
+    id: 'log-10',
+    timestamp: '2024-01-15T10:30:13.890Z',
+    timestamp_date: '2024-01-15',
+    timestamp_time: '10:30:13.890',
+    severity_number: 13,
+    severity_text: 'Warn',
+    body: 'Kustomize build: deprecated field "patchesStrategicMerge" detected in kustomization.yaml, migrate to "patches" — see https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/',
+    service_name: 'runner',
+    scope_name: 'oteljob',
+    log_stream_id: 'lgsf8k2m4npq1rvx3wtz6yba7',
+    org_id: 'orgrok933tcyzji01s7us3aeo3',
+    runner_id: 'rnr4x8gkm2vp7qtw1ycz5nbjh',
+    runner_group_id: 'rgrpnk3m7fvx9qtz2wyc4abj6',
+    runner_job_id: 'jobrx3m7npq4fvk8wtz1ycba2',
+    runner_job_execution_id: 'runpx6m9npq2fvk5wtz8ycba3',
+    runner_job_execution_step: 'kustomize-build',
+    trace_id: 'a7b8c9d0e1f2a3b4c5d6a1b2c3d4e5f6',
+    span_id: 'f1e2d3c4b5a6f7e8',
+    log_attributes: {
+      'log_stream.id': 'lgsf8k2m4npq1rvx3wtz6yba7',
+      'runner_job.id': 'jobrx3m7npq4fvk8wtz1ycba2',
+      'runner_job.type': 'k8s-manifest',
+      'runner_job_execution.id': 'runpx6m9npq2fvk5wtz8ycba3',
+      'runner_job_execution_step.name': 'kustomize-build',
+      step: 'kustomize-build',
+      'kustomize.deprecated_field': 'patchesStrategicMerge',
+      'kustomize.replacement_field': 'patches',
+    },
+    resource_attributes: {
+      'service.name': 'runner',
+      'service.version': 'v0.14.82',
+      'host.name': 'runner-7b8f4d6c9-xk2m4',
+      'os.type': 'linux',
+    },
+    scope_attributes: {
+      'otel.scope.name': 'oteljob',
+      'otel.scope.version': 'v1',
+    },
   },
 ] as TOTELLog[]
 
 const mockFilters: TLogFiltersProps = {
-  selectedSeverities: new Set(['Info', 'Warn', 'Error', 'Fatal']),
+  selectedSeverities: new Set(['Trace', 'Debug', 'Info', 'Warn', 'Error', 'Fatal']),
   handleSeverityInputToggle: noop,
   handleSeverityButtonClick: noop,
   handleSeverityReset: noop,
-  selectedServices: new Set(['api', 'runner']),
-  availableServices: new Set(['api', 'runner']),
+  selectedServices: new Set(['runner']),
+  availableServices: new Set(['runner']),
   handleServiceInputToggle: noop,
   handleServiceButtonClick: noop,
   handleServiceReset: noop,
@@ -76,10 +440,10 @@ const mockFilters: TLogFiltersProps = {
   handleSearchChange: noop,
   handleSortToggle: noop,
   handleSortChange: noop,
-  filterStats: { selectedCount: 5, totalCount: 5 },
+  filterStats: { selectedCount: 10, totalCount: 10 },
   sortStats: { direction: 'desc', isNewestFirst: true, isOldestFirst: false },
-  severityStats: { selectedCount: 4, totalCount: 4 },
-  serviceStats: { selectedCount: 2, totalCount: 2, isAllSelected: false },
+  severityStats: { selectedCount: 6, totalCount: 6 },
+  serviceStats: { selectedCount: 1, totalCount: 1, isAllSelected: true },
 } as unknown as TLogFiltersProps
 
 const mockLogStream: TLogStream = {
@@ -106,50 +470,99 @@ const Providers = ({ children }: { children: React.ReactNode }) => (
   </LogStreamContext.Provider>
 )
 
-export const Default = () => (
-  <Providers>
-    <SSELogs
-      filteredLogs={mockLogs}
-      filters={mockFilters}
-      activeLog={undefined}
-      handleActiveLog={noop}
-      loadMore={noop}
-      hasMore={false}
-      isLoading={false}
-      isStreamOpen={false}
-    />
-  </Providers>
-)
+const useLogPanel = () => {
+  const [activeLog, setActiveLog] = useState<TOTELLog | undefined>()
+  const cycleDirectionRef = useRef<'up' | 'down' | undefined>()
+  const { addPanel, updatePanel, removePanel } = useSurfaces()
+  const panelIdRef = useRef<string | undefined>()
 
-export const WithActiveLog = () => (
-  <Providers>
-    <SSELogs
-      filteredLogs={mockLogs}
-      filters={mockFilters}
-      activeLog={mockLogs[0]}
-      handleActiveLog={noop}
-      loadMore={noop}
-      hasMore={false}
-      isLoading={false}
-      isStreamOpen={false}
-    />
-  </Providers>
-)
+  const handleActiveLog = useCallback(
+    (logId?: string) => {
+      const log = logId ? mockLogs.find((l) => l.id === logId) : undefined
+      setActiveLog(log)
+    },
+    []
+  )
 
-export const WithLoadMore = () => (
-  <Providers>
-    <SSELogs
-      filteredLogs={mockLogs}
-      filters={mockFilters}
-      activeLog={undefined}
-      handleActiveLog={noop}
-      loadMore={noop}
-      hasMore={true}
-      isLoading={false}
-      isStreamOpen={false}
-    />
-  </Providers>
-)
+  useArrowKeys({
+    onDownArrow() {
+      if (!activeLog) return
+      cycleDirectionRef.current = 'down'
+      const idx = mockLogs.findIndex((l) => l.id === activeLog.id)
+      const nextIdx = idx + 1 >= mockLogs.length ? 0 : idx + 1
+      handleActiveLog(mockLogs[nextIdx]?.id)
+    },
+    onUpArrow() {
+      if (!activeLog) return
+      cycleDirectionRef.current = 'up'
+      const idx = mockLogs.findIndex((l) => l.id === activeLog.id)
+      handleActiveLog(mockLogs.at(idx - 1)?.id)
+    },
+  })
+
+  useEffect(() => {
+    if (activeLog) {
+      const panel = (
+        <LogPanel
+          log={activeLog}
+          cycleDirection={cycleDirectionRef.current}
+          onClose={() => handleActiveLog(undefined)}
+        />
+      )
+      if (panelIdRef.current) {
+        updatePanel(panelIdRef.current, panel)
+      } else {
+        cycleDirectionRef.current = undefined
+        panelIdRef.current = 'log-panel'
+        addPanel(panel, undefined, 'log-panel')
+      }
+    } else if (panelIdRef.current) {
+      cycleDirectionRef.current = undefined
+      removePanel(panelIdRef.current)
+      panelIdRef.current = undefined
+    }
+  }, [activeLog])
+
+  return { activeLog, handleActiveLog }
+}
+
+export const Default = () => {
+  const { activeLog, handleActiveLog } = useLogPanel()
+
+  return (
+    <Providers>
+      <SSELogs
+        filteredLogs={mockLogs}
+        filters={mockFilters}
+        activeLog={activeLog}
+        handleActiveLog={handleActiveLog}
+        loadMore={noop}
+        hasMore={false}
+        isLoading={false}
+        isStreamOpen={false}
+      />
+    </Providers>
+  )
+}
+
+export const WithLoadMore = () => {
+  const { activeLog, handleActiveLog } = useLogPanel()
+
+  return (
+    <Providers>
+      <SSELogs
+        filteredLogs={mockLogs}
+        filters={mockFilters}
+        activeLog={activeLog}
+        handleActiveLog={handleActiveLog}
+        loadMore={noop}
+        hasMore={true}
+        isLoading={false}
+        isStreamOpen={false}
+      />
+    </Providers>
+  )
+}
 
 export const Loading = () => (
   <Providers>

--- a/services/dashboard-ui/client/components/log-stream/SSELogs/SSELogs.tsx
+++ b/services/dashboard-ui/client/components/log-stream/SSELogs/SSELogs.tsx
@@ -31,7 +31,7 @@ interface ISSELogs {
 }
 
 export const SSELogs = ({
-  filterClassName = '-top-6',
+  filterClassName = 'top-0',
   filteredLogs,
   filters,
   activeLog,

--- a/services/dashboard-ui/client/components/log-stream/SSELogs/SSELogsContainer.tsx
+++ b/services/dashboard-ui/client/components/log-stream/SSELogs/SSELogsContainer.tsx
@@ -3,7 +3,7 @@ import { useLogViewer, useUnifiedLogData } from '@/hooks/use-logs'
 import { SSELogs } from './SSELogs'
 
 export const SSELogsContainer = ({
-  filterClassName = '-top-6',
+  filterClassName = 'top-0',
 }: {
   filterClassName?: string
 }) => {

--- a/services/dashboard-ui/client/components/roles/AppRolesTable/AppRolesTable.stories.tsx
+++ b/services/dashboard-ui/client/components/roles/AppRolesTable/AppRolesTable.stories.tsx
@@ -11,6 +11,7 @@ const mockSurfaces = {
   addModal: () => '',
   removeModal: () => {},
   addPanel: () => '',
+  updatePanel: () => {},
   removePanel: () => {},
   clearPanels: () => {},
 }

--- a/services/dashboard-ui/client/components/roles/InstallRolesTable/InstallRolesTable.stories.tsx
+++ b/services/dashboard-ui/client/components/roles/InstallRolesTable/InstallRolesTable.stories.tsx
@@ -11,6 +11,7 @@ const mockSurfaces = {
   addModal: () => '',
   removeModal: () => {},
   addPanel: () => '',
+  updatePanel: () => {},
   removePanel: () => {},
   clearPanels: () => {},
 }

--- a/services/dashboard-ui/client/components/spotlight/HelpModal/HelpModal.tsx
+++ b/services/dashboard-ui/client/components/spotlight/HelpModal/HelpModal.tsx
@@ -73,6 +73,14 @@ export const HelpModal = ({ ...props }: IModal) => {
           </Keys>
         ),
       },
+      {
+        shortcut: 'Cycle log lines (when log panel is open)',
+        keys: (
+          <Keys>
+            <Kbd>↑</Kbd> <Kbd>↓</Kbd> or <Kbd>K</Kbd> <Kbd>J</Kbd>
+          </Keys>
+        ),
+      },
     ],
     [mod, alt, shift]
   )

--- a/services/dashboard-ui/client/components/surfaces/Panel.css
+++ b/services/dashboard-ui/client/components/surfaces/Panel.css
@@ -57,5 +57,6 @@
 }
 
 .panel {
-  transition: width var(--duration-fastest) var(--ease-cubic);
+  transition: width var(--duration-fastest) var(--ease-cubic),
+    border-color var(--duration-fastest) var(--ease-cubic);
 }

--- a/services/dashboard-ui/client/components/surfaces/Panel.tsx
+++ b/services/dashboard-ui/client/components/surfaces/Panel.tsx
@@ -16,10 +16,12 @@ type TPanelSize = 'default' | 'half' | '3/4' | 'full'
 
 export interface IPanel extends React.HTMLAttributes<HTMLDivElement> {
   childrenClassName?: string
+  defaultExpanded?: boolean
   heading?: React.ReactNode
   headerClassName?: string
   isVisible?: boolean
   onClose?: () => void
+  onSizeChange?: (size: TPanelSize) => void
   panelId?: string
   panelKey?: string
   size?: TPanelSize
@@ -30,16 +32,18 @@ export const PanelBase = ({
   className,
   children,
   childrenClassName,
+  defaultExpanded,
   heading,
   headerClassName,
   isVisible = false,
   onClose,
+  onSizeChange,
   panelId,
   panelKey,
   size: initSize = 'default',
   ...props
 }: Omit<IPanel, 'triggerButton'>) => {
-  const [size, setSize] = useState(initSize)
+  const [size, setSize] = useState(defaultExpanded ? 'full' : initSize)
   const { removePanel, panels } = useSurfaces()
   const handleClose = () => {
     if (onClose) onClose?.()
@@ -112,11 +116,9 @@ export const PanelBase = ({
                     variant="ghost"
                     onClick={() => {
                       setSize((prev: TPanelSize) => {
-                        if (prev === initSize) {
-                          return 'full'
-                        } else {
-                          return initSize
-                        }
+                        const next = prev === initSize ? 'full' : initSize
+                        onSizeChange?.(next)
+                        return next
                       })
                     }}
                     aria-label={

--- a/services/dashboard-ui/client/components/surfaces/Panel.tsx
+++ b/services/dashboard-ui/client/components/surfaces/Panel.tsx
@@ -8,6 +8,7 @@ import { TransitionDiv } from '@/components/common/TransitionDiv'
 import { useAutoFocusOnVisible } from '@/hooks/use-auto-focus-on-visible'
 import { useEscapeKey } from '@/hooks/use-escape-key'
 import { useSurfaces } from '@/hooks/use-surfaces'
+import { Tooltip } from '@/components/common/Tooltip'
 import { cn } from '@/utils/classnames'
 import './Panel.css'
 
@@ -96,43 +97,55 @@ export const PanelBase = ({
             ) : null}
             <div className="flex items-center gap-4">
               {initSize !== 'full' ? (
+                <Tooltip
+                  position="bottom"
+                  tipContent={
+                    <Text variant="subtext">
+                      {size === 'full'
+                        ? `Resize to ${initSize} size`
+                        : 'Expand to full screen'}
+                    </Text>
+                  }
+                >
+                  <Button
+                    className="!p-2 ml-auto"
+                    variant="ghost"
+                    onClick={() => {
+                      setSize((prev: TPanelSize) => {
+                        if (prev === initSize) {
+                          return 'full'
+                        } else {
+                          return initSize
+                        }
+                      })
+                    }}
+                    aria-label={
+                      size === 'full'
+                        ? `Resize to ${initSize} size`
+                        : 'Expand to full screen'
+                    }
+                  >
+                    <Icon
+                      variant={size === 'full' ? 'CornersIn' : 'CornersOut'}
+                    />
+                  </Button>
+                </Tooltip>
+              ) : null}
+              <Tooltip
+                position="bottom"
+                tipContent={
+                  <Text variant="subtext">Close panel</Text>
+                }
+              >
                 <Button
                   className="!p-2 ml-auto"
                   variant="ghost"
-                  onClick={() => {
-                    setSize((prev: TPanelSize) => {
-                      if (prev === initSize) {
-                        return 'full'
-                      } else {
-                        return initSize
-                      }
-                    })
-                  }}
-                  title={
-                    size === 'full'
-                      ? `Resize to ${initSize} size`
-                      : 'Expand to full screen'
-                  }
-                  aria-label={
-                    size === 'full'
-                      ? `Resize to ${initSize} size`
-                      : 'Expand to full screen'
-                  }
+                  onClick={handleClose}
+                  aria-label="Close panel"
                 >
-                  <Icon
-                    variant={size === 'full' ? 'CornersIn' : 'CornersOut'}
-                  />
+                  <Icon variant="ArrowLineRight" />
                 </Button>
-              ) : null}
-              <Button
-                className="!p-2 ml-auto"
-                variant="ghost"
-                onClick={handleClose}
-                title="Close panel"
-                aria-label="Close panel"
-              >
-                <Icon variant="ArrowLineRight" />
-              </Button>
+              </Tooltip>
             </div>
           </header>
           <div

--- a/services/dashboard-ui/client/components/workflows/step-details/StepMetadata.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/StepMetadata.stories.tsx
@@ -13,7 +13,17 @@ const mockStep = {
     status: 'success',
     history: [
       { status: 'pending', created_at_ts: 1704067200 },
-      { status: 'in-progress', created_at_ts: 1704067260 },
+      {
+        status: 'in-progress',
+        created_at_ts: 1704067260,
+        status_human_description: 'Waiting for runner to pick up job',
+      },
+      {
+        status: 'failed',
+        created_at_ts: 1704067320,
+        status_human_description:
+          'Error: terraform apply failed with exit code 1 — resource quota exceeded in us-east-1',
+      },
     ],
   },
 } as TWorkflowStep

--- a/services/dashboard-ui/client/components/workflows/step-details/StepMetadata.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/StepMetadata.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Code } from '@/components/common/Code'
 import { CodeBlock } from '@/components/common/CodeBlock'
 import { Expand } from '@/components/common/Expand'
 import { Status } from '@/components/common/Status'
@@ -12,14 +13,36 @@ import type { IStepDetails } from './types'
 
 const StepHistoryStatus = ({
   status,
+  id,
 }: {
   status: IStepDetails['step']['status']['history'][number]
+  id: string
 }) => {
+  const description = status.status_human_description
+
+  if (!description) {
+    return (
+      <span className="flex items-center gap-4 py-2">
+        <Status status={status.status} variant="badge" />
+        <Time seconds={status.created_at_ts} variant="subtext" theme="neutral" />
+      </span>
+    )
+  }
+
   return (
-    <span className="flex items-center gap-4 py-2">
-      <Status status={status.status} variant="badge" />
-      <Time seconds={status.created_at_ts} variant="subtext" theme="neutral" />
-    </span>
+    <Expand
+      id={id}
+      hasNoHoverStyle
+      headerClassName="!p-0"
+      heading={
+        <span className="flex items-center gap-4 py-2">
+          <Status status={status.status} variant="badge" />
+          <Time seconds={status.created_at_ts} variant="subtext" theme="neutral" />
+        </span>
+      }
+    >
+      <Code className="mb-2 !text-xs">{description}</Code>
+    </Expand>
   )
 }
 
@@ -47,9 +70,10 @@ export const StepMetadata = ({ step }: IStepDetails) => {
             <StepHistoryStatus
               key={`${status.created_at_ts}-${idx}`}
               status={status}
+              id={`step-history-${idx}`}
             />
           ))}
-          <StepHistoryStatus status={step.status} />
+          <StepHistoryStatus status={step.status} id="step-history-current" />
         </div>
       </Expand>
 

--- a/services/dashboard-ui/client/components/workflows/step-details/SyncSecretsStepDetails/SyncSecretsStepDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/SyncSecretsStepDetails/SyncSecretsStepDetails.tsx
@@ -27,7 +27,9 @@ export const SyncSecretsStepDetails = ({ step }: ISyncSecretsStepDetails) => {
           </UnifiedLogsProvider>
         </LogStreamProvider>
       ) : (
-        <LogsSkeleton />
+        <div className="flex flex-col divide-y">
+          <LogsSkeleton />
+        </div>
       )}
     </div>
   )

--- a/services/dashboard-ui/client/providers/log-viewer-provider.tsx
+++ b/services/dashboard-ui/client/providers/log-viewer-provider.tsx
@@ -28,8 +28,9 @@ export function LogViewerProvider({ children }: LogViewerProviderProps) {
 
   const { logs } = unifiedLogsContext
   const [activeLog, setActiveLog] = useState<TOTELLog | undefined>()
+  const cycleDirectionRef = useRef<'up' | 'down' | undefined>()
   const filters = useLogFilters(logs || [])
-  const { addPanel, removePanel } = useSurfaces()
+  const { addPanel, updatePanel, removePanel } = useSurfaces()
   const navigate = useNavigate()
 
   function setLogParam(logId?: string) {
@@ -43,67 +44,58 @@ export function LogViewerProvider({ children }: LogViewerProviderProps) {
   }
 
   function handleActiveLog(id?: string) {
-    setActiveLog(id ? filters.filteredLogs?.find((l) => l.id === id) : undefined)
+    const log = id ? filters.filteredLogs?.find((l) => l.id === id) : undefined
+    setActiveLog(log)
+    setLogParam(log?.id)
   }
 
   useArrowKeys({
     onDownArrow() {
       if (activeLog && filters.filteredLogs && filters.filteredLogs.length > 0) {
-        removePanel(activeLog?.id)
-        setLogParam(undefined)
-        const activeLogIndex = filters.filteredLogs.findIndex((l) => l.id === activeLog.id)
-        const nextLogIndex = activeLogIndex + 1
-        const nextLog = filters.filteredLogs?.at(
-          nextLogIndex === filters.filteredLogs?.length ? 0 : nextLogIndex
-        )
-        setTimeout(() => {
-          handleActiveLog(nextLog?.id)
-        }, 160)
+        cycleDirectionRef.current = 'down'
+        const idx = filters.filteredLogs.findIndex((l) => l.id === activeLog.id)
+        const nextIdx = idx + 1 >= filters.filteredLogs.length ? 0 : idx + 1
+        handleActiveLog(filters.filteredLogs[nextIdx]?.id)
       }
     },
     onUpArrow() {
       if (activeLog && filters.filteredLogs && filters.filteredLogs.length > 0) {
-        removePanel(activeLog?.id)
-        setLogParam(undefined)
-        const activeLogIndex = filters.filteredLogs.findIndex((l) => l.id === activeLog.id)
-        const prevLog = filters.filteredLogs?.at(activeLogIndex - 1)
-        setTimeout(() => {
-          handleActiveLog(prevLog?.id)
-        }, 160)
+        cycleDirectionRef.current = 'up'
+        const idx = filters.filteredLogs.findIndex((l) => l.id === activeLog.id)
+        handleActiveLog(filters.filteredLogs.at(idx - 1)?.id)
       }
     },
   })
 
-  const activeLogIdRef = useRef<string | undefined>()
+  const panelIdRef = useRef<string | undefined>()
 
   useEffect(() => {
-    if (activeLog && activeLog.id !== activeLogIdRef.current) {
-      if (activeLogIdRef.current) {
-        removePanel(activeLogIdRef.current)
-      }
-      activeLogIdRef.current = activeLog.id
-      addPanel(
+    if (activeLog) {
+      const panel = (
         <LogPanel
           log={activeLog}
-          onClose={() => {
-            handleActiveLog(undefined)
-            setLogParam(undefined)
-          }}
-        />,
-        undefined,
-        activeLog.id
+          cycleDirection={cycleDirectionRef.current}
+          onClose={() => handleActiveLog(undefined)}
+        />
       )
-      setLogParam(activeLog.id)
-    } else if (!activeLog && activeLogIdRef.current) {
-      removePanel(activeLogIdRef.current)
-      activeLogIdRef.current = undefined
+      if (panelIdRef.current) {
+        updatePanel(panelIdRef.current, panel)
+      } else {
+        cycleDirectionRef.current = undefined
+        panelIdRef.current = 'log-panel'
+        addPanel(panel, undefined, 'log-panel')
+      }
+    } else if (panelIdRef.current) {
+      cycleDirectionRef.current = undefined
+      removePanel(panelIdRef.current)
+      panelIdRef.current = undefined
     }
   }, [activeLog])
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
     const logId = params.get('log')
-    if (logId && !activeLogIdRef.current && filters.filteredLogs?.length) {
+    if (logId && !panelIdRef.current && filters.filteredLogs?.length) {
       handleActiveLog(logId)
     }
   }, [filters.filteredLogs?.length])

--- a/services/dashboard-ui/client/providers/surfaces-provider.tsx
+++ b/services/dashboard-ui/client/providers/surfaces-provider.tsx
@@ -34,6 +34,7 @@ type TSurfacesContext = {
   panels: TPanels
   modals: TModals
   addPanel: (content: TPanelEl, panelKey?: string, panelId?: string) => string
+  updatePanel: (id: string, content: TPanelEl) => void
   clearPanels: () => void
   removePanel: (id: string, panelKey?: string) => void
   addModal: (content: TModalEl, modalKey?: string) => string
@@ -69,6 +70,13 @@ export function SurfacesProvider({ children }: { children: ReactNode }) {
       return id
     },
     [navigate]
+  )
+
+  const updatePanel = useCallback(
+    (id: string, content: TPanelEl) => {
+      setPanels((ps) => ps.map((p) => (p.id === id ? { ...p, content } : p)))
+    },
+    []
   )
 
   const removePanel = useCallback(
@@ -141,6 +149,7 @@ export function SurfacesProvider({ children }: { children: ReactNode }) {
         panels,
         modals,
         addPanel,
+        updatePanel,
         clearPanels,
         removePanel,
         addModal,

--- a/services/dashboard-ui/client/styles.css
+++ b/services/dashboard-ui/client/styles.css
@@ -138,6 +138,7 @@
   --ease-cubic: cubic-bezier(0.65, 0, 0.35, 1);
   --duration-fastest: 150ms;
   --duration-fast: 250ms;
+  --duration-log-cycle: 100ms;
 }
 
 :root {
@@ -236,11 +237,11 @@ body {
 
 /* general enter & exit animations */
 .fade.enter {
-  animation: enter-fade var(--duration-fastest) var(--ease-cubic) forwards;
+  animation: enter-fade var(--duration-log-cycle) var(--ease-cubic) forwards;
 }
 
 .fade.exit {
-  animation: exit-fade var(--duration-fastest) var(--ease-cubic) forwards;
+  animation: exit-fade var(--duration-log-cycle) var(--ease-cubic) forwards;
 }
 
 @keyframes enter-fade {
@@ -262,7 +263,7 @@ body {
 }
 
 .slide-in {
-  animation: enter-slide-in var(--duration-fastest) var(--ease-cubic) forwards;
+  animation: enter-slide-in var(--duration-log-cycle) var(--ease-cubic) forwards;
 }
 
 @keyframes enter-slide-in {
@@ -293,62 +294,141 @@ body {
 }
 
 /* log panel cycle transitions */
+
 .animate-slide-in-from-bottom {
-  animation: slide-in-from-bottom 150ms var(--ease-cubic) forwards;
+  animation: slide-in-from-bottom var(--duration-log-cycle) var(--ease-cubic) forwards;
 }
 
 .animate-slide-in-from-top {
-  animation: slide-in-from-top 150ms var(--ease-cubic) forwards;
+  animation: slide-in-from-top var(--duration-log-cycle) var(--ease-cubic) forwards;
 }
 
 .animate-slide-exit-up {
-  animation: slide-exit-up 150ms var(--ease-cubic) forwards;
+  animation: slide-exit-up var(--duration-log-cycle) var(--ease-cubic) forwards;
 }
 
 .animate-slide-exit-down {
-  animation: slide-exit-down 150ms var(--ease-cubic) forwards;
+  animation: slide-exit-down var(--duration-log-cycle) var(--ease-cubic) forwards;
 }
 
 @keyframes slide-in-from-bottom {
   from {
-    transform: translateY(1.5rem);
+    transform: translate3d(0, 0.75rem, 0);
     opacity: 0;
   }
   to {
-    transform: translateY(0);
+    transform: translate3d(0, 0, 0);
     opacity: 1;
   }
 }
 
 @keyframes slide-in-from-top {
   from {
-    transform: translateY(-1.5rem);
+    transform: translate3d(0, -0.75rem, 0);
     opacity: 0;
   }
   to {
-    transform: translateY(0);
+    transform: translate3d(0, 0, 0);
     opacity: 1;
   }
 }
 
 @keyframes slide-exit-up {
   from {
-    transform: translateY(0);
+    transform: translate3d(0, 0, 0);
     opacity: 1;
   }
   to {
-    transform: translateY(-1.5rem);
+    transform: translate3d(0, -0.75rem, 0);
     opacity: 0;
   }
 }
 
 @keyframes slide-exit-down {
   from {
-    transform: translateY(0);
+    transform: translate3d(0, 0, 0);
     opacity: 1;
   }
   to {
-    transform: translateY(1.5rem);
+    transform: translate3d(0, 0.75rem, 0);
     opacity: 0;
+  }
+}
+
+.animate-slide-exit-left {
+  animation: slide-exit-left var(--duration-log-cycle) var(--ease-cubic) forwards;
+}
+
+.animate-slide-exit-right {
+  animation: slide-exit-right var(--duration-log-cycle) var(--ease-cubic) forwards;
+}
+
+.animate-slide-in-from-right {
+  animation: slide-in-from-right var(--duration-log-cycle) var(--ease-cubic) forwards;
+}
+
+.animate-slide-in-from-left {
+  animation: slide-in-from-left var(--duration-log-cycle) var(--ease-cubic) forwards;
+}
+
+.animate-heading-exit {
+  animation: heading-exit var(--duration-log-cycle) var(--ease-cubic) forwards;
+}
+
+.animate-heading-enter {
+  animation: heading-enter var(--duration-log-cycle) var(--ease-cubic) forwards;
+}
+
+@keyframes heading-exit {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@keyframes heading-enter {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slide-exit-left {
+  from {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+  to {
+    transform: translate3d(-1.5rem, 0, 0);
+    opacity: 0;
+  }
+}
+
+@keyframes slide-exit-right {
+  from {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+  to {
+    transform: translate3d(1.5rem, 0, 0);
+    opacity: 0;
+  }
+}
+
+@keyframes slide-in-from-right {
+  from {
+    transform: translate3d(1.5rem, 0, 0);
+    opacity: 0;
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-in-from-left {
+  from {
+    transform: translate3d(-1.5rem, 0, 0);
+    opacity: 0;
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
   }
 }

--- a/services/dashboard-ui/client/styles.css
+++ b/services/dashboard-ui/client/styles.css
@@ -291,3 +291,64 @@ body {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+/* log panel cycle transitions */
+.animate-slide-in-from-bottom {
+  animation: slide-in-from-bottom 150ms var(--ease-cubic) forwards;
+}
+
+.animate-slide-in-from-top {
+  animation: slide-in-from-top 150ms var(--ease-cubic) forwards;
+}
+
+.animate-slide-exit-up {
+  animation: slide-exit-up 150ms var(--ease-cubic) forwards;
+}
+
+.animate-slide-exit-down {
+  animation: slide-exit-down 150ms var(--ease-cubic) forwards;
+}
+
+@keyframes slide-in-from-bottom {
+  from {
+    transform: translateY(1.5rem);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-in-from-top {
+  from {
+    transform: translateY(-1.5rem);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-exit-up {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(-1.5rem);
+    opacity: 0;
+  }
+}
+
+@keyframes slide-exit-down {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(1.5rem);
+    opacity: 0;
+  }
+}

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -1962,6 +1962,11 @@ export interface paths {
   "/v1/orgs/current/webhooks/{webhook_id}": {
     /** delete a webhook for the current org */
     delete: operations["DeleteCurrentOrgWebhook"];
+    /**
+     * update a webhook for the current org
+     * @description Replaces the webhook's interests filter and/or rotates its signing secret. WebhookURL is part of the (org_id, webhook_url) unique index and cannot be changed in place — delete and recreate to rename.
+     */
+    patch: operations["UpdateCurrentOrgWebhook"];
   };
   "/v1/orgs/features": {
     /**
@@ -5968,6 +5973,7 @@ export interface components {
       github_install_id: string;
     };
     "service.CreateCurrentOrgWebhookRequest": {
+      interests?: Record<string, never>;
       webhook_secret?: string;
       webhook_url: string;
     };
@@ -6241,6 +6247,7 @@ export interface components {
       created_by_id?: string;
       has_secret?: boolean;
       id?: string;
+      interests?: Record<string, never>;
       org_id?: string;
       updated_at?: string;
       webhook_url?: string;
@@ -6496,6 +6503,10 @@ export interface components {
       };
       name: string;
       var_name?: string;
+    };
+    "service.UpdateCurrentOrgWebhookRequest": {
+      interests?: Record<string, never>;
+      webhook_secret?: string;
     };
     "service.UpdateInstallConfigRequest": {
       approval_option?: components["schemas"]["app.InstallApprovalOption"];
@@ -20846,6 +20857,62 @@ export interface operations {
       /** @description No Content */
       204: {
         content: never;
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * update a webhook for the current org
+   * @description Replaces the webhook's interests filter and/or rotates its signing secret. WebhookURL is part of the (org_id, webhook_url) unique index and cannot be changed in place — delete and recreate to rename.
+   */
+  UpdateCurrentOrgWebhook: {
+    parameters: {
+      path: {
+        /** @description webhook ID */
+        webhook_id: string;
+      };
+    };
+    /** @description Input */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["service.UpdateCurrentOrgWebhookRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["service.CurrentOrgWebhookResponse"];
+        };
       };
       /** @description Bad Request */
       400: {

--- a/services/dashboard-ui/client/views/app/BuildDetail.tsx
+++ b/services/dashboard-ui/client/views/app/BuildDetail.tsx
@@ -87,7 +87,7 @@ export const BuildDetail = () => {
   })
 
   return (
-    <div className="flex flex-col flex-1 overflow-hidden">
+    <div className="flex flex-col flex-1">
       <PageTitle title={`Build | ${app?.name}`} />
       <Breadcrumbs
         breadcrumbs={[


### PR DESCRIPTION
## Log panel cycling (surfaces-provider, log-viewer-provider, LogPanel)
  - Added updatePanel to SurfacesProvider — replaces panel content in-place without close/open animation
  - Simplified arrow key handlers in LogViewerProvider — no more removePanel/setTimeout/addPanel per keystroke
  - Panel opens once, content swaps via updatePanel on subsequent selections
  - Sequenced exit-then-enter animation when cycling (old content slides out, new slides in)
  - Header fades out/in, body slides vertically based on cycle direction
  - useLayoutEffect to prevent flash of new content before exit starts
  - requestAnimationFrame to align phase transitions with browser paint cycle

## Panel improvements (Panel.tsx, Panel.css)
  - Added onSizeChange callback prop — notifies parent when user toggles panel size
  - Added defaultExpanded prop — starts panel at full size while keeping resize toggle functional
  - Added border-color to Panel CSS transition for smooth severity color changes

## Log panel fullscreen persistence (LogPanel)
  - Reads/writes log-panel-fullscreen in localStorage
  - Remembers if user expanded the log panel, restores on next open

## Help modal (HelpModal)
  - Added arrow key / J/K log cycling shortcut to keyboard shortcuts section

## SSELogs stories
  - Wired up real useSurfaces + useArrowKeys so panels open and cycling works in Ladle
  - Fleshed out mock logs with full OTEL attributes (log/resource/scope), trace IDs, realistic runner data across all severity levels

## Sync secrets loading (SyncSecretsStepDetails)
  - Wrapped LogsSkeleton in proper flex flex-col divide-y container to fix layout

## CSS animations (styles.css)
  - Added --duration-log-cycle token (100ms)
  - Added slide-in/out keyframes for vertical body transitions and horizontal header variants
  - Added heading fade keyframes
