### PR TITLE
feat: (composite-errors): spec + prototype with terraform/aws parsers

### DIFF
--- a/pkg/composite_error/catalog/catalog.go
+++ b/pkg/composite_error/catalog/catalog.go
@@ -1,0 +1,171 @@
+// Package catalog is the in-memory registry for CompositeError types and
+// Parsers, populated via init() blocks in per-type packages.
+//
+// This mirrors pkg/queue/catalog: there is no DB-backed catalog table.
+// On every process start, importing a type's package runs its init() which
+// registers the factory and parser(s) here.
+package catalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+)
+
+// typeRegistry maps a Type to a factory that returns a fresh, zero-valued
+// instance of the implementing struct. Hydrate() unmarshals the persisted
+// JSON into a value produced by the factory.
+var (
+	typeMu       sync.RWMutex
+	typeRegistry = map[composite_error.Type]func() composite_error.CompositeError{}
+
+	parserMu     sync.RWMutex
+	parsersByCtx = map[composite_error.ParseContext][]composite_error.Parser{}
+	allParsers   []composite_error.Parser
+)
+
+// RegisterType associates a CompositeError type with its factory.
+// Panics on duplicate registration — same contract as pkg/queue/catalog.
+func RegisterType(typ composite_error.Type, fn func() composite_error.CompositeError) {
+	typeMu.Lock()
+	defer typeMu.Unlock()
+
+	if _, exists := typeRegistry[typ]; exists {
+		panic(fmt.Sprintf("composite_error: duplicate type registered: %q", typ))
+	}
+	typeRegistry[typ] = fn
+}
+
+// LookupType returns the factory registered for typ, or (nil, false).
+func LookupType(typ composite_error.Type) (func() composite_error.CompositeError, bool) {
+	typeMu.RLock()
+	defer typeMu.RUnlock()
+
+	fn, ok := typeRegistry[typ]
+	return fn, ok
+}
+
+// Hydrate looks up the factory for typ, instantiates an empty value, and
+// unmarshals data into it. Returns an error if the type is not registered or
+// the JSON does not match the type's schema.
+func Hydrate(typ composite_error.Type, data []byte) (composite_error.CompositeError, error) {
+	fn, ok := LookupType(typ)
+	if !ok {
+		return nil, fmt.Errorf("composite_error: unknown type %q", typ)
+	}
+
+	val := fn()
+	if len(data) == 0 {
+		return val, nil
+	}
+	if err := json.Unmarshal(data, val); err != nil {
+		return nil, fmt.Errorf("composite_error: hydrate %q: %w", typ, err)
+	}
+	return val, nil
+}
+
+// Types returns all registered type identifiers, sorted. Useful for the
+// admin dashboard catalog browser.
+func Types() []composite_error.Type {
+	typeMu.RLock()
+	defer typeMu.RUnlock()
+
+	out := make([]composite_error.Type, 0, len(typeRegistry))
+	for t := range typeRegistry {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// RegisterParser indexes p under each of its declared ParseContexts.
+// Panics if Contexts() is empty — every parser must opt in to at least one
+// subtree (see specs/composite-errors.md).
+func RegisterParser(p composite_error.Parser) {
+	parserMu.Lock()
+	defer parserMu.Unlock()
+
+	ctxs := p.Contexts()
+	if len(ctxs) == 0 {
+		panic(fmt.Sprintf("composite_error: parser %q registered with no contexts", p.Name()))
+	}
+	for _, c := range ctxs {
+		parsersByCtx[c] = append(parsersByCtx[c], p)
+	}
+	allParsers = append(allParsers, p)
+}
+
+// ParsersForContext returns the parsers that should be invoked for a given
+// dispatch context, ordered most-specific to least-specific. Within a level
+// parsers are returned in registration order.
+//
+// Walking is by "/"-segment ancestry: "terraform/plan" matches parsers
+// registered against "terraform/plan", "terraform", and "" (root).
+func ParsersForContext(c composite_error.ParseContext) []composite_error.Parser {
+	parserMu.RLock()
+	defer parserMu.RUnlock()
+
+	ancestors := ancestorsOf(c)
+	out := make([]composite_error.Parser, 0)
+	for _, a := range ancestors {
+		out = append(out, parsersByCtx[a]...)
+	}
+	return out
+}
+
+// AllParsers returns every registered parser, in registration order.
+// Used by the admin dashboard catalog browser.
+func AllParsers() []composite_error.Parser {
+	parserMu.RLock()
+	defer parserMu.RUnlock()
+
+	out := make([]composite_error.Parser, len(allParsers))
+	copy(out, allParsers)
+	return out
+}
+
+// ancestorsOf returns c, its parents, and "" (root), most-specific first.
+//
+//	"terraform/plan/init" → ["terraform/plan/init", "terraform/plan", "terraform", ""]
+//	"terraform"           → ["terraform", ""]
+//	""                    → [""]
+func ancestorsOf(c composite_error.ParseContext) []composite_error.ParseContext {
+	s := string(c)
+	out := []composite_error.ParseContext{c}
+	for {
+		i := lastSlash(s)
+		if i < 0 {
+			break
+		}
+		s = s[:i]
+		out = append(out, composite_error.ParseContext(s))
+	}
+	if c != "" {
+		out = append(out, "")
+	}
+	return out
+}
+
+func lastSlash(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '/' {
+			return i
+		}
+	}
+	return -1
+}
+
+// Reset clears all registrations. Test-only.
+func Reset() {
+	typeMu.Lock()
+	parserMu.Lock()
+	defer typeMu.Unlock()
+	defer parserMu.Unlock()
+
+	typeRegistry = map[composite_error.Type]func() composite_error.CompositeError{}
+	parsersByCtx = map[composite_error.ParseContext][]composite_error.Parser{}
+	allParsers = nil
+}

--- a/pkg/composite_error/catalog/catalog_test.go
+++ b/pkg/composite_error/catalog/catalog_test.go
@@ -1,0 +1,149 @@
+package catalog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+)
+
+// fakeError is a minimal CompositeError for catalog tests.
+type fakeError struct {
+	Msg string `json:"msg"`
+}
+
+func (f *fakeError) Type() composite_error.Type         { return "test_fake" }
+func (f *fakeError) Domain() composite_error.Domain     { return composite_error.DomainNuon }
+func (f *fakeError) Severity() composite_error.Severity { return composite_error.SeverityError }
+func (f *fakeError) Render(_ context.Context) composite_error.Render {
+	return composite_error.Render{Title: f.Msg}
+}
+
+type fakeParser struct {
+	name     string
+	contexts []composite_error.ParseContext
+}
+
+func (p fakeParser) Name() string                             { return p.name }
+func (p fakeParser) Version() string                          { return "1" }
+func (p fakeParser) Contexts() []composite_error.ParseContext { return p.contexts }
+func (p fakeParser) Parse(_ context.Context, _ composite_error.ParseInput) composite_error.ParseResult {
+	return composite_error.ParseResult{Matched: false}
+}
+
+func TestRegisterTypeAndHydrate(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	RegisterType("test_fake", func() composite_error.CompositeError { return &fakeError{} })
+
+	got, err := Hydrate("test_fake", []byte(`{"msg":"hello"}`))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	fe, ok := got.(*fakeError)
+	require.True(t, ok)
+	assert.Equal(t, "hello", fe.Msg)
+}
+
+func TestRegisterTypePanicsOnDuplicate(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	RegisterType("test_fake", func() composite_error.CompositeError { return &fakeError{} })
+	assert.Panics(t, func() {
+		RegisterType("test_fake", func() composite_error.CompositeError { return &fakeError{} })
+	})
+}
+
+func TestHydrateUnknownTypeErrors(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	_, err := Hydrate("not_registered", []byte(`{}`))
+	assert.Error(t, err)
+}
+
+func TestRegisterParserPanicsWithoutContexts(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	assert.Panics(t, func() {
+		RegisterParser(fakeParser{name: "no-ctx", contexts: nil})
+	})
+}
+
+func TestParsersForContextWalksAncestors(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	root := fakeParser{name: "root", contexts: []composite_error.ParseContext{""}}
+	tf := fakeParser{name: "tf", contexts: []composite_error.ParseContext{"terraform"}}
+	tfPlan := fakeParser{name: "tf-plan", contexts: []composite_error.ParseContext{"terraform/plan"}}
+	helm := fakeParser{name: "helm", contexts: []composite_error.ParseContext{"helm"}}
+
+	RegisterParser(root)
+	RegisterParser(tf)
+	RegisterParser(tfPlan)
+	RegisterParser(helm)
+
+	got := ParsersForContext("terraform/plan")
+	require.Len(t, got, 3, "should return tf-plan + tf + root, not helm")
+	assert.Equal(t, "tf-plan", got[0].Name(), "most-specific first")
+	assert.Equal(t, "tf", got[1].Name())
+	assert.Equal(t, "root", got[2].Name())
+}
+
+func TestParsersForContextOnlyTerraform(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	tf := fakeParser{name: "tf", contexts: []composite_error.ParseContext{"terraform"}}
+	helm := fakeParser{name: "helm", contexts: []composite_error.ParseContext{"helm"}}
+	RegisterParser(tf)
+	RegisterParser(helm)
+
+	got := ParsersForContext("terraform/apply")
+	require.Len(t, got, 1)
+	assert.Equal(t, "tf", got[0].Name())
+}
+
+func TestParserCanRegisterAcrossSubtrees(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	cross := fakeParser{
+		name:     "aws-perm",
+		contexts: []composite_error.ParseContext{"terraform", "helm", "runner/job"},
+	}
+	RegisterParser(cross)
+
+	for _, ctx := range []composite_error.ParseContext{
+		"terraform/plan", "terraform/apply", "helm/install", "runner/job",
+	} {
+		got := ParsersForContext(ctx)
+		require.Len(t, got, 1, ctx)
+		assert.Equal(t, "aws-perm", got[0].Name())
+	}
+
+	// Unrelated context: no match.
+	assert.Len(t, ParsersForContext("kubernetes/rollout"), 0)
+}
+
+func TestAncestorsOf(t *testing.T) {
+	cases := []struct {
+		in   composite_error.ParseContext
+		want []composite_error.ParseContext
+	}{
+		{"", []composite_error.ParseContext{""}},
+		{"terraform", []composite_error.ParseContext{"terraform", ""}},
+		{"terraform/plan", []composite_error.ParseContext{"terraform/plan", "terraform", ""}},
+		{"a/b/c", []composite_error.ParseContext{"a/b/c", "a/b", "a", ""}},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, ancestorsOf(tc.in), string(tc.in))
+	}
+}

--- a/pkg/composite_error/directive.go
+++ b/pkg/composite_error/directive.go
@@ -1,0 +1,52 @@
+package composite_error
+
+// DirectiveKind aligns with WorkflowStep.ResultDirective so the conductor can
+// apply an override without translation.
+type DirectiveKind string
+
+const (
+	// DirectiveNone is the zero value — "no opinion, defer to signal defaults".
+	DirectiveNone DirectiveKind = ""
+
+	DirectiveContinue      DirectiveKind = "continue"
+	DirectiveStop          DirectiveKind = "stop"
+	DirectiveRetry         DirectiveKind = "retry"
+	DirectiveRetryGroup    DirectiveKind = "retry-group"
+	DirectiveSkipGroup     DirectiveKind = "skip-group"
+	DirectiveAwaitApproval DirectiveKind = "await-approval"
+)
+
+// Directive is the override an error type can apply to a step's outcome.
+// Returned by ErrorWithDirective.OverrideDirective().
+//
+// The struct shape is intentional: future fields (MaxRetries, Backoff, …) can be
+// added without breaking the capability interface.
+type Directive struct {
+	Kind DirectiveKind `json:"kind"`
+}
+
+// ErrorWithDirective is implemented by error types that override the conductor's
+// default directive for a failed step.
+//
+// Returning Directive{Kind: DirectiveNone} (the zero value) means the type has
+// no opinion and the signal's default applies.
+type ErrorWithDirective interface {
+	OverrideDirective() Directive
+}
+
+// ErrorWithDocsLink is implemented by error types that point at a docs page.
+type ErrorWithDocsLink interface {
+	DocsURL() string
+}
+
+// ErrorWithReferences is implemented by error types that declare static
+// references in addition to anything the parser attaches dynamically.
+type ErrorWithReferences interface {
+	References() []Reference
+}
+
+// ErrorWithJSONSchema is implemented by error types that provide a JSON Schema
+// for their Data payload, validated by helpers.Record() before persisting.
+type ErrorWithJSONSchema interface {
+	JSONSchema() []byte
+}

