### PR TITLE
fix: use value from --nuon-path in dashboard-ui watch

### DIFF
--- a/services/dashboard-ui/scripts/dev.sh
+++ b/services/dashboard-ui/scripts/dev.sh
@@ -16,7 +16,7 @@ if [ -f dist/.port ]; then
 fi
 
 echo "Building dashboard server..."
-go build -C "$NUON_ROOT/nuon" -o /tmp/dashboard-server ./services/dashboard-ui/server
+go build -C "${NUON_DIR:-$NUON_ROOT/nuon}" -o /tmp/dashboard-server ./services/dashboard-ui/server
 
 rm -f dist/.port
 /tmp/dashboard-server serve &


### PR DESCRIPTION
## Problem

While trying out the bare repository pattern for using git worktrees, I found that when passing in --nuon-path, the value wasn't being passed through to dashboard-ui. It was still trying to watch my main worktree, instead of the worktree that I had selected.

## Solution

Reference the path passed in from nuonctl (from this PR: https://github.com/nuonco/mono/pull/12588).