### PR TITLE
perf: app configs view v3

### DIFF
--- a/services/ctl-api/internal/app/app_config.go
+++ b/services/ctl-api/internal/app/app_config.go
@@ -114,15 +114,15 @@ func (a AppConfig) UseView() bool {
 }
 
 func (a AppConfig) ViewVersion() string {
-	return "v2"
+	return "v3"
 }
 
 func (i *AppConfig) Views(db *gorm.DB) []migrations.View {
 	return []migrations.View{
 		{
-			Name:          views.DefaultViewName(db, &AppConfig{}, 2),
-			SQL:           viewsql.AppConfigViewV2,
-			AlwaysReapply: false,
+			Name:          views.DefaultViewName(db, &AppConfig{}, 3),
+			SQL:           viewsql.AppConfigViewV3,
+			AlwaysReapply: true,
 		},
 		{
 			Name:          views.CustomViewName(db, &AppConfig{}, "latest_view_v1"),

--- a/services/ctl-api/internal/pkg/db/viewsql/app_configs_view_v3.sql
+++ b/services/ctl-api/internal/pkg/db/viewsql/app_configs_view_v3.sql
@@ -1,0 +1,12 @@
+SELECT
+    (
+        SELECT n FROM (
+            SELECT ac2.id AS id,
+                   row_number() OVER (ORDER BY ac2.created_at) AS n
+            FROM app_configs ac2
+            WHERE ac2.app_id = ac.app_id
+        ) sub
+        WHERE sub.id = ac.id
+    ) AS version,
+    ac.*
+FROM app_configs ac

--- a/services/ctl-api/internal/pkg/db/viewsql/viewsql.go
+++ b/services/ctl-api/internal/pkg/db/viewsql/viewsql.go
@@ -37,6 +37,9 @@ var DriftsViewV2 string
 //go:embed app_configs_view_v2.sql
 var AppConfigViewV2 string
 
+//go:embed app_configs_view_v3.sql
+var AppConfigViewV3 string
+
 //go:embed app_branch_configs_view_v1.sql
 var AppBranchConfigsViewV1 string
 


### PR DESCRIPTION
Rewrites app_configs_view so by-id lookups use the PK index instead of a full-table parallel seq scan + external disk sort. Currently ~8.5% of prod DB CPU.