### PR TITLE
fix: bugs for noop checks, state, and workflow runs

### DIFF
--- a/bins/runner/cmd/run.go
+++ b/bins/runner/cmd/run.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"slices"
 
 	"github.com/spf13/cobra"
@@ -20,6 +23,7 @@ import (
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/jobloop"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/process"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/settings"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/workspace"
 
 	check "github.com/nuonco/nuon/bins/runner/internal/jobs/healthcheck/check"
 )
@@ -36,6 +40,12 @@ func (c *cli) registerRun() error {
 }
 
 func (c *cli) runRun(cmd *cobra.Command, _ []string) {
+	// Clean up any orphaned temp directories from a previous runner process.
+	// This runs once at startup before any job loops start, so it's safe.
+	if err := workspace.CleanupAll(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: unable to cleanup old workspaces: %v\n", err)
+	}
+
 	providers := []fx.Option{}
 
 	// common providers

--- a/bins/runner/internal/pkg/jobloop/exec_job.go
+++ b/bins/runner/internal/pkg/jobloop/exec_job.go
@@ -136,11 +136,6 @@ func (j *jobLoop) executeJob(ctx context.Context, job *models.AppRunnerJob) erro
 		}
 
 		handler = sandboxhandler.New(sandboxCfg, j.apiClient, j.cfg, j.shutdowner, job, execution)
