### PR TITLE
feat: Add base abstraction package for CompositeError

### DIFF
--- a/pkg/composite_error/catalog/catalog.go
+++ b/pkg/composite_error/catalog/catalog.go
@@ -1,0 +1,171 @@
+// Package catalog is the in-memory registry for CompositeError types and
+// Parsers, populated via init() blocks in per-type packages.
+//
+// This mirrors pkg/queue/catalog: there is no DB-backed catalog table.
+// On every process start, importing a type's package runs its init() which
+// registers the factory and parser(s) here.
+package catalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+)
+
+var (
+	typeMu       sync.RWMutex
+	typeRegistry = map[composite_error.Type]func() composite_error.CompositeError{}
+
+	parserMu     sync.RWMutex
+	parsersByCtx = map[composite_error.ParseContext][]composite_error.Parser{}
+	allParsers   []composite_error.Parser
+)
+
+// RegisterType associates a CompositeError type with its factory. Panics on
+// duplicate registration — same contract as pkg/queue/catalog.
+//
+// The factory must return a fresh, zero-valued instance of the implementing
+// struct on each call.
+func RegisterType(typ composite_error.Type, fn func() composite_error.CompositeError) {
+	typeMu.Lock()
+	defer typeMu.Unlock()
+
+	if _, exists := typeRegistry[typ]; exists {
+		panic(fmt.Sprintf("composite_error: duplicate type registered: %q", typ))
+	}
+	typeRegistry[typ] = fn
+}
+
+// LookupType returns the factory registered for typ, or (nil, false).
+func LookupType(typ composite_error.Type) (func() composite_error.CompositeError, bool) {
+	typeMu.RLock()
+	defer typeMu.RUnlock()
+
+	fn, ok := typeRegistry[typ]
+	return fn, ok
+}
+
+// Hydrate looks up the factory for typ, instantiates an empty value, and
+// unmarshals data into it. Returns an error if the type is not registered or
+// the JSON does not match the type's schema.
+func Hydrate(typ composite_error.Type, data []byte) (composite_error.CompositeError, error) {
+	fn, ok := LookupType(typ)
+	if !ok {
+		return nil, fmt.Errorf("composite_error: unknown type %q", typ)
+	}
+
+	val := fn()
+	if len(data) == 0 {
+		return val, nil
+	}
+	if err := json.Unmarshal(data, val); err != nil {
+		return nil, fmt.Errorf("composite_error: hydrate %q: %w", typ, err)
+	}
+	return val, nil
+}
+
+// Types returns all registered type identifiers, sorted. Useful for the
+// admin dashboard catalog browser.
+func Types() []composite_error.Type {
+	typeMu.RLock()
+	defer typeMu.RUnlock()
+
+	out := make([]composite_error.Type, 0, len(typeRegistry))
+	for t := range typeRegistry {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// RegisterParser indexes p under each of its declared ParseContexts. Panics
+// if Contexts() is empty — every parser must opt in to at least one subtree
+// (see specs/composite-errors.md).
+func RegisterParser(p composite_error.Parser) {
+	parserMu.Lock()
+	defer parserMu.Unlock()
+
+	ctxs := p.Contexts()
+	if len(ctxs) == 0 {
+		panic(fmt.Sprintf("composite_error: parser %q registered with no contexts", p.Name()))
+	}
+	for _, c := range ctxs {
+		parsersByCtx[c] = append(parsersByCtx[c], p)
+	}
+	allParsers = append(allParsers, p)
+}
+
+// ParsersForContext returns the parsers that should be invoked for a given
+// dispatch context, ordered most-specific to least-specific. Within a level
+// parsers are returned in registration order.
+//
+// Walking is by "/"-segment ancestry: "terraform/plan" matches parsers
+// registered against "terraform/plan", "terraform", and "" (root).
+func ParsersForContext(c composite_error.ParseContext) []composite_error.Parser {
+	parserMu.RLock()
+	defer parserMu.RUnlock()
+
+	ancestors := ancestorsOf(c)
+	out := make([]composite_error.Parser, 0)
+	for _, a := range ancestors {
+		out = append(out, parsersByCtx[a]...)
+	}
+	return out
+}
+
+// AllParsers returns every registered parser, in registration order.
+// Used by the admin dashboard catalog browser.
+func AllParsers() []composite_error.Parser {
+	parserMu.RLock()
+	defer parserMu.RUnlock()
+
+	out := make([]composite_error.Parser, len(allParsers))
+	copy(out, allParsers)
+	return out
+}
+
+// ancestorsOf returns c, its parents, and "" (root), most-specific first.
+//
+//	"terraform/plan/init" → ["terraform/plan/init", "terraform/plan", "terraform", ""]
+//	"terraform"           → ["terraform", ""]
+//	""                    → [""]
+func ancestorsOf(c composite_error.ParseContext) []composite_error.ParseContext {
+	s := string(c)
+	out := []composite_error.ParseContext{c}
+	for {
+		i := lastSlash(s)
+		if i < 0 {
+			break
+		}
+		s = s[:i]
+		out = append(out, composite_error.ParseContext(s))
+	}
+	if c != "" {
+		out = append(out, "")
+	}
+	return out
+}
+
+func lastSlash(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '/' {
+			return i
+		}
+	}
+	return -1
+}
+
+// Reset clears all registrations. Test-only.
+func Reset() {
+	typeMu.Lock()
+	parserMu.Lock()
+	defer typeMu.Unlock()
+	defer parserMu.Unlock()
+
+	typeRegistry = map[composite_error.Type]func() composite_error.CompositeError{}
+	parsersByCtx = map[composite_error.ParseContext][]composite_error.Parser{}
+	allParsers = nil
+}

--- a/pkg/composite_error/catalog/catalog_test.go
+++ b/pkg/composite_error/catalog/catalog_test.go
@@ -1,0 +1,159 @@
+package catalog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+)
+
+// fakeError is a minimal CompositeError for catalog tests.
+type fakeError struct {
+	Msg string `json:"msg"`
+}
+
+func (f *fakeError) Type() composite_error.Type         { return "test_fake" }
+func (f *fakeError) Domain() composite_error.Domain     { return composite_error.DomainNuon }
+func (f *fakeError) Severity() composite_error.Severity { return composite_error.SeverityError }
+func (f *fakeError) Render(_ context.Context) composite_error.Render {
+	return composite_error.Render{Title: f.Msg}
+}
+
+type fakeParser struct {
+	name     string
+	contexts []composite_error.ParseContext
+}
+
+func (p fakeParser) Name() string                             { return p.name }
+func (p fakeParser) Version() string                          { return "1" }
+func (p fakeParser) Contexts() []composite_error.ParseContext { return p.contexts }
+func (p fakeParser) Parse(_ context.Context, _ composite_error.ParseInput) composite_error.ParseResult {
+	return composite_error.ParseResult{Matched: false}
+}
+
+func TestRegisterTypeAndHydrate(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	RegisterType("test_fake", func() composite_error.CompositeError { return &fakeError{} })
+
+	got, err := Hydrate("test_fake", []byte(`{"msg":"hello"}`))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	fe, ok := got.(*fakeError)
+	require.True(t, ok)
+	assert.Equal(t, "hello", fe.Msg)
+}
+
+func TestRegisterTypePanicsOnDuplicate(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	RegisterType("test_fake", func() composite_error.CompositeError { return &fakeError{} })
+	assert.Panics(t, func() {
+		RegisterType("test_fake", func() composite_error.CompositeError { return &fakeError{} })
+	})
+}
+
+func TestHydrateUnknownTypeErrors(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	_, err := Hydrate("not_registered", []byte(`{}`))
+	assert.Error(t, err)
+}
+
+func TestHydrateEmptyDataReturnsZeroValue(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	RegisterType("test_fake", func() composite_error.CompositeError { return &fakeError{} })
+
+	got, err := Hydrate("test_fake", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	fe := got.(*fakeError)
+	assert.Empty(t, fe.Msg)
+}
+
+func TestRegisterParserPanicsWithoutContexts(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	assert.Panics(t, func() {
+		RegisterParser(fakeParser{name: "no-ctx"})
+	})
+}
+
+func TestParsersForContextWalksAncestors(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	root := fakeParser{name: "root", contexts: []composite_error.ParseContext{""}}
+	tf := fakeParser{name: "tf", contexts: []composite_error.ParseContext{"terraform"}}
+	tfPlan := fakeParser{name: "tf-plan", contexts: []composite_error.ParseContext{"terraform/plan"}}
+	helm := fakeParser{name: "helm", contexts: []composite_error.ParseContext{"helm"}}
+
+	RegisterParser(root)
+	RegisterParser(tf)
+	RegisterParser(tfPlan)
+	RegisterParser(helm)
+
+	got := ParsersForContext("terraform/plan")
+	require.Len(t, got, 3, "should return tf-plan + tf + root, not helm")
+	assert.Equal(t, "tf-plan", got[0].Name())
+	assert.Equal(t, "tf", got[1].Name())
+	assert.Equal(t, "root", got[2].Name())
+}
+
+func TestParserCanRegisterAcrossSubtrees(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	cross := fakeParser{
+		name:     "aws-perm",
+		contexts: []composite_error.ParseContext{"terraform", "helm", "runner/job"},
+	}
+	RegisterParser(cross)
+
+	for _, ctx := range []composite_error.ParseContext{
+		"terraform/plan", "terraform/apply", "helm/install", "runner/job",
+	} {
+		got := ParsersForContext(ctx)
+		require.Len(t, got, 1, ctx)
+		assert.Equal(t, "aws-perm", got[0].Name())
+	}
+	assert.Empty(t, ParsersForContext("kubernetes/rollout"))
+}
+
+func TestAncestorsOf(t *testing.T) {
+	cases := []struct {
+		in   composite_error.ParseContext
+		want []composite_error.ParseContext
+	}{
+		{"", []composite_error.ParseContext{""}},
+		{"terraform", []composite_error.ParseContext{"terraform", ""}},
+		{"terraform/plan", []composite_error.ParseContext{"terraform/plan", "terraform", ""}},
+		{"a/b/c", []composite_error.ParseContext{"a/b/c", "a/b", "a", ""}},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, ancestorsOf(tc.in), string(tc.in))
+	}
+}
+
+func TestTypesReturnsSortedRegisteredTypes(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	RegisterType("zeta", func() composite_error.CompositeError { return &fakeError{} })
+	RegisterType("alpha", func() composite_error.CompositeError { return &fakeError{} })
+	RegisterType("mu", func() composite_error.CompositeError { return &fakeError{} })
+
+	got := Types()
+	assert.Equal(t, []composite_error.Type{"alpha", "mu", "zeta"}, got)
+}

