### PR TITLE
fix: auto-approve bug and others

### DIFF
--- a/pkg/config/install.go
+++ b/pkg/config/install.go
@@ -14,18 +14,18 @@ type InstallApprovalOption string
 
 const (
 	InstallApprovalOptionApproveAll InstallApprovalOption = "approve-all"
+	InstallApprovalOptionAuto       InstallApprovalOption = "auto"
 	InstallApprovalOptionPrompt     InstallApprovalOption = "prompt"
 	InstallApprovalOptionUnknown    InstallApprovalOption = ""
 )
 
 func (o InstallApprovalOption) APIType() models.AppInstallApprovalOption {
 	switch o {
-	case InstallApprovalOptionApproveAll:
+	case InstallApprovalOptionApproveAll, InstallApprovalOptionAuto:
 		return models.AppInstallApprovalOptionApproveDashAll
 	case InstallApprovalOptionPrompt:
 		return models.AppInstallApprovalOptionPrompt
 	default:
-		// In case for unknown options, default to prompting for approval.
 		return models.AppInstallApprovalOptionPrompt
 	}
 }

--- a/services/ctl-api/internal/app/admin-dashboard/client/lib/admin-api/sandbox-mode.ts
+++ b/services/ctl-api/internal/app/admin-dashboard/client/lib/admin-api/sandbox-mode.ts
@@ -22,6 +22,9 @@ export const upsertSandboxRunnerJobConfig = (jobType: string, body: any) =>
 export const disableAllSignals = () =>
   api<{ status: string }>({ path: 'sandbox-mode/signals/disable-all', method: 'POST' })
 
+export const deleteRunnerJobConfig = (configId: string) =>
+  api<{ deleted: boolean }>({ path: `sandbox-mode/runner-jobs/${encodeURIComponent(configId)}`, method: 'DELETE' })
+
 export const disableAllRunnerJobs = () =>
   api<{ status: string }>({ path: 'sandbox-mode/runner-jobs/disable-all', method: 'POST' })
 

