### PR TITLE
fix: hard error on unknown signal

### DIFF
--- a/services/ctl-api/internal/pkg/queue/activities/get_queue_signal_signal.go
+++ b/services/ctl-api/internal/pkg/queue/activities/get_queue_signal_signal.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/catalog"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+	"go.temporal.io/sdk/temporal"
 )
 
 // @temporal-gen-v2 activity
@@ -19,6 +21,13 @@ func (a *Activities) getQueueSignalSignal(ctx context.Context, queueSignalID str
 		return nil, generics.TemporalGormError(err, "unable to get queue signal")
 	}
 
+	if queueSignal.Signal.Signal == nil {
+		return nil, temporal.NewNonRetryableApplicationError(
+			"signal type not registered in catalog",
+			catalog.SignalTypeNotRegisteredErrorType,
+			nil,
+		)
+	}
 	return queueSignal.Signal.Signal, nil
 }
 

--- a/services/ctl-api/internal/pkg/queue/catalog/obj.go
+++ b/services/ctl-api/internal/pkg/queue/catalog/obj.go
@@ -4,14 +4,14 @@ import (
 	"errors"
 	"fmt"
 
+	"go.temporal.io/sdk/temporal"
+
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 )
 
-// ErrSignalTypeNotRegistered is returned by NewFromType when the given signal
-// type is not present in the catalog. Callers can use errors.Is to detect this
-// specific condition — e.g. to gracefully skip stale DB rows that reference
-// deprecated signal types instead of failing the whole query.
 var ErrSignalTypeNotRegistered = errors.New("signal type not registered")
+
+const SignalTypeNotRegisteredErrorType = "SignalTypeNotRegistered"
 
 func NewFromType(typ signal.SignalType) (signal.Signal, error) {
 	constructor, ok := SignalCatalog[typ]
@@ -20,4 +20,18 @@ func NewFromType(typ signal.SignalType) (signal.Signal, error) {
 	}
 
 	return constructor(), nil
+}
+
+func IsSignalTypeNotRegistered(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrSignalTypeNotRegistered) {
+		return true
+	}
+	var appErr *temporal.ApplicationError
+	if errors.As(err, &appErr) && appErr.Type() == SignalTypeNotRegisteredErrorType {
+		return true
+	}
+	return false
 }

--- a/services/ctl-api/internal/pkg/queue/catalog/obj.go
+++ b/services/ctl-api/internal/pkg/queue/catalog/obj.go
@@ -1,15 +1,22 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 )
 
+// ErrSignalTypeNotRegistered is returned by NewFromType when the given signal
+// type is not present in the catalog. Callers can use errors.Is to detect this
+// specific condition — e.g. to gracefully skip stale DB rows that reference
+// deprecated signal types instead of failing the whole query.
+var ErrSignalTypeNotRegistered = errors.New("signal type not registered")
+
 func NewFromType(typ signal.SignalType) (signal.Signal, error) {
 	constructor, ok := SignalCatalog[typ]
 	if !ok {
-		return nil, fmt.Errorf("invalid signal type %s - not registered", typ)
+		return nil, fmt.Errorf("%w: %s", ErrSignalTypeNotRegistered, typ)
 	}
 
 	return constructor(), nil

--- a/services/ctl-api/internal/pkg/queue/handler/state.go
+++ b/services/ctl-api/internal/pkg/queue/handler/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/catalog"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
@@ -53,10 +54,15 @@ func (h *handler) initializeState(ctx workflow.Context) error {
 
 	sig, err := activities.AwaitGetQueueSignalSignalByQueueSignalID(ctx, h.queueSignalID)
 	if err != nil {
+		if catalog.IsSignalTypeNotRegistered(err) {
+			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+				QueueSignalID:     h.queueSignalID,
+				Status:            app.StatusPending,
+				StatusDescription: "signal type not registered in current build; parked for redeploy",
+			})
+			return nil
+		}
 		return errors.Wrap(err, "unable to get signal")
-	}
-	if sig == nil {
-		panic("signal was nil")
 	}
 	h.sig = sig
 

--- a/services/ctl-api/internal/pkg/queue/signal/db/dataconverter_test.go
+++ b/services/ctl-api/internal/pkg/queue/signal/db/dataconverter_test.go
@@ -223,8 +223,8 @@ func (s *PayloadConverterTestSuite) TestFromPayload_InvalidCatalogType() {
 	var resultSig signal.Signal
 	err := s.converter.FromPayload(invalidPayload, &resultSig)
 	require.Error(s.T(), err)
-	assert.Contains(s.T(), err.Error(), "invalid signal type")
-	assert.Contains(s.T(), err.Error(), "not registered")
+	assert.ErrorIs(s.T(), err, catalog.ErrSignalTypeNotRegistered)
+	assert.Contains(s.T(), err.Error(), "invalid-signal-type")
 }
 
 // TestFromPayload_NilPointer verifies error handling for nil valuePtr

--- a/services/ctl-api/internal/pkg/queue/signal/db/signal.go
+++ b/services/ctl-api/internal/pkg/queue/signal/db/signal.go
@@ -3,8 +3,10 @@ package signaldb
 import (
 	"database/sql/driver"
 	"encoding/json"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/catalog"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
@@ -35,7 +37,18 @@ func (s *SignalData) Scan(value interface{}) error {
 		return errors.New("invalid type")
 	}
 
-	return s.unmarshalSignalJSON(bytes)
+	if err := s.unmarshalSignalJSON(bytes); err != nil {
+		// this was done to make this part of code rollback compatible, if a signal in db is not found in catalog
+		// it should handle the case since its very possible in case of new signal additions. Here, if its a
+		// signal not registered error, we return a nil signal and let caller handle the case.
+		if stderrors.Is(err, catalog.ErrSignalTypeNotRegistered) {
+			zap.L().Warn("signal type from DB not registered in catalog; leaving Signal nil",
+				zap.Error(err))
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler so that standard JSON serialization


### PR DESCRIPTION
when a new signal is introduced in db and then is removed from code, multiple code paths fail because Scan method hard fails on signal not found.
Instead of hard failing, we now log the failure and continue forward and rely on signal nil check for further operations.
:x

