### PR TITLE
fix(ctl-api): route missed flows through queue mode

### DIFF
--- a/services/ctl-api/internal/app/apps/service/admin_reprovision_app.go
+++ b/services/ctl-api/internal/app/apps/service/admin_reprovision_app.go
@@ -1,11 +1,15 @@
 package service
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/apps/signals"
+	appreprovision "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/signals/v2/reprovision"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
 
 type ReprovisionAppRequest struct{}
@@ -30,8 +34,30 @@ func (s *service) AdminReprovisionApp(ctx *gin.Context) {
 		return
 	}
 
-	s.evClient.Send(ctx, appID, &signals.Signal{
-		Type: signals.OperationReprovision,
-	})
+	useQueues, err := s.featuresClient.AllFeaturesEnabled(ctx, app.OrgFeatureAppBranches, app.OrgFeatureQueues)
+	if err != nil {
+		ctx.Error(fmt.Errorf("unable to check features: %w", err))
+		return
+	}
+	if useQueues {
+		q, err := s.queueClient.GetQueueByOwner(ctx, appID, "apps")
+		if err != nil {
+			ctx.Error(fmt.Errorf("unable to get app queue: %w", err))
+			return
+		}
+		if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID:   q.ID,
+			OwnerID:   appID,
+			OwnerType: "apps",
+			Signal:    &appreprovision.Signal{AppID: appID},
+		}); err != nil {
+			ctx.Error(fmt.Errorf("unable to enqueue app reprovision signal: %w", err))
+			return
+		}
+	} else {
+		s.evClient.Send(ctx, appID, &signals.Signal{
+			Type: signals.OperationReprovision,
+		})
+	}
 	ctx.JSON(http.StatusOK, true)
 }

--- a/services/ctl-api/internal/app/components/service/admin_delete.go
+++ b/services/ctl-api/internal/app/components/service/admin_delete.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
 )
 
 type AdminDeleteComponentRequest struct{}
@@ -24,8 +22,9 @@ type AdminDeleteComponentRequest struct{}
 func (s *service) AdminDeleteComponent(ctx *gin.Context) {
 	componentID := ctx.Param("component_id")
 
-	s.evClient.Send(ctx, componentID, &signals.Signal{
-		Type: signals.OperationDelete,
-	})
+	if err := s.dispatchComponentDelete(ctx, componentID); err != nil {
+		ctx.Error(err)
+		return
+	}
 	ctx.JSON(http.StatusOK, true)
 }

--- a/services/ctl-api/internal/app/components/service/admin_restart.go
+++ b/services/ctl-api/internal/app/components/service/admin_restart.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
+	componentrestart "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/v2/restart"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
 
 type RestartComponentRequest struct{}
@@ -40,9 +42,31 @@ func (s *service) RestartComponent(ctx *gin.Context) {
 		return
 	}
 
-	s.evClient.Send(ctx, component.ID, &signals.Signal{
-		Type: signals.OperationRestart,
-	})
+	useQueues, err := s.featuresClient.AllFeaturesEnabled(ctx, app.OrgFeatureAppBranches, app.OrgFeatureQueues)
+	if err != nil {
+		ctx.Error(fmt.Errorf("unable to check features: %w", err))
+		return
+	}
+	if useQueues {
+		q, err := s.queueClient.GetQueueByOwner(ctx, component.ID, "components")
+		if err != nil {
+			ctx.Error(fmt.Errorf("unable to get component queue: %w", err))
+			return
+		}
+		if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID:   q.ID,
+			OwnerID:   component.ID,
+			OwnerType: "components",
+			Signal:    &componentrestart.Signal{ComponentID: component.ID},
+		}); err != nil {
+			ctx.Error(fmt.Errorf("unable to enqueue component restart signal: %w", err))
+			return
+		}
+	} else {
+		s.evClient.Send(ctx, component.ID, &signals.Signal{
+			Type: signals.OperationRestart,
+		})
+	}
 	ctx.JSON(http.StatusOK, true)
 }
 

--- a/services/ctl-api/internal/app/components/service/delete_component.go
+++ b/services/ctl-api/internal/app/components/service/delete_component.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -8,7 +9,9 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals"
+	componentdelete "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/v2/delete"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
 
 // @ID						DeleteAppComponent
@@ -50,9 +53,10 @@ func (s *service) DeleteAppComponent(ctx *gin.Context) {
 		return
 	}
 
-	s.evClient.Send(ctx, componentID, &signals.Signal{
-		Type: signals.OperationDelete,
-	})
+	if err := s.dispatchComponentDelete(ctx, componentID); err != nil {
+		ctx.Error(err)
+		return
+	}
 	ctx.JSON(http.StatusOK, app.EmptyResponse{})
 }
 
@@ -95,8 +99,39 @@ func (s *service) DeleteComponent(ctx *gin.Context) {
 		return
 	}
 