--- a/pkg/composite_error/directive.go
+++ b/pkg/composite_error/directive.go
@@ -1,0 +1,50 @@
+package composite_error
+
+// DirectiveKind aligns with WorkflowStep.ResultDirective so the conductor can
+// apply an error-driven override without translation.
+type DirectiveKind string
+
+const (
+	// DirectiveNone is the zero value — "no opinion, defer to signal defaults".
+	DirectiveNone DirectiveKind = ""
+
+	DirectiveContinue      DirectiveKind = "continue"
+	DirectiveStop          DirectiveKind = "stop"
+	DirectiveRetry         DirectiveKind = "retry"
+	DirectiveRetryGroup    DirectiveKind = "retry-group"
+	DirectiveSkipGroup     DirectiveKind = "skip-group"
+	DirectiveAwaitApproval DirectiveKind = "await-approval"
+)
+
+// Directive is the override an error type can apply to a step's outcome. The
+// shape is intentional: future fields (MaxRetries, Backoff, …) can be added
+// without breaking the capability interface.
+type Directive struct {
+	Kind DirectiveKind `json:"kind"`
+}
+
+// ErrorWithDirective is implemented by error types that override the conductor's
+// default directive for a failed step.
+//
+// Returning Directive{Kind: DirectiveNone} (the zero value) means the type has
+// no opinion and the signal's default applies.
+type ErrorWithDirective interface {
+	OverrideDirective() Directive
+}
+
+// ErrorWithDocsLink is implemented by error types that point at a docs page.
+type ErrorWithDocsLink interface {
+	DocsURL() string
+}
+
+// ErrorWithReferences is implemented by error types that declare static
+// references in addition to anything the parser attaches dynamically.
+type ErrorWithReferences interface {
+	References() []Reference
+}
+
+// ErrorWithJSONSchema is implemented by error types that provide a JSON Schema
+// for their Data payload, validated by helpers.Record() before persisting.
+type ErrorWithJSONSchema interface {
+	JSONSchema() []byte
+}

