### PR TITLE
fix: reduce jitter window for cron emitter

### DIFF
--- a/services/ctl-api/internal/app/runners/helpers/create_process_queues.go
+++ b/services/ctl-api/internal/app/runners/helpers/create_process_queues.go
@@ -43,7 +43,7 @@ func (h *Helpers) CreateProcessQueues(ctx context.Context, runnerID string, proc
 		Description:  "Periodic process health check",
 		Mode:         app.QueueEmitterModeCron,
 		CronSchedule: "* * * * *",
-		JitterWindow: time.Minute,
+		JitterWindow: time.Second * 30,
 		SignalType:   "process_healthcheck",
 		SignalTemplate: queuesignal.NewRaw("process_healthcheck", map[string]any{
 			"runner_id":  runnerID,

--- a/services/ctl-api/internal/app/runners/helpers/create_runner_queues.go
+++ b/services/ctl-api/internal/app/runners/helpers/create_runner_queues.go
@@ -75,7 +75,7 @@ func (h *Helpers) CreateRunnerQueues(ctx context.Context, runner *app.Runner, se
 		Description:    "Periodic runner health check",
 		Mode:           app.QueueEmitterModeCron,
 		CronSchedule:   "* * * * *",
-		JitterWindow:   time.Minute,
+		JitterWindow:   time.Second * 30,
 		SignalType:     healthcheckSignalType,
 		SignalTemplate: &healthcheckSignalTemplate{RunnerID: runner.ID},
 	}); err != nil {

--- a/services/ctl-api/internal/app/runners/helpers/ensure_runner_queues.go
+++ b/services/ctl-api/internal/app/runners/helpers/ensure_runner_queues.go
@@ -73,7 +73,7 @@ func (h *Helpers) EnsureRunnerJobGroupQueues(ctx context.Context, runner *app.Ru
 		Description:    "Periodic runner health check",
 		Mode:           app.QueueEmitterModeCron,
 		CronSchedule:   "* * * * *",
-		JitterWindow:   time.Minute,
+		JitterWindow:   time.Second * 30,
 		SignalType:     healthcheckSignalType,
 		SignalTemplate: &healthcheckSignalTemplate{RunnerID: runner.ID},
 	}); err != nil {


### PR DESCRIPTION
cron emitters are triggered every min, having 30 sec jitter window gives time to recover the run itself and not get overwhelmed by next iteration
