### PR TITLE
feat: link new orgs to slack at creation time

### DIFF
--- a/services/ctl-api/internal/app/general/worker/activities/activities.go
+++ b/services/ctl-api/internal/app/general/worker/activities/activities.go
@@ -13,19 +13,21 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	appshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/eventloop"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/slack/autolink"
 	slackclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/slack/client"
 )
 
 type Activities struct {
-	cfg         *internal.Config
-	db          *gorm.DB
-	chDB        *gorm.DB
-	appsHelpers *appshelpers.Helpers
-	evClient    eventloop.Client
-	mw          metrics.Writer
-	logger      *temporalzap.Logger
-	tClient     temporalclient.Client
-	slackClient *slackclient.Client
+	cfg            *internal.Config
+	db             *gorm.DB
+	chDB           *gorm.DB
+	appsHelpers    *appshelpers.Helpers
+	evClient       eventloop.Client
+	mw             metrics.Writer
+	logger         *temporalzap.Logger
+	tClient        temporalclient.Client
+	slackClient    *slackclient.Client
+	autoLinkHelper *autolink.Helper
 }
 
 type Params struct {
@@ -39,6 +41,7 @@ type Params struct {
 	MW             metrics.Writer
 	TemporalClient temporalclient.Client
 	SlackClient    *slackclient.Client
+	AutoLinkHelper *autolink.Helper
 }
 
 func New(params Params) (*Activities, error) {
@@ -48,14 +51,15 @@ func New(params Params) (*Activities, error) {
 		return nil, fmt.Errorf("unable to create temporal logger: %w", err)
 	}
 	return &Activities{
-		cfg:         params.Cfg,
-		db:          params.DB,
-		chDB:        params.CHDB,
-		appsHelpers: params.AppsHelpers,
-		evClient:    params.EvClient,
-		mw:          params.MW,
-		logger:      tlogger,
-		tClient:     params.TemporalClient,
-		slackClient: params.SlackClient,
+		cfg:            params.Cfg,
+		db:             params.DB,
+		chDB:           params.CHDB,
+		appsHelpers:    params.AppsHelpers,
+		evClient:       params.EvClient,
+		mw:             params.MW,
+		logger:         tlogger,
+		tClient:        params.TemporalClient,
+		slackClient:    params.SlackClient,
+		autoLinkHelper: params.AutoLinkHelper,
 	}, nil
 }

--- a/services/ctl-api/internal/app/general/worker/activities/ensure_slack_auto_links.go
+++ b/services/ctl-api/internal/app/general/worker/activities/ensure_slack_auto_links.go
@@ -6,11 +6,9 @@ import (
 	"fmt"
 
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 
 	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/interests"
 )
 
 // EnsureSlackAutoLinksRequest has no params — policy comes from a.cfg.SlackAutoLink*.
@@ -36,22 +34,19 @@ func (a *Activities) EnsureSlackAutoLinks(ctx context.Context, _ EnsureSlackAuto
 	teamID := a.cfg.SlackAutoLinkTeamID
 	labelKey := a.cfg.SlackAutoLinkOrgLabelKey
 	channelID := a.cfg.SlackAutoLinkChannelID
-
 	if teamID == "" || labelKey == "" {
 		return res, nil
 	}
 
-	var install app.SlackInstallation
 	switch err := a.db.WithContext(ctx).
 		Where(app.SlackInstallation{TeamID: teamID, Status: app.SlackInstallationStatusActive}).
-		First(&install).Error; {
+		First(&app.SlackInstallation{}).Error; {
 	case errors.Is(err, gorm.ErrRecordNotFound):
 		return res, nil
 	case err != nil:
 		return nil, fmt.Errorf("lookup slack installation: %w", err)
 	}
 
-	// Empty value → "*" wildcard matches any value at the configured key.
 	value := a.cfg.SlackAutoLinkOrgLabelValue
 	if value == "" {
 		value = "*"
@@ -68,121 +63,23 @@ func (a *Activities) EnsureSlackAutoLinks(ctx context.Context, _ EnsureSlackAuto
 	res.OrgsConsidered = len(orgs)
 
 	for _, org := range orgs {
-		linkID, created, err := a.upsertAutoLink(ctx, install, org.ID)
+		r, err := a.autoLinkHelper.EnsureForOrg(ctx, org.ID)
 		if err != nil {
-			return nil, fmt.Errorf("upsert org link for %s: %w", org.ID, err)
+			return nil, fmt.Errorf("ensure for %s: %w", org.ID, err)
 		}
-		if created {
+		if r.LinkCreated || r.LinkRevived {
 			res.LinksCreated++
 		} else {
 			res.LinksAlreadyActive++
 		}
-
-		// Never re-seed: a deleted seed sub is intentional — leave it gone.
-		if channelID == "" {
-			continue
-		}
-		seeded, err := a.seedDefaultSubscription(ctx, install, linkID, org.ID, channelID)
-		if err != nil {
-			return nil, fmt.Errorf("seed default sub for %s: %w", org.ID, err)
-		}
-		if seeded {
-			res.SubsSeeded++
-		} else {
-			res.SubsAlreadyExist++
+		if channelID != "" {
+			if r.SubSeeded {
+				res.SubsSeeded++
+			} else {
+				res.SubsAlreadyExist++
+			}
 		}
 	}
 
-	a.mw.Count("event_loop.general.slack_auto_link.links_created", int64(res.LinksCreated), nil)
-	a.mw.Count("event_loop.general.slack_auto_link.subs_seeded", int64(res.SubsSeeded), nil)
 	return res, nil
-}
-
-// upsertAutoLink mirrors the OAuth-callback link upsert in
-// slack_oauth_callback.go: Unscoped() to revive soft-deleted rows,
-// provenance attributed to the workspace installer.
-func (a *Activities) upsertAutoLink(ctx context.Context, install app.SlackInstallation, orgID string) (string, bool, error) {
-	var existing app.SlackOrgLink
-	err := a.db.WithContext(ctx).
-		Unscoped().
-		Where(app.SlackOrgLink{TeamID: install.TeamID, OrgID: orgID}).
-		First(&existing).Error
-	switch {
-	case errors.Is(err, gorm.ErrRecordNotFound):
-		link := &app.SlackOrgLink{
-			TeamID:            install.TeamID,
-			OrgID:             orgID,
-			Status:            app.SlackOrgLinkStatusVerified,
-			LinkedByAccountID: install.InstalledByAccountID,
-			CreatedByID:       install.InstalledByAccountID,
-		}
-		if err := a.db.WithContext(ctx).Create(link).Error; err != nil {
-			return "", false, fmt.Errorf("create org link: %w", err)
-		}
-		return link.ID, true, nil
-	case err != nil:
-		return "", false, fmt.Errorf("lookup existing org link: %w", err)
-	}
-
-	// Skip churning updated_at on an already-verified, live row.
-	if existing.Status == app.SlackOrgLinkStatusVerified && existing.DeletedAt == 0 {
-		return existing.ID, false, nil
-	}
-	existing.Status = app.SlackOrgLinkStatusVerified
-	existing.DeletedAt = 0
-	if err := a.db.WithContext(ctx).Unscoped().Save(&existing).Error; err != nil {
-		return "", false, fmt.Errorf("revive org link: %w", err)
-	}
-	return existing.ID, true, nil
-}
-
-// seedDefaultSubscription inserts one nil-Match (org-wide), AllEvents-true
-// sub when no live sub exists on this link. The "no existing sub" gate makes
-// it one-shot: once an admin deletes or replaces the seed, we won't recreate.
-// A failed channel-name lookup falls back to the channel ID — a Slack API
-// blip must not leave orgs unlinked.
-func (a *Activities) seedDefaultSubscription(ctx context.Context, install app.SlackInstallation, linkID, orgID, channelID string) (bool, error) {
-	var count int64
-	if err := a.db.WithContext(ctx).
-		Model(&app.SlackChannelSubscription{}).
-		Where(&app.SlackChannelSubscription{OrgLinkID: linkID, OrgID: orgID}).
-		Count(&count).Error; err != nil {
-		return false, fmt.Errorf("count existing subs: %w", err)
-	}
-	if count > 0 {
-		return false, nil
-	}
-
-	channelName := channelID
-	if info, err := a.slackClient.ConversationsInfo(ctx, install.BotAccessToken, channelID); err == nil && info.Channel.Name != "" {
-		channelName = info.Channel.Name
-	}
-
-	accountID := install.InstalledByAccountID
-	sub := app.SlackChannelSubscription{
-		OrgLinkID:          linkID,
-		OrgID:              orgID,
-		TeamID:             install.TeamID,
-		ChannelID:          channelID,
-		ChannelName:        channelName,
-		Interests:          interests.AllEvents(),
-		CreatedByAccountID: &accountID,
-		CreatedByID:        accountID,
-	}
-
-	// Count gate above is racy; the unique index (team_id, channel_id,
-	// org_link_id, match_canonical, deleted_at) is the actual guard.
-	if err := a.db.WithContext(ctx).Clauses(clause.OnConflict{
-		Columns: []clause.Column{
-			{Name: "team_id"},
-			{Name: "channel_id"},
-			{Name: "org_link_id"},
-			{Name: "match_canonical"},
-			{Name: "deleted_at"},
-		},
-		DoNothing: true,
-	}).Create(&sub).Error; err != nil {
-		return false, fmt.Errorf("create seed subscription: %w", err)
-	}
-	return true, nil
 }

--- a/services/ctl-api/internal/app/orgs/helpers/create_org.go
+++ b/services/ctl-api/internal/app/orgs/helpers/create_org.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -97,6 +99,13 @@ func (h *Helpers) CreateOrg(ctx context.Context, acct *app.Account, params *Crea
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to create org-signals queue: %w", err)
+	}
+
+	// Best-effort: failures are picked up by the periodic reconciler.
+	if h.slackAutoLinkHelper != nil {
+		if _, err := h.slackAutoLinkHelper.EnsureForOrg(ctx, org.ID); err != nil && h.logger != nil {
+			h.logger.Warn("slack auto-link on org create failed", zap.String("org_id", org.ID), zap.Error(err))
+		}
 	}
 
 	return &org, nil

--- a/services/ctl-api/internal/app/orgs/helpers/helpers.go
+++ b/services/ctl-api/internal/app/orgs/helpers/helpers.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"github.com/go-playground/validator/v10"
 	"go.uber.org/fx"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal"
@@ -10,38 +11,45 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/authz"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/slack/autolink"
 )
 
 type Params struct {
 	fx.In
 
-	Cfg            *internal.Config
-	DB             *gorm.DB `name:"psql"`
-	V              *validator.Validate
-	AcctClient     *account.Client
-	AuthzClient    *authz.Client
-	RunnersHelpers *runnershelpers.Helpers
-	QueueClient    *queueclient.Client
+	Cfg                 *internal.Config
+	DB                  *gorm.DB `name:"psql"`
+	Logger              *zap.Logger
+	V                   *validator.Validate
+	AcctClient          *account.Client
+	AuthzClient         *authz.Client
+	RunnersHelpers      *runnershelpers.Helpers
+	QueueClient         *queueclient.Client
+	SlackAutoLinkHelper *autolink.Helper
 }
 
 type Helpers struct {
-	cfg            *internal.Config
-	db             *gorm.DB
-	v              *validator.Validate
-	acctClient     *account.Client
-	authzClient    *authz.Client
-	runnersHelpers *runnershelpers.Helpers
-	queueClient    *queueclient.Client
+	cfg                 *internal.Config
+	db                  *gorm.DB
+	logger              *zap.Logger
+	v                   *validator.Validate
+	acctClient          *account.Client
+	authzClient         *authz.Client
+	runnersHelpers      *runnershelpers.Helpers
+	queueClient         *queueclient.Client
+	slackAutoLinkHelper *autolink.Helper
 }
 
 func New(params Params) *Helpers {
 	return &Helpers{
-		v:              params.V,
-		cfg:            params.Cfg,
-		db:             params.DB,
-		acctClient:     params.AcctClient,
-		authzClient:    params.AuthzClient,
-		runnersHelpers: params.RunnersHelpers,
-		queueClient:    params.QueueClient,
+		v:                   params.V,
+		cfg:                 params.Cfg,
+		db:                  params.DB,
+		logger:              params.Logger,
+		acctClient:          params.AcctClient,
+		authzClient:         params.AuthzClient,
+		runnersHelpers:      params.RunnersHelpers,
+		queueClient:         params.QueueClient,
+		slackAutoLinkHelper: params.SlackAutoLinkHelper,
 	}
 }

--- a/services/ctl-api/internal/fxmodules/slack_libs.go
+++ b/services/ctl-api/internal/fxmodules/slack_libs.go
@@ -4,6 +4,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/slack/autolink"
 	slackclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/slack/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/slack/statejwt"
 )
@@ -24,4 +25,5 @@ var SlackLibsModule = fx.Module("slack-libs",
 	fx.Provide(func(cfg *internal.Config) (*statejwt.Encoder, error) {
 		return statejwt.New(cfg.SlackStateJWTSecret)
 	}),
+	fx.Provide(autolink.New),
 )

--- a/services/ctl-api/internal/pkg/slack/autolink/autolink.go
+++ b/services/ctl-api/internal/pkg/slack/autolink/autolink.go
@@ -1,0 +1,206 @@
+// Package autolink ensures a SlackOrgLink and optional default channel
+// subscription for a single org under the same gating policy the
+// reconciler applies, so org creation and the periodic sweep share one
+// code path.
+package autolink
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.uber.org/fx"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/nuonco/nuon/pkg/labels"
+	"github.com/nuonco/nuon/pkg/metrics"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/interests"
+	slackclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/slack/client"
+)
+
+type Helper struct {
+	cfg         *internal.Config
+	db          *gorm.DB
+	slackClient *slackclient.Client
+	mw          metrics.Writer
+}
+
+type Params struct {
+	fx.In
+
+	Cfg         *internal.Config
+	DB          *gorm.DB `name:"psql"`
+	SlackClient *slackclient.Client
+	MW          metrics.Writer
+}
+
+func New(p Params) *Helper {
+	return &Helper{cfg: p.Cfg, db: p.DB, slackClient: p.SlackClient, mw: p.MW}
+}
+
+type Result struct {
+	LinkCreated   bool
+	LinkRevived   bool
+	SubSeeded     bool
+	SkippedReason string
+}
+
+// EnsureForOrg upserts the SlackOrgLink and seeds the default channel
+// subscription for one org. Skips silently when the policy is
+// unconfigured, the workspace install is missing, or the org is not
+// labeled for auto-link.
+func (h *Helper) EnsureForOrg(ctx context.Context, orgID string) (*Result, error) {
+	res := &Result{}
+
+	teamID := h.cfg.SlackAutoLinkTeamID
+	labelKey := h.cfg.SlackAutoLinkOrgLabelKey
+	channelID := h.cfg.SlackAutoLinkChannelID
+	if teamID == "" || labelKey == "" {
+		res.SkippedReason = "policy_unconfigured"
+		return res, nil
+	}
+
+	var org app.Org
+	if err := h.db.WithContext(ctx).Select("id", "labels").Where(&app.Org{ID: orgID}).First(&org).Error; err != nil {
+		return nil, fmt.Errorf("lookup org: %w", err)
+	}
+	if !labelMatches(org.Labels, labelKey, h.cfg.SlackAutoLinkOrgLabelValue) {
+		res.SkippedReason = "label_gate_unmatched"
+		return res, nil
+	}
+
+	var install app.SlackInstallation
+	switch err := h.db.WithContext(ctx).
+		Where(app.SlackInstallation{TeamID: teamID, Status: app.SlackInstallationStatusActive}).
+		First(&install).Error; {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		res.SkippedReason = "no_active_installation"
+		return res, nil
+	case err != nil:
+		return nil, fmt.Errorf("lookup slack installation: %w", err)
+	}
+
+	linkID, created, err := h.upsertAutoLink(ctx, install, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("upsert org link: %w", err)
+	}
+	res.LinkCreated = created
+	res.LinkRevived = !created
+
+	if channelID != "" {
+		seeded, err := h.seedDefaultSubscription(ctx, install, linkID, orgID, channelID)
+		if err != nil {
+			return nil, fmt.Errorf("seed default subscription: %w", err)
+		}
+		res.SubSeeded = seeded
+	}
+
+	if h.mw != nil {
+		if res.LinkCreated {
+			h.mw.Count("event_loop.general.slack_auto_link.links_created", 1, nil)
+		}
+		if res.SubSeeded {
+			h.mw.Count("event_loop.general.slack_auto_link.subs_seeded", 1, nil)
+		}
+	}
+	return res, nil
+}
+
+// labelMatches treats an empty configured value as a wildcard.
+func labelMatches(have labels.Labels, key, want string) bool {
+	got, ok := have[key]
+	if !ok {
+		return false
+	}
+	if want == "" {
+		return true
+	}
+	return got == want
+}
+
+// upsertAutoLink revives soft-deleted rows so a re-link reuses the
+// original link id, and attributes the row to the workspace installer.
+func (h *Helper) upsertAutoLink(ctx context.Context, install app.SlackInstallation, orgID string) (string, bool, error) {
+	var existing app.SlackOrgLink
+	err := h.db.WithContext(ctx).
+		Unscoped().
+		Where(app.SlackOrgLink{TeamID: install.TeamID, OrgID: orgID}).
+		First(&existing).Error
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		link := &app.SlackOrgLink{
+			TeamID:            install.TeamID,
+			OrgID:             orgID,
+			Status:            app.SlackOrgLinkStatusVerified,
+			LinkedByAccountID: install.InstalledByAccountID,
+			CreatedByID:       install.InstalledByAccountID,
+		}
+		if err := h.db.WithContext(ctx).Create(link).Error; err != nil {
+			return "", false, fmt.Errorf("create org link: %w", err)
+		}
+		return link.ID, true, nil
+	case err != nil:
+		return "", false, fmt.Errorf("lookup existing org link: %w", err)
+	}
+
+	if existing.Status == app.SlackOrgLinkStatusVerified && existing.DeletedAt == 0 {
+		return existing.ID, false, nil
+	}
+	existing.Status = app.SlackOrgLinkStatusVerified
+	existing.DeletedAt = 0
+	if err := h.db.WithContext(ctx).Unscoped().Save(&existing).Error; err != nil {
+		return "", false, fmt.Errorf("revive org link: %w", err)
+	}
+	return existing.ID, true, nil
+}
+
+// seedDefaultSubscription inserts one org-wide AllEvents sub iff none
+// exists on this link, so removing or replacing the seed is permanent.
+// Falls back to the channel id when the name lookup fails, so a Slack
+// API blip doesn't block the link.
+func (h *Helper) seedDefaultSubscription(ctx context.Context, install app.SlackInstallation, linkID, orgID, channelID string) (bool, error) {
+	var count int64
+	if err := h.db.WithContext(ctx).
+		Model(&app.SlackChannelSubscription{}).
+		Where(&app.SlackChannelSubscription{OrgLinkID: linkID, OrgID: orgID}).
+		Count(&count).Error; err != nil {
+		return false, fmt.Errorf("count existing subs: %w", err)
+	}
+	if count > 0 {
+		return false, nil
+	}
+
+	channelName := channelID
+	if info, err := h.slackClient.ConversationsInfo(ctx, install.BotAccessToken, channelID); err == nil && info.Channel.Name != "" {
+		channelName = info.Channel.Name
+	}
+
+	accountID := install.InstalledByAccountID
+	sub := app.SlackChannelSubscription{
+		OrgLinkID:          linkID,
+		OrgID:              orgID,
+		TeamID:             install.TeamID,
+		ChannelID:          channelID,
+		ChannelName:        channelName,
+		Interests:          interests.AllEvents(),
+		CreatedByAccountID: &accountID,
+		CreatedByID:        accountID,
+	}
+
+	if err := h.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "team_id"},
+			{Name: "channel_id"},
+			{Name: "org_link_id"},
+			{Name: "match_canonical"},
+			{Name: "deleted_at"},
+		},
+		DoNothing: true,
+	}).Create(&sub).Error; err != nil {
+		return false, fmt.Errorf("create seed subscription: %w", err)
+	}
+	return true, nil
+}


### PR DESCRIPTION
Newly created orgs get their slack workspace link and default channel subscription synchronously, instead of waiting on the next reconciler tick.