--- a/pkg/composite_error/error.go
+++ b/pkg/composite_error/error.go
@@ -1,0 +1,110 @@
+// Package composite_error defines the typed, catalogable error abstraction
+// used across the Nuon platform.
+//
+// See specs/composite-errors.md for design rationale.
+//
+// At a high level:
+//
+//   - A CompositeError is a typed Go value (one struct per error type) that
+//     knows how to render itself for users.
+//   - Each type registers a factory in the in-memory catalog via init(),
+//     mirroring how queue signals are registered.
+//   - Parsers (also registered in the catalog) consume raw error material
+//     (Temporal errors, runner stderr, terraform output, …) and emit typed
+//     CompositeErrors via a dispatch pipeline.
+//   - The conductor / step finalizer honors optional capability interfaces
+//     on a CompositeError (see directive.go) to override step directives
+//     (fail-fast, retry, downgrade, …).
+//
+// Phase 1 lands the abstraction and the catalog only; the helpers, GORM models,
+// and parser implementations live alongside ctl-api.
+package composite_error
+
+import "context"
+
+// Type is the catalog identifier for a CompositeError implementation.
+// Stored on the persisted row and used to look up the factory in the catalog.
+type Type string
+
+// Domain is the broad classification of an error — what kind of error it is,
+// not where it came from. Domain is flat (no hierarchy) and lives on the row
+// for filtering, metrics, and UI grouping.
+type Domain string
+
+// Standard domains. New domains are introduced as needed; kept short and stable.
+const (
+	DomainNuon       Domain = "nuon"
+	DomainTerraform  Domain = "terraform"
+	DomainHelm       Domain = "helm"
+	DomainKubernetes Domain = "kubernetes"
+	DomainAWS        Domain = "aws"
+	DomainGCP        Domain = "gcp"
+	DomainAzure      Domain = "azure"
+	DomainRunner     Domain = "runner"
+)
+
+// Severity controls how the UI presents an error and whether it is treated as
+// a hard failure. The conductor reacts to OverrideDirective(), not Severity —
+// severity is a UX concept.
+type Severity string
+
+const (
+	SeverityFatal   Severity = "fatal"
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+	SeverityInfo    Severity = "info"
+)
+
+// CompositeError is the typed, in-memory view of a stored composite error.
+//
+// Implementations live alongside ctl-api under
+// services/ctl-api/internal/app/composite_errors/types/<name>/ and register
+// themselves into the catalog via init().
+//
+// A CompositeError MUST be JSON round-trippable: marshalling the implementing
+// struct and unmarshalling into a fresh value produced by the catalog factory
+// must yield an equivalent value. The persisted row's Data column holds
+// exactly the JSON representation of the implementing struct.
+type CompositeError interface {
+	Type() Type
+	Domain() Domain
+	Severity() Severity
+
+	// Render produces the user-facing view from the typed fields on the
+	// implementing struct. Always called at read time. The TitleCached /
+	// SummaryCached columns on the persisted row are denormalized copies
+	// populated from Render() at write time and used only for admin
+	// search / listing.
+	Render(ctx context.Context) Render
+}
+
+// Render is the user-facing payload computed from a CompositeError's typed
+// fields. Sections and UserActions are ordered.
+type Render struct {
+	Title       string          `json:"title"`
+	Summary     string          `json:"summary,omitempty"`
+	Sections    []RenderSection `json:"sections,omitempty"`
+	UserActions []UserAction    `json:"user_actions,omitempty"`
+}
+
+// RenderSection is a heading + markdown body. Sections typically follow a
+// what / why / how-to-fix structure.
+type RenderSection struct {
+	Heading string `json:"heading"`
+	Body    string `json:"body"`
+}
+
+// UserAction is a structured CTA the UI can render as a button or chip.
+type UserAction struct {
+	Kind  UserActionKind `json:"kind"`
+	Label string         `json:"label"`
+	Value string         `json:"value,omitempty"` // url, snippet, command, etc.
+}
+
+type UserActionKind string
+
+const (
+	UserActionKindLink    UserActionKind = "link"
+	UserActionKindCopy    UserActionKind = "copy"
+	UserActionKindCommand UserActionKind = "command"
+)

