### PR TITLE
fix: don't soft delete the health check

### DIFF
--- a/services/ctl-api/internal/app/runners/signals/v2/processhealthcheck/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/v2/processhealthcheck/signal.go
@@ -83,7 +83,8 @@ func (s *Signal) Execute(ctx workflow.Context) (err error) {
 	// deferred latency emit captures the final state. Owner labels are added
 	// with collision guards so standard tags always win.
 	tags := map[string]string{
-		"runner_id": s.RunnerID,
+		"runner_id":    s.RunnerID,
+		"process_type": "unknown",
 	}
 	addLabels := func(labels map[string]string) {
 		for k, v := range labels {

--- a/services/ctl-api/internal/pkg/queue/emitter/activities/emit_signal.go
+++ b/services/ctl-api/internal/pkg/queue/emitter/activities/emit_signal.go
@@ -66,11 +66,15 @@ func (a *Activities) EmitSignal(ctx context.Context, req *EmitSignalRequest) (*E
 				}
 			}
 			if len(staleIDs) > 0 {
+				// Do NOT soft-delete: a handler may already be running this signal,
+				// and removing the row would cause its status-update activities to
+				// loop on ErrRecordNotFound. Marking status=error is enough to
+				// release EmitSignal's in-flight check; the handler will finish
+				// (or its own writes will overwrite this status) naturally.
 				if res := a.db.WithContext(ctx).Exec(`
 					UPDATE queue_signals
 					SET status = jsonb_set(status, '{status}', '"error"'::jsonb)
 					           || jsonb_build_object('metadata', jsonb_build_object('stale_drop', 'exceeded max_in_flight_age')),
-					    deleted_at = extract(epoch from now())::bigint,
 					    updated_at = now()
 					WHERE id IN (?)`, staleIDs); res.Error != nil {
 					return nil, errors.Wrap(res.Error, "unable to mark stale in-flight signals as failed")


### PR DESCRIPTION
soft deleting health check might result in already running workflow to get stuck on updating it's status as it won't be visible to him. ideally we just update it's status and leave it to the handler to do future updates on it.

also default `process_type` tag to `unknown` so DD stops showing N/A on error paths before the lookup runs.