### PR TITLE
fix: Do not terminate CronTicker abruptly while parent workflow closes

### DIFF
--- a/services/ctl-api/internal/app/runners/helpers/create_process_queues.go
+++ b/services/ctl-api/internal/app/runners/helpers/create_process_queues.go
@@ -43,7 +43,7 @@ func (h *Helpers) CreateProcessQueues(ctx context.Context, runnerID string, proc
 		Description:  "Periodic process health check",
 		Mode:         app.QueueEmitterModeCron,
 		CronSchedule: "* * * * *",
-		JitterWindow: time.Minute,
+		JitterWindow: time.Second * 30,
 		SignalType:   "process_healthcheck",
 		SignalTemplate: queuesignal.NewRaw("process_healthcheck", map[string]any{
 			"runner_id":  runnerID,

--- a/services/ctl-api/internal/app/runners/helpers/create_runner_queues.go
+++ b/services/ctl-api/internal/app/runners/helpers/create_runner_queues.go
@@ -75,7 +75,7 @@ func (h *Helpers) CreateRunnerQueues(ctx context.Context, runner *app.Runner, se
 		Description:    "Periodic runner health check",
 		Mode:           app.QueueEmitterModeCron,
 		CronSchedule:   "* * * * *",
-		JitterWindow:   time.Minute,
+		JitterWindow:   time.Second * 30,
 		SignalType:     healthcheckSignalType,
 		SignalTemplate: &healthcheckSignalTemplate{RunnerID: runner.ID},
 	}); err != nil {

--- a/services/ctl-api/internal/app/runners/helpers/ensure_runner_queues.go
+++ b/services/ctl-api/internal/app/runners/helpers/ensure_runner_queues.go
@@ -73,7 +73,7 @@ func (h *Helpers) EnsureRunnerJobGroupQueues(ctx context.Context, runner *app.Ru
 		Description:    "Periodic runner health check",
 		Mode:           app.QueueEmitterModeCron,
 		CronSchedule:   "* * * * *",
-		JitterWindow:   time.Minute,
+		JitterWindow:   time.Second * 30,
 		SignalType:     healthcheckSignalType,
 		SignalTemplate: &healthcheckSignalTemplate{RunnerID: runner.ID},
 	}); err != nil {

--- a/services/ctl-api/internal/pkg/queue/emitter/run_cron.go
+++ b/services/ctl-api/internal/pkg/queue/emitter/run_cron.go
@@ -79,15 +79,12 @@ func (e *emitterWorkflow) runCronMode(ctx workflow.Context, l *zap.Logger, emitt
 func (e *emitterWorkflow) ensureCronTickerRunning(ctx workflow.Context, l *zap.Logger, emitter *app.QueueEmitter, childWorkflowID string) error {
 	parentInfo := workflow.GetInfo(ctx)
 
-	// WorkflowIDReusePolicy=TERMINATE_IF_RUNNING so a stale cron child from a
-	// previous parent run (e.g. abandoned across continue-as-new) is
-	// terminated and replaced by this run's child. Fire-and-forget — we do
-	// not block on the child start.
 	childCtx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
 		WorkflowID:            childWorkflowID,
 		TaskQueue:             parentInfo.TaskQueueName,
 		CronSchedule:          emitter.CronSchedule,
-		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+		ParentClosePolicy:     enums.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 0,
 		},


### PR DESCRIPTION
The default parent close policy is to terminate. In case of Emitter and CronTicker, this will abruptly terminate the CronTicker, in the worst case causing a signal to be written to DB, but not enqueued.

This kind of signal can block an entire emitter, as we wait for the previous Signal to start before enqueuing a new one.