--- a/pkg/composite_error/parser.go
+++ b/pkg/composite_error/parser.go
@@ -1,0 +1,102 @@
+package composite_error
+
+import "context"
+
+// ParseContext is a hierarchical, "/"-separated path identifying the producer
+// of the raw error material being parsed. Examples:
+//
+//	"terraform"
+//	"terraform/plan"
+//	"terraform/apply"
+//	"helm/install"
+//	"helm/install/rbac"
+//	"kubernetes/rollout"
+//	"runner/job"
+//	"build/helm"
+//
+// Parsers register against one or more ParseContexts and each entry matches
+// itself plus all descendants. ParseContext is purely a dispatch concept and
+// is never persisted on a CompositeError row — that's what Domain is for.
+type ParseContext string
+
+// ParseInput is what the dispatch pipeline hands to a parser. Not every field
+// is required to be set — a parser examines what it cares about and returns
+// Matched=false if the input doesn't apply.
+type ParseInput struct {
+	// Raw is the bytes the producer emitted (stderr, stdout, log buffer, …).
+	Raw []byte
+
+	// ExitCode of the producing process, if applicable.
+	ExitCode int
+
+	// GoErr carries the producing Go error. By convention the caller has
+	// already stripped Temporal activity / workflow error envelopes via
+	// `signal.HumanError` before handing it to the pipeline — parsers
+	// should treat GoErr.Error() as the user-facing message and must not
+	// re-walk Temporal wrappers themselves.
+	GoErr error
+
+	// Invocation describes who/what produced Raw.
+	Invocation InvocationContext
+}
+
+// InvocationContext is metadata about who/what produced the raw input.
+// Optional and best-effort — parsers must tolerate empty fields.
+type InvocationContext struct {
+	OrgID     string
+	OwnerID   string
+	OwnerType string
+
+	ComponentID   string
+	ComponentType string // "terraform_module", "helm_chart", "docker_build", ...
+
+	InstallID string
+	BuildID   string
+	StepID    string
+
+	// CloudPlatform is "aws" / "gcp" / "azure" if known.
+	CloudPlatform string
+
+	// Extra is a free-form bag for parser-specific hints.
+	Extra map[string]any
+}
+
+// ParseResult is what a parser returns.
+//
+// Matched=false means "this parser does not claim the input"; Error/Source/Refs
+// are ignored. Causes is a recursive list of sub-results that, when this result
+// becomes the primary, are recorded as children in the cause graph.
+type ParseResult struct {
+	Matched bool
+	Error   CompositeError
+	Source  Source
+	Refs    []Reference
+	Causes  []ParseResult
+}
+
+// Parser turns raw error material into a typed CompositeError.
+//
+// Implementations live alongside their error type and register themselves
+// into the parser catalog via init().
+//
+// Parsers MUST be best-effort, fast, and side-effect-free. The pipeline
+// recovers panics, but a parser that panics on every call drowns the failure
+// path in noise.
+type Parser interface {
+	// Name is the stable, human-readable identifier of the parser. Persisted
+	// on the resulting CompositeError row's Source.ParserName for traceability.
+	Name() string
+
+	// Version is incremented when the parser's matching/extraction logic
+	// changes in a way that would produce different output for the same input.
+	Version() string
+
+	// Contexts declares the ParseContext subtrees this parser opts into.
+	// Each entry matches itself + descendants. An empty slice is a registration
+	// error — every parser must opt in to at least one subtree.
+	Contexts() []ParseContext
+
+	// Parse examines the input and returns a ParseResult. If the input is not
+	// a match, return ParseResult{Matched: false}.
+	Parse(ctx context.Context, in ParseInput) ParseResult
+}