--- a/services/ctl-api/internal/app/admin-dashboard/client/types/admin.types.ts
+++ b/services/ctl-api/internal/app/admin-dashboard/client/types/admin.types.ts
@@ -520,6 +520,7 @@ export type TSandboxModeResponse = {
   flow_templates?: any[]
   all_signal_types?: string[]
   all_runner_job_types?: string[]
+  all_runner_job_operation_types?: string[]
 }
 
 export type TTemporalWorkersResponse = {

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/sandbox-mode/SandboxMode.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/sandbox-mode/SandboxMode.tsx
@@ -5,6 +5,7 @@ import {
   getSandboxMode,
   upsertSandboxRunnerJobConfig,
   upsertSandboxSignalConfig,
+  deleteRunnerJobConfig,
   disableAllSignals,
   disableAllRunnerJobs,
   applyFlowTemplate,
@@ -78,6 +79,10 @@ export const SandboxMode = () => {
     onSuccess: () => { invalidate(); setEditingSignalType(null) },
   })
 
+  const deleteJobMutation = useMutation({
+    mutationFn: (configId: string) => deleteRunnerJobConfig(configId),
+    onSuccess: invalidate,
+  })
   const disableSignalsMutation = useMutation({ mutationFn: disableAllSignals, onSuccess: invalidate })
   const disableJobsMutation = useMutation({ mutationFn: disableAllRunnerJobs, onSuccess: invalidate })
   const applyTemplateMutation = useMutation({ mutationFn: applyFlowTemplate, onSuccess: invalidate })
@@ -92,6 +97,7 @@ export const SandboxMode = () => {
   const flowTemplates = data.flow_templates || []
   const allTemplates = data.templates || []
   const allRunnerJobTypes: string[] = data.all_runner_job_types || []
+  const allRunnerJobOperationTypes: string[] = data.all_runner_job_operation_types || []
   const allSignalTypes: string[] = data.all_signal_types || []
 
   const templateOptions = allTemplates.map((t: any) => t.key || t.Key || String(t))
@@ -240,12 +246,18 @@ export const SandboxMode = () => {
                       <td className="text-xs text-gray-500 dark:text-gray-400">
                         {[config.log_template, config.plan_template, config.state_template, config.output_template].filter(Boolean).join(', ') || '-'}
                       </td>
-                      <td>
+                      <td className="flex gap-2">
                         <button
                           onClick={() => openEditJob(config)}
                           className="text-xs text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 font-medium"
                         >
                           Edit
+                        </button>
+                        <button
+                          onClick={() => { if (confirm('Delete this config?')) deleteJobMutation.mutate(config.id) }}
+                          className="text-xs text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-200 font-medium"
+                        >
+                          Delete
                         </button>
                       </td>
                     </tr>
@@ -442,7 +454,12 @@ function JobFormPanel({
           <input type="checkbox" checked={form.trigger_shutdown} onChange={(e) => setForm((f) => ({ ...f, trigger_shutdown: e.target.checked }))} className="mt-1" />
         </Field>
         <Field label="Operation">
-          <input type="text" value={form.operation} onChange={(e) => setForm((f) => ({ ...f, operation: e.target.value }))} placeholder="optional" className="w-full rounded-md border-gray-300 dark:border-gray-700 text-sm py-1.5 px-2" />
+          <select value={form.operation} onChange={(e) => setForm((f) => ({ ...f, operation: e.target.value }))} className="w-full rounded-md border-gray-300 dark:border-gray-700 text-sm py-1.5 px-2">
+            <option value="">any (optional)</option>
+            {allRunnerJobOperationTypes.map((op) => (
+              <option key={op} value={op}>{op}</option>
+            ))}
+          </select>
         </Field>
         <Field label="Log template">
           <TemplateSelect value={form.log_template} onChange={(v) => setForm((f) => ({ ...f, log_template: v }))} options={templateOptions} />

--- a/services/ctl-api/internal/app/admin-dashboard/service/sandbox_mode.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/sandbox_mode.go
@@ -38,13 +38,14 @@ func (s *service) SandboxMode(c *gin.Context) {
 	stackConfig, _ := s.getSandboxStackConfig(ctx)
 
 	c.JSON(http.StatusOK, gin.H{
-		"runner_job_configs":   runnerJobConfigs,
-		"signal_configs":       signalConfigs,
-		"stack_config":         stackConfig,
-		"all_signal_types":     signals.AllSignalTypes(),
-		"all_runner_job_types": sandboxmode.AllRunnerJobTypes(),
-		"templates":            sbtemplates.AllTemplates(),
-		"flow_templates":       sbtemplates.FlowTemplates(),
+		"runner_job_configs":             runnerJobConfigs,
+		"signal_configs":                 signalConfigs,
+		"stack_config":                   stackConfig,
+		"all_signal_types":               signals.AllSignalTypes(),
+		"all_runner_job_types":           sandboxmode.AllRunnerJobTypes(),
+		"all_runner_job_operation_types": sandboxmode.AllRunnerJobOperationTypes(),
+		"templates":                      sbtemplates.AllTemplates(),
+		"flow_templates":                 sbtemplates.FlowTemplates(),
 	})
 }
 

--- a/services/ctl-api/internal/app/admin-dashboard/service/sandbox_mode.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/sandbox_mode.go
@@ -247,10 +247,10 @@ func (s *service) SandboxModeUpsertRunnerJobConfig(c *gin.Context) {
 		return
 	}
 
-	// Re-read the saved config to get the full record
+	// Re-read the saved config to get the full record (match both job_type and operation)
 	var saved app.SandboxModeJobConfig
 	s.db.WithContext(c.Request.Context()).
-		Where(app.SandboxModeJobConfig{JobType: jobType}).
+		Where(map[string]interface{}{"job_type": jobType, "operation": req.Operation}).
 		First(&saved)
 
 	c.JSON(http.StatusOK, gin.H{
@@ -268,6 +268,17 @@ func (s *service) SandboxModeDisableAllSignals(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "disabled"})
+}
+
+func (s *service) SandboxModeDeleteRunnerJobConfig(c *gin.Context) {
+	configID := c.Param("config_id")
+	if res := s.db.WithContext(c.Request.Context()).
+		Where("id = ?", configID).
+		Delete(&app.SandboxModeJobConfig{}); res.Error != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": res.Error.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"deleted": true})
 }
 
 func (s *service) SandboxModeDisableAllRunnerJobs(c *gin.Context) {

--- a/services/ctl-api/internal/app/admin-dashboard/service/service.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/service.go
@@ -221,6 +221,7 @@ func (s *service) RegisterAdminDashboardRoutes(e *gin.Engine) error {
 		api.GET("/sandbox-mode/stacks", s.SandboxModeStacksTable)
 		api.PUT("/sandbox-mode/signals/:signal_type", s.SandboxModeUpsertSignalConfig)
 		api.PUT("/sandbox-mode/runner-jobs/:job_type", s.SandboxModeUpsertRunnerJobConfig)
+		api.DELETE("/sandbox-mode/runner-jobs/:config_id", s.SandboxModeDeleteRunnerJobConfig)
 		api.POST("/sandbox-mode/signals/disable-all", s.SandboxModeDisableAllSignals)
 		api.POST("/sandbox-mode/runner-jobs/disable-all", s.SandboxModeDisableAllRunnerJobs)
 		api.POST("/sandbox-mode/templates/:template_key/apply", s.SandboxModeApplyFlowTemplate)

--- a/services/ctl-api/internal/app/apps/service/create_app_config.go
+++ b/services/ctl-api/internal/app/apps/service/create_app_config.go
@@ -95,11 +95,15 @@ func (s *service) CreateAppConfig(ctx *gin.Context) {
 }
 
 func (s *service) createAppConfig(ctx context.Context, orgID, appID string, req *CreateAppConfigRequest) (*app.AppConfig, error) {
+	pendingStatus := app.NewCompositeStatus(ctx, app.Status(app.AppConfigStatusPending))
+	pendingStatus.StatusHumanDescription = "sync pending"
+
 	inputs := app.AppConfig{
 		OrgID:              orgID,
 		AppID:              appID,
 		Status:             app.AppConfigStatusPending,
 		StatusDescription:  "sync pending",
+		StatusV2:           pendingStatus,
 		Readme:             req.Readme,
 		CLIVersion:         req.CLIVersion,
 		IntermediateConfig: &blobstore.Blob{},

--- a/services/ctl-api/internal/app/apps/service/update_app_config.go
+++ b/services/ctl-api/internal/app/apps/service/update_app_config.go
@@ -144,9 +144,13 @@ func (s *service) updateAppConfig(ctx context.Context, appConfigID string, req *
 		return nil, fmt.Errorf("unable to find app config: %w", err)
 	}
 
+	updateStatus := app.NewCompositeStatus(ctx, app.Status(req.Status))
+	updateStatus.StatusHumanDescription = req.StatusDescription
+
 	appConfig := app.AppConfig{
 		Status:            req.Status,
 		StatusDescription: req.StatusDescription,
+		StatusV2:          updateStatus,
 		State:             req.State,
 	}
 

--- a/services/ctl-api/internal/app/apps/signals/v2/branches/activities/create_app_config.go
+++ b/services/ctl-api/internal/app/apps/signals/v2/branches/activities/create_app_config.go
@@ -29,6 +29,9 @@ func (a *Activities) createAppConfig(ctx context.Context, req *CreateAppConfigIn
 		return nil, fmt.Errorf("invalid request: %w", err)
 	}
 
+	pendingStatus := app.NewCompositeStatus(ctx, app.Status(app.AppConfigStatusPending))
+	pendingStatus.StatusHumanDescription = "pending sync"
+
 	appConfig := &app.AppConfig{
 		AppID:              req.AppID,
 		OrgID:              req.OrgID,
@@ -36,6 +39,7 @@ func (a *Activities) createAppConfig(ctx context.Context, req *CreateAppConfigIn
 		AppBranchID:        generics.NewNullString(req.AppBranchID),
 		Status:             app.AppConfigStatusPending,
 		StatusDescription:  "pending sync",
+		StatusV2:           pendingStatus,
 		IntermediateConfig: &blobstore.Blob{},
 	}
 	appConfig.IntermediateConfig.Set(req.IntermediateConfigJSON)

--- a/services/ctl-api/internal/app/install_config.go
+++ b/services/ctl-api/internal/app/install_config.go
@@ -34,7 +34,7 @@ type InstallConfig struct {
 	InstallID string  `json:"install_id,omitzero" gorm:"notnull;default null" temporaljson:"install_id,omitzero,omitempty"`
 	Install   Install `json:"-" temporaljson:"install,omitzero,omitempty"`
 
-	ApprovalOption InstallApprovalOption `json:"approval_option,omitzero" gorm:"not null;default 'auto'" temporaljson:"approval_option,omitzero,omitempty"`
+	ApprovalOption InstallApprovalOption `json:"approval_option,omitzero" gorm:"not null;default 'prompt'" temporaljson:"approval_option,omitzero,omitempty"`
 
 	// Per-install stack template overrides (nil = use app config default)
 	VPCNestedTemplateURL    *string                    `json:"vpc_nested_template_url,omitempty" gorm:"column:vpc_nested_template_url" temporaljson:"vpc_nested_template_url,omitempty"`

--- a/services/ctl-api/internal/app/installs/helpers/create_install.go
+++ b/services/ctl-api/internal/app/installs/helpers/create_install.go
@@ -59,7 +59,10 @@ func (s *Helpers) CreateInstall(ctx context.Context, appID string, req *CreateIn
 			return db.Order("app_input_configs.created_at DESC").Limit(1)
 		}).
 		Preload("AppConfigs", func(db *gorm.DB) *gorm.DB {
-			return db.Order(views.TableOrViewName(s.db, &app.AppConfig{}, ".created_at DESC")).Limit(1)
+			return db.
+				Where(views.TableOrViewName(s.db, &app.AppConfig{}, ".status_v2 ->> 'status' = ?"), string(app.AppConfigStatusActive)).
+				Order(views.TableOrViewName(s.db, &app.AppConfig{}, ".created_at DESC")).
+				Limit(1)
 		}).
 		Preload("AppPermissionsConfigs", func(db *gorm.DB) *gorm.DB {
 			return db.Order("app_permissions_configs.created_at DESC").Limit(1)
@@ -68,6 +71,13 @@ func (s *Helpers) CreateInstall(ctx context.Context, appID string, req *CreateIn
 		First(&parentApp, "id = ?", appID)
 	if res.Error != nil {
 		return nil, fmt.Errorf("unable to get app: %w", res.Error)
+	}
+
+	if len(parentApp.AppConfigs) == 0 {
+		return nil, stderr.ErrUser{
+			Err:         fmt.Errorf("no active app config found for app %s", appID),
+			Description: "No active app config found. Please sync your app configuration before creating an install.",
+		}
 	}
 
 	// make sure the inputs are valid

--- a/services/ctl-api/internal/app/installs/helpers/create_install_workflow.go
+++ b/services/ctl-api/internal/app/installs/helpers/create_install_workflow.go
@@ -63,17 +63,28 @@ func (s *Helpers) createWorkflow(ctx context.Context,
 		approvalOption = installConfig.ApprovalOption
 	}
 
+	// Label the approval source so the UI can show where auto-approve came from
+	if approvalOption == app.InstallApprovalOptionApproveAll {
+		metadata["approval_type"] = "install-config"
+	}
+
 	metadata["install_id"] = installID
 	var install app.Install
 	if res := s.db.WithContext(ctx).Where("id = ?", installID).First(&install); res.Error == nil && install.Name != "" {
 		metadata[app.WorkflowMetadataKeyOwnerName] = install.Name
 	}
+
+	status := app.NewCompositeStatus(ctx, app.StatusPending)
+	if approvalOption == app.InstallApprovalOptionApproveAll {
+		status.Metadata["approval_type"] = "install-config"
+	}
+
 	installWorkflow := app.Workflow{
 		Type:      workflowType,
 		OwnerID:   installID,
 		OwnerType: "installs",
 		Metadata:  generics.ToHstore(metadata),
-		Status:    app.NewCompositeStatus(ctx, app.StatusPending),
+		Status:    status,
 		// DEPRECATED: for now we always abort on step errors
 		StepErrorBehavior: app.StepErrorBehaviorAbort,
 		ApprovalOption:    approvalOption,

--- a/services/ctl-api/internal/app/installs/service/generate_cli_install_config.go
+++ b/services/ctl-api/internal/app/installs/service/generate_cli_install_config.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"net/http"
 	"slices"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/iancoleman/strcase"
@@ -52,8 +53,14 @@ func (s *service) GenerateCLIInstallConfig(ctx *gin.Context) {
 		return
 	}
 
+	// Add a comment above the approval_option field to document valid values
+	output := strings.Replace(response.String(),
+		"approval_option = ",
+		"# Valid options: 'prompt' (default, requires manual approval) or 'approve-all' (automatic approval)\napproval_option = ",
+		1)
+
 	ctx.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.toml\"", strcase.ToSnake(installCfg.Name)))
-	ctx.Data(http.StatusOK, "application/octet-stream", response.Bytes())
+	ctx.Data(http.StatusOK, "application/octet-stream", []byte(output))
 }
 
 func (s *service) genCLIInstallConfig(ctx context.Context, installID string) (*config.Install, error) {
@@ -79,7 +86,14 @@ func (s *service) genCLIInstallConfig(ctx context.Context, installID string) (*c
 	}
 
 	if installConfig != nil {
-		installCfg.ApprovalOption = config.InstallApprovalOption(installConfig.ApprovalOption)
+		// Normalize the approval option: "auto" and empty both map to "prompt" in the generated config.
+		approvalOpt := config.InstallApprovalOption(installConfig.ApprovalOption)
+		switch approvalOpt {
+		case config.InstallApprovalOptionApproveAll:
+			installCfg.ApprovalOption = config.InstallApprovalOptionApproveAll
+		default:
+			installCfg.ApprovalOption = config.InstallApprovalOptionPrompt
+		}
 
 		so := &config.InstallStackOverrides{}
 		if installConfig.VPCNestedTemplateURL != nil {

--- a/services/ctl-api/internal/app/installs/service/update_workflow.go
+++ b/services/ctl-api/internal/app/installs/service/update_workflow.go
@@ -119,5 +119,17 @@ func (s *service) updateWorkflow(ctx context.Context, installWorkflowID string, 
 		return nil, fmt.Errorf("install workflow not found: %w", gorm.ErrRecordNotFound)
 	}
 
+	// Label the approval source on the workflow metadata when approve-all is set via the API
+	if req.ApprovalOption != nil && *req.ApprovalOption == app.InstallApprovalOptionApproveAll {
+		s.db.WithContext(ctx).Exec(
+			`UPDATE install_workflows SET metadata = COALESCE(metadata, ''::hstore) || hstore('approval_type', 'approve-workflow') WHERE id = ?`,
+			installWorkflowID,
+		)
+		s.db.WithContext(ctx).Exec(
+			`UPDATE install_workflows SET status = jsonb_set(COALESCE(status::jsonb, '{}'::jsonb), '{metadata,approval_type}', '"approve-workflow"'::jsonb) WHERE id = ?`,
+			installWorkflowID,
+		)
+	}
+
 	return &currentWorkflow, nil
 }

--- a/services/ctl-api/internal/app/installs/signals/v2/actionworkflowrun/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/actionworkflowrun/signal.go
@@ -146,6 +146,14 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return errors.Wrap(err, "unable to create action workflow run")
 	}
 
+	defer func() {
+		if errors.Is(workflow.ErrCanceled, ctx.Err()) {
+			updateCtx, updateCtxCancel := workflow.NewDisconnectedContext(ctx)
+			defer updateCtxCancel()
+			s.updateActionRunStatus(updateCtx, actionWorkflowRun.ID, app.InstallActionRunStatusCancelled, "action workflow run cancelled")
+		}
+	}()
+
 	if s.WorkflowStepID != "" {
 		if err := activities.AwaitUpdateInstallWorkflowStepTarget(ctx, activities.UpdateInstallWorkflowStepTargetRequest{
 			StepID:         s.WorkflowStepID,
@@ -172,6 +180,14 @@ func (s *Signal) executeAdhocRun(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to get adhoc action run")
 	}
+
+	defer func() {
+		if errors.Is(workflow.ErrCanceled, ctx.Err()) {
+			updateCtx, updateCtxCancel := workflow.NewDisconnectedContext(ctx)
+			defer updateCtxCancel()
+			s.updateActionRunStatus(updateCtx, run.ID, app.InstallActionRunStatusCancelled, "adhoc action workflow run cancelled")
+		}
+	}()
 
 	if s.WorkflowStepID != "" {
 		if err := activities.AwaitUpdateInstallWorkflowStepTarget(ctx, activities.UpdateInstallWorkflowStepTargetRequest{

--- a/services/ctl-api/internal/app/installs/signals/v2/componentdeployapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentdeployapplyplan/signal.go
@@ -56,10 +56,12 @@ var (
 	_ signal.SignalWithAutoRetry        = (*Signal)(nil)
 	_ signal.SignalWithMaxRetries       = (*Signal)(nil)
 	_ signal.SignalWithMaxAutoRetries   = (*Signal)(nil)
+	_ signal.SignalWithRetryGroup       = (*Signal)(nil)
 )
 
-func (s *Signal) AutoRetry() bool { return true }
-func (s *Signal) MaxRetries() int { return 15 }
+func (s *Signal) AutoRetry() bool  { return true }
+func (s *Signal) MaxRetries() int  { return 15 }
+func (s *Signal) RetryGroup() bool { return true }
 
 func (s *Signal) MaxAutoRetries(ctx workflow.Context) int {
 	install, err := activities.AwaitGetByInstallID(ctx, s.InstallID)
@@ -157,6 +159,14 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		s.updateDeployStatus(ctx, "", app.InstallDeployStatusError, "unable to get install deploy from previous step")
 		return errors.Wrap(err, "unable to get install deploy")
 	}
+
+	defer func() {
+		if errors.Is(workflow.ErrCanceled, ctx.Err()) {
+			updateCtx, updateCtxCancel := workflow.NewDisconnectedContext(ctx)
+			defer updateCtxCancel()
+			s.updateDeployStatus(updateCtx, installDeploy.ID, app.InstallDeployStatusCancelled, "deploy apply cancelled")
+		}
+	}()
 
 	ctx = cctx.SetLogStreamWorkflowContext(ctx, &installDeploy.LogStream)
 	l, err := log.WorkflowLogger(ctx)

--- a/services/ctl-api/internal/app/installs/signals/v2/deprovisionsandboxapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/deprovisionsandboxapplyplan/signal.go
@@ -43,10 +43,12 @@ var _ signal.SignalWithCancel = (*Signal)(nil)
 var _ signal.SignalWithAutoRetry = (*Signal)(nil)
 var _ signal.SignalWithMaxRetries = (*Signal)(nil)
 var _ signal.SignalWithMaxAutoRetries = (*Signal)(nil)
+var _ signal.SignalWithRetryGroup = (*Signal)(nil)
 
 func (s *Signal) AutoRetry() bool                       { return true }
 func (s *Signal) MaxRetries() int                       { return 5 }
 func (s *Signal) MaxAutoRetries(_ workflow.Context) int { return 3 }
+func (s *Signal) RetryGroup() bool                      { return true }
 
 func (s *Signal) Cancel(ctx workflow.Context) error {
 	cancelCtx, cancel := workflow.NewDisconnectedContext(ctx)
@@ -141,6 +143,14 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to get install deploy")
 	}
+
+	defer func() {
+		if errors.Is(workflow.ErrCanceled, ctx.Err()) {
+			updateCtx, updateCtxCancel := workflow.NewDisconnectedContext(ctx)
+			defer updateCtxCancel()
+			s.updateRunStatus(updateCtx, installRun.ID, app.SandboxRunStatusCancelled, "sandbox deprovision apply cancelled")
+		}
+	}()
 
 	ctx = cctx.SetLogStreamWorkflowContext(ctx, &installRun.LogStream)
 	l := workflow.GetLogger(ctx)

--- a/services/ctl-api/internal/app/installs/signals/v2/provisionsandboxapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/provisionsandboxapplyplan/signal.go
@@ -44,10 +44,12 @@ var _ signal.SignalWithCancel = (*Signal)(nil)
 var _ signal.SignalWithAutoRetry = (*Signal)(nil)
 var _ signal.SignalWithMaxRetries = (*Signal)(nil)
 var _ signal.SignalWithMaxAutoRetries = (*Signal)(nil)
+var _ signal.SignalWithRetryGroup = (*Signal)(nil)
 
 func (s *Signal) AutoRetry() bool                       { return true }
 func (s *Signal) MaxRetries() int                       { return 5 }
 func (s *Signal) MaxAutoRetries(_ workflow.Context) int { return 3 }
+func (s *Signal) RetryGroup() bool                      { return true }
 
 func (s *Signal) Cancel(ctx workflow.Context) error {
 	cancelCtx, cancel := workflow.NewDisconnectedContext(ctx)
@@ -143,6 +145,14 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to get install deploy")
 	}
+
+	defer func() {
+		if errors.Is(workflow.ErrCanceled, ctx.Err()) {
+			updateCtx, updateCtxCancel := workflow.NewDisconnectedContext(ctx)
+			defer updateCtxCancel()
+			s.updateRunStatus(updateCtx, sandboxRun.ID, app.SandboxRunStatusCancelled, "sandbox apply cancelled")
+		}
+	}()
 
 	s.updateRunStatus(ctx, sandboxRun.ID, app.SandboxRunStatusProvisioning, "provisioning sandbox")
 

--- a/services/ctl-api/internal/app/installs/signals/v2/reprovisionsandboxapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/reprovisionsandboxapplyplan/signal.go
@@ -148,6 +148,14 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return errors.Wrap(err, "unable to get install deploy")
 	}
 
+	defer func() {
+		if errors.Is(workflow.ErrCanceled, ctx.Err()) {
+			updateCtx, updateCtxCancel := workflow.NewDisconnectedContext(ctx)
+			defer updateCtxCancel()
+			s.updateRunStatus(updateCtx, sandboxRun.ID, app.SandboxRunStatusCancelled, "sandbox reprovision apply cancelled")
+		}
+	}()
+
 	ctx = cctx.SetLogStreamWorkflowContext(ctx, &sandboxRun.LogStream)
 	l := workflow.GetLogger(ctx)
 

--- a/services/ctl-api/internal/app/installs/signals/v2/syncsecrets/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/syncsecrets/signal.go
@@ -3,6 +3,7 @@ package syncsecrets
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
@@ -31,9 +32,15 @@ type Signal struct {
 var _ signal.Signal = &Signal{}
 var _ signal.SignalWithStepContext = (*Signal)(nil)
 var _ signal.SignalWithAutoRetry = (*Signal)(nil)
+var _ signal.SignalWithMaxRetries = (*Signal)(nil)
+var _ signal.SignalWithMaxAutoRetries = (*Signal)(nil)
 var _ signal.SignalWithCancel = (*Signal)(nil)
+var _ signal.SignalWithTimeout = (*Signal)(nil)
 
-func (s *Signal) AutoRetry() bool { return true }
+func (s *Signal) AutoRetry() bool                       { return true }
+func (s *Signal) MaxRetries() int                       { return 3 }
+func (s *Signal) MaxAutoRetries(_ workflow.Context) int { return 3 }
+func (s *Signal) Timeout() time.Duration                { return 180 * 24 * time.Hour }
 
 func (s *Signal) Cancel(ctx workflow.Context) error {
 	cancelCtx, cancel := workflow.NewDisconnectedContext(ctx)

--- a/services/ctl-api/internal/app/installs/workflows/v2/reprovision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/reprovision.go
@@ -27,17 +27,8 @@ func Reprovision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRes
 
 	sg := newStepGroup(flw)
 
-	sg.nextGroupEager() // generate install state
-	step, err := sg.installSignalStep(ctx, installID, "generate install state", pgtype.Hstore{}, &generatestate.Signal{
-		InstallID: installID,
-	}, flw.PlanOnly, WithSkippable(false))
-	if err != nil {
-		return nil, err
-	}
-	steps = append(steps, step)
-
 	sg.nextGroupEager() // reprovision service account
-	step, err = sg.installSignalStep(ctx, installID, "reprovision runner service account", pgtype.Hstore{}, &reprovisionrunner.Signal{
+	step, err := sg.installSignalStep(ctx, installID, "reprovision runner service account", pgtype.Hstore{}, &reprovisionrunner.Signal{
 		InstallID: installID,
 	}, flw.PlanOnly)
 	if err != nil {
@@ -72,6 +63,15 @@ func Reprovision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRes
 		InstallStackID:          stack.ID,
 		SkipInputUpdateWorkflow: true,
 	}, flw.PlanOnly)
+	if err != nil {
+		return nil, err
+	}
+	steps = append(steps, step)
+
+	sg.nextGroupEager() // generate install state (after stack is ready)
+	step, err = sg.installSignalStep(ctx, installID, "generate install state", pgtype.Hstore{}, &generatestate.Signal{
+		InstallID: installID,
+	}, flw.PlanOnly, WithSkippable(false))
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/onboarding/signals/activities/sync_custom_app_config.go
+++ b/services/ctl-api/internal/app/onboarding/signals/activities/sync_custom_app_config.go
@@ -37,10 +37,14 @@ func (a *Activities) syncCustomAppConfig(ctx context.Context, onboardingID strin
 	appID := *onboarding.AppID
 
 	// Create AppConfig record for the syncer to link child records to
+	pendingStatus := app.NewCompositeStatus(ctx, app.Status(app.AppConfigStatusPending))
+	pendingStatus.StatusHumanDescription = "pending sync"
+
 	appConfig := &app.AppConfig{
 		AppID:             appID,
 		Status:            app.AppConfigStatusPending,
 		StatusDescription: "pending sync",
+		StatusV2:          pendingStatus,
 	}
 
 	if err := a.db.WithContext(ctx).Create(appConfig).Error; err != nil {

--- a/services/ctl-api/internal/app/workflow.go
+++ b/services/ctl-api/internal/app/workflow.go
@@ -196,7 +196,7 @@ type Workflow struct {
 	// DEPRECATED: for now we always abort on step errors
 	StepErrorBehavior StepErrorBehavior `json:"step_error_behavior,omitzero" temporaljson:"step_error_behavior,omitzero,omitempty" swaggertype:"string"`
 
-	ApprovalOption InstallApprovalOption `json:"approval_option,omitzero" gorm:"default 'auto'" temporaljson:"approval_option,omitzero,omitempty"`
+	ApprovalOption InstallApprovalOption `json:"approval_option,omitzero" gorm:"default 'prompt'" temporaljson:"approval_option,omitzero,omitempty"`
 
 	PlanOnly bool `json:"plan_only"`
 

--- a/services/ctl-api/internal/pkg/db/psql/migrations/099_app_config_backfill_status_v2.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/099_app_config_backfill_status_v2.go
@@ -1,0 +1,29 @@
+package migrations
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// Migration099AppConfigBackfillStatusV2 backfills the status_v2 JSONB column
+// from the legacy v1 status + status_description fields for all app_configs
+// that don't yet have a v2 status set.
+func (m *Migrations) Migration099AppConfigBackfillStatusV2(ctx context.Context, db *gorm.DB) error {
+	if res := db.WithContext(ctx).
+		Exec(`UPDATE app_configs
+SET status_v2 = jsonb_build_object(
+    'status', status,
+    'status_human_description', COALESCE(status_description, ''),
+    'created_by_id', COALESCE(created_by_id, ''),
+    'created_at_ts', EXTRACT(EPOCH FROM updated_at)::bigint,
+    'metadata', jsonb_build_object('migrated', true),
+    'history', '[]'::jsonb
+)
+WHERE deleted_at = 0
+AND (status_v2 IS NULL OR status_v2 = '{}'::jsonb OR status_v2 = 'null'::jsonb);`); res.Error != nil {
+		return res.Error
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/100_fix_approval_option_default.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/100_fix_approval_option_default.go
@@ -1,0 +1,36 @@
+package migrations
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// Migration100FixApprovalOptionDefault fixes the approval_option column default
+// from 'auto' (invalid) to 'prompt' and backfills existing rows.
+func (m *Migrations) Migration100FixApprovalOptionDefault(ctx context.Context, db *gorm.DB) error {
+	// Fix existing install_configs with invalid 'auto' value
+	if res := db.WithContext(ctx).
+		Exec(`UPDATE install_configs SET approval_option = 'prompt' WHERE approval_option = 'auto' AND deleted_at = 0;`); res.Error != nil {
+		return res.Error
+	}
+
+	// Fix existing workflows with invalid 'auto' value
+	if res := db.WithContext(ctx).
+		Exec(`UPDATE install_workflows SET approval_option = 'prompt' WHERE approval_option = 'auto' AND deleted_at = 0;`); res.Error != nil {
+		return res.Error
+	}
+
+	// Update column defaults
+	if res := db.WithContext(ctx).
+		Exec(`ALTER TABLE install_configs ALTER COLUMN approval_option SET DEFAULT 'prompt';`); res.Error != nil {
+		return res.Error
+	}
+
+	if res := db.WithContext(ctx).
+		Exec(`ALTER TABLE install_workflows ALTER COLUMN approval_option SET DEFAULT 'prompt';`); res.Error != nil {
+		return res.Error
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/all.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/all.go
@@ -68,5 +68,13 @@ func (m *Migrations) All() []migrations.Migration {
 			Name: "098-backfill-queue-signal-enqueue-finished-at",
 			Fn:   m.Migration098BackfillQueueSignalEnqueueFinishedAt,
 		},
+		{
+			Name: "099-app-config-backfill-status-v2",
+			Fn:   m.Migration099AppConfigBackfillStatusV2,
+		},
+		{
+			Name: "100-fix-approval-option-default",
+			Fn:   m.Migration100FixApprovalOptionDefault,
+		},
 	}
 }

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
@@ -55,6 +55,24 @@ func (s *Signal) handleStepError(ctx workflow.Context, l *zap.Logger, step *app.
 			zap.Int("max_retries", maxRetries),
 			zap.Int("retry_index", retryIndex))
 
+		// If the step is skippable, mark it as failed but continue the workflow
+		// instead of stopping. This allows post-trigger action steps to fail
+		// without blocking the entire workflow.
+		if step.Skippable {
+			l.Info("step is skippable, continuing workflow after exhausted retries",
+				zap.String("step_id", step.ID))
+			_ = s.markStepFailed(ctx, step, stepErr, map[string]any{
+				"retries_exhausted":  true,
+				"max_retries":        maxRetries,
+				"retry_index":        retryIndex,
+				"skipped_on_failure": true,
+			})
+			if err := setResultDirective(ctx, step.ID, DirectiveContinue); err != nil {
+				return errors.Wrap(err, "unable to set result directive")
+			}
+			return nil
+		}
+
 		if err := setResultDirective(ctx, step.ID, DirectiveStop); err != nil {
 			return errors.Wrap(err, "unable to set result directive")
 		}
@@ -72,6 +90,24 @@ func (s *Signal) handleStepError(ctx workflow.Context, l *zap.Logger, step *app.
 			zap.Int("max_auto_retries", maxAutoRetries),
 			zap.Int("max_retries", maxRetries),
 			zap.Int("retry_index", retryIndex))
+
+		// If the step is skippable and all retries (including manual) are exhausted
+		// at the auto-retry level, allow the workflow to continue.
+		if step.Skippable && maxAutoRetries >= maxRetries {
+			l.Info("step is skippable, continuing workflow after exhausted retries",
+				zap.String("step_id", step.ID))
+			_ = s.markStepFailed(ctx, step, stepErr, map[string]any{
+				"auto_retries_exhausted": true,
+				"max_auto_retries":       maxAutoRetries,
+				"max_retries":            maxRetries,
+				"retry_index":            retryIndex,
+				"skipped_on_failure":     true,
+			})
+			if err := setResultDirective(ctx, step.ID, DirectiveContinue); err != nil {
+				return errors.Wrap(err, "unable to set result directive")
+			}
+			return nil
+		}
 
 		return s.markStepFailed(ctx, step, stepErr, map[string]any{
 			"auto_retries_exhausted": true,

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_plan_auto_approval.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_plan_auto_approval.go
@@ -37,6 +37,14 @@ func (s *Signal) runAutoApprovalCheck(ctx workflow.Context, step *app.WorkflowSt
 		return false, nil
 	}
 
+	// Determine the approval source from workflow status metadata
+	approvalType := "unknown"
+	if at, ok := flw.Status.Metadata["approval_type"]; ok {
+		if s, ok := at.(string); ok {
+			approvalType = s
+		}
+	}
+
 	// Create approval response
 	_, err := activities.AwaitCreateApprovalResponse(ctx, activities.CreateStepApprovalResponseRequest{
 		StepApprovalID: step.Approval.ID,
@@ -57,6 +65,7 @@ func (s *Signal) runAutoApprovalCheck(ctx workflow.Context, step *app.WorkflowSt
 				"step_idx":      step.Idx,
 				"status":        "auto-approved",
 				"auto_approved": true,
+				"approval_type": approvalType,
 			},
 		},
 	}); err != nil {
@@ -70,8 +79,9 @@ func (s *Signal) runAutoApprovalCheck(ctx workflow.Context, step *app.WorkflowSt
 			Status:                 app.StatusInProgress,
 			StatusHumanDescription: "auto-approved step " + strconv.Itoa(step.Idx+1),
 			Metadata: map[string]any{
-				"step_idx": step.Idx,
-				"status":   "auto-approved",
+				"step_idx":      step.Idx,
+				"status":        "auto-approved",
+				"approval_type": approvalType,
 			},
 		},
 	}); err != nil {

--- a/services/ctl-api/internal/pkg/sandboxmode/job_types.go
+++ b/services/ctl-api/internal/pkg/sandboxmode/job_types.go
@@ -1,5 +1,16 @@
 package sandboxmode
 
+// AllRunnerJobOperationTypes returns all known runner job operation types.
+func AllRunnerJobOperationTypes() []string {
+	return []string{
+		"exec",
+		"build",
+		"create-apply-plan",
+		"create-teardown-plan",
+		"apply-plan",
+	}
+}
+
 // AllRunnerJobTypes returns all known runner job types.
 func AllRunnerJobTypes() []string {
 	return []string{

--- a/services/ctl-api/internal/pkg/workflows/poll/poll.go
+++ b/services/ctl-api/internal/pkg/workflows/poll/poll.go
@@ -42,6 +42,11 @@ func Poll(ctx workflow.Context, v *validator.Validate, opts PollOpts) error {
 	currentIteration := 0
 	currentInterval := opts.InitialInterval
 	for {
+		// Check for context cancellation before each iteration
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		currentIteration++
 
 		err := opts.Fn(ctx)
@@ -58,6 +63,10 @@ func Poll(ctx workflow.Context, v *validator.Validate, opts PollOpts) error {
 			}
 		}
 		if err := workflow.Sleep(ctx, currentInterval); err != nil {
+			// If sleep was interrupted by cancellation, exit immediately
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			return errors.Wrap(err, "sleep failed")
 		}
 

--- a/services/dashboard-ui/client/components/workflows/WorkflowTimeline/WorkflowTimeline.tsx
+++ b/services/dashboard-ui/client/components/workflows/WorkflowTimeline/WorkflowTimeline.tsx
@@ -95,6 +95,16 @@ export const WorkflowTimeline = ({
                     cron scheduled
                   </Badge>
                 ) : null}
+                {workflow?.approval_option === 'approve-all' &&
+                workflow?.metadata?.approval_type ? (
+                  <Badge variant="code" size="sm">
+                    {workflow.metadata.approval_type === 'approve-workflow'
+                      ? 'auto-approve (workflow)'
+                      : workflow.metadata.approval_type === 'install-config'
+                        ? 'auto-approve (config)'
+                        : 'auto-approve'}
+                  </Badge>
+                ) : null}
               </span>
             }
             badge={getWorkflowBadge(workflow)}

--- a/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowHeader/WorkflowHeader.tsx
+++ b/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowHeader/WorkflowHeader.tsx
@@ -42,6 +42,16 @@ export const WorkflowHeader = ({ workflow, install }: IWorkflowHeader) => {
                 drift detected
               </Badge>
             ) : null}
+            {workflow?.approval_option === 'approve-all' &&
+            workflow?.metadata?.approval_type ? (
+              <Badge variant="code" size="sm">
+                {workflow.metadata.approval_type === 'approve-workflow'
+                  ? 'auto-approve (workflow)'
+                  : workflow.metadata.approval_type === 'install-config'
+                    ? 'auto-approve (config)'
+                    : 'auto-approve'}
+              </Badge>
+            ) : null}
           </Text>
           <Text theme="neutral">
             Watch your app get updated here and provide needed approvals.


### PR DESCRIPTION
Fixing some bugs:

1. auto approval setting on configs was not synced correctly, and did not work in a workflow.
1. cancelling a stack run did not work properly.
1. app-config status was not respected when syncing a config / creating an install.
1. cancellation of a sandbox-run did not work correctly.
1. issue where stack runs could only be outstanding 2 hours.
