### PR TITLE
feat(slack): admin-triggered auto-link of orgs to a workspace

### DIFF
--- a/services/ctl-api/internal/app/general/helpers/helpers.go
+++ b/services/ctl-api/internal/app/general/helpers/helpers.go
@@ -4,23 +4,27 @@ import (
 	"go.uber.org/fx"
 	"gorm.io/gorm"
 
+	"github.com/nuonco/nuon/services/ctl-api/internal"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
 
 type Params struct {
 	fx.In
 
+	Cfg         *internal.Config
 	DB          *gorm.DB `name:"psql"`
 	QueueClient *queueclient.Client
 }
 
 type Helpers struct {
+	cfg         *internal.Config
 	db          *gorm.DB
 	queueClient *queueclient.Client
 }
 
 func New(params Params) *Helpers {
 	return &Helpers{
+		cfg:         params.Cfg,
 		db:          params.DB,
 		queueClient: params.QueueClient,
 	}

--- a/services/ctl-api/internal/app/general/service/admin_slack_auto_link.go
+++ b/services/ctl-api/internal/app/general/service/admin_slack_auto_link.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	slackautolink "github.com/nuonco/nuon/services/ctl-api/internal/app/general/signals/v2/slack_auto_link"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+)
+
+// @ID				AdminSlackAutoLink
+// @Summary		Trigger Slack auto-link reconciliation
+// @Description	Enqueues a one-shot general-slack-auto-link signal that reconciles SlackOrgLink rows for orgs matching the configured label gate, and (if SLACK_AUTO_LINK_CHANNEL_ID is set) seeds a default org-wide subscription per link. Idempotent and additive — never removes existing links or subs.
+// @Tags			general/admin
+// @Security		AdminEmail
+// @Accept			json
+// @Produce		json
+// @Success		200	{object}	app.EmptyResponse
+// @Router			/v1/general/slack-auto-link [POST]
+func (s *service) AdminSlackAutoLink(ctx *gin.Context) {
+	q, err := s.generalHelpers.EnsureGeneralQueue(ctx)
+	if err != nil {
+		ctx.Error(fmt.Errorf("unable to ensure general queue: %w", err))
+		return
+	}
+
+	if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+		QueueID: q.ID,
+		Signal:  &slackautolink.Signal{},
+	}); err != nil {
+		ctx.Error(fmt.Errorf("unable to enqueue slack auto-link signal: %w", err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, app.EmptyResponse{})
+}

--- a/services/ctl-api/internal/app/general/service/service.go
+++ b/services/ctl-api/internal/app/general/service/service.go
@@ -78,6 +78,7 @@ func (s *service) RegisterInternalRoutes(api *gin.Engine) error {
 		general.POST("/admin-static-token", s.AdminCreateStaticToken)
 		general.POST("/admin-delete-account", s.AdminDeleteAccount)
 		general.POST("/promotion", s.AdminPromotion)
+		general.POST("/slack-auto-link", s.AdminSlackAutoLink)
 		general.POST("/terminate-event-loops", s.AdminTerminateEventLoops)
 		general.GET("/waitlist", s.AdminGetWaitlist)
 

--- a/services/ctl-api/internal/app/general/signals/v2/promotion/signal.go
+++ b/services/ctl-api/internal/app/general/signals/v2/promotion/signal.go
@@ -48,5 +48,19 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		l.Info("requested CAN on queues", zap.Int64("rows_affected", queueResp.RowsAffected))
 	}
 
+	// Idempotent + additive — chained off promote so new label-tagged
+	// orgs land without a separate POST.
+	autoLinkResp, err := generalactivities.AwaitEnsureSlackAutoLinks(ctx, generalactivities.EnsureSlackAutoLinksRequest{})
+	if err != nil {
+		return fmt.Errorf("ensure slack auto links: %w", err)
+	}
+	if l != nil {
+		l.Info("reconciled slack auto-links",
+			zap.Int("orgs_considered", autoLinkResp.OrgsConsidered),
+			zap.Int("links_created", autoLinkResp.LinksCreated),
+			zap.Int("subs_seeded", autoLinkResp.SubsSeeded),
+		)
+	}
+
 	return nil
 }

