### PR TITLE
feat(cli): `installs actions run` subcommand with --wait, --env, --timeout

### DIFF
--- a/bins/cli/cmd/installs.go
+++ b/bins/cli/cmd/installs.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -978,7 +980,6 @@ Available service names: api, runner (or any service name present in the logs)`,
 	stacksLatestCmd.MarkFlagRequired("install-id")
 	stacksCmd.AddCommand(stacksLatestCmd)
 
-	// NOTE(fd): this may not be the place where this ends up living
 	actionsCmd := &cobra.Command{
 		Use:   "actions",
 		Short: "Manage install actions [preview]",
@@ -1020,6 +1021,51 @@ By default, launches an interactive TUI to browse and execute actions.`,
 		}),
 	}
 	actionsCmd.AddCommand(actionsListCmd)
+
+	var (
+		actionEnvVars []string
+		actionWait    bool
+		actionTimeout time.Duration
+	)
+	actionsRunCmd := &cobra.Command{
+		Use:         "run",
+		Short:       "Run an action and optionally wait for completion",
+		Args:        cobra.NoArgs,
+		Annotations: previewAnnotation(),
+		Long: `Trigger an action on an install. Use --wait to block until completion
+and print the outputs. Use --env to pass parameters.
+
+Examples:
+  nuon installs actions run -i <install> --action-workflow-id my_action --wait
+  nuon installs actions run -i <install> --action-workflow-id my_action --env KEY=val --env KEY2=val2 --wait -j`,
+		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
+			if actionWorkflowID == "" {
+				ui.PrintWarning("missing --action-workflow-id; pass an action workflow ID or slug")
+				return nil
+			}
+			envVars := make(map[string]string)
+			for _, kv := range actionEnvVars {
+				parts := strings.SplitN(kv, "=", 2)
+				if len(parts) != 2 {
+					return ui.PrintError(fmt.Errorf("invalid --env value %q, expected KEY=VALUE", kv))
+				}
+				envVars[parts[0]] = parts[1]
+			}
+			svc := installs.New(c.apiClient, c.cfg)
+			return svc.ActionRun(cmd.Context(), installs.ActionRunOpts{
+				InstallID: id,
+				ActionID:  actionWorkflowID,
+				EnvVars:   envVars,
+				Wait:      actionWait,
+				Timeout:   actionTimeout,
+				AsJSON:    PrintJSON,
+			})
+		}),
+	}
+	actionsRunCmd.Flags().StringArrayVar(&actionEnvVars, "env", nil, "Environment variables (KEY=VALUE, repeatable)")
+	actionsRunCmd.Flags().BoolVarP(&actionWait, "wait", "w", false, "Wait for action to complete and print outputs")
+	actionsRunCmd.Flags().DurationVar(&actionTimeout, "timeout", 5*time.Minute, "Timeout when waiting")
+	actionsCmd.AddCommand(actionsRunCmd)
 
 	actionsOutputsCmd := &cobra.Command{
 		Use:         "outputs",

--- a/bins/cli/cmd/installs.go
+++ b/bins/cli/cmd/installs.go
@@ -339,6 +339,19 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 	sandboxRunLogsCmd.Flags().StringVarP(&installCompID, "install-comp-id", "c", "", "The ID of the install component to view logs for")
 	installsCmds.AddCommand(sandboxRunLogsCmd)
 
+	sandboxOutputsCmd := &cobra.Command{
+		Use:   "sandbox-outputs",
+		Short: "View sandbox outputs",
+		Long:  "View the latest sandbox outputs for an install",
+		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
+			svc := installs.New(c.apiClient, c.cfg)
+			return svc.SandboxOutputs(cmd.Context(), id, PrintJSON)
+		}),
+	}
+	sandboxOutputsCmd.Flags().StringVarP(&id, "install-id", "i", "", "The ID or name of the install")
+	sandboxOutputsCmd.MarkFlagRequired("install-id")
+	installsCmds.AddCommand(sandboxOutputsCmd)
+
 	currentInputs := &cobra.Command{
 		Use:   "current-inputs",
 		Short: "View current inputs",

--- a/bins/cli/cmd/installs.go
+++ b/bins/cli/cmd/installs.go
@@ -355,14 +355,15 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 	outputsCmd := &cobra.Command{
 		Use:   "outputs",
 		Short: "View all install outputs",
-		Long:  "View unified outputs from stack, sandbox, and components for an install",
+		Long:  "View unified outputs from stack, sandbox, and components for an install. Use -c to filter by component.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			svc := installs.New(c.apiClient, c.cfg)
-			return svc.Outputs(cmd.Context(), id, PrintJSON)
+			return svc.Outputs(cmd.Context(), id, componentID, PrintJSON)
 		}),
 	}
 	outputsCmd.Flags().StringVarP(&id, "install-id", "i", "", "The ID or name of the install")
 	outputsCmd.MarkFlagRequired("install-id")
