### PR TITLE
fix: (runner) Allow recreation of CronTicker workflow if Emitter continues as new

### DIFF
--- a/services/ctl-api/internal/pkg/queue/emitter/run_cron.go
+++ b/services/ctl-api/internal/pkg/queue/emitter/run_cron.go
@@ -79,11 +79,15 @@ func (e *emitterWorkflow) runCronMode(ctx workflow.Context, l *zap.Logger, emitt
 func (e *emitterWorkflow) ensureCronTickerRunning(ctx workflow.Context, l *zap.Logger, emitter *app.QueueEmitter, childWorkflowID string) error {
 	parentInfo := workflow.GetInfo(ctx)
 
+	// WorkflowIDReusePolicy=ALLOW_DUPLICATE_FAILED_ONLY so we can restart the
+	// cron child after the previous run has been terminated, especially when
+	// Continuing As New. With the default ParentClosePolicy=TERMINATE the
+	// cron child is cleaned up automatically when the parent closes.
 	childCtx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
 		WorkflowID:            childWorkflowID,
 		TaskQueue:             parentInfo.TaskQueueName,
 		CronSchedule:          emitter.CronSchedule,
-		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 0,
 		},
@@ -98,7 +102,7 @@ func (e *emitterWorkflow) ensureCronTickerRunning(ctx workflow.Context, l *zap.L
 
 	var childExec workflow.Execution
 	if err := childFuture.GetChildWorkflowExecution().Get(ctx, &childExec); err != nil {
-		l.Error("cron ticker child workflow already running or failed to start",
+		l.Error("failed to start cron ticker child workflow",
 			zap.String("child-workflow-id", childWorkflowID),
 			zap.Error(err),
 		)

--- a/services/ctl-api/internal/pkg/queue/emitter/run_cron.go
+++ b/services/ctl-api/internal/pkg/queue/emitter/run_cron.go
@@ -79,15 +79,15 @@ func (e *emitterWorkflow) runCronMode(ctx workflow.Context, l *zap.Logger, emitt
 func (e *emitterWorkflow) ensureCronTickerRunning(ctx workflow.Context, l *zap.Logger, emitter *app.QueueEmitter, childWorkflowID string) error {
 	parentInfo := workflow.GetInfo(ctx)
 
-	// WorkflowIDReusePolicy=ALLOW_DUPLICATE_FAILED_ONLY so we can restart the
-	// cron child after the previous run has been terminated, especially when
-	// Continuing As New. With the default ParentClosePolicy=TERMINATE the
-	// cron child is cleaned up automatically when the parent closes.
+	// WorkflowIDReusePolicy=TERMINATE_IF_RUNNING so a stale cron child from a
+	// previous parent run (e.g. abandoned across continue-as-new) is
+	// terminated and replaced by this run's child. Fire-and-forget — we do
+	// not block on the child start; Temporal will reconcile the lifecycle.
 	childCtx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
 		WorkflowID:            childWorkflowID,
 		TaskQueue:             parentInfo.TaskQueueName,
 		CronSchedule:          emitter.CronSchedule,
-		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 0,
 		},
@@ -98,22 +98,6 @@ func (e *emitterWorkflow) ensureCronTickerRunning(ctx workflow.Context, l *zap.L
 		EmitterID: e.emitterID,
 	}
 
-	childFuture := workflow.ExecuteChildWorkflow(childCtx, "CronTicker", req)
-
-	var childExec workflow.Execution
-	if err := childFuture.GetChildWorkflowExecution().Get(ctx, &childExec); err != nil {
-		l.Error("failed to start cron ticker child workflow",
-			zap.String("child-workflow-id", childWorkflowID),
-			zap.Error(err),
-		)
-		return errors.Wrap(err, "failed to start cron ticker child workflow")
-	}
-
-	l.Info("cron ticker child workflow running",
-		zap.String("child-workflow-id", childExec.ID),
-		zap.String("child-run-id", childExec.RunID),
-		zap.String("cron-schedule", emitter.CronSchedule),
-	)
-
+	workflow.ExecuteChildWorkflow(childCtx, "CronTicker", req)
 	return nil
 }


### PR DESCRIPTION
This PR updates the logic that ensures the `CronTicker` is running to work with temporal's ContinueAsNew semantics. When the parent workflow is continued as new, we try to ensure the cron ticker is running by executing the child workflow, which fails sometimes as a workflow with same id still exists.

We have updated the `CronTicker` workflow's policy to Terminate and re create the workflow if it is already running.
