### PR TITLE
fix(ui): action run cancel btn, action run log steps, dev server

### DIFF
--- a/services/dashboard-ui/client/components/actions/InstallActionRunHeader/InstallActionRunHeaderContainer.tsx
+++ b/services/dashboard-ui/client/components/actions/InstallActionRunHeader/InstallActionRunHeaderContainer.tsx
@@ -31,9 +31,14 @@ export const InstallActionRunHeaderContainer = ({
   const basePath = `/${org?.id}/installs/${install?.id}`
 
   const hasWorkflow = !!installActionRun?.install_workflow_id
+  const runnerJobStatus = installActionRun?.runner_job?.status
+  const isRunnerJobActive =
+    runnerJobStatus === 'queued' ||
+    runnerJobStatus === 'in-progress' ||
+    runnerJobStatus === 'available'
   const cancelButton = hasWorkflow ? (
     <CancelWorkflowButton workflow={workflow} />
-  ) : installActionRun?.runner_job ? (
+  ) : installActionRun?.runner_job && isRunnerJobActive ? (
     <CancelRunnerJobButton runnerJob={installActionRun.runner_job} jobType="actions" />
   ) : null
 

--- a/services/dashboard-ui/client/components/actions/InstallActionRunLogs/InstallActionRunLogs.stories.tsx
+++ b/services/dashboard-ui/client/components/actions/InstallActionRunLogs/InstallActionRunLogs.stories.tsx
@@ -210,3 +210,57 @@ const LoadingStory = () => {
   )
 }
 export { LoadingStory as Loading }
+
+const longNameConfig: TActionConfig = {
+  steps: [
+    { id: 'step-1', name: 'alb-healthcheck-ctl-api-public', idx: 0 },
+    { id: 'step-2', name: 'alb-healthcheck-ctl-api-runner-internal', idx: 1 },
+    { id: 'step-3', name: 'short-step', idx: 2 },
+  ],
+} as TActionConfig
+
+const longNameLogs = [
+  ...Array.from({ length: 3 }, (_, i) => ({
+    id: `long-1-${i}`,
+    body: `Checking endpoint health ${i + 1}...`,
+    timestamp: new Date(Date.now() - (10 - i) * 60000).toISOString(),
+    severity_number: 9,
+    severity_text: 'Info',
+    service_name: 'action',
+    scope_name: 'oteljob',
+    log_attributes: { workflow_step_name: 'alb-healthcheck-ctl-api-public' },
+  })),
+  ...Array.from({ length: 2 }, (_, i) => ({
+    id: `long-2-${i}`,
+    body: `Runner internal check ${i + 1}...`,
+    timestamp: new Date(Date.now() - (5 - i) * 60000).toISOString(),
+    severity_number: 9,
+    severity_text: 'Info',
+    service_name: 'action',
+    scope_name: 'oteljob',
+    log_attributes: { workflow_step_name: 'alb-healthcheck-ctl-api-runner-internal' },
+  })),
+] as any
+
+const LongStepNamesStory = () => {
+  const filters = useLogFilters(longNameLogs)
+  return (
+    <LogStreamContext.Provider value={{ ...mockLogStreamContext, logs: longNameLogs }}>
+      <InstallActionRunLogs
+        actionConfig={longNameConfig}
+        layout="vertical"
+        allLogs={longNameLogs}
+        filteredLogs={filters.filteredLogs ?? []}
+        isLoading={false}
+        activeLog={undefined}
+        handleActiveLog={noop}
+        filters={filters}
+        stepStatuses={{
+          'alb-healthcheck-ctl-api-public': 'success',
+          'alb-healthcheck-ctl-api-runner-internal': 'in-progress',
+        }}
+      />
+    </LogStreamContext.Provider>
+  )
+}
+export { LongStepNamesStory as LongStepNames }

--- a/services/dashboard-ui/client/components/actions/InstallActionRunLogs/InstallActionRunLogs.tsx
+++ b/services/dashboard-ui/client/components/actions/InstallActionRunLogs/InstallActionRunLogs.tsx
@@ -103,13 +103,13 @@ export const InstallActionRunLogs = ({
             setActiveStep(step?.name)
           }}
         >
-          <span className="flex items-center gap-2">
+          <span className="flex items-center gap-2 min-w-0 w-full">
             {stepStatuses?.[step?.name] && (
-              <Status status={stepStatuses[step.name]} isWithoutText />
+              <Status status={stepStatuses[step.name]} isWithoutText className="shrink-0" />
             )}
             <span className="truncate">{step?.name}</span>
             {allLogStepCounts[step?.name] > 0 && (
-              <Badge size="sm">{allLogStepCounts[step.name]}</Badge>
+              <Badge size="sm" className="shrink-0">{allLogStepCounts[step.name]}</Badge>
             )}
           </span>
         </Button>
@@ -156,7 +156,7 @@ export const InstallActionRunLogs = ({
 
   return (
     <div className="flex items-start flex-auto">
-      <div className="flex flex-col gap-2 w-fit md:min-w-64 pr-2 h-full">
+      <div className="flex flex-col gap-2 min-w-48 max-w-64 pr-2 h-full shrink-0">
         {stepButtons}
       </div>
       <div className="pl-2 w-full border-l">

--- a/services/dashboard-ui/client/views/install/ActionRunLayout.tsx
+++ b/services/dashboard-ui/client/views/install/ActionRunLayout.tsx
@@ -18,14 +18,14 @@ const ActionRunLayoutInner = () => {
 
   const basePath = `/${org?.id}/installs/${install?.id}/actions/${actionId}/runs/${actionRunId}`
   const { data: action } = useQuery({
-    queryKey: ['action', org?.id, installActionRun?.install_action_workflow_id],
+    queryKey: ['action', org?.id, actionId],
     queryFn: () =>
       getInstallAction({
-        orgId: org.id,
-        installId: install?.id,
-        actionId: actionId,
+        orgId: org!.id,
+        installId: install!.id,
+        actionId: actionId!,
       }),
-    enabled: !!org?.id && !!installActionRun?.install_workflow_id,
+    enabled: !!org?.id && !!install?.id && !!actionId,
   })
 
   const { data: workflow } = useQuery({

--- a/services/dashboard-ui/scripts/dev-server.js
+++ b/services/dashboard-ui/scripts/dev-server.js
@@ -45,6 +45,7 @@ Bun.serve({
       method: req.method,
       headers: req.headers,
       body: req.body,
+      redirect: "manual",
     });
 
     if ((res.headers.get("content-type") || "").includes("text/html")) {


### PR DESCRIPTION
- Fixes action cancel button showing when runner job is finished
- Fixes guarding action query when workflow doesn't exist. Instead fetch when the actionId exist
- Fixes overflow issue with action run logs with long step names
- Fixes issue with auth redirect in dev proxy