### PR TITLE
feat: add namespace into worker gorm metrics

### DIFF
--- a/services/ctl-api/internal/interceptors/metrics/activity_interceptor.go
+++ b/services/ctl-api/internal/interceptors/metrics/activity_interceptor.go
@@ -51,6 +51,7 @@ func (a *actInterceptor) ExecuteActivity(
 		Method:     "temporal",
 		RequestURI: info.WorkflowType.Name,
 		Context:    "worker",
+		Namespace:  info.WorkflowNamespace,
 		SignalType: info.ActivityType.Name,
 	}
 	ctx = context.WithValue(ctx, keys.MetricsKey, metricCtx)

--- a/services/ctl-api/internal/pkg/cctx/metrics.go
+++ b/services/ctl-api/internal/pkg/cctx/metrics.go
@@ -15,6 +15,7 @@ type MetricContext struct {
 	OrgID      string
 	RunnerID   string
 	Context    string
+	Namespace  string
 
 	IsPanic      bool
 	IsTimeout    bool

--- a/services/ctl-api/internal/pkg/db/plugins/metrics/metrics_plugin.go
+++ b/services/ctl-api/internal/pkg/db/plugins/metrics/metrics_plugin.go
@@ -124,6 +124,7 @@ func (m *metricsWriterPlugin) afterAll(tx *gorm.DB, operationType OperationType)
 		"method:"+metricCtx.Method,
 		"endpoint:"+metricCtx.Endpoint,
 		"org_id:"+metricCtx.OrgID,
+		"namespace:"+metricCtx.Namespace,
 	)
 
 	respSize := 0
@@ -153,6 +154,7 @@ func (m *metricsWriterPlugin) afterAll(tx *gorm.DB, operationType OperationType)
 			"endpoint", metricCtx.Endpoint,
 			"method", metricCtx.Method,
 			"org_id", metricCtx.OrgID,
+			"namespace", metricCtx.Namespace,
 			"response_size", respSize,
 		)
 	}
@@ -188,6 +190,7 @@ func (m *metricsWriterPlugin) afterAll(tx *gorm.DB, operationType OperationType)
 		"endpoint", metricCtx.Endpoint,
 		"method", metricCtx.Method,
 		"org_id", metricCtx.OrgID,
+		"namespace", metricCtx.Namespace,
 		"latency_ms", dur.Milliseconds(),
 		"prepared_sql", tx.Statement.SQL.String(),
 		"vars", tx.Statement.Vars,


### PR DESCRIPTION
Adds namespace tags to our gorm metrics, allowing us to break down queries by individual workers.