+	outputsCmd.Flags().StringVarP(&componentID, "component", "c", "", "Filter by component name or ID")
 	installsCmds.AddCommand(outputsCmd)
 
 	currentInputs := &cobra.Command{

--- a/bins/cli/cmd/installs.go
+++ b/bins/cli/cmd/installs.go
@@ -352,6 +352,19 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 	sandboxOutputsCmd.MarkFlagRequired("install-id")
 	installsCmds.AddCommand(sandboxOutputsCmd)
 
+	outputsCmd := &cobra.Command{
+		Use:   "outputs",
+		Short: "View all install outputs",
+		Long:  "View unified outputs from stack, sandbox, and components for an install",
+		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
+			svc := installs.New(c.apiClient, c.cfg)
+			return svc.Outputs(cmd.Context(), id, PrintJSON)
+		}),
+	}
+	outputsCmd.Flags().StringVarP(&id, "install-id", "i", "", "The ID or name of the install")
+	outputsCmd.MarkFlagRequired("install-id")
+	installsCmds.AddCommand(outputsCmd)
+
 	currentInputs := &cobra.Command{
 		Use:   "current-inputs",
 		Short: "View current inputs",

--- a/bins/cli/internal/services/installs/action_run.go
+++ b/bins/cli/internal/services/installs/action_run.go
@@ -1,0 +1,195 @@
+package installs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/nuonco/nuon/bins/cli/internal/lookup"
+	"github.com/nuonco/nuon/bins/cli/internal/ui"
+	"github.com/nuonco/nuon/sdks/nuon-go/models"
+)
+
+type ActionRunOpts struct {
+	InstallID string
+	ActionID  string
+	EnvVars   map[string]string
+	Wait      bool
+	Timeout   time.Duration
+	AsJSON    bool
+}
+
+func (s *Service) ActionRun(ctx context.Context, opts ActionRunOpts) error {
+	installID, err := lookup.InstallID(ctx, s.api, opts.InstallID)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+
+	// Resolve action name → ID + get latest config.
+	install, err := s.api.GetInstall(ctx, installID)
+	if err != nil {
+		return ui.PrintError(fmt.Errorf("fetching install: %w", err))
+	}
+
+	actions, _, err := s.api.GetActionWorkflows(ctx, install.AppID, nil)
+	if err != nil {
+		return ui.PrintError(fmt.Errorf("listing actions: %w", err))
+	}
+
+	var actionWorkflow *models.AppActionWorkflow
+	for _, a := range actions {
+		if a.Name == opts.ActionID || a.ID == opts.ActionID {
+			actionWorkflow = a
+			break
+		}
+	}
+	if actionWorkflow == nil {
+		names := make([]string, 0, len(actions))
+		for _, a := range actions {
+			names = append(names, a.Name)
+		}
+		return ui.PrintError(fmt.Errorf("action %q not found. available: %s", opts.ActionID, strings.Join(names, ", ")))
+	}
+
+	config, err := s.api.GetActionWorkflowLatestConfig(ctx, actionWorkflow.ID)
+	if err != nil {
+		return ui.PrintError(fmt.Errorf("fetching action config: %w", err))
+	}
+
+	// Record the current latest run ID so we can detect when our new run appears.
+	// The Create endpoint doesn't return an ID, so we also capture the trigger time
+	// and only adopt a run whose CreatedAt is at or after that timestamp.
+	recentRuns, _, _ := s.api.GetInstallActionWorkflowRecentRuns(ctx, installID, actionWorkflow.ID, &models.GetPaginatedQuery{Limit: 1})
+	var prevRunID string
+	if recentRuns != nil && len(recentRuns.Runs) > 0 {
+		prevRunID = recentRuns.Runs[0].ID
+	}
+
+	// Trigger the run.
+	configID := config.ID
+	triggerTime := time.Now().Add(-time.Second) // small skew tolerance
+	err = s.api.CreateInstallActionWorkflowRun(ctx, installID, &models.ServiceCreateInstallActionWorkflowRunRequest{
+		ActionWorkflowConfigID: &configID,
+		RunEnvVars:             opts.EnvVars,
+	})
+	if err != nil {
+		return ui.PrintError(fmt.Errorf("triggering action: %w", err))
+	}
+
+	if !opts.Wait {
+		fmt.Fprintf(os.Stderr, "Triggered %s on %s\n", actionWorkflow.Name, installID)
+		return nil
+	}
+
+	// Poll until the new run appears and reaches a terminal state.
+	fmt.Fprintf(os.Stderr, "Triggered %s, waiting for completion...\n", actionWorkflow.Name)
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 5 * time.Minute
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var (
+		runID            string
+		consecutiveErrs  int
+		maxConsecutiveErrs = 5
+	)
+	for {
+		select {
+		case <-waitCtx.Done():
+			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+				return ui.PrintError(fmt.Errorf("timed out after %s waiting for run to complete", timeout))
+			}
+			return ui.PrintError(waitCtx.Err())
+		case <-time.After(2 * time.Second):
+		}
+
+		recentRuns, _, err := s.api.GetInstallActionWorkflowRecentRuns(waitCtx, installID, actionWorkflow.ID, &models.GetPaginatedQuery{Limit: 1})
+		if err != nil {
+			consecutiveErrs++
+			fmt.Fprintf(os.Stderr, "warning: polling failed (%d/%d): %s\n", consecutiveErrs, maxConsecutiveErrs, err)
+			if consecutiveErrs >= maxConsecutiveErrs {
+				return ui.PrintError(fmt.Errorf("aborting after %d consecutive poll failures: %w", consecutiveErrs, err))
+			}
+			continue
+		}
+		consecutiveErrs = 0
+
+		if recentRuns == nil || len(recentRuns.Runs) == 0 {
+			continue
+		}
+
+		latest := recentRuns.Runs[0]
+		// Only adopt a run that is distinct from the pre-trigger latest and
+		// whose creation timestamp is at or after our trigger.
+		if latest.ID == prevRunID || !runCreatedAfter(latest.CreatedAt, triggerTime) {
+			continue
+		}
+
+		if runID == "" {
+			runID = latest.ID
+			fmt.Fprintf(os.Stderr, "Run %s started\n", runID)
+		}
+
+		// Action workflow run statuses are defined server-side in
+		// app.InstallActionWorkflowRunStatus and are NOT the same vocabulary as
+		// models.AppStatus — "finished" is terminal success, not "success".
+		switch latest.Status {
+		case "finished":
+			fmt.Fprintf(os.Stderr, "Run %s completed (%s)\n", runID, latest.Status)
+			return s.printActionOutputs(waitCtx, installID, actionWorkflow, opts.AsJSON)
+		case "error", "timed-out", "cancelled":
+			fmt.Fprintf(os.Stderr, "Run %s failed (%s)\n", runID, latest.StatusDescription)
+			return ui.PrintError(fmt.Errorf("action %s: %s", latest.Status, latest.StatusDescription))
+		}
+	}
+}
+
+// runCreatedAfter parses an RFC3339-ish CreatedAt timestamp and reports whether it
+// is at or after the trigger time. On parse failure it returns true so we don't get
+// stuck waiting on a run we can't timestamp-match.
+func runCreatedAfter(createdAt string, trigger time.Time) bool {
+	if createdAt == "" {
+		return true
+	}
+	t, err := time.Parse(time.RFC3339Nano, createdAt)
+	if err != nil {
+		t, err = time.Parse(time.RFC3339, createdAt)
+		if err != nil {
+			return true
+		}
+	}
+	return !t.Before(trigger)
+}
+
+func (s *Service) printActionOutputs(ctx context.Context, installID string, action *models.AppActionWorkflow, asJSON bool) error {
+	outputs, err := s.api.GetInstallActionWorkflowOutputs(ctx, installID, action.ID)
+	if err != nil {
+		return ui.PrintError(fmt.Errorf("fetching outputs: %w", err))
+	}
+
+	if asJSON {
+		ui.PrintJSON(outputs)
+		return nil
+	}
+
+	if m, ok := outputs.(map[string]any); ok {
+		if len(m) == 0 {
+			fmt.Fprintln(os.Stderr, "no outputs")
+			return nil
+		}
+		view := ui.NewListView()
+		flat := make(map[string]string)
+		flattenMap("", m, flat)
+		printSection(view, flat)
+		return nil
+	}
+
+	ui.PrintJSON(outputs)
+	return nil
+}

