### PR TITLE
perf: installs view v8

### DIFF
--- a/services/ctl-api/internal/app/install.go
+++ b/services/ctl-api/internal/app/install.go
@@ -105,14 +105,14 @@ func (i *Install) UseView() bool {
 }
 
 func (i *Install) ViewVersion() string {
-	return "v7"
+	return "v8"
 }
 
 func (i *Install) Views(db *gorm.DB) []migrations.View {
 	return []migrations.View{
 		{
-			Name:          views.DefaultViewName(db, &Install{}, 7),
-			SQL:           viewsql.InstallsViewV7,
+			Name:          views.DefaultViewName(db, &Install{}, 8),
+			SQL:           viewsql.InstallsViewV8,
 			AlwaysReapply: true,
 		},
 		{

--- a/services/ctl-api/internal/pkg/db/viewsql/installs_view_v8.sql
+++ b/services/ctl-api/internal/pkg/db/viewsql/installs_view_v8.sql
@@ -1,0 +1,23 @@
+SELECT
+    i.*,
+    is_data.status AS sandbox_status,
+    is_data.status_description AS sandbox_status_run,
+    (
+        SELECT hstore(array_agg(ic.component_id), array_agg(ic.status))
+        FROM install_components ic
+        WHERE ic.deleted_at = 0 AND ic.install_id = i.id
+    ) AS component_statuses,
+    (
+        SELECT n FROM (
+            SELECT i2.id AS id,
+                   row_number() OVER (ORDER BY is2.created_at) AS n
+            FROM installs i2
+            LEFT JOIN install_sandboxes is2
+              ON i2.id = is2.install_id AND is2.deleted_at = 0
+            WHERE i2.app_id = i.app_id
+        ) sub
+        WHERE sub.id = i.id
+    ) AS install_number
+FROM installs i
+LEFT JOIN install_sandboxes is_data
+  ON i.id = is_data.install_id AND is_data.deleted_at = 0

--- a/services/ctl-api/internal/pkg/db/viewsql/viewsql.go
+++ b/services/ctl-api/internal/pkg/db/viewsql/viewsql.go
@@ -22,6 +22,9 @@ var InstallsViewV6 string
 //go:embed installs_view_v7.sql
 var InstallsViewV7 string
 
+//go:embed installs_view_v8.sql
+var InstallsViewV8 string
+
 //go:embed install_states_view_v1.sql
 var InstallStatesViewV1 string
 


### PR DESCRIPTION
Rewrites `installs_view` so single-row lookups use indexes instead of seq scans. ~60% of prod DB CPU is currently spent on `WHERE id=?` against v7; v8 takes the same query from ~29 ms / 732 buffers to <1 ms / ~12 buffers.