### PR TITLE
fix: fallback to legacy state gen if state manager queues are not found in db

### DIFF
--- a/services/ctl-api/internal/app/admin-dashboard/client/views/installs/InstallDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/installs/InstallDetail.tsx
@@ -173,7 +173,7 @@ export const InstallDetail = () => {
               View Dashboard
             </a>
           )}
-          <Link to={`/queues?search=${install.id}`} className="text-sm text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 underline">
+          <Link to={`/queues?owner_id=${install.id}`} className="text-sm text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-200 underline">
             View Queues
           </Link>
         </div>

--- a/services/ctl-api/internal/app/installs/helpers/ensure_install_queues.go
+++ b/services/ctl-api/internal/app/installs/helpers/ensure_install_queues.go
@@ -9,7 +9,7 @@ import (
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
 
-// EnsureInstallQueues creates the four install queues if they don't already exist.
+// EnsureInstallQueues creates the install queues if they don't already exist.
 // Safe to call multiple times — queueClient.Create is idempotent.
 func (s *Helpers) EnsureInstallQueues(ctx context.Context, installID string) error {
 	queues := []struct {
@@ -20,6 +20,7 @@ func (s *Helpers) EnsureInstallQueues(ctx context.Context, installID string) err
 		{InstallSignalsQueueName, 20},
 		{InstallWorkflowStepGroupsQueueName, 10},
 		{InstallWorkflowStepsQueueName, 10},
+		{InstallStateManagerQueueName, 5},
 	}
 
 	ownerType := plugins.TableName(s.db, app.Install{})

--- a/services/ctl-api/internal/app/installs/helpers/stategen/stategen.go
+++ b/services/ctl-api/internal/app/installs/helpers/stategen/stategen.go
@@ -1,0 +1,65 @@
+package stategen
+
+import (
+	"github.com/pkg/errors"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
+	workerstate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/state"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+	state "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
+	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
+)
+
+type Request struct {
+	StateGenV2      bool
+	InstallID       string
+	Targets         []state.PartialTarget
+	AllTargets      bool
+	ForceAll        bool
+	TriggeredByID   string
+	TriggeredByType string
+}
+
+// HintOrGenerate hints the state manager via state-partial-generate when StateGenV2
+// is set and the install has a state-manager queue; otherwise (and on missing-queue
+// fallback) it runs legacy in-band generation.
+func HintOrGenerate(ctx workflow.Context, req Request) error {
+	if req.StateGenV2 {
+		enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
+			OwnerID:   req.InstallID,
+			OwnerType: "installs",
+			QueueName: helpers.InstallStateManagerQueueName,
+			Signal: &statepartialgenerate.Signal{
+				InstallID:       req.InstallID,
+				Targets:         req.Targets,
+				AllTargets:      req.AllTargets,
+				ForceAll:        req.ForceAll,
+				TriggeredByID:   req.TriggeredByID,
+				TriggeredByType: req.TriggeredByType,
+			},
+		})
+		if err != nil {
+			if !generics.IsGormErrRecordNotFound(err) {
+				return errors.Wrap(err, "unable to hint state manager")
+			}
+			// state-manager queue missing — fall through to legacy generation
+		} else {
+			if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
+				return errors.Wrap(err, "unable to await state generation")
+			}
+			return nil
+		}
+	}
+
+	if _, err := workerstate.AwaitGenerateState(ctx, &workerstate.GenerateStateRequest{
+		InstallID:       req.InstallID,
+		TriggeredByID:   req.TriggeredByID,
+		TriggeredByType: req.TriggeredByType,
+	}); err != nil {
+		return errors.Wrap(err, "unable to generate state")
+	}
+	return nil
+}

