### PR TITLE
feat: stack waits for runner to connect

### DIFF
--- a/services/ctl-api/internal/app/installs/worker/activities/activities.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/activities.go
@@ -26,6 +26,7 @@ type Params struct {
 
 	V                 *validator.Validate
 	DB                *gorm.DB `name:"psql"`
+	CHDB              *gorm.DB `name:"ch"`
 	AppsHelpers       *appshelpers.Helpers
 	ComponentsHelpers *componentshelpers.Helpers
 	RunnersHelpers    *runnershelpers.Helpers
@@ -46,6 +47,7 @@ type Params struct {
 type Activities struct {
 	v                 *validator.Validate
 	db                *gorm.DB
+	chDB              *gorm.DB
 	cfg               *internal.Config
 	cfTemplates       *cloudformation.Templates
 	appsHelpers       *appshelpers.Helpers
@@ -66,6 +68,7 @@ type Activities struct {
 func New(params Params) *Activities {
 	return &Activities{
 		db:                params.DB,
+		chDB:              params.CHDB,
 		v:                 params.V,
 		cfg:               params.Cfg,
 		cfTemplates:       params.CFTemplates,

--- a/services/ctl-api/internal/app/installs/worker/activities/get_latest_runner_heart_beat.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/get_latest_runner_heart_beat.go
@@ -1,0 +1,34 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+type GetLatestRunnerHeartBeatRequest struct {
+	RunnerID    string                `validate:"required"`
+	ProcessType app.RunnerProcessType `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+// @by-field RunnerID
+func (a *Activities) GetLatestRunnerHeartBeat(ctx context.Context, req GetLatestRunnerHeartBeatRequest) (*app.LatestRunnerHeartBeat, error) {
+	var hb app.LatestRunnerHeartBeat
+	res := a.chDB.WithContext(ctx).
+		Where("runner_id = ? AND process = ?", req.RunnerID, req.ProcessType).
+		Order("created_at_latest desc").
+		First(&hb)
+	if res.Error != nil {
+		if res.Error == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("no heartbeat found for runner %s process %s", req.RunnerID, req.ProcessType)
+		}
+
+		return nil, fmt.Errorf("unable to get latest runner heartbeat: %w", res.Error)
+	}
+
+	return &hb, nil
+}

--- a/services/ctl-api/internal/app/installs/worker/stack/install_stack_version_run.go
+++ b/services/ctl-api/internal/app/installs/worker/stack/install_stack_version_run.go
@@ -133,6 +133,59 @@ func (w *Workflows) InstallStackVersionRun(ctx workflow.Context, sreq signals.Re
 		return errors.Wrap(err, "unable to get install stack run in time")
 	}
 
+	if !install.SandboxMode.Bool {
+		runner, err := activities.AwaitGetRunnerByID(ctx, install.RunnerID)
+		if err != nil {
+			return errors.Wrap(err, "unable to get runner")
+		}
+		processType := app.InstallProcessForRunnerGroupType(runner.RunnerGroup.Type)
+		if processType == app.RunnerProcessTypeUnknown {
+			return errors.Errorf("unsupported runner group type %s for heartbeat gating", runner.RunnerGroup.Type)
+		}
+
+		const freshWindow = 30 * time.Second
+
+		if err := poll.Poll(ctx, w.v, poll.PollOpts{
+			MaxTS:           workflow.Now(ctx).Add(30 * time.Minute),
+			InitialInterval: 10 * time.Second,
+			MaxInterval:     30 * time.Second,
+			BackoffFactor:   1.1,
+			Fn: func(ctx workflow.Context) error {
+				hb, err := activities.AwaitGetLatestRunnerHeartBeat(ctx, activities.GetLatestRunnerHeartBeatRequest{
+					RunnerID:    install.RunnerID,
+					ProcessType: processType,
+				})
+				if err != nil {
+					return err
+				}
+				if age := workflow.Now(ctx).Sub(hb.CreatedAt); age > freshWindow {
+					return errors.Errorf("heartbeat is stale (%s old)", age)
+				}
+				return nil
+			},
+			PostAttemptHook: func(ctx workflow.Context, dur time.Duration) error {
+				l, _ := log.WorkflowLogger(ctx)
+				if l != nil {
+					l.Debug("waiting for runner to heartbeat", zap.Duration("next_check_in", dur))
+				}
+				return nil
+			},
+		}); err != nil {
+			if statusErr := statusactivities.AwaitPkgStatusUpdateInstallWorkflowStepStatus(ctx, statusactivities.UpdateStatusRequest{
+				ID: sreq.WorkflowStepID,
+				Status: app.CompositeStatus{
+					Status: app.StatusError,
+					Metadata: map[string]any{
+						"err_step_message": "Runner did not start heartbeating in time. Check the EC2 instance and runner logs.",
+					},
+				},
+			}); statusErr != nil {
+				return status.WrapStatusErr(err, statusErr)
+			}
+			return errors.Wrap(err, "runner did not start heartbeating in time")
+		}
+	}
+
 	w.evClient.Send(ctx, install.RunnerID, &runnersignals.Signal{
 		Type:                     runnersignals.OperationInstallStackVersionRun,
 		InstallStackVersionRunID: run.ID,


### PR DESCRIPTION
## Problem

Currently, a stack becomes "active" when all resources are provisioned. This isn't actually useful, because, if the resources aren't tagged correctly, or if there is something like a firewall blocking egress, the runner will not be able to connect. The runner itself may be configured correctly, but fail to connect because the stack did not actually provision what it needed to run.

## Solution

This PR updates the "await install stack" step to wait for the first runner heartbeat to come in. It's a minimal change that ensure that the stack actually, fully, successfully provisioned.

This change will be built on in further iterations to work with the Stack SDK to provide more visibility into the state of the stack and the runner, so that when the runner fails it's clear to both the customer and the vendor why it failed.