--- a/pkg/composite_error/pipeline.go
+++ b/pkg/composite_error/pipeline.go
@@ -1,0 +1,109 @@
+package composite_error
+
+import "context"
+
+// ParserLookup returns parsers applicable to a ParseContext, ordered
+// most-specific → least-specific. The catalog package implements this against
+// its in-memory registry; tests can substitute a stub.
+type ParserLookup func(ParseContext) []Parser
+
+// UnknownErrorBuilder constructs the safety-net result when no parser matches.
+// Provided by the unknown_error builtin via NewPipeline.
+type UnknownErrorBuilder func(in ParseInput) ParseResult
+
+// PanicHandler is invoked when a parser panics. The pipeline always treats
+// the panicking parser's call as a non-match; the handler is for observability.
+// nil is a no-op.
+type PanicHandler func(parserName string, panicValue any)
+
+// Pipeline dispatches ParseInput to registered parsers and produces a
+// PipelineResult: a primary CompositeError plus zero-or-more secondaries.
+//
+// Pipeline is stateless and safe for concurrent use.
+type Pipeline struct {
+	lookup  ParserLookup
+	unknown UnknownErrorBuilder
+	onPanic PanicHandler
+}
+
+// NewPipeline constructs a Pipeline. Both lookup and unknown are required.
+//
+//   - lookup is typically catalog.ParsersForContext.
+//   - unknown is typically unknown_error.Build.
+func NewPipeline(lookup ParserLookup, unknown UnknownErrorBuilder, onPanic PanicHandler) *Pipeline {
+	return &Pipeline{lookup: lookup, unknown: unknown, onPanic: onPanic}
+}
+
+// PipelineResult is the output of Pipeline.Parse.
+type PipelineResult struct {
+	// Primary is the headline error to attach to the owner. Always non-nil
+	// after Parse() (the pipeline guarantees a fallback).
+	Primary ParseResult
+
+	// Secondaries are additional matches at any level that the caller may
+	// also persist as separate rows on the same owner.
+	Secondaries []ParseResult
+}
+
+// Parse runs the parsers registered for parseCtx against in and returns a
+// PipelineResult.
+//
+// Dispatch rule:
+//
+//  1. Walk ancestors of parseCtx, most-specific → least-specific (via the
+//     ParserLookup).
+//  2. At each level, run every registered parser in registration order.
+//  3. The first matching result becomes Primary.
+//  4. All other matches at any level become Secondaries.
+//  5. If nothing matches, fall back to the unknown error builder.
+//
+// Parser panics are recovered, treated as a non-match, and reported via
+// the onPanic handler if one was supplied.
+func (p *Pipeline) Parse(ctx context.Context, parseCtx ParseContext, in ParseInput) PipelineResult {
+	if p.lookup == nil {
+		return PipelineResult{Primary: p.fallback(in)}
+	}
+
+	parsers := p.lookup(parseCtx)
+
+	var primary *ParseResult
+	var secondaries []ParseResult
+
+	for _, parser := range parsers {
+		res := p.safeParse(ctx, parser, in)
+		if !res.Matched || res.Error == nil {
+			continue
+		}
+		if primary == nil {
+			primary = &res
+			continue
+		}
+		secondaries = append(secondaries, res)
+	}
+
+	if primary == nil {
+		return PipelineResult{Primary: p.fallback(in)}
+	}
+
+	return PipelineResult{Primary: *primary, Secondaries: secondaries}
+}
+
+// fallback returns the unknown_error result.
+func (p *Pipeline) fallback(in ParseInput) ParseResult {
+	if p.unknown != nil {
+		return p.unknown(in)
+	}
+	return ParseResult{Matched: false}
+}
+
+func (p *Pipeline) safeParse(ctx context.Context, parser Parser, in ParseInput) (out ParseResult) {
+	defer func() {
+		if r := recover(); r != nil {
+			if p.onPanic != nil {
+				p.onPanic(parser.Name(), r)
+			}
+			out = ParseResult{Matched: false}
+		}
+	}()
+	return parser.Parse(ctx, in)
+}