--- a/pkg/composite_error/error.go
+++ b/pkg/composite_error/error.go
@@ -1,0 +1,103 @@
+// Package composite_error defines the typed, catalogable error abstraction
+// used across the Nuon platform.
+//
+// See specs/composite-errors.md for design rationale.
+//
+// At a high level:
+//
+//   - A CompositeError is a typed Go value (one struct per error type)
+//     that knows how to render itself for users.
+//   - Each type registers a factory in the in-memory catalog via init(),
+//     mirroring how queue signals are registered.
+//   - Parsers (also registered in the catalog) consume raw error material
+//     (Temporal errors, runner stderr, terraform output, …) and emit
+//     typed CompositeErrors.
+//   - The conductor honors optional capability interfaces on a CompositeError
+//     to override step directives (fail-fast, retry, downgrade, …).
+package composite_error
+
+import "context"
+
+// Type is the catalog identifier for a CompositeError implementation.
+// Stored on the persisted row and used to look up the factory in the catalog.
+type Type string
+
+// Domain is the broad classification of an error — what kind of error it is,
+// not where it came from. Domain is flat (no hierarchy) and lives on the row
+// for filtering, metrics, and UI grouping.
+type Domain string
+
+// Standard domains. New domains are introduced as needed; kept short and stable.
+const (
+	DomainNuon       Domain = "nuon"
+	DomainTerraform  Domain = "terraform"
+	DomainHelm       Domain = "helm"
+	DomainKubernetes Domain = "kubernetes"
+	DomainAWS        Domain = "aws"
+	DomainGCP        Domain = "gcp"
+	DomainAzure      Domain = "azure"
+	DomainRunner     Domain = "runner"
+)
+
+// Severity controls whether the error blocks workflow progress and how the UI
+// presents it. The conductor reacts to OverrideDirective(), not Severity —
+// severity is a UX concept.
+type Severity string
+
+const (
+	SeverityFatal   Severity = "fatal"
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+	SeverityInfo    Severity = "info"
+)
+
+// CompositeError is the typed, in-memory view of a stored composite error.
+// Implementations live in services/ctl-api/internal/app/composite_errors/types/<name>/.
+//
+// A CompositeError MUST be JSON round-trippable: marshalling the implementing
+// struct and unmarshalling into a fresh value from the catalog factory must
+// yield an equivalent value. The stored JSONB column holds exactly the JSON
+// representation of the implementing struct.
+type CompositeError interface {
+	Type() Type
+	Domain() Domain
+	Severity() Severity
+
+	// Render produces the user-facing view from the typed fields on the
+	// implementing struct. Always called at read time. The Title/Summary
+	// columns on the persisted row are denormalized copies populated from
+	// Render() at write time, used only for admin search/listing.
+	Render(ctx context.Context) Render
+}
+
+// Render is the user-facing payload computed from a CompositeError's
+// typed fields.
+type Render struct {
+	Title       string          `json:"title"`
+	Summary     string          `json:"summary,omitempty"`
+	Sections    []RenderSection `json:"sections,omitempty"`
+	UserActions []UserAction    `json:"user_actions,omitempty"`
+}
+
+// RenderSection is a heading + markdown body. Sections are rendered in order
+// and typically follow a what / why / how-to-fix structure.
+type RenderSection struct {
+	Heading string `json:"heading"`
+	Body    string `json:"body"`
+}
+
+// UserAction is a structured CTA the UI can render as a button or chip.
+type UserAction struct {
+	Kind  UserActionKind `json:"kind"`
+	Label string         `json:"label"`
+	Value string         `json:"value,omitempty"` // url, snippet, command, etc.
+}
+
+type UserActionKind string
+
+const (
+	UserActionKindLink    UserActionKind = "link"
+	UserActionKindCopy    UserActionKind = "copy"
+	UserActionKindCommand UserActionKind = "command"
+	UserActionKindRetry   UserActionKind = "retry"
+)

--- a/pkg/composite_error/parser.go
+++ b/pkg/composite_error/parser.go
@@ -1,0 +1,102 @@
+package composite_error
+
+import "context"
+
+// ParseContext is a hierarchical, "/"-separated path identifying the producer
+// of the raw error material being parsed. Examples:
+//
+//	"terraform"
+//	"terraform/plan"
+//	"terraform/apply"
+//	"helm/install"
+//	"helm/install/rbac"
+//	"kubernetes/rollout"
+//	"runner/job"
+//	"build/helm"
+//
+// Parsers register against one or more ParseContexts and each entry matches
+// itself plus all descendants. ParseContext is purely a dispatch concept and
+// is never persisted on a CompositeError row — that's what Domain is for.
+type ParseContext string
+
+// ParseInput is what the dispatch pipeline hands to a parser.
+//
+// The pipeline does not require every field to be set. A parser examines what
+// it cares about and returns Matched=false if the input doesn't apply.
+type ParseInput struct {
+	// Raw is the bytes the producer emitted (stderr, stdout, log buffer, …).
+	Raw []byte
+
+	// ExitCode of the producing process, if applicable.
+	ExitCode int
+
+	// GoErr is the original Go/Temporal error chain. Parsers should generally
+	// route through the cleaned form using HumanError() when text-matching.
+	GoErr error
+
+	// Invocation describes who/what produced Raw. Used by parsers that need
+	// component-aware context.
+	Invocation InvocationContext
+}
+
+// InvocationContext is the metadata about who/what produced the raw input.
+// Optional and best-effort — parsers must tolerate empty fields.
+type InvocationContext struct {
+	OrgID     string
+	OwnerID   string
+	OwnerType string
+
+	ComponentID   string
+	ComponentType string // "terraform_module", "helm_chart", "docker_build", ...
+
+	InstallID string
+	BuildID   string
+	StepID    string
+
+	// CloudPlatform is "aws" / "gcp" / "azure" if known.
+	CloudPlatform string
+
+	// Extra is a free-form bag for parser-specific hints.
+	Extra map[string]any
+}
+
+// ParseResult is what a parser returns.
+//
+// Matched=false means "this parser does not claim the input"; Error/Source/Refs
+// are ignored. Causes is a recursive list of sub-results that, when this result
+// becomes the primary, become children in the cause graph.
+type ParseResult struct {
+	Matched bool
+	Error   CompositeError
+	Source  Source
+	Refs    []Reference
+	Causes  []ParseResult
+}
+
+// Parser turns raw error material into a typed CompositeError.
+//
+// Implementations live alongside their error type in
+// services/ctl-api/internal/app/composite_errors/types/<name>/parser.go and
+// register themselves into the parser catalog via init().
+//
+// Parsers MUST be best-effort, fast, and side-effect-free. The pipeline
+// recovers panics, but a parser that panics on every call drowns the failure
+// path in noise.
+type Parser interface {
+	// Name is the stable, human-readable identifier of the parser. Persisted
+	// on the resulting CompositeError row's Source.ParserName for traceability.
+	Name() string
+
+	// Version is incremented when the parser's matching/extraction logic
+	// changes in a way that would produce different output for the same input.
+	Version() string
+
+	// Contexts declares the ParseContext subtrees this parser opts into.
+	// Each entry matches itself + descendants. An empty slice is a registration
+	// error — every parser must opt in to at least one subtree.
+	Contexts() []ParseContext
+
+	// Parse examines the input and returns a ParseResult. If the input is not
+	// a match, return ParseResult{Matched: false}.
+	Parse(ctx context.Context, in ParseInput) ParseResult
+}

--- a/pkg/composite_error/pipeline.go
+++ b/pkg/composite_error/pipeline.go
@@ -1,0 +1,106 @@
+package composite_error
+
+import (
+	"context"
+	"fmt"
+)
+
+// ParserLookup returns parsers applicable to a ParseContext, ordered
+// most-specific → least-specific. The catalog package implements this against
+// its in-memory registry; tests can substitute a stub.
+type ParserLookup func(ParseContext) []Parser
+
+// UnknownErrorBuilder constructs the safety-net result when no parser matches.
+// Provided by the unknown_error type's package via SetUnknownBuilder().
+type UnknownErrorBuilder func(in ParseInput) ParseResult
+
+// Pipeline dispatches ParseInput to registered parsers and produces a
+// PipelineResult: a primary CompositeError plus zero-or-more secondaries.
+//
+// Pipeline is stateless and safe for concurrent use.
+type Pipeline struct {
+	lookup  ParserLookup
+	unknown UnknownErrorBuilder
+}
+
+// NewPipeline constructs a Pipeline. Both arguments are required:
+//
+//   - lookup is typically catalog.ParsersForContext.
+//   - unknown is typically the factory the unknown_error package exposes.
+func NewPipeline(lookup ParserLookup, unknown UnknownErrorBuilder) *Pipeline {
+	return &Pipeline{lookup: lookup, unknown: unknown}
+}
+
+// PipelineResult is the output of Pipeline.Parse.
+type PipelineResult struct {
+	// Primary is the headline error to attach to the owner. Always non-nil.
+	Primary ParseResult
+
+	// Secondaries are additional matches at any level that the caller may
+	// also persist as separate rows on the same owner.
+	Secondaries []ParseResult
+}
+
+// Parse runs the parsers registered for ctx against in and returns a
+// PipelineResult.
+//
+// Dispatch rule:
+//
+//  1. Walk ancestors of ctx, most-specific → least-specific.
+//  2. At each level, run every registered parser in registration order.
+//  3. The first matching result at the most-specific level becomes Primary.
+//  4. All other matches at any level become Secondaries.
+//  5. If nothing matches, fall back to the unknown error builder.
+//
+// Parser panics are recovered and treated as a non-match.
+func (p *Pipeline) Parse(ctx context.Context, parseCtx ParseContext, in ParseInput) PipelineResult {
+	if p.lookup == nil {
+		return PipelineResult{Primary: p.fallback(in)}
+	}
+
+	parsers := p.lookup(parseCtx)
+
+	var primary *ParseResult
+	var secondaries []ParseResult
+
+	for _, parser := range parsers {
+		res := safeParse(ctx, parser, in)
+		if !res.Matched || res.Error == nil {
+			continue
+		}
+		if primary == nil {
+			primary = &res
+			continue
+		}
+		secondaries = append(secondaries, res)
+	}
+
+	if primary == nil {
+		return PipelineResult{Primary: p.fallback(in)}
+	}
+
+	return PipelineResult{Primary: *primary, Secondaries: secondaries}
+}
+
+// fallback returns the unknown_error result. If no builder is wired, returns
+// a Matched=false envelope so callers can decide what to do (helpers will
+// upgrade this into a synthetic unknown row).
+func (p *Pipeline) fallback(in ParseInput) ParseResult {
+	if p.unknown != nil {
+		return p.unknown(in)
+	}
+	return ParseResult{Matched: false}
+}
+
+func safeParse(ctx context.Context, parser Parser, in ParseInput) (out ParseResult) {
+	defer func() {
+		if r := recover(); r != nil {
+			// A parser panic must never break the failure path.
+			// Log via the standard library so we don't bring a logger
+			// into the core package; helpers add structured logging.
+			fmt.Printf("composite_error: parser %q panicked: %v\n", parser.Name(), r)
+			out = ParseResult{Matched: false}
+		}
+	}()
+	return parser.Parse(ctx, in)
+}

--- a/pkg/composite_error/pipeline_test.go
+++ b/pkg/composite_error/pipeline_test.go
@@ -1,0 +1,112 @@
+package composite_error
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubError is a minimal CompositeError used only by pipeline tests.
+type stubError struct {
+	id string
+}
+
+func (s *stubError) Type() Type                      { return Type(s.id) }
+func (s *stubError) Domain() Domain                  { return DomainNuon }
+func (s *stubError) Severity() Severity              { return SeverityError }
+func (s *stubError) Render(_ context.Context) Render { return Render{Title: s.id} }
+
+// stubParser is a deterministic parser fixture.
+type stubParser struct {
+	name     string
+	matches  bool
+	emit     string
+	contexts []ParseContext
+	calls    int
+	panics   bool
+}
+
+func (s *stubParser) Name() string             { return s.name }
+func (s *stubParser) Version() string          { return "1" }
+func (s *stubParser) Contexts() []ParseContext { return s.contexts }
+func (s *stubParser) Parse(_ context.Context, _ ParseInput) ParseResult {
+	s.calls++
+	if s.panics {
+		panic("boom")
+	}
+	if !s.matches {
+		return ParseResult{Matched: false}
+	}
+	return ParseResult{Matched: true, Error: &stubError{id: s.emit}}
+}
+
+// staticLookup builds a ParserLookup from a static list, walking ancestors
+// most-specific first, the same way the catalog does.
+func staticLookup(specific, broad []Parser) ParserLookup {
+	return func(_ ParseContext) []Parser {
+		out := append([]Parser{}, specific...)
+		out = append(out, broad...)
+		return out
+	}
+}
+
+func unknownBuilder(in ParseInput) ParseResult {
+	return ParseResult{Matched: true, Error: &stubError{id: "unknown"}}
+}
+
+func TestPipeline_FirstMatchWinsAsPrimary(t *testing.T) {
+	specific := &stubParser{name: "specific", matches: true, emit: "specific_err"}
+	broad := &stubParser{name: "broad", matches: true, emit: "broad_err"}
+
+	p := NewPipeline(staticLookup([]Parser{specific}, []Parser{broad}), unknownBuilder)
+	res := p.Parse(context.Background(), "terraform/plan", ParseInput{})
+
+	require.NotNil(t, res.Primary.Error)
+	assert.Equal(t, "specific_err", string(res.Primary.Error.Type()), "specific parser at higher specificity wins")
+	require.Len(t, res.Secondaries, 1, "broader match becomes a secondary")
+	assert.Equal(t, "broad_err", string(res.Secondaries[0].Error.Type()))
+}
+
+func TestPipeline_FallsBackToUnknownWhenNoMatch(t *testing.T) {
+	a := &stubParser{name: "a", matches: false}
+	b := &stubParser{name: "b", matches: false}
+
+	p := NewPipeline(staticLookup([]Parser{a}, []Parser{b}), unknownBuilder)
+	res := p.Parse(context.Background(), "terraform", ParseInput{})
+
+	require.NotNil(t, res.Primary.Error)
+	assert.Equal(t, "unknown", string(res.Primary.Error.Type()))
+	assert.Empty(t, res.Secondaries)
+	assert.Equal(t, 1, a.calls)
+	assert.Equal(t, 1, b.calls)
+}
+
+func TestPipeline_PanickingParserDoesNotBreak(t *testing.T) {
+	bomb := &stubParser{name: "bomb", panics: true, contexts: []ParseContext{"terraform"}}
+	good := &stubParser{name: "good", matches: true, emit: "ok"}
+
+	p := NewPipeline(staticLookup([]Parser{bomb}, []Parser{good}), unknownBuilder)
+	res := p.Parse(context.Background(), "terraform/apply", ParseInput{})
+
+	require.NotNil(t, res.Primary.Error)
+	assert.Equal(t, "ok", string(res.Primary.Error.Type()), "good parser still wins after bomb is recovered")
+}
+
+func TestPipeline_SafetyNetWhenLookupNil(t *testing.T) {
+	p := NewPipeline(nil, unknownBuilder)
+	res := p.Parse(context.Background(), "anything", ParseInput{})
+	assert.Equal(t, "unknown", string(res.Primary.Error.Type()))
+}
+
+func TestPipeline_NonMatchedResultIgnored(t *testing.T) {
+	half := &stubParser{name: "half", matches: false}
+	good := &stubParser{name: "good", matches: true, emit: "got"}
+
+	p := NewPipeline(staticLookup([]Parser{half, good}, nil), unknownBuilder)
+	res := p.Parse(context.Background(), "terraform", ParseInput{})
+
+	assert.Equal(t, "got", string(res.Primary.Error.Type()))
+	assert.Empty(t, res.Secondaries)
+}

