### PR TITLE
feat: create org cleanup dashboard

### DIFF
--- a/sdks/nuon-go/client/nuon_client.go
+++ b/sdks/nuon-go/client/nuon_client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+
 	"github.com/nuonco/nuon/sdks/nuon-go/client/operations"
 )
 

--- a/services/ctl-api/internal/app/admin-dashboard/client/lib/admin-api/orgs.ts
+++ b/services/ctl-api/internal/app/admin-dashboard/client/lib/admin-api/orgs.ts
@@ -25,7 +25,7 @@ export const migrateOrgQueues = (id: string) =>
   api<{ status: string }>({ path: `orgs/${id}/migrate-queues`, method: 'POST' })
 
 export const clearOrgQueues = (id: string) =>
-  api<{ status: string; queues_cleared: number }>({ path: `orgs/${id}/clear-queues`, method: 'POST' })
+  api<{ status: string; signal_id: string; queue_id: string; message: string }>({ path: `orgs/${id}/clear-queues`, method: 'POST' })
 
 export const forceRestartOrgQueues = (id: string) =>
   api<{ status: string; queues_restarted: number }>({ path: `orgs/${id}/force-restart-queues`, method: 'POST' })
@@ -60,6 +60,9 @@ export const terminateOrgWorkflows = (id: string) =>
 
 export const getOrgQueueSignals = (id: string) =>
   api<{ signals: any[] }>({ path: `orgs/${id}/queue-signals` })
+
+export const getOrgQueueSignalStats = (id: string) =>
+  api<{ stats: { type: string; status: string; count: number }[]; total: number }>({ path: `orgs/${id}/queue-signal-stats` })
 
 export const deleteOrgQueueSignals = (id: string) =>
   api<{ status: string; signals_deleted: number }>({ path: `orgs/${id}/delete-queue-signals`, method: 'POST' })

--- a/services/ctl-api/internal/app/admin-dashboard/client/lib/admin-api/orgs.ts
+++ b/services/ctl-api/internal/app/admin-dashboard/client/lib/admin-api/orgs.ts
@@ -38,3 +38,35 @@ export const shutdownOrgRunnerProcesses = (id: string) =>
 
 export const shutdownHintOrgRunnerProcesses = (id: string) =>
   api<{ status: string; processes_shutdown: number }>({ path: `orgs/${id}/shutdown-hint-runner-processes`, method: 'POST' })
+
+// Org cleanup
+export const deprovisionOrg = (id: string) =>
+  api<{ status: string }>({ path: `orgs/${id}/deprovision`, method: 'POST' })
+
+export const forgetOrg = (id: string) =>
+  api<{ status: string }>({ path: `orgs/${id}/forget`, method: 'POST' })
+
+export const forgetOrgInstalls = (id: string) =>
+  api<{ status: string }>({ path: `orgs/${id}/forget-installs`, method: 'POST' })
+
+export const deprovisionOrgApps = (id: string) =>
+  api<{ status: string; apps_updated: number; apps_total: number; errors: string[] }>({ path: `orgs/${id}/deprovision-apps`, method: 'POST' })
+
+export const getOrgWorkflows = (id: string) =>
+  api<{ workflows: any[] }>({ path: `orgs/${id}/workflows` })
+
+export const terminateOrgWorkflows = (id: string) =>
+  api<{ status: string; signal_id: string; message: string }>({ path: `orgs/${id}/terminate-workflows`, method: 'POST' })
+
+export const getOrgQueueSignals = (id: string) =>
+  api<{ signals: any[] }>({ path: `orgs/${id}/queue-signals` })
+
+export const deleteOrgQueueSignals = (id: string) =>
+  api<{ status: string; signals_deleted: number }>({ path: `orgs/${id}/delete-queue-signals`, method: 'POST' })
+
+// Install cleanup
+export const forgetInstall = (id: string) =>
+  api<{ status: string }>({ path: `installs/${id}/forget`, method: 'POST' })
+
+export const deprovisionInstall = (id: string) =>
+  api<{ status: string }>({ path: `installs/${id}/deprovision`, method: 'POST' })

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/orgs/OrgDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/orgs/OrgDetail.tsx
@@ -8,7 +8,7 @@ import {
   deprovisionOrg, forgetOrg, forgetOrgInstalls, deprovisionOrgApps,
   forgetInstall, deprovisionInstall,
   getOrgWorkflows, terminateOrgWorkflows,
-  getOrgQueueSignals, deleteOrgQueueSignals,
+  getOrgQueueSignals, getOrgQueueSignalStats, deleteOrgQueueSignals,
 } from '@/lib/admin-api'
 import { Badge } from '@/components/common/Badge'
 import { Pagination } from '@/components/common/Pagination'
@@ -24,7 +24,7 @@ function getStatus(s: any): string {
   return String(s)
 }
 