+	if err := s.dispatchComponentDelete(ctx, componentID); err != nil {
+		ctx.Error(err)
+		return
+	}
+	ctx.JSON(http.StatusOK, app.EmptyResponse{})
+}
+
+// dispatchComponentDelete enqueues the v2 delete signal in queue mode, otherwise
+// falls back to the legacy event loop OperationDelete signal.
+func (s *service) dispatchComponentDelete(ctx context.Context, componentID string) error {
+	useQueues, err := s.featuresClient.AllFeaturesEnabled(ctx, app.OrgFeatureAppBranches, app.OrgFeatureQueues)
+	if err != nil {
+		return fmt.Errorf("unable to check features: %w", err)
+	}
+
+	if useQueues {
+		q, err := s.queueClient.GetQueueByOwner(ctx, componentID, "components")
+		if err != nil {
+			return fmt.Errorf("unable to get component queue: %w", err)
+		}
+		if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID:   q.ID,
+			OwnerID:   componentID,
+			OwnerType: "components",
+			Signal:    &componentdelete.Signal{ComponentID: componentID},
+		}); err != nil {
+			return fmt.Errorf("unable to enqueue component delete signal: %w", err)
+		}
+		return nil
+	}
+
 	s.evClient.Send(ctx, componentID, &signals.Signal{
 		Type: signals.OperationDelete,
 	})
-	ctx.JSON(http.StatusOK, app.EmptyResponse{})
+	return nil
 }

--- a/services/ctl-api/internal/app/installs/helpers/create_and_start_update_input_workflow.go
+++ b/services/ctl-api/internal/app/installs/helpers/create_and_start_update_input_workflow.go
@@ -40,6 +40,10 @@ func (h *Helpers) CreateAndStartInputUpdateWorkflow(
 		return nil, err
 	}
 
+	// Legacy fallback: signal the legacy event loop. Callers in queue mode
+	// must send their own queue signals (see update_install_input.go).
+	// This helper cannot import v2 signal packages due to an import cycle:
+	// helpers -> v2 -> worker/activities -> helpers.
 	h.evClient.Send(ctx, installID, &signals.Signal{
 		Type:              signals.OperationUpdated,
 		InstallWorkflowID: workflow.ID,
@@ -49,5 +53,5 @@ func (h *Helpers) CreateAndStartInputUpdateWorkflow(
 		InstallWorkflowID: workflow.ID,
 	})
 
-	return workflow, err
+	return workflow, nil
 }

--- a/services/ctl-api/internal/app/installs/service/create_install.go
+++ b/services/ctl-api/internal/app/installs/service/create_install.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/appconfigupdated"
 	installscreated "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/created"
 	polldependencies "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/polldependencies"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
