### PR TITLE
fix: (queues) Raise long-running activity HeartbeatTimeout to 60s

### DIFF
--- a/services/ctl-api/internal/pkg/queue/handle_signal.go
+++ b/services/ctl-api/internal/pkg/queue/handle_signal.go
@@ -24,10 +24,14 @@ var ErrSignalNoop = errors.New("queue signal already in terminal state")
 // (validate, execute) which block until the signal finishes. These can run for
 // extended periods. Heartbeating ensures Temporal can detect dead workers and retry.
 // Idempotent update IDs ensure retried update calls are deduplicated by Temporal.
+//
+// HeartbeatTimeout is 60s to give the 30s heartbeat ticker (see heartbeat.WithHeartbeat
+// usage in handler/activities and client/) headroom for one missed beat without
+// the server tripping a HeartbeatTimeout.
 var longRunningActivityOptions = &workflow.ActivityOptions{
 	StartToCloseTimeout:    5 * time.Minute,
 	ScheduleToCloseTimeout: 2 * time.Hour,
-	HeartbeatTimeout:       10 * time.Second,
+	HeartbeatTimeout:       60 * time.Second,
 }
 
 func (q *queue) handleQueueSignal(ctx workflow.Context, queueRef QueueRef) error {


### PR DESCRIPTION
The `longRunningActivityOptions` used by `handleQueueSignal` for the validate/execute update-handler activities set `HeartbeatTimeout` to `10s`, but those activities heartbeat on a `30s` ticker via `heartbeat.WithHeartbeat`. Any attempt that genuinely blocked past 10s was being killed by the server with `HeartbeatTimeoutType` and retried.

This was not a problem in many cases, as we were finishing well within 10 seconds, but under pressure, and in case we want to do some validation with DB calls etc, we would enter a retry loop.

This PR bumps the timeout to 60 seconds, which accounts for one missing heartbeat before marking the activity as dead and retrying.