### PR TITLE
refactor(ui): error page for 500s, org provider handle org session check

### DIFF
--- a/services/dashboard-ui/client/App.tsx
+++ b/services/dashboard-ui/client/App.tsx
@@ -6,6 +6,7 @@ import { AuthLayout } from '@/components/layout/AuthLayout'
 import { APIHealthProvider } from '@/providers/api-health-provider'
 import { AuthProvider } from '@/providers/auth-provider'
 import { ConfigProvider } from '@/providers/config-provider'
+import { Error } from '@/views/Error'
 import { NotFound } from '@/views/NotFound'
 import { RouteError } from '@/views/RouteError'
 import { Onboarding } from '@/views/Onboarding'
@@ -43,6 +44,7 @@ const router = createBrowserRouter([
     element: <AuthLayout />,
     errorElement: <RouteError />,
     children: [
+      { path: '/error', element: <Error /> },
       { path: '/onboarding', element: <Onboarding /> },
       ...orgRoutes,
       { path: '*', element: <NotFound /> },

--- a/services/dashboard-ui/client/lib/cookies.ts
+++ b/services/dashboard-ui/client/lib/cookies.ts
@@ -14,6 +14,9 @@ function getCookie(name: string): string | undefined {
 
 export const getOrgSession = () => getCookie('org_session')
 export const setOrgSession = (orgId: string) => setCookie('org_session', orgId)
+export const clearOrgSession = () => {
+  document.cookie = 'org_session=; path=/; SameSite=Lax; max-age=0'
+}
 
 export const getSidebarOpen = () => getCookie('sidebar_open') === '1'
 export const setSidebarOpen = (isOpen: boolean) =>

--- a/services/dashboard-ui/client/providers/org-provider.tsx
+++ b/services/dashboard-ui/client/providers/org-provider.tsx
@@ -2,10 +2,10 @@ import { createContext, useEffect } from 'react'
 import { useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import { getOrg } from '@/lib/ctl-api/orgs'
-import { setOrgSession } from '@/lib/cookies'
+import { clearOrgSession, setOrgSession } from '@/lib/cookies'
 import { ProviderError } from '@/components/layout/ProviderError'
 import { ProviderLoading } from '@/components/layout/ProviderLoading'
-import type { TOrg } from '@/types'
+import type { TAPIError, TOrg } from '@/types'
 
 type OrgContextValue = {
   org: TOrg
@@ -29,6 +29,17 @@ export function OrgProvider({ children }: { children: React.ReactNode }) {
       setOrgSession(orgId)
     }
   }, [orgId])
+
+  // If the org doesn't exist (404/403), clear the stale session cookie
+  // and redirect to / so the BFF can resolve a valid org via GetOrgs.
+  useEffect(() => {
+    if (!error) return
+    const status = (error as TAPIError)?.status
+    if (status === 404 || status === 403) {
+      clearOrgSession()
+      window.location.href = '/'
+    }
+  }, [error])
 
   if (error && !org) return <ProviderError error={error} />
 

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -8,7 +8,7 @@ export interface paths {
   "/slack/commands/nuon": {
     /**
      * Slack /nuon slash command webhook
-     * @description Slack invokes this endpoint when a user runs `/nuon <subcommand>` in any channel of an installed workspace. Authenticated via the Slack signing-secret middleware (X-Slack-Signature + X-Slack-Request-Timestamp); not via API key. Subcommands: subscribe, unsubscribe, help. Responses are ephemeral.
+     * @description Slack invokes this endpoint when a user runs `/nuon <subcommand>` in any channel of an installed workspace. Authenticated via the Slack signing-secret middleware (X-Slack-Signature + X-Slack-Request-Timestamp); not via API key. Subcommands: subscribe, unsubscribe, status, help. Responses are ephemeral.
      */
     post: operations["SlackSlashCommand"];
   };
@@ -18,6 +18,13 @@ export interface paths {
      * @description Receives lifecycle events from Slack: url_verification (handshake), app_uninstalled (workspace removed Nuon), tokens_revoked (bot token invalidated). Authenticated via Slack signing-secret middleware (X-Slack-Signature + X-Slack-Request-Timestamp); not via API key. Returns 200 even for unhandled event types so Slack does not retry.
      */
     post: operations["SlackEvents"];
+  };
+  "/slack/interactions": {
+    /**
+     * Slack interactivity & shortcuts request URL
+     * @description Receives interactive payloads (view_submission, block_actions, block_suggestion, shortcut). Authenticated via Slack signing-secret middleware (X-Slack-Signature + X-Slack-Request-Timestamp); not via API key. Dispatches subscribe/unsubscribe modal submissions, block_actions (scope/notif radios, Remove buttons), and the install picker's external_select block_suggestion handshake. Returns 200 on every parseable envelope so Slack does not retry; unhandled payload types are logged and acked.
+     */
+    post: operations["SlackInteractions"];
   };
   "/slack/oauth/callback": {
     /**
@@ -2029,6 +2036,11 @@ export interface paths {
      * @description Soft-deletes a SlackChannelSubscription belonging to the current org. ABAC scoped at the DB query so callers cannot delete subscriptions outside their org.
      */
     delete: operations["DeleteSlackChannelSubscription"];
+    /**
+     * Update a Slack channel subscription
+     * @description Mutates a per-channel routing rule. Pass only the fields you want to change. Updating `match` may collide with the `(team_id, channel_id, org_link_id, match_canonical)` unique index — the API returns 409 with a clear description in that case so the dashboard can render the same toast it shows on a duplicate create. The subscription must belong to the calling org (ABAC enforced at the DB query level).
+     */
+    patch: operations["UpdateSlackChannelSubscription"];
   };
   "/v1/orgs/{org_id}/slack/install-url": {
     /**
@@ -4726,10 +4738,19 @@ export interface components {
       created_by_slack_user_id?: string;
       id?: string;
       /**
-       * @description Interests filters which event categories route to this channel
-       * (e.g. workflow lifecycle, approvals). Empty/nil means "all".
+       * @description Interests is the per-subscription event filter. Stored as JSONB; one
+       * shape is shared with webhooks (see internal/pkg/interests). New rows
+       * default to AllEvents=true via the create handler when the request omits
+       * the field.
        */
-      interests?: string[];
+      interests?: Record<string, never>;
+      /**
+       * @description Match is the per-subscription routing predicate. Nil = match every
+       * event in the org. Non-nil = evaluated by labels.SubscriptionMatch
+       * against the dispatch-time labels.EventTargets. swaggertype:"object"
+       * keeps the SDK from materialising the full nested type tree.
+       */
+      match?: Record<string, never>;
       /** @description OrgID is denormalized from OrgLink for query convenience. */
       org_id?: string;
       org_link_id?: string;
@@ -6143,7 +6164,8 @@ export interface components {
     "service.CreateChannelSubscriptionRequest": {
       channel_id: string;
       channel_name?: string;
-      interests?: string[];
+      interests?: Record<string, never>;
+      match?: Record<string, never>;
       org_link_id: string;
     };
     "service.CreateComponentBuildRequest": {
@@ -6167,6 +6189,7 @@ export interface components {
     };
     "service.CreateCurrentOrgWebhookRequest": {
       interests?: Record<string, never>;
+      match?: Record<string, never>;
       webhook_secret?: string;
       webhook_url: string;
     };
@@ -6285,6 +6308,13 @@ export interface components {
         [key: string]: string;
       };
       install_config?: components["schemas"]["helpers.CreateInstallConfigParams"];
+      /**
+       * @description Labels are key/value pairs to attach to the install at creation time.
+       * They are merged into the install's existing labels (which is empty for a brand-new install).
+       */
+      labels?: {
+        [key: string]: string;
+      };
       metadata?: components["schemas"]["helpers.InstallMetadata"];
       name: string;
     };
@@ -6304,6 +6334,13 @@ export interface components {
         [key: string]: string;
       };
       install_config?: components["schemas"]["helpers.CreateInstallConfigParams"];
+      /**
+       * @description Labels are key/value pairs to attach to the install at creation time.
+       * They are merged into the install's existing labels (which is empty for a brand-new install).
+       */
+      labels?: {
+        [key: string]: string;
+      };
       metadata?: components["schemas"]["helpers.InstallMetadata"];
       name: string;
     };
@@ -6444,6 +6481,7 @@ export interface components {
       has_secret?: boolean;
       id?: string;
       interests?: Record<string, never>;
+      match?: Record<string, never>;
       org_id?: string;
       updated_at?: string;
       webhook_url?: string;
@@ -6727,6 +6765,12 @@ export interface components {
       name?: string;
       slack_webhook_url?: string;
     };
+    "service.UpdateChannelSubscriptionRequest": {
+      channel_id?: string;
+      channel_name?: string;
+      interests?: Record<string, never>;
+      match?: Record<string, never>;
+    };
     "service.UpdateComponentRequest": {
       dependencies?: string[];
       labels?: {
@@ -6737,6 +6781,7 @@ export interface components {
     };
     "service.UpdateCurrentOrgWebhookRequest": {
       interests?: Record<string, never>;
+      match?: Record<string, never>;
       webhook_secret?: string;
     };
     "service.UpdateInstallConfigRequest": {
@@ -6994,7 +7039,7 @@ export interface operations {
 
   /**
    * Slack /nuon slash command webhook
-   * @description Slack invokes this endpoint when a user runs `/nuon <subcommand>` in any channel of an installed workspace. Authenticated via the Slack signing-secret middleware (X-Slack-Signature + X-Slack-Request-Timestamp); not via API key. Subcommands: subscribe, unsubscribe, help. Responses are ephemeral.
+   * @description Slack invokes this endpoint when a user runs `/nuon <subcommand>` in any channel of an installed workspace. Authenticated via the Slack signing-secret middleware (X-Slack-Signature + X-Slack-Request-Timestamp); not via API key. Subcommands: subscribe, unsubscribe, status, help. Responses are ephemeral.
    */
   SlackSlashCommand: {
     requestBody?: {
@@ -7041,6 +7086,26 @@ export interface operations {
         content: {
           "application/json": components["schemas"]["service.slackChallengeResponse"];
         };
+      };
+    };
+  };
+  /**
+   * Slack interactivity & shortcuts request URL
+   * @description Receives interactive payloads (view_submission, block_actions, block_suggestion, shortcut). Authenticated via Slack signing-secret middleware (X-Slack-Signature + X-Slack-Request-Timestamp); not via API key. Dispatches subscribe/unsubscribe modal submissions, block_actions (scope/notif radios, Remove buttons), and the install picker's external_select block_suggestion handshake. Returns 200 on every parseable envelope so Slack does not retry; unhandled payload types are logged and acked.
+   */
+  SlackInteractions: {
+    requestBody?: {
+      content: {
+        "application/x-www-form-urlencoded": {
+          /** @description JSON-encoded interaction payload */
+          payload: string;
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: never;
       };
     };
   };
@@ -21493,6 +21558,64 @@ export interface operations {
       };
       /** @description Not Found */
       404: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * Update a Slack channel subscription
+   * @description Mutates a per-channel routing rule. Pass only the fields you want to change. Updating `match` may collide with the `(team_id, channel_id, org_link_id, match_canonical)` unique index — the API returns 409 with a clear description in that case so the dashboard can render the same toast it shows on a duplicate create. The subscription must belong to the calling org (ABAC enforced at the DB query level).
+   */
+  UpdateSlackChannelSubscription: {
+    parameters: {
+      path: {
+        /** @description Org ID */
+        org_id: string;
+        /** @description Subscription ID */
+        sub_id: string;
+      };
+    };
+    /** @description Input */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["service.UpdateChannelSubscriptionRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["app.SlackChannelSubscription"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Conflict */
+      409: {
         content: {
           "application/json": components["schemas"]["stderr.ErrResponse"];
         };

--- a/services/dashboard-ui/client/views/Error.tsx
+++ b/services/dashboard-ui/client/views/Error.tsx
@@ -1,0 +1,47 @@
+import { useSearchParams } from 'react-router'
+import { EmptyState } from '@/components/common/EmptyState'
+import { Button } from '@/components/common/Button'
+
+const messages: Record<string, { title: string; message: string }> = {
+  'orgs-failed': {
+    title: 'Unable to load your organizations',
+    message:
+      'We had trouble connecting to our servers. This is usually temporary.',
+  },
+  'api-error': {
+    title: 'Unable to connect to the API',
+    message: 'Something went wrong on our end. This is usually temporary.',
+  },
+}
+
+const fallback = {
+  title: 'Something went wrong',
+  message: 'An unexpected error occurred. Please try again.',
+}
+
+export const Error = () => {
+  const [params] = useSearchParams()
+  const reason = params.get('reason') ?? ''
+  const { title, message } = messages[reason] ?? fallback
+
+  return (
+    <div className="flex flex-col flex-1 items-center justify-center h-full">
+      <EmptyState
+        variant="404"
+        emptyTitle={title}
+        emptyMessage={message}
+        action={
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => {
+              window.location.href = '/'
+            }}
+          >
+            Try again
+          </Button>
+        }
+      />
+    </div>
+  )
+}

--- a/services/dashboard-ui/server/internal/handlers/root.go
+++ b/services/dashboard-ui/server/internal/handlers/root.go
@@ -65,47 +65,66 @@ const maxRetries = 2
 const retryDelay = 500 * time.Millisecond
 
 func (h *RootHandler) Handle(c *gin.Context) {
+	start := time.Now()
+
 	token, err := c.Cookie(authCookie)
 	if (err != nil || token == "") && h.cfg.AuthServiceUrl != "" {
+		h.l.Info("root: no auth token, redirecting to auth service")
 		c.Redirect(http.StatusFound, h.cfg.AuthServiceUrl+"/?url="+url.QueryEscape(h.cfg.AppUrl))
 		return
 	}
 
+	hasToken := token != ""
+	_, orgCookieErr := c.Cookie(orgCookie)
+	hasOrgCookie := orgCookieErr == nil
+
+	h.l.Info("root: handling request",
+		zap.Bool("has_token", hasToken),
+		zap.Bool("has_org_cookie", hasOrgCookie),
+	)
+
+	// Trust the org session cookie and redirect immediately. The SPA's
+	// OrgProvider will validate the org and show an error if it's stale.
+	// This avoids an expensive GetOrg API call that loads all roles/policies
+	// for the account, which is slow for users with many orgs.
 	if orgId, err := c.Cookie(orgCookie); err == nil && orgId != "" {
-		orgClient, err := nuon.New(
-			nuon.WithURL(h.cfg.APIUrl),
-			nuon.WithAuthToken(token),
-			nuon.WithOrgID(orgId),
+		h.l.Info("root: redirecting to org from session cookie",
+			zap.String("org_id", orgId),
+			zap.Duration("duration", time.Since(start)),
 		)
-		if err == nil {
-			if org, err := orgClient.GetOrg(c.Request.Context()); err == nil {
-				c.Redirect(http.StatusFound, orgLandingPath(org))
-				return
-			} else {
-				h.l.Warn("failed to get org from session cookie",
-					zap.String("org_id", orgId),
-					zap.Error(err),
-				)
-			}
-		}
+		c.Redirect(http.StatusFound, "/"+orgId)
+		return
 	}
 
 	client, err := nuon.New(nuon.WithURL(h.cfg.APIUrl), nuon.WithAuthToken(token))
 	if err != nil {
-		h.l.Error("failed to create nuon client", zap.Error(err))
-		c.Redirect(http.StatusFound, "/onboarding")
+		h.l.Error("root: failed to create nuon client",
+			zap.Error(err),
+			zap.Duration("duration", time.Since(start)),
+		)
+		c.Redirect(http.StatusFound, "/error?reason=api-error")
 		return
 	}
 
+	h.l.Info("root: no org cookie, fetching orgs from API")
+
 	var orgs []*models.AppOrg
 	for attempt := 0; attempt <= maxRetries; attempt++ {
+		attemptStart := time.Now()
 		orgs, _, err = client.GetOrgs(c.Request.Context(), &models.GetPaginatedQuery{Limit: 1})
 		if err == nil {
+			h.l.Info("root: GetOrgs succeeded",
+				zap.Int("attempt", attempt+1),
+				zap.Int("org_count", len(orgs)),
+				zap.Duration("attempt_duration", time.Since(attemptStart)),
+			)
 			break
 		}
-		h.l.Warn("failed to get orgs",
+		h.l.Warn("root: GetOrgs failed",
 			zap.Error(err),
 			zap.Int("attempt", attempt+1),
+			zap.Bool("retryable", isRetryableError(err)),
+			zap.Duration("attempt_duration", time.Since(attemptStart)),
 		)
 		if !isRetryableError(err) || attempt == maxRetries {
 			break
@@ -114,18 +133,27 @@ func (h *RootHandler) Handle(c *gin.Context) {
 	}
 
 	if err != nil {
-		h.l.Error("all attempts to get orgs failed, redirecting to onboarding",
+		h.l.Error("root: all attempts to get orgs failed, redirecting to error page",
 			zap.Error(err),
+			zap.Duration("duration", time.Since(start)),
 		)
-		c.Redirect(http.StatusFound, "/onboarding")
+		c.Redirect(http.StatusFound, "/error?reason=orgs-failed")
 		return
 	}
 
 	if len(orgs) > 0 {
-		c.Redirect(http.StatusFound, orgLandingPath(orgs[0]))
+		dest := orgLandingPath(orgs[0])
+		h.l.Info("root: redirecting to org",
+			zap.String("org_id", orgs[0].ID),
+			zap.String("destination", dest),
+			zap.Duration("duration", time.Since(start)),
+		)
+		c.Redirect(http.StatusFound, dest)
 		return
 	}
 
-	h.l.Info("no orgs found for account, redirecting to onboarding")
+	h.l.Info("root: no orgs found, redirecting to onboarding",
+		zap.Duration("duration", time.Since(start)),
+	)
 	c.Redirect(http.StatusFound, "/onboarding")
 }


### PR DESCRIPTION
- BFF returns 500 if api response with 500 during org check
- Org session check is moved to the org-provider
- - If org session returns 404 then clear org session cookie and redirect back to root
- Add debug logs for org check