--- a/bins/cli/internal/services/installs/outputs.go
+++ b/bins/cli/internal/services/installs/outputs.go
@@ -2,9 +2,11 @@ package installs
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/nuonco/nuon/bins/cli/internal/lookup"
@@ -18,7 +20,7 @@ type installOutputs struct {
 	Components map[string]map[string]any `json:"components,omitempty"`
 }
 
-func (s *Service) Outputs(ctx context.Context, installID string, asJSON bool) error {
+func (s *Service) Outputs(ctx context.Context, installID, componentFilter string, asJSON bool) error {
 	installID, err := lookup.InstallID(ctx, s.api, installID)
 	if err != nil {
 		return ui.PrintError(err)
@@ -79,8 +81,8 @@ func (s *Service) Outputs(ctx context.Context, installID string, asJSON bool) er
 		Components: make(map[string]map[string]any),
 	}
 
-	// Stack outputs.
-	if stack != nil && stack.InstallStackOutputs != nil {
+	// Stack outputs (skip when filtering by component).
+	if componentFilter == "" && stack != nil && stack.InstallStackOutputs != nil {
 		outputs := stack.InstallStackOutputs
 		flat := make(map[string]any)
 		if outputs.Aws != nil {
@@ -135,18 +137,20 @@ func (s *Service) Outputs(ctx context.Context, installID string, asJSON bool) er
 		out.Stack = flat
 	}
 
-	// Sandbox outputs — latest successful/active run.
-	for _, run := range sandboxes {
-		if (run.Status == "active" || run.Status == "succeeded") && run.Outputs != nil {
-			out.Sandbox = run.Outputs
-			break
+	// Sandbox outputs (skip when filtering by component).
+	if componentFilter == "" {
+		for _, run := range sandboxes {
+			if (run.Status == "active" || run.Status == "succeeded") && run.Outputs != nil {
+				out.Sandbox = run.Outputs
+				break
+			}
+		}
+		if out.Sandbox == nil && len(sandboxes) > 0 && sandboxes[0].Outputs != nil {
+			out.Sandbox = sandboxes[0].Outputs
 		}
 	}
-	if out.Sandbox == nil && len(sandboxes) > 0 && sandboxes[0].Outputs != nil {
-		out.Sandbox = sandboxes[0].Outputs
-	}
 
-	// Component outputs — fetch latest deploy for each in parallel.
+	// Component outputs — fetch terraform state outputs via workspace state JSON.
 	if len(components) > 0 {
 		var cmu sync.Mutex
 		var cwg sync.WaitGroup
@@ -158,19 +162,42 @@ func (s *Service) Outputs(ctx context.Context, installID string, asJSON bool) er
 				if comp.Component != nil && comp.Component.Name != "" {
 					name = comp.Component.Name
 				}
-				deploy, err := s.api.GetInstallComponentLatestDeploy(ctx, installID, comp.ComponentID)
-				if err != nil || deploy == nil || deploy.Outputs == nil || len(deploy.Outputs) == 0 {
+
+				// Skip if filtering and this isn't the target.
+				if componentFilter != "" &&
+					!strings.EqualFold(name, componentFilter) &&
+					!strings.EqualFold(comp.ComponentID, componentFilter) {
 					return
 				}
+
+				if comp.TerraformWorkspace == nil || comp.TerraformWorkspace.ID == "" {
+					return
+				}
+
+				outputs, err := s.getTerraformOutputs(ctx, comp.TerraformWorkspace.ID)
 				cmu.Lock()
-				out.Components[name] = deploy.Outputs
-				cmu.Unlock()
+				defer cmu.Unlock()
+				if err != nil {
+					warnings = append(warnings, fmt.Sprintf("component %s: error fetching outputs: %s", name, err))
+					return
+				}
+				if len(outputs) == 0 {
+					return
+				}
+				out.Components[name] = outputs
 			}(ic)
 		}
 		cwg.Wait()
 	}
 
 	if asJSON {
+		if componentFilter != "" && len(out.Components) == 1 {
+			// When filtering by component in JSON mode, return just that component's outputs.
+			for _, v := range out.Components {
+				ui.PrintJSON(v)
+				return nil
+			}
+		}
 		ui.PrintJSON(out)
 		return nil
 	}
@@ -212,7 +239,24 @@ func (s *Service) Outputs(ctx context.Context, installID string, asJSON bool) er
 	}
 
 	if empty {
-		view.Print("No outputs available for this install.")
+		if componentFilter != "" {
+			fmt.Printf("No outputs found for component %q.\n", componentFilter)
+			// List available components.
+			names := make([]string, 0, len(components))
+			for _, c := range components {
+				name := c.ComponentID
+				if c.Component != nil && c.Component.Name != "" {
+					name = c.Component.Name
+				}
+				names = append(names, name)
+			}
+			if len(names) > 0 {
+				sort.Strings(names)
+				fmt.Printf("\nAvailable components: %s\n", strings.Join(names, ", "))
+			}
+		} else {
+			view.Print("No outputs available for this install.")
+		}
 	}
 
 	if len(warnings) > 0 {
@@ -223,6 +267,88 @@ func (s *Service) Outputs(ctx context.Context, installID string, asJSON bool) er
 	}
 
 	return nil
+}
+
+// getTerraformOutputs fetches the latest terraform state JSON for a workspace
+// and extracts the output values.
+func (s *Service) getTerraformOutputs(ctx context.Context, workspaceID string) (map[string]any, error) {
+	// Try state-json by ID — returns terraform show -json directly.
+	raw, err := s.api.GetTerraformWorkspaceLatestStateJSON(ctx, workspaceID)
+	if err == nil && len(raw) > 0 {
+		if outputs := parseTerraformShowOutputs(raw); len(outputs) > 0 {
+			return outputs, nil
+		}
+		if outputs, parseErr := parseRawTerraformStateOutputs(raw); parseErr == nil && len(outputs) > 0 {
+			return outputs, nil
+		}
+	}
+
+	// Fall back to raw state by ID.
+	state, stateErr := s.api.GetTerraformWorkspaceLatestState(ctx, workspaceID)
+	if stateErr == nil && state != nil && len(state.Contents) > 0 {
+		raw := int64SliceToBytes(state.Contents)
+		if outputs := parseTerraformShowOutputs(raw); len(outputs) > 0 {
+			return outputs, nil
+		}
+		return parseRawTerraformStateOutputs(raw)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("state-json: %w", err)
+	}
+	if stateErr != nil {
+		return nil, fmt.Errorf("raw state: %w", stateErr)
+	}
+	return nil, fmt.Errorf("no state data available")
+}
+
+func int64SliceToBytes(s []int64) []byte {
+	b := make([]byte, len(s))
+	for i, v := range s {
+		b[i] = byte(v)
+	}
+	return b
+}
+
+// parseTerraformShowOutputs parses `terraform show -json` format: {values: {outputs: {name: {value, type}}}}
+func parseTerraformShowOutputs(raw []byte) map[string]any {
+	var tfShow struct {
+		Values struct {
+			Outputs map[string]struct {
+				Value any `json:"value"`
+				Type  any `json:"type"`
+			} `json:"outputs"`
+		} `json:"values"`
+	}
+	if err := json.Unmarshal(raw, &tfShow); err != nil {
+		return nil
+	}
+	result := make(map[string]any, len(tfShow.Values.Outputs))
+	for k, v := range tfShow.Values.Outputs {
+		result[k] = v.Value
+	}
+	return result
+}
+
+// parseRawTerraformStateOutputs parses raw terraform state: {outputs: {name: {value, type}}}
+func parseRawTerraformStateOutputs(raw []byte) (map[string]any, error) {
+	var tfState struct {
+		Outputs map[string]struct {
+			Value any    `json:"value"`
+			Type  string `json:"type"`
+		} `json:"outputs"`
+	}
+	if err := json.Unmarshal(raw, &tfState); err != nil {
+		return nil, fmt.Errorf("parsing terraform state: %w", err)
+	}
+	if len(tfState.Outputs) == 0 {
+		return nil, nil
+	}
+	result := make(map[string]any, len(tfState.Outputs))
+	for k, v := range tfState.Outputs {
+		result[k] = v.Value
+	}
+	return result, nil
 }
 
 func printSection(view *ui.ListView, flat map[string]string) {

--- a/bins/cli/internal/services/installs/outputs.go
+++ b/bins/cli/internal/services/installs/outputs.go
@@ -1,0 +1,240 @@
+package installs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+
+	"github.com/nuonco/nuon/bins/cli/internal/lookup"
+	"github.com/nuonco/nuon/bins/cli/internal/ui"
+	"github.com/nuonco/nuon/sdks/nuon-go/models"
+)
+
+type installOutputs struct {
+	Stack      map[string]any            `json:"stack,omitempty"`
+	Sandbox    map[string]any            `json:"sandbox,omitempty"`
+	Components map[string]map[string]any `json:"components,omitempty"`
+}
+
+func (s *Service) Outputs(ctx context.Context, installID string, asJSON bool) error {
+	installID, err := lookup.InstallID(ctx, s.api, installID)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+
+	// Fetch all data in parallel.
+	var (
+		stack      *models.AppInstallStack
+		sandboxes  []*models.AppInstallSandboxRun
+		components []*models.AppInstallComponent
+		mu         sync.Mutex
+		wg         sync.WaitGroup
+		fetchErrs  []error
+	)
+
+	var warnings []string
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		stk, err := s.api.GetInstallStack(ctx, installID)
+		mu.Lock()
+		defer mu.Unlock()
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("stack outputs unavailable: %s", err))
+			return
+		}
+		stack = stk
+	}()
+	go func() {
+		defer wg.Done()
+		runs, _, err := s.api.GetInstallSandboxRuns(ctx, installID, &models.GetPaginatedQuery{Limit: 50})
+		mu.Lock()
+		defer mu.Unlock()
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("sandbox outputs unavailable: %s", err))
+			return
+		}
+		sandboxes = runs
+	}()
+	go func() {
+		defer wg.Done()
+		comps, _, err := s.api.GetInstallComponents(ctx, installID, &models.GetPaginatedQuery{Limit: 100})
+		mu.Lock()
+		defer mu.Unlock()
+		if err != nil {
+			fetchErrs = append(fetchErrs, err)
+			return
+		}
+		components = comps
+	}()
+	wg.Wait()
+
+	if len(fetchErrs) > 0 {
+		return ui.PrintError(fetchErrs[0])
+	}
+
+	out := installOutputs{
+		Components: make(map[string]map[string]any),
+	}
+
+	// Stack outputs.
+	if stack != nil && stack.InstallStackOutputs != nil {
+		outputs := stack.InstallStackOutputs
+		flat := make(map[string]any)
+		if outputs.Aws != nil {
+			aws := outputs.Aws
+			if aws.AccountID != "" {
+				flat["account_id"] = aws.AccountID
+			}
+			if aws.Region != "" {
+				flat["region"] = aws.Region
+			}
+			if aws.VpcID != "" {
+				flat["vpc_id"] = aws.VpcID
+			}
+			if aws.RunnerSubnet != "" {
+				flat["runner_subnet"] = aws.RunnerSubnet
+			}
+			if len(aws.PrivateSubnets) > 0 {
+				flat["private_subnets"] = aws.PrivateSubnets
+			}
+			if len(aws.PublicSubnets) > 0 {
+				flat["public_subnets"] = aws.PublicSubnets
+			}
+			if aws.ProvisionIamRoleArn != "" {
+				flat["provision_iam_role_arn"] = aws.ProvisionIamRoleArn
+			}
+			if aws.DeprovisionIamRoleArn != "" {
+				flat["deprovision_iam_role_arn"] = aws.DeprovisionIamRoleArn
+			}
+			if aws.MaintenanceIamRoleArn != "" {
+				flat["maintenance_iam_role_arn"] = aws.MaintenanceIamRoleArn
+			}
+			if aws.RunnerIamRoleArn != "" {
+				flat["runner_iam_role_arn"] = aws.RunnerIamRoleArn
+			}
+			if len(aws.BreakGlassRoleArns) > 0 {
+				flat["break_glass_role_arns"] = aws.BreakGlassRoleArns
+			}
+			if len(aws.CustomRoleArns) > 0 {
+				flat["custom_role_arns"] = aws.CustomRoleArns
+			}
+		}
+		if outputs.Data != nil {
+			for k, v := range outputs.Data {
+				flat[k] = v
+			}
+		}
+		if outputs.DataContents != nil {
+			for k, v := range outputs.DataContents {
+				flat[k] = v
+			}
+		}
+		out.Stack = flat
+	}
+
+	// Sandbox outputs — latest successful/active run.
+	for _, run := range sandboxes {
+		if (run.Status == "active" || run.Status == "succeeded") && run.Outputs != nil {
+			out.Sandbox = run.Outputs
+			break
+		}
+	}
+	if out.Sandbox == nil && len(sandboxes) > 0 && sandboxes[0].Outputs != nil {
+		out.Sandbox = sandboxes[0].Outputs
+	}
+
+	// Component outputs — fetch latest deploy for each in parallel.
+	if len(components) > 0 {
+		var cmu sync.Mutex
+		var cwg sync.WaitGroup
+		cwg.Add(len(components))
+		for _, ic := range components {
+			go func(comp *models.AppInstallComponent) {
+				defer cwg.Done()
+				name := comp.ComponentID
+				if comp.Component != nil && comp.Component.Name != "" {
+					name = comp.Component.Name
+				}
+				deploy, err := s.api.GetInstallComponentLatestDeploy(ctx, installID, comp.ComponentID)
+				if err != nil || deploy == nil || deploy.Outputs == nil || len(deploy.Outputs) == 0 {
+					return
+				}
+				cmu.Lock()
+				out.Components[name] = deploy.Outputs
+				cmu.Unlock()
+			}(ic)
+		}
+		cwg.Wait()
+	}
+
+	if asJSON {
+		ui.PrintJSON(out)
+		return nil
+	}
+
+	// Human-friendly table output grouped by section.
+	view := ui.NewListView()
+	empty := true
+
+	if len(out.Stack) > 0 {
+		empty = false
+		fmt.Println("Stack:")
+		flat := make(map[string]string)
+		flattenMap("", out.Stack, flat)
+		printSection(view, flat)
+	}
+
+	if len(out.Sandbox) > 0 {
+		empty = false
+		if len(out.Stack) > 0 {
+			fmt.Println()
+		}
+		fmt.Println("Sandbox:")
+		flat := make(map[string]string)
+		flattenMap("", out.Sandbox, flat)
+		printSection(view, flat)
+	}
+
+	compNames := make([]string, 0, len(out.Components))
+	for name := range out.Components {
+		compNames = append(compNames, name)
+	}
+	sort.Strings(compNames)
+	for _, name := range compNames {
+		empty = false
+		fmt.Printf("\nComponent %s:\n", name)
+		flat := make(map[string]string)
+		flattenMap("", out.Components[name], flat)
+		printSection(view, flat)
+	}
+
+	if empty {
+		view.Print("No outputs available for this install.")
+	}
+
+	if len(warnings) > 0 {
+		fmt.Fprintln(os.Stderr)
+		for _, w := range warnings {
+			fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+		}
+	}
+
+	return nil
+}
+
+func printSection(view *ui.ListView, flat map[string]string) {
+	keys := make([]string, 0, len(flat))
+	for k := range flat {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	data := [][]string{{"KEY", "VALUE"}}
+	for _, k := range keys {
+		data = append(data, []string{k, flat[k]})
+	}
+	view.Render(data)
+}

--- a/bins/cli/internal/services/installs/sandbox_outputs.go
+++ b/bins/cli/internal/services/installs/sandbox_outputs.go
@@ -1,0 +1,87 @@
+package installs
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nuonco/nuon/bins/cli/internal/lookup"
+	"github.com/nuonco/nuon/bins/cli/internal/ui"
+	"github.com/nuonco/nuon/sdks/nuon-go/models"
+)
+
+func (s *Service) SandboxOutputs(ctx context.Context, installID string, asJSON bool) error {
+	installID, err := lookup.InstallID(ctx, s.api, installID)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+
+	runs, _, err := s.api.GetInstallSandboxRuns(ctx, installID, &models.GetPaginatedQuery{Limit: 50})
+	if err != nil {
+		return ui.PrintError(err)
+	}
+
+	// Find latest successful/active run with outputs.
+	var outputs map[string]any
+	for _, run := range runs {
+		if (run.Status == "active" || run.Status == "succeeded") && run.Outputs != nil {
+			outputs = run.Outputs
+			break
+		}
+	}
+	if outputs == nil && len(runs) > 0 && runs[0].Outputs != nil {
+		outputs = runs[0].Outputs
+	}
+	if outputs == nil {
+		view := ui.NewGetView()
+		view.Print("No sandbox outputs available for this install.")
+		return nil
+	}
+
+	if asJSON {
+		ui.PrintJSON(outputs)
+		return nil
+	}
+
+	// Flatten nested map into dot-notation key/value pairs for table display.
+	flat := make(map[string]string)
+	flattenMap("", outputs, flat)
+
+	keys := make([]string, 0, len(flat))
+	for k := range flat {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	data := [][]string{{"KEY", "VALUE"}}
+	for _, k := range keys {
+		data = append(data, []string{k, flat[k]})
+	}
+
+	view := ui.NewListView()
+	view.Render(data)
+	return nil
+}
+
+// flattenMap recursively flattens a nested map into dot-notation keys.
+func flattenMap(prefix string, m map[string]any, out map[string]string) {
+	for k, v := range m {
+		key := k
+		if prefix != "" {
+			key = prefix + "." + k
+		}
+		switch val := v.(type) {
+		case map[string]any:
+			flattenMap(key, val, out)
+		case []any:
+			parts := make([]string, len(val))
+			for i, item := range val {
+				parts[i] = fmt.Sprintf("%v", item)
+			}
+			out[key] = strings.Join(parts, ", ")
+		default:
+			out[key] = fmt.Sprintf("%v", v)
+		}
+	}
+}

--- a/sdks/nuon-go/client.go
+++ b/sdks/nuon-go/client.go
@@ -2,6 +2,7 @@ package nuon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -207,6 +208,12 @@ type Client interface {
 	GetLogStream(ctx context.Context, logStreamID string) (*models.AppLogStream, error)
 	LogStreamReadLogs(ctx context.Context, logStreamId string, offset string) ([]*models.AppOtelLogRecord, error)
 	LogStreamReadLogsWithNextOffset(ctx context.Context, logStreamId string, offset string) ([]*models.AppOtelLogRecord, string, error)
+
+	// terraform workspaces
+	GetTerraformWorkspaceStatesJSON(ctx context.Context, workspaceID string) ([]*models.AppTerraformWorkspaceStateJSON, error)
+	GetTerraformWorkspaceStates(ctx context.Context, workspaceID string) ([]*models.AppTerraformWorkspaceState, error)
+	GetTerraformWorkspaceLatestState(ctx context.Context, workspaceID string) (*models.AppTerraformWorkspaceState, error)
+	GetTerraformWorkspaceLatestStateJSON(ctx context.Context, workspaceID string) (json.RawMessage, error)
 
 	// components
 	GetAllComponents(ctx context.Context, query *models.GetPaginatedQuery) ([]*models.AppComponent, bool, error)

--- a/sdks/nuon-go/terraform_workspaces.go
+++ b/sdks/nuon-go/terraform_workspaces.go
@@ -1,0 +1,98 @@
+package nuon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/nuonco/nuon/sdks/nuon-go/client/operations"
+	"github.com/nuonco/nuon/sdks/nuon-go/models"
+)
+
+func (c *client) GetTerraformWorkspaceStatesJSON(ctx context.Context, workspaceID string) ([]*models.AppTerraformWorkspaceStateJSON, error) {
+	limit := int64(1)
+	resp, err := c.genClient.Operations.GetTerraformWorkspaceStatesJSONV2(
+		&operations.GetTerraformWorkspaceStatesJSONV2Params{
+			WorkspaceID: workspaceID,
+			Limit:       &limit,
+			Context:     ctx,
+		},
+		c.getOrgIDAuthInfo(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetPayload(), nil
+}
+
+func (c *client) GetTerraformWorkspaceStates(ctx context.Context, workspaceID string) ([]*models.AppTerraformWorkspaceState, error) {
+	limit := int64(1)
+	resp, err := c.genClient.Operations.GetTerraformStatesV2(
+		&operations.GetTerraformStatesV2Params{
+			WorkspaceID: workspaceID,
+			Limit:       &limit,
+			Context:     ctx,
+		},
+		c.getOrgIDAuthInfo(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetPayload(), nil
+}
+
+// GetTerraformWorkspaceLatestState fetches the latest state with contents by first
+// listing states (which omits Contents) then fetching by ID (which includes Contents).
+func (c *client) GetTerraformWorkspaceLatestState(ctx context.Context, workspaceID string) (*models.AppTerraformWorkspaceState, error) {
+	states, err := c.GetTerraformWorkspaceStates(ctx, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("listing states: %w", err)
+	}
+	if len(states) == 0 {
+		return nil, nil
+	}
+
+	resp, err := c.genClient.Operations.GetTerraformWorkspaceStateByIDV2(
+		&operations.GetTerraformWorkspaceStateByIDV2Params{
+			WorkspaceID: workspaceID,
+			StateID:     states[0].ID,
+			Context:     ctx,
+		},
+		c.getOrgIDAuthInfo(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("fetching state by ID: %w", err)
+	}
+	return resp.GetPayload(), nil
+}
+
+// GetTerraformWorkspaceLatestStateJSON fetches the latest state-json (terraform show -json format)
+// by listing state-json records then fetching by ID. The by-ID endpoint returns the raw
+// terraform show -json output directly, so we return it as json.RawMessage rather than re-marshaling
+// the generated client's typed payload — callers consume it as raw JSON.
+func (c *client) GetTerraformWorkspaceLatestStateJSON(ctx context.Context, workspaceID string) (json.RawMessage, error) {
+	states, err := c.GetTerraformWorkspaceStatesJSON(ctx, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("listing state-json: %w", err)
+	}
+	if len(states) == 0 {
+		return nil, nil
+	}
+
+	resp, err := c.genClient.Operations.GetTerraformWorkspaceStatesJSONByIDV2(
+		&operations.GetTerraformWorkspaceStatesJSONByIDV2Params{
+			WorkspaceID: workspaceID,
+			StateID:     states[0].ID,
+			Context:     ctx,
+		},
+		c.getOrgIDAuthInfo(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("fetching state-json by ID: %w", err)
+	}
+	raw, err := json.Marshal(resp.GetPayload())
+	if err != nil {
+		return nil, fmt.Errorf("marshaling state-json payload: %w", err)
+	}
+	return raw, nil
+}


### PR DESCRIPTION
## Summary

Adds **`nuon installs actions run`** — trigger an action workflow on an install from the CLI, with optional sync wait + outputs printing.

```bash
# Fire-and-forget
nuon installs actions run -i <install> --action-workflow-id my_action

# Wait for completion and print outputs
nuon installs actions run -i <install> --action-workflow-id my_action --wait

# Pass parameters and wait, JSON output
nuon installs actions run -i <install> --action-workflow-id my_action \
  --env KEY=val --env KEY2=val2 --wait -j
```

Flags:
- `--action-workflow-id` (persistent on `installs actions`) — name or ID of the action workflow
- `--env KEY=VALUE` (repeatable) — environment variables passed to the run
- `--wait` / `-w` — block until terminal state
- `--timeout` (default `5m`) — wait deadline

## Implementation notes

- Resolves action name → ID via `GetActionWorkflows`.
- Records the pre-trigger latest run ID and trigger timestamp; the poll loop only adopts a run whose `ID != prevRunID` **and** `CreatedAt >= triggerTime` (with 1s skew tolerance), so a concurrently-created run can't be misidentified as ours. The `Create` SDK endpoint doesn't return the new run ID, hence the timestamp-based binding.
- Wait loop wraps the parent context in `context.WithTimeout` and uses `select { case <-ctx.Done(): ... case <-time.After(2s): }`, so Ctrl-C and the deadline both work correctly.
- Polling errors are tolerated up to 5 consecutive failures (with stderr warnings), then aborts — avoids silent spin on persistent 401/403/network failures.
- Terminal-success status is `"finished"` (see `app.InstallActionWorkflowRunStatus` in `services/ctl-api/internal/app/install_action_workflow_run.go`); `"error"`, `"timed-out"`, `"cancelled"` are treated as failure. Note: this enum is **not** the same vocabulary as `models.AppStatus`.
- Outputs render via PR1's `flattenMap` / `printSection` helpers; empty-map prints `"no outputs"` on stderr.

## ⚠️ Stacked on #1375

Depends on PR1 (`pr/outputs-family`) — uses the `flattenMap` and `printSection` helpers introduced there. The diff in this PR will include PR1's changes until PR1 merges. Review #1375 first; this PR's own diff is in commit `add nuon installs actions run subcommand with sync wait and outputs`.

## Test plan

Tested end-to-end on a GCP canary install (output sanitized — see [test 1 comment](https://github.com/nuonco/nuon/pull/1376#issuecomment-4485461594), [`--wait` failure-path comment](https://github.com/nuonco/nuon/pull/1376#issuecomment-4485510759), [`--wait` success-path + `--timeout` + Ctrl-C comment](https://github.com/nuonco/nuon/pull/1376#issuecomment-4485980551)):

- [x] `nuon installs actions run -i <install> --action-workflow-id <name>` triggers a run *(implicitly verified by the `--wait` success runs binding to fresh run IDs)*
- [x] `... --wait` blocks until success and prints outputs as a table
- [x] `... --wait -j` blocks until success and prints outputs as JSON
- [x] `... --env KEY=val --env KEY2=val2 --wait` runs with multiple env vars set *(used `--env RECIPIENT_PUBLIC_KEY=... --env ACCESS_LEVEL=support`)*
- [x] `--timeout 5s` against a long-running action exits with a timeout error
- [x] Ctrl-C during `--wait` returns promptly (context cancellation, ~2s worst case)
- [x] An action that fails returns a non-zero exit with the status_description
- [x] `--help` text renders correctly
- [x] Missing `--action-workflow-id` is reported clearly (no silent exit) — **fixed during testing**: validation paths now use `ui.PrintWarning` / `ui.PrintError` instead of returning `fmt.Errorf` from inside `wrapCmd` (which `os.Exit(1)`s silently)
- [x] Invalid `--env KEY` (no `=VALUE`) is rejected with a clear error before any API call
- [x] Unknown action name lists available actions and exits non-zero, before any Create call

### Known limitation (not blocking this PR)

Table output for action runs is visibly truncated for base64 outputs because the shared `ui.ListView` renderer caps each cell at the terminal width and replaces overflow with `…`. Affects all current table renders, not specific to this PR. Workaround: use `-j` for full output. A `ui` change to wrap or disable truncation would be a worthwhile follow-up.