--- a/services/ctl-api/internal/app/general/signals/v2/slack_auto_link/init.go
+++ b/services/ctl-api/internal/app/general/signals/v2/slack_auto_link/init.go
@@ -1,0 +1,12 @@
+package slackautolink
+
+import (
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/catalog"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+func init() {
+	catalog.Register(SignalType, func() signal.Signal {
+		return &Signal{}
+	})
+}

--- a/services/ctl-api/internal/app/general/signals/v2/slack_auto_link/signal.go
+++ b/services/ctl-api/internal/app/general/signals/v2/slack_auto_link/signal.go
@@ -1,0 +1,28 @@
+package slackautolink
+
+import (
+	"fmt"
+
+	"go.temporal.io/sdk/workflow"
+
+	generalactivities "github.com/nuonco/nuon/services/ctl-api/internal/app/general/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+const SignalType signal.SignalType = "general-slack-auto-link"
+
+var _ signal.Signal = (*Signal)(nil)
+
+// Signal has no per-invocation params — the activity reads cfg.SlackAutoLink*.
+type Signal struct{}
+
+func (s *Signal) Type() signal.SignalType { return SignalType }
+
+func (s *Signal) Validate(_ workflow.Context) error { return nil }
+
+func (s *Signal) Execute(ctx workflow.Context) error {
+	if _, err := generalactivities.AwaitEnsureSlackAutoLinks(ctx, generalactivities.EnsureSlackAutoLinksRequest{}); err != nil {
+		return fmt.Errorf("ensure slack auto links: %w", err)
+	}
+	return nil
+}

--- a/services/ctl-api/internal/app/general/worker/activities/activities.go
+++ b/services/ctl-api/internal/app/general/worker/activities/activities.go
@@ -10,11 +10,14 @@ import (
 	"github.com/nuonco/nuon/pkg/metrics"
 	temporalclient "github.com/nuonco/nuon/pkg/temporal/client"
 	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
 	appshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/eventloop"
+	slackclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/slack/client"
 )
 
 type Activities struct {
+	cfg         *internal.Config
 	db          *gorm.DB
 	chDB        *gorm.DB
 	appsHelpers *appshelpers.Helpers
@@ -22,17 +25,20 @@ type Activities struct {
 	mw          metrics.Writer
 	logger      *temporalzap.Logger
 	tClient     temporalclient.Client
+	slackClient *slackclient.Client
 }
 
 type Params struct {
 	fx.In
 
+	Cfg            *internal.Config
 	DB             *gorm.DB `name:"psql"`
 	CHDB           *gorm.DB `name:"ch"`
 	AppsHelpers    *appshelpers.Helpers
 	EvClient       eventloop.Client
 	MW             metrics.Writer
 	TemporalClient temporalclient.Client
+	SlackClient    *slackclient.Client
 }
 
 func New(params Params) (*Activities, error) {
@@ -42,6 +48,7 @@ func New(params Params) (*Activities, error) {
 		return nil, fmt.Errorf("unable to create temporal logger: %w", err)
 	}
 	return &Activities{
+		cfg:         params.Cfg,
 		db:          params.DB,
 		chDB:        params.CHDB,
 		appsHelpers: params.AppsHelpers,
@@ -49,5 +56,6 @@ func New(params Params) (*Activities, error) {
 		mw:          params.MW,
 		logger:      tlogger,
 		tClient:     params.TemporalClient,
+		slackClient: params.SlackClient,
 	}, nil
 }

--- a/services/ctl-api/internal/app/general/worker/activities/ensure_slack_auto_links.go
+++ b/services/ctl-api/internal/app/general/worker/activities/ensure_slack_auto_links.go
@@ -1,0 +1,188 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/nuonco/nuon/pkg/labels"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/interests"
+)
+
+// EnsureSlackAutoLinksRequest has no params — policy comes from a.cfg.SlackAutoLink*.
+type EnsureSlackAutoLinksRequest struct{}
+
+type EnsureSlackAutoLinksResult struct {
+	OrgsConsidered     int
+	LinksCreated       int
+	LinksAlreadyActive int
+	SubsSeeded         int
+	SubsAlreadyExist   int
+}
+
+// @temporal-gen-v2 activity
+//
+// EnsureSlackAutoLinks reconciles SlackOrgLink (and optionally a default
+// SlackChannelSubscription) for every org whose labels match the configured
+// gate. Idempotent and additive: removals must go through the Slack /nuon
+// flow, never this reconciler.
+func (a *Activities) EnsureSlackAutoLinks(ctx context.Context, _ EnsureSlackAutoLinksRequest) (*EnsureSlackAutoLinksResult, error) {
+	res := &EnsureSlackAutoLinksResult{}
+
+	teamID := a.cfg.SlackAutoLinkTeamID
+	labelKey := a.cfg.SlackAutoLinkOrgLabelKey
+	channelID := a.cfg.SlackAutoLinkChannelID
+
+	if teamID == "" || labelKey == "" {
+		return res, nil
+	}
+
+	var install app.SlackInstallation
+	switch err := a.db.WithContext(ctx).
+		Where(app.SlackInstallation{TeamID: teamID, Status: app.SlackInstallationStatusActive}).
+		First(&install).Error; {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return res, nil
+	case err != nil:
+		return nil, fmt.Errorf("lookup slack installation: %w", err)
+	}
+
+	// Empty value → "*" wildcard matches any value at the configured key.
+	value := a.cfg.SlackAutoLinkOrgLabelValue
+	if value == "" {
+		value = "*"
+	}
+	gate := labels.Labels{labelKey: value}
+
+	var orgs []app.Org
+	if err := a.db.WithContext(ctx).
+		Scopes(labels.WithLabels("labels", gate)).
+		Select("id").
+		Find(&orgs).Error; err != nil {
+		return nil, fmt.Errorf("list matching orgs: %w", err)
+	}
+	res.OrgsConsidered = len(orgs)
+
+	for _, org := range orgs {
+		linkID, created, err := a.upsertAutoLink(ctx, install, org.ID)
+		if err != nil {
+			return nil, fmt.Errorf("upsert org link for %s: %w", org.ID, err)
+		}
+		if created {
+			res.LinksCreated++
+		} else {
+			res.LinksAlreadyActive++
+		}
+
+		// Never re-seed: a deleted seed sub is intentional — leave it gone.
+		if channelID == "" {
+			continue
+		}
+		seeded, err := a.seedDefaultSubscription(ctx, install, linkID, org.ID, channelID)
+		if err != nil {
+			return nil, fmt.Errorf("seed default sub for %s: %w", org.ID, err)
+		}
+		if seeded {
+			res.SubsSeeded++
+		} else {
+			res.SubsAlreadyExist++
+		}
+	}
+
+	a.mw.Count("event_loop.general.slack_auto_link.links_created", int64(res.LinksCreated), nil)
+	a.mw.Count("event_loop.general.slack_auto_link.subs_seeded", int64(res.SubsSeeded), nil)
+	return res, nil
+}
+
+// upsertAutoLink mirrors the OAuth-callback link upsert in
+// slack_oauth_callback.go: Unscoped() to revive soft-deleted rows,
+// provenance attributed to the workspace installer.
+func (a *Activities) upsertAutoLink(ctx context.Context, install app.SlackInstallation, orgID string) (string, bool, error) {
+	var existing app.SlackOrgLink
+	err := a.db.WithContext(ctx).
+		Unscoped().
+		Where(app.SlackOrgLink{TeamID: install.TeamID, OrgID: orgID}).
+		First(&existing).Error
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		link := &app.SlackOrgLink{
+			TeamID:            install.TeamID,
+			OrgID:             orgID,
+			Status:            app.SlackOrgLinkStatusVerified,
+			LinkedByAccountID: install.InstalledByAccountID,
+			CreatedByID:       install.InstalledByAccountID,
+		}
+		if err := a.db.WithContext(ctx).Create(link).Error; err != nil {
+			return "", false, fmt.Errorf("create org link: %w", err)
+		}
+		return link.ID, true, nil
+	case err != nil:
+		return "", false, fmt.Errorf("lookup existing org link: %w", err)
+	}
+
+	// Skip churning updated_at on an already-verified, live row.
+	if existing.Status == app.SlackOrgLinkStatusVerified && existing.DeletedAt == 0 {
+		return existing.ID, false, nil
+	}
+	existing.Status = app.SlackOrgLinkStatusVerified
+	existing.DeletedAt = 0
+	if err := a.db.WithContext(ctx).Unscoped().Save(&existing).Error; err != nil {
+		return "", false, fmt.Errorf("revive org link: %w", err)
+	}
+	return existing.ID, true, nil
+}
+
+// seedDefaultSubscription inserts one nil-Match (org-wide), AllEvents-true
+// sub when no live sub exists on this link. The "no existing sub" gate makes
+// it one-shot: once an admin deletes or replaces the seed, we won't recreate.
+// A failed channel-name lookup falls back to the channel ID — a Slack API
+// blip must not leave orgs unlinked.
+func (a *Activities) seedDefaultSubscription(ctx context.Context, install app.SlackInstallation, linkID, orgID, channelID string) (bool, error) {
+	var count int64
+	if err := a.db.WithContext(ctx).
+		Model(&app.SlackChannelSubscription{}).
+		Where(&app.SlackChannelSubscription{OrgLinkID: linkID, OrgID: orgID}).
+		Count(&count).Error; err != nil {
+		return false, fmt.Errorf("count existing subs: %w", err)
+	}
+	if count > 0 {
+		return false, nil
+	}
+
+	channelName := channelID
+	if info, err := a.slackClient.ConversationsInfo(ctx, install.BotAccessToken, channelID); err == nil && info.Channel.Name != "" {
+		channelName = info.Channel.Name
+	}
+
+	accountID := install.InstalledByAccountID
+	sub := app.SlackChannelSubscription{
+		OrgLinkID:          linkID,
+		OrgID:              orgID,
+		TeamID:             install.TeamID,
+		ChannelID:          channelID,
+		ChannelName:        channelName,
+		Interests:          interests.AllEvents(),
+		CreatedByAccountID: &accountID,
+		CreatedByID:        accountID,
+	}
+
+	// Count gate above is racy; the unique index (team_id, channel_id,
+	// org_link_id, match_canonical, deleted_at) is the actual guard.
+	if err := a.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "team_id"},
+			{Name: "channel_id"},
+			{Name: "org_link_id"},
+			{Name: "match_canonical"},
+			{Name: "deleted_at"},
+		},
+		DoNothing: true,
+	}).Create(&sub).Error; err != nil {
+		return false, fmt.Errorf("create seed subscription: %w", err)
+	}
+	return true, nil
+}

