### PR TITLE
fix: remove hard-coded step workouts

### DIFF
--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
@@ -58,12 +58,11 @@ type Signal struct {
 	pauseRequested bool
 }
 
-var _ qsignal.Signal = (*Signal)(nil)
-var _ qsignal.SignalWithUpdateHandlers = (*Signal)(nil)
-var _ qsignal.SignalWithLifecycleContext = (*Signal)(nil)
-var _ qsignal.SignalWithTimeout = (*Signal)(nil)
-
-func (s *Signal) Timeout() time.Duration { return 2 * time.Hour }
+var (
+	_ qsignal.Signal                     = (*Signal)(nil)
+	_ qsignal.SignalWithUpdateHandlers   = (*Signal)(nil)
+	_ qsignal.SignalWithLifecycleContext = (*Signal)(nil)
+)
 
 func (s *Signal) Type() qsignal.SignalType  { return SignalType }
 func (s *Signal) SleepAfter() time.Duration { return time.Second }

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/signal.go
@@ -92,11 +92,13 @@ type Signal struct {
 	mw metrics.Writer
 }
 
-var _ signal.Signal = (*Signal)(nil)
-var _ signal.SignalWithCancel = (*Signal)(nil)
-var _ signal.SignalWithUpdateHandlers = (*Signal)(nil)
-var _ signal.SignalWithTimeout = (*Signal)(nil)
-var _ signal.SignalWithParams = (*Signal)(nil)
+var (
+	_ signal.Signal                   = (*Signal)(nil)
+	_ signal.SignalWithCancel         = (*Signal)(nil)
+	_ signal.SignalWithUpdateHandlers = (*Signal)(nil)
+	_ signal.SignalWithTimeout        = (*Signal)(nil)
+	_ signal.SignalWithParams         = (*Signal)(nil)
+)
 
 func (s *Signal) WithParams(params *signal.Params) {
 	s.mw = params.MW
@@ -106,7 +108,7 @@ func (s *Signal) Timeout() time.Duration {
 	if s.DerivedTimeout > 0 {
 		return s.DerivedTimeout
 	}
-	return 2 * time.Hour
+	return 30 * 24 * time.Hour
 }
 
 func (s *Signal) Type() signal.SignalType   { return SignalType }


### PR DESCRIPTION
Under the hood, our step signals are all creating the correct timeouts. However, the step-group and workflow themselves 
still rely on a default timeout. This bumps those, and in follow ups, we should be able to remove them entirely.