-	} else {
-		l.Info("sandbox mode NOT active, using real handler",
-			zap.String("job_type", string(job.Type)),
-			zap.Bool("sandbox_mode_setting", j.settings.SandboxMode),
-		)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/bins/runner/internal/pkg/jobloop/job_step_reset.go
+++ b/bins/runner/internal/pkg/jobloop/job_step_reset.go
@@ -3,21 +3,12 @@ package jobloop
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 
 	"github.com/nuonco/nuon/bins/runner/internal/jobs"
-	"github.com/nuonco/nuon/bins/runner/internal/pkg/workspace"
 )
 
 func (j *jobLoop) executeResetJobStep(ctx context.Context, handler jobs.JobHandler, job *models.AppRunnerJob, jobExecution *models.AppRunnerJobExecution) error {
-	// Skip workspace cleanup in sandbox mode — no real workspaces to clean
-	if !j.isSandbox(job) {
-		if err := workspace.CleanupAll(ctx); err != nil {
-			return errors.Wrap(err, "unable to cleanup old workspaces")
-		}
-	}
-
 	statefulHandler, ok := handler.(jobs.StatefulJobHandler)
 	if !ok {
 		return nil

--- a/services/ctl-api/internal/app/apps/helpers/ensure_app_queue.go
+++ b/services/ctl-api/internal/app/apps/helpers/ensure_app_queue.go
@@ -14,6 +14,7 @@ const (
 	AppSignalsQueueName            = "app-signals"
 	AppWorkflowStepGroupsQueueName = "app-workflow-step-groups"
 	AppWorkflowStepsQueueName      = "app-workflow-steps"
+	AppGenerateStepsQueueName      = "app-generate-steps"
 )
 
 // EnsureAppQueue creates all Temporal queue workflows needed for an app to
@@ -68,6 +69,18 @@ func (h *Helpers) EnsureAppQueue(ctx context.Context, appID string) error {
 		MaxDepth:    50,
 	}); err != nil {
 		return fmt.Errorf("unable to ensure app-workflow-steps queue for app %s: %w", appID, err)
+	}
+
+	// app-generate-steps queue — handles generate-steps signals
+	if _, err := h.queueClient.Create(ctx, &queueclient.CreateQueueRequest{
+		OwnerID:     appID,
+		OwnerType:   ownerType,
+		Namespace:   "apps",
+		Name:        AppGenerateStepsQueueName,
+		MaxInFlight: 10,
+		MaxDepth:    50,
+	}); err != nil {
+		return fmt.Errorf("unable to ensure app-generate-steps queue for app %s: %w", appID, err)
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/component_config_connection.go
+++ b/services/ctl-api/internal/app/component_config_connection.go
@@ -198,7 +198,7 @@ func (c *ComponentConfigConnection) BeforeCreate(tx *gorm.DB) error {
 	c.CreatedByID = createdByIDFromContext(tx.Statement.Context)
 	c.OrgID = orgIDFromContext(tx.Statement.Context)
 	if c.SkipNoops == nil {
-		c.SkipNoops = generics.ToPtr(true)
+		c.SkipNoops = generics.ToPtr(false)
 	}
 	return nil
 }

--- a/services/ctl-api/internal/app/install_action_workflow_run.go
+++ b/services/ctl-api/internal/app/install_action_workflow_run.go
@@ -27,6 +27,7 @@ const (
 	InstallActionRunStatusTimedOut   InstallActionWorkflowRunStatus = "timed-out"
 	InstallActionRunStatusCancelled  InstallActionWorkflowRunStatus = "cancelled"
 	InstallActionRunStatusUnknown    InstallActionWorkflowRunStatus = "unknown"
+	InstallActionRunStatusRetried    InstallActionWorkflowRunStatus = "retried"
 )
 
 type InstallActionWorkflowRun struct {

--- a/services/ctl-api/internal/app/install_deploy.go
+++ b/services/ctl-api/internal/app/install_deploy.go
@@ -79,6 +79,12 @@ type InstallDeploy struct {
 	// Role to be used when running this component
 	Role string `json:"role,omitempty" gorm:"column:role"`
 
+	// PlannedAt is set when the plan runner job completes successfully.
+	PlannedAt *time.Time `json:"planned_at,omitzero" gorm:"default null" temporaljson:"planned_at,omitzero,omitempty"`
+
+	// AppliedAt is set when the apply runner job completes successfully.
+	AppliedAt *time.Time `json:"applied_at,omitzero" gorm:"default null" temporaljson:"applied_at,omitzero,omitempty"`
+
 	Status            InstallDeployStatus `json:"status,omitzero" gorm:"notnull" swaggertype:"string" temporaljson:"status,omitzero,omitempty"`
 	StatusDescription string              `json:"status_description,omitzero" gorm:"notnull" temporaljson:"status_description,omitzero,omitempty"`
 	Type              InstallDeployType   `json:"install_deploy_type,omitzero" temporaljson:"type,omitzero,omitempty"`

--- a/services/ctl-api/internal/app/install_sandbox_run.go
+++ b/services/ctl-api/internal/app/install_sandbox_run.go
@@ -43,6 +43,7 @@ const (
 	SandboxRunDriftDetected        SandboxRunStatus = "drift-detected"
 	SandboxRunNoDrift              SandboxRunStatus = "no-drift"
 	SandboxRunAutoSkipped          SandboxRunStatus = "auto-skipped"
+	SandboxRunStatusRetried        SandboxRunStatus = "retried"
 )
 
 type InstallSandboxRun struct {
@@ -75,6 +76,12 @@ type InstallSandboxRun struct {
 
 	// Role to be used when planning and applying sandbox runs
 	Role string `json:"role,omitempty" gorm:"column:role"`
+
+	// PlannedAt is set when the plan runner job completes successfully.
+	PlannedAt *time.Time `json:"planned_at,omitzero" gorm:"default null" temporaljson:"planned_at,omitzero,omitempty"`
+
+	// AppliedAt is set when the apply runner job completes successfully.
+	AppliedAt *time.Time `json:"applied_at,omitzero" gorm:"default null" temporaljson:"applied_at,omitzero,omitempty"`
 
 	RunType           SandboxRunType   `json:"run_type,omitzero" temporaljson:"run_type,omitzero,omitempty"`
 	Status            SandboxRunStatus `json:"status,omitzero" gorm:"notnull" swaggertype:"string" temporaljson:"status,omitzero,omitempty"`

--- a/services/ctl-api/internal/app/installs/helpers/create_install.go
+++ b/services/ctl-api/internal/app/installs/helpers/create_install.go
@@ -255,6 +255,19 @@ func (s *Helpers) CreateInstall(ctx context.Context, appID string, req *CreateIn
 		return nil, fmt.Errorf("unable to create install-workflow-steps queue: %w", err)
 	}
 
+	// Create the install-generate-steps queue (handles generate-steps signals, throttled like workflows)
+	_, err = s.queueClient.Create(ctx, &queueclient.CreateQueueRequest{
+		OwnerID:     install.ID,
+		OwnerType:   plugins.TableName(s.db, app.Install{}),
+		Namespace:   "installs",
+		Name:        InstallGenerateStepsQueueName,
+		MaxInFlight: 10,
+		MaxDepth:    50,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to create install-generate-steps queue: %w", err)
+	}
+
 	// Create the state-manager queue (handles state regeneration operations)
 	_, err = s.queueClient.Create(ctx, &queueclient.CreateQueueRequest{
 		OwnerID:     install.ID,

--- a/services/ctl-api/internal/app/installs/helpers/ensure_install_queues.go
+++ b/services/ctl-api/internal/app/installs/helpers/ensure_install_queues.go
@@ -21,6 +21,7 @@ func (s *Helpers) EnsureInstallQueues(ctx context.Context, installID string) err
 		{InstallWorkflowStepGroupsQueueName, 10},
 		{InstallWorkflowStepsQueueName, 10},
 		{InstallStateManagerQueueName, 5},
+		{InstallGenerateStepsQueueName, 10},
 	}
 
 	ownerType := plugins.TableName(s.db, app.Install{})

--- a/services/ctl-api/internal/app/installs/helpers/get_install_component.go
+++ b/services/ctl-api/internal/app/installs/helpers/get_install_component.go
@@ -7,6 +7,8 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
 )
 
 func (h *Helpers) GetInstallComponent(ctx context.Context, installID, componentID string) (*app.InstallComponent, error) {
@@ -14,7 +16,7 @@ func (h *Helpers) GetInstallComponent(ctx context.Context, installID, componentI
 	res := h.db.WithContext(ctx).
 		Preload("InstallDeploys", func(db *gorm.DB) *gorm.DB {
 			return db.
-				Order("install_deploys.created_at DESC").Limit(1)
+				Scopes(scopes.WithOverrideTable(views.CustomViewName(db, &app.InstallDeploy{}, "state_view_v1")))
 		}).
 		Preload("TerraformWorkspace").
 		Where(&app.InstallComponent{

--- a/services/ctl-api/internal/app/installs/helpers/get_install_sandbox_runs.go
+++ b/services/ctl-api/internal/app/installs/helpers/get_install_sandbox_runs.go
@@ -7,12 +7,15 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
 )
 
 // getInstallSandboxRuns reads an install's sandbox runs from the DB.
 func (h *Helpers) getInstallSandboxRuns(ctx context.Context, installID string) ([]app.InstallSandboxRun, error) {
 	var installSandboxRuns []app.InstallSandboxRun
 	res := h.db.WithContext(ctx).
+		Scopes(scopes.WithOverrideTable(views.CustomViewName(h.db, &app.InstallSandboxRun{}, "state_view_v1"))).
 		Preload("AppSandboxConfig").
 		Preload("AppSandboxConfig.PublicGitVCSConfig").
 		Preload("AppSandboxConfig.ConnectedGithubVCSConfig").
@@ -24,7 +27,6 @@ func (h *Helpers) getInstallSandboxRuns(ctx context.Context, installID string) (
 		Where(app.InstallSandboxRun{
 			InstallID: installID,
 		}).
-		Order("updated_at desc").
 		Limit(5).
 		Find(&installSandboxRuns)
 	if res.Error != nil {

--- a/services/ctl-api/internal/app/installs/helpers/helpers.go
+++ b/services/ctl-api/internal/app/installs/helpers/helpers.go
@@ -32,6 +32,10 @@ const (
 	// InstallStateManagerQueueName is the queue that handles state manager operations
 	// (force-regenerate, regenerate, hint) for an install.
 	InstallStateManagerQueueName = "state-manager"
+
+	// InstallGenerateStepsQueueName is the queue that handles generate-steps signals.
+	// Throttled at the same concurrency as workflows to prevent overload.
+	InstallGenerateStepsQueueName = "install-generate-steps"
 )
 
 type Params struct {

--- a/services/ctl-api/internal/app/installs/service/cancel_workflow.go
+++ b/services/ctl-api/internal/app/installs/service/cancel_workflow.go
@@ -100,6 +100,7 @@ func (s *service) cancelSingleWorkflow(ctx *gin.Context, orgID, workflowID strin
 		app.StatusPending,
 		app.AwaitingApproval,
 		app.Status("awaiting-approval"),
+		app.StatusFailedPendingRetry,
 	}) {
 		return fmt.Errorf("workflow is not cancelable (status: %s)", wf.Status.Status)
 	}
@@ -157,7 +158,7 @@ func (s *service) cancelSingleWorkflow(ctx *gin.Context, orgID, workflowID strin
 func (s *service) findCancelableStep(wf *app.Workflow) *app.WorkflowStep {
 	for i := range wf.Steps {
 		switch wf.Steps[i].Status.Status {
-		case app.StatusInProgress, app.AwaitingApproval, app.Status("awaiting-approval"):
+		case app.StatusInProgress, app.AwaitingApproval, app.Status("awaiting-approval"), app.StatusFailedPendingRetry:
 			return &wf.Steps[i]
 		}
 	}

--- a/services/ctl-api/internal/app/installs/service/cancel_workflow_step.go
+++ b/services/ctl-api/internal/app/installs/service/cancel_workflow_step.go
@@ -65,6 +65,7 @@ func (s *service) CancelWorkflowStep(ctx *gin.Context) {
 		app.StatusPending,
 		app.AwaitingApproval,
 		app.Status("awaiting-approval"),
+		app.StatusFailedPendingRetry,
 	}
 	cancelable := false
 	for _, status := range cancelableStatuses {

--- a/services/ctl-api/internal/app/installs/signals/v2/actionworkflowrun/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/actionworkflowrun/signal.go
@@ -49,6 +49,7 @@ var _ signal.SignalWithCancel = (*Signal)(nil)
 var _ signal.SignalWithAutoRetry = (*Signal)(nil)
 var _ signal.SignalWithMaxRetries = (*Signal)(nil)
 var _ signal.SignalWithMaxAutoRetries = (*Signal)(nil)
+var _ signal.SignalWithOnRetry = (*Signal)(nil)
 
 func (s *Signal) Cancel(ctx workflow.Context) error {
 	cancelCtx, cancel := workflow.NewDisconnectedContext(ctx)
@@ -56,6 +57,16 @@ func (s *Signal) Cancel(ctx workflow.Context) error {
 	if s.runnerJobID != "" {
 		jobactivities.AwaitPkgWorkflowsJobCancelJobByID(cancelCtx, s.runnerJobID)
 	}
+	return nil
+}
+
+func (s *Signal) OnRetry(ctx workflow.Context) error {
+	// For adhoc runs, mark the existing run as retried.
+	if s.AdhocActionRunID != "" {
+		s.updateActionRunStatus(ctx, s.AdhocActionRunID, app.InstallActionRunStatusRetried, "retrying")
+	}
+	// Regular runs create the run during Execute — the old run was already
+	// marked as error and a new run will be created on the retry clone.
 	return nil
 }
 

--- a/services/ctl-api/internal/app/installs/signals/v2/componentdeployapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentdeployapplyplan/signal.go
@@ -59,7 +59,20 @@ var (
 	_ signal.SignalWithMaxRetries       = (*Signal)(nil)
 	_ signal.SignalWithMaxAutoRetries   = (*Signal)(nil)
 	_ signal.SignalWithRetryGroup       = (*Signal)(nil)
+	_ signal.SignalWithOnRetry          = (*Signal)(nil)
 )
+
+func (s *Signal) OnRetry(ctx workflow.Context) error {
+	deploy, err := activities.AwaitGetInstallDeployForApplyStep(ctx, activities.GetInstallDeployForApplyStep{
+		InstallWorkflowID: s.FlowID,
+		ComponentID:       s.ComponentID,
+	})
+	if err != nil {
+		return nil
+	}
+	s.updateDeployStatus(ctx, deploy.ID, app.InstallDeployStatusRetried, "deploy retried")
+	return nil
+}
 
 func (s *Signal) AutoRetry() bool  { return true }
 func (s *Signal) MaxRetries() int  { return 15 }
@@ -181,6 +194,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		s.updateDeployStatus(ctx, installDeploy.ID, app.InstallDeployStatusError, "unable to deploy")
 		return errors.Wrap(err, "unable to execute deploy")
 	}
+
+	_ = activities.AwaitSetDeployAppliedAt(ctx, activities.SetDeployAppliedAtRequest{
+		DeployID: installDeploy.ID,
+	})
 
 	s.updateDeployStatus(ctx, installDeploy.ID, app.InstallDeployStatusActive, "finished")
 	orgEnabled, err := activities.AwaitHasFeatureByFeature(ctx, string(app.OrgFeatureStateGenV2))

--- a/services/ctl-api/internal/app/installs/signals/v2/componentdeploysyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentdeploysyncandplan/signal.go
@@ -128,12 +128,12 @@ func (s *Signal) Clone(ctx workflow.Context, stepName string) ([]signal.CloneSte
 func (s *Signal) SkipNoops(ctx workflow.Context) bool {
 	install, err := activities.AwaitGetInstallForInstallComponentByInstallComponentID(ctx, s.InstallComponentID)
 	if err != nil {
-		return true // default to skipping on error
+		return false
 	}
 
 	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
 	if err != nil {
-		return true
+		return false
 	}
 
 	for _, ccc := range appCfg.ComponentConfigConnections {

--- a/services/ctl-api/internal/app/installs/signals/v2/componentdeploysyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentdeploysyncandplan/signal.go
@@ -141,7 +141,7 @@ func (s *Signal) SkipNoops(ctx workflow.Context) bool {
 			return ccc.GetSkipNoops()
 		}
 	}
-	return true
+	return false
 }
 
 func (s *Signal) AutoApproveOnPoliciesPassing(ctx workflow.Context) bool {

--- a/services/ctl-api/internal/app/installs/signals/v2/componentdeploysyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentdeploysyncandplan/signal.go
@@ -64,7 +64,32 @@ var (
 	_ signal.SignalWithClone                        = (*Signal)(nil)
 	_ signal.SignalWithSkipNoops                    = (*Signal)(nil)
 	_ signal.SignalWithAutoApproveOnPoliciesPassing = (*Signal)(nil)
+	_ signal.SignalWithOnRetry                      = (*Signal)(nil)
+	_ signal.SignalWithApprovalValidation           = (*Signal)(nil)
 )
+
+func (s *Signal) ValidateApproval(ctx workflow.Context) error {
+	if s.DeployID == "" {
+		return nil
+	}
+	superseded, err := activities.AwaitCheckDeploySuperseded(ctx, activities.CheckDeploySupersededRequest{
+		DeployID: s.DeployID,
+	})
+	if err != nil {
+		return nil
+	}
+	if superseded {
+		return fmt.Errorf("a newer deploy for this component has completed since this plan was created")
+	}
+	return nil
+}
+
+func (s *Signal) OnRetry(ctx workflow.Context) error {
+	if s.DeployID != "" {
+		s.updateDeployStatusWithoutStatusSync(ctx, s.DeployID, app.InstallDeployStatusRetried, "deploy retried")
+	}
+	return nil
+}
 
 func (s *Signal) IsNoOpCheckable() bool          { return true }
 func (s *Signal) RequiresPolicyEvaluation() bool { return true }
@@ -83,12 +108,8 @@ func (s *Signal) Cancel(ctx workflow.Context) error {
 }
 
 func (s *Signal) Clone(ctx workflow.Context, stepName string) ([]signal.CloneStepDef, error) {
-	// Mark the old deploy as retried so the UI shows it was superseded.
-	if s.DeployID != "" {
-		s.updateDeployStatusWithoutStatusSync(ctx, s.DeployID, app.InstallDeployStatusRetried, "deploy retried")
-	}
-
 	// Return a clean signal — Execute() will create a fresh deploy.
+	// OnRetry() handles marking the old deploy as retried.
 	return []signal.CloneStepDef{
 		{
 			Signal: &Signal{
@@ -258,6 +279,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		s.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusError, "unable to deploy")
 		return errors.Wrap(err, "unable to execute deploy")
 	}
+
+	_ = activities.AwaitSetDeployPlannedAt(ctx, activities.SetDeployPlannedAtRequest{
+		DeployID: installDeploy.ID,
+	})
 
 	s.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusPendingApproval, "pending-approval")
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/v2/componentsyncimage/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentsyncimage/signal.go
@@ -51,6 +51,14 @@ func (s *Signal) SetStepContext(stepID, flowID string) {
 var _ signal.SignalWithStepContext = (*Signal)(nil)
 var _ signal.SignalWithAutoRetry = (*Signal)(nil)
 var _ signal.SignalWithCancel = (*Signal)(nil)
+var _ signal.SignalWithOnRetry = (*Signal)(nil)
+
+func (s *Signal) OnRetry(ctx workflow.Context) error {
+	if s.DeployID != "" {
+		s.updateDeployStatusWithoutStatusSync(ctx, s.DeployID, app.InstallDeployStatusRetried, "deploy retried")
+	}
+	return nil
+}
 
 func (s *Signal) AutoRetry() bool { return true }
 

--- a/services/ctl-api/internal/app/installs/signals/v2/componentteardownapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentteardownapplyplan/signal.go
@@ -58,7 +58,20 @@ var (
 	_ signal.SignalWithAutoRetry        = (*Signal)(nil)
 	_ signal.SignalWithMaxRetries       = (*Signal)(nil)
 	_ signal.SignalWithMaxAutoRetries   = (*Signal)(nil)
+	_ signal.SignalWithOnRetry          = (*Signal)(nil)
 )
+
+func (s *Signal) OnRetry(ctx workflow.Context) error {
+	deploy, err := activities.AwaitGetInstallDeployForApplyStep(ctx, activities.GetInstallDeployForApplyStep{
+		InstallWorkflowID: s.FlowID,
+		ComponentID:       s.ComponentID,
+	})
+	if err != nil {
+		return nil
+	}
+	s.updateDeployStatus(ctx, deploy.ID, app.InstallDeployStatusRetried, "deploy retried")
+	return nil
+}
 
 func (s *Signal) AutoRetry() bool { return true }
 func (s *Signal) MaxRetries() int { return 15 }
@@ -196,6 +209,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		s.updateDeployStatus(ctx, installDeploy.ID, app.InstallDeployStatusError, "unable to deploy")
 		return errors.Wrap(err, "unable to execute deploy")
 	}
+
+	_ = activities.AwaitSetDeployAppliedAt(ctx, activities.SetDeployAppliedAtRequest{
+		DeployID: installDeploy.ID,
+	})
 
 	s.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusInactive, "successfully torn down")
 	s.updateInstallComponentStatus(ctx, installDeploy.InstallComponentID, app.InstallComponentStatusInactive, "successfully torn down")

--- a/services/ctl-api/internal/app/installs/signals/v2/componentteardownsyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentteardownsyncandplan/signal.go
@@ -118,12 +118,12 @@ func (s *Signal) Cancel(ctx workflow.Context) error {
 func (s *Signal) SkipNoops(ctx workflow.Context) bool {
 	install, err := activities.AwaitGetInstallForInstallComponentByInstallComponentID(ctx, s.InstallComponentID)
 	if err != nil {
-		return true
+		return false
 	}
 
 	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
 	if err != nil {
-		return true
+		return false
 	}
 
 	for _, ccc := range appCfg.ComponentConfigConnections {

--- a/services/ctl-api/internal/app/installs/signals/v2/componentteardownsyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentteardownsyncandplan/signal.go
@@ -62,6 +62,43 @@ var _ signal.SignalWithMaxAutoRetries = (*Signal)(nil)
 var _ signal.SignalWithCancel = (*Signal)(nil)
 var _ signal.SignalWithSkipNoops = (*Signal)(nil)
 var _ signal.SignalWithAutoApproveOnPoliciesPassing = (*Signal)(nil)
+var _ signal.SignalWithOnRetry = (*Signal)(nil)
+var _ signal.SignalWithApprovalValidation = (*Signal)(nil)
+
+func (s *Signal) ValidateApproval(ctx workflow.Context) error {
+	if s.ComponentID == "" || s.FlowID == "" {
+		return nil
+	}
+	deploy, err := activities.AwaitGetInstallDeployForApplyStep(ctx, activities.GetInstallDeployForApplyStep{
+		InstallWorkflowID: s.FlowID,
+		ComponentID:       s.ComponentID,
+	})
+	if err != nil {
+		return nil
+	}
+	superseded, err := activities.AwaitCheckDeploySuperseded(ctx, activities.CheckDeploySupersededRequest{
+		DeployID: deploy.ID,
+	})
+	if err != nil {
+		return nil
+	}
+	if superseded {
+		return fmt.Errorf("a newer deploy for this component has completed since this plan was created")
+	}
+	return nil
+}
+
+func (s *Signal) OnRetry(ctx workflow.Context) error {
+	deploy, err := activities.AwaitGetInstallDeployForApplyStep(ctx, activities.GetInstallDeployForApplyStep{
+		InstallWorkflowID: s.FlowID,
+		ComponentID:       s.ComponentID,
+	})
+	if err != nil {
+		return nil
+	}
+	s.updateDeployStatusWithoutStatusSync(ctx, deploy.ID, app.InstallDeployStatusRetried, "deploy retried")
+	return nil
+}
 
 func (s *Signal) IsNoOpCheckable() bool                 { return true }
 func (s *Signal) RequiresPolicyEvaluation() bool        { return true }
@@ -258,6 +295,10 @@ func (s *Signal) doTeardown(ctx workflow.Context, install *app.Install, installD
 		s.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusError, "error deploying")
 		return errors.Wrap(err, "unable to execute deploy")
 	}
+
+	_ = activities.AwaitSetDeployPlannedAt(ctx, activities.SetDeployPlannedAtRequest{
+		DeployID: installDeploy.ID,
+	})
 
 	s.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusPendingApproval, "pending-approval")
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/v2/componentteardownsyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/componentteardownsyncandplan/signal.go
@@ -131,7 +131,7 @@ func (s *Signal) SkipNoops(ctx workflow.Context) bool {
 			return ccc.GetSkipNoops()
 		}
 	}
-	return true
+	return false
 }
 
 func (s *Signal) AutoApproveOnPoliciesPassing(ctx workflow.Context) bool {

--- a/services/ctl-api/internal/app/installs/signals/v2/deprovisionsandboxapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/deprovisionsandboxapplyplan/signal.go
@@ -46,6 +46,22 @@ var _ signal.SignalWithAutoRetry = (*Signal)(nil)
 var _ signal.SignalWithMaxRetries = (*Signal)(nil)
 var _ signal.SignalWithMaxAutoRetries = (*Signal)(nil)
 var _ signal.SignalWithRetryGroup = (*Signal)(nil)
+var _ signal.SignalWithOnRetry = (*Signal)(nil)
+
+func (s *Signal) OnRetry(ctx workflow.Context) error {
+	if s.InstallID == "" || s.FlowID == "" {
+		return nil
+	}
+	run, err := activities.AwaitGetInstallSandboxRunForApplyStep(ctx, activities.GetInstallSandboxRunForApplyStep{
+		InstallWorkflowID: s.FlowID,
+		InstallID:         s.InstallID,
+	})
+	if err != nil {
+		return nil
+	}
+	s.updateRunStatus(ctx, run.ID, app.SandboxRunStatusRetried, "retrying")
+	return nil
+}
 
 func (s *Signal) AutoRetry() bool  { return true }
 func (s *Signal) MaxRetries() int  { return 5 }
@@ -173,6 +189,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		s.updateRunStatus(ctx, installRun.ID, app.SandboxRunStatusError, "job did not succeed")
 		return errors.Wrap(err, "unable to execute deploy")
 	}
+	_ = activities.AwaitSetSandboxRunAppliedAt(ctx, activities.SetSandboxRunAppliedAtRequest{
+		SandboxRunID: installRun.ID,
+	})
+
 	s.updateRunStatus(ctx, installRun.ID, app.SandboxRunStatusDeprovisioned, "successfully deprovisioned")
 
 	orgEnabled, err := activities.AwaitHasFeatureByFeature(ctx, string(app.OrgFeatureStateGenV2))

--- a/services/ctl-api/internal/app/installs/signals/v2/deprovisionsandboxplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/deprovisionsandboxplan/signal.go
@@ -50,6 +50,46 @@ var _ signal.SignalWithMaxAutoRetries = (*Signal)(nil)
 var _ signal.SignalWithCancel = (*Signal)(nil)
 var _ signal.SignalWithSkipNoops = (*Signal)(nil)
 var _ signal.SignalWithAutoApproveOnPoliciesPassing = (*Signal)(nil)
+var _ signal.SignalWithOnRetry = (*Signal)(nil)
+var _ signal.SignalWithApprovalValidation = (*Signal)(nil)
+
+func (s *Signal) ValidateApproval(ctx workflow.Context) error {
+	if s.InstallID == "" || s.FlowID == "" {
+		return nil
+	}
+	run, err := activities.AwaitGetInstallSandboxRunForApplyStep(ctx, activities.GetInstallSandboxRunForApplyStep{
+		InstallWorkflowID: s.FlowID,
+		InstallID:         s.InstallID,
+	})
+	if err != nil {
+		return nil
+	}
+	superseded, err := activities.AwaitCheckSandboxRunSuperseded(ctx, activities.CheckSandboxRunSupersededRequest{
+		SandboxRunID: run.ID,
+	})
+	if err != nil {
+		return nil
+	}
+	if superseded {
+		return fmt.Errorf("a newer sandbox run has completed since this plan was created")
+	}
+	return nil
+}
+
+func (s *Signal) OnRetry(ctx workflow.Context) error {
+	if s.InstallID == "" || s.FlowID == "" {
+		return nil
+	}
+	run, err := activities.AwaitGetInstallSandboxRunForApplyStep(ctx, activities.GetInstallSandboxRunForApplyStep{
+		InstallWorkflowID: s.FlowID,
+		InstallID:         s.InstallID,
+	})
+	if err != nil {
+		return nil
+	}
+	s.updateRunStatusWithoutStatusSync(ctx, run.ID, app.SandboxRunStatusRetried, "retrying")
+	return nil
+}
 
 func (s *Signal) IsNoOpCheckable() bool                 { return true }
 func (s *Signal) RequiresPolicyEvaluation() bool        { return true }
@@ -237,6 +277,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return err
 	}
 
+	_ = activities.AwaitSetSandboxRunPlannedAt(ctx, activities.SetSandboxRunPlannedAtRequest{
+		SandboxRunID: installRun.ID,
+	})
+
 	l.Info("deprovision plan was successful")
 	s.updateRunStatusWithoutStatusSync(ctx, installRun.ID, app.SandboxRunPendingApproval, "auto skipped")
 	return nil
@@ -357,6 +401,7 @@ func (s *Signal) updateRunStatusWithoutStatusSync(ctx workflow.Context, runID st
 		RunID:             runID,
 		Status:            status,
 		StatusDescription: statusDescription,
+		SkipStatusSync:    true,
 	}); err != nil {
 		l.Error("unable to update run status v2", zap.String("run-id", runID), zap.Error(err))
 	}

--- a/services/ctl-api/internal/app/installs/signals/v2/generateworkflowsteps/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/generateworkflowsteps/signal.go
@@ -35,6 +35,11 @@ type Signal struct {
 	// remaining groups are still generating. Set before done to allow early consumption.
 	eagerStepGroups      *app.GenerateStepsResult
 	eagerStepGroupsReady bool
+
+	// fetched tracks whether each update handler has been called, so Execute
+	// can block until all consumers have retrieved results before completing.
+	fetchStepsCalled      bool
+	eagerStepGroupsCalled bool
 }
 
 var (
@@ -131,14 +136,17 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	s.result = result
 	s.done = true
 
-	// Wait for the FetchSteps update to be called so the conductor can
+	// Wait for both update handlers to be called so the conductor can
 	// retrieve the generated steps before this signal completes.
-	return workflow.Await(ctx, func() bool { return false })
+	return workflow.Await(ctx, func() bool {
+		return s.fetchStepsCalled && s.eagerStepGroupsCalled
+	})
 }
 
 func (s *Signal) RegisterUpdateHandlers(ctx workflow.Context) error {
 	if err := workflow.SetUpdateHandlerWithOptions(ctx, "eager-step-groups",
 		func(ctx workflow.Context) (*app.GenerateStepsResult, error) {
+			defer func() { s.eagerStepGroupsCalled = true }()
 			// Block until eager step groups are ready.
 			if err := workflow.Await(ctx, func() bool { return s.eagerStepGroupsReady }); err != nil {
 				return nil, err
@@ -155,6 +163,7 @@ func (s *Signal) RegisterUpdateHandlers(ctx workflow.Context) error {
 
 	return workflow.SetUpdateHandlerWithOptions(ctx, "FetchSteps",
 		func(ctx workflow.Context) (*app.GenerateStepsResult, error) {
+			defer func() { s.fetchStepsCalled = true }()
 			// Block until Execute has finished generating steps.
 			if err := workflow.Await(ctx, func() bool { return s.done }); err != nil {
 				return nil, err

--- a/services/ctl-api/internal/app/installs/signals/v2/provisionsandboxapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/provisionsandboxapplyplan/signal.go
@@ -47,6 +47,22 @@ var _ signal.SignalWithAutoRetry = (*Signal)(nil)
 var _ signal.SignalWithMaxRetries = (*Signal)(nil)
 var _ signal.SignalWithMaxAutoRetries = (*Signal)(nil)
 var _ signal.SignalWithRetryGroup = (*Signal)(nil)
+var _ signal.SignalWithOnRetry = (*Signal)(nil)
+
+func (s *Signal) OnRetry(ctx workflow.Context) error {
+	if s.InstallID == "" || s.FlowID == "" {
+		return nil
+	}
+	run, err := activities.AwaitGetInstallSandboxRunForApplyStep(ctx, activities.GetInstallSandboxRunForApplyStep{
+		InstallWorkflowID: s.FlowID,
+		InstallID:         s.InstallID,
+	})
+	if err != nil {
+		return nil
+	}
+	s.updateRunStatus(ctx, run.ID, app.SandboxRunStatusRetried, "retrying")
+	return nil
+}
 
 func (s *Signal) AutoRetry() bool  { return true }
 func (s *Signal) MaxRetries() int  { return 5 }
@@ -177,6 +193,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		s.updateRunStatus(ctx, sandboxRun.ID, app.SandboxRunStatusError, "job did not succeed")
 		return errors.Wrap(err, "unable to execute deploy")
 	}
+
+	_ = activities.AwaitSetSandboxRunAppliedAt(ctx, activities.SetSandboxRunAppliedAtRequest{
+		SandboxRunID: sandboxRun.ID,
+	})
 
 	s.updateRunStatus(ctx, sandboxRun.ID, app.SandboxRunStatusActive, "successfully provisioned")
 	orgEnabled, err := activities.AwaitHasFeatureByFeature(ctx, string(app.OrgFeatureStateGenV2))

--- a/services/ctl-api/internal/app/installs/signals/v2/provisionsandboxplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/provisionsandboxplan/signal.go
@@ -51,7 +51,47 @@ var (
 	_ signal.SignalWithCancel                       = (*Signal)(nil)
 	_ signal.SignalWithSkipNoops                    = (*Signal)(nil)
 	_ signal.SignalWithAutoApproveOnPoliciesPassing = (*Signal)(nil)
+	_ signal.SignalWithOnRetry                      = (*Signal)(nil)
+	_ signal.SignalWithApprovalValidation           = (*Signal)(nil)
 )
+
+func (s *Signal) ValidateApproval(ctx workflow.Context) error {
+	if s.InstallID == "" || s.FlowID == "" {
+		return nil
+	}
+	run, err := activities.AwaitGetInstallSandboxRunForApplyStep(ctx, activities.GetInstallSandboxRunForApplyStep{
+		InstallWorkflowID: s.FlowID,
+		InstallID:         s.InstallID,
+	})
+	if err != nil {
+		return nil
+	}
+	superseded, err := activities.AwaitCheckSandboxRunSuperseded(ctx, activities.CheckSandboxRunSupersededRequest{
+		SandboxRunID: run.ID,
+	})
+	if err != nil {
+		return nil
+	}
+	if superseded {
+		return fmt.Errorf("a newer sandbox run has completed since this plan was created")
+	}
+	return nil
+}
+
+func (s *Signal) OnRetry(ctx workflow.Context) error {
+	if s.InstallID == "" || s.FlowID == "" {
+		return nil
+	}
+	run, err := activities.AwaitGetInstallSandboxRunForApplyStep(ctx, activities.GetInstallSandboxRunForApplyStep{
+		InstallWorkflowID: s.FlowID,
+		InstallID:         s.InstallID,
+	})
+	if err != nil {
+		return nil
+	}
+	s.updateRunStatusWithoutStatusSync(ctx, run.ID, app.SandboxRunStatusRetried, "retrying")
+	return nil
+}
 
 func (s *Signal) IsNoOpCheckable() bool                 { return true }
 func (s *Signal) RequiresPolicyEvaluation() bool        { return true }
@@ -238,6 +278,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return err
 	}
 
+	_ = activities.AwaitSetSandboxRunPlannedAt(ctx, activities.SetSandboxRunPlannedAtRequest{
+		SandboxRunID: installRun.ID,
+	})
+
 	s.updateRunStatusWithoutStatusSync(ctx, installRun.ID, app.SandboxRunPendingApproval, "pending approval")
 	l.Info("provision plan was successful")
 	return nil
@@ -359,6 +403,7 @@ func (s *Signal) updateRunStatusWithoutStatusSync(ctx workflow.Context, runID st
 		RunID:             runID,
 		Status:            status,
 		StatusDescription: statusDescription,
+		SkipStatusSync:    true,
 	}); err != nil {
 		l.Error("unable to update run status v2", zap.String("run-id", runID), zap.Error(err))
 	}

--- a/services/ctl-api/internal/app/installs/signals/v2/reprovisionsandboxapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/reprovisionsandboxapplyplan/signal.go
@@ -47,7 +47,23 @@ var (
 	_ signal.SignalWithAutoRetry        = (*Signal)(nil)
 	_ signal.SignalWithRetryGroup       = (*Signal)(nil)
 	_ signal.SignalWithCancel           = (*Signal)(nil)
+	_ signal.SignalWithOnRetry          = (*Signal)(nil)
 )
+
+func (s *Signal) OnRetry(ctx workflow.Context) error {
+	if s.InstallID == "" || s.FlowID == "" {
+		return nil
+	}
+	run, err := activities.AwaitGetInstallSandboxRunForApplyStep(ctx, activities.GetInstallSandboxRunForApplyStep{
+		InstallWorkflowID: s.FlowID,
+		InstallID:         s.InstallID,
+	})
+	if err != nil {
+		return nil
+	}
+	s.updateRunStatus(ctx, run.ID, app.SandboxRunStatusRetried, "retrying")
+	return nil
+}
 
 func (s *Signal) MaxRetries() int  { return 5 }
 func (s *Signal) AutoRetry() bool  { return true }
@@ -179,6 +195,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return errors.Wrap(err, "unable to execute deploy")
 	}
 	l.Debug("finished executing sandbox apply plan", zap.String("install_run.id", sandboxRun.ID))
+
+	_ = activities.AwaitSetSandboxRunAppliedAt(ctx, activities.SetSandboxRunAppliedAtRequest{
+		SandboxRunID: sandboxRun.ID,
+	})
 
 	l.Info("updating install sandbox run status", zap.String("install_run.id", sandboxRun.ID))
 	s.updateRunStatus(ctx, sandboxRun.ID, app.SandboxRunStatusActive, "successfully reprovisioned")

--- a/services/ctl-api/internal/app/installs/signals/v2/reprovisionsandboxplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/v2/reprovisionsandboxplan/signal.go
@@ -51,7 +51,47 @@ var (
 	_ signal.SignalWithCancel                       = (*Signal)(nil)
 	_ signal.SignalWithSkipNoops                    = (*Signal)(nil)
 	_ signal.SignalWithAutoApproveOnPoliciesPassing = (*Signal)(nil)
+	_ signal.SignalWithOnRetry                      = (*Signal)(nil)
+	_ signal.SignalWithApprovalValidation           = (*Signal)(nil)
 )
+
+func (s *Signal) ValidateApproval(ctx workflow.Context) error {
+	if s.InstallID == "" || s.FlowID == "" {
+		return nil
+	}
+	run, err := activities.AwaitGetInstallSandboxRunForApplyStep(ctx, activities.GetInstallSandboxRunForApplyStep{
+		InstallWorkflowID: s.FlowID,
+		InstallID:         s.InstallID,
+	})
+	if err != nil {
+		return nil
+	}
+	superseded, err := activities.AwaitCheckSandboxRunSuperseded(ctx, activities.CheckSandboxRunSupersededRequest{
+		SandboxRunID: run.ID,
+	})
+	if err != nil {
+		return nil
+	}
+	if superseded {
+		return fmt.Errorf("a newer sandbox run has completed since this plan was created")
+	}
+	return nil
+}
+
+func (s *Signal) OnRetry(ctx workflow.Context) error {
+	if s.InstallID == "" || s.FlowID == "" {
+		return nil
+	}
+	run, err := activities.AwaitGetInstallSandboxRunForApplyStep(ctx, activities.GetInstallSandboxRunForApplyStep{
+		InstallWorkflowID: s.FlowID,
+		InstallID:         s.InstallID,
+	})
+	if err != nil {
+		return nil // best-effort: run may not exist yet
+	}
+	s.updateRunStatusWithoutStatusSync(ctx, run.ID, app.SandboxRunStatusRetried, "retrying")
+	return nil
+}
 
 func (s *Signal) IsNoOpCheckable() bool                 { return true }
 func (s *Signal) RequiresPolicyEvaluation() bool        { return true }
@@ -237,6 +277,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return err
 	}
 
+	_ = activities.AwaitSetSandboxRunPlannedAt(ctx, activities.SetSandboxRunPlannedAtRequest{
+		SandboxRunID: installRun.ID,
+	})
+
 	s.updateRunStatusWithoutStatusSync(ctx, installRun.ID, app.SandboxRunPendingApproval, "pending approval")
 	l.Info("reprovision plan was successful")
 	return nil
@@ -357,6 +401,7 @@ func (s *Signal) updateRunStatusWithoutStatusSync(ctx workflow.Context, runID st
 		RunID:             runID,
 		Status:            status,
 		StatusDescription: statusDescription,
+		SkipStatusSync:    true,
 	}); err != nil {
 		l.Error("unable to update run status v2", zap.String("run-id", runID), zap.Error(err))
 	}

--- a/services/ctl-api/internal/app/installs/worker/activities/check_superseded.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/check_superseded.go
@@ -1,0 +1,85 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"gorm.io/gorm"
+)
+
+type CheckSandboxRunSupersededRequest struct {
+	SandboxRunID string `validate:"required"`
+}
+
+// CheckSandboxRunSuperseded checks whether a newer sandbox run has been applied
+// for the same sandbox since this run's plan was created.
+//
+// Returns false (not superseded) if the run has no planned_at set (backward
+// compatible with records created before this field existed).
+//
+// @temporal-gen-v2 activity
+func (a *Activities) CheckSandboxRunSuperseded(ctx context.Context, req CheckSandboxRunSupersededRequest) (bool, error) {
+	var run app.InstallSandboxRun
+	if err := a.db.WithContext(ctx).First(&run, "id = ?", req.SandboxRunID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return false, nil
+		}
+		return false, fmt.Errorf("unable to find sandbox run: %w", err)
+	}
+
+	if run.PlannedAt == nil || run.InstallSandboxID == nil {
+		return false, nil
+	}
+
+	var newerRun app.InstallSandboxRun
+	res := a.db.WithContext(ctx).
+		Where(app.InstallSandboxRun{InstallSandboxID: run.InstallSandboxID}).
+		Where("applied_at > ? AND id != ?", *run.PlannedAt, run.ID).
+		First(&newerRun)
+	if res.Error == gorm.ErrRecordNotFound {
+		return false, nil
+	}
+	if res.Error != nil {
+		return false, fmt.Errorf("unable to check for newer sandbox runs: %w", res.Error)
+	}
+	return true, nil
+}
+
+type CheckDeploySupersededRequest struct {
+	DeployID string `validate:"required"`
+}
+
+// CheckDeploySuperseded checks whether a newer deploy has been applied for the
+// same component since this deploy's plan was created.
+//
+// Returns false (not superseded) if the deploy has no planned_at set (backward
+// compatible with records created before this field existed).
+//
+// @temporal-gen-v2 activity
+func (a *Activities) CheckDeploySuperseded(ctx context.Context, req CheckDeploySupersededRequest) (bool, error) {
+	var deploy app.InstallDeploy
+	if err := a.db.WithContext(ctx).First(&deploy, "id = ?", req.DeployID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return false, nil
+		}
+		return false, fmt.Errorf("unable to find deploy: %w", err)
+	}
+
+	if deploy.PlannedAt == nil {
+		return false, nil
+	}
+
+	var newerDeploy app.InstallDeploy
+	res := a.db.WithContext(ctx).
+		Where(app.InstallDeploy{ComponentID: deploy.ComponentID, InstallComponentID: deploy.InstallComponentID}).
+		Where("applied_at > ? AND id != ?", *deploy.PlannedAt, deploy.ID).
+		First(&newerDeploy)
+	if res.Error == gorm.ErrRecordNotFound {
+		return false, nil
+	}
+	if res.Error != nil {
+		return false, fmt.Errorf("unable to check for newer deploys: %w", res.Error)
+	}
+	return true, nil
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/get_sandbox_run_state.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/get_sandbox_run_state.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
 )
 
 type GetInstallSandboxRunStateRequest struct {
@@ -18,6 +20,7 @@ type GetInstallSandboxRunStateRequest struct {
 func (a *Activities) GetInstallSandboxRunState(ctx context.Context, req GetInstallSandboxRunStateRequest) (*app.InstallSandboxRun, error) {
 	var installSandboxRun app.InstallSandboxRun
 	res := a.db.WithContext(ctx).
+		Scopes(scopes.WithOverrideTable(views.CustomViewName(a.db, &app.InstallSandboxRun{}, "state_view_v1"))).
 		Preload("AppSandboxConfig").
 		Preload("AppSandboxConfig.PublicGitVCSConfig").
 		Preload("AppSandboxConfig.ConnectedGithubVCSConfig").
@@ -29,7 +32,6 @@ func (a *Activities) GetInstallSandboxRunState(ctx context.Context, req GetInsta
 		Where(app.InstallSandboxRun{
 			InstallID: req.InstallID,
 		}).
-		Order("updated_at desc").
 		First(&installSandboxRun)
 	if res.Error != nil {
 		return nil, generics.TemporalGormError(res.Error, "unable to get install sandbox run state")

--- a/services/ctl-api/internal/app/installs/worker/activities/set_plan_timestamps.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/set_plan_timestamps.go
@@ -1,0 +1,77 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+type SetDeployPlannedAtRequest struct {
+	DeployID string `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) SetDeployPlannedAt(ctx context.Context, req SetDeployPlannedAtRequest) error {
+	now := time.Now().UTC()
+	res := a.db.WithContext(ctx).
+		Model(&app.InstallDeploy{}).
+		Where(app.InstallDeploy{ID: req.DeployID}).
+		Update("planned_at", now)
+	if res.Error != nil {
+		return fmt.Errorf("unable to set planned_at on deploy: %w", res.Error)
+	}
+	return nil
+}
+
+type SetDeployAppliedAtRequest struct {
+	DeployID string `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) SetDeployAppliedAt(ctx context.Context, req SetDeployAppliedAtRequest) error {
+	now := time.Now().UTC()
+	res := a.db.WithContext(ctx).
+		Model(&app.InstallDeploy{}).
+		Where(app.InstallDeploy{ID: req.DeployID}).
+		Update("applied_at", now)
+	if res.Error != nil {
+		return fmt.Errorf("unable to set applied_at on deploy: %w", res.Error)
+	}
+	return nil
+}
+
+type SetSandboxRunPlannedAtRequest struct {
+	SandboxRunID string `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) SetSandboxRunPlannedAt(ctx context.Context, req SetSandboxRunPlannedAtRequest) error {
+	now := time.Now().UTC()
+	res := a.db.WithContext(ctx).
+		Model(&app.InstallSandboxRun{}).
+		Where(app.InstallSandboxRun{ID: req.SandboxRunID}).
+		Update("planned_at", now)
+	if res.Error != nil {
+		return fmt.Errorf("unable to set planned_at on sandbox run: %w", res.Error)
+	}
+	return nil
+}
+
+type SetSandboxRunAppliedAtRequest struct {
+	SandboxRunID string `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) SetSandboxRunAppliedAt(ctx context.Context, req SetSandboxRunAppliedAtRequest) error {
+	now := time.Now().UTC()
+	res := a.db.WithContext(ctx).
+		Model(&app.InstallSandboxRun{}).
+		Where(app.InstallSandboxRun{ID: req.SandboxRunID}).
+		Update("applied_at", now)
+	if res.Error != nil {
+		return fmt.Errorf("unable to set applied_at on sandbox run: %w", res.Error)
+	}
+	return nil
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/104_fix_stuck_generate_workflow_steps_signals.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/104_fix_stuck_generate_workflow_steps_signals.go
@@ -1,0 +1,18 @@
+package migrations
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+func (m *Migrations) Migration104FixStuckGenerateWorkflowStepsSignals(ctx context.Context, db *gorm.DB) error {
+	res := db.WithContext(ctx).Exec(`
+		UPDATE queue_signals
+		SET status = jsonb_set(status, '{status}', '"success"')
+		WHERE type = 'generate-workflow-steps'
+		AND (status->>'status') NOT IN ('success', 'error', 'cancelled')
+		AND created_at < NOW() - INTERVAL '15 minute';
+	`)
+	return res.Error
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/105_fix_skip_noops_default.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/105_fix_skip_noops_default.go
@@ -1,0 +1,14 @@
+package migrations
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// Migration105FixSkipNoopsDefault resets skip_noops to false for all component
+// config connections that were created with the incorrect default of true.
+func (m *Migrations) Migration105FixSkipNoopsDefault(ctx context.Context, db *gorm.DB) error {
+	res := db.WithContext(ctx).Exec(`UPDATE component_config_connections SET skip_noops = false WHERE skip_noops = true;`)
+	return res.Error
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/all.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/all.go
@@ -88,5 +88,13 @@ func (m *Migrations) All() []migrations.Migration {
 			Name: "103-queue-signals-inflight-index",
 			Fn:   m.Migration103QueueSignalsInflightIndex,
 		},
+		{
+			Name: "104-fix-stuck-generate-workflow-steps-signals",
+			SQL: `UPDATE queue_signals
+				SET status = jsonb_set(status, '{status}', '"success"')
+				WHERE type = 'generate-workflow-steps'
+				AND (status->>'status') NOT IN ('success', 'error', 'cancelled')
+				AND created_at < NOW() - INTERVAL '1 hour';`,
+		},
 	}
 }

--- a/services/ctl-api/internal/pkg/db/psql/migrations/all.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/all.go
@@ -90,11 +90,11 @@ func (m *Migrations) All() []migrations.Migration {
 		},
 		{
 			Name: "104-fix-stuck-generate-workflow-steps-signals",
-			SQL: `UPDATE queue_signals
-				SET status = jsonb_set(status, '{status}', '"success"')
-				WHERE type = 'generate-workflow-steps'
-				AND (status->>'status') NOT IN ('success', 'error', 'cancelled')
-				AND created_at < NOW() - INTERVAL '1 hour';`,
+			Fn:   m.Migration104FixStuckGenerateWorkflowStepsSignals,
+		},
+		{
+			Name: "105-fix-skip-noops-default",
+			Fn:   m.Migration105FixSkipNoopsDefault,
 		},
 	}
 }

--- a/services/ctl-api/internal/pkg/flow/checks/noop/check.go
+++ b/services/ctl-api/internal/pkg/flow/checks/noop/check.go
@@ -86,6 +86,7 @@ func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workf
 
 	return directive.CheckResult{
 		Directive: directive.StepSkipGroup,
+		Status:    app.StatusAutoSkipped,
 		Reason: directive.CheckReason{
 			Check:   "noop",
 			Summary: "Noop plan, automatically skipped",

--- a/services/ctl-api/internal/pkg/flow/checks/noop/check.go
+++ b/services/ctl-api/internal/pkg/flow/checks/noop/check.go
@@ -65,6 +65,20 @@ func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workf
 	if !shouldSkip {
 		l.Debug("noop plan detected but skip_noops not enabled, proceeding to approval",
 			zap.String("step_id", step.ID))
+
+		// Decorate the step with a noop label so the approval UI can display it,
+		// then pass through to let the approval pipeline handle it normally.
+		_ = statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
+			ID: step.ID,
+			Status: app.CompositeStatus{
+				Status:                 app.StatusCheckPlan,
+				StatusHumanDescription: "noop plan detected, awaiting approval",
+				Metadata: map[string]any{
+					"noop": true,
+				},
+			},
+		})
+
 		return directive.Pass(), nil
 	}
 

--- a/services/ctl-api/internal/pkg/flow/checks/noop/check.go
+++ b/services/ctl-api/internal/pkg/flow/checks/noop/check.go
@@ -53,20 +53,24 @@ func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workf
 		return directive.Pass(), nil
 	}
 
-	// Check org-level auto-skip-noop feature flag first.
-	if c.OrgAutoSkipNoop {
-		l.Debug("noop plan detected and org auto-skip-noop enabled",
-			zap.String("step_id", step.ID))
-		// Fall through to skip handling below.
-	} else {
-		// Check signal-level SkipNoops. When it returns false, noop plans
-		// proceed through the normal approval flow.
-		if sn, ok := c.sig.(signal.SignalWithSkipNoops); ok && !sn.SkipNoops(ctx) {
-			l.Debug("noop plan detected but skip_noops disabled, proceeding to approval",
-				zap.String("step_id", step.ID))
-			return directive.Pass(), nil
+	// Determine whether noop plans should be auto-skipped. Only skip when
+	// explicitly enabled at the org level OR the component level.
+	shouldSkip := c.OrgAutoSkipNoop
+	if !shouldSkip {
+		if sn, ok := c.sig.(signal.SignalWithSkipNoops); ok {
+			shouldSkip = sn.SkipNoops(ctx)
 		}
 	}
+
+	if !shouldSkip {
+		l.Debug("noop plan detected but skip_noops not enabled, proceeding to approval",
+			zap.String("step_id", step.ID))
+		return directive.Pass(), nil
+	}
+
+	l.Debug("noop plan detected and skip_noops enabled",
+		zap.String("step_id", step.ID),
+		zap.Bool("org_auto_skip", c.OrgAutoSkipNoop))
 
 	l.Debug("approval plan contents empty",
 		zap.String("step_id", step.ID),

--- a/services/ctl-api/internal/pkg/flow/checks/superseded/check.go
+++ b/services/ctl-api/internal/pkg/flow/checks/superseded/check.go
@@ -1,0 +1,71 @@
+package superseded
+
+import (
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/directive"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+// Check implements directive.ApprovalResponseCheck for superseded plan detection.
+// It delegates to the signal's ValidateApproval method to determine whether a
+// newer deploy or sandbox run has occurred since the plan was created. If so,
+// the step is auto-retried to generate a fresh plan.
+type Check struct {
+	// stepSignalFn extracts the inner signal from a workflow step.
+	stepSignalFn func(step *app.WorkflowStep) signal.Signal
+
+	SetResultDirective func(ctx workflow.Context, stepID string, d directive.Step) error
+}
+
+func New(
+	stepSignalFn func(step *app.WorkflowStep) signal.Signal,
+	setDirective func(workflow.Context, string, directive.Step) error,
+) directive.ApprovalResponseCheck {
+	return &Check{
+		stepSignalFn:       stepSignalFn,
+		SetResultDirective: setDirective,
+	}
+}
+
+func (c *Check) Name() string { return "superseded" }
+
+func (c *Check) ShouldRun(step *app.WorkflowStep, flw *app.Workflow, resp *app.WorkflowStepApprovalResponse) bool {
+	if resp.Type != app.WorkflowStepApprovalResponseTypeApprove {
+		return false
+	}
+	sig := c.stepSignalFn(step)
+	_, ok := sig.(signal.SignalWithApprovalValidation)
+	return ok
+}
+
+func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workflow, resp *app.WorkflowStepApprovalResponse) (directive.CheckResult, error) {
+	sig := c.stepSignalFn(step)
+	av, ok := sig.(signal.SignalWithApprovalValidation)
+	if !ok {
+		return directive.Pass(), nil
+	}
+
+	err := av.ValidateApproval(ctx)
+	if err == nil {
+		return directive.Pass(), nil
+	}
+
+	// Plan is superseded — auto-retry the group so a fresh plan is generated.
+	if dirErr := c.SetResultDirective(ctx, step.ID, directive.StepRetryGroup); dirErr != nil {
+		return directive.Pass(), dirErr
+	}
+
+	return directive.CheckResult{
+		Directive: directive.StepRetry,
+		Reason: directive.CheckReason{
+			Check:   "superseded",
+			Summary: "Plan superseded, auto-retrying",
+			Detail:  err.Error(),
+			Labels: map[string]string{
+				"superseded": "true",
+			},
+		},
+	}, nil
+}

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
@@ -288,6 +288,12 @@ func (s *Signal) handle(ctx workflow.Context, startFromGroupIdx int) error {
 	l.Debug("executing groups for workflow", zap.Int("group_count", len(groups)))
 
 	for gi := startFromGroupIdx; gi < len(groups); gi++ {
+		if s.cancelRequested {
+			s.markRemainingGroupStepsDiscarded(ctx, l, groups, gi-1)
+			s.markRemainingStepsNotAttempted(ctx, l)
+			return nil
+		}
+
 		group := &groups[gi]
 
 		l.Debug("dispatching group", zap.Int("group_idx", group.GroupIdx), zap.Int("group_position", gi), zap.String("step_group_id", group.ID), zap.Bool("parallel", group.Parallel))
@@ -336,6 +342,11 @@ func (s *Signal) handle(ctx workflow.Context, startFromGroupIdx int) error {
 
 		switch flowdirective.Group(directive) {
 		case flowdirective.GroupContinue, "":
+			if s.cancelRequested {
+				s.markRemainingGroupStepsDiscarded(ctx, l, groups, gi)
+				s.markRemainingStepsNotAttempted(ctx, l)
+				return nil
+			}
 			// Check if pause was requested
 			if s.pauseRequested {
 				return &flow.ApprovalPauseErr{StepID: "paused"}
@@ -618,11 +629,12 @@ func isStepTerminal(status app.Status) bool {
 // stepConfig returns the StepConfig for this signal.
 func (s *Signal) stepConfig() flow.StepConfig {
 	return flow.StepConfig{
-		GroupQueueName:  s.StepGroupQueueName,
-		QueueName:       s.StepQueueName,
-		TargetQueueName: s.StepTargetQueueName,
-		OwnerID:         s.OwnerID,
-		OwnerType:       s.OwnerType,
+		GroupQueueName:         s.StepGroupQueueName,
+		QueueName:              s.StepQueueName,
+		TargetQueueName:        s.StepTargetQueueName,
+		GenerateStepsQueueName: s.GenerateStepsQueueName,
+		OwnerID:                s.OwnerID,
+		OwnerType:              s.OwnerType,
 	}
 }
 

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
@@ -28,11 +28,12 @@ type Signal struct {
 	OrgName      string `json:"org_name,omitempty"`
 
 	// Conductor configuration — set by the creator when enqueuing.
-	StepGroupQueueName  string `json:"step_group_queue_name"`
-	StepQueueName       string `json:"step_queue_name"`
-	StepTargetQueueName string `json:"step_target_queue_name"`
-	OwnerID             string `json:"owner_id"`
-	OwnerType           string `json:"owner_type"`
+	StepGroupQueueName     string `json:"step_group_queue_name"`
+	StepQueueName          string `json:"step_queue_name"`
+	StepTargetQueueName    string `json:"step_target_queue_name"`
+	GenerateStepsQueueName string `json:"generate_steps_queue_name"`
+	OwnerID                string `json:"owner_id"`
+	OwnerType              string `json:"owner_type"`
 	// OwnerName is the human-readable owner label resolved during Validate()
 	// (e.g. install/app/app_branch name). Stamped onto SignalLifecycleContext
 	// so workflow lifecycle webhook payloads carry owner_name without a
@@ -147,7 +148,7 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 	}
 
 	// Resolve queue names from owner type if not explicitly set.
-	if s.StepGroupQueueName == "" || s.StepQueueName == "" || s.StepTargetQueueName == "" {
+	if s.StepGroupQueueName == "" || s.StepQueueName == "" || s.StepTargetQueueName == "" || s.GenerateStepsQueueName == "" {
 		switch s.OwnerType {
 		case "installs":
 			if s.StepGroupQueueName == "" {
@@ -159,6 +160,9 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 			if s.StepTargetQueueName == "" {
 				s.StepTargetQueueName = "install-signals"
 			}
+			if s.GenerateStepsQueueName == "" {
+				s.GenerateStepsQueueName = "install-generate-steps"
+			}
 		case "apps":
 			if s.StepGroupQueueName == "" {
 				s.StepGroupQueueName = "app-workflow-step-groups"
@@ -169,6 +173,9 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 			if s.StepTargetQueueName == "" {
 				s.StepTargetQueueName = "app-signals"
 			}
+			if s.GenerateStepsQueueName == "" {
+				s.GenerateStepsQueueName = "app-generate-steps"
+			}
 		case "app_branches":
 			if s.StepGroupQueueName == "" {
 				s.StepGroupQueueName = "app-branch-workflow-step-groups"
@@ -178,6 +185,9 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 			}
 			if s.StepTargetQueueName == "" {
 				s.StepTargetQueueName = "app-branch-signals"
+			}
+			if s.GenerateStepsQueueName == "" {
+				s.GenerateStepsQueueName = "app-branch-generate-steps"
 			}
 		default:
 			return s.failWorkflow(ctx, errors.Errorf("unable to resolve queue names for owner type %s", s.OwnerType))

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
@@ -149,6 +149,14 @@ func (s *Signal) handleStepError(ctx workflow.Context, l *zap.Logger, step *app.
 		zap.Int("retry_index", nextRetryIndex),
 		zap.Int("max_retries", maxRetries))
 
+	// Call OnRetry so the signal can update its target object's status
+	// (e.g. mark a deploy or sandbox run as "retried").
+	if or, ok := sig.(signal.SignalWithOnRetry); ok {
+		if err := or.OnRetry(ctx); err != nil {
+			l.Warn("OnRetry hook failed", zap.String("step_id", step.ID), zap.Error(err))
+		}
+	}
+
 	// Record auto-retry metadata on the error status. We intentionally do NOT
 	// set retried=true here — the dashboard uses that flag to hide the error,
 	// and we want the error to remain visible. The auto_retried metadata field

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_plan.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_plan.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/checks/planonly"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/checks/policy"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/checks/staleplan"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/checks/superseded"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/directive"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	qsignal "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
@@ -138,6 +139,7 @@ func (s *Signal) approvalResponseChecks(ctx workflow.Context) []directive.Approv
 	}
 	return []directive.ApprovalResponseCheck{
 		staleplan.New(threshold, setResultDirective),
+		superseded.New(stepSignal, setResultDirective),
 	}
 }
 

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/update_create_step_retry.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/update_create_step_retry.go
@@ -53,6 +53,14 @@ func (s *Signal) createStepRetryHandler(ctx workflow.Context) (*CreateStepRetryR
 		directive = DirectiveRetryGroup
 	}
 
+	// Call OnRetry so the signal can update its target object's status
+	// (e.g. mark a deploy or sandbox run as "retried").
+	if or, ok := sig.(signal.SignalWithOnRetry); ok {
+		if err := or.OnRetry(ctx); err != nil {
+			return nil, errors.Wrap(err, "OnRetry hook failed")
+		}
+	}
+
 	// Mark original step as retried.
 	if err := activities.AwaitPkgWorkflowsFlowUpdateFlowStepRetried(ctx, activities.UpdateFlowStepRetriedRequest{
 		StepID: step.ID,

--- a/services/ctl-api/internal/pkg/flow/step_dispatch.go
+++ b/services/ctl-api/internal/pkg/flow/step_dispatch.go
@@ -15,11 +15,12 @@ import (
 // workflow steps. Used by both the execute-flow signal (directly) and the
 // WorkflowConductor (for backward compatibility).
 type StepConfig struct {
-	GroupQueueName  string
-	QueueName       string
-	TargetQueueName string
-	OwnerID         string
-	OwnerType       string
+	GroupQueueName         string
+	QueueName              string
+	TargetQueueName        string
+	GenerateStepsQueueName string
+	OwnerID                string
+	OwnerType              string
 }
 
 // DispatchStepSignal enqueues the execute-workflow-step signal to the step queue.

--- a/services/ctl-api/internal/pkg/flow/step_generate_signal.go
+++ b/services/ctl-api/internal/pkg/flow/step_generate_signal.go
@@ -154,10 +154,17 @@ func enqueueGenerateStepsSignal(ctx workflow.Context, cfg StepConfig, flw *app.W
 		setter.SetWorkflowID(flw.ID)
 	}
 
+	// Use the dedicated generate-steps queue if configured, otherwise fall back
+	// to the target queue for backward compatibility with existing installs.
+	queueName := cfg.GenerateStepsQueueName
+	if queueName == "" {
+		queueName = cfg.TargetQueueName
+	}
+
 	enqueueResp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
 		OwnerID:         cfg.OwnerID,
 		OwnerType:       cfg.OwnerType,
-		QueueName:       cfg.TargetQueueName,
+		QueueName:       queueName,
 		Signal:          flw.GenerateStepsSignal.Signal,
 		SignalOwnerID:   flw.ID,
 		SignalOwnerType: "install_workflows",

--- a/services/ctl-api/internal/pkg/queue/activities/get_queue_signals.go
+++ b/services/ctl-api/internal/pkg/queue/activities/get_queue_signals.go
@@ -20,7 +20,7 @@ func (a *Activities) getQueueSignals(ctx context.Context, queueID string) ([]*ap
 		Operator: "IN",
 		Field:    "status",
 		Path:     "status",
-		Value:    []string{string(app.StatusQueued), string(app.StatusInProgress)},
+		Value:    []string{string(app.StatusQueued)},
 	}).Where(app.QueueSignal{
 		QueueID:  queueID,
 		Enqueued: true,

--- a/services/ctl-api/internal/pkg/queue/activities/reset_stale_in_progress_signals.go
+++ b/services/ctl-api/internal/pkg/queue/activities/reset_stale_in_progress_signals.go
@@ -1,0 +1,34 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+)
+
+type ResetStaleInProgressSignalsRequest struct {
+	QueueID string `json:"queue_id" validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 1m
+func (a *Activities) ResetStaleInProgressSignals(ctx context.Context, req *ResetStaleInProgressSignalsRequest) error {
+	jdb := generics.NewJSONBQuery(a.db.WithContext(ctx))
+	res := jdb.WhereJSON(generics.JSONBQuery{
+		Operator: "=",
+		Field:    "status",
+		Path:     "status",
+		Value:    string(app.StatusInProgress),
+	}).Where(app.QueueSignal{
+		QueueID:  req.QueueID,
+		Enqueued: true,
+	}).Model(&app.QueueSignal{}).Update("status", map[string]any{
+		"status": string(app.StatusQueued),
+	})
+	if res.Error != nil {
+		return generics.TemporalGormError(res.Error, "unable to reset stale in-progress signals")
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/queue/handler/execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/execute.go
@@ -46,6 +46,9 @@ func (h *handler) executeHandler(ctx workflow.Context) (*ExecuteResponse, error)
 			QueueSignalID:     h.queueSignalID,
 			Status:            app.StatusError,
 			StatusDescription: blockedErr.Error(),
+			Metadata: map[string]any{
+				"execute_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
+			},
 		})
 		h.setFinished(app.StatusError, blockedErr.Error())
 		return nil, blockedErr

--- a/services/ctl-api/internal/pkg/queue/handler/state.go
+++ b/services/ctl-api/internal/pkg/queue/handler/state.go
@@ -23,6 +23,11 @@ func (h *handler) initializeState(ctx workflow.Context) error {
 	// If a previous handler crashed mid-validate or mid-execute, the started_at timestamp
 	// will exist but the finished_at timestamp will not.
 	if meta := queueSignal.Status.Metadata; meta != nil {
+		// If init previously failed, the signal is already in a terminal error state.
+		if _, initFailed := meta["init_failed_at"]; initFailed {
+			return nil
+		}
+
 		_, valStarted := meta["validate_started_at"]
 		_, valFinished := meta["validate_finished_at"]
 		if valStarted && !valFinished {
@@ -81,6 +86,9 @@ func (h *handler) initializeState(ctx workflow.Context) error {
 			QueueSignalID:     h.queueSignalID,
 			Status:            app.StatusError,
 			StatusDescription: initErr.Error(),
+			Metadata: map[string]any{
+				"init_failed_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
+			},
 		})
 		return initErr
 	}

--- a/services/ctl-api/internal/pkg/queue/requeue.go
+++ b/services/ctl-api/internal/pkg/queue/requeue.go
@@ -15,6 +15,14 @@ func (w *queue) requeueSignals(ctx workflow.Context) error {
 		return err
 	}
 
+	// Reset any in-progress signals from a previous queue run back to queued.
+	// These are stale — their handler workflows ran in a prior execution context.
+	if err := activities.AwaitResetStaleInProgressSignals(ctx, &activities.ResetStaleInProgressSignalsRequest{
+		QueueID: w.queueID,
+	}); err != nil {
+		l.Warn("unable to reset stale in-progress signals", zap.Error(err))
+	}
+
 	// fetching jobs from the queue in the DB
 	l.Info("fetching previous signals from database and requeueing them")
 	queueSignals, err := activities.AwaitGetQueueSignalsByQueueID(ctx, w.queueID)

--- a/services/ctl-api/internal/pkg/queue/run.go
+++ b/services/ctl-api/internal/pkg/queue/run.go
@@ -93,8 +93,8 @@ func (q *queue) run(ctx workflow.Context) (bool, error) {
 		// Wait until active workers drain before restarting or stopping.
 		return q.activeWorkers == 0
 	}); err != nil {
-		l.Info("timeout while waiting on queue to drain")
-		return false, err
+		l.Info("drain timeout exceeded, proceeding with restart",
+			zap.Int("active_workers", q.activeWorkers))
 	}
 
 	if q.restarted {

--- a/services/ctl-api/internal/pkg/queue/signal/interfaces.go
+++ b/services/ctl-api/internal/pkg/queue/signal/interfaces.go
@@ -153,8 +153,9 @@ type SignalWithOnApprove interface {
 	OnApprove(ctx workflow.Context) error
 }
 
-// SignalWithOnRetry is called when an approval step receives a "retry plan" response.
-// Signals can implement this to perform cleanup or preparation before the retry clone is created.
+// SignalWithOnRetry is called on any retry (auto or manual) before the step is
+// cloned. Signals implement this to update the target object's status (e.g. mark
+// the deploy or sandbox run as "retried") so the UI reflects the retry immediately.
 type SignalWithOnRetry interface {
 	OnRetry(ctx workflow.Context) error
 }
@@ -171,6 +172,21 @@ type SignalWithOnSkip interface {
 // Signals can implement this to perform cleanup when approval is denied.
 type SignalWithOnDeny interface {
 	OnDeny(ctx workflow.Context) error
+}
+
+// ---------------------------------------------------------------------------
+// Approval Validation
+// ---------------------------------------------------------------------------
+
+// SignalWithApprovalValidation is implemented by plan signals that can check
+// whether their plan has been superseded by a newer deploy or sandbox run.
+// Called as a post-approval response check — if the plan is superseded, the
+// step is auto-retried so a fresh plan is generated.
+//
+// The signal looks up its own run/deploy record and checks whether anything
+// newer exists for the same target from a different workflow.
+type SignalWithApprovalValidation interface {
+	ValidateApproval(ctx workflow.Context) error
 }
 
 // SignalWithSkipGroup is implemented by signals that want a "skip" approval

--- a/services/dashboard-ui/client/components/actions/InstallActionRunHeader/InstallActionRunHeaderContainer.tsx
+++ b/services/dashboard-ui/client/components/actions/InstallActionRunHeader/InstallActionRunHeaderContainer.tsx
@@ -1,5 +1,6 @@
 import { RunnerJobPlanButton } from '@/components/runners/RunnerJobPlan'
 import { CancelWorkflowButton } from '@/components/workflows/CancelWorkflow'
+import { CancelRunnerJobButton } from '@/components/runners/CancelRunnerJob'
 import { useInstall } from '@/hooks/use-install'
 import { useInstallActionRun } from '@/hooks/use-install-action-run'
 import { useOrg } from '@/hooks/use-org'
@@ -29,6 +30,13 @@ export const InstallActionRunHeaderContainer = ({
   })
   const basePath = `/${org?.id}/installs/${install?.id}`
 
+  const hasWorkflow = !!installActionRun?.install_workflow_id
+  const cancelButton = hasWorkflow ? (
+    <CancelWorkflowButton workflow={workflow} />
+  ) : installActionRun?.runner_job ? (
+    <CancelRunnerJobButton runnerJob={installActionRun.runner_job} jobType="actions" />
+  ) : null
+
   return (
     <InstallActionRunHeader
       actionId={actionId}
@@ -38,7 +46,7 @@ export const InstallActionRunHeaderContainer = ({
       basePath={basePath}
       isAdmin={isAdmin}
       step={step}
-      cancelWorkflowButton={<CancelWorkflowButton workflow={workflow} />}
+      cancelWorkflowButton={cancelButton}
       runnerJobPlanButton={
         installActionRun?.runner_job?.id ? (
           <RunnerJobPlanButton


### PR DESCRIPTION
Fixes a small number of bugs around state when things are canceled.

- state for sandboxes
- generate steps lingering when cancelled
- workflows not cancelling all the time

From there, we add:

- a superceded plan will fail when approved (ie: stale)
- fixed a bug where action runs would have a 404
- fixed an issue where a queue could back up
