### PR TITLE
fix(ui): serve static files before auth check

### DIFF
--- a/services/dashboard-ui/server/internal/handlers/proxy.go
+++ b/services/dashboard-ui/server/internal/handlers/proxy.go
@@ -220,7 +220,7 @@ func (h *ProxyHandler) requireAuth() gin.HandlerFunc {
 			c.AbortWithStatus(http.StatusUnauthorized)
 			return
 		}
-		h.l.Info("requireAuth calling GetAuthMe", zap.String("path", c.Request.URL.Path), zap.String("method", c.Request.Method))
+		h.l.Debug("requireAuth calling GetAuthMe", zap.String("path", c.Request.URL.Path))
 		if _, err := client.GetAuthMe(c.Request.Context()); err != nil {
 			c.Redirect(http.StatusFound, loginURL)
 			c.Abort()
@@ -234,7 +234,7 @@ func (h *ProxyHandler) requireNuonEmail() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		token, _ := c.Cookie(authCookie)
 		client, _ := nuon.New(nuon.WithURL(h.cfg.APIUrl), nuon.WithAuthToken(token))
-		h.l.Info("requireNuonEmail calling GetAuthMe", zap.String("path", c.Request.URL.Path), zap.String("method", c.Request.Method))
+		h.l.Debug("requireNuonEmail calling GetAuthMe", zap.String("path", c.Request.URL.Path))
 		me, err := client.GetAuthMe(c.Request.Context())
 		if err != nil || !strings.HasSuffix(me.Email, "@nuon.co") {
 			c.AbortWithStatus(http.StatusForbidden)

--- a/services/dashboard-ui/server/internal/handlers/proxy.go
+++ b/services/dashboard-ui/server/internal/handlers/proxy.go
@@ -220,6 +220,7 @@ func (h *ProxyHandler) requireAuth() gin.HandlerFunc {
 			c.AbortWithStatus(http.StatusUnauthorized)
 			return
 		}
+		h.l.Info("requireAuth calling GetAuthMe", zap.String("path", c.Request.URL.Path), zap.String("method", c.Request.Method))
 		if _, err := client.GetAuthMe(c.Request.Context()); err != nil {
 			c.Redirect(http.StatusFound, loginURL)
 			c.Abort()
@@ -233,6 +234,7 @@ func (h *ProxyHandler) requireNuonEmail() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		token, _ := c.Cookie(authCookie)
 		client, _ := nuon.New(nuon.WithURL(h.cfg.APIUrl), nuon.WithAuthToken(token))
+		h.l.Info("requireNuonEmail calling GetAuthMe", zap.String("path", c.Request.URL.Path), zap.String("method", c.Request.Method))
 		me, err := client.GetAuthMe(c.Request.Context())
 		if err != nil || !strings.HasSuffix(me.Email, "@nuon.co") {
 			c.AbortWithStatus(http.StatusForbidden)

--- a/services/dashboard-ui/server/internal/middlewares/auth/auth.go
+++ b/services/dashboard-ui/server/internal/middlewares/auth/auth.go
@@ -63,7 +63,7 @@ func (m *middleware) Handler() gin.HandlerFunc {
 			return
 		}
 
-		m.l.Info("auth middleware calling GetAuthMe", zap.String("path", c.Request.URL.Path), zap.String("method", c.Request.Method))
+		m.l.Debug("auth middleware calling GetAuthMe", zap.String("path", c.Request.URL.Path))
 		if _, err := client.GetAuthMe(c.Request.Context()); err != nil {
 			m.l.Warn("auth check failed", zap.Error(err))
 			c.Redirect(http.StatusFound, loginURL)

--- a/services/dashboard-ui/server/internal/middlewares/auth/auth.go
+++ b/services/dashboard-ui/server/internal/middlewares/auth/auth.go
@@ -63,6 +63,7 @@ func (m *middleware) Handler() gin.HandlerFunc {
 			return
 		}
 
+		m.l.Info("auth middleware calling GetAuthMe", zap.String("path", c.Request.URL.Path), zap.String("method", c.Request.Method))
 		if _, err := client.GetAuthMe(c.Request.Context()); err != nil {
 			m.l.Warn("auth check failed", zap.Error(err))
 			c.Redirect(http.StatusFound, loginURL)

--- a/services/dashboard-ui/server/internal/spa/serve.go
+++ b/services/dashboard-ui/server/internal/spa/serve.go
@@ -153,11 +153,6 @@ func (h *Handler) registerStatic(e *gin.Engine) error {
 			return
 		}
 
-		authHandler(c)
-		if c.IsAborted() {
-			return
-		}
-
 		filePath := strings.TrimPrefix(c.Request.URL.Path, "/")
 
 		if publicFS != nil {
@@ -172,6 +167,11 @@ func (h *Handler) registerStatic(e *gin.Engine) error {
 				distFileServer.ServeHTTP(c.Writer, c.Request)
 				return
 			}
+		}
+
+		authHandler(c)
+		if c.IsAborted() {
+			return
 		}
 
 		if !hasSPAFallback {
@@ -198,17 +198,17 @@ func (h *Handler) registerDevProxy(e *gin.Engine) error {
 			return
 		}
 
-		authHandler(c)
-		if c.IsAborted() {
-			return
-		}
-
 		if publicFS != nil {
 			filePath := strings.TrimPrefix(c.Request.URL.Path, "/")
 			if _, err := fs.Stat(publicFS, filePath); err == nil {
 				http.FileServer(http.FS(publicFS)).ServeHTTP(c.Writer, c.Request)
 				return
 			}
+		}
+
+		authHandler(c)
+		if c.IsAborted() {
+			return
 		}
 
 		proxy := &http.Transport{}


### PR DESCRIPTION
The NoRoute handler was running the auth middleware (which calls GetAuthMe) before checking if the request was for a static file. This meant every SVG, font, and other public asset triggered an auth/me API call on each page load.

Move the static file checks (public/ and dist/) above the auth handler so only the SPA HTML fallback requires authentication.