--- a/pkg/composite_error/reference.go
+++ b/pkg/composite_error/reference.go
@@ -1,0 +1,50 @@
+package composite_error
+
+// ReferenceType enumerates the kinds of things a CompositeError can point at
+// for dynamic resolution at read time.
+type ReferenceType string
+
+const (
+	RefTypeLogStream                ReferenceType = "log_stream"
+	RefTypeRunnerJobExecution       ReferenceType = "runner_job_execution"
+	RefTypeRunnerJobExecutionResult ReferenceType = "runner_job_execution_result"
+	RefTypeTerraformPlanResult      ReferenceType = "terraform_plan_result"
+	RefTypeWorkflowStep             ReferenceType = "workflow_step"
+	RefTypeInstallDeploy            ReferenceType = "install_deploy"
+	RefTypeComponentBuild           ReferenceType = "component_build"
+	RefTypeDocURL                   ReferenceType = "doc_url"
+	RefTypeRunbookURL               ReferenceType = "runbook_url"
+)
+
+// Reference points at another entity (or a URL) that the UI can dereference
+// lazily. Keeps bulk material out of the persisted error row.
+type Reference struct {
+	Type  ReferenceType  `json:"type"`
+	ID    string         `json:"id,omitempty"` // entity id, or url for *_url types
+	Label string         `json:"label,omitempty"`
+	Meta  map[string]any `json:"meta,omitempty"` // renderer-specific (e.g. {"start_line": 1421})
+}
+
+// Source captures the parser-input snippet that produced an error, plus
+// identifiers for the parser that classified it. Kept small (capped) so
+// debugging parser decisions doesn't require re-running the producing job.
+type Source struct {
+	ParserName    string `json:"parser_name,omitempty"`
+	ParserVersion string `json:"parser_version,omitempty"`
+	Snippet       string `json:"snippet,omitempty"` // capped at SourceSnippetMax bytes
+	ExitCode      *int   `json:"exit_code,omitempty"`
+	GoError       string `json:"go_error,omitempty"` // HumanError() output of the producing Go error
+}
+
+// SourceSnippetMax caps how much raw input we persist on a CompositeError row.
+const SourceSnippetMax = 8 * 1024
+
+// CapSnippet truncates s to at most SourceSnippetMax bytes, appending an
+// ellipsis marker when truncation occurs.
+func CapSnippet(s string) string {
+	if len(s) <= SourceSnippetMax {
+		return s
+	}
+	const marker = "\n…[truncated]"
+	return s[:SourceSnippetMax-len(marker)] + marker
+}

--- a/services/ctl-api/internal/app/composite_errors/doc.go
+++ b/services/ctl-api/internal/app/composite_errors/doc.go
@@ -1,0 +1,14 @@
+// Package composite_errors is the umbrella for the typed CompositeError
+// implementations registered into the catalog at process start.
+//
+// Each error type lives in its own subpackage under types/<name>/ and
+// registers itself via init():
+//
+//   - aws_missing_iam_permission
+//   - terraform_apply_failed
+//   - unknown_error
+//
+// Importing this package directly does NOT register types — callers must
+// import the desired type packages individually (or the umbrella `register`
+// package, see register.go) so init() runs.
+package composite_errors

--- a/services/ctl-api/internal/app/composite_errors/integration_test.go
+++ b/services/ctl-api/internal/app/composite_errors/integration_test.go
@@ -1,0 +1,131 @@
+package composite_errors_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+	"github.com/nuonco/nuon/pkg/composite_error/catalog"
+
+	// Side-effect imports register every built-in CompositeError type.
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/composite_errors/register"
+
+	awsperm "github.com/nuonco/nuon/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission"
+	tferr "github.com/nuonco/nuon/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed"
+	unknown "github.com/nuonco/nuon/services/ctl-api/internal/app/composite_errors/types/unknown_error"
+)
+
+// loadFixture pulls a testdata file from one of the type subpackages.
+func loadFixture(t *testing.T, typeDir, name string) []byte {
+	t.Helper()
+	p := filepath.Join("types", typeDir, "testdata", name)
+	b, err := os.ReadFile(p)
+	require.NoError(t, err)
+	return b
+}
+
+// pipeline returns a Pipeline wired against the real catalog and the
+// unknown_error fallback builder.
+func pipeline() *composite_error.Pipeline {
+	return composite_error.NewPipeline(catalog.ParsersForContext, unknown.Build)
+}
+
+// TestEndToEnd_AWSPermissionWinsOverGenericTerraform verifies that when both
+// the broad terraform parser and the cross-cutting AWS parser match the same
+// input, the more specific (parser-declared) AWS one becomes the primary and
+// the broader terraform diagnostic becomes a secondary.
+//
+// In v1, "specificity" is determined by parser order at the same registration
+// level. Both parsers register at the "terraform" subtree, so order matters —
+// AWS is intentionally registered first by the type package's init.
+func TestEndToEnd_AWSPermissionWinsOverGenericTerraform(t *testing.T) {
+	raw := loadFixture(t, "aws_missing_iam_permission", "terraform_apply_access_denied.txt")
+
+	res := pipeline().Parse(context.Background(), "terraform/apply", composite_error.ParseInput{
+		Raw: raw,
+		Invocation: composite_error.InvocationContext{
+			OwnerType:     "install_apply_step",
+			CloudPlatform: "aws",
+		},
+	})
+
+	require.NotNil(t, res.Primary.Error)
+	assert.Equal(t, awsperm.Type, res.Primary.Error.Type(), "AWS perm parser should claim the input")
+
+	// The terraform broad parser also matches and becomes a secondary.
+	require.Len(t, res.Secondaries, 1)
+	assert.Equal(t, tferr.Type, res.Secondaries[0].Error.Type())
+}
+
+// TestEndToEnd_GenericTerraformDiagnosticOnNonAWSError verifies that a
+// terraform error which is not an AWS permission failure falls through to
+// the broad terraform parser as primary, with no secondaries.
+func TestEndToEnd_GenericTerraformDiagnosticOnNonAWSError(t *testing.T) {
+	raw := loadFixture(t, "terraform_apply_failed", "terraform_apply_subnet_failure.txt")
+
+	res := pipeline().Parse(context.Background(), "terraform/apply", composite_error.ParseInput{
+		Raw: raw,
+	})
+
+	require.NotNil(t, res.Primary.Error)
+	assert.Equal(t, tferr.Type, res.Primary.Error.Type())
+	assert.Empty(t, res.Secondaries)
+
+	te := res.Primary.Error.(*tferr.Error)
+	require.Len(t, te.Diagnostics, 1)
+	assert.Contains(t, te.Diagnostics[0].Summary, "InvalidSubnet.Range")
+}
+
+// TestEndToEnd_UnknownFallback verifies the safety-net behaviour: input that
+// no parser claims yields a single unknown_error primary.
+func TestEndToEnd_UnknownFallback(t *testing.T) {
+	res := pipeline().Parse(context.Background(), "kubernetes/rollout", composite_error.ParseInput{
+		Raw: []byte("a wild error appeared"),
+	})
+
+	require.NotNil(t, res.Primary.Error)
+	assert.Equal(t, unknown.Type, res.Primary.Error.Type())
+	assert.Empty(t, res.Secondaries)
+}
+
+// TestEndToEnd_HydrateRoundTrip verifies the persistence round-trip:
+// marshal a typed error → store as JSON → hydrate via the catalog → render.
+//
+// This is the contract the DB layer will rely on once helpers.Record() lands.
+func TestEndToEnd_HydrateRoundTrip(t *testing.T) {
+	original := &awsperm.Error{
+		Action:    "ec2:CreateVpc",
+		Resource:  "*",
+		Principal: "arn:aws:iam::1:role/runner",
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	got, err := catalog.Hydrate(awsperm.Type, data)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, awsperm.Type, got.Type())
+
+	rendered := got.Render(context.Background())
+	assert.Contains(t, rendered.Title, "ec2:CreateVpc")
+}
+
+// TestEndToEnd_PipelineHonorsParseContextScoping verifies the AWS perm parser
+// does not run for kubernetes/rollout (it only opts into terraform, helm, and
+// runner/job).
+func TestEndToEnd_PipelineHonorsParseContextScoping(t *testing.T) {
+	// An input that WOULD match the AWS parser if it ran, but kubernetes/rollout
+	// is outside its declared subtrees, so it should fall back to unknown.
+	res := pipeline().Parse(context.Background(), "kubernetes/rollout", composite_error.ParseInput{
+		Raw: []byte("AccessDenied: User: arn:aws:iam::1:role/r is not authorized to perform: s3:GetObject on resource: arn:aws:s3:::x"),
+	})
+
+	assert.Equal(t, unknown.Type, res.Primary.Error.Type())
+}

--- a/services/ctl-api/internal/app/composite_errors/register/register.go
+++ b/services/ctl-api/internal/app/composite_errors/register/register.go
@@ -1,0 +1,16 @@
+// Package register is a convenience umbrella that registers every built-in
+// CompositeError type into the catalog at process start.
+//
+// Importing this package with the blank identifier:
+//
+//	import _ "github.com/nuonco/nuon/services/ctl-api/internal/app/composite_errors/register"
+//
+// runs the init() of every type subpackage. Callers that only want a subset
+// of types can import the individual packages directly.
+package register
+
+import (
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission"
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed"
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/composite_errors/types/unknown_error"
+)