--- a/services/ctl-api/internal/app/installs/signals/v2/actionworkflowrun/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/actionworkflowrun/signal.go
@@ -10,18 +10,14 @@ import (
 
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/plan"
-	workerstate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/state"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
-	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
-	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
 	jobactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
@@ -331,34 +327,15 @@ func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, install *app.Ins
 	if err != nil {
 		return errors.Wrap(err, "unable to check state-gen-v2 feature")
 	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	if stateGenV2 {
-		enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-			OwnerID:   installID,
-			OwnerType: "installs",
-			QueueName: installshelpers.InstallStateManagerQueueName,
-			Signal: &statepartialgenerate.Signal{
-				InstallID:       installID,
-				Targets:         statemanager.TargetsForHint(statemanager.HintActionRan, s.InstallActionWorkflowID),
-				ForceAll:        true,
-				TriggeredByID:   actionWorkflowRunID,
-				TriggeredByType: "install_action_workflow_runs",
-			},
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to hint state manager")
-		} else if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
-			return errors.Wrap(err, "unable to await state generation")
-		}
-
-	} else {
-		if _, err := workerstate.AwaitGenerateState(ctx, &workerstate.GenerateStateRequest{
-			InstallID:       installID,
-			TriggeredByID:   actionWorkflowRunID,
-			TriggeredByType: "install_action_workflow_runs",
-		}); err != nil {
-			return errors.Wrap(err, "unable to generate state")
-		}
+	if err := stategen.HintOrGenerate(ctx, stategen.Request{
+		StateGenV2:      statemanager.UseStateGenV2(orgEnabled, install.Metadata),
+		InstallID:       installID,
+		Targets:         statemanager.TargetsForHint(statemanager.HintActionRan, s.InstallActionWorkflowID),
+		ForceAll:        true,
+		TriggeredByID:   actionWorkflowRunID,
+		TriggeredByType: "install_action_workflow_runs",
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/v2/awaitinstallstackversionrun/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/awaitinstallstackversionrun/signal.go
@@ -12,13 +12,10 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/apps/helpers"
-	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
-	workerstate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/state"
 
 	runnersignalsv2 "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/signals/v2/installstackversionrun"
-	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
 	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
@@ -216,34 +213,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to check state-gen-v2 feature")
 	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	if stateGenV2 {
-		enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-			OwnerID:   install.ID,
-			OwnerType: "installs",
-			QueueName: installshelpers.InstallStateManagerQueueName,
-			Signal: &statepartialgenerate.Signal{
-				InstallID:       install.ID,
-				Targets:         statemanager.TargetsForHint(statemanager.HintStackRunCompleted, ""),
-				ForceAll:        true,
-				TriggeredByID:   run.ID,
-				TriggeredByType: "install_stack_version_runs",
-			},
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to hint state manager")
-		} else if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
-			return errors.Wrap(err, "unable to await state generation")
-		}
-
-	} else {
-		if _, err := workerstate.AwaitGenerateState(ctx, &workerstate.GenerateStateRequest{
-			InstallID:       install.ID,
-			TriggeredByID:   run.ID,
-			TriggeredByType: "install_stack_version_runs",
-		}); err != nil {
-			return errors.Wrap(err, "unable to generate state")
-		}
+	if err := stategen.HintOrGenerate(ctx, stategen.Request{
+		StateGenV2:      statemanager.UseStateGenV2(orgEnabled, install.Metadata),
+		InstallID:       install.ID,
+		Targets:         statemanager.TargetsForHint(statemanager.HintStackRunCompleted, ""),
+		ForceAll:        true,
+		TriggeredByID:   run.ID,
+		TriggeredByType: "install_stack_version_runs",
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/v2/componentdeployapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentdeployapplyplan/signal.go
@@ -10,19 +10,15 @@ import (
 
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/componentdeploysyncandplan"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/plan"
-	workerstate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/state"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
-	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
-	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
 	jobactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
@@ -191,33 +187,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to check state-gen-v2 feature")
 	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	if stateGenV2 {
-		enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-			OwnerID:   install.ID,
-			OwnerType: "installs",
-			QueueName: installshelpers.InstallStateManagerQueueName,
-			Signal: &statepartialgenerate.Signal{
-				InstallID:       install.ID,
-				Targets:         statemanager.TargetsForHint(statemanager.HintDeployCompleted, s.InstallComponentID),
-				ForceAll:        true,
-				TriggeredByID:   installDeploy.ID,
-				TriggeredByType: "install_deploys",
-			},
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to hint state manager")
-		} else if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
-			return errors.Wrap(err, "unable to await state generation")
-		}
-	} else {
-		if _, err := workerstate.AwaitGenerateState(ctx, &workerstate.GenerateStateRequest{
-			InstallID:       install.ID,
-			TriggeredByID:   installDeploy.ID,
-			TriggeredByType: "install_deploys",
-		}); err != nil {
-			return errors.Wrap(err, "unable to generate state")
-		}
+	if err := stategen.HintOrGenerate(ctx, stategen.Request{
+		StateGenV2:      statemanager.UseStateGenV2(orgEnabled, install.Metadata),
+		InstallID:       install.ID,
+		Targets:         statemanager.TargetsForHint(statemanager.HintDeployCompleted, s.InstallComponentID),
+		ForceAll:        true,
+		TriggeredByID:   installDeploy.ID,
+		TriggeredByType: "install_deploys",
+	}); err != nil {
+		return err
 	}
 	return nil
 }

--- a/services/ctl-api/internal/app/installs/signals/v2/componentsyncimage/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentsyncimage/signal.go
@@ -12,18 +12,14 @@ import (
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/pkg/types/state"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/plan"
-	workerstate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/state"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
-	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
-	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
 	jobactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
@@ -159,34 +155,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to check state-gen-v2 feature")
 	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	if stateGenV2 {
-		enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-			OwnerID:   install.ID,
-			OwnerType: "installs",
-			QueueName: installshelpers.InstallStateManagerQueueName,
-			Signal: &statepartialgenerate.Signal{
-				InstallID:       install.ID,
-				Targets:         statemanager.TargetsForHint(statemanager.HintDeployCompleted, s.InstallComponentID),
-				ForceAll:        true,
-				TriggeredByID:   installDeploy.ID,
-				TriggeredByType: "install_deploys",
-			},
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to hint state manager")
-		} else if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
-			return errors.Wrap(err, "unable to await state generation")
-		}
-
-	} else {
-		if _, err := workerstate.AwaitGenerateState(ctx, &workerstate.GenerateStateRequest{
-			InstallID:       install.ID,
-			TriggeredByID:   installDeploy.ID,
-			TriggeredByType: "install_deploys",
-		}); err != nil {
-			return errors.Wrap(err, "unable to generate state")
-		}
+	if err := stategen.HintOrGenerate(ctx, stategen.Request{
+		StateGenV2:      statemanager.UseStateGenV2(orgEnabled, install.Metadata),
+		InstallID:       install.ID,
+		Targets:         statemanager.TargetsForHint(statemanager.HintDeployCompleted, s.InstallComponentID),
+		ForceAll:        true,
+		TriggeredByID:   installDeploy.ID,
+		TriggeredByType: "install_deploys",
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/v2/componentteardownapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentteardownapplyplan/signal.go
@@ -10,19 +10,15 @@ import (
 
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/componentteardownsyncandplan"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/plan"
-	workerstate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/state"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
-	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
-	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
 	jobactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
@@ -208,34 +204,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to check state-gen-v2 feature")
 	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	if stateGenV2 {
-		enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-			OwnerID:   install.ID,
-			OwnerType: "installs",
-			QueueName: installshelpers.InstallStateManagerQueueName,
-			Signal: &statepartialgenerate.Signal{
-				InstallID:       install.ID,
-				Targets:         statemanager.TargetsForHint(statemanager.HintComponentTeardown, s.InstallComponentID),
-				ForceAll:        true,
-				TriggeredByID:   installDeploy.ID,
-				TriggeredByType: "install_deploys",
-			},
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to hint state manager")
-		} else if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
-			return errors.Wrap(err, "unable to await state generation")
-		}
-
-	} else {
-		if _, err := workerstate.AwaitGenerateState(ctx, &workerstate.GenerateStateRequest{
-			InstallID:       install.ID,
-			TriggeredByID:   installDeploy.ID,
-			TriggeredByType: "install_deploys",
-		}); err != nil {
-			return errors.Wrap(err, "unable to generate state")
-		}
+	if err := stategen.HintOrGenerate(ctx, stategen.Request{
+		StateGenV2:      statemanager.UseStateGenV2(orgEnabled, install.Metadata),
+		InstallID:       install.ID,
+		Targets:         statemanager.TargetsForHint(statemanager.HintComponentTeardown, s.InstallComponentID),
+		ForceAll:        true,
+		TriggeredByID:   installDeploy.ID,
+		TriggeredByType: "install_deploys",
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/v2/deprovisionsandboxapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/deprovisionsandboxapplyplan/signal.go
@@ -11,18 +11,14 @@ import (
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/deprovisionsandboxplan"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/plan"
-	workerstate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/state"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
-	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
-	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
 	jobactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
@@ -176,34 +172,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to check state-gen-v2 feature")
 	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	if stateGenV2 {
-		enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-			OwnerID:   install.ID,
-			OwnerType: "installs",
-			QueueName: installshelpers.InstallStateManagerQueueName,
-			Signal: &statepartialgenerate.Signal{
-				InstallID:       install.ID,
-				Targets:         statemanager.TargetsForHint(statemanager.HintSandboxDeprovisioned, ""),
-				ForceAll:        true,
-				TriggeredByID:   installRun.ID,
-				TriggeredByType: "install_sandbox_runs",
-			},
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to hint state manager")
-		} else if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
-			return errors.Wrap(err, "unable to await state generation")
-		}
-
-	} else {
-		if _, err := workerstate.AwaitGenerateState(ctx, &workerstate.GenerateStateRequest{
-			InstallID:       install.ID,
-			TriggeredByID:   installRun.ID,
-			TriggeredByType: "install_sandbox_runs",
-		}); err != nil {
-			return errors.Wrap(err, "unable to generate state")
-		}
+	if err := stategen.HintOrGenerate(ctx, stategen.Request{
+		StateGenV2:      statemanager.UseStateGenV2(orgEnabled, install.Metadata),
+		InstallID:       install.ID,
+		Targets:         statemanager.TargetsForHint(statemanager.HintSandboxDeprovisioned, ""),
+		ForceAll:        true,
+		TriggeredByID:   installRun.ID,
+		TriggeredByType: "install_sandbox_runs",
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/v2/provisionrunner/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/provisionrunner/signal.go
@@ -6,13 +6,10 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
-	workerstate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/state"
 
 	runnersignals "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/signals/v2/provisionserviceaccount"
-	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
 	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
@@ -84,34 +81,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to check state-gen-v2 feature")
 	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	if stateGenV2 {
-		enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-			OwnerID:   s.InstallID,
-			OwnerType: "installs",
-			QueueName: installshelpers.InstallStateManagerQueueName,
-			Signal: &statepartialgenerate.Signal{
-				InstallID:       s.InstallID,
-				Targets:         statemanager.TargetsForHint(statemanager.HintRunnerUpdated, ""),
-				ForceAll:        true,
-				TriggeredByID:   install.RunnerID,
-				TriggeredByType: "runners",
-			},
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to hint state manager")
-		} else if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
-			return errors.Wrap(err, "unable to await state generation")
-		}
-
-	} else {
-		if _, err := workerstate.AwaitGenerateState(ctx, &workerstate.GenerateStateRequest{
-			InstallID:       s.InstallID,
-			TriggeredByID:   install.RunnerID,
-			TriggeredByType: "runners",
-		}); err != nil {
-			return errors.Wrap(err, "unable to generate state")
-		}
+	if err := stategen.HintOrGenerate(ctx, stategen.Request{
+		StateGenV2:      statemanager.UseStateGenV2(orgEnabled, install.Metadata),
+		InstallID:       s.InstallID,
+		Targets:         statemanager.TargetsForHint(statemanager.HintRunnerUpdated, ""),
+		ForceAll:        true,
+		TriggeredByID:   install.RunnerID,
+		TriggeredByType: "runners",
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/v2/provisionsandboxapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/provisionsandboxapplyplan/signal.go
@@ -11,18 +11,14 @@ import (
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/provisionsandboxplan"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/plan"
-	workerstate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/state"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
-	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
-	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
 	jobactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
@@ -180,34 +176,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to check state-gen-v2 feature")
 	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	if stateGenV2 {
-		enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-			OwnerID:   install.ID,
-			OwnerType: "installs",
-			QueueName: installshelpers.InstallStateManagerQueueName,
-			Signal: &statepartialgenerate.Signal{
-				InstallID:       install.ID,
-				Targets:         statemanager.TargetsForHint(statemanager.HintSandboxProvisioned, ""),
-				ForceAll:        true,
-				TriggeredByID:   s.InstallWorkflowID,
-				TriggeredByType: "install_sandbox_runs",
-			},
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to hint state manager")
-		} else if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
-			return errors.Wrap(err, "unable to await state generation")
-		}
-
-	} else {
-		if _, err := workerstate.AwaitGenerateState(ctx, &workerstate.GenerateStateRequest{
-			InstallID:       install.ID,
-			TriggeredByID:   s.InstallWorkflowID,
-			TriggeredByType: "install_sandbox_runs",
-		}); err != nil {
-			return errors.Wrap(err, "unable to generate state")
-		}
+	if err := stategen.HintOrGenerate(ctx, stategen.Request{
+		StateGenV2:      statemanager.UseStateGenV2(orgEnabled, install.Metadata),
+		InstallID:       install.ID,
+		Targets:         statemanager.TargetsForHint(statemanager.HintSandboxProvisioned, ""),
+		ForceAll:        true,
+		TriggeredByID:   s.InstallWorkflowID,
+		TriggeredByType: "install_sandbox_runs",
+	}); err != nil {
+		return err
 	}
 	return nil
 }

--- a/services/ctl-api/internal/app/installs/signals/v2/reprovisionrunner/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/reprovisionrunner/signal.go
@@ -6,13 +6,10 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
-	workerstate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/state"
 
 	runnersignals "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/signals/v2/reprovisionserviceaccount"
-	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
 	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
@@ -84,34 +81,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to check state-gen-v2 feature")
 	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	if stateGenV2 {
-		enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-			OwnerID:   s.InstallID,
-			OwnerType: "installs",
-			QueueName: installshelpers.InstallStateManagerQueueName,
-			Signal: &statepartialgenerate.Signal{
-				InstallID:       s.InstallID,
-				Targets:         statemanager.TargetsForHint(statemanager.HintRunnerUpdated, ""),
-				ForceAll:        true,
-				TriggeredByID:   install.RunnerID,
-				TriggeredByType: "runners",
-			},
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to hint state manager")
-		} else if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
-			return errors.Wrap(err, "unable to await state generation")
-		}
-
-	} else {
-		if _, err := workerstate.AwaitGenerateState(ctx, &workerstate.GenerateStateRequest{
-			InstallID:       s.InstallID,
-			TriggeredByID:   install.RunnerID,
-			TriggeredByType: "runners",
-		}); err != nil {
-			return errors.Wrap(err, "unable to generate state")
-		}
+	if err := stategen.HintOrGenerate(ctx, stategen.Request{
+		StateGenV2:      statemanager.UseStateGenV2(orgEnabled, install.Metadata),
+		InstallID:       s.InstallID,
+		Targets:         statemanager.TargetsForHint(statemanager.HintRunnerUpdated, ""),
+		ForceAll:        true,
+		TriggeredByID:   install.RunnerID,
+		TriggeredByType: "runners",
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/v2/reprovisionsandboxapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/reprovisionsandboxapplyplan/signal.go
@@ -11,18 +11,14 @@ import (
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/reprovisionsandboxplan"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/plan"
-	workerstate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/state"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
-	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
-	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
 	jobactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
@@ -184,34 +180,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to check state-gen-v2 feature")
 	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	if stateGenV2 {
-		enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-			OwnerID:   install.ID,
-			OwnerType: "installs",
-			QueueName: installshelpers.InstallStateManagerQueueName,
-			Signal: &statepartialgenerate.Signal{
-				InstallID:       install.ID,
-				Targets:         statemanager.TargetsForHint(statemanager.HintSandboxReprovisioned, ""),
-				ForceAll:        true,
-				TriggeredByID:   sandboxRun.ID,
-				TriggeredByType: "install_sandbox_runs",
-			},
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to hint state manager")
-		} else if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
-			return errors.Wrap(err, "unable to await state generation")
-		}
-
-	} else {
-		if _, err := workerstate.AwaitGenerateState(ctx, &workerstate.GenerateStateRequest{
-			InstallID:       install.ID,
-			TriggeredByID:   sandboxRun.ID,
-			TriggeredByType: "install_sandbox_runs",
-		}); err != nil {
-			return errors.Wrap(err, "unable to generate state")
-		}
+	if err := stategen.HintOrGenerate(ctx, stategen.Request{
+		StateGenV2:      statemanager.UseStateGenV2(orgEnabled, install.Metadata),
+		InstallID:       install.ID,
+		Targets:         statemanager.TargetsForHint(statemanager.HintSandboxReprovisioned, ""),
+		ForceAll:        true,
+		TriggeredByID:   sandboxRun.ID,
+		TriggeredByType: "install_sandbox_runs",
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/v2/state/generatestate/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/state/generatestate/signal.go
@@ -3,16 +3,12 @@ package generatestate
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
-	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 
-	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
-	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 )
 
 const SignalType signal.SignalType = "generate-full-state"
@@ -48,22 +44,11 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 }
 
 func (s *Signal) Execute(ctx workflow.Context) error {
-	enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-		OwnerID:   s.InstallID,
-		OwnerType: "installs",
-		QueueName: installshelpers.InstallStateManagerQueueName,
-		Signal: &statepartialgenerate.Signal{
-			InstallID:       s.InstallID,
-			AllTargets:      true,
-			TriggeredByID:   s.InstallID,
-			TriggeredByType: "installs",
-		},
+	return stategen.HintOrGenerate(ctx, stategen.Request{
+		StateGenV2:      true,
+		InstallID:       s.InstallID,
+		AllTargets:      true,
+		TriggeredByID:   s.InstallID,
+		TriggeredByType: "installs",
 	})
-	if err != nil {
-		return errors.Wrap(err, "unable to force-regenerate state")
-	}
-	if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
-		return errors.Wrap(err, "unable to await state generation")
-	}
-	return nil
 }

--- a/services/ctl-api/internal/app/installs/signals/v2/syncsecrets/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/syncsecrets/signal.go
@@ -11,17 +11,13 @@ import (
 
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/plan"
-	workerstate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/state"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
-	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
-	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
 	jobactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job/activities"
 )
@@ -186,34 +182,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to check state-gen-v2 feature")
 	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	if stateGenV2 {
-		enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-			OwnerID:   s.InstallID,
-			OwnerType: "installs",
-			QueueName: installshelpers.InstallStateManagerQueueName,
-			Signal: &statepartialgenerate.Signal{
-				InstallID:       s.InstallID,
-				Targets:         statemanager.TargetsForHint(statemanager.HintSecretsUpdated, ""),
-				ForceAll:        true,
-				TriggeredByID:   runnerJob.ID,
-				TriggeredByType: "runner_jobs",
-			},
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to hint state manager")
-		} else if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
-			return errors.Wrap(err, "unable to await state generation")
-		}
-
-	} else {
-		if _, err := workerstate.AwaitGenerateState(ctx, &workerstate.GenerateStateRequest{
-			InstallID:       s.InstallID,
-			TriggeredByID:   runnerJob.ID,
-			TriggeredByType: "runner_jobs",
-		}); err != nil {
-			return errors.Wrap(err, "unable to generate state")
-		}
+	if err := stategen.HintOrGenerate(ctx, stategen.Request{
+		StateGenV2:      statemanager.UseStateGenV2(orgEnabled, install.Metadata),
+		InstallID:       s.InstallID,
+		Targets:         statemanager.TargetsForHint(statemanager.HintSecretsUpdated, ""),
+		ForceAll:        true,
+		TriggeredByID:   runnerJob.ID,
+		TriggeredByType: "runner_jobs",
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/v2/updateinstallstackoutputs/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/updateinstallstackoutputs/signal.go
@@ -10,16 +10,12 @@ import (
 
 	pkggenerics "github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/v2/state/statepartialgenerate"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
-	workerstate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/state"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
-	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
-	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 )
 
 const SignalType signal.SignalType = "update-install-stack-outputs"
@@ -199,34 +195,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to check state-gen-v2 feature")
 	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	if stateGenV2 {
-		enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-			OwnerID:   install.ID,
-			OwnerType: "installs",
-			QueueName: installshelpers.InstallStateManagerQueueName,
-			Signal: &statepartialgenerate.Signal{
-				InstallID:       install.ID,
-				Targets:         statemanager.TargetsForHint(statemanager.HintStackOutputsUpdated, ""),
-				ForceAll:        true,
-				TriggeredByID:   run.ID,
-				TriggeredByType: "install_stack_version_runs",
-			},
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to hint state manager")
-		} else if _, err := queueclient.AwaitQueueSignal(ctx, enqueueResp.QueueSignalID); err != nil {
-			return errors.Wrap(err, "unable to await state generation")
-		}
-
-	} else {
-		if _, err := workerstate.AwaitGenerateState(ctx, &workerstate.GenerateStateRequest{
-			InstallID:       install.ID,
-			TriggeredByID:   run.ID,
-			TriggeredByType: "install_stack_version_runs",
-		}); err != nil {
-			return errors.Wrap(err, "unable to generate state")
-		}
+	if err := stategen.HintOrGenerate(ctx, stategen.Request{
+		StateGenV2:      statemanager.UseStateGenV2(orgEnabled, install.Metadata),
+		InstallID:       install.ID,
+		Targets:         statemanager.TargetsForHint(statemanager.HintStackOutputsUpdated, ""),
+		ForceAll:        true,
+		TriggeredByID:   run.ID,
+		TriggeredByType: "install_stack_version_runs",
+	}); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Currently we fail if an org and install has state manager feature flag
enabled but state manager queues not present, given the importance of
state gen, we shuold fallback to legacy and log the error regardin same.

This pr also fixes issue with state manger queue not being listed in
ensure install queues endpoint.

side fix:
- update query for admin dash > install > view queues
