### PR TITLE
fix(ui): sse log loading on closed log stream

### DIFF
--- a/services/dashboard-ui/client/providers/log-stream-provider.tsx
+++ b/services/dashboard-ui/client/providers/log-stream-provider.tsx
@@ -33,6 +33,7 @@ export function LogStreamProvider({
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const isCatchingUpRef = useRef(false)
   const catchUpBufferRef = useRef<TOTELLog[]>([])
+  const isCompleteRef = useRef(false)
 
   const connectSSE = () => {
     if (!logStreamId || !org?.id || eventSourceRef.current) return
@@ -86,6 +87,11 @@ export function LogStreamProvider({
             return Array.from(logMap.values())
           })
         }
+      } else if (event.data === 'complete') {
+        isCompleteRef.current = true
+        eventSource.close()
+        eventSourceRef.current = null
+        setConnectionState('disconnected')
       }
     })
 
@@ -110,6 +116,8 @@ export function LogStreamProvider({
     eventSource.onerror = () => {
       eventSource.close()
       eventSourceRef.current = null
+
+      if (isCompleteRef.current) return
 
       setConnectionState('reconnecting')
       const backoffDelay = Math.min(1000 * Math.pow(2, reconnectAttempt), 30000)
@@ -140,6 +148,7 @@ export function LogStreamProvider({
   }
 
   useEffect(() => {
+    isCompleteRef.current = false
     if (logStreamId && org?.id) {
       connectSSE()
     }

--- a/services/dashboard-ui/server/internal/handlers/log_streams.go
+++ b/services/dashboard-ui/server/internal/handlers/log_streams.go
@@ -21,6 +21,8 @@ const (
 	streamingDelay     = 200 * time.Millisecond
 	pollInterval       = 1 * time.Second
 	errorRetryDelay    = 5 * time.Second
+	// How often to re-check whether an open stream has closed.
+	streamStatusCheck = 10 * time.Second
 )
 
 type LogStreamsHandler struct {
@@ -59,6 +61,15 @@ func (h *LogStreamsHandler) StreamLogs(c *gin.Context) {
 		return
 	}
 
+	ctx := c.Request.Context()
+
+	logStream, err := client.GetLogStream(ctx, logStreamID)
+	if err != nil {
+		h.l.Error("failed to get log stream", zap.Error(err), zap.String("logStreamID", logStreamID))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get log stream"})
+		return
+	}
+
 	c.Writer.Header().Set("Content-Type", "text/event-stream")
 	c.Writer.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	c.Writer.Header().Set("Connection", "keep-alive")
@@ -66,10 +77,11 @@ func (h *LogStreamsHandler) StreamLogs(c *gin.Context) {
 	c.Writer.WriteHeader(http.StatusOK)
 	c.Writer.Flush()
 
-	ctx := c.Request.Context()
 	var currentOffset string
 	isCatchingUp := false
 	hasSeenFirstBatch := false
+	isOpen := logStream.Open
+	lastStatusCheck := time.Now()
 
 	sendEvent := func(logs []*models.AppOtelLogRecord) {
 		b, _ := json.Marshal(logs)
@@ -138,6 +150,25 @@ func (h *LogStreamsHandler) StreamLogs(c *gin.Context) {
 					}
 					sendEvent([]*models.AppOtelLogRecord{log})
 				}
+			}
+		}
+
+		// If the stream is closed and we've exhausted all pages, tell the
+		// client and wait for it to close the connection. Returning here would
+		// close the HTTP response, which causes EventSource to auto-reconnect
+		// before the browser processes the "complete" event.
+		if !isOpen && nextOffset == "" {
+			sendStatus("complete")
+			<-ctx.Done()
+			return
+		}
+
+		// Periodically re-check whether an open stream has closed.
+		if isOpen && time.Since(lastStatusCheck) >= streamStatusCheck {
+			lastStatusCheck = time.Now()
+			ls, err := client.GetLogStream(ctx, logStreamID)
+			if err == nil && !ls.Open {
+				isOpen = false
 			}
 		}
 


### PR DESCRIPTION
Close sse connection once all logs are loaded on closed log streams