### PR TITLE
fix(queue): cancel handler workflows on stale-drop + fix heartbeat timeout

### DIFF
--- a/services/ctl-api/internal/pkg/queue/client/cancel_handler_workflow.go
+++ b/services/ctl-api/internal/pkg/queue/client/cancel_handler_workflow.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"go.temporal.io/api/serviceerror"
+)
+
+// CancelHandlerWorkflow cancels a queue-signal handler workflow. Used by the
+// emitter when stale-dropping signals so the handler exits cleanly instead of
+// looping on a now-soft-deleted row. NotFound is treated as success.
+func (c *Client) CancelHandlerWorkflow(ctx context.Context, namespace, workflowID string) error {
+	if err := c.tClient.CancelWorkflowInNamespace(ctx, namespace, workflowID, ""); err != nil {
+		var notFoundErr *serviceerror.NotFound
+		if errors.As(err, &notFoundErr) {
+			return nil
+		}
+		return errors.Wrap(err, "unable to cancel handler workflow")
+	}
+	return nil
+}

--- a/services/ctl-api/internal/pkg/queue/emitter/activities/emit_signal.go
+++ b/services/ctl-api/internal/pkg/queue/emitter/activities/emit_signal.go
@@ -55,17 +55,21 @@ func (a *Activities) EmitSignal(ctx context.Context, req *EmitSignalRequest) (*E
 
 	if len(existingSignals) > 0 {
 		if maxAge := signal.DeriveMaxInFlightAge(emitter.SignalTemplate.Signal); maxAge > 0 {
-			staleIDs := make([]string, 0, len(existingSignals))
+			stale := make([]*app.QueueSignal, 0, len(existingSignals))
 			live := existingSignals[:0]
 			now := time.Now()
 			for _, s := range existingSignals {
 				if now.Sub(s.CreatedAt) > maxAge {
-					staleIDs = append(staleIDs, s.ID)
+					stale = append(stale, s)
 				} else {
 					live = append(live, s)
 				}
 			}
-			if len(staleIDs) > 0 {
+			if len(stale) > 0 {
+				staleIDs := make([]string, 0, len(stale))
+				for _, s := range stale {
+					staleIDs = append(staleIDs, s.ID)
+				}
 				if res := a.db.WithContext(ctx).Exec(`
 					UPDATE queue_signals
 					SET status = jsonb_set(status, '{status}', '"error"'::jsonb)
@@ -78,9 +82,20 @@ func (a *Activities) EmitSignal(ctx context.Context, req *EmitSignalRequest) (*E
 				a.l.Warn("dropped stale in-flight signals exceeding max-in-flight age",
 					zap.String("emitter-id", req.EmitterID),
 					zap.String("queue-id", req.QueueID),
-					zap.Int("stale-count", len(staleIDs)),
+					zap.Int("stale-count", len(stale)),
 					zap.Duration("max-in-flight-age", maxAge),
 				)
+				// Cancel each stale signal's handler workflow so it stops
+				// trying to update the now-soft-deleted row.
+				for _, s := range stale {
+					if err := a.queueClient.CancelHandlerWorkflow(ctx, s.Workflow.Namespace, s.Workflow.ID); err != nil {
+						a.l.Warn("unable to cancel handler workflow for stale signal",
+							zap.String("queue-signal-id", s.ID),
+							zap.String("workflow-id", s.Workflow.ID),
+							zap.Error(err),
+						)
+					}
+				}
 			}
 			existingSignals = live
 		}

--- a/services/ctl-api/internal/pkg/queue/handle_signal.go
+++ b/services/ctl-api/internal/pkg/queue/handle_signal.go
@@ -24,10 +24,12 @@ var ErrSignalNoop = errors.New("queue signal already in terminal state")
 // (validate, execute) which block until the signal finishes. These can run for
 // extended periods. Heartbeating ensures Temporal can detect dead workers and retry.
 // Idempotent update IDs ensure retried update calls are deduplicated by Temporal.
+// HeartbeatTimeout must be > the 30s ticker in heartbeat.WithHeartbeat used by
+// the validate/execute activities, otherwise every blocking call times out.
 var longRunningActivityOptions = &workflow.ActivityOptions{
 	StartToCloseTimeout:    5 * time.Minute,
 	ScheduleToCloseTimeout: 2 * time.Hour,
-	HeartbeatTimeout:       10 * time.Second,
+	HeartbeatTimeout:       60 * time.Second,
 }
 
 func (q *queue) handleQueueSignal(ctx workflow.Context, queueRef QueueRef) error {


### PR DESCRIPTION
Stale-dropped signals left handler workflows running forever, paralyzing MaxInFlight=1 queues. Cancel them on stale-drop and fix the 10s heartbeat-timeout vs 30s tick-interval contradiction.