### PR TITLE
fix: (queue) Register workflow handlers in deterministic order

### DIFF
--- a/services/ctl-api/internal/pkg/queue/emitter/handlers.go
+++ b/services/ctl-api/internal/pkg/queue/emitter/handlers.go
@@ -21,51 +21,28 @@ const (
 )
 
 type handler struct {
+	name             string
 	typ              handlerType
 	handler          any
 	handlerValidator any
 }
 
 func (e *emitterWorkflow) registerHandlers(ctx workflow.Context) error {
-	updateHandlers := map[string]handler{
-		StopUpdateName: {
-			handlerTypeUpdate,
-			e.stopHandler,
-			nil,
-		},
-		RestartUpdateName: {
-			handlerTypeUpdate,
-			e.restartHandler,
-			nil,
-		},
-		StatusUpdateName: {
-			handlerTypeUpdate,
-			e.statusHandler,
-			nil,
-		},
-		EnsureRunningUpdateName: {
-			handlerTypeUpdate,
-			e.ensureRunningHandler,
-			nil,
-		},
-		PauseUpdateName: {
-			handlerTypeUpdate,
-			e.pauseHandler,
-			nil,
-		},
-		ResumeUpdateName: {
-			handlerTypeUpdate,
-			e.resumeHandler,
-			nil,
-		},
+	updateHandlers := []handler{
+		{StopUpdateName, handlerTypeUpdate, e.stopHandler, nil},
+		{RestartUpdateName, handlerTypeUpdate, e.restartHandler, nil},
+		{StatusUpdateName, handlerTypeUpdate, e.statusHandler, nil},
+		{EnsureRunningUpdateName, handlerTypeUpdate, e.ensureRunningHandler, nil},
+		{PauseUpdateName, handlerTypeUpdate, e.pauseHandler, nil},
+		{ResumeUpdateName, handlerTypeUpdate, e.resumeHandler, nil},
 	}
 
-	for name, h := range updateHandlers {
+	for _, h := range updateHandlers {
 		opts := workflow.UpdateHandlerOptions{
 			Validator: h.handlerValidator,
 		}
-		if err := workflow.SetUpdateHandlerWithOptions(ctx, name, h.handler, opts); err != nil {
-			return errors.Wrapf(err, "unable to create update handler %s", name)
+		if err := workflow.SetUpdateHandlerWithOptions(ctx, h.name, h.handler, opts); err != nil {
+			return errors.Wrapf(err, "unable to create update handler %s", h.name)
 		}
 	}
 

--- a/services/ctl-api/internal/pkg/queue/handler/handlers.go
+++ b/services/ctl-api/internal/pkg/queue/handler/handlers.go
@@ -13,59 +13,36 @@ const (
 )
 
 type workflowHandler struct {
+	name             string
 	typ              handlerType
 	handler          any
 	handlerValidator any
 }
 
 func (h *handler) registerHandlers(ctx workflow.Context) error {
-	handlers := map[string]workflowHandler{
-		StatusQueryName: {
-			handlerTypeQuery,
-			h.statusHandler,
-			nil,
-		},
-		ReadyHandlerName: {
-			handlerTypeUpdate,
-			h.readyHandler,
-			nil,
-		},
-		ValidateUpdateName: {
-			handlerTypeUpdate,
-			h.validateHandler,
-			nil,
-		},
-		ExecuteUpdateName: {
-			handlerTypeUpdate,
-			h.executeHandler,
-			nil,
-		},
-		CancelUpdateName: {
-			handlerTypeUpdate,
-			h.cancelHandler,
-			nil,
-		},
-		FinishedHandlerName: {
-			handlerTypeUpdate,
-			h.finishedHandler,
-			nil,
-		},
+	handlers := []workflowHandler{
+		{StatusQueryName, handlerTypeQuery, h.statusHandler, nil},
+		{ReadyHandlerName, handlerTypeUpdate, h.readyHandler, nil},
+		{ValidateUpdateName, handlerTypeUpdate, h.validateHandler, nil},
+		{ExecuteUpdateName, handlerTypeUpdate, h.executeHandler, nil},
+		{CancelUpdateName, handlerTypeUpdate, h.cancelHandler, nil},
+		{FinishedHandlerName, handlerTypeUpdate, h.finishedHandler, nil},
 	}
 
-	for name, handler := range handlers {
-		switch handler.typ {
+	for _, wh := range handlers {
+		switch wh.typ {
 		// register query handler
 		case handlerTypeQuery:
-			if err := workflow.SetQueryHandler(ctx, string(name), handler.handler); err != nil {
-				return errors.Wrapf(err, "unable to create query handler %s", name)
+			if err := workflow.SetQueryHandler(ctx, wh.name, wh.handler); err != nil {
+				return errors.Wrapf(err, "unable to create query handler %s", wh.name)
 			}
 			// register update handler
 		case handlerTypeUpdate:
 			opts := workflow.UpdateHandlerOptions{
-				Validator: handler.handlerValidator,
+				Validator: wh.handlerValidator,
 			}
-			if err := workflow.SetUpdateHandlerWithOptions(ctx, name, handler.handler, opts); err != nil {
-				return errors.Wrapf(err, "unable to create update handler %s", name)
+			if err := workflow.SetUpdateHandlerWithOptions(ctx, wh.name, wh.handler, opts); err != nil {
+				return errors.Wrapf(err, "unable to create update handler %s", wh.name)
 			}
 		}
 	}

--- a/services/ctl-api/internal/pkg/queue/handlers.go
+++ b/services/ctl-api/internal/pkg/queue/handlers.go
@@ -13,69 +13,39 @@ const (
 )
 
 type handler struct {
+	name             string
 	typ              handlerType
 	handler          any
 	handlerValidator any
 }
 
 func (w *queue) registerHandlers(ctx workflow.Context) error {
-	updateHandlers := map[string]handler{
-		EnqueueUpdateName: {
-			handlerTypeUpdate,
-			w.enqueueHandler,
-			nil,
-		},
-		ReadyHandlerName: {
-			handlerTypeQuery,
-			w.readyHandler,
-			nil,
-		},
-		StatusHandlerName: {
-			handlerTypeUpdate,
-			w.statusHandler,
-			nil,
-		},
-		PauseHandlerName: {
-			handlerTypeUpdate,
-			w.pauseHandler,
-			nil,
-		},
-		ResumeHandlerName: {
-			handlerTypeUpdate,
-			w.resumeHandler,
-			nil,
-		},
-		StopUpdateName: {
-			handlerTypeUpdate,
-			w.stopUpdateHandler,
-			nil,
-		},
-		DirectExecuteUpdateName: {
-			handlerTypeUpdate,
-			w.directExecuteHandler,
-			nil,
-		},
-		CheckCANUpdateName: {
-			handlerTypeUpdate,
-			w.checkCANHandler,
-			nil,
-		},
+	// Using a slice for temporal determinism.
+	updateHandlers := []handler{
+		{EnqueueUpdateName, handlerTypeUpdate, w.enqueueHandler, nil},
+		{ReadyHandlerName, handlerTypeQuery, w.readyHandler, nil},
+		{StatusHandlerName, handlerTypeUpdate, w.statusHandler, nil},
+		{PauseHandlerName, handlerTypeUpdate, w.pauseHandler, nil},
+		{ResumeHandlerName, handlerTypeUpdate, w.resumeHandler, nil},
+		{StopUpdateName, handlerTypeUpdate, w.stopUpdateHandler, nil},
+		{DirectExecuteUpdateName, handlerTypeUpdate, w.directExecuteHandler, nil},
+		{CheckCANUpdateName, handlerTypeUpdate, w.checkCANHandler, nil},
 	}
-	for name, handler := range updateHandlers {
-		switch handler.typ {
+	for _, h := range updateHandlers {
+		switch h.typ {
 		// register query handler
 		case handlerTypeQuery:
-			if err := workflow.SetQueryHandler(ctx, string(name), handler.handler); err != nil {
-				return errors.Wrapf(err, "unable to create query handler %s", name)
+			if err := workflow.SetQueryHandler(ctx, h.name, h.handler); err != nil {
+				return errors.Wrapf(err, "unable to create query handler %s", h.name)
 			}
 
 			// register update handler
 		case handlerTypeUpdate:
 			opts := workflow.UpdateHandlerOptions{
-				Validator: handler.handlerValidator,
+				Validator: h.handlerValidator,
 			}
-			if err := workflow.SetUpdateHandlerWithOptions(ctx, name, handler.handler, opts); err != nil {
-				return errors.Wrapf(err, "unable to create update handler %s", name)
+			if err := workflow.SetUpdateHandlerWithOptions(ctx, h.name, h.handler, opts); err != nil {
+				return errors.Wrapf(err, "unable to create update handler %s", h.name)
 			}
 		}
 	}


### PR DESCRIPTION
The queue, queue handler, and emitter workflows registered their query/update handlers by iterating a `map[string]handler`. Go map iteration order is randomized, so each workflow run/replay registered handlers in a different sequence. This breaks Temporal replay determinism: buffered updates received before registration are dispatched in registration order, so the activities they schedule end up with different scheduledEventIDs across runs.

Replace the maps with fixed-order `[]handler` / `[]workflowHandler` slices so registration (and therefore buffered-update dispatch) is identical across runs and replays.