### PR TITLE
chore(ctl-api): make runner instance type configurable

### DIFF
--- a/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
@@ -28,6 +28,11 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 	// vpcParams := t.getVPCNestedStackParams(inp)
 	maps.Copy(tmpl.Parameters, vpcParams)
 
+	// Top-level Runner parameters: exposed on the parent stack so customers can
+	// override the defaults; the runner ASG nested stack references these.
+	runnerParams := t.getRunnerParameters()
+	maps.Copy(tmpl.Parameters, runnerParams)
+
 	// When using local runners (dev mode), skip the ASG and runner-EC2-specific
 	// resources to save ~5-6 minutes during stack creation.
 	// PhoneHome resources are always created as the provision workflow depends on
@@ -105,6 +110,12 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 	// parameter groups
 	var pgs []map[string]any
 	paramGroups := []map[string]any{
+		{
+			"Label": map[string]any{
+				"default": "Runner Configuration",
+			},
+			"Parameters": pkggenerics.MapToKeys(runnerParams),
+		},
 		{
 			"Label": map[string]any{
 				"default": "VPC Configuration",

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
@@ -52,8 +52,8 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 		"InstallId":           inp.Install.ID,
 		"RunnerId":            inp.Runner.ID,
 		"RunnerApiUrl":        a.cfg.RunnerAPIURL,
-		"InstanceType":        "t3a.medium",            // NOTE(fd): this may be a good thing to make configurable later
-		"RootVolumeSize":      "30",                    // NOTE(fd): this may be a good thing to make configurable later
+		"InstanceType":        cloudformation.Ref("RunnerInstanceType"),
+		"RootVolumeSize":      cloudformation.Ref("RunnerRootVolumeSize"),
 		"RunnerInitScriptUrl": inp.RunnerInitScriptURL, // NOTE(fd): this is user- (provided/configurable)
 	}
 
@@ -80,47 +80,30 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 	}, nil
 }
 
-// VPCNestedStackParameters returns the parameters for the VPC nested stack
-func (a *Templates) getRunnerASGNestedStackParams() map[string]cloudformation.Parameter {
+// getRunnerParameters returns the user-overridable top-level parameters for
+// the runner. These are exposed at the parent stack so customers can override
+// the defaults when creating/updating the stack; the nested runner ASG stack
+// references them via Ref().
+func (a *Templates) getRunnerParameters() map[string]cloudformation.Parameter {
 	return map[string]cloudformation.Parameter{
-		"SubnetId": {
-			Type:        "AWS::EC2::Subnet::Id",
-			Description: generics.ToPtr("The subnet on which the app will run within the selected VPC."),
-		},
-		"RunnerEgressGroupId": {
-			Type:        "AWS::EC2::SecurityGroup::Id",
-			Description: generics.ToPtr("The security group for the runner instance that allows outbound traffic."),
-		},
-		"InstallId": {
-			Type:        "String",
-			Description: generics.ToPtr("The install ID"),
-		},
-		"RunnerId": {
-			Type:        "String",
-			Description: generics.ToPtr("The runner ID"),
-		},
-		"RunnerApiUrl": {
-			Type:        "String",
-			Description: generics.ToPtr("API URL for the runner"),
-			Default:     "https://runner.nuon.co",
-		},
-		"InstanceType": {
+		"RunnerInstanceType": {
 			Type:        "String",
 			Description: generics.ToPtr("EC2 instance type for the runner"),
 			Default:     "t3a.medium",
 			AllowedValues: []interface{}{
 				"t3.small",
 				"t3.medium",
+				"t3.large",
 				"t3a.small",
 				"t3a.medium",
 				"t3a.large",
-				"m5.large",
-				"m5a.large",
+				"c4.large",
+				"c5.large",
 			},
 		},
-		"RootVolumeSize": {
+		"RunnerRootVolumeSize": {
 			Type:        "Number",
-			Description: generics.ToPtr("EC2 instance type for the runner"),
+			Description: generics.ToPtr("Root EBS volume size (GiB) for the runner"),
 			Default:     "30",
 			MinValue:    ptr(8.0),
 			MaxValue:    ptr(100.0),


### PR DESCRIPTION
### Description

The Runner instance type is a paramter in the nested cf stack but we do not expose an input field for it. We do now.


<details><summary>Screenshots</summary>
<p>

<img width="600" height="373" alt="image" src="https://github.com/user-attachments/assets/acf8d4de-99ce-41e1-8116-1c48db24ae39" />
<img width="600" height="373" alt="image" src="https://github.com/user-attachments/assets/acf8d4de-99ce-41e1-8116-1c48db24ae39" />


</p>
</details> 