--- a/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission/error.go
+++ b/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission/error.go
@@ -1,0 +1,143 @@
+// Package aws_missing_iam_permission is the cross-cutting CompositeError for
+// AWS API calls that fail with AccessDenied / UnauthorizedOperation errors
+// because the caller's IAM principal is missing a permission.
+//
+// This is the showcase parser: it can be triggered from terraform-plan,
+// terraform-apply, helm-install (when EKS providers fail to assume a role),
+// or runner-job output (when the runner itself lacks a permission). The
+// parser registers against multiple ParseContext subtrees rather than a
+// single hierarchy node.
+package aws_missing_iam_permission
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+)
+
+const Type composite_error.Type = "aws_missing_iam_permission"
+
+// Error is the typed payload.
+type Error struct {
+	// Action is the IAM action the caller lacked, e.g. "ec2:CreateVpc",
+	// "s3:GetObject". May be empty if extraction failed (rare; the parser
+	// only matches when it's confident enough to populate this).
+	Action string `json:"action"`
+
+	// Resource is the ARN (or wildcard) the call targeted, when known.
+	Resource string `json:"resource,omitempty"`
+
+	// Principal is the IAM principal ARN the call was made as, when known.
+	Principal string `json:"principal,omitempty"`
+
+	// AWSErrorCode is the API error code we matched on (AccessDenied,
+	// UnauthorizedOperation, AccessDeniedException, …). Useful for the UI
+	// when surfacing related runbook links.
+	AWSErrorCode string `json:"aws_error_code,omitempty"`
+
+	// RawMessage is the AWS-emitted error message we extracted the fields from.
+	RawMessage string `json:"raw_message,omitempty"`
+}
+
+var _ composite_error.CompositeError = (*Error)(nil)
+var _ composite_error.ErrorWithDirective = (*Error)(nil)
+var _ composite_error.ErrorWithDocsLink = (*Error)(nil)
+
+func (e *Error) Type() composite_error.Type         { return Type }
+func (e *Error) Domain() composite_error.Domain     { return composite_error.DomainAWS }
+func (e *Error) Severity() composite_error.Severity { return composite_error.SeverityError }
+
+// OverrideDirective tells the conductor to stop retrying — auto-retrying an
+// IAM permission failure without user action is wasted work.
+func (e *Error) OverrideDirective() composite_error.Directive {
+	return composite_error.Directive{Kind: composite_error.DirectiveStop}
+}
+
+func (e *Error) DocsURL() string {
+	return "https://docs.nuon.co/troubleshooting/aws-iam-permissions"
+}
+
+func (e *Error) Render(_ context.Context) composite_error.Render {
+	r := composite_error.Render{}
+
+	if e.Action != "" {
+		r.Title = fmt.Sprintf("Missing AWS IAM permission: %s", e.Action)
+	} else {
+		r.Title = "Missing AWS IAM permission"
+	}
+
+	r.Summary = "The IAM principal used by this deployment is missing a permission required to perform the operation. Grant the permission to the principal and retry."
+
+	if e.RawMessage != "" {
+		r.Sections = append(r.Sections, composite_error.RenderSection{
+			Heading: "AWS response",
+			Body:    "```\n" + e.RawMessage + "\n```",
+		})
+	}
+
+	// Show the principal/resource so the user knows what role to edit.
+	if e.Principal != "" || e.Resource != "" {
+		var b strings.Builder
+		if e.Principal != "" {
+			fmt.Fprintf(&b, "Principal: `%s`\n", e.Principal)
+		}
+		if e.Resource != "" {
+			fmt.Fprintf(&b, "Resource: `%s`\n", e.Resource)
+		}
+		r.Sections = append(r.Sections, composite_error.RenderSection{
+			Heading: "Context",
+			Body:    strings.TrimRight(b.String(), "\n"),
+		})
+	}
+
+	// Always offer a copy-pasteable IAM policy fragment when we have the action.
+	if e.Action != "" {
+		r.Sections = append(r.Sections, composite_error.RenderSection{
+			Heading: "Suggested IAM policy statement",
+			Body:    "Add the following to the role used by this deployment:\n\n```json\n" + e.policyStatementJSON() + "\n```",
+		})
+		r.UserActions = append(r.UserActions, composite_error.UserAction{
+			Kind:  composite_error.UserActionKindCopy,
+			Label: "Copy IAM policy statement",
+			Value: e.policyStatementJSON(),
+		})
+	}
+
+	r.UserActions = append(r.UserActions,
+		composite_error.UserAction{
+			Kind:  composite_error.UserActionKindLink,
+			Label: "Troubleshooting docs",
+			Value: e.DocsURL(),
+		},
+		composite_error.UserAction{
+			Kind:  composite_error.UserActionKindRetry,
+			Label: "Retry after granting the permission",
+		},
+	)
+
+	return r
+}
+
+// policyStatementJSON renders a minimal IAM policy statement granting the
+// missing action on the resource (or "*" if the resource isn't known).
+func (e *Error) policyStatementJSON() string {
+	resource := e.Resource
+	if resource == "" {
+		resource = "*"
+	}
+	stmt := map[string]any{
+		"Version": "2012-10-17",
+		"Statement": []map[string]any{
+			{
+				"Effect":   "Allow",
+				"Action":   []string{e.Action},
+				"Resource": resource,
+			},
+		},
+	}
+	b, _ := json.MarshalIndent(stmt, "", "  ")
+	return string(b)
+}

--- a/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission/init.go
+++ b/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission/init.go
@@ -1,0 +1,13 @@
+package aws_missing_iam_permission
+
+import (
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+	"github.com/nuonco/nuon/pkg/composite_error/catalog"
+)
+
+func init() {
+	catalog.RegisterType(Type, func() composite_error.CompositeError {
+		return &Error{}
+	})
+	catalog.RegisterParser(Parser{})
+}

--- a/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission/parser.go
+++ b/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission/parser.go
@@ -1,0 +1,139 @@
+package aws_missing_iam_permission
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+)
+
+const (
+	parserName    = "aws.missing_iam_permission"
+	parserVersion = "1"
+)
+
+// Parser extracts AccessDenied / UnauthorizedOperation errors from any AWS-
+// touching context: terraform, helm (when terraform is the IaC backing it),
+// and runner-job output.
+//
+// The parser is conservative: it only matches when it can extract the IAM
+// action. If the action isn't recoverable, it returns Matched=false so the
+// broader parser (e.g. terraform_apply_failed) handles the input.
+type Parser struct{}
+
+var _ composite_error.Parser = (*Parser)(nil)
+
+func (Parser) Name() string    { return parserName }
+func (Parser) Version() string { return parserVersion }
+
+// Contexts: register against every subtree where AWS API calls happen.
+// Adding a new subtree (e.g. "build/terraform") is just a one-line addition
+// here — no need to re-register elsewhere.
+func (Parser) Contexts() []composite_error.ParseContext {
+	return []composite_error.ParseContext{
+		"terraform",
+		"helm",
+		"runner/job",
+	}
+}
+
+// Patterns we attempt, in order. Each must define named groups for "action",
+// and may define "principal" / "resource" / "code".
+var awsPatterns = []*regexp.Regexp{
+	// Classic AccessDenied with principal + action + resource.
+	// e.g. "User: arn:aws:iam::123456789012:user/foo is not authorized to perform: ec2:CreateVpc on resource: arn:aws:ec2:..."
+	regexp.MustCompile(
+		`(?P<code>AccessDenied(?:Exception)?|AuthorizationError):\s*(?:User|Principal):\s*(?P<principal>arn:[^\s]+)\s+is not authorized to perform:\s*(?P<action>[a-zA-Z0-9-]+:[a-zA-Z0-9*]+)(?:\s+on\s+resource:\s*(?P<resource>\S+))?`,
+	),
+	// Same shape without explicit AccessDenied prefix (some SDK clients).
+	regexp.MustCompile(
+		`(?:User|Principal):\s*(?P<principal>arn:[^\s]+)\s+is not authorized to perform:\s*(?P<action>[a-zA-Z0-9-]+:[a-zA-Z0-9*]+)(?:\s+on\s+resource:\s*(?P<resource>\S+))?`,
+	),
+	// EC2-style UnauthorizedOperation. Action lives in a separate sentence.
+	// e.g. "UnauthorizedOperation: You are not authorized to perform this operation. ... Operation: ec2:DescribeVpcs"
+	regexp.MustCompile(
+		`(?P<code>UnauthorizedOperation):[^\n]*?(?:Operation|operation):\s*(?P<action>[a-zA-Z0-9-]+:[a-zA-Z0-9*]+)`,
+	),
+}
+
+func (p Parser) Parse(_ context.Context, in composite_error.ParseInput) composite_error.ParseResult {
+	raw := string(in.Raw)
+	if !strings.Contains(raw, "AccessDenied") &&
+		!strings.Contains(raw, "UnauthorizedOperation") &&
+		!strings.Contains(raw, "not authorized to perform") &&
+		!strings.Contains(raw, "AuthorizationError") {
+		return composite_error.ParseResult{Matched: false}
+	}
+
+	for _, re := range awsPatterns {
+		match := re.FindStringSubmatch(raw)
+		if match == nil {
+			continue
+		}
+		fields := groupMap(re, match)
+		action := fields["action"]
+		if action == "" {
+			continue
+		}
+
+		e := &Error{
+			Action:       action,
+			Resource:     trimTrailingPunct(fields["resource"]),
+			Principal:    fields["principal"],
+			AWSErrorCode: fields["code"],
+			RawMessage:   extractRelevantLine(raw, match[0]),
+		}
+
+		return composite_error.ParseResult{
+			Matched: true,
+			Error:   e,
+			Source: composite_error.Source{
+				ParserName:    parserName,
+				ParserVersion: parserVersion,
+				Snippet:       composite_error.CapSnippet(raw),
+			},
+		}
+	}
+
+	return composite_error.ParseResult{Matched: false}
+}
+
+func groupMap(re *regexp.Regexp, match []string) map[string]string {
+	out := map[string]string{}
+	for i, name := range re.SubexpNames() {
+		if name == "" {
+			continue
+		}
+		if i < len(match) {
+			out[name] = match[i]
+		}
+	}
+	return out
+}
+
+// trimTrailingPunct strips trailing punctuation that often glues to ARNs
+// when AWS embeds them in sentences.
+func trimTrailingPunct(s string) string {
+	return strings.TrimRight(s, ".,;:")
+}
+
+// extractRelevantLine returns the line containing matchStr, trimmed of the
+// terraform "│ " prefix when present.
+func extractRelevantLine(raw, matchStr string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		if strings.Contains(line, firstFiftyChars(matchStr)) {
+			t := strings.TrimSpace(line)
+			t = strings.TrimPrefix(t, "│")
+			return strings.TrimSpace(t)
+		}
+	}
+	return strings.TrimSpace(matchStr)
+}
+
+func firstFiftyChars(s string) string {
+	if len(s) <= 50 {
+		return s
+	}
+	return s[:50]
+}

--- a/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission/parser_test.go
+++ b/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission/parser_test.go
@@ -1,0 +1,124 @@
+package aws_missing_iam_permission
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+)
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	return b
+}
+
+func TestParser_NoMatchOnUnrelatedInput(t *testing.T) {
+	p := Parser{}
+	res := p.Parse(context.Background(), composite_error.ParseInput{
+		Raw: []byte("Error: creating EC2 Subnet: InvalidSubnet.Range\n"),
+	})
+	assert.False(t, res.Matched, "non-IAM terraform errors should not match")
+}
+
+func TestParser_AccessDeniedExtractsActionPrincipalResource(t *testing.T) {
+	p := Parser{}
+	res := p.Parse(context.Background(), composite_error.ParseInput{
+		Raw: loadFixture(t, "terraform_apply_access_denied.txt"),
+	})
+	require.True(t, res.Matched)
+
+	e, ok := res.Error.(*Error)
+	require.True(t, ok)
+	assert.Equal(t, "s3:CreateBucket", e.Action)
+	assert.Equal(t, "arn:aws:s3:::acme-prod-assets", e.Resource)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/nuon-runner", e.Principal)
+	assert.Equal(t, "AccessDenied", e.AWSErrorCode)
+	assert.NotEmpty(t, e.RawMessage)
+}
+
+func TestParser_UnauthorizedOperationExtractsAction(t *testing.T) {
+	p := Parser{}
+	res := p.Parse(context.Background(), composite_error.ParseInput{
+		Raw: loadFixture(t, "ec2_unauthorized_operation.txt"),
+	})
+	require.True(t, res.Matched)
+
+	e := res.Error.(*Error)
+	assert.Equal(t, "ec2:CreateVpc", e.Action)
+	assert.Equal(t, "UnauthorizedOperation", e.AWSErrorCode)
+}
+
+func TestErrorOverridesDirectiveToStop(t *testing.T) {
+	var ce composite_error.CompositeError = &Error{Action: "s3:CreateBucket"}
+	od, ok := ce.(composite_error.ErrorWithDirective)
+	require.True(t, ok)
+	assert.Equal(t, composite_error.DirectiveStop, od.OverrideDirective().Kind)
+}
+
+func TestRender_IncludesPolicyStatement(t *testing.T) {
+	e := &Error{
+		Action:   "s3:GetObject",
+		Resource: "arn:aws:s3:::acme/*",
+	}
+	r := e.Render(context.Background())
+
+	assert.Contains(t, r.Title, "s3:GetObject")
+	require.NotEmpty(t, r.Sections)
+
+	var foundPolicy bool
+	for _, s := range r.Sections {
+		if s.Heading == "Suggested IAM policy statement" {
+			foundPolicy = true
+			assert.Contains(t, s.Body, "s3:GetObject")
+			assert.Contains(t, s.Body, "arn:aws:s3:::acme/*")
+		}
+	}
+	assert.True(t, foundPolicy)
+
+	// UserActions should include a copy + a docs link + a retry.
+	kinds := map[composite_error.UserActionKind]int{}
+	for _, ua := range r.UserActions {
+		kinds[ua.Kind]++
+	}
+	assert.Equal(t, 1, kinds[composite_error.UserActionKindCopy])
+	assert.Equal(t, 1, kinds[composite_error.UserActionKindLink])
+	assert.Equal(t, 1, kinds[composite_error.UserActionKindRetry])
+}
+
+func TestRender_PolicyStatementUsesWildcardWhenResourceUnknown(t *testing.T) {
+	e := &Error{Action: "ec2:DescribeVpcs"}
+	r := e.Render(context.Background())
+
+	var policy string
+	for _, s := range r.Sections {
+		if s.Heading == "Suggested IAM policy statement" {
+			policy = s.Body
+		}
+	}
+	require.NotEmpty(t, policy)
+	assert.Contains(t, policy, `"Resource": "*"`)
+}
+
+func TestErrorJSONRoundTrip(t *testing.T) {
+	original := &Error{
+		Action:       "s3:GetObject",
+		Resource:     "arn:aws:s3:::a/*",
+		Principal:    "arn:aws:iam::1:role/r",
+		AWSErrorCode: "AccessDenied",
+		RawMessage:   "User is not authorized",
+	}
+	b, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded Error
+	require.NoError(t, json.Unmarshal(b, &decoded))
+	assert.Equal(t, *original, decoded)
+}

