### PR TITLE
fix: queue_signals inflight index predicate

### DIFF
--- a/services/ctl-api/internal/pkg/db/psql/migrations/103_queue_signals_inflight_index.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/103_queue_signals_inflight_index.go
@@ -1,0 +1,38 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// Replaces a manually-created sibling whose partial predicate referenced
+// 'in_progress' instead of the Go enum value 'in-progress', so it was never used.
+func (m *Migrations) Migration103QueueSignalsInflightIndex(ctx context.Context, db *gorm.DB) error {
+	const name = "idx_queue_signals_emitter_id_queue_id_inflight"
+
+	var indexdef string
+	if err := db.WithContext(ctx).
+		Raw(`SELECT indexdef FROM pg_indexes WHERE indexname = ?`, name).
+		Scan(&indexdef).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+
+	if strings.Contains(indexdef, "'in_progress'") {
+		if res := db.WithContext(ctx).Exec(
+			`DROP INDEX CONCURRENTLY IF EXISTS ` + name,
+		); res.Error != nil {
+			return res.Error
+		}
+	}
+
+	res := db.WithContext(ctx).Exec(
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS ` + name + `
+ON queue_signals (emitter_id, queue_id)
+WHERE deleted_at = 0
+  AND (status->>'status') IN ('queued', 'in-progress')`,
+	)
+	return res.Error
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/all.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/all.go
@@ -84,5 +84,9 @@ func (m *Migrations) All() []migrations.Migration {
 			Name: "102-webhooks-match",
 			Fn:   m.Migration102WebhooksMatch,
 		},
+		{
+			Name: "103-queue-signals-inflight-index",
+			Fn:   m.Migration103QueueSignalsInflightIndex,
+		},
 	}
 }


### PR DESCRIPTION
Existing index used `'in_progress'`; Go enum is `'in-progress'`. Predicate never matched, drove ReadIOPS to 1000-3000+. Already fixed in prod DB; this codifies it.