--- a/pkg/composite_error/pipeline_test.go
+++ b/pkg/composite_error/pipeline_test.go
@@ -1,0 +1,117 @@
+package composite_error
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubError is a minimal CompositeError used only by pipeline tests.
+type stubError struct {
+	id string
+}
+
+func (s *stubError) Type() Type                      { return Type(s.id) }
+func (s *stubError) Domain() Domain                  { return DomainNuon }
+func (s *stubError) Severity() Severity              { return SeverityError }
+func (s *stubError) Render(_ context.Context) Render { return Render{Title: s.id} }
+
+// stubParser is a deterministic parser fixture.
+type stubParser struct {
+	name     string
+	matches  bool
+	emit     string
+	contexts []ParseContext
+	calls    int
+	panics   bool
+}
+
+func (s *stubParser) Name() string             { return s.name }
+func (s *stubParser) Version() string          { return "1" }
+func (s *stubParser) Contexts() []ParseContext { return s.contexts }
+func (s *stubParser) Parse(_ context.Context, _ ParseInput) ParseResult {
+	s.calls++
+	if s.panics {
+		panic("boom")
+	}
+	if !s.matches {
+		return ParseResult{Matched: false}
+	}
+	return ParseResult{Matched: true, Error: &stubError{id: s.emit}}
+}
+
+// staticLookup builds a ParserLookup from explicit specific/broad lists,
+// emulating the catalog's most-specific-first iteration order.
+func staticLookup(specific, broad []Parser) ParserLookup {
+	return func(_ ParseContext) []Parser {
+		out := append([]Parser{}, specific...)
+		out = append(out, broad...)
+		return out
+	}
+}
+
+func unknownBuilder(_ ParseInput) ParseResult {
+	return ParseResult{Matched: true, Error: &stubError{id: "unknown"}}
+}
+
+func TestPipeline_FirstMatchWinsAsPrimary(t *testing.T) {
+	specific := &stubParser{name: "specific", matches: true, emit: "specific_err"}
+	broad := &stubParser{name: "broad", matches: true, emit: "broad_err"}
+
+	p := NewPipeline(staticLookup([]Parser{specific}, []Parser{broad}), unknownBuilder, nil)
+	res := p.Parse(context.Background(), "terraform/plan", ParseInput{})
+
+	require.NotNil(t, res.Primary.Error)
+	assert.Equal(t, "specific_err", string(res.Primary.Error.Type()))
+	require.Len(t, res.Secondaries, 1)
+	assert.Equal(t, "broad_err", string(res.Secondaries[0].Error.Type()))
+}
+
+func TestPipeline_FallsBackToUnknownWhenNoMatch(t *testing.T) {
+	a := &stubParser{name: "a", matches: false}
+	b := &stubParser{name: "b", matches: false}
+
+	p := NewPipeline(staticLookup([]Parser{a}, []Parser{b}), unknownBuilder, nil)
+	res := p.Parse(context.Background(), "terraform", ParseInput{})
+
+	require.NotNil(t, res.Primary.Error)
+	assert.Equal(t, "unknown", string(res.Primary.Error.Type()))
+	assert.Empty(t, res.Secondaries)
+	assert.Equal(t, 1, a.calls)
+	assert.Equal(t, 1, b.calls)
+}
+
+func TestPipeline_PanickingParserDoesNotBreakAndReportsToHandler(t *testing.T) {
+	bomb := &stubParser{name: "bomb", panics: true}
+	good := &stubParser{name: "good", matches: true, emit: "ok"}
+
+	var caughtName string
+	var caughtPanic any
+	p := NewPipeline(staticLookup([]Parser{bomb}, []Parser{good}), unknownBuilder,
+		func(name string, val any) { caughtName, caughtPanic = name, val })
+	res := p.Parse(context.Background(), "terraform/apply", ParseInput{})
+
+	require.NotNil(t, res.Primary.Error)
+	assert.Equal(t, "ok", string(res.Primary.Error.Type()))
+	assert.Equal(t, "bomb", caughtName)
+	assert.Equal(t, "boom", caughtPanic)
+}
+
+func TestPipeline_SafetyNetWhenLookupNil(t *testing.T) {
+	p := NewPipeline(nil, unknownBuilder, nil)
+	res := p.Parse(context.Background(), "anything", ParseInput{})
+	assert.Equal(t, "unknown", string(res.Primary.Error.Type()))
+}
+
+func TestPipeline_NonMatchedResultIgnored(t *testing.T) {
+	half := &stubParser{name: "half", matches: false}
+	good := &stubParser{name: "good", matches: true, emit: "got"}
+
+	p := NewPipeline(staticLookup([]Parser{half, good}, nil), unknownBuilder, nil)
+	res := p.Parse(context.Background(), "terraform", ParseInput{})
+
+	assert.Equal(t, "got", string(res.Primary.Error.Type()))
+	assert.Empty(t, res.Secondaries)
+}

--- a/pkg/composite_error/reference.go
+++ b/pkg/composite_error/reference.go
@@ -1,0 +1,109 @@
+package composite_error
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// ReferenceType enumerates the kinds of things a CompositeError can point at
+// for dynamic resolution at read time. Lets the persisted error stay small
+// while letting the UI dereference bulk material lazily.
+type ReferenceType string
+
+const (
+	RefTypeLogStream                ReferenceType = "log_stream"
+	RefTypeRunnerJobExecution       ReferenceType = "runner_job_execution"
+	RefTypeRunnerJobExecutionResult ReferenceType = "runner_job_execution_result"
+	RefTypeTerraformPlanResult      ReferenceType = "terraform_plan_result"
+	RefTypeWorkflowStep             ReferenceType = "workflow_step"
+	RefTypeInstallDeploy            ReferenceType = "install_deploy"
+	RefTypeComponentBuild           ReferenceType = "component_build"
+	RefTypeDocURL                   ReferenceType = "doc_url"
+	RefTypeRunbookURL               ReferenceType = "runbook_url"
+)
+
+// Reference points at another entity (or a URL) the UI can dereference at
+// read time. Meta is renderer-specific (e.g. {"start_line": 1421}).
+type Reference struct {
+	Type  ReferenceType  `json:"type"`
+	ID    string         `json:"id,omitempty"`
+	Label string         `json:"label,omitempty"`
+	Meta  map[string]any `json:"meta,omitempty"`
+}
+
+// References is a slice of Reference that satisfies sql.Scanner and
+// driver.Valuer so it can be stored directly as a JSONB column on the
+// composite_errors row.
+type References []Reference
+
+func (r References) Value() (driver.Value, error) {
+	if len(r) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(r)
+}
+
+func (r *References) Scan(v any) error {
+	if v == nil {
+		return nil
+	}
+	bytes, ok := v.([]byte)
+	if !ok {
+		return errors.New("composite_error.References: invalid scan type")
+	}
+	if len(bytes) == 0 || string(bytes) == "null" {
+		return nil
+	}
+	return json.Unmarshal(bytes, r)
+}
+
+func (References) GormDataType() string { return "jsonb" }
+
+// Source captures the parser-input snippet that produced an error, plus
+// identifiers for the parser that classified it. Kept small (capped) so that
+// debugging parser decisions doesn't require re-running the producing job.
+type Source struct {
+	ParserName    string `json:"parser_name,omitempty"`
+	ParserVersion string `json:"parser_version,omitempty"`
+	Snippet       string `json:"snippet,omitempty"`
+	ExitCode      *int   `json:"exit_code,omitempty"`
+	GoError       string `json:"go_error,omitempty"`
+}
+
+// SourceSnippetMax caps how much raw input we persist on a CompositeError row.
+const SourceSnippetMax = 8 * 1024
+
+// CapSnippet truncates s to at most SourceSnippetMax bytes, appending an
+// ellipsis marker when truncation occurs.
+func CapSnippet(s string) string {
+	if len(s) <= SourceSnippetMax {
+		return s
+	}
+	const marker = "\n…[truncated]"
+	return s[:SourceSnippetMax-len(marker)] + marker
+}
+
+func (s Source) Value() (driver.Value, error) {
+	if s == (Source{}) {
+		return nil, nil
+	}
+	return json.Marshal(s)
+}
+
+func (s *Source) Scan(v any) error {
+	if v == nil {
+		return nil
+	}
+	bytes, ok := v.([]byte)
+	if !ok {
+		return errors.New("composite_error.Source: invalid scan type")
+	}
+	if len(bytes) == 0 || string(bytes) == "null" {
+		return nil
+	}
+	return json.Unmarshal(bytes, s)
+}
+
+func (Source) GormDataType() string { return "jsonb" }

