### PR TITLE
chore(dev): add nix flake and direnv for local dev tooling

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,3 @@
+use flake
+dotenv_if_exists .env.dev
+export GITHUB_APP_KEY="$(cat .dev/github-app-key.pem 2>/dev/null || echo dummy)"

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,21 @@ bins/nuonctl/nuonctl
 bins/lsp/lsp
 *.vsix
 
+# local dev data (process-compose)
+.dev/
+preprocessed_configs/
+*.preprocessed_configuration.xml
+
+# direnv local config (copy from .envrc.example)
+.envrc
+
+# direnv cache
+.direnv/
+
+# nix build output symlinks
+result
+result-*
+
 # ignore workspaces
 ws-*/
 agent-day2/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "revCount": 980183,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.980183%2Brev-4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9/019d927d-72eb-7ff0-8888-fde211b3ffbd/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,79 @@
+{
+  description = "Nuon BYOC platform development environment";
+
+  inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1"; # Unstable for latest Go
+
+  outputs =
+    { self, ... }@inputs:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      forEachSupportedSystem =
+        f:
+        inputs.nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          f {
+            inherit system;
+            pkgs = import inputs.nixpkgs {
+              inherit system;
+              config.allowUnfree = true;
+            };
+          }
+        );
+    in
+    {
+      devShells = forEachSupportedSystem (
+        { pkgs, system }:
+        {
+          default = pkgs.mkShellNoCC {
+            packages = with pkgs; [
+              self.formatter.${system}
+
+              # Go
+              go
+              gotools # goimports
+              golangci-lint
+              mockgen
+
+              # Node.js (dashboard-ui, docs, website)
+              nodejs
+
+              # Infrastructure
+              terraform
+              kubectl
+              kustomize
+              kubernetes-helm
+              temporal-cli
+              awscli2
+              azure-cli
+
+              # Container tooling
+              oras
+
+              # Database clients (local debugging)
+              postgresql
+              clickhouse
+
+              # Utilities
+              jq
+              process-compose
+              air
+            ];
+
+            env = {
+            };
+
+            shellHook = ''
+              export PATH=''${PATH}:$(go env GOPATH)/bin
+            '';
+          };
+        }
+      );
+
+      formatter = forEachSupportedSystem ({ pkgs, ... }: pkgs.nixfmt);
+    };
+}

--- a/services/ctl-api/internal/app/slack/manifest.example.yml
+++ b/services/ctl-api/internal/app/slack/manifest.example.yml
@@ -2,7 +2,7 @@
 #
 # Usage:
 #   1. Replace `<your-public-host>` below with the host that fronts ctl-api's
-#      Slack listener (port 8088). For local dev this is your cloudflare /
+#      Slack listener (port 8089). For local dev this is your cloudflare /
 #      ngrok tunnel; in stage/prod it's the public hostname routed to the
 #      ctl-api Slack listener.
 #   2. Visit https://api.slack.com/apps -> "Create New App" -> "From a manifest",

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -20,7 +20,7 @@ func init() {
 	config.RegisterDefault("runner_http_port", "8083")
 	config.RegisterDefault("auth_http_port", "8084")
 	config.RegisterDefault("admin_dashboard_http_port", "8087")
-	config.RegisterDefault("slack_http_port", "8088")
+	config.RegisterDefault("slack_http_port", "8089")
 	// Slack secrets: dev-only insecure defaults so the slack-libs FX module
 	// (statejwt.New) and signing.Middleware construction don't fail boot
 	// when no SLACK_* env is set. Prod overrides via env. Same pattern as


### PR DESCRIPTION
Introduces a Nix flake-based dev shell for developer tooling across the repo (Go, Node.js, Terraform, kubectl, helm, temporal-cli, awscli, azure-cli, oras, postgres + clickhouse clients, jq).

With this, devs can have all the binaries needed to run the stack. 

A .envrc with 'use flake' lets direnv auto-load the dev shell on cd.

