### PR TITLE
feat: component-build: Use CompositeError for "component is not active" error  

### DIFF
--- a/services/ctl-api/internal/app/component_build.go
+++ b/services/ctl-api/internal/app/component_build.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/plugin/soft_delete"
 
 	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/indexes"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
 )
@@ -54,6 +55,11 @@ type ComponentBuild struct {
 	Status            ComponentBuildStatus `json:"status,omitzero" gorm:"notnull" swaggertype:"string" temporaljson:"status,omitzero,omitempty"`
 	StatusDescription string               `json:"status_description,omitzero" gorm:"notnull" temporaljson:"status_description,omitzero,omitempty"`
 	StatusV2          CompositeStatus      `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
+
+	// CompositeError is the typed, structured error attached to this build,
+	// when one applies. Optional — set inline at failure sites via
+	// compositeerrors.New(&someTypedError{}).
+	CompositeError *compositeerrors.CompositeErrorData `json:"composite_error,omitzero" gorm:"type:jsonb" temporaljson:"composite_error,omitzero,omitempty"`
 
 	GitRef *string `json:"git_ref,omitzero" temporaljson:"git_ref,omitzero,omitempty"`
 

--- a/services/ctl-api/internal/app/components/signals/build/signal.go
+++ b/services/ctl-api/internal/app/components/signals/build/signal.go
@@ -16,6 +16,7 @@ import (
 	orgprovision "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/provision"
 	orgreprovision "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/reprovision"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/notifications"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
@@ -209,13 +210,20 @@ func (s *Signal) execBuild(ctx workflow.Context, compID, buildID string, current
 	return nil
 }
 
-// updateBuildStatus updates the build status
-func (s *Signal) updateBuildStatus(ctx workflow.Context, bldID string, status app.ComponentBuildStatus, statusDescription string) {
+// updateBuildStatus updates the build status. An optional CompositeErrorData
+// can be passed as the final argument to also persist a typed structured
+// error against the build's composite_error column.
+func (s *Signal) updateBuildStatus(ctx workflow.Context, bldID string, status app.ComponentBuildStatus, statusDescription string, ces ...*compositeerrors.CompositeErrorData) {
 	l := workflow.GetLogger(ctx)
+	var ce *compositeerrors.CompositeErrorData
+	if len(ces) > 0 {
+		ce = ces[0]
+	}
 	err := activities.AwaitUpdateBuildStatus(ctx, activities.UpdateBuildStatus{
 		BuildID:           bldID,
 		Status:            status,
 		StatusDescription: statusDescription,
+		CompositeError:    ce,
 	})
 	if err != nil {
 		l.Error("unable to update build status",

--- a/services/ctl-api/internal/app/components/signals/inlinebuild/signal.go
+++ b/services/ctl-api/internal/app/components/signals/inlinebuild/signal.go
@@ -14,6 +14,8 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/plan"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors/types/validation"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/notifications"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
@@ -128,7 +130,12 @@ func (s *Signal) execBuild(ctx workflow.Context, buildID string) error {
 	}
 
 	if comp.Status != app.ComponentStatusActive {
-		s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "component is not active")
+		s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "component is not active",
+			compositeerrors.New(&validation.Error{
+				Field:   "component.status",
+				Message: "component must be active before a build can run",
+				Got:     string(comp.Status),
+			}))
 		return notify(fmt.Errorf("component is not active"))
 	}
 
@@ -226,13 +233,20 @@ func (s *Signal) execBuild(ctx workflow.Context, buildID string) error {
 	return nil
 }
 
-// updateBuildStatus updates the build status.
-func (s *Signal) updateBuildStatus(ctx workflow.Context, bldID string, status app.ComponentBuildStatus, statusDescription string) {
+// updateBuildStatus updates the build status. An optional CompositeErrorData
+// can be passed as the final argument to also persist a typed structured
+// error against the build's composite_error column.
+func (s *Signal) updateBuildStatus(ctx workflow.Context, bldID string, status app.ComponentBuildStatus, statusDescription string, ces ...*compositeerrors.CompositeErrorData) {
 	l := workflow.GetLogger(ctx)
+	var ce *compositeerrors.CompositeErrorData
+	if len(ces) > 0 {
+		ce = ces[0]
+	}
 	err := activities.AwaitUpdateBuildStatus(ctx, activities.UpdateBuildStatus{
 		BuildID:           bldID,
 		Status:            status,
 		StatusDescription: statusDescription,
+		CompositeError:    ce,
 	})
 	if err != nil {
 		l.Error("unable to update build status",

--- a/services/ctl-api/internal/app/components/worker/activities/update_build_status.go
+++ b/services/ctl-api/internal/app/components/worker/activities/update_build_status.go
@@ -7,12 +7,18 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
 )
 
 type UpdateBuildStatus struct {
 	BuildID           string                   `validate:"required"`
 	Status            app.ComponentBuildStatus `validate:"required"`
 	StatusDescription string                   `validate:"required"`
+
+	// CompositeError is an optional typed, structured error to attach to the
+	// build alongside the status update. When non-nil it is persisted to the
+	// build's composite_error JSONB column.
+	CompositeError *compositeerrors.CompositeErrorData
 }
 
 // @temporal-gen-v2 activity
@@ -20,10 +26,14 @@ func (a *Activities) UpdateBuildStatus(ctx context.Context, req UpdateBuildStatu
 	currentApp := app.ComponentBuild{
 		ID: req.BuildID,
 	}
-	res := a.db.WithContext(ctx).Model(&currentApp).Updates(app.ComponentBuild{
+	updates := app.ComponentBuild{
 		Status:            req.Status,
 		StatusDescription: req.StatusDescription,
-	})
+	}
+	if req.CompositeError != nil {
+		updates.CompositeError = req.CompositeError
+	}
+	res := a.db.WithContext(ctx).Model(&currentApp).Updates(updates)
 	if res.Error != nil {
 		return fmt.Errorf("unable to update build: %w", res.Error)
 	}

--- a/services/ctl-api/internal/app/components/worker/build_status.go
+++ b/services/ctl-api/internal/app/components/worker/build_status.go
@@ -6,15 +6,24 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
-func (w *Workflows) updateBuildStatus(ctx workflow.Context, bldID string, status app.ComponentBuildStatus, statusDescription string) {
+// updateBuildStatus updates the build status. An optional CompositeErrorData
+// can be passed as the final argument to also persist a typed structured
+// error against the build's composite_error column.
+func (w *Workflows) updateBuildStatus(ctx workflow.Context, bldID string, status app.ComponentBuildStatus, statusDescription string, ces ...*compositeerrors.CompositeErrorData) {
 	l := workflow.GetLogger(ctx)
+	var ce *compositeerrors.CompositeErrorData
+	if len(ces) > 0 {
+		ce = ces[0]
+	}
 	err := activities.AwaitUpdateBuildStatus(ctx, activities.UpdateBuildStatus{
 		BuildID:           bldID,
 		Status:            status,
 		StatusDescription: statusDescription,
+		CompositeError:    ce,
 	})
 	if err != nil {
 		l.Error("unable to update build status",

--- a/services/ctl-api/internal/pkg/compositeerrors/types/validation/error.go
+++ b/services/ctl-api/internal/pkg/compositeerrors/types/validation/error.go
@@ -1,0 +1,43 @@
+// Package validation provides a generic validation CompositeError used when
+// an owner's preconditions or inputs are invalid (a bad field, an entity in a
+// wrong state, etc.). Producers construct it inline at the failure site:
+//
+//	build.CompositeError = compositeerrors.New(&validation.Error{
+//	    Field:   "component.status",
+//	    Message: "component must be active before a build can run",
+//	    Got:     string(comp.Status),
+//	})
+package validation
+
+import (
+	"fmt"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+// Error is a typed validation failure. Implements the standard error
+// interface plus compositeerrors.CompositeError so it can be returned from any
+// func() error and wrapped at the persistence boundary via compositeerrors.New.
+type Error struct {
+	// Field is the dotted path to the offending field or condition
+	// (e.g. "component.status", "manifest.name").
+	Field string `json:"field"`
+
+	// Message is the user-facing explanation of what's wrong.
+	Message string `json:"message"`
+
+	// Got is the actual value observed, when meaningful. Optional.
+	Got string `json:"got,omitempty"`
+}
+
+var _ compositeerrors.CompositeError = (*Error)(nil)
+
+func (e *Error) Error() string                      { return fmt.Sprintf("%s: %s", e.Field, e.Message) }
+func (e *Error) Type() compositeerrors.Type         { return "validation" }
+func (e *Error) Severity() compositeerrors.Severity { return compositeerrors.SeverityError }
+func (e *Error) Sections() []compositeerrors.Section {
+	if e.Got == "" {
+		return nil
+	}
+	return []compositeerrors.Section{{Heading: "Got", Body: e.Got}}
+}


### PR DESCRIPTION
This PR adds a `CompositeError` JSONB column to `ComponentBuild` and a first concrete typed implementation (validation.Error). The activity that updates a build's status now optionally accepts a `*CompositeErrorData` and persists it in DB.