--- a/pkg/composite_error/unknown/error.go
+++ b/pkg/composite_error/unknown/error.go
@@ -1,0 +1,60 @@
+// Package unknown is the always-last fallback CompositeError type, shipped as
+// a builtin so that every recorded incident has a typed, catalog-registered
+// representation even when no parser matches.
+package unknown
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+)
+
+// Type is the catalog identifier for the unknown error.
+const Type composite_error.Type = "unknown_error"
+
+// Error is the typed representation of an unclassified error. All fields are
+// best-effort: even an empty value renders to a usable (if generic) view.
+type Error struct {
+	// Message is the cleaned outermost error string. Used as the headline.
+	Message string `json:"message,omitempty"`
+
+	// Details is the full (capped) raw error text. Rendered as an "Error
+	// details" section when it carries information beyond Message — i.e.
+	// multi-line stderr, wrapped Go error chains, etc.
+	Details string `json:"details,omitempty"`
+
+	// ExitCode of the producing process, when known.
+	ExitCode *int `json:"exit_code,omitempty"`
+}
+
+var _ composite_error.CompositeError = (*Error)(nil)
+
+func (e *Error) Type() composite_error.Type         { return Type }
+func (e *Error) Domain() composite_error.Domain     { return composite_error.DomainNuon }
+func (e *Error) Severity() composite_error.Severity { return composite_error.SeverityError }
+
+func (e *Error) Render(_ context.Context) composite_error.Render {
+	title := e.Message
+	if title == "" {
+		title = "An unknown error occurred"
+	}
+
+	r := composite_error.Render{
+		Title: title,
+	}
+	if details := strings.TrimSpace(e.Details); details != "" && details != strings.TrimSpace(e.Message) {
+		r.Sections = append(r.Sections, composite_error.RenderSection{
+			Heading: "Error details",
+			Body:    details,
+		})
+	}
+	if e.ExitCode != nil {
+		r.Sections = append(r.Sections, composite_error.RenderSection{
+			Heading: "Exit code",
+			Body:    fmt.Sprintf("%d", *e.ExitCode),
+		})
+	}
+	return r
+}