--- a/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission/testdata/ec2_unauthorized_operation.txt
+++ b/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission/testdata/ec2_unauthorized_operation.txt
@@ -1,0 +1,10 @@
+module.network.aws_vpc.main: Creating...
+╷
+│ Error: creating EC2 VPC: UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message: aBcDeFgHiJkLmNoPqRsTuVwXyZ012345 Operation: ec2:CreateVpc
+│ 	status code: 403, request id: 11112222-aaaa-bbbb-cccc-333344445555
+│
+│   with module.network.aws_vpc.main,
+│   on .terraform/modules/network/vpc.tf line 8, in resource "aws_vpc" "main":
+│    8: resource "aws_vpc" "main" {
+│
+╵

--- a/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission/testdata/terraform_apply_access_denied.txt
+++ b/services/ctl-api/internal/app/composite_errors/types/aws_missing_iam_permission/testdata/terraform_apply_access_denied.txt
@@ -1,0 +1,10 @@
+module.app.aws_s3_bucket.assets: Creating...
+╷
+│ Error: creating S3 Bucket (acme-prod-assets): AccessDenied: User: arn:aws:iam::123456789012:role/nuon-runner is not authorized to perform: s3:CreateBucket on resource: arn:aws:s3:::acme-prod-assets because no identity-based policy allows the s3:CreateBucket action
+│ 	status code: 403, request id: D5E6F7G8H9, host id: abcDEF/123==
+│
+│   with module.app.aws_s3_bucket.assets,
+│   on main.tf line 42, in resource "aws_s3_bucket" "assets":
+│   42: resource "aws_s3_bucket" "assets" {
+│
+╵

--- a/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed/error.go
+++ b/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed/error.go
@@ -1,0 +1,113 @@
+// Package terraform_apply_failed is the broad CompositeError type for a failed
+// terraform run (init / plan / apply / destroy).
+//
+// It is the "generic" fallback for the terraform domain — when a more specific
+// parser (e.g. aws_missing_iam_permission) doesn't claim the input, this one
+// catches it and surfaces the resource-level diagnostics terraform prints.
+package terraform_apply_failed
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+)
+
+const Type composite_error.Type = "terraform_apply_failed"
+
+// Diagnostic is one resource-level error block emitted by terraform.
+//
+// Terraform's CLI output for an error block looks like:
+//
+//	╷
+//	│ Error: creating EC2 Subnet: ...
+//	│
+//	│   with module.vpc.aws_subnet.public[0],
+//	│   on .terraform/modules/vpc/main.tf line 218, in resource "aws_subnet" "public":
+//	│  218: resource "aws_subnet" "public" {
+//	│
+//	╵
+//
+// We capture the structured fields so the dashboard can render them as a
+// table; the raw block is preserved for fidelity.
+type Diagnostic struct {
+	Summary    string `json:"summary"`               // first "Error:" line, after the prefix
+	Resource   string `json:"resource,omitempty"`    // e.g. "module.vpc.aws_subnet.public[0]"
+	SourceFile string `json:"source_file,omitempty"` // e.g. ".terraform/modules/vpc/main.tf"
+	SourceLine int    `json:"source_line,omitempty"`
+	Raw        string `json:"raw,omitempty"`
+}
+
+// Error is the typed payload for a terraform_apply_failed CompositeError.
+type Error struct {
+	// Stage is "init" | "plan" | "apply" | "destroy" — best effort from
+	// the parser context.
+	Stage string `json:"stage,omitempty"`
+
+	// Diagnostics extracted from the terraform output. May be empty if no
+	// structured diagnostics were found, in which case Message holds the
+	// first line of the raw output.
+	Diagnostics []Diagnostic `json:"diagnostics,omitempty"`
+
+	// Message is a fallback short message when no diagnostics were extracted.
+	Message string `json:"message,omitempty"`
+}
+
+var _ composite_error.CompositeError = (*Error)(nil)
+
+func (e *Error) Type() composite_error.Type         { return Type }
+func (e *Error) Domain() composite_error.Domain     { return composite_error.DomainTerraform }
+func (e *Error) Severity() composite_error.Severity { return composite_error.SeverityError }
+
+func (e *Error) Render(_ context.Context) composite_error.Render {
+	stage := e.Stage
+	if stage == "" {
+		stage = "apply"
+	}
+
+	r := composite_error.Render{}
+
+	switch len(e.Diagnostics) {
+	case 0:
+		r.Title = fmt.Sprintf("Terraform %s failed", stage)
+		if e.Message != "" {
+			r.Summary = e.Message
+		}
+	case 1:
+		r.Title = fmt.Sprintf("Terraform %s failed: %s", stage, truncate(e.Diagnostics[0].Summary, 100))
+	default:
+		r.Title = fmt.Sprintf("Terraform %s failed with %d errors", stage, len(e.Diagnostics))
+		summaries := make([]string, 0, len(e.Diagnostics))
+		for _, d := range e.Diagnostics {
+			summaries = append(summaries, "• "+d.Summary)
+		}
+		r.Summary = strings.Join(summaries, "\n")
+	}
+
+	for _, d := range e.Diagnostics {
+		body := d.Summary
+		if d.Resource != "" {
+			body += fmt.Sprintf("\n\nResource: `%s`", d.Resource)
+		}
+		if d.SourceFile != "" {
+			body += fmt.Sprintf("\nLocation: `%s`", d.SourceFile)
+			if d.SourceLine > 0 {
+				body += fmt.Sprintf(" (line %d)", d.SourceLine)
+			}
+		}
+		r.Sections = append(r.Sections, composite_error.RenderSection{
+			Heading: "Error",
+			Body:    body,
+		})
+	}
+
+	return r
+}
+
+func truncate(s string, n int) string {
+	if n <= 0 || len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed/init.go
+++ b/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed/init.go
@@ -1,0 +1,13 @@
+package terraform_apply_failed
+
+import (
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+	"github.com/nuonco/nuon/pkg/composite_error/catalog"
+)
+
+func init() {
+	catalog.RegisterType(Type, func() composite_error.CompositeError {
+		return &Error{}
+	})
+	catalog.RegisterParser(Parser{})
+}

--- a/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed/parser.go
+++ b/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed/parser.go
@@ -1,0 +1,208 @@
+package terraform_apply_failed
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+)
+
+const (
+	parserName    = "terraform.generic"
+	parserVersion = "1"
+)
+
+// Parser implements the broad fallback for terraform output. It registers
+// against the entire "terraform" subtree so it runs for plan, apply, init,
+// and destroy contexts.
+type Parser struct{}
+
+var _ composite_error.Parser = (*Parser)(nil)
+
+func (Parser) Name() string    { return parserName }
+func (Parser) Version() string { return parserVersion }
+func (Parser) Contexts() []composite_error.ParseContext {
+	return []composite_error.ParseContext{"terraform"}
+}
+
+func (p Parser) Parse(_ context.Context, in composite_error.ParseInput) composite_error.ParseResult {
+	raw := string(in.Raw)
+	if !looksLikeTerraform(raw) {
+		return composite_error.ParseResult{Matched: false}
+	}
+
+	stage := stageFromContext(in.Invocation)
+	diagnostics := extractDiagnostics(raw)
+
+	e := &Error{
+		Stage:       stage,
+		Diagnostics: diagnostics,
+	}
+	if len(diagnostics) == 0 {
+		e.Message = firstNonEmptyLine(raw)
+	}
+
+	return composite_error.ParseResult{
+		Matched: true,
+		Error:   e,
+		Source: composite_error.Source{
+			ParserName:    parserName,
+			ParserVersion: parserVersion,
+			Snippet:       composite_error.CapSnippet(raw),
+		},
+	}
+}
+
+// looksLikeTerraform detects terraform CLI output. We accept either the
+// box-drawing diagnostic markers (╷ │ ╵) or one of the standard Error/Warning
+// prefixes followed by a colon.
+func looksLikeTerraform(s string) bool {
+	if strings.ContainsRune(s, '╷') || strings.ContainsRune(s, '╵') {
+		return true
+	}
+	for _, marker := range []string{"\nError:", "\n│ Error:", "Error: "} {
+		if strings.Contains(s, marker) {
+			return true
+		}
+	}
+	// Also accept first-line Error: prefix.
+	if strings.HasPrefix(strings.TrimSpace(s), "Error:") {
+		return true
+	}
+	return false
+}
+
+func stageFromContext(inv composite_error.InvocationContext) string {
+	if inv.Extra != nil {
+		if v, ok := inv.Extra["terraform_stage"].(string); ok && v != "" {
+			return v
+		}
+	}
+	// Best-effort guess from the OwnerType — refined as we wire more
+	// invocation sites.
+	switch {
+	case strings.Contains(inv.OwnerType, "plan"):
+		return "plan"
+	case strings.Contains(inv.OwnerType, "apply"):
+		return "apply"
+	case strings.Contains(inv.OwnerType, "destroy"):
+		return "destroy"
+	}
+	return ""
+}
+
+// firstNonEmptyLine returns the first non-empty line of s, trimmed.
+func firstNonEmptyLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// extractDiagnostics walks s and returns one Diagnostic per ╷…╵ block.
+//
+// Each block looks like:
+//
+//	╷
+//	│ Error: <summary>
+//	│
+//	│   with <resource>,
+//	│   on <file> line <n>, in resource "..." "...":
+//	│  <n>: ...
+//	│
+//	╵
+//
+// Lines inside the block start with "│ " (or "│" with no space).
+// We strip the prefix and parse "Error:", "with ...,", and "on ... line N,".
+func extractDiagnostics(s string) []Diagnostic {
+	var diags []Diagnostic
+	lines := strings.Split(s, "\n")
+
+	inBlock := false
+	var current []string
+	for _, line := range lines {
+		trim := strings.TrimRight(line, "\r")
+		switch {
+		case strings.HasPrefix(strings.TrimSpace(trim), "╷"):
+			inBlock = true
+			current = nil
+		case strings.HasPrefix(strings.TrimSpace(trim), "╵"):
+			if inBlock {
+				if d, ok := parseBlock(current); ok {
+					diags = append(diags, d)
+				}
+			}
+			inBlock = false
+			current = nil
+		case inBlock:
+			current = append(current, stripBlockPrefix(trim))
+		}
+	}
+
+	// Also catch ungroup'd "Error: ..." lines that didn't appear inside a
+	// box (older terraform versions, certain providers).
+	if len(diags) == 0 {
+		if d, ok := parseLooseError(s); ok {
+			diags = append(diags, d)
+		}
+	}
+
+	return diags
+}
+
+func stripBlockPrefix(line string) string {
+	t := strings.TrimSpace(line)
+	t = strings.TrimPrefix(t, "│")
+	if strings.HasPrefix(t, " ") {
+		t = t[1:]
+	}
+	return t
+}
+
+var (
+	resourceRegex = regexp.MustCompile(`^\s*with\s+([^,]+),\s*$`)
+	locationRegex = regexp.MustCompile(`^\s*on\s+(\S+)\s+line\s+(\d+)`)
+)
+
+func parseBlock(lines []string) (Diagnostic, bool) {
+	var d Diagnostic
+	for _, l := range lines {
+		switch {
+		case strings.HasPrefix(l, "Error:"):
+			d.Summary = strings.TrimSpace(strings.TrimPrefix(l, "Error:"))
+		case d.Resource == "":
+			if m := resourceRegex.FindStringSubmatch(l); m != nil {
+				d.Resource = strings.TrimSpace(m[1])
+			}
+		}
+		if m := locationRegex.FindStringSubmatch(l); m != nil {
+			d.SourceFile = m[1]
+			if n, err := strconv.Atoi(m[2]); err == nil {
+				d.SourceLine = n
+			}
+		}
+	}
+	d.Raw = strings.Join(lines, "\n")
+	if d.Summary == "" {
+		return Diagnostic{}, false
+	}
+	return d, true
+}
+
+func parseLooseError(s string) (Diagnostic, bool) {
+	for _, line := range strings.Split(s, "\n") {
+		t := strings.TrimSpace(line)
+		if strings.HasPrefix(t, "Error:") {
+			return Diagnostic{
+				Summary: strings.TrimSpace(strings.TrimPrefix(t, "Error:")),
+				Raw:     t,
+			}, true
+		}
+	}
+	return Diagnostic{}, false
+}

--- a/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed/parser_test.go
+++ b/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed/parser_test.go
@@ -1,0 +1,133 @@
+package terraform_apply_failed
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+)
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	return b
+}
+
+func TestParser_NoMatchOnNonTerraformInput(t *testing.T) {
+	p := Parser{}
+	res := p.Parse(context.Background(), composite_error.ParseInput{
+		Raw: []byte("some random non-terraform error"),
+	})
+	assert.False(t, res.Matched)
+}
+
+func TestParser_ExtractsSingleDiagnostic(t *testing.T) {
+	p := Parser{}
+	res := p.Parse(context.Background(), composite_error.ParseInput{
+		Raw:        loadFixture(t, "terraform_apply_subnet_failure.txt"),
+		Invocation: composite_error.InvocationContext{OwnerType: "install_apply_step"},
+	})
+	require.True(t, res.Matched)
+
+	e, ok := res.Error.(*Error)
+	require.True(t, ok)
+	assert.Equal(t, "apply", e.Stage)
+	require.Len(t, e.Diagnostics, 1)
+
+	d := e.Diagnostics[0]
+	assert.Contains(t, d.Summary, "creating EC2 Subnet")
+	assert.Contains(t, d.Summary, "InvalidSubnet.Range")
+	assert.Equal(t, "module.vpc.aws_subnet.public[2]", d.Resource)
+	assert.Equal(t, ".terraform/modules/vpc/main.tf", d.SourceFile)
+	assert.Equal(t, 218, d.SourceLine)
+}
+
+func TestParser_ExtractsMultipleDiagnostics(t *testing.T) {
+	p := Parser{}
+	res := p.Parse(context.Background(), composite_error.ParseInput{
+		Raw: loadFixture(t, "terraform_apply_multiple_diagnostics.txt"),
+	})
+	require.True(t, res.Matched)
+
+	e, ok := res.Error.(*Error)
+	require.True(t, ok)
+	require.Len(t, e.Diagnostics, 2)
+
+	assert.Contains(t, e.Diagnostics[0].Summary, "EntityAlreadyExists")
+	assert.Equal(t, "module.eks.aws_iam_role.cluster", e.Diagnostics[0].Resource)
+	assert.Equal(t, ".terraform/modules/eks/iam.tf", e.Diagnostics[0].SourceFile)
+	assert.Equal(t, 12, e.Diagnostics[0].SourceLine)
+
+	assert.Contains(t, e.Diagnostics[1].Summary, "VPCIdNotSpecified")
+	assert.Equal(t, "module.eks.aws_security_group.cluster", e.Diagnostics[1].Resource)
+}
+
+func TestParser_StageFallsBackFromExtra(t *testing.T) {
+	p := Parser{}
+	res := p.Parse(context.Background(), composite_error.ParseInput{
+		Raw: loadFixture(t, "terraform_apply_subnet_failure.txt"),
+		Invocation: composite_error.InvocationContext{
+			Extra: map[string]any{"terraform_stage": "destroy"},
+		},
+	})
+	require.True(t, res.Matched)
+	e := res.Error.(*Error)
+	assert.Equal(t, "destroy", e.Stage)
+}
+
+func TestRender_SingleDiagnosticIncludesResource(t *testing.T) {
+	e := &Error{
+		Stage: "apply",
+		Diagnostics: []Diagnostic{{
+			Summary:    "creating EC2 Subnet: InvalidSubnet.Range",
+			Resource:   "module.vpc.aws_subnet.public[2]",
+			SourceFile: ".terraform/modules/vpc/main.tf",
+			SourceLine: 218,
+		}},
+	}
+	r := e.Render(context.Background())
+	assert.Contains(t, r.Title, "Terraform apply failed")
+	require.Len(t, r.Sections, 1)
+	assert.Contains(t, r.Sections[0].Body, "module.vpc.aws_subnet.public[2]")
+	assert.Contains(t, r.Sections[0].Body, "line 218")
+}
+
+func TestRender_MultipleDiagnosticsHaveSummaryList(t *testing.T) {
+	e := &Error{
+		Stage: "apply",
+		Diagnostics: []Diagnostic{
+			{Summary: "first"},
+			{Summary: "second"},
+		},
+	}
+	r := e.Render(context.Background())
+	assert.Contains(t, r.Title, "2 errors")
+	assert.True(t, strings.HasPrefix(r.Summary, "• "))
+}
+
+func TestErrorJSONRoundTrip(t *testing.T) {
+	original := &Error{
+		Stage: "apply",
+		Diagnostics: []Diagnostic{{
+			Summary:    "boom",
+			Resource:   "aws_vpc.main",
+			SourceFile: "main.tf",
+			SourceLine: 7,
+			Raw:        "│ Error: boom",
+		}},
+	}
+	b, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded Error
+	require.NoError(t, json.Unmarshal(b, &decoded))
+	assert.Equal(t, *original, decoded)
+}