@@ -127,6 +128,13 @@ func (s *service) CreateInstallV2(ctx *gin.Context) {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
+		// reconcile cron/drift emitters from app config triggers
+		if err := s.enqueueInstallSignal(ctx, signalsQueueID, &appconfigupdated.Signal{
+			InstallID: install.ID,
+		}, "", ""); err != nil {
+			ctx.Error(fmt.Errorf("enqueue reconcile-emitters signal: %w", err))
+			return
+		}
 	} else {
 		s.evClient.Send(ctx, install.ID, &signals.Signal{
 			Type: signals.OperationCreated,
@@ -138,11 +146,10 @@ func (s *service) CreateInstallV2(ctx *gin.Context) {
 			Type:              signals.OperationExecuteFlow,
 			InstallWorkflowID: workflow.ID,
 		})
+		s.evClient.Send(ctx, install.ID, &signals.Signal{
+			Type: signals.OperationSyncActionWorkflowTriggers,
+		})
 	}
-	// SyncActionWorkflowTriggers must stay legacy - it starts a child workflow in the event loop
-	s.evClient.Send(ctx, install.ID, &signals.Signal{
-		Type: signals.OperationSyncActionWorkflowTriggers,
-	})
 
 	// Update user journey step for first install creation
 	user, err := cctx.AccountFromGinContext(ctx)
@@ -267,6 +274,13 @@ func (s *service) CreateInstall(ctx *gin.Context) {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
+		// reconcile cron/drift emitters from app config triggers
+		if err := s.enqueueInstallSignal(ctx, signalsQueueID, &appconfigupdated.Signal{
+			InstallID: install.ID,
+		}, "", ""); err != nil {
+			ctx.Error(fmt.Errorf("enqueue reconcile-emitters signal: %w", err))
+			return
+		}
 	} else {
 		s.evClient.Send(ctx, install.ID, &signals.Signal{
 			Type: signals.OperationCreated,
@@ -278,11 +292,10 @@ func (s *service) CreateInstall(ctx *gin.Context) {
 			Type:              signals.OperationExecuteFlow,
 			InstallWorkflowID: workflow.ID,
 		})
+		s.evClient.Send(ctx, install.ID, &signals.Signal{
+			Type: signals.OperationSyncActionWorkflowTriggers,
+		})
 	}
-	// SyncActionWorkflowTriggers must stay legacy - it starts a child workflow in the event loop
-	s.evClient.Send(ctx, install.ID, &signals.Signal{
-		Type: signals.OperationSyncActionWorkflowTriggers,
-	})
 
 	// Update user journey step for first install creation
 	user, err := cctx.AccountFromGinContext(ctx)

--- a/services/ctl-api/internal/app/installs/service/update_install_input.go
+++ b/services/ctl-api/internal/app/installs/service/update_install_input.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/updated"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	executeflow "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeflow"
@@ -125,6 +124,8 @@ func (s *service) UpdateInstallInputs(ctx *gin.Context) {
 		return
 	}
 
+	// In queue mode the helper's legacy signals are dropped (legacy event loop is
+	// not running). Enqueue queue equivalents so the input-update workflow runs.
 	useQueues, err := s.featuresClient.AllFeaturesEnabled(ctx, app.OrgFeatureAppBranches, app.OrgFeatureQueues)
 	if err != nil {
 		ctx.Error(fmt.Errorf("checking features: %w", err))
@@ -153,16 +154,8 @@ func (s *service) UpdateInstallInputs(ctx *gin.Context) {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
-	} else {
-		s.evClient.Send(ctx, install.ID, &signals.Signal{
-			Type:              signals.OperationUpdated,
-			InstallWorkflowID: workflow.ID,
-		})
-		s.evClient.Send(ctx, install.ID, &signals.Signal{
-			Type:              signals.OperationExecuteFlow,
-			InstallWorkflowID: workflow.ID,
-		})
 	}
+	// In legacy mode the helper already sent OperationUpdated + OperationExecuteFlow.
 
 	inputs.WorkflowID = &workflow.ID
 	ctx.JSON(http.StatusOK, inputs)

--- a/services/ctl-api/internal/app/onboarding/service/complete_install_step.go
+++ b/services/ctl-api/internal/app/onboarding/service/complete_install_step.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	installsignals "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/appconfigupdated"
 	installscreated "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/created"
 	polldependencies "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/polldependencies"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
@@ -218,6 +219,13 @@ func (s *service) CompleteInstallStep(ctx *gin.Context) {
 			ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 			return
 		}
+		// reconcile cron/drift emitters from app config triggers
+		if err := s.enqueueInstallSignal(ctx, signalsQueueID, &appconfigupdated.Signal{
+			InstallID: install.ID,
+		}, "", ""); err != nil {
+			ctx.Error(fmt.Errorf("enqueue reconcile-emitters signal: %w", err))
+			return
+		}
 	} else {
 		s.evClient.Send(ctx, install.ID, &installsignals.Signal{
 			Type: installsignals.OperationCreated,
@@ -229,11 +237,10 @@ func (s *service) CompleteInstallStep(ctx *gin.Context) {
 			Type:              installsignals.OperationExecuteFlow,
 			InstallWorkflowID: workflow.ID,
 		})
+		s.evClient.Send(ctx, install.ID, &installsignals.Signal{
+			Type: installsignals.OperationSyncActionWorkflowTriggers,
+		})
 	}
-	// SyncActionWorkflowTriggers must stay legacy - it starts a child workflow in the event loop
-	s.evClient.Send(ctx, install.ID, &installsignals.Signal{
-		Type: installsignals.OperationSyncActionWorkflowTriggers,
-	})
 
 	// Update onboarding with install/workflow references and advance step
 	onboarding.InstallID = &install.ID

--- a/services/ctl-api/internal/app/onboarding/signals/activities/activities.go
+++ b/services/ctl-api/internal/app/onboarding/signals/activities/activities.go
@@ -13,6 +13,7 @@ import (
 	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	orgshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/eventloop"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
 
@@ -30,6 +31,7 @@ type Params struct {
 	OrgsHelpers      *orgshelpers.Helpers
 	EvClient         eventloop.Client
 	QueueClient      *queueclient.Client
+	FeaturesClient   *features.Features
 }
 
 type Activities struct {
@@ -44,6 +46,7 @@ type Activities struct {
 	orgsHelpers      *orgshelpers.Helpers
 	evClient         eventloop.Client
 	queueClient      *queueclient.Client
+	featuresClient   *features.Features
 }
 
 func New(params Params) (*Activities, error) {
@@ -59,5 +62,6 @@ func New(params Params) (*Activities, error) {
 		orgsHelpers:      params.OrgsHelpers,
 		evClient:         params.EvClient,
 		queueClient:      params.QueueClient,
+		featuresClient:   params.FeaturesClient,
 	}, nil
 }

--- a/services/ctl-api/internal/app/onboarding/signals/activities/create_install.go
+++ b/services/ctl-api/internal/app/onboarding/signals/activities/create_install.go
@@ -7,7 +7,12 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	installsignals "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/appconfigupdated"
+	installscreated "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/created"
+	polldependencies "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/polldependencies"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	executeflow "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeflow"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
 
 type CreateOnboardingInstallInput struct {
@@ -93,17 +98,6 @@ func (a *Activities) createOnboardingInstall(ctx context.Context, input *CreateO
 		return nil, fmt.Errorf("unable to create install: %w", err)
 	}
 
-	// Send v1 event loop signals (matching installs/service/create_install.go:85-109)
-	a.evClient.Send(ctx, install.ID, &installsignals.Signal{
-		Type: installsignals.OperationCreated,
-	})
-	a.evClient.Send(ctx, install.ID, &installsignals.Signal{
-		Type: installsignals.OperationPollDependencies,
-	})
-	a.evClient.Send(ctx, install.ID, &installsignals.Signal{
-		Type: installsignals.OperationSyncActionWorkflowTriggers,
-	})
-
 	// Create provision workflow
 	workflow, err := a.installsHelpers.CreateWorkflow(ctx,
 		install.ID,
@@ -115,13 +109,75 @@ func (a *Activities) createOnboardingInstall(ctx context.Context, input *CreateO
 		return nil, fmt.Errorf("unable to create provision workflow: %w", err)
 	}
 
-	a.evClient.Send(ctx, install.ID, &installsignals.Signal{
-		Type:              installsignals.OperationExecuteFlow,
-		InstallWorkflowID: workflow.ID,
-	})
+	useQueues, err := a.featuresClient.AllFeaturesEnabled(ctx, app.OrgFeatureAppBranches, app.OrgFeatureQueues)
+	if err != nil {
+		return nil, fmt.Errorf("checking features: %w", err)
+	}
+
+	if useQueues {
+		signalsQueue, err := a.getInstallQueue(ctx, install.ID, helpers.InstallSignalsQueueName)
+		if err != nil {
+			return nil, err
+		}
+		workflowsQueue, err := a.getInstallQueue(ctx, install.ID, helpers.InstallWorkflowsQueueName)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := a.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID: signalsQueue.ID,
+			Signal:  &installscreated.Signal{InstallID: install.ID},
+		}); err != nil {
+			return nil, fmt.Errorf("enqueue created signal: %w", err)
+		}
+		if _, err := a.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID: signalsQueue.ID,
+			Signal:  &polldependencies.Signal{InstallID: install.ID},
+		}); err != nil {
+			return nil, fmt.Errorf("enqueue polldependencies signal: %w", err)
+		}
+		if _, err := a.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID:   workflowsQueue.ID,
+			OwnerID:   workflow.ID,
+			OwnerType: "install_workflows",
+			Signal:    &executeflow.Signal{WorkflowID: workflow.ID},
+		}); err != nil {
+			return nil, fmt.Errorf("enqueue executeflow signal: %w", err)
+		}
+		// reconcile cron/drift emitters from app config triggers
+		if _, err := a.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID: signalsQueue.ID,
+			Signal:  &appconfigupdated.Signal{InstallID: install.ID},
+		}); err != nil {
+			return nil, fmt.Errorf("enqueue reconcile-emitters signal: %w", err)
+		}
+	} else {
+		a.evClient.Send(ctx, install.ID, &installsignals.Signal{
+			Type: installsignals.OperationCreated,
+		})
+		a.evClient.Send(ctx, install.ID, &installsignals.Signal{
+			Type: installsignals.OperationPollDependencies,
+		})
+		a.evClient.Send(ctx, install.ID, &installsignals.Signal{
+			Type: installsignals.OperationSyncActionWorkflowTriggers,
+		})
+		a.evClient.Send(ctx, install.ID, &installsignals.Signal{
+			Type:              installsignals.OperationExecuteFlow,
+			InstallWorkflowID: workflow.ID,
+		})
+	}
 
 	return &CreateOnboardingInstallResponse{
 		InstallID:  install.ID,
 		WorkflowID: workflow.ID,
 	}, nil
+}
+
+func (a *Activities) getInstallQueue(ctx context.Context, installID, queueName string) (*app.Queue, error) {
+	var queue app.Queue
+	if res := a.db.WithContext(ctx).
+		Where("owner_id = ? AND name = ?", installID, queueName).
+		First(&queue); res.Error != nil {
+		return nil, fmt.Errorf("unable to get install queue %s: %w", queueName, res.Error)
+	}
+	return &queue, nil
 }


### PR DESCRIPTION
Cron triggers, single-component delete, admin reprovision/restart, onboarding installs, and input updates were routing through the legacy event loop in queue mode where it never starts — fixed each to enqueue the v2 signal.