--- a/pkg/composite_error/unknown/error_test.go
+++ b/pkg/composite_error/unknown/error_test.go
@@ -1,0 +1,95 @@
+package unknown
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+	"github.com/nuonco/nuon/pkg/composite_error/catalog"
+)
+
+func TestBuild_PopulatesMessageFromFirstLine(t *testing.T) {
+	res := Build(composite_error.ParseInput{Raw: []byte("first line\nsecond line\n")})
+	require.True(t, res.Matched)
+
+	e := res.Error.(*Error)
+	assert.Equal(t, "first line", e.Message)
+	assert.Equal(t, "first line\nsecond line", e.Details)
+}
+
+func TestBuild_FallsBackToGoError(t *testing.T) {
+	res := Build(composite_error.ParseInput{GoErr: assertErr("hi")})
+	e := res.Error.(*Error)
+	assert.Equal(t, "hi", e.Message)
+	assert.Equal(t, "hi", e.Details)
+}
+
+func TestBuild_CapturesExitCode(t *testing.T) {
+	res := Build(composite_error.ParseInput{Raw: []byte("oh no"), ExitCode: 42})
+	e := res.Error.(*Error)
+	require.NotNil(t, e.ExitCode)
+	assert.Equal(t, 42, *e.ExitCode)
+	require.NotNil(t, res.Source.ExitCode)
+	assert.Equal(t, 42, *res.Source.ExitCode)
+}
+
+func TestBuild_PopulatesSourceMetadata(t *testing.T) {
+	res := Build(composite_error.ParseInput{
+		Raw:   []byte("err"),
+		GoErr: assertErr("wrapper"),
+	})
+	assert.Equal(t, "unknown_error.builder", res.Source.ParserName)
+	assert.Equal(t, "1", res.Source.ParserVersion)
+	assert.Equal(t, "wrapper", res.Source.GoError)
+	assert.Equal(t, "err", res.Source.Snippet)
+}
+
+func TestRender_DefaultTitle(t *testing.T) {
+	r := (&Error{}).Render(context.Background())
+	assert.Equal(t, "An unknown error occurred", r.Title)
+}
+
+func TestRender_DetailsSectionWhenMultiLine(t *testing.T) {
+	e := &Error{Message: "first line", Details: "first line\nsecond line"}
+	r := e.Render(context.Background())
+	assert.Equal(t, "first line", r.Title)
+	require.Len(t, r.Sections, 1)
+	assert.Equal(t, "Error details", r.Sections[0].Heading)
+	assert.Equal(t, "first line\nsecond line", r.Sections[0].Body)
+}
+
+func TestRender_NoDetailsSectionWhenIdenticalToMessage(t *testing.T) {
+	e := &Error{Message: "boom", Details: "boom"}
+	r := e.Render(context.Background())
+	assert.Empty(t, r.Sections)
+}
+
+// TestRoundTrip_EncodeStoreHydrateRender exercises the contract the DB layer
+// will rely on: marshal a typed error → store as JSON → hydrate via the
+// catalog → render. This is the spec's Phase 1 round-trip test.
+func TestRoundTrip_EncodeStoreHydrateRender(t *testing.T) {
+	original := &Error{Message: "boom"}
+	exit := 7
+	original.ExitCode = &exit
+
+	stored, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	hydrated, err := catalog.Hydrate(Type, stored)
+	require.NoError(t, err)
+	require.NotNil(t, hydrated)
+
+	rendered := hydrated.Render(context.Background())
+	assert.Equal(t, "boom", rendered.Title)
+	require.Len(t, rendered.Sections, 1)
+	assert.Equal(t, "Exit code", rendered.Sections[0].Heading)
+	assert.Equal(t, "7", rendered.Sections[0].Body)
+}
+
+type assertErr string
+
+func (a assertErr) Error() string { return string(a) }

--- a/pkg/composite_error/unknown/init.go
+++ b/pkg/composite_error/unknown/init.go
@@ -1,0 +1,74 @@
+package unknown
+
+import (
+	"strings"
+
+	composite_error "github.com/nuonco/nuon/pkg/composite_error"
+	"github.com/nuonco/nuon/pkg/composite_error/catalog"
+)
+
+func init() {
+	catalog.RegisterType(Type, func() composite_error.CompositeError {
+		return &Error{}
+	})
+}
+
+// Build constructs an unknown_error ParseResult from raw input. The pipeline
+// uses this as its safety-net builder when no parser matches.
+//
+// Lives on the type package (rather than the pipeline package) so that the
+// rules for "what does an unknown error look like" stay alongside the type.
+func Build(in composite_error.ParseInput) composite_error.ParseResult {
+	raw := strings.TrimSpace(string(in.Raw))
+	msg := firstLine(raw)
+	if msg == "" && in.GoErr != nil {
+		msg = in.GoErr.Error()
+	}
+
+	// Details captures the full (capped) raw text so the dashboard can
+	// expand past the one-line Message. Falls back to the wrapped Go
+	// error string when no raw bytes were supplied.
+	details := raw
+	if details == "" && in.GoErr != nil {
+		details = in.GoErr.Error()
+	}
+	if details != "" {
+		details = composite_error.CapSnippet(details)
+	}
+
+	e := &Error{Message: msg, Details: details}
+	if in.ExitCode != 0 {
+		ec := in.ExitCode
+		e.ExitCode = &ec
+	}
+
+	src := composite_error.Source{
+		ParserName:    "unknown_error.builder",
+		ParserVersion: "1",
+		Snippet:       composite_error.CapSnippet(string(in.Raw)),
+	}
+	if in.ExitCode != 0 {
+		ec := in.ExitCode
+		src.ExitCode = &ec
+	}
+	if in.GoErr != nil {
+		src.GoError = in.GoErr.Error()
+	}
+
+	return composite_error.ParseResult{
+		Matched: true,
+		Error:   e,
+		Source:  src,
+	}
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
+}


### PR DESCRIPTION
Self-contained typed-error abstraction with no ctl-api dependencies.

  - CompositeError interface + Type / Domain / Severity enums
  - Render / RenderSection / UserAction value types
  - Reference + Source JSONB value types
  - Parser interface, ParseContext (path-like), ParseInput
  - Pipeline that walks ParseContext ancestors via the catalog
  - Directive + ErrorWithDirective capability interface
  - In-memory catalog (RegisterType / RegisterParser / Hydrate / Dispatch)
  - unknown_error builtin as the always-last fallback type

Render() output is intentionally terse — the unknown_error builtin returns just the underlying message as the title with no apologetic summary copy. This is the bar all future Render() implementations should meet.