-type Tab = 'overview' | 'cleanup'
+type Tab = 'overview' | 'queues' | 'cleanup'
 
 export const OrgDetail = () => {
   const { id } = useParams<{ id: string }>()
@@ -63,21 +63,6 @@ export const OrgDetail = () => {
 
   const supportMutation = useMutation({
     mutationFn: () => addSupportUsers(id!),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org', id] }),
-  })
-
-  const migrateMutation = useMutation({
-    mutationFn: () => migrateOrgQueues(id!),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org', id] }),
-  })
-
-  const clearQueuesMutation = useMutation({
-    mutationFn: () => clearOrgQueues(id!),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org', id] }),
-  })
-
-  const forceRestartQueuesMutation = useMutation({
-    mutationFn: () => forceRestartOrgQueues(id!),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org', id] }),
   })
 
@@ -150,7 +135,7 @@ export const OrgDetail = () => {
       {/* Tabs */}
       <div className="border-b border-gray-200 dark:border-gray-800">
         <nav className="flex gap-4">
-          {(['overview', 'cleanup'] as Tab[]).map((tab) => (
+          {(['overview', 'queues', 'cleanup'] as Tab[]).map((tab) => (
             <button
               key={tab}
               onClick={() => setTab(tab)}
@@ -167,7 +152,7 @@ export const OrgDetail = () => {
       </div>
 
       {/* Tab Content */}
-      {activeTab === 'overview' ? (
+      {activeTab === 'overview' && (
         <OverviewTab
           org={org}
           orgLabels={orgLabels}
@@ -185,16 +170,13 @@ export const OrgDetail = () => {
           addLabelMutation={addLabelMutation}
           removeLabelMutation={removeLabelMutation}
           supportMutation={supportMutation}
-          migrateMutation={migrateMutation}
-          clearQueuesMutation={clearQueuesMutation}
-          forceRestartQueuesMutation={forceRestartQueuesMutation}
           removeOldProcessesMutation={removeOldProcessesMutation}
           shutdownProcessesMutation={shutdownProcessesMutation}
           shutdownHintProcessesMutation={shutdownHintProcessesMutation}
         />
-      ) : (
-        <CleanupTab orgId={id!} installs={installs} />
       )}
+      {activeTab === 'queues' && <QueuesTab orgId={id!} />}
+      {activeTab === 'cleanup' && <CleanupTab orgId={id!} installs={installs} />}
     </div>
   )
 }
@@ -204,9 +186,8 @@ function OverviewTab({
   org, orgLabels, installs, installsPage, setInstallsPage, installs_total_pages,
   recent_app, graph_dot,
   labelKey, setLabelKey, labelValue, setLabelValue, handleAddLabel,
-  addLabelMutation, removeLabelMutation, supportMutation, migrateMutation,
-  clearQueuesMutation, forceRestartQueuesMutation, removeOldProcessesMutation,
-  shutdownProcessesMutation, shutdownHintProcessesMutation,
+  addLabelMutation, removeLabelMutation, supportMutation,
+  removeOldProcessesMutation, shutdownProcessesMutation, shutdownHintProcessesMutation,
 }: any) {
   return (
     <>
@@ -319,9 +300,6 @@ function OverviewTab({
         <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Actions</h2>
         <div className="mt-2 flex gap-3">
           <ActionButton mutation={supportMutation} label="Add support users" pendingLabel="Adding..." />
-          <ActionButton mutation={migrateMutation} label="Migrate queues" pendingLabel="Migrating..." color="orange" />
-          <ActionButton mutation={clearQueuesMutation} label="Clear org queues" pendingLabel="Clearing..." color="red" />
-          <ActionButton mutation={forceRestartQueuesMutation} label="Force restart org queues" pendingLabel="Restarting..." color="red" />
           <ActionButton mutation={removeOldProcessesMutation} label="Remove old runner processes" pendingLabel="Removing..." color="orange" />
           <ActionButton mutation={shutdownProcessesMutation} label="Shutdown runner processes" pendingLabel="Shutting down..." color="red" />
           <ActionButton mutation={shutdownHintProcessesMutation} label="Send shutdown hint" pendingLabel="Sending..." color="red" />
@@ -395,11 +373,159 @@ function OverviewTab({
   )
 }
 
+// ---------- Queues Tab ----------
+function QueuesTab({ orgId }: { orgId: string }) {
+  const queryClient = useQueryClient()
+
+  const migrateMutation = useMutation({
+    mutationFn: () => migrateOrgQueues(orgId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org-queue-signal-stats', orgId] }),
+  })
+
+  const clearQueuesMutation = useMutation({
+    mutationFn: () => clearOrgQueues(orgId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['org-queue-signal-stats', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['org-queue-signals', orgId] })
+    },
+  })
+
+  const forceRestartQueuesMutation = useMutation({
+    mutationFn: () => forceRestartOrgQueues(orgId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['org-queue-signal-stats', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['org-queue-signals', orgId] })
+    },
+  })
+
+  const signalStatsQuery = useQuery({
+    queryKey: ['org-queue-signal-stats', orgId],
+    queryFn: () => getOrgQueueSignalStats(orgId),
+    refetchInterval: 10000,
+  })
+
+  const queueSignalsQuery = useQuery({
+    queryKey: ['org-queue-signals', orgId],
+    queryFn: () => getOrgQueueSignals(orgId),
+    refetchInterval: 10000,
+  })
+
+  const deleteSignalsMutation = useMutation({
+    mutationFn: () => deleteOrgQueueSignals(orgId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['org-queue-signals', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['org-queue-signal-stats', orgId] })
+    },
+  })
+
+  const signals = queueSignalsQuery.data?.signals ?? []
+
+  return (
+    <div className="space-y-6">
+      {/* Queue Actions */}
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Queue Actions</h2>
+        <div className="mt-2 flex flex-wrap gap-3">
+          <ActionButton mutation={migrateMutation} label="Migrate queues" pendingLabel="Migrating..." color="orange" />
+          <SignalActionButton mutation={clearQueuesMutation} label="Clear org queues" pendingLabel="Enqueueing..." color="red" />
+          <ActionButton mutation={forceRestartQueuesMutation} label="Force restart org queues" pendingLabel="Restarting..." color="red" />
+        </div>
+      </div>
+
+      {/* Queue Signal Stats */}
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          Queue Signal Stats
+          {signalStatsQuery.data && <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">({signalStatsQuery.data.total} total)</span>}
+        </h2>
+        {signalStatsQuery.isLoading ? (
+          <div className="mt-2"><LoadingSpinner /></div>
+        ) : signalStatsQuery.data && signalStatsQuery.data.stats.length > 0 ? (
+          <QueueSignalStatsTable stats={signalStatsQuery.data.stats} />
+        ) : (
+          <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">No queue signals</p>
+        )}
+      </div>
+
+      {/* Queue Signals List */}
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Recent Signals
+            {signals.length > 0 && <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">({signals.length})</span>}
+          </h2>
+          {signals.length > 0 && (
+            <ConfirmButton
+              mutation={deleteSignalsMutation}
+              label="Delete All"
+              pendingLabel="Deleting..."
+              confirmMessage={`Delete all queue signals for this org?`}
+            />
+          )}
+        </div>
+        {queueSignalsQuery.isLoading ? (
+          <div className="mt-2"><LoadingSpinner /></div>
+        ) : (
+          <div className="mt-2 table-card">
+            <table>
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Type</th>
+                  <th>Queue</th>
+                  <th>Status</th>
+                  <th>Enqueued</th>
+                  <th>Executions</th>
+                  <th>Created</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+                {signals.map((sig: any) => (
+                  <tr key={sig.id}>
+                    <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">{truncateId(sig.id)}</td>
+                    <td><Badge>{sig.type || '-'}</Badge></td>
+                    <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">
+                      {sig.queue_id ? (
+                        <Link to={`/queues/${sig.queue_id}`} className="text-primary-600 dark:text-primary-400 hover:underline">
+                          {truncateId(sig.queue_id)}
+                        </Link>
+                      ) : '-'}
+                    </td>
+                    <td>
+                      {getStatus(sig.status) && (
+                        <Badge variant="status" status={getStatus(sig.status)}>{getStatus(sig.status)}</Badge>
+                      )}
+                    </td>
+                    <td>
+                      {sig.enqueued
+                        ? <Badge variant="status" status="yes">Yes</Badge>
+                        : <Badge variant="status" status="no">No</Badge>}
+                    </td>
+                    <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">{sig.execution_count ?? 0}</td>
+                    <td className="text-gray-500 dark:text-gray-400 text-xs">{formatDate(sig.created_at)}</td>
+                  </tr>
+                ))}
+                {signals.length === 0 && (
+                  <tr><td colSpan={7} className="text-center text-gray-500 dark:text-gray-400 py-6">No queue signals found</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {deleteSignalsMutation.isSuccess && (
+          <p className="mt-2 text-sm text-green-600 dark:text-green-400">
+            Deleted {(deleteSignalsMutation.data as any)?.signals_deleted ?? 0} signal(s)
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
 // ---------- Cleanup Tab ----------
 function CleanupTab({ orgId, installs }: { orgId: string; installs: any[] }) {
   const queryClient = useQueryClient()
 
-  // Cleanup action mutations
   const markDeletedMutation = useMutation({
     mutationFn: () => addOrgLabels(orgId, { delete: 'true' }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org', orgId] }),
@@ -437,18 +563,6 @@ function CleanupTab({ orgId, installs }: { orgId: string; installs: any[] }) {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org-workflows', orgId] }),
   })
 
-  // Queue signals
-  const queueSignalsQuery = useQuery({
-    queryKey: ['org-queue-signals', orgId],
-    queryFn: () => getOrgQueueSignals(orgId),
-    refetchInterval: 10000,
-  })
-
-  const deleteSignalsMutation = useMutation({
-    mutationFn: () => deleteOrgQueueSignals(orgId),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org-queue-signals', orgId] }),
-  })
-
   // Per-install mutations
   const forgetInstallMutation = useMutation({
     mutationFn: (installId: string) => forgetInstall(installId),
@@ -461,7 +575,6 @@ function CleanupTab({ orgId, installs }: { orgId: string; installs: any[] }) {
   })
 
   const workflows = workflowsQuery.data?.workflows ?? []
-  const signals = queueSignalsQuery.data?.signals ?? []
 
   return (
     <div className="space-y-6">
@@ -608,76 +721,71 @@ function CleanupTab({ orgId, installs }: { orgId: string; installs: any[] }) {
           </p>
         )}
       </div>
+    </div>
+  )
+}
 
-      {/* Org Queue Signals */}
-      <div className="rounded-lg border border-gray-200 dark:border-gray-800 p-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-            Queue Signals
-            {signals.length > 0 && <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">({signals.length})</span>}
-          </h2>
-          {signals.length > 0 && (
-            <ConfirmButton
-              mutation={deleteSignalsMutation}
-              label="Delete All"
-              pendingLabel="Deleting..."
-              confirmMessage={`Delete all ${signals.length} queue signal(s)?`}
-            />
-          )}
-        </div>
-        {queueSignalsQuery.isLoading ? (
-          <div className="mt-2"><LoadingSpinner /></div>
-        ) : (
-          <div className="mt-2 table-card">
-            <table>
-              <thead>
-                <tr>
-                  <th>ID</th>
-                  <th>Signal Type</th>
-                  <th>Queue ID</th>
-                  <th>Status</th>
-                  <th>Created</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
-                {signals.map((sig: any) => (
-                  <tr key={sig.id}>
-                    <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">{truncateId(sig.id)}</td>
-                    <td className="text-gray-700 dark:text-gray-300 text-xs">{sig.signal_type || '-'}</td>
-                    <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">
-                      {sig.queue_id ? (
-                        <Link to={`/queues/${sig.queue_id}`} className="text-primary-600 dark:text-primary-400 hover:underline">
-                          {truncateId(sig.queue_id)}
-                        </Link>
-                      ) : '-'}
-                    </td>
-                    <td>
-                      {getStatus(sig.status) && (
-                        <Badge variant="status" status={getStatus(sig.status)}>{getStatus(sig.status)}</Badge>
-                      )}
-                    </td>
-                    <td className="text-gray-500 dark:text-gray-400 text-xs">{formatDate(sig.created_at)}</td>
-                  </tr>
-                ))}
-                {signals.length === 0 && (
-                  <tr><td colSpan={5} className="text-center text-gray-500 dark:text-gray-400 py-6">No queue signals found</td></tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-        )}
-        {deleteSignalsMutation.isSuccess && (
-          <p className="mt-2 text-sm text-green-600 dark:text-green-400">
-            Deleted {(deleteSignalsMutation.data as any)?.signals_deleted ?? 0} signal(s)
-          </p>
-        )}
-      </div>
+// ---------- Queue Signal Stats ----------
+function QueueSignalStatsTable({ stats }: { stats: { type: string; status: string; count: number }[] }) {
+  // Pivot: rows = signal types, columns = statuses
+  const statuses = [...new Set(stats.map((s) => s.status))].sort()
+  const typeMap = new Map<string, Map<string, number>>()
+  const typeTotals = new Map<string, number>()
+
+  for (const row of stats) {
+    if (!typeMap.has(row.type)) typeMap.set(row.type, new Map())
+    typeMap.get(row.type)!.set(row.status, row.count)
+    typeTotals.set(row.type, (typeTotals.get(row.type) || 0) + row.count)
+  }
+
+  // Sort types by total count descending
+  const types = [...typeMap.keys()].sort((a, b) => (typeTotals.get(b) || 0) - (typeTotals.get(a) || 0))
+
+  return (
+    <div className="mt-2 table-card overflow-x-auto">
+      <table>
+        <thead>
+          <tr>
+            <th>Signal Type</th>
+            {statuses.map((s) => (
+              <th key={s} className="text-right">{s}</th>
+            ))}
+            <th className="text-right">Total</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+          {types.map((type) => (
+            <tr key={type}>
+              <td className="text-gray-700 dark:text-gray-300 text-xs font-mono">{type}</td>
+              {statuses.map((status) => {
+                const count = typeMap.get(type)?.get(status) || 0
+                return (
+                  <td key={status} className="text-right text-xs tabular-nums">
+                    {count > 0 ? (
+                      <span className={
+                        status === 'error' ? 'text-red-600 dark:text-red-400 font-medium' :
+                        status === 'in-progress' ? 'text-blue-600 dark:text-blue-400' :
+                        status === 'queued' ? 'text-yellow-600 dark:text-yellow-400' :
+                        status === 'success' ? 'text-green-600 dark:text-green-400' :
+                        'text-gray-700 dark:text-gray-300'
+                      }>{count}</span>
+                    ) : (
+                      <span className="text-gray-300 dark:text-gray-700">-</span>
+                    )}
+                  </td>
+                )
+              })}
+              <td className="text-right text-xs font-medium tabular-nums text-gray-900 dark:text-gray-100">{typeTotals.get(type) || 0}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   )
 }
 
 // ---------- Shared Components ----------
-function ActionButton({ mutation, label, pendingLabel, color = 'primary' }: {
+function SignalActionButton({ mutation, label, pendingLabel, color = 'red' }: {
   mutation: any
   label: string
   pendingLabel: string
@@ -698,7 +806,42 @@ function ActionButton({ mutation, label, pendingLabel, color = 'primary' }: {
       >
         {mutation.isPending ? pendingLabel : label}
       </button>
-      {mutation.isSuccess && <span className="ml-2 text-sm text-green-600 dark:text-green-400">Done</span>}
+      {mutation.isSuccess && mutation.data?.signal_id && (
+        <Link
+          to={`/queues/${mutation.data.queue_id}/signals/${mutation.data.signal_id}`}
+          className="ml-2 text-sm text-primary-600 dark:text-primary-400 hover:underline"
+        >
+          View signal
+        </Link>
+      )}
+      {mutation.isError && <span className="ml-2 text-sm text-red-600 dark:text-red-400">Failed</span>}
+    </div>
+  )
+}
+
+function ActionButton({ mutation, label, pendingLabel, color = 'primary', successMessage }: {
+  mutation: any
+  label: string
+  pendingLabel: string
+  color?: 'primary' | 'red' | 'orange'
+  successMessage?: string
+}) {
+  const colorClasses = {
+    primary: 'bg-primary-600 dark:bg-primary-500 hover:bg-primary-700 dark:hover:bg-primary-600',
+    red: 'bg-red-600 dark:bg-red-500 hover:bg-red-700 dark:hover:bg-red-600',
+    orange: 'bg-orange-600 hover:bg-orange-700 dark:hover:bg-orange-600',
+  }
+
+  return (
+    <div>
+      <button
+        onClick={() => mutation.mutate()}
+        disabled={mutation.isPending}
+        className={`rounded-md px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50 ${colorClasses[color]}`}
+      >
+        {mutation.isPending ? pendingLabel : label}
+      </button>
+      {mutation.isSuccess && <span className="ml-2 text-sm text-green-600 dark:text-green-400">{successMessage || 'Done'}</span>}
       {mutation.isError && <span className="ml-2 text-sm text-red-600 dark:text-red-400">Failed</span>}
     </div>
   )

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/orgs/OrgDetail.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/orgs/OrgDetail.tsx
@@ -1,7 +1,15 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
-import { Link, useParams } from 'react-router'
-import { getOrgDetail, addOrgLabels, removeOrgLabel, addSupportUsers, migrateOrgQueues, clearOrgQueues, forceRestartOrgQueues, removeOldRunnerProcesses, shutdownOrgRunnerProcesses, shutdownHintOrgRunnerProcesses } from '@/lib/admin-api'
+import { Link, useParams, useSearchParams } from 'react-router'
+import {
+  getOrgDetail, addOrgLabels, removeOrgLabel, addSupportUsers, migrateOrgQueues,
+  clearOrgQueues, forceRestartOrgQueues, removeOldRunnerProcesses,
+  shutdownOrgRunnerProcesses, shutdownHintOrgRunnerProcesses,
+  deprovisionOrg, forgetOrg, forgetOrgInstalls, deprovisionOrgApps,
+  forgetInstall, deprovisionInstall,
+  getOrgWorkflows, terminateOrgWorkflows,
+  getOrgQueueSignals, deleteOrgQueueSignals,
+} from '@/lib/admin-api'
 import { Badge } from '@/components/common/Badge'
 import { Pagination } from '@/components/common/Pagination'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
@@ -16,12 +24,20 @@ function getStatus(s: any): string {
   return String(s)
 }
 
+type Tab = 'overview' | 'cleanup'
+
 export const OrgDetail = () => {
   const { id } = useParams<{ id: string }>()
   const queryClient = useQueryClient()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const activeTab = (searchParams.get('tab') as Tab) || 'overview'
   const [installsPage, setInstallsPage] = useState(1)
   const [labelKey, setLabelKey] = useState('')
   const [labelValue, setLabelValue] = useState('')
+
+  const setTab = (tab: Tab) => {
+    setSearchParams(tab === 'overview' ? {} : { tab })
+  }
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['org', id, installsPage],
@@ -30,6 +46,7 @@ export const OrgDetail = () => {
     refetchInterval: 20000,
   })
 
+  // --- Overview mutations ---
   const addLabelMutation = useMutation({
     mutationFn: (labels: Record<string, string>) => addOrgLabels(id!, labels),
     onSuccess: () => {
@@ -130,6 +147,69 @@ export const OrgDetail = () => {
         </div>
       </div>
 
+      {/* Tabs */}
+      <div className="border-b border-gray-200 dark:border-gray-800">
+        <nav className="flex gap-4">
+          {(['overview', 'cleanup'] as Tab[]).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setTab(tab)}
+              className={`pb-2 text-sm font-medium border-b-2 transition-colors ${
+                activeTab === tab
+                  ? 'border-primary-600 text-primary-600 dark:border-primary-400 dark:text-primary-400'
+                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+              }`}
+            >
+              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {/* Tab Content */}
+      {activeTab === 'overview' ? (
+        <OverviewTab
+          org={org}
+          orgLabels={orgLabels}
+          installs={installs}
+          installsPage={installsPage}
+          setInstallsPage={setInstallsPage}
+          installs_total_pages={installs_total_pages}
+          recent_app={recent_app}
+          graph_dot={graph_dot}
+          labelKey={labelKey}
+          setLabelKey={setLabelKey}
+          labelValue={labelValue}
+          setLabelValue={setLabelValue}
+          handleAddLabel={handleAddLabel}
+          addLabelMutation={addLabelMutation}
+          removeLabelMutation={removeLabelMutation}
+          supportMutation={supportMutation}
+          migrateMutation={migrateMutation}
+          clearQueuesMutation={clearQueuesMutation}
+          forceRestartQueuesMutation={forceRestartQueuesMutation}
+          removeOldProcessesMutation={removeOldProcessesMutation}
+          shutdownProcessesMutation={shutdownProcessesMutation}
+          shutdownHintProcessesMutation={shutdownHintProcessesMutation}
+        />
+      ) : (
+        <CleanupTab orgId={id!} installs={installs} />
+      )}
+    </div>
+  )
+}
+
+// ---------- Overview Tab ----------
+function OverviewTab({
+  org, orgLabels, installs, installsPage, setInstallsPage, installs_total_pages,
+  recent_app, graph_dot,
+  labelKey, setLabelKey, labelValue, setLabelValue, handleAddLabel,
+  addLabelMutation, removeLabelMutation, supportMutation, migrateMutation,
+  clearQueuesMutation, forceRestartQueuesMutation, removeOldProcessesMutation,
+  shutdownProcessesMutation, shutdownHintProcessesMutation,
+}: any) {
+  return (
+    <>
       {/* Labels */}
       <div className="rounded-lg border border-gray-200 dark:border-gray-800 p-4">
         <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Labels</h2>
@@ -238,90 +318,13 @@ export const OrgDetail = () => {
       <div className="rounded-lg border border-gray-200 dark:border-gray-800 p-4">
         <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Actions</h2>
         <div className="mt-2 flex gap-3">
-          <div>
-            <button
-              onClick={() => supportMutation.mutate()}
-              disabled={supportMutation.isPending}
-              className="rounded-md bg-primary-600 dark:bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700 dark:hover:bg-primary-600 disabled:opacity-50"
-            >
-              {supportMutation.isPending ? 'Adding...' : 'Add support users'}
-            </button>
-            {supportMutation.isSuccess && <span className="ml-2 text-sm text-green-600 dark:text-green-400">Done</span>}
-            {supportMutation.isError && <span className="ml-2 text-sm text-red-600 dark:text-red-400">Failed</span>}
-          </div>
-          <div>
-            <button
-              onClick={() => migrateMutation.mutate()}
-              disabled={migrateMutation.isPending}
-              className="rounded-md bg-orange-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-orange-700 dark:hover:bg-orange-600 disabled:opacity-50"
-            >
-              {migrateMutation.isPending ? 'Migrating...' : 'Migrate queues'}
-            </button>
-            {migrateMutation.isSuccess && <span className="ml-2 text-sm text-green-600 dark:text-green-400">Migration started</span>}
-            {migrateMutation.isError && <span className="ml-2 text-sm text-red-600 dark:text-red-400">Failed</span>}
-          </div>
-          <div>
-            <button
-              onClick={() => clearQueuesMutation.mutate()}
-              disabled={clearQueuesMutation.isPending}
-              className="rounded-md bg-red-600 dark:bg-red-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50"
-            >
-              {clearQueuesMutation.isPending ? 'Clearing...' : 'Clear org queues'}
-            </button>
-            {clearQueuesMutation.isSuccess && <span className="ml-2 text-sm text-green-600 dark:text-green-400">Cleared</span>}
-            {clearQueuesMutation.isError && <span className="ml-2 text-sm text-red-600 dark:text-red-400">Failed</span>}
-          </div>
-          <div>
-            <button
-              onClick={() => forceRestartQueuesMutation.mutate()}
-              disabled={forceRestartQueuesMutation.isPending}
-              className="rounded-md bg-red-600 dark:bg-red-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50"
-            >
-              {forceRestartQueuesMutation.isPending ? 'Restarting...' : 'Force restart org queues'}
-            </button>
-            {forceRestartQueuesMutation.isSuccess && <span className="ml-2 text-sm text-green-600 dark:text-green-400">Restarted</span>}
-            {forceRestartQueuesMutation.isError && <span className="ml-2 text-sm text-red-600 dark:text-red-400">Failed</span>}
-          </div>
-          <div>
-            <button
-              onClick={() => removeOldProcessesMutation.mutate()}
-              disabled={removeOldProcessesMutation.isPending}
-              className="rounded-md bg-orange-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-orange-700 dark:hover:bg-orange-600 disabled:opacity-50"
-            >
-              {removeOldProcessesMutation.isPending ? 'Removing...' : 'Remove old runner processes'}
-            </button>
-            {removeOldProcessesMutation.isSuccess && <span className="ml-2 text-sm text-green-600 dark:text-green-400">Removed</span>}
-            {removeOldProcessesMutation.isError && <span className="ml-2 text-sm text-red-600 dark:text-red-400">Failed</span>}
-          </div>
-          <div>
-            <button
-              onClick={() => shutdownProcessesMutation.mutate()}
-              disabled={shutdownProcessesMutation.isPending}
-              className="rounded-md bg-red-600 dark:bg-red-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50"
-            >
-              {shutdownProcessesMutation.isPending ? 'Shutting down...' : 'Shutdown runner processes'}
-            </button>
-            {shutdownProcessesMutation.isSuccess && (
-              <span className="ml-2 text-sm">
-                <span className="text-green-600 dark:text-green-400">Shut down {(shutdownProcessesMutation.data as any)?.processes_shutdown ?? 0} processes</span>
-                {(shutdownProcessesMutation.data as any)?.create_errors?.length > 0 && (
-                  <span className="ml-2 text-red-600 dark:text-red-400">({(shutdownProcessesMutation.data as any).create_errors.length} errors)</span>
-                )}
-              </span>
-            )}
-            {shutdownProcessesMutation.isError && <span className="ml-2 text-sm text-red-600 dark:text-red-400">Failed</span>}
-          </div>
-          <div>
-            <button
-              onClick={() => shutdownHintProcessesMutation.mutate()}
-              disabled={shutdownHintProcessesMutation.isPending}
-              className="rounded-md bg-red-600 dark:bg-red-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50"
-            >
-              {shutdownHintProcessesMutation.isPending ? 'Sending...' : 'Send shutdown hint'}
-            </button>
-            {shutdownHintProcessesMutation.isSuccess && <span className="ml-2 text-sm text-green-600 dark:text-green-400">Hint sent</span>}
-            {shutdownHintProcessesMutation.isError && <span className="ml-2 text-sm text-red-600 dark:text-red-400">Failed</span>}
-          </div>
+          <ActionButton mutation={supportMutation} label="Add support users" pendingLabel="Adding..." />
+          <ActionButton mutation={migrateMutation} label="Migrate queues" pendingLabel="Migrating..." color="orange" />
+          <ActionButton mutation={clearQueuesMutation} label="Clear org queues" pendingLabel="Clearing..." color="red" />
+          <ActionButton mutation={forceRestartQueuesMutation} label="Force restart org queues" pendingLabel="Restarting..." color="red" />
+          <ActionButton mutation={removeOldProcessesMutation} label="Remove old runner processes" pendingLabel="Removing..." color="orange" />
+          <ActionButton mutation={shutdownProcessesMutation} label="Shutdown runner processes" pendingLabel="Shutting down..." color="red" />
+          <ActionButton mutation={shutdownHintProcessesMutation} label="Send shutdown hint" pendingLabel="Sending..." color="red" />
         </div>
       </div>
 
@@ -388,6 +391,340 @@ export const OrgDetail = () => {
         </div>
         <Pagination page={installsPage} totalPages={installs_total_pages} onPageChange={setInstallsPage} />
       </div>
+    </>
+  )
+}
+
+// ---------- Cleanup Tab ----------
+function CleanupTab({ orgId, installs }: { orgId: string; installs: any[] }) {
+  const queryClient = useQueryClient()
+
+  // Cleanup action mutations
+  const markDeletedMutation = useMutation({
+    mutationFn: () => addOrgLabels(orgId, { delete: 'true' }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org', orgId] }),
+  })
+
+  const deprovisionOrgMutation = useMutation({
+    mutationFn: () => deprovisionOrg(orgId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org', orgId] }),
+  })
+
+  const forgetOrgMutation = useMutation({
+    mutationFn: () => forgetOrg(orgId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org', orgId] }),
+  })
+
+  const deprovisionAppsMutation = useMutation({
+    mutationFn: () => deprovisionOrgApps(orgId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org', orgId] }),
+  })
+
+  const forgetInstallsMutation = useMutation({
+    mutationFn: () => forgetOrgInstalls(orgId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org', orgId] }),
+  })
+
+  // Workflows
+  const workflowsQuery = useQuery({
+    queryKey: ['org-workflows', orgId],
+    queryFn: () => getOrgWorkflows(orgId),
+    refetchInterval: 10000,
+  })
+
+  const terminateWorkflowsMutation = useMutation({
+    mutationFn: () => terminateOrgWorkflows(orgId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org-workflows', orgId] }),
+  })
+
+  // Queue signals
+  const queueSignalsQuery = useQuery({
+    queryKey: ['org-queue-signals', orgId],
+    queryFn: () => getOrgQueueSignals(orgId),
+    refetchInterval: 10000,
+  })
+
+  const deleteSignalsMutation = useMutation({
+    mutationFn: () => deleteOrgQueueSignals(orgId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org-queue-signals', orgId] }),
+  })
+
+  // Per-install mutations
+  const forgetInstallMutation = useMutation({
+    mutationFn: (installId: string) => forgetInstall(installId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org', orgId] }),
+  })
+
+  const deprovisionInstallMutation = useMutation({
+    mutationFn: (installId: string) => deprovisionInstall(installId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['org', orgId] }),
+  })
+
+  const workflows = workflowsQuery.data?.workflows ?? []
+  const signals = queueSignalsQuery.data?.signals ?? []
+
+  return (
+    <div className="space-y-6">
+      {/* Cleanup Actions */}
+      <div className="rounded-lg border border-red-200 dark:border-red-900 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Cleanup Actions</h2>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Destructive operations for org cleanup. Use with care.</p>
+        <div className="mt-3 flex flex-wrap gap-3">
+          <ActionButton mutation={markDeletedMutation} label="Mark Deleted" pendingLabel="Marking..." color="orange" />
+          <ActionButton mutation={deprovisionOrgMutation} label="Deprovision Org" pendingLabel="Deprovisioning..." color="red" />
+          <ConfirmButton
+            mutation={forgetOrgMutation}
+            label="Forget Org"
+            pendingLabel="Forgetting..."
+            confirmMessage="Are you sure you want to forget this org? This is irreversible."
+          />
+          <ActionButton mutation={deprovisionAppsMutation} label="Deprovision Apps" pendingLabel="Deprovisioning..." color="red" />
+          <ConfirmButton
+            mutation={forgetInstallsMutation}
+            label="Forget Installs"
+            pendingLabel="Forgetting..."
+            confirmMessage="Are you sure you want to forget all installs for this org? This is irreversible."
+          />
+        </div>
+      </div>
+
+      {/* Installs with per-install actions */}
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 p-4">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Installs</h2>
+        <div className="mt-2 table-card">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>ID</th>
+                <th>Status</th>
+                <th>Created</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+              {installs.map((install: any) => {
+                const isDeleted = !!install.deleted_at
+                return (
+                  <tr key={install.id} className={isDeleted ? 'opacity-50' : ''}>
+                    <td>
+                      <div className="flex items-center gap-2">
+                        <Link to={`/installs/${install.id}`} className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium">
+                          {install.name || truncateId(install.id)}
+                        </Link>
+                        {isDeleted && <Badge variant="status" status="error">Deleted</Badge>}
+                      </div>
+                    </td>
+                    <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">{truncateId(install.id)}</td>
+                    <td>
+                      {getStatus(install.runner_status) && (
+                        <Badge variant="status" status={getStatus(install.runner_status)}>{getStatus(install.runner_status)}</Badge>
+                      )}
+                    </td>
+                    <td className="text-gray-500 dark:text-gray-400">{formatDate(install.created_at)}</td>
+                    <td>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => deprovisionInstallMutation.mutate(install.id)}
+                          disabled={deprovisionInstallMutation.isPending || isDeleted}
+                          className="rounded-md bg-red-600 dark:bg-red-500 px-2 py-1 text-xs font-medium text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50"
+                        >
+                          Deprovision
+                        </button>
+                        <button
+                          onClick={() => {
+                            if (window.confirm(`Forget install ${install.name || install.id}?`)) {
+                              forgetInstallMutation.mutate(install.id)
+                            }
+                          }}
+                          disabled={forgetInstallMutation.isPending || isDeleted}
+                          className="rounded-md bg-red-600 dark:bg-red-500 px-2 py-1 text-xs font-medium text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50"
+                        >
+                          Forget
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+              {installs.length === 0 && (
+                <tr><td colSpan={5} className="text-center text-gray-500 dark:text-gray-400 py-6">No installs found</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Org Workflows */}
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Org Workflows
+            {workflows.length > 0 && <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">({workflows.length})</span>}
+          </h2>
+          {workflows.length > 0 && (
+            <ConfirmButton
+              mutation={terminateWorkflowsMutation}
+              label="Terminate All"
+              pendingLabel="Terminating..."
+              confirmMessage={`Terminate all ${workflows.length} workflow(s)?`}
+            />
+          )}
+        </div>
+        {workflowsQuery.isLoading ? (
+          <div className="mt-2"><LoadingSpinner /></div>
+        ) : (
+          <div className="mt-2 table-card">
+            <table>
+              <thead>
+                <tr>
+                  <th>Workflow ID</th>
+                  <th>Type</th>
+                  <th>Namespace</th>
+                  <th>Status</th>
+                  <th>Start Time</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+                {workflows.map((wf: any) => (
+                  <tr key={`${wf.namespace}-${wf.workflow_id}-${wf.run_id}`}>
+                    <td className="text-gray-700 dark:text-gray-300 font-mono text-xs max-w-xs truncate" title={wf.workflow_id}>{wf.workflow_id}</td>
+                    <td className="text-gray-700 dark:text-gray-300 text-xs">{wf.workflow_type}</td>
+                    <td className="text-gray-500 dark:text-gray-400 text-xs">{wf.namespace}</td>
+                    <td><Badge variant="status" status={wf.status}>{wf.status}</Badge></td>
+                    <td className="text-gray-500 dark:text-gray-400 text-xs">{wf.start_time ? formatDate(wf.start_time) : '-'}</td>
+                  </tr>
+                ))}
+                {workflows.length === 0 && (
+                  <tr><td colSpan={5} className="text-center text-gray-500 dark:text-gray-400 py-6">No workflows found</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {terminateWorkflowsMutation.isSuccess && (
+          <p className="mt-2 text-sm text-green-600 dark:text-green-400">
+            {(terminateWorkflowsMutation.data as any)?.message || 'Terminate signal enqueued'}
+          </p>
+        )}
+      </div>
+
+      {/* Org Queue Signals */}
+      <div className="rounded-lg border border-gray-200 dark:border-gray-800 p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Queue Signals
+            {signals.length > 0 && <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">({signals.length})</span>}
+          </h2>
+          {signals.length > 0 && (
+            <ConfirmButton
+              mutation={deleteSignalsMutation}
+              label="Delete All"
+              pendingLabel="Deleting..."
+              confirmMessage={`Delete all ${signals.length} queue signal(s)?`}
+            />
+          )}
+        </div>
+        {queueSignalsQuery.isLoading ? (
+          <div className="mt-2"><LoadingSpinner /></div>
+        ) : (
+          <div className="mt-2 table-card">
+            <table>
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Signal Type</th>
+                  <th>Queue ID</th>
+                  <th>Status</th>
+                  <th>Created</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+                {signals.map((sig: any) => (
+                  <tr key={sig.id}>
+                    <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">{truncateId(sig.id)}</td>
+                    <td className="text-gray-700 dark:text-gray-300 text-xs">{sig.signal_type || '-'}</td>
+                    <td className="text-gray-500 dark:text-gray-400 font-mono text-xs">
+                      {sig.queue_id ? (
+                        <Link to={`/queues/${sig.queue_id}`} className="text-primary-600 dark:text-primary-400 hover:underline">
+                          {truncateId(sig.queue_id)}
+                        </Link>
+                      ) : '-'}
+                    </td>
+                    <td>
+                      {getStatus(sig.status) && (
+                        <Badge variant="status" status={getStatus(sig.status)}>{getStatus(sig.status)}</Badge>
+                      )}
+                    </td>
+                    <td className="text-gray-500 dark:text-gray-400 text-xs">{formatDate(sig.created_at)}</td>
+                  </tr>
+                ))}
+                {signals.length === 0 && (
+                  <tr><td colSpan={5} className="text-center text-gray-500 dark:text-gray-400 py-6">No queue signals found</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {deleteSignalsMutation.isSuccess && (
+          <p className="mt-2 text-sm text-green-600 dark:text-green-400">
+            Deleted {(deleteSignalsMutation.data as any)?.signals_deleted ?? 0} signal(s)
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------- Shared Components ----------
+function ActionButton({ mutation, label, pendingLabel, color = 'primary' }: {
+  mutation: any
+  label: string
+  pendingLabel: string
+  color?: 'primary' | 'red' | 'orange'
+}) {
+  const colorClasses = {
+    primary: 'bg-primary-600 dark:bg-primary-500 hover:bg-primary-700 dark:hover:bg-primary-600',
+    red: 'bg-red-600 dark:bg-red-500 hover:bg-red-700 dark:hover:bg-red-600',
+    orange: 'bg-orange-600 hover:bg-orange-700 dark:hover:bg-orange-600',
+  }
+
+  return (
+    <div>
+      <button
+        onClick={() => mutation.mutate()}
+        disabled={mutation.isPending}
+        className={`rounded-md px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50 ${colorClasses[color]}`}
+      >
+        {mutation.isPending ? pendingLabel : label}
+      </button>
+      {mutation.isSuccess && <span className="ml-2 text-sm text-green-600 dark:text-green-400">Done</span>}
+      {mutation.isError && <span className="ml-2 text-sm text-red-600 dark:text-red-400">Failed</span>}
+    </div>
+  )
+}
+
+function ConfirmButton({ mutation, label, pendingLabel, confirmMessage }: {
+  mutation: any
+  label: string
+  pendingLabel: string
+  confirmMessage: string
+}) {
+  return (
+    <div>
+      <button
+        onClick={() => {
+          if (window.confirm(confirmMessage)) {
+            mutation.mutate()
+          }
+        }}
+        disabled={mutation.isPending}
+        className="rounded-md bg-red-600 dark:bg-red-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 dark:hover:bg-red-600 disabled:opacity-50"
+      >
+        {mutation.isPending ? pendingLabel : label}
+      </button>
+      {mutation.isSuccess && <span className="ml-2 text-sm text-green-600 dark:text-green-400">Done</span>}
+      {mutation.isError && <span className="ml-2 text-sm text-red-600 dark:text-red-400">Failed</span>}
     </div>
   )
 }

--- a/services/ctl-api/internal/app/admin-dashboard/service/clear_org_queues.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/clear_org_queues.go
@@ -7,33 +7,40 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	orgshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/helpers"
+	clearorgqueues "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/clear_org_queues"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
 
 func (s *service) ClearOrgQueues(c *gin.Context) {
 	orgID := c.Param("id")
-	ctx := cctx.SetOrgIDContext(c.Request.Context(), orgID)
+	ctx := c.Request.Context()
 
-	var queues []app.Queue
+	// Find the org's signals queue.
+	var queue app.Queue
 	if res := s.db.WithContext(ctx).
-		Where("org_id = ?", orgID).
-		Find(&queues); res.Error != nil {
-		s.l.Error("failed to list org queues", zap.Error(res.Error), zap.String("org_id", orgID))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list queues"})
+		Where(app.Queue{OwnerID: orgID, Name: orgshelpers.OrgSignalsQueueName}).
+		First(&queue); res.Error != nil {
+		s.l.Error("unable to find org signals queue", zap.String("org_id", orgID), zap.Error(res.Error))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to find org signals queue"})
 		return
 	}
 
-	cleared := 0
-	for _, q := range queues {
-		if err := s.queueClient.ClearQueue(ctx, q.ID); err != nil {
-			s.l.Warn("clear-org-queues: failed to clear queue",
-				zap.String("queue_id", q.ID),
-				zap.String("org_id", orgID),
-				zap.Error(err))
-			continue
-		}
-		cleared++
+	// Enqueue the clear-org-queues signal.
+	resp, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+		QueueID: queue.ID,
+		Signal:  &clearorgqueues.Signal{OrgID: orgID},
+	})
+	if err != nil {
+		s.l.Error("unable to enqueue clear-org-queues signal", zap.String("org_id", orgID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to enqueue clear-org-queues signal: " + err.Error()})
+		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"status": "cleared", "queues_cleared": cleared})
+	c.JSON(http.StatusOK, gin.H{
+		"status":    "enqueued",
+		"signal_id": resp.ID,
+		"queue_id":  queue.ID,
+		"message":   "Clear org queues signal enqueued. Queues will be cleared in the background.",
+	})
 }

--- a/services/ctl-api/internal/app/admin-dashboard/service/clear_queue.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/clear_queue.go
@@ -29,11 +29,12 @@ func (s *service) ClearQueue(c *gin.Context) {
 		ctx = cctx.SetOrgIDContext(ctx, *q.OrgID)
 	}
 
-	if err := s.queueClient.ClearQueue(ctx, q.ID); err != nil {
+	cancelled, err := s.queueClient.ClearQueue(ctx, q.ID)
+	if err != nil {
 		s.l.Error("failed to clear queue", zap.Error(err), zap.String("queue_id", queueID))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to clear queue"})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"status": "cleared"})
+	c.JSON(http.StatusOK, gin.H{"status": "cleared", "signals_cancelled": cancelled})
 }

--- a/services/ctl-api/internal/app/admin-dashboard/service/deprovision_org_apps.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/deprovision_org_apps.go
@@ -26,7 +26,7 @@ func (s *service) DeprovisionOrgApps(c *gin.Context) {
 	updated := 0
 	var errs []string
 	for _, a := range apps {
-		if a.Status == app.AppStatusDeleteQueued || a.Status == app.AppStatusDeleted {
+		if a.Status == app.AppStatusDeleteQueued || a.Status == app.AppStatusDeleteQueued {
 			continue
 		}
 

--- a/services/ctl-api/internal/app/admin-dashboard/service/deprovision_org_apps.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/deprovision_org_apps.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// DeprovisionOrgApps marks all apps in an org as delete-queued.
+func (s *service) DeprovisionOrgApps(c *gin.Context) {
+	orgID := c.Param("id")
+	ctx := c.Request.Context()
+
+	var apps []app.App
+	if res := s.db.WithContext(ctx).
+		Where(app.App{OrgID: orgID}).
+		Find(&apps); res.Error != nil {
+		s.l.Error("failed to list org apps", zap.Error(res.Error), zap.String("org_id", orgID))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list apps"})
+		return
+	}
+
+	updated := 0
+	var errs []string
+	for _, a := range apps {
+		if a.Status == app.AppStatusDeleteQueued || a.Status == app.AppStatusDeleted {
+			continue
+		}
+
+		res := s.db.WithContext(ctx).
+			Model(&app.App{ID: a.ID}).
+			Updates(app.App{
+				Status:            app.AppStatusDeleteQueued,
+				StatusDescription: "delete queued via admin cleanup",
+			})
+		if res.Error != nil {
+			s.l.Warn("failed to mark app for deletion",
+				zap.String("app_id", a.ID), zap.Error(res.Error))
+			errs = append(errs, a.ID)
+			continue
+		}
+		updated++
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":       "deprovisioning",
+		"apps_updated": updated,
+		"apps_total":   len(apps),
+		"errors":       errs,
+	})
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/deprovision_org_apps.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/deprovision_org_apps.go
@@ -26,7 +26,7 @@ func (s *service) DeprovisionOrgApps(c *gin.Context) {
 	updated := 0
 	var errs []string
 	for _, a := range apps {
-		if a.Status == app.AppStatusDeleteQueued || a.Status == app.AppStatusDeleteQueued {
+		if a.Status == app.AppStatusDeleteQueued || a.Status == app.AppStatusDeprovisioning {
 			continue
 		}
 

--- a/services/ctl-api/internal/app/admin-dashboard/service/in_flight_signals.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/in_flight_signals.go
@@ -22,7 +22,7 @@ func (s *service) InFlightSignals(c *gin.Context) {
 		return
 	}
 
-	namespaces, err := s.getDistinctNamespaces(ctx)
+	namespaces, err := s.getDistinctNamespaces(ctx, "24h")
 	if err != nil {
 		s.l.Error("failed to get namespaces", zap.Error(err))
 	}

--- a/services/ctl-api/internal/app/admin-dashboard/service/org_cleanup_proxy.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/org_cleanup_proxy.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// ProxyDeprovisionOrg proxies the deprovision request to the internal admin API.
+func (s *service) ProxyDeprovisionOrg(c *gin.Context) {
+	orgID := c.Param("id")
+	path := fmt.Sprintf("/v1/orgs/%s/admin-deprovision", orgID)
+	s.proxyToInternalAPI(c, "POST", path, c.Request.Body)
+}
+
+// ProxyForgetOrg proxies the forget request to the internal admin API.
+func (s *service) ProxyForgetOrg(c *gin.Context) {
+	orgID := c.Param("id")
+	path := fmt.Sprintf("/v1/orgs/%s/admin-forget", orgID)
+	s.proxyToInternalAPI(c, "POST", path, c.Request.Body)
+}
+
+// ProxyForgetOrgInstalls proxies the forget-installs request to the internal admin API.
+func (s *service) ProxyForgetOrgInstalls(c *gin.Context) {
+	orgID := c.Param("id")
+	path := fmt.Sprintf("/v1/orgs/%s/admin-forget-installs", orgID)
+	s.proxyToInternalAPI(c, "POST", path, c.Request.Body)
+}
+
+// ProxyForgetInstall proxies the forget request for a single install to the internal admin API.
+func (s *service) ProxyForgetInstall(c *gin.Context) {
+	installID := c.Param("id")
+	path := fmt.Sprintf("/v1/installs/%s/admin-forget", installID)
+	s.proxyToInternalAPI(c, "POST", path, c.Request.Body)
+}
+
+// ProxyDeprovisionInstall proxies the deprovision request for a single install.
+// It looks up the install's org_id and forwards to the public API with the org context header.
+func (s *service) ProxyDeprovisionInstall(c *gin.Context) {
+	installID := c.Param("id")
+
+	var install app.Install
+	if res := s.db.WithContext(c.Request.Context()).
+		Select("id", "org_id").
+		Where("id = ?", installID).
+		First(&install); res.Error != nil {
+		s.l.Error("failed to look up install", zap.Error(res.Error), zap.String("install_id", installID))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to look up install"})
+		return
+	}
+
+	targetURL := fmt.Sprintf("http://localhost:%s/v1/installs/%s/deprovision", s.cfg.HTTPPort, installID)
+	target, err := url.Parse(targetURL)
+	if err != nil {
+		s.l.Error("invalid proxy target", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal proxy error"})
+		return
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL = target
+			req.Method = "POST"
+			req.Host = target.Host
+			if token, _ := c.Cookie("X-Nuon-Auth"); token != "" {
+				req.Header.Set("Authorization", "Bearer "+token)
+			}
+			if email := c.GetHeader("X-Nuon-Admin-Email"); email != "" {
+				req.Header.Set("X-Nuon-Admin-Email", email)
+			}
+			req.Header.Set("X-Nuon-Org-ID", install.OrgID)
+		},
+	}
+	proxy.ServeHTTP(c.Writer, c.Request)
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/org_queue_signal_stats.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/org_queue_signal_stats.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+type queueSignalStatRow struct {
+	Type   string `json:"type"`
+	Status string `json:"status"`
+	Count  int64  `json:"count"`
+}
+
+// OrgQueueSignalStats returns queue signal counts grouped by type and status for an org.
+func (s *service) OrgQueueSignalStats(c *gin.Context) {
+	orgID := c.Param("id")
+
+	var rows []queueSignalStatRow
+	if res := s.readDB().WithContext(c.Request.Context()).
+		Table("queue_signals").
+		Select("type, status->>'status' as status, COUNT(*) as count").
+		Where("org_id = ? AND deleted_at = 0", orgID).
+		Group("type, status->>'status'").
+		Order("count DESC").
+		Scan(&rows); res.Error != nil {
+		s.l.Error("failed to query queue signal stats", zap.Error(res.Error), zap.String("org_id", orgID))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to query queue signal stats"})
+		return
+	}
+
+	total := int64(0)
+	for _, r := range rows {
+		total += r.Count
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"stats": rows,
+		"total": total,
+	})
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/org_queue_signals.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/org_queue_signals.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// OrgQueueSignals returns all queue signals for an org.
+func (s *service) OrgQueueSignals(c *gin.Context) {
+	orgID := c.Param("id")
+
+	var signals []app.QueueSignal
+	if res := s.readDB().WithContext(c.Request.Context()).
+		Where("org_id = ?", orgID).
+		Order("created_at DESC").
+		Limit(200).
+		Find(&signals); res.Error != nil {
+		s.l.Error("failed to list org queue signals", zap.Error(res.Error), zap.String("org_id", orgID))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list queue signals"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"signals": signals})
+}
+
+// DeleteOrgQueueSignals hard-deletes all queue signals for an org.
+func (s *service) DeleteOrgQueueSignals(c *gin.Context) {
+	orgID := c.Param("id")
+
+	res := s.db.WithContext(c.Request.Context()).
+		Where("org_id = ?", orgID).
+		Unscoped().
+		Delete(&app.QueueSignal{})
+	if res.Error != nil {
+		s.l.Error("failed to delete org queue signals", zap.Error(res.Error), zap.String("org_id", orgID))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete queue signals"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":          "deleted",
+		"signals_deleted": res.RowsAffected,
+	})
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/org_workflows.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/org_workflows.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	orgshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/helpers"
+	terminateworkflows "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/terminate_workflows"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+)
+
+type orgWorkflowEntry struct {
+	WorkflowID   string            `json:"workflow_id"`
+	RunID        string            `json:"run_id"`
+	WorkflowType string            `json:"workflow_type"`
+	Namespace    string            `json:"namespace"`
+	Status       string            `json:"status"`
+	StartTime    string            `json:"start_time,omitempty"`
+	Memo         map[string]string `json:"memo,omitempty"`
+}
+
+// OrgWorkflows lists all running Temporal workflows that belong to an org (via org-id memo).
+func (s *service) OrgWorkflows(c *gin.Context) {
+	orgID := c.Param("id")
+	ctx := c.Request.Context()
+
+	var allEntries []orgWorkflowEntry
+	var mu sync.Mutex
+
+	for _, ns := range temporalWorkerNamespaces {
+		nsClient, err := s.temporalClient.GetNamespaceClient(ns)
+		if err != nil {
+			s.l.Warn("failed to get namespace client", zap.Error(err), zap.String("namespace", ns))
+			continue
+		}
+
+		var nextPageToken []byte
+		for {
+			resp, err := nsClient.ListWorkflow(ctx, &workflowservice.ListWorkflowExecutionsRequest{
+				Namespace:     ns,
+				PageSize:      100,
+				NextPageToken: nextPageToken,
+				Query:         "ExecutionStatus='Running'",
+			})
+			if err != nil {
+				s.l.Warn("failed to list workflows", zap.Error(err), zap.String("namespace", ns))
+				break
+			}
+
+			for _, wf := range resp.Executions {
+				memo := decodeMemo(wf.Memo)
+				if memo["org-id"] != orgID && memo["owner-id"] != orgID {
+					continue
+				}
+
+				entry := orgWorkflowEntry{
+					WorkflowID:   wf.Execution.WorkflowId,
+					RunID:        wf.Execution.RunId,
+					WorkflowType: wf.Type.Name,
+					Namespace:    ns,
+					Status:       cleanStatus(wf.Status.String()),
+					Memo:         memo,
+				}
+				if wf.StartTime != nil {
+					entry.StartTime = wf.StartTime.AsTime().Format(time.RFC3339)
+				}
+
+				mu.Lock()
+				allEntries = append(allEntries, entry)
+				mu.Unlock()
+			}
+
+			nextPageToken = resp.NextPageToken
+			if len(nextPageToken) == 0 {
+				break
+			}
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"workflows": allEntries})
+}
+
+// TerminateOrgWorkflows enqueues a signal to terminate all running Temporal workflows
+// belonging to an org. This runs asynchronously in the org's signal queue.
+func (s *service) TerminateOrgWorkflows(c *gin.Context) {
+	orgID := c.Param("id")
+	ctx := c.Request.Context()
+
+	// Find the org's signals queue.
+	var queue app.Queue
+	if res := s.db.WithContext(ctx).
+		Where(app.Queue{OwnerID: orgID, Name: orgshelpers.OrgSignalsQueueName}).
+		First(&queue); res.Error != nil {
+		s.l.Error("unable to find org signals queue", zap.String("org_id", orgID), zap.Error(res.Error))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to find org signals queue"})
+		return
+	}
+
+	// Enqueue the terminate-workflows signal.
+	resp, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+		QueueID: queue.ID,
+		Signal:  &terminateworkflows.Signal{OrgID: orgID},
+	})
+	if err != nil {
+		s.l.Error("unable to enqueue terminate-workflows signal", zap.String("org_id", orgID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to enqueue terminate signal: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":    "enqueued",
+		"signal_id": resp.ID,
+		"message":   "Terminate workflows signal enqueued. Workflows will be terminated in the background.",
+	})
+}

--- a/services/ctl-api/internal/app/admin-dashboard/service/queue_signals.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/queue_signals.go
@@ -42,12 +42,12 @@ func (s *service) QueueSignals(c *gin.Context) {
 		return
 	}
 
-	namespaces, err := s.getDistinctNamespaces(ctx)
+	namespaces, err := s.getDistinctNamespaces(ctx, since)
 	if err != nil {
 		s.l.Error("failed to get namespaces", zap.Error(err))
 	}
 
-	signalTypes, err := s.getDistinctSignalTypes(ctx, namespace)
+	signalTypes, err := s.getDistinctSignalTypes(ctx, namespace, since)
 	if err != nil {
 		s.l.Error("failed to get signal types", zap.Error(err))
 	}
@@ -81,12 +81,12 @@ func (s *service) QueueSignalsGlobalTable(c *gin.Context) {
 		return
 	}
 
-	namespaces, err := s.getDistinctNamespaces(ctx)
+	namespaces, err := s.getDistinctNamespaces(ctx, since)
 	if err != nil {
 		s.l.Warn("failed to get namespaces", zap.Error(err))
 	}
 
-	signalTypes, err := s.getDistinctSignalTypes(ctx, namespace)
+	signalTypes, err := s.getDistinctSignalTypes(ctx, namespace, since)
 	if err != nil {
 		s.l.Warn("failed to get signal types", zap.Error(err))
 	}
@@ -107,8 +107,9 @@ func (s *service) QueueSignalsGlobalTable(c *gin.Context) {
 func (s *service) QueueSignalTypeOptions(c *gin.Context) {
 	ctx := c.Request.Context()
 	namespace := c.Query("namespace")
+	since := c.DefaultQuery("since", "24h")
 
-	signalTypes, err := s.getDistinctSignalTypes(ctx, namespace)
+	signalTypes, err := s.getDistinctSignalTypes(ctx, namespace, since)
 	if err != nil {
 		s.l.Error("failed to get signal types", zap.Error(err))
 	}
@@ -195,13 +196,16 @@ func (s *service) getQueueSignals(ctx context.Context, search, ownerID, orgID, s
 	return signals, totalPages, nil
 }
 
-func (s *service) getDistinctNamespaces(ctx context.Context) ([]string, error) {
+func (s *service) getDistinctNamespaces(ctx context.Context, since string) ([]string, error) {
 	var namespaces []string
-	res := s.readDB().WithContext(ctx).
+	query := s.readDB().WithContext(ctx).
 		Model(&app.QueueSignal{}).
 		Select("DISTINCT workflow->>'namespace'").
-		Where("workflow->>'namespace' != ''").
-		Pluck("workflow->>'namespace'", &namespaces)
+		Where("workflow->>'namespace' != ''")
+	if interval, ok := allowedSinceValues[since]; ok {
+		query = query.Where("created_at >= NOW() - INTERVAL '" + interval + "'")
+	}
+	res := query.Pluck("workflow->>'namespace'", &namespaces)
 	if res.Error != nil {
 		return nil, fmt.Errorf("unable to get distinct namespaces: %w", res.Error)
 	}
@@ -209,9 +213,12 @@ func (s *service) getDistinctNamespaces(ctx context.Context) ([]string, error) {
 	return namespaces, nil
 }
 
-func (s *service) getDistinctSignalTypes(ctx context.Context, namespace string) ([]string, error) {
+func (s *service) getDistinctSignalTypes(ctx context.Context, namespace string, since string) ([]string, error) {
 	var types []string
 	query := s.readDB().WithContext(ctx).Model(&app.QueueSignal{})
+	if interval, ok := allowedSinceValues[since]; ok {
+		query = query.Where("created_at >= NOW() - INTERVAL '" + interval + "'")
+	}
 	if namespace != "" {
 		query = query.Where("workflow->>'namespace' = ?", namespace)
 	}

--- a/services/ctl-api/internal/app/admin-dashboard/service/service.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/service.go
@@ -199,6 +199,7 @@ func (s *service) RegisterAdminDashboardRoutes(e *gin.Engine) error {
 		api.GET("/orgs/:id/workflows", s.OrgWorkflows)
 		api.POST("/orgs/:id/terminate-workflows", s.TerminateOrgWorkflows)
 		api.GET("/orgs/:id/queue-signals", s.OrgQueueSignals)
+		api.GET("/orgs/:id/queue-signal-stats", s.OrgQueueSignalStats)
 		api.POST("/orgs/:id/delete-queue-signals", s.DeleteOrgQueueSignals)
 
 		// Accounts

--- a/services/ctl-api/internal/app/admin-dashboard/service/service.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/service.go
@@ -191,6 +191,16 @@ func (s *service) RegisterAdminDashboardRoutes(e *gin.Engine) error {
 		api.POST("/orgs/:id/shutdown-hint-runner-processes", s.ShutdownHintOrgRunnerProcesses)
 		api.GET("/orgs/:id/installs", s.InstallsTable)
 
+		// Org cleanup
+		api.POST("/orgs/:id/deprovision", s.ProxyDeprovisionOrg)
+		api.POST("/orgs/:id/forget", s.ProxyForgetOrg)
+		api.POST("/orgs/:id/forget-installs", s.ProxyForgetOrgInstalls)
+		api.POST("/orgs/:id/deprovision-apps", s.DeprovisionOrgApps)
+		api.GET("/orgs/:id/workflows", s.OrgWorkflows)
+		api.POST("/orgs/:id/terminate-workflows", s.TerminateOrgWorkflows)
+		api.GET("/orgs/:id/queue-signals", s.OrgQueueSignals)
+		api.POST("/orgs/:id/delete-queue-signals", s.DeleteOrgQueueSignals)
+
 		// Accounts
 		api.GET("/accounts", s.Accounts)
 		api.GET("/accounts/table", s.AccountsTable)
@@ -227,6 +237,10 @@ func (s *service) RegisterAdminDashboardRoutes(e *gin.Engine) error {
 		api.GET("/installs/:id/workflows", s.InstallWorkflowsTable)
 		api.POST("/installs/:id/labels", s.AddInstallLabel)
 		api.POST("/installs/:id/labels/remove/:key", s.RemoveInstallLabel)
+
+		// Install cleanup
+		api.POST("/installs/:id/forget", s.ProxyForgetInstall)
+		api.POST("/installs/:id/deprovision", s.ProxyDeprovisionInstall)
 
 		// Workflows
 		api.GET("/workflows", s.Workflows)

--- a/services/ctl-api/internal/app/general/worker/activities/terminate_org_workflows.go
+++ b/services/ctl-api/internal/app/general/worker/activities/terminate_org_workflows.go
@@ -1,0 +1,116 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/converter"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
+)
+
+type TerminateOrgWorkflowsRequest struct {
+	OrgID string `json:"org_id" validate:"required"`
+}
+
+type TerminateOrgWorkflowsResponse struct {
+	Terminated int      `json:"terminated"`
+	Errors     []string `json:"errors,omitempty"`
+}
+
+var orgWorkflowNamespaces = []string{
+	"general",
+	"installs",
+	"runners",
+	"orgs",
+	"components",
+	"apps",
+	"actions",
+	"vcs",
+	"onboardings",
+}
+
+// @temporal-gen-v2 activity
+// @by-field OrgID
+// @schedule-to-close-timeout 300s
+// @start-to-close-timeout 300s
+func (a *Activities) TerminateOrgWorkflows(ctx context.Context, req TerminateOrgWorkflowsRequest) (*TerminateOrgWorkflowsResponse, error) {
+	l := temporalzap.GetActivityLogger(ctx)
+	l = l.With(zap.String("org_id", req.OrgID))
+
+	resp := &TerminateOrgWorkflowsResponse{}
+
+	for _, ns := range orgWorkflowNamespaces {
+		client, err := a.tClient.GetNamespaceClient(ns)
+		if err != nil {
+			l.Warn("unable to get namespace client", zap.String("namespace", ns), zap.Error(err))
+			continue
+		}
+
+		var token []byte
+		for {
+			wfs, err := client.ListWorkflow(ctx, &workflowservice.ListWorkflowExecutionsRequest{
+				Namespace:     ns,
+				PageSize:      100,
+				NextPageToken: token,
+				Query:         "ExecutionStatus='Running'",
+			})
+			if err != nil {
+				l.Warn("unable to list workflows", zap.String("namespace", ns), zap.Error(err))
+				break
+			}
+
+			for _, wf := range wfs.Executions {
+				orgID := memoStringValue(wf.Memo, "org-id")
+				ownerID := memoStringValue(wf.Memo, "owner-id")
+				if orgID != req.OrgID && ownerID != req.OrgID {
+					continue
+				}
+
+				l.Info("terminating workflow",
+					zap.String("namespace", ns),
+					zap.String("workflow_id", wf.Execution.WorkflowId),
+				)
+
+				if err := client.TerminateWorkflow(ctx, wf.Execution.WorkflowId, wf.Execution.RunId, fmt.Sprintf("admin org cleanup for %s", req.OrgID)); err != nil {
+					l.Warn("unable to terminate workflow",
+						zap.String("workflow_id", wf.Execution.WorkflowId),
+						zap.Error(err))
+					resp.Errors = append(resp.Errors, wf.Execution.WorkflowId)
+					continue
+				}
+				resp.Terminated++
+			}
+
+			token = wfs.NextPageToken
+			if len(token) == 0 {
+				break
+			}
+		}
+	}
+
+	l.Info("org workflow termination complete",
+		zap.Int("terminated", resp.Terminated),
+		zap.Int("errors", len(resp.Errors)))
+
+	return resp, nil
+}
+
+// memoStringValue extracts a string value from a Temporal workflow Memo by key.
+func memoStringValue(memo *commonpb.Memo, key string) string {
+	if memo == nil {
+		return ""
+	}
+	payload, ok := memo.Fields[key]
+	if !ok {
+		return ""
+	}
+	var val string
+	if err := converter.GetDefaultDataConverter().FromPayload(payload, &val); err != nil {
+		return ""
+	}
+	return val
+}

--- a/services/ctl-api/internal/app/orgs/signals/v2/clear_org_queues/init.go
+++ b/services/ctl-api/internal/app/orgs/signals/v2/clear_org_queues/init.go
@@ -1,0 +1,12 @@
+package clearorgqueues
+
+import (
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/catalog"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+func init() {
+	catalog.Register(SignalType, func() signal.Signal {
+		return &Signal{}
+	})
+}

--- a/services/ctl-api/internal/app/orgs/signals/v2/clear_org_queues/signal.go
+++ b/services/ctl-api/internal/app/orgs/signals/v2/clear_org_queues/signal.go
@@ -1,0 +1,48 @@
+package clearorgqueues
+
+import (
+	"fmt"
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
+
+	orgactivities "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+const SignalType signal.SignalType = "org-clear-queues"
+
+type Signal struct {
+	OrgID string `json:"org_id"`
+}
+
+var _ signal.Signal = (*Signal)(nil)
+
+func (s *Signal) Type() signal.SignalType { return SignalType }
+
+func (s *Signal) Validate(ctx workflow.Context) error {
+	if s.OrgID == "" {
+		return fmt.Errorf("org_id is required")
+	}
+	return nil
+}
+
+func (s *Signal) Execute(ctx workflow.Context) error {
+	l := workflow.GetLogger(ctx)
+	l.Info("clearing all queues for org", zap.String("org_id", s.OrgID))
+
+	opts := &workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Minute,
+	}
+	resp, err := orgactivities.AwaitClearOrgQueuesByOrgID(ctx, s.OrgID, opts)
+	if err != nil {
+		return fmt.Errorf("unable to clear org queues: %w", err)
+	}
+
+	l.Info("org queue clear complete",
+		zap.Int("queues_cleared", resp.QueuesCleared),
+		zap.Int("signals_cancelled", resp.SignalsCancelled))
+
+	return nil
+}

--- a/services/ctl-api/internal/app/orgs/signals/v2/terminate_workflows/init.go
+++ b/services/ctl-api/internal/app/orgs/signals/v2/terminate_workflows/init.go
@@ -1,0 +1,12 @@
+package terminateworkflows
+
+import (
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/catalog"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+func init() {
+	catalog.Register(SignalType, func() signal.Signal {
+		return &Signal{}
+	})
+}

--- a/services/ctl-api/internal/app/orgs/signals/v2/terminate_workflows/signal.go
+++ b/services/ctl-api/internal/app/orgs/signals/v2/terminate_workflows/signal.go
@@ -1,0 +1,49 @@
+package terminateworkflows
+
+import (
+	"fmt"
+
+	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/general/worker/activities"
+	orgactivities "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+const SignalType signal.SignalType = "org-terminate-workflows"
+
+type Signal struct {
+	OrgID string `json:"org_id"`
+}
+
+var _ signal.Signal = (*Signal)(nil)
+
+func (s *Signal) Type() signal.SignalType { return SignalType }
+
+func (s *Signal) Validate(ctx workflow.Context) error {
+	if s.OrgID == "" {
+		return fmt.Errorf("org_id is required")
+	}
+	_, err := orgactivities.AwaitGetByOrgID(ctx, s.OrgID)
+	if err != nil {
+		return fmt.Errorf("org not found: %w", err)
+	}
+	return nil
+}
+
+func (s *Signal) Execute(ctx workflow.Context) error {
+	l := workflow.GetLogger(ctx)
+	l.Info("terminating all workflows for org", zap.String("org_id", s.OrgID))
+
+	resp, err := activities.AwaitTerminateOrgWorkflowsByOrgID(ctx, s.OrgID)
+	if err != nil {
+		return fmt.Errorf("unable to terminate org workflows: %w", err)
+	}
+
+	l.Info("org workflow termination complete",
+		zap.Int("terminated", resp.Terminated),
+		zap.Int("errors", len(resp.Errors)))
+
+	return nil
+}

--- a/services/ctl-api/internal/app/orgs/worker/activities/clear_org_queues.go
+++ b/services/ctl-api/internal/app/orgs/worker/activities/clear_org_queues.go
@@ -1,0 +1,76 @@
+package activities
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+type ClearOrgQueuesRequest struct {
+	OrgID string `validate:"required"`
+}
+
+type ClearOrgQueuesResponse struct {
+	QueuesCleared    int `json:"queues_cleared"`
+	SignalsCancelled int `json:"signals_cancelled"`
+}
+
+// @temporal-gen-v2 activity
+// @by-field OrgID
+func (a *Activities) ClearOrgQueues(ctx context.Context, req ClearOrgQueuesRequest) (*ClearOrgQueuesResponse, error) {
+	var queues []app.Queue
+	if res := a.db.WithContext(ctx).
+		Where("org_id = ?", req.OrgID).
+		Find(&queues); res.Error != nil {
+		return nil, errors.Wrap(res.Error, "unable to list org queues")
+	}
+
+	cleared := 0
+	signalsCancelled := 0
+
+	for _, q := range queues {
+		var signals []app.QueueSignal
+		if res := a.db.WithContext(ctx).
+			Where(app.QueueSignal{QueueID: q.ID}).
+			Find(&signals); res.Error != nil {
+			continue
+		}
+
+		for _, qs := range signals {
+			if isTerminalStatus(qs.Status.Status) {
+				continue
+			}
+
+			cancelledStatus := app.CompositeStatus{
+				CreatedAtTS:            time.Now().Unix(),
+				Status:                 app.StatusCancelled,
+				StatusHumanDescription: "cancelled by clear-org-queues",
+				Metadata:               map[string]any{"cancelled_by": "clear-org-queues"},
+			}
+			if res := a.db.WithContext(ctx).
+				Model(&app.QueueSignal{}).
+				Where("id = ?", qs.ID).
+				Update("status", cancelledStatus); res.Error != nil {
+				continue
+			}
+			signalsCancelled++
+		}
+		cleared++
+	}
+
+	return &ClearOrgQueuesResponse{
+		QueuesCleared:    cleared,
+		SignalsCancelled: signalsCancelled,
+	}, nil
+}
+
+func isTerminalStatus(s app.Status) bool {
+	switch s {
+	case app.StatusSuccess, app.StatusCancelled, app.StatusDiscarded, app.StatusError:
+		return true
+	}
+	return false
+}

--- a/services/ctl-api/internal/app/queue_signal.go
+++ b/services/ctl-api/internal/app/queue_signal.go
@@ -97,6 +97,29 @@ func (r *QueueSignal) Indexes(db *gorm.DB) []migrations.Index {
 			},
 			Option: "WHERE deleted_at = 0 AND (status->>'status') IN ('queued','in_progress')",
 		},
+		{
+			Name: indexes.Name(db, &QueueSignal{}, "org_id_type_deleted_at"),
+			Columns: []string{
+				"org_id",
+				"type",
+				"deleted_at",
+			},
+		},
+		{
+			Name: indexes.Name(db, &QueueSignal{}, "org_id_status_deleted_at"),
+			Columns: []string{
+				"org_id",
+				"(status->>'status')",
+				"deleted_at",
+			},
+		},
+		{
+			Name: indexes.Name(db, &QueueSignal{}, "created_at_deleted_at"),
+			Columns: []string{
+				"created_at DESC",
+				"deleted_at",
+			},
+		},
 	}
 }
 

--- a/services/ctl-api/internal/pkg/queue/catalog/allsignals/allsignals.go
+++ b/services/ctl-api/internal/pkg/queue/catalog/allsignals/allsignals.go
@@ -81,6 +81,7 @@ import (
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/onboarding/signals/create_org"
 
 	// orgs signals
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/clear_org_queues"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/created"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/delete"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/deprovision"

--- a/services/ctl-api/internal/pkg/queue/catalog/allsignals/allsignals.go
+++ b/services/ctl-api/internal/pkg/queue/catalog/allsignals/allsignals.go
@@ -95,6 +95,7 @@ import (
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/restart"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/restart_queues"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/restart_runners"
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/terminate_workflows"
 
 	// runners signals
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/signals/v2/created"

--- a/services/ctl-api/internal/pkg/queue/client/clear_queue.go
+++ b/services/ctl-api/internal/pkg/queue/client/clear_queue.go
@@ -13,14 +13,15 @@ import (
 // ClearQueue cancels all in-flight (non-terminal) signals in the given queue.
 // Every affected signal is set to StatusCancelled with a "cancelled by
 // clear-queue" description.
-func (c *Client) ClearQueue(ctx context.Context, queueID string) error {
+func (c *Client) ClearQueue(ctx context.Context, queueID string) (int, error) {
 	var signals []app.QueueSignal
 	if res := c.db.WithContext(ctx).
 		Where(app.QueueSignal{QueueID: queueID}).
 		Find(&signals); res.Error != nil {
-		return errors.Wrap(res.Error, "unable to list queue signals")
+		return 0, errors.Wrap(res.Error, "unable to list queue signals")
 	}
 
+	cancelled := 0
 	for _, qs := range signals {
 		if isTerminalStatus(qs.Status.Status) {
 			continue
@@ -50,7 +51,9 @@ func (c *Client) ClearQueue(ctx context.Context, queueID string) error {
 				zap.String("queue_signal_id", qs.ID),
 				zap.Error(res.Error))
 		}
+
+		cancelled++
 	}
 
-	return nil
+	return cancelled, nil
 }

--- a/services/ctl-api/internal/pkg/queue/client/client.go
+++ b/services/ctl-api/internal/pkg/queue/client/client.go
@@ -50,6 +50,24 @@ func New(params Params) *Client {
 	}
 }
 
+// queueMemo returns the standard memo map for a queue workflow.
+func queueMemo(q *app.Queue) map[string]any {
+	m := map[string]any{
+		"type":          "queue",
+		"id":            q.ID,
+		"name":          q.Name,
+		"owner-id":      q.OwnerID,
+		"owner-type":    q.OwnerType,
+		"max-in-flight": q.MaxInFlight,
+		"max-depth":     q.MaxDepth,
+		"idle-timeout":  time.Duration(q.IdleTimeout).String(),
+	}
+	if q.OrgID != nil {
+		m["org-id"] = *q.OrgID
+	}
+	return m
+}
+
 // queueStartOperation builds a WithStartWorkflowOperation for a queue workflow.
 // This is used by update-with-start calls to ensure the queue workflow is running.
 func (c *Client) queueStartOperation(q *app.Queue) tclient.WithStartWorkflowOperation {
@@ -58,14 +76,9 @@ func (c *Client) queueStartOperation(q *app.Queue) tclient.WithStartWorkflowOper
 		Version: c.cfg.Version,
 	}
 	startOpts := tclient.StartWorkflowOptions{
-		ID:        q.Workflow.ID,
-		TaskQueue: workflows.APITaskQueue,
-		Memo: map[string]any{
-			"id":           q.ID,
-			"owner-id":     q.OwnerID,
-			"owner-type":   q.OwnerType,
-			"idle-timeout": time.Duration(q.IdleTimeout).String(),
-		},
+		ID:                       q.Workflow.ID,
+		TaskQueue:                workflows.APITaskQueue,
+		Memo:                     queueMemo(q),
 		WorkflowIDConflictPolicy: enumsv1.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 0,

--- a/services/ctl-api/internal/pkg/queue/client/create.go
+++ b/services/ctl-api/internal/pkg/queue/client/create.go
@@ -79,7 +79,7 @@ func (c *Client) Create(ctx context.Context, req *CreateQueueRequest) (*app.Queu
 	opts := tclient.StartWorkflowOptions{
 		ID:                    q.Workflow.ID,
 		TaskQueue:             workflows.APITaskQueue,
-		Memo:                  queueMemo(q),
+		Memo:                  queueMemo(&q),
 		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 0,

--- a/services/ctl-api/internal/pkg/queue/client/create.go
+++ b/services/ctl-api/internal/pkg/queue/client/create.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/pkg/errors"
@@ -78,18 +77,9 @@ func (c *Client) Create(ctx context.Context, req *CreateQueueRequest) (*app.Queu
 		Version: c.cfg.Version,
 	}
 	opts := tclient.StartWorkflowOptions{
-		ID:        q.Workflow.ID,
-		TaskQueue: workflows.APITaskQueue,
-		Memo: map[string]any{
-			"type":          "queue",
-			"id":            q.ID,
-			"name":          q.Name,
-			"owner-id":      q.OwnerID,
-			"owner-type":    q.OwnerType,
-			"max-in-flight": q.MaxInFlight,
-			"max-depth":     q.MaxDepth,
-			"idle-timeout":  time.Duration(q.IdleTimeout).String(),
-		},
+		ID:                    q.Workflow.ID,
+		TaskQueue:             workflows.APITaskQueue,
+		Memo:                  queueMemo(q),
 		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 0,

--- a/services/ctl-api/internal/pkg/queue/client/force_restart.go
+++ b/services/ctl-api/internal/pkg/queue/client/force_restart.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -34,18 +33,9 @@ func (c *Client) ForceRestart(ctx context.Context, queueID string) error {
 		Version: c.cfg.Version,
 	}
 	opts := tclient.StartWorkflowOptions{
-		ID:        q.Workflow.ID,
-		TaskQueue: workflows.APITaskQueue,
-		Memo: map[string]any{
-			"type":          "queue",
-			"id":            q.ID,
-			"name":          q.Name,
-			"owner-id":      q.OwnerID,
-			"owner-type":    q.OwnerType,
-			"max-in-flight": q.MaxInFlight,
-			"max-depth":     q.MaxDepth,
-			"idle-timeout":  time.Duration(q.IdleTimeout).String(),
-		},
+		ID:                    q.Workflow.ID,
+		TaskQueue:             workflows.APITaskQueue,
+		Memo:                  queueMemo(q),
 		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 0,

--- a/services/ctl-api/internal/pkg/queue/emitter/client/emitter.go
+++ b/services/ctl-api/internal/pkg/queue/emitter/client/emitter.go
@@ -98,15 +98,9 @@ func (c *Client) CreateEmitter(ctx context.Context, req *CreateEmitterRequest) (
 	}
 
 	opts := tclient.StartWorkflowOptions{
-		ID:        em.Workflow.ID,
-		TaskQueue: workflows.APITaskQueue,
-		Memo: map[string]any{
-			"id":       em.ID,
-			"queue-id": q.ID,
-			"name":     em.Name,
-			"mode":     string(em.Mode),
-			"emitter":  true,
-		},
+		ID:                    em.Workflow.ID,
+		TaskQueue:             workflows.APITaskQueue,
+		Memo:                  emitterMemo(&em),
 		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 0,
@@ -149,6 +143,18 @@ func (c *Client) getEmitterByID(ctx context.Context, emitterID string) (*app.Que
 		return nil, errors.Wrap(err, "unable to get emitter")
 	}
 	return em, nil
+}
+
+// emitterMemo returns the standard memo map for an emitter workflow.
+func emitterMemo(em *app.QueueEmitter) map[string]any {
+	return map[string]any{
+		"id":       em.ID,
+		"queue-id": em.QueueID,
+		"org-id":   em.OrgID,
+		"name":     em.Name,
+		"mode":     string(em.Mode),
+		"emitter":  true,
+	}
 }
 
 func (c *Client) getEmitter(ctx context.Context, emitterID string) (*app.QueueEmitter, error) {
@@ -294,15 +300,9 @@ func (c *Client) RestartEmitterWorkflow(ctx context.Context, emitterID string) (
 	}
 
 	opts := tclient.StartWorkflowOptions{
-		ID:        em.Workflow.ID,
-		TaskQueue: workflows.APITaskQueue,
-		Memo: map[string]any{
-			"id":       em.ID,
-			"queue-id": em.QueueID,
-			"name":     em.Name,
-			"mode":     string(em.Mode),
-			"emitter":  true,
-		},
+		ID:                    em.Workflow.ID,
+		TaskQueue:             workflows.APITaskQueue,
+		Memo:                  emitterMemo(em),
 		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 0,


### PR DESCRIPTION
Creating a dashboard that allows for cleaning up an org:

1. forget installs
1. remove org infra
1. remove queues
1. remove queue signals
1. remove temporal workflows