--- a/services/ctl-api/internal/app/orgs/helpers/create_org.go
+++ b/services/ctl-api/internal/app/orgs/helpers/create_org.go
@@ -3,7 +3,10 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/nuonco/nuon/pkg/labels"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
@@ -46,6 +49,7 @@ func (h *Helpers) CreateOrg(ctx context.Context, acct *app.Account, params *Crea
 			"queues":               true,
 			"parallel-runner-jobs": true,
 		},
+		Labeled: labels.Labeled{Labels: defaultOrgLabels(h.cfg, acct)},
 	}
 	if h.cfg.ForceSandboxMode {
 		org.SandboxMode = true
@@ -96,4 +100,40 @@ func (h *Helpers) CreateOrg(ctx context.Context, acct *app.Account, params *Crea
 	}
 
 	return &org, nil
+}
+
+// defaultOrgLabels seeds the configured slack-auto-link label on new orgs.
+// Returns nil when the policy is unconfigured or the creator's email domain
+// is in cfg.InternalEmailDomains.
+func defaultOrgLabels(cfg *internal.Config, acct *app.Account) labels.Labels {
+	key := cfg.SlackAutoLinkOrgLabelKey
+	if key == "" {
+		return nil
+	}
+	if isInternalEmail(acct.Email, cfg.InternalEmailDomains) {
+		return nil
+	}
+	value := cfg.SlackAutoLinkOrgLabelValue
+	if value == "" {
+		value = "true"
+	}
+	return labels.Labels{key: value}
+}
+
+func isInternalEmail(email string, domains []string) bool {
+	if email == "" || len(domains) == 0 {
+		return false
+	}
+	at := strings.LastIndex(email, "@")
+	if at < 0 || at == len(email)-1 {
+		return false
+	}
+	got := strings.ToLower(email[at+1:])
+	for _, d := range domains {
+		d = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(d, "@")))
+		if d != "" && d == got {
+			return true
+		}
+	}
+	return false
 }

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -115,6 +115,14 @@ func init() {
 	config.RegisterDefault("event_loop_general_purge_stale_data_cron", "0 6 * * *")
 	config.RegisterDefault("event_loop_general_purge_stale_data_duration_ago", "168h")
 
+	// Slack auto-link: empty TeamID or empty OrgLabelKey disables the feature.
+	config.RegisterDefault("slack_auto_link_team_id", "")
+	config.RegisterDefault("slack_auto_link_channel_id", "")
+	config.RegisterDefault("slack_auto_link_org_label_key", "")
+	config.RegisterDefault("slack_auto_link_org_label_value", "")
+
+	config.RegisterDefault("internal_email_domains", []string{})
+
 	// Nuon Auth Service Configs
 	config.RegisterDefault("nuon_auth_session_key", "insecure-session-key-for-dev-giqi8x82Ti2+qTQ5ofpazomHkQPSnMY")
 	config.RegisterDefault("nuon_auth_allow_all_users", false)
@@ -358,6 +366,17 @@ type Config struct {
 
 	EventLoopGeneralPurgeStaleDataCron        string        `config:"event_loop_general_purge_stale_data_cron"`
 	EventLoopGeneralPurgeStaleDataDurationAgo time.Duration `config:"event_loop_general_purge_stale_data_duration_ago" validate:"required"`
+
+	// Slack auto-link reconciler. TeamID + OrgLabelKey must both be set;
+	// ChannelID is optional and seeds a default org-wide subscription per link.
+	SlackAutoLinkTeamID        string `config:"slack_auto_link_team_id"`
+	SlackAutoLinkChannelID     string `config:"slack_auto_link_channel_id"`
+	SlackAutoLinkOrgLabelKey   string `config:"slack_auto_link_org_label_key"`
+	SlackAutoLinkOrgLabelValue string `config:"slack_auto_link_org_label_value"`
+
+	// InternalEmailDomains: creator emails matching these skip the default
+	// slack-auto-link label seeding in CreateOrg.
+	InternalEmailDomains []string `config:"internal_email_domains"`
 
 	// Blob storage configuration
 	BlobStorageBucket string `config:"blob_storage_bucket" validate:"required"`

--- a/services/ctl-api/internal/pkg/queue/catalog/allsignals/allsignals.go
+++ b/services/ctl-api/internal/pkg/queue/catalog/allsignals/allsignals.go
@@ -21,6 +21,7 @@ import (
 
 	// general signals
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/general/signals/v2/promotion"
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/general/signals/v2/slack_auto_link"
 
 	// components signals
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/v2/build"

--- a/services/ctl-api/internal/pkg/slack/client/client.go
+++ b/services/ctl-api/internal/pkg/slack/client/client.go
@@ -257,6 +257,34 @@ func (c *Client) ConversationsList(ctx context.Context, botToken string, req Con
 	return &resp, nil
 }
 
+type ConversationsInfoResponse struct {
+	baseResponse
+
+	Channel Conversation `json:"channel"`
+}
+
+// ConversationsInfo fetches metadata for a single channel by ID.
+func (c *Client) ConversationsInfo(ctx context.Context, botToken, channelID string) (*ConversationsInfoResponse, error) {
+	q := url.Values{}
+	q.Set("channel", channelID)
+
+	endpoint := c.baseURL + "/conversations.info?" + q.Encode()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("slack: build conversations.info: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+botToken)
+
+	var resp ConversationsInfoResponse
+	if err := c.do(httpReq, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("slack conversations.info: %s", resp.Error)
+	}
+	return &resp, nil
+}
+
 // ViewsOpenRequest opens a modal in response to a trigger_id from an
 // interactive surface (slash command, button click, etc.). View is the
 // Block-Kit modal definition; we accept it as a generic map so callers can


### PR DESCRIPTION
wires an activity into the existing general-promotion signal so each promote reconciles slack auto-links,  the activity is idempotent and additive (no-ops when the feature is unconfigured, when the workspace install is missing, or when everything is already in sync), so a fresh deploy that adds new label-tagged orgs picks them up without an operator having to remember a follow-up POST.