### PR TITLE
feat(api/ui): search installs by runner id

### DIFF
--- a/services/ctl-api/internal/app/installs/service/admin_forget_org_installs.go
+++ b/services/ctl-api/internal/app/installs/service/admin_forget_org_installs.go
@@ -30,7 +30,7 @@ type AdminForgetOrgInstallsRequest struct{}
 func (s *service) ForgetOrgInstalls(ctx *gin.Context) {
 	orgID := ctx.Param("org_id")
 
-	installs, err := s.getOrgInstalls(ctx, orgID, "", nil)
+	installs, err := s.getOrgInstalls(ctx, orgID, "", nil, "")
 	if err != nil {
 		ctx.Error(fmt.Errorf("unable to get org installs: %w", err))
 		return

--- a/services/ctl-api/internal/app/installs/service/admin_org_installs.go
+++ b/services/ctl-api/internal/app/installs/service/admin_org_installs.go
@@ -26,7 +26,7 @@ type AdminGetOrgRequest struct {
 func (s *service) AdminGetOrgInstalls(ctx *gin.Context) {
 	orgID := ctx.Param("org_id")
 
-	installs, err := s.getOrgInstalls(ctx, orgID, "", nil)
+	installs, err := s.getOrgInstalls(ctx, orgID, "", nil, "")
 	if err != nil {
 		ctx.Error(fmt.Errorf("unable to get org installs: %w", err))
 		return

--- a/services/ctl-api/internal/app/installs/service/get_org_installs.go
+++ b/services/ctl-api/internal/app/installs/service/get_org_installs.go
@@ -21,6 +21,7 @@ import (
 // @Param					offset						query	int		false	"offset of results to return"	Default(0)
 // @Param         q								 query	string	false	"search query to filter installs by name"
 // @Param					labels						query	string	false	"label filter (key:value,key:value)"
+// @Param					runner_id				query	string	false	"filter by runner ID"
 // @Param					limit						query	int		false	"limit of results to return"	Default(10)
 // @Param					page						query	int		false	"page number of results to return"	Default(0)
 // @Tags					installs
@@ -44,8 +45,9 @@ func (s *service) GetOrgInstalls(ctx *gin.Context) {
 
 	q := ctx.Query("q")
 	lbls := labels.ParseLabelsQuery(ctx.Query("labels"))
+	runnerID := ctx.Query("runner_id")
 
-	install, err := s.getOrgInstalls(ctx, org.ID, q, lbls)
+	install, err := s.getOrgInstalls(ctx, org.ID, q, lbls, runnerID)
 	if err != nil {
 		ctx.Error(fmt.Errorf("unable to get installs for org %s: %w", org.ID, err))
 		return
@@ -54,7 +56,7 @@ func (s *service) GetOrgInstalls(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, install)
 }
 
-func (s *service) getOrgInstalls(ctx *gin.Context, orgID, q string, lbls labels.Labels) ([]app.Install, error) {
+func (s *service) getOrgInstalls(ctx *gin.Context, orgID, q string, lbls labels.Labels, runnerID string) ([]app.Install, error) {
 	var installs []app.Install
 	tx := s.db.WithContext(ctx).
 		Scopes(scopes.WithOffsetPagination).
@@ -81,6 +83,14 @@ func (s *service) getOrgInstalls(ctx *gin.Context, orgID, q string, lbls labels.
 		Joins("JOIN orgs ON orgs.id=apps.org_id").
 		Where(views.TableOrViewName(s.db, &app.Install{}, ".org_id")+" = ?", orgID).
 		Order("name ASC")
+
+	if runnerID != "" {
+		viewName := views.TableOrViewName(s.db, &app.Install{}, "")
+		tx = tx.
+			Joins("JOIN runner_groups ON runner_groups.owner_id = "+viewName+".id AND runner_groups.owner_type = 'installs' AND runner_groups.deleted_at = 0").
+			Joins("JOIN runners ON runners.runner_group_id = runner_groups.id AND runners.deleted_at = 0").
+			Where("runners.id = ?", runnerID)
+	}
 
 	if q != "" {
 		tx = tx.Where(views.TableOrViewName(s.db, &app.Install{}, ".name")+" ILIKE ?", "%"+q+"%")

--- a/services/dashboard-ui/client/components/spotlight/Spotlight/SpotlightModal.tsx
+++ b/services/dashboard-ui/client/components/spotlight/Spotlight/SpotlightModal.tsx
@@ -10,6 +10,8 @@ import { Modal, type IModal } from '@/components/surfaces/Modal'
 import { SearchInput } from '@/components/common/SearchInput'
 import { Text } from '@/components/common/Text'
 import { Badge } from '@/components/common/Badge'
+import { Button } from '@/components/common/Button'
+import { Icon } from '@/components/common/Icon'
 import { Skeleton } from '@/components/common/Skeleton'
 import { FILTER_PREFIXES, COMMANDS_BY_PREFIX, parseQuery, getAutocompletion } from '../types'
 import { useSpotlightResults } from '../use-spotlight-results'
@@ -31,6 +33,13 @@ export const SpotlightModal = ({ orgId, onClose, onNavigate, onAddModal, orgFeat
   const autocompletion = useMemo(() => getAutocompletion(raw), [raw])
   const listRef = useRef<HTMLDivElement>(null)
   const inputWrapperRef = useRef<HTMLDivElement>(null)
+
+  const rawPrefix = useMemo(() => {
+    const colonIdx = raw.indexOf(':')
+    if (colonIdx < 0) return null
+    return raw.slice(0, colonIdx + 1)
+  }, [raw])
+  const queryAfterPrefix = rawPrefix ? raw.slice(rawPrefix.length) : raw
 
   useEffect(() => {
     const t = setTimeout(() => {
@@ -112,23 +121,62 @@ export const SpotlightModal = ({ orgId, onClose, onNavigate, onAddModal, orgFeat
         onKeyDown={handleKeyDown}
       >
         <div className="relative">
-          <SearchInput
-            className="w-full bg-transparent"
-            labelClassName="w-full"
-            placeholder="Search pages, apps, installs, components, actions…"
-            value={raw}
-            onChange={setRaw}
-            onClear={() => setRaw('')}
-            autoFocus
-          />
-          {autocompletion && (
-            <div className="absolute inset-0 pointer-events-none flex items-center pl-8 pr-3.5 text-sm text-cool-grey-500 dark:text-cool-grey-500 whitespace-pre">
-              <span className="invisible">{raw}</span>
-              <span>{autocompletion.slice(raw.length)}</span>
-              <span className="ml-1.5 text-xs text-cool-grey-500 dark:text-cool-grey-500 border border-cool-grey-400 dark:border-dark-grey-500 rounded px-1">
-                tab
-              </span>
-            </div>
+          {liveParsed.prefix && rawPrefix ? (
+            <label className="relative w-full flex items-center rounded-md border h-[36px] bg-white dark:bg-dark-grey-900">
+              <Icon
+                variant="MagnifyingGlass"
+                className="text-cool-grey-500 dark:text-cool-grey-700 ml-2 shrink-0"
+              />
+              <Badge size="sm" variant="code" theme="neutral" className="ml-1.5 shrink-0">
+                {rawPrefix}
+              </Badge>
+              <input
+                className="flex-1 bg-transparent pl-2.5 pr-3.5 py-1.5 h-full font-sans text-sm outline-none placeholder:text-cool-grey-500 dark:placeholder:text-cool-grey-700"
+                type="text"
+                autoComplete="off"
+                placeholder="Search…"
+                value={queryAfterPrefix}
+                onChange={(e) => setRaw(rawPrefix + e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Backspace' && queryAfterPrefix === '') {
+                    e.preventDefault()
+                    setRaw('')
+                  }
+                }}
+                autoFocus
+              />
+              {raw && (
+                <Button
+                  className="!p-0.5 !h-fit absolute top-1/2 right-1.5 -translate-y-1/2"
+                  variant="ghost"
+                  title="clear search"
+                  onClick={() => setRaw('')}
+                >
+                  <Icon variant="XCircle" />
+                </Button>
+              )}
+            </label>
+          ) : (
+            <>
+              <SearchInput
+                className="w-full bg-transparent"
+                labelClassName="w-full"
+                placeholder="Search pages, apps, installs, components, actions…"
+                value={raw}
+                onChange={setRaw}
+                onClear={() => setRaw('')}
+                autoFocus
+              />
+              {autocompletion && (
+                <div className="absolute inset-0 pointer-events-none flex items-center pl-8 pr-3.5 text-sm text-cool-grey-500 dark:text-cool-grey-500 whitespace-pre">
+                  <span className="invisible">{raw}</span>
+                  <span>{autocompletion.slice(raw.length)}</span>
+                  <span className="ml-1.5 text-xs text-cool-grey-500 dark:text-cool-grey-500 border border-cool-grey-400 dark:border-dark-grey-500 rounded px-1">
+                    tab
+                  </span>
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>
@@ -153,11 +201,11 @@ export const SpotlightModal = ({ orgId, onClose, onNavigate, onAddModal, orgFeat
         )}
         {liveParsed.prefix && COMMANDS_BY_PREFIX[liveParsed.prefix] && liveParsed.command === null && (
           <div className="px-2 py-1 flex items-center gap-1.5">
-            <Text variant="subtext" className="text-cool-grey-600">
-              Type{' '}
+            <Text variant="subtext" className="text-cool-grey-600" flex>
+              Type
               <Badge size="sm" variant="code" theme="neutral">
                 /
-              </Badge>{' '}
+              </Badge>
               to run commands
             </Text>
           </div>

--- a/services/dashboard-ui/client/components/spotlight/use-spotlight-results/use-spotlight-results.tsx
+++ b/services/dashboard-ui/client/components/spotlight/use-spotlight-results/use-spotlight-results.tsx
@@ -58,11 +58,20 @@ export function useSpotlightResults(
     enabled: (parsed.prefix === 'app' || (parsed.prefix === null && parsed.query.length > 0)) && !!orgId,
   })
 
+  const isRunnerIdQuery = parsed.query.startsWith('run')
+
   const { data: installsResult, isFetching: installsFetching } = useQuery({
     queryKey: ['spotlight', 'installs', parsed.query, orgId],
     queryFn: () =>
       getInstalls({ orgId, q: parsed.query || undefined, limit: 5 }),
     enabled: (parsed.prefix === 'install' || (parsed.prefix === null && parsed.query.length > 0)) && !!orgId,
+  })
+
+  const { data: runnerInstallsResult, isFetching: runnerInstallsFetching } = useQuery({
+    queryKey: ['spotlight', 'installs-by-runner', parsed.query, orgId],
+    queryFn: () =>
+      getInstalls({ orgId, runner_id: parsed.query, limit: 5 }),
+    enabled: isRunnerIdQuery && (parsed.prefix === null || parsed.prefix === 'install') && !!orgId,
   })
 
   const { data: actionResults, isFetching: actionsFetching } = useQuery({
@@ -165,14 +174,29 @@ export function useSpotlightResults(
         path: `/apps/${app.id}`,
         icon: 'AppWindow',
       }))
-      const installs = (installsResult?.data ?? []).map((install): SpotlightResult => ({
+      const nameInstalls = installsResult?.data ?? []
+      const runnerInstalls = runnerInstallsResult?.data ?? []
+      const seen = new Set<string>()
+      const allInstalls = [...runnerInstalls, ...nameInstalls].filter((i) => {
+        if (seen.has(i.id!)) return false
+        seen.add(i.id!)
+        return true
+      })
+      const runnerPages: SpotlightResult[] = runnerInstalls.map((install): SpotlightResult => ({
+        label: `${install.name ?? install.id!} › Runner`,
+        subtitle: install.app?.name,
+        tag: 'install',
+        path: `/installs/${install.id}/runner`,
+        icon: 'Cube',
+      }))
+      const installs = allInstalls.map((install): SpotlightResult => ({
         label: install.name ?? install.id!,
         subtitle: install.app?.name,
         tag: 'install',
         path: `/installs/${install.id}`,
         icon: 'Cube',
       }))
-      return [...matched, ...apps, ...installs]
+      return [...matched, ...apps, ...runnerPages, ...installs]
     }
 
     if (parsed.prefix === 'app') {
@@ -218,12 +242,29 @@ export function useSpotlightResults(
     }
 
     if (parsed.prefix === 'install') {
-      const installs = installsResult?.data ?? []
+      const nameInstalls = installsResult?.data ?? []
+      const runnerInstalls = runnerInstallsResult?.data ?? []
+      const seen = new Set<string>()
+      const installs = [...runnerInstalls, ...nameInstalls].filter((i) => {
+        if (seen.has(i.id!)) return false
+        seen.add(i.id!)
+        return true
+      })
+      const runnerIdSet = new Set(runnerInstalls.map((i) => i.id!))
       const items: SpotlightResult[] = []
       for (const install of installs) {
         const installId = install.id!
         const name = install.name ?? installId
         if (parsed.command === null) {
+          if (runnerIdSet.has(installId)) {
+            items.push({
+              label: `${name} › Runner`,
+              subtitle: install.app?.name,
+              tag: 'install',
+              path: `/installs/${installId}/runner`,
+              icon: 'Cube',
+            })
+          }
           items.push({
             label: name,
             subtitle: install.app?.name,
@@ -469,9 +510,9 @@ export function useSpotlightResults(
     }
 
     return []
-  }, [liveParsed, parsed, appsResult, installsResult, orgsResult, actionResults, componentResults, appSubPages, addModal, orgFeatures])
+  }, [liveParsed, parsed, appsResult, installsResult, runnerInstallsResult, orgsResult, actionResults, componentResults, appSubPages, addModal, orgFeatures])
 
-  const isFetching = appsFetching || installsFetching || orgsFetching || actionsFetching || componentsFetching
+  const isFetching = appsFetching || installsFetching || runnerInstallsFetching || orgsFetching || actionsFetching || componentsFetching
 
   return { results, isFetching }
 }

--- a/services/dashboard-ui/client/lib/ctl-api/installs/get-installs.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/installs/get-installs.ts
@@ -8,9 +8,10 @@ export const getInstalls = ({
   orgId,
   q,
   labels,
-}: { orgId: string; q?: string; labels?: string } & TPaginationParams) =>
+  runner_id,
+}: { orgId: string; q?: string; labels?: string; runner_id?: string } & TPaginationParams) =>
   api<TInstall[]>({
-    path: `installs${buildQueryParams({ limit, offset, q, labels })}`,
+    path: `installs${buildQueryParams({ limit, offset, q, labels, runner_id })}`,
     orgId,
     paginated: true,
   })

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -5277,7 +5277,7 @@ export interface components {
       };
       sandbox_mode?: components["schemas"]["plantypes.SandboxMode"];
       steps?: components["schemas"]["plantypes.ActionWorkflowRunStepPlan"][];
-      timeout?: components["schemas"]["time.Duration"];
+      timeout?: number;
     };
     "plantypes.ActionWorkflowRunStepPlan": {
       attrs?: {
@@ -6735,11 +6735,6 @@ export interface components {
       error?: string;
       user_error?: boolean;
     };
-    /**
-     * Format: int64
-     * @enum {integer}
-     */
-    "time.Duration": -9223372036854776000 | 9223372036854776000 | 1 | 1000 | 1000000 | 1000000000 | 60000000000 | 3600000000000;
     "types.StringBoolMap": {
       [key: string]: boolean;
     };
@@ -15153,6 +15148,8 @@ export interface operations {
         q?: string;
         /** @description label filter (key:value,key:value) */
         labels?: string;
+        /** @description filter by runner ID */
+        runner_id?: string;
         /** @description limit of results to return */
         limit?: number;
         /** @description page number of results to return */


### PR DESCRIPTION
- Backend (get_org_installs.go): Added runner_id query param to GetOrgInstalls — when present, joins through runner_groups → runners to filter
  installs by runner ID
- Frontend API (get-installs.ts): Added optional runner_id param to getInstalls()                                                                
- Spotlight search (use-spotlight-results.tsx): When query starts with run, fires a second query using runner_id instead of name search.         
  Runner-matched installs show a "› Runner" link first, then the install itself, deduplicated with name results                                    
- Spotlight input (SpotlightModal.tsx): Filter prefixes (e.g. install:) now render as styled badges inside the input instead of plain text.      
  Backspace on empty query clears the prefix                                                                                                       
- Spotlight hint (SpotlightModal.tsx): Fixed "Type / to run commands" rendering on multiple lines by using flex prop on Text