--- a/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed/testdata/terraform_apply_multiple_diagnostics.txt
+++ b/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed/testdata/terraform_apply_multiple_diagnostics.txt
@@ -1,0 +1,20 @@
+module.eks.aws_iam_role.cluster: Creating...
+module.eks.aws_security_group.cluster: Creating...
+╷
+│ Error: creating IAM Role (eks-cluster-role): EntityAlreadyExists: Role with name eks-cluster-role already exists.
+│ 	status code: 409, request id: aaaaaaaa-1111-2222-3333-444444444444
+│
+│   with module.eks.aws_iam_role.cluster,
+│   on .terraform/modules/eks/iam.tf line 12, in resource "aws_iam_role" "cluster":
+│   12: resource "aws_iam_role" "cluster" {
+│
+╵
+╷
+│ Error: creating Security Group (eks-cluster-sg): VPCIdNotSpecified: No default VPC for this user.
+│ 	status code: 400, request id: bbbbbbbb-5555-6666-7777-888888888888
+│
+│   with module.eks.aws_security_group.cluster,
+│   on .terraform/modules/eks/main.tf line 47, in resource "aws_security_group" "cluster":
+│   47: resource "aws_security_group" "cluster" {
+│
+╵

--- a/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed/testdata/terraform_apply_subnet_failure.txt
+++ b/services/ctl-api/internal/app/composite_errors/types/terraform_apply_failed/testdata/terraform_apply_subnet_failure.txt
@@ -1,0 +1,34 @@
+Acquiring state lock. This may take a few moments...
+module.vpc.aws_vpc.this[0]: Refreshing state... [id=vpc-0123abcd]
+module.vpc.aws_subnet.public[0]: Refreshing state... [id=subnet-aaaa1111]
+module.vpc.aws_subnet.public[1]: Refreshing state... [id=subnet-bbbb2222]
+
+Terraform used the selected providers to generate the following execution plan.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.vpc.aws_subnet.public[2] will be created
+  + resource "aws_subnet" "public" {
+      + arn                                            = (known after apply)
+      + assign_ipv6_address_on_creation                = false
+      + availability_zone                              = "us-west-2c"
+      + cidr_block                                     = "10.0.96.0/19"
+      + id                                             = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+
+module.vpc.aws_subnet.public[2]: Creating...
+╷
+│ Error: creating EC2 Subnet (us-west-2c, 10.0.96.0/19): InvalidSubnet.Range: The CIDR '10.0.96.0/19' is invalid.
+│ 	status code: 400, request id: 8c4eee29-1234-5678-9abc-def012345678
+│
+│   with module.vpc.aws_subnet.public[2],
+│   on .terraform/modules/vpc/main.tf line 218, in resource "aws_subnet" "public":
+│  218: resource "aws_subnet" "public" {
+│
+╵
+
+Releasing state lock. This may take a few moments...

--- a/services/ctl-api/internal/app/composite_errors/types/unknown_error/error.go
+++ b/services/ctl-api/internal/app/composite_errors/types/unknown_error/error.go
@@ -1,0 +1,54 @@
+// Package unknown_error is the always-last fallback CompositeError type.
+//
+// When no parser matches the raw error material, the pipeline produces an
+// instance of this type so every recorded incident has a typed,
+// catalog-registered representation.
+package unknown_error
+
+import (
+	"context"
+	"fmt"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+)
+
+// Type is the catalog identifier for this error.
+const Type composite_error.Type = "unknown_error"
+
+// Error is the typed representation of an unclassified error.
+//
+// All fields are best-effort: they are populated from whatever the producer
+// gave us. Even an empty value renders to a usable (if generic) view.
+type Error struct {
+	// Message is the cleaned outermost error string (HumanError() output, or
+	// the raw stderr first line). Used as the headline.
+	Message string `json:"message,omitempty"`
+
+	// ExitCode of the producing process, when known.
+	ExitCode *int `json:"exit_code,omitempty"`
+}
+
+var _ composite_error.CompositeError = (*Error)(nil)
+
+func (e *Error) Type() composite_error.Type         { return Type }
+func (e *Error) Domain() composite_error.Domain     { return composite_error.DomainNuon }
+func (e *Error) Severity() composite_error.Severity { return composite_error.SeverityError }
+
+func (e *Error) Render(_ context.Context) composite_error.Render {
+	title := e.Message
+	if title == "" {
+		title = "An unknown error occurred"
+	}
+
+	r := composite_error.Render{
+		Title:   title,
+		Summary: "We weren't able to classify this error. The raw output is preserved in the error source.",
+	}
+	if e.ExitCode != nil {
+		r.Sections = append(r.Sections, composite_error.RenderSection{
+			Heading: "Exit code",
+			Body:    fmt.Sprintf("%d", *e.ExitCode),
+		})
+	}
+	return r
+}

--- a/services/ctl-api/internal/app/composite_errors/types/unknown_error/init.go
+++ b/services/ctl-api/internal/app/composite_errors/types/unknown_error/init.go
@@ -1,0 +1,62 @@
+package unknown_error
+
+import (
+	"strings"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+	"github.com/nuonco/nuon/pkg/composite_error/catalog"
+)
+
+func init() {
+	catalog.RegisterType(Type, func() composite_error.CompositeError {
+		return &Error{}
+	})
+}
+
+// Build constructs an unknown_error ParseResult from raw input. The pipeline
+// uses this as its safety-net builder when no parser matches.
+//
+// Lives on the type package (rather than the pipeline package) so the rules
+// for "what does an unknown error look like" stay alongside the type itself.
+func Build(in composite_error.ParseInput) composite_error.ParseResult {
+	msg := firstLine(string(in.Raw))
+	if msg == "" && in.GoErr != nil {
+		msg = in.GoErr.Error()
+	}
+
+	e := &Error{Message: msg}
+	if in.ExitCode != 0 {
+		ec := in.ExitCode
+		e.ExitCode = &ec
+	}
+
+	src := composite_error.Source{
+		ParserName:    "unknown_error.builder",
+		ParserVersion: "1",
+		Snippet:       composite_error.CapSnippet(string(in.Raw)),
+	}
+	if in.ExitCode != 0 {
+		ec := in.ExitCode
+		src.ExitCode = &ec
+	}
+	if in.GoErr != nil {
+		src.GoError = in.GoErr.Error()
+	}
+
+	return composite_error.ParseResult{
+		Matched: true,
+		Error:   e,
+		Source:  src,
+	}
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
+}

--- a/specs/composite-errors.md
+++ b/specs/composite-errors.md
@@ -1,0 +1,651 @@
+# Composite Errors
+
+Status: draft
+Owner: TBD
+
+A platform-wide abstraction for capturing, classifying, persisting, and rendering
+errors that arise across the Nuon platform — workflow steps, runner jobs, component
+builds, install deploys, and the components that drive them.
+
+Today, errors flow up to the user as a single `status_description` line on a step
+or as raw bytes inside a runner job execution result. There is no way to:
+
+- attach rich, type-safe context to an error (e.g. the missing IAM action and the
+  resource ARN behind a Terraform apply failure);
+- drive workflow control-flow off an error (fail fast vs. retry vs. downgrade to
+  warning);
+- render a useful error view on a deployment object that pulls together logs,
+  parsed output, and remediation hints;
+- collect statistics about what kinds of errors orgs are hitting.
+
+Composite Errors are the abstraction that fixes that. They are first-class,
+catalogable, persisted entities. They mirror the existing **signal catalog** pattern
+(`pkg/queue/catalog`) — types are registered in-process via `init()`, hydrated from
+JSONB at read time, and behave like typed Go values everywhere they are consumed.
+
+## Goals
+
+- A typed, catalogable error abstraction that can be **persisted, attached to many
+  owner types, rendered in the dashboard, and queried in admin tooling**.
+- A **parser pipeline** that classifies raw error material (Temporal errors, runner
+  stderr, terraform output, helm output, …) into typed errors.
+- The ability for an error to **override the directive** the conductor would
+  otherwise apply (fail-fast, force-retry, skip-group, downgrade-to-warning).
+- A **tree of causes** so an `install_deploy_failed` can point at a
+  `terraform_apply_failed` whose primary cause is `aws_missing_iam_permission`.
+- A path to **multi-error per owner** so a single step can carry several related
+  errors when relevant.
+
+## Non-goals (v1)
+
+- API error envelopes — `stderr.Err` already does that job.
+- Cross-owner deduplication (e.g. one `aws_missing_iam_permission` row attached to
+  12 steps). Out of scope; we will revisit if grouping at read time isn't enough.
+- Org-level overrides (admins customizing severity / behavior per error type).
+- Runner-side classification. v1 keeps the runner dumb; ctl-api parses everything.
+- Localization.
+
+## Design overview
+
+```diagram
+╭──────────────────────────────╮  init() registers   ╭──────────────────────────────╮
+│ Catalog (in-memory)          │◀────────────────────│ Per-package error type       │
+│  type → factory()            │                     │ + parser(s) + Render()       │
+╰──────────────┬───────────────╯                     ╰──────────────────────────────╯
+               │
+               ▼
+╭──────────────────────────────╮  polymorphic owner   ╭──────────────────────────────╮
+│ composite_errors (DB row)    │◀────────────────────│ workflow_step                │
+│  - type, domain, severity    │                      │ runner_job_execution_result  │
+│  - data jsonb (typed)        │                      │ component_build              │
+│  - source jsonb (snippet)    │                      │ install_deploy / install     │
+│  - references jsonb          │                      │ ...                          │
+│  - title/summary cached      │                      ╰──────────────────────────────╯
+│  - resolution fields         │
+╰──────────────┬───────────────╯
+               │
+               ▼
+╭──────────────────────────────╮      ╭──────────────────────────────╮
+│ composite_error_causes       │      │ Conductor / step finalizer   │
+│  parent_id, child_id,        │      │  hydrates typed instance,    │
+│  idx, is_primary             │      │  honors OverrideDirective()  │
+╰──────────────────────────────╯      ╰──────────────────────────────╯
+```
+
+The model has two distinct layers:
+
+1. **Type layer (in-process):** Go interface + capability interfaces. Each error
+   type lives in its own package under `internal/app/composite_errors/types/<name>/`
+   with `error.go`, `parser.go`, and `init.go` calling `catalog.Register(...)`.
+   This mirrors `internal/app/installs/signals/v2/<name>/`.
+2. **Instance layer (DB):** one `composite_errors` row per recorded incident, with
+   a JSONB `data` column that round-trips through the catalog factory back into
+   the typed Go value.
+
+## The two axes: parse context vs. error domain
+
+It is important to distinguish *where the error material came from* from *what kind
+of error it is*. They use different shapes and they cross-cut.
+
+| Axis | Lives on | Hierarchical | Examples |
+|---|---|---|---|
+| **`ParseContext`** — *where the bytes came from* | parser registration + dispatch input | yes (path-like) | `terraform`, `terraform/plan`, `terraform/apply`, `helm/install`, `helm/install/rbac`, `kubernetes/rollout`, `runner/job`, `build/helm` |
+| **`Domain`** — *what kind of error this is* | the error row + type | no (flat enum) | `terraform`, `helm`, `kubernetes`, `aws`, `gcp`, `azure`, `nuon`, `runner` |
+
+`Domain` lives on the row for filtering / metrics / UI grouping. `ParseContext` is
+purely a dispatch concept — it never gets stored.
+
+The split is what lets `aws_missing_iam_permission` (a single parser) run on
+TF-apply, Helm-install, and runner-job output without being re-registered into a TF
+hierarchy.
+
+## Type interface
+
+```go
+// pkg/composite_error/error.go
+package composite_error
+
+type Type     string
+type Domain   string
+type Severity string
+
+const (
+    SeverityFatal   Severity = "fatal"
+    SeverityError   Severity = "error"
+    SeverityWarning Severity = "warning"
+    SeverityInfo    Severity = "info"
+)
+
+// CompositeError is the in-memory typed view of a stored composite error.
+// Implementations live in internal/app/composite_errors/types/<name>/error.go
+// and are registered into the catalog via init().
+type CompositeError interface {
+    Type() Type
+    Domain() Domain
+    Severity() Severity
+
+    // Render produces the user-facing view from the typed Data on the
+    // implementing struct. Always called at read time — never cached
+    // anywhere except the denormalized title/summary on the row, which
+    // exist purely for admin search/listing.
+    Render(ctx context.Context) Render
+}
+
+type Render struct {
+    Title       string           // one line, ≤120 chars
+    Summary     string           // one paragraph, user-facing
+    Sections    []RenderSection  // ordered: what / why / how to fix
+    UserActions []UserAction     // CTAs (copy IAM JSON, run command, retry, link)
+}
+
+type RenderSection struct {
+    Heading string
+    Body    string  // markdown
+}
+
+type UserAction struct {
+    Kind  UserActionKind  // link | copy | command | retry
+    Label string
+    Value string          // url, snippet, command
+}
+```
+
+### Optional capability interfaces
+
+Following the `signal/interfaces.go` pattern: each capability is a tiny opt-in
+interface that the conductor / helpers check at runtime via type assertion.
+
+```go
+// Single override knob — replaces a swarm of per-capability interfaces.
+// Returning the zero value means "no opinion, defer to signal defaults".
+type ErrorWithDirective interface {
+    OverrideDirective() Directive
+}
+
+type Directive struct {
+    Kind DirectiveKind  // continue | stop | retry | retry-group | skip-group | await-approval
+    // Future-proofed: leave room without breaking the interface
+    // MaxRetries *int
+    // Backoff    *time.Duration
+}
+
+// Optional rendering / linkage helpers
+type ErrorWithDocsLink   interface{ DocsURL() string }
+type ErrorWithReferences interface{ References() []Reference }
+type ErrorWithJSONSchema interface{ JSONSchema() []byte } // validate Data on Record
+```
+
+The `Directive.Kind` vocabulary aligns with `WorkflowStep.ResultDirective` so the
+conductor can apply it without translation.
+
+The conductor merges directives in this order:
+
+```diagram
+╭──────────────────────╮     ╭──────────────────────────╮
+│ signal defaults      │ →  │ error catalog override    │
+│ (AutoRetry,          │     │ (OverrideDirective() if   │
+│  MaxRetry, etc.)     │     │  the type implements it)  │
+╰──────────────────────╯     ╰──────────────────────────╯
+```
+
+Org-level overrides may be added in a future iteration without changing the
+interface — they slot in after catalog overrides.
+
+## Catalog (in-memory, mirrors signal catalog)
+
+```go
+// pkg/composite_error/catalog/catalog.go
+package catalog
+
+var typeRegistry = map[composite_error.Type]func() composite_error.CompositeError{}
+
+func Register(typ composite_error.Type, fn func() composite_error.CompositeError) {
+    if _, exists := typeRegistry[typ]; exists {
+        panic(fmt.Sprintf("duplicate composite error type registered: %q", typ))
+    }
+    typeRegistry[typ] = fn
+}
+
+// Hydrate looks up the factory for `typ`, instantiates an empty value,
+// and unmarshals `data` (the JSONB blob) into it.
+func Hydrate(typ composite_error.Type, data []byte) (composite_error.CompositeError, error) { ... }
+```
+
+Each error type's package looks exactly like a signal package today:
+
+```
+internal/app/composite_errors/types/aws_missing_iam_permission/
+├── error.go      // typed struct + Type()/Domain()/Severity()/Render()/OverrideDirective()
+├── parser.go     // implements composite_error.Parser
+├── init.go       // catalog.Register(Type, factory) + parser_catalog.Register(parser)
+└── parser_test.go
+```
+
+## Parsers
+
+```go
+// pkg/composite_error/parser.go
+package composite_error
+
+type ParseContext string  // path-like, "/" separator, e.g. "terraform/plan"
+
+type Parser interface {
+    // Contexts this parser opts into. Each entry matches itself + descendants.
+    //   {"terraform"}        → terraform, terraform/plan, terraform/apply
+    //   {"terraform/plan"}   → only terraform/plan and below
+    //   {"terraform","helm"} → cross-cutting (e.g. AWS perm parser)
+    Contexts() []ParseContext
+
+    Parse(ctx context.Context, in ParseInput) ParseResult
+}
+
+type ParseInput struct {
+    Raw         []byte                       // logs / stderr / stdout / JSON output
+    ExitCode    int
+    GoErr       error                        // raw Go/Temporal error (use HumanError to clean)
+    Ctx         ParseInvocationContext       // owner type/id, component type, install id, etc.
+}
+
+type ParseResult struct {
+    Matched  bool
+    Error    CompositeError                  // typed instance, hydratable
+    Causes   []ParseResult                   // optional cause sub-results
+    Source   Source                          // small input snippet to persist
+    Refs     []Reference                     // dynamic refs (log_stream, plan, etc.)
+}
+```
+
+Empty `Contexts()` is a registration error — every parser must opt in to at least
+one subtree.
+
+### Dispatch rule
+
+The pipeline runs in the conductor / step finalizer. Given a `ParseContext` like
+`terraform/plan`:
+
+1. Walk ancestors most-specific → least-specific:
+   `terraform/plan` → `terraform` → `""` (root).
+2. At each level, run every registered parser in registration order.
+3. **First non-empty match at the most-specific level becomes the primary error.**
+4. Other matches at any level are kept and attached as **secondary errors**
+   (separate rows, polymorphically owned by the same owner).
+5. If nothing matches, emit a single `unknown_error` primary.
+
+Example: a Terraform plan failing on missing IAM permission produces:
+
+```
+primary:   terraform_plan_failed     (matched by terraform/plan parser)
+   └─ cause: aws_missing_iam_permission   (matched by AWS parser at "terraform")
+```
+
+Parser registration order is deterministic by Go's `init()` ordering, but tests
+should not depend on it across packages. For parsers at the same context level, we
+sort by `(depth desc, registration order)`.
+
+### Parsing guarantees
+
+- Parsers are **best-effort** — a panicking or erroring parser must never break the
+  workflow. The pipeline recovers panics and logs.
+- Parsers must be **fast** (microsecond-millisecond). They run on the failure path
+  of every step.
+- `unknown_error` is always the safety net.
+
+## Storage
+
+### `composite_errors`
+
+```go
+type CompositeError struct {
+    ID            string                     `gorm:"primaryKey;check:id_checker,char_length(id)=26"`
+    CreatedByID   string
+    CreatedBy     Account                    `json:"-"`
+    CreatedAt     time.Time
+    UpdatedAt     time.Time
+    DeletedAt     soft_delete.DeletedAt
+
+    OrgID         string                     `gorm:"index;not null"`     // RLS
+    Org           Org                        `json:"-"`
+
+    // polymorphic owner — same pattern as QueueSignal
+    OwnerID       string                     `gorm:"index:idx_ce_owner;not null"`
+    OwnerType     string                     `gorm:"index:idx_ce_owner;not null"`
+
+    // catalog classification
+    Type          composite_error.Type       `gorm:"index;not null"`
+    Domain        composite_error.Domain     `gorm:"index;not null"`
+    Severity      composite_error.Severity   `gorm:"index;not null"`
+
+    // typed payload — round-trips through Catalog.Hydrate(Type, Data)
+    SchemaVersion int                        `gorm:"not null;default:1"`
+    Data          datatypes.JSON             `gorm:"type:jsonb;not null"`
+
+    // small parser-input snippet (capped) so we can debug parser decisions later
+    Source        Source                     `gorm:"type:jsonb"`
+
+    // references resolved at read time (log streams, plan results, …)
+    References    References                 `gorm:"type:jsonb"`
+
+    // denormalized for admin search / list — populated at write time from Render()
+    TitleCached   string                     `gorm:"type:text"`
+    SummaryCached string                     `gorm:"type:text"`
+
+    // resolution lifecycle (separate from row existence)
+    ResolvedAt    *time.Time
+    ResolvedByID  *string
+    ResolvedNote  string                     `gorm:"type:text"`
+}
+
+type Source struct {
+    ParserName    string `json:"parser_name,omitempty"`
+    ParserVersion string `json:"parser_version,omitempty"`
+    Snippet       string `json:"snippet,omitempty"`        // ≤ 8 KB cap
+    ExitCode      *int   `json:"exit_code,omitempty"`
+    GoError       string `json:"go_error,omitempty"`        // HumanError() output
+}
+
+type References []Reference
+type Reference struct {
+    Type  ReferenceType  `json:"type"`            // log_stream | runner_job_execution_result | terraform_plan_result | doc_url | ...
+    ID    string         `json:"id,omitempty"`    // entity id, or url for *_url types
+    Label string         `json:"label,omitempty"`
+    Meta  map[string]any `json:"meta,omitempty"`  // e.g. {"start_line":1421,"end_line":1438}
+}
+```
+
+Indexes:
+
+- `(org_id)` for RLS scans.
+- `(owner_type, owner_id, deleted_at)` for the owner-side preload.
+- `(type)`, `(domain)`, `(severity)` for admin filtering / metrics rollups.
+- `(created_at desc)` for recent-errors views.
+
+### `composite_error_causes`
+
+A separate edge table keeps the cause graph queryable in both directions and
+multi-cause-friendly.
+
+```go
+type CompositeErrorCause struct {
+    ParentID  string    `gorm:"primaryKey;not null"`  // higher-level error
+    ChildID   string    `gorm:"primaryKey;not null"`  // underlying cause
+    Idx       int       `gorm:"not null"`             // ordering of children
+    IsPrimary bool      `gorm:"not null"`             // the headline cause
+    CreatedAt time.Time
+}
+```
+
+Constraints:
+
+- FKs on both sides into `composite_errors(id)` with `ON DELETE CASCADE`.
+- Unique `(parent_id, child_id)`.
+- Helper enforces no cycles before insert.
+- Exactly one row per parent may have `IsPrimary = true` (enforced in helper +
+  partial unique index).
+
+### Owner-side change
+
+Each owner that wants to display attached errors declares a single GORM
+polymorphic association — no FK migration on the owner.
+
+```go
+// WorkflowStep
+CompositeErrors []CompositeError `gorm:"polymorphic:Owner;polymorphicValue:install_workflow_steps" json:"composite_errors,omitempty"`
+
+// RunnerJobExecutionResult
+CompositeErrors []CompositeError `gorm:"polymorphic:Owner;polymorphicValue:runner_job_execution_results" json:"composite_errors,omitempty"`
+
+// ComponentBuild, InstallDeploy, InstallWorkflow, Install, Component, ...
+```
+
+There is no central registry of allowed owner types — anything can attach errors,
+mirroring how anything can own a `QueueSignal`. This keeps the abstraction generic.
+
+### Soft-delete and retention
+
+- `composite_errors` rows soft-delete with their owner. When the owner is hard
+  deleted, errors cascade.
+- Resolution does **not** delete a row — `ResolvedAt` is set and the row stays
+  queryable for analytics ("this org keeps hitting throttling").
+- A future retention sweeper hard-deletes resolved errors older than N days.
+
+## Helpers
+
+Following the helpers pattern in `ctl-api/AGENTS.md`, all cross-domain access
+goes through `internal/app/composite_errors/helpers/`.
+
+```go
+type Helpers struct {
+    cfg *internal.Config
+    db  *gorm.DB
+    l   *zap.Logger
+}
+
+// RecordInput is the unified write entrypoint.
+type RecordInput struct {
+    OwnerID, OwnerType string
+    Error              composite_error.CompositeError  // typed instance
+    Source             composite_error.Source
+    References         []composite_error.Reference
+    Causes             []RecordCause                   // child errors to record + link
+}
+
+type RecordCause struct {
+    Error      composite_error.CompositeError
+    Source     composite_error.Source
+    References []composite_error.Reference
+    IsPrimary  bool
+}
+
+// Record persists the error (and its causes recursively) in a single transaction.
+// Validates Data against ErrorWithJSONSchema if implemented.
+// Renders Title/Summary into the cached columns.
+func (h *Helpers) Record(ctx context.Context, in RecordInput) (*app.CompositeError, error)
+
+// RecordFromError is the convenience entry point used by step finalizers.
+// It runs the parser pipeline against the raw inputs and records the result.
+func (h *Helpers) RecordFromError(
+    ctx context.Context,
+    owner Ownerable,
+    parseCtx composite_error.ParseContext,
+    in composite_error.ParseInput,
+) (*app.CompositeError, error)
+
+// Hydrate loads the row and returns the typed instance via Catalog.Hydrate.
+func (h *Helpers) Hydrate(ctx context.Context, id string) (*app.CompositeError, composite_error.CompositeError, error)
+
+// ListByOwner returns all attached errors for an owner, ordered by
+// (severity desc, created_at asc). Used for the dashboard / public API.
+func (h *Helpers) ListByOwner(ctx context.Context, ownerType, ownerID string) ([]*app.CompositeError, error)
+
+// Primary returns the single highest-severity, oldest error attached to an
+// owner, or nil. Convenience for badge / status surfaces.
+func (h *Helpers) Primary(ctx context.Context, ownerType, ownerID string) (*app.CompositeError, error)
+
+// Tree returns the cause graph rooted at id, depth-bounded.
+func (h *Helpers) Tree(ctx context.Context, id string, maxDepth int) (*ErrorTree, error)
+
+// Resolve marks a row resolved (does not delete).
+func (h *Helpers) Resolve(ctx context.Context, id, byAccountID, note string) error
+```
+
+The helpers package is registered via FX in `cmd/cli.go` next to the existing
+`accountshelpers.New` etc.
+
+## Lifecycle: write path
+
+```diagram
+                                                 ╭─ catalog override ─╮
+   step error          parsers (context tree)    │  Directive.Kind     │
+        │                       │                ╰──────────┬──────────╯
+        ▼                       ▼                           │
+╭───────────────╮    ╭──────────────────────╮               │
+│ HumanError()  │──▶│ Pipeline.Parse(ctx,   │──▶ typed CE ──┤
+│ on Temporal   │    │   ParseInput)         │   + causes    │
+│ error chain   │    ╰──────────────────────╯               │
+╰───────────────╯                                            ▼
+                              ╭──────────────────────────────────────╮
+                              │ helpers.Record():                    │
+                              │  - validate (JSONSchema)             │
+                              │  - render → Title/Summary cached     │
+                              │  - persist row + edges (one tx)      │
+                              │  - attach polymorphic owner          │
+                              ╰──────────────────────────────────────╯
+                                                 │
+                                                 ▼
+                              ╭──────────────────────────────────────╮
+                              │ conductor merges                     │
+                              │  signal defaults ⊕ catalog override  │
+                              │  → step ResultDirective              │
+                              ╰──────────────────────────────────────╯
+```
+
+Where parsing runs:
+
+| Surface | Runs in |
+|---|---|
+| Workflow step failures | conductor / step finalizer activity in ctl-api |
+| Runner job execution results | runner-result intake handler in ctl-api |
+| Component build failures | build completion path in ctl-api |
+| Install deploy aggregations | deploy finalizer in ctl-api |
+
+Runner stays "dumb" in v1 — it reports raw `RunnerJobExecutionResult` and ctl-api
+parses. We may push parsing into the runner later for faster cancellation; the
+abstraction does not preclude this.
+
+## Lifecycle: read path
+
+- **Public API** — owner endpoints (step, build, deploy, …) preload
+  `CompositeErrors` via the polymorphic association and include them in the
+  response. Frontend renders by `Type` using the typed `Data`.
+- **Dashboard UI** — generic `<CompositeError />` component reads `Title` /
+  `Summary` / `Sections` / `UserActions` and dereferences `References` lazily
+  (e.g. fetches the linked `LogStream`). Type-specific subviews can be registered
+  in a small frontend registry; falls back to generic markdown render.
+- **Admin Dashboard** — two new pages under `internal/app/admin-dashboard/`:
+  - **Catalog browser**: tree of `ParseContext` nodes with parsers and the error
+    types they can emit. Mirrors a Signals catalog browser.
+  - **Instance search**: filter by org / type / domain / severity / owner /
+    resolved.
+- **CLI** — surfaces `Title` + first `UserAction` in step output;
+  `--verbose` prints the full structured form.
+
+## Severity vs. step status
+
+- Severity is a property of the error, not a new step status.
+- A `warning`-severity error attached to a successful step does not change the
+  step status. The dashboard renders a badge sourced from
+  `count(composite_errors WHERE severity='warning')`.
+- A `fatal` or `error` severity composite error on a failed step is the headline
+  surface — it replaces the long form `status_description` in the UI. The short
+  form `status_description` stays as a one-liner for compact rendering.
+- The conductor only acts on `OverrideDirective()`; severity itself does not move
+  the workflow.
+
+## Warnings during successful execution
+
+Warnings can be emitted mid-execution against successful owners:
+
+```go
+helpers.RecordWarning(ctx, owner, parseCtx, parseInput)
+```
+
+This is the same code path as `RecordFromError` but only produces a row when a
+matched parser yields severity `warning`. Keeps "rich event" decoupled from
+"failure handling".
+
+## Resolution semantics
+
+- **Implicit:** when an owner that has open errors transitions to a terminal
+  success state on retry, the helpers mark all open errors on that owner
+  `resolved` automatically (`ResolvedNote = "auto-resolved by retry success"`,
+  `ResolvedByID = nil`).
+- **Explicit:** an admin or user can call the resolve endpoint with a note
+  (e.g. "added IAM permission to role X").
+- Resolved errors stay queryable forever (until the retention sweeper clears
+  them). They power historical analytics and admin dashboards.
+
+## Initial type catalog
+
+Start small; let parsers drive the roadmap.
+
+| Type | Domain | Severity | Notes |
+|---|---|---|---|
+| `unknown_error` | `nuon` | `error` | Always-last fallback. |
+| `nuon_internal_error` | `nuon` | `error` | DB write fails, transient infra issues. Directive: `retry`. |
+| `terraform_init_failed` | `terraform` | `error` | |
+| `terraform_plan_failed` | `terraform` | `error` | |
+| `terraform_apply_failed` | `terraform` | `error` | |
+| `terraform_state_locked` | `terraform` | `error` | Directive: `retry` with backoff once that's wired in. |
+| `aws_missing_iam_permission` | `aws` | `error` | Directive: `stop`. Parses action + resource ARN out of stderr. |
+| `aws_quota_exceeded` | `aws` | `error` | Directive: `stop`. |
+| `aws_throttled` | `aws` | `warning`/`error` | Directive: `retry`. |
+| `helm_install_failed` | `helm` | `error` | |
+| `kubernetes_resource_not_ready` | `kubernetes` | `error` | |
+| `oci_artifact_pull_failed` | `nuon` | `error` | Image not present in customer ECR. |
+| `runner_unhealthy` | `runner` | `error` | Heartbeat / dispatch failure. |
+| `component_no_active_build` | `nuon` | `error` | Sync-time validation. Directive: `stop`. |
+
+Each type lives in its own package under
+`services/ctl-api/internal/app/composite_errors/types/<name>/`.
+
+## Phased delivery
+
+### Phase 0 — design lock-in
+This document. No code.
+
+### Phase 1 — core abstraction
+- `pkg/composite_error/`: interface, capability interfaces, `Type` / `Domain` /
+  `Severity` enums, `Render`, `Reference`, `Source`, `Parser`, dispatch
+  pipeline, `unknown_error` builtin.
+- `pkg/composite_error/catalog/`: in-memory registry (mirrors `pkg/queue/catalog`).
+- `app.CompositeError` + `app.CompositeErrorCause` GORM models + migration.
+- `composite_errors/helpers/`: `Record`, `RecordFromError`, `Hydrate`,
+  `ListByOwner`, `Primary`, `Tree`, `Resolve`.
+- Round-trip tests (encode → store → hydrate → render).
+- Pipeline tests against synthetic parsers.
+
+### Phase 2 — workflow step integration
+- Add `CompositeErrors` polymorphic association to `WorkflowStep`.
+- Hook step-completion path: wrap `HumanError()`, run pipeline, persist via helper.
+- Apply `OverrideDirective()` in the conductor.
+- Preload + return `composite_errors` from public step endpoints.
+- Generic dashboard renderer (no per-type UI yet).
+
+### Phase 3 — first parsers (highest user payoff)
+- `terraform_init_failed`, `terraform_plan_failed`, `terraform_apply_failed`,
+  `terraform_state_locked`.
+- `aws_missing_iam_permission`, `aws_quota_exceeded`, `aws_throttled`.
+- Parser fixtures in `testdata/` per package, captured from real failures.
+
+### Phase 4 — broader integration
+- Add associations + recording to `RunnerJobExecutionResult`, `ComponentBuild`,
+  `InstallDeploy`, `Install`.
+- Helm + Kubernetes parsers.
+- Cause chaining wired from runner-job → step → deploy.
+
+### Phase 5 — UX
+- Per-type renderers in dashboard-ui (start with `aws_missing_iam_permission`).
+- Admin dashboard catalog browser + instance search.
+- CLI surface.
+
+### Phase 6 — operations
+- Implicit auto-resolve on retry success.
+- Retention sweeper.
+- Metrics: `composite_errors_recorded{type,severity,domain}` counter,
+  `composite_errors_unknown` ratio (drives parser coverage roadmap).
+
+## Open follow-ups (not blocking v1)
+
+- **Cross-owner attachment / dedup.** One row attached to many owners. Defer; revisit if read-time grouping by `(type, data hash)` isn't enough.
+- **Org-level overrides.** Admins customizing severity / behavior per error type.
+- **Runner-side classification.** Push parsers into the runner for fast local fail-fast and reduced ctl-api round-trips.
+- **i18n.** `i18nKey` on `Render` outputs.
+- **Richer `Directive`.** Grow into a struct with `MaxRetries *int` and `Backoff *time.Duration` if/when parser knowledge demonstrably beats signal defaults.
+
+## Related
+
+- [`pkg/queue/signal`](file:///Users/prem/space/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal) — reference pattern for catalog + capability interfaces.
+- [`pkg/queue/catalog/catalog.go`](file:///Users/prem/space/nuonco/nuon/services/ctl-api/internal/pkg/queue/catalog/catalog.go) — in-memory registry pattern.
+- [`internal/app/status.go`](file:///Users/prem/space/nuonco/nuon/services/ctl-api/internal/app/status.go) — `CompositeStatus` shape (JSONB + `Scan`/`Value`/`GormDataType`).
+- [`internal/app/queue_signal.go`](file:///Users/prem/space/nuonco/nuon/services/ctl-api/internal/app/queue_signal.go) — polymorphic owner pattern.
+- [`pkg/queue/signal/human_error.go`](file:///Users/prem/space/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/human_error.go) — Temporal error unwrapping; consumed by the parser pipeline.


### PR DESCRIPTION
Adds the Composite Errors abstraction for capturing, classifying, and rendering errors across the platform. See specs/composite-errors.md.

This commit lands the spec and a working prototype with no DB layer:

- pkg/composite_error: typed error interface, capability interfaces (OverrideDirective, DocsLink, References, JSONSchema), Reference/Source shapes, Parser interface with hierarchical ParseContext, in-memory catalog (mirrors pkg/queue/catalog), and a panic-safe dispatch pipeline.

- composite_errors/types/unknown_error: always-last fallback type.

- composite_errors/types/terraform_apply_failed: broad parser registered against the 'terraform' subtree; extracts \u2577 \u2502 \u2575 diagnostic blocks (resource, source file/line) into structured Diagnostic records.

- composite_errors/types/aws_missing_iam_permission: cross-cutting parser registered against terraform/helm/runner/job; extracts action/resource/principal from AccessDenied & UnauthorizedOperation responses, overrides directive to 'stop', and renders a copy-pasteable IAM policy fragment as a UserAction.

- composite_errors/register: blank-import umbrella so a single side-effect import wires every built-in type into the catalog.

- tests covering registry duplicate-panic, ancestor walk, cross-subtree registration, pipeline most-specific-wins + secondaries, panic recovery, fallback to unknown, parser extraction against real terraform/AWS fixtures in testdata/, JSON round-trip via Hydrate(), Render output, and parse-context scoping.