### PR TITLE
refactor(ui): update workflow badges

### DIFF
--- a/services/dashboard-ui/client/components/workflows/WorkflowSteps/WorkflowSteps.tsx
+++ b/services/dashboard-ui/client/components/workflows/WorkflowSteps/WorkflowSteps.tsx
@@ -44,7 +44,7 @@ export const WorkflowSteps = ({
       <div className="flex flex-col gap-4">
         {filteredSteps.length ? (
           filteredSteps.map((step) => {
-            const badgeConfig = getStepBadge(step, approvalPrompt)
+            const badgeConfig = getStepBadge(step, approvalPrompt, planOnly)
 
             return (
               <div

--- a/services/dashboard-ui/client/utils/workflow-utils.test.ts
+++ b/services/dashboard-ui/client/utils/workflow-utils.test.ts
@@ -110,6 +110,22 @@ describe('workflow-utils', () => {
       })
     })
 
+    test('should return "Plan created" badge for approved step when planOnly', () => {
+      const step: TWorkflowStep = {
+        execution_type: 'approval',
+        status: {
+          status: 'approved',
+        },
+        retried: false,
+      } as TWorkflowStep
+
+      const badge = getStepBadge(step, false, true)
+      expect(badge).toEqual({
+        children: 'Plan created',
+        theme: 'success',
+      })
+    })
+
     test('should return correct badge for approval-denied step', () => {
       const step: TWorkflowStep = {
         status: {

--- a/services/dashboard-ui/client/utils/workflow-utils.ts
+++ b/services/dashboard-ui/client/utils/workflow-utils.ts
@@ -33,7 +33,8 @@ export function getWorkflowBadge(workflow: TWorkflow): TBadgeCfg {
 
 export function getStepBadge(
   step: TWorkflowStep,
-  isApprovalPrompt?: boolean
+  isApprovalPrompt?: boolean,
+  planOnly?: boolean
 ): TBadgeCfg {
   const metadata = step?.status?.metadata
 
@@ -46,7 +47,7 @@ export function getStepBadge(
   }
 
   if (metadata?.is_retry) {
-    const retryIdx = metadata.retry_idx ?? metadata.group_retry_idx ?? 0
+    const retryIdx = (Number(metadata.retry_idx ?? metadata.group_retry_idx ?? 0)) + 1
     const retryLabel = metadata.retry_type === 'manual' ? 'Manual retry' : metadata.retry_type === 'auto' ? 'Auto retry' : 'Retry'
     return { children: `${retryLabel} #${retryIdx}`, theme: 'info' }
   }
@@ -60,6 +61,9 @@ export function getStepBadge(
 
   if (step?.execution_type === 'approval' && !isApprovalPrompt) {
     if (step?.status?.status === 'approved') {
+      if (planOnly) {
+        return { children: 'Plan created', theme: 'success' }
+      }
       return WORKFLOW_BADGE_MAP['approved']
     } else if (
       step?.status?.status === 'pending' ||


### PR DESCRIPTION
- Show "Plan created" on drift scan plan steps
- Start retry count at 1