### PR TITLE
feat: read from replica

### DIFF
--- a/pkg/gen/temporal-gen-v2/internal/generator/templates/activity.tmpl
+++ b/pkg/gen/temporal-gen-v2/internal/generator/templates/activity.tmpl
@@ -14,6 +14,9 @@ type {{$reqType}} struct {
 
 // {{if .Options.WrapperPrefix}}{{.Options.WrapperPrefix}}{{end}}{{.Name | ToPascal}} is a wrapper for the {{.OriginalName}} activity
 func (a {{.Receiver}}) {{if .Options.WrapperPrefix}}{{.Options.WrapperPrefix}}{{end}}{{.Name | ToPascal}}(ctx context.Context, req {{$reqType}}) ({{if .OutputType}}{{.OutputType}}, {{end}}error) {
+	{{- if .Options.ReplicaRead}}
+	ctx = routing.WithReplica(ctx)
+	{{- end}}
 	return a.{{.OriginalName}}(ctx, {{range .Params}}req.{{.ExportedName}}, {{end}})
 }
 {{- end}}

--- a/pkg/gen/temporal-gen-v2/internal/parser/parser.go
+++ b/pkg/gen/temporal-gen-v2/internal/parser/parser.go
@@ -27,6 +27,7 @@ type ActivityOptions struct {
 	ByFieldOnly            bool
 	GenerateWrapper        bool
 	WrapperPrefix          string // Prefix to add to generated wrapper function name
+	ReplicaRead            bool
 }
 
 type WorkflowOptions struct {
@@ -65,6 +66,9 @@ func (a *Annotation) Validate() error {
 		}
 		if a.ActivityOpts.WrapperPrefix != "" && !a.ActivityOpts.GenerateWrapper {
 			return fmt.Errorf("@wrapper-prefix requires @as-wrapper to be specified")
+		}
+		if a.ActivityOpts.ReplicaRead && !a.ActivityOpts.GenerateWrapper {
+			return fmt.Errorf("@replica-read requires @as-wrapper to be specified")
 		}
 	}
 	if a.WorkflowOpts != nil {
@@ -306,6 +310,12 @@ func Parse(comments []string) (*Annotation, error) {
 				continue
 			}
 			annotation.ActivityOpts.GenerateWrapper = true
+
+		case "@replica-read":
+			if annotation.Type != "activity" {
+				continue
+			}
+			annotation.ActivityOpts.ReplicaRead = true
 
 		case "@wrapper-prefix":
 			if annotation.Type != "activity" {

--- a/pkg/gen/temporal-gen-v2/internal/parser/parser_test.go
+++ b/pkg/gen/temporal-gen-v2/internal/parser/parser_test.go
@@ -276,6 +276,27 @@ func TestParse(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		"Activity with replica-read and as-wrapper": {
+			comments: []string{
+				"// @" + config.AnnotationPrefix + " activity",
+				"// @as-wrapper",
+				"// @replica-read",
+			},
+			expected: &Annotation{
+				Type: "activity",
+				ActivityOpts: &ActivityOptions{
+					GenerateWrapper: true,
+					ReplicaRead:     true,
+				},
+			},
+		},
+		"Activity with replica-read without as-wrapper (invalid)": {
+			comments: []string{
+				"// @" + config.AnnotationPrefix + " activity",
+				"// @replica-read",
+			},
+			wantErr: true,
+		},
 		"Workflow with single memo": {
 			comments: []string{
 				"// @" + config.AnnotationPrefix + " workflow",

--- a/services/ctl-api/internal/app/installs/service/service.go
+++ b/services/ctl-api/internal/app/installs/service/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	componenthelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/replica"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/eventloop"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
@@ -85,7 +86,7 @@ func (s *service) RegisterPublicRoutes(ge *gin.Engine) error {
 	// individual installs
 	installs := ge.Group("/v1/installs/:install_id")
 	{
-		installs.GET("", s.GetInstall)
+		installs.GET("", replica.OptIn(), s.GetInstall)
 		installs.PATCH("", s.UpdateInstall)
 		installs.DELETE("", s.DeleteInstall)
 		installs.POST("/labels", s.AddInstallLabels)

--- a/services/ctl-api/internal/app/installs/worker/activities/get.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/get.go
@@ -10,14 +10,12 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
 )
 
-type GetRequest struct {
-	InstallID string `validate:"required"`
-}
-
 // @temporal-gen-v2 activity
-// @by-field InstallID
-func (a *Activities) Get(ctx context.Context, req GetRequest) (*app.Install, error) {
-	return a.getInstall(ctx, req.InstallID)
+// @as-wrapper
+// @by-field installID
+// @replica-read
+func (a *Activities) get(ctx context.Context, installID string) (*app.Install, error) {
+	return a.getInstall(ctx, installID)
 }
 
 func (a *Activities) getInstall(ctx context.Context, installID string) (*app.Install, error) {

--- a/services/ctl-api/internal/app/orgs/service/get_orgs.go
+++ b/services/ctl-api/internal/app/orgs/service/get_orgs.go
@@ -51,7 +51,7 @@ func (s *service) GetCurrentUserOrgs(ctx *gin.Context) {
 func (s *service) getOrgs(ctx *gin.Context, orgIDs []string, q string) ([]app.Org, error) {
 	var orgs []app.Org
 	tx := s.db.WithContext(ctx).
-		Scopes(scopes.WithOffsetPagination).
+		Scopes(scopes.WithOffsetPagination, scopes.WithReplica).
 		Joins("JOIN accounts ON accounts.id = orgs.created_by_id").
 		Where("orgs.id IN ?", orgIDs).
 		Order(fmt.Sprintf("CASE WHEN accounts.account_type = '%s' THEN 1 ELSE 0 END, orgs.id", app.AccountTypeCanary))

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -171,6 +171,9 @@ type Config struct {
 	DBName                       string `config:"db_name" validate:"required"`
 	DBHost                       string `config:"db_host" validate:"required"`
 	DBReplicaHost                string `config:"db_replica_host"`
+	DBGormReplicaHost            string `config:"db_gorm_replica_host"`
+	DBReplicaEnabled             bool   `config:"db_replica_enabled"`
+	DBReplicaBypassOptIn         bool   `config:"db_replica_bypass_opt_in"`
 	DBPort                       string `config:"db_port" validate:"required"`
 	DBSSLMode                    string `config:"db_ssl_mode" validate:"required"`
 	DBPassword                   string `config:"db_password"`

--- a/services/ctl-api/internal/middlewares/replica/middleware.go
+++ b/services/ctl-api/internal/middlewares/replica/middleware.go
@@ -1,0 +1,21 @@
+package replica
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/routing"
+)
+
+func OptIn() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Request = c.Request.WithContext(routing.WithReplica(c.Request.Context()))
+		c.Next()
+	}
+}
+
+func OptOut() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Request = c.Request.WithContext(routing.WithoutReplica(c.Request.Context()))
+		c.Next()
+	}
+}

--- a/services/ctl-api/internal/pkg/db/plugins/metrics/metrics_plugin.go
+++ b/services/ctl-api/internal/pkg/db/plugins/metrics/metrics_plugin.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/nuonco/nuon/pkg/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/routing"
 )
 
 type contextKey string
@@ -114,6 +115,9 @@ func (m *metricsWriterPlugin) afterAll(tx *gorm.DB, operationType OperationType)
 		"db_type:" + m.dbType,
 		"db_operation_type:" + string(operationType),
 		"within_target_latency:" + strconv.FormatBool(withinTargetLatency),
+	}
+	if m.dbType == "psql" {
+		tags = append(tags, "pool:"+string(routing.DecisionFromContext(ctx)))
 	}
 
 	metricCtx, err := cctx.MetricsContextFromGinContext(ctx)

--- a/services/ctl-api/internal/pkg/db/psql/db.go
+++ b/services/ctl-api/internal/pkg/db/psql/db.go
@@ -7,7 +7,9 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
 	"go.uber.org/fx"
+	"go.uber.org/zap"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"moul.io/zapgorm2"
@@ -15,6 +17,7 @@ import (
 	"github.com/nuonco/nuon/pkg/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/querycollector"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/routing"
 )
 
 // database represents the set of configuration options for creating a database connection. If UseIAM is set, we will
@@ -35,6 +38,7 @@ type database struct {
 
 	// pool configuration
 	MaxConnections int32
+	Role           string
 
 	Logger zapgorm2.Logger `validate:"required"`
 
@@ -88,7 +92,92 @@ func New(v *validator.Validate,
 	cfg *internal.Config,
 	qc *querycollector.Collector,
 ) (*gorm.DB, error) {
-	return open(v, l, metricsWriter, lc, cfg, qc, cfg.DBHost)
+	primary, err := newDatabase(cfg, l, metricsWriter, qc, cfg.DBHost)
+	if err != nil {
+		return nil, fmt.Errorf("unable to build primary database config: %w", err)
+	}
+	primary.Role = "primary"
+	if err := primary.Validate(v); err != nil {
+		return nil, err
+	}
+
+	primaryPool, err := primary.createPool()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create primary pool: %w", err)
+	}
+	primary.pool = primaryPool
+	primarySQL := stdlib.OpenDBFromPool(primaryPool)
+
+	var replica *database
+	connPool := routing.NewConnPool(primarySQL, nil)
+
+	if cfg.DBReplicaEnabled && cfg.DBGormReplicaHost != "" {
+		replica, err = newDatabase(cfg, l, metricsWriter, qc, cfg.DBGormReplicaHost)
+		if err != nil {
+			return nil, fmt.Errorf("unable to build replica database config: %w", err)
+		}
+		replica.Role = "replica"
+		if err := replica.Validate(v); err != nil {
+			return nil, fmt.Errorf("unable to validate replica database: %w", err)
+		}
+
+		replicaPool, err := replica.createPool()
+		if err != nil {
+			return nil, fmt.Errorf("unable to create replica pool: %w", err)
+		}
+		replica.pool = replicaPool
+
+		connPool = routing.NewConnPool(primarySQL, stdlib.OpenDBFromPool(replicaPool))
+		l.ZapLogger.Info("replica pool initialized",
+			zap.String("host", cfg.DBGormReplicaHost),
+			zap.Bool("bypass_opt_in", cfg.DBReplicaBypassOptIn),
+		)
+	} else {
+		l.ZapLogger.Info("replica routing disabled, primary-only pool",
+			zap.Bool("enabled", cfg.DBReplicaEnabled),
+			zap.String("host", cfg.DBGormReplicaHost),
+		)
+	}
+
+	postgresCfg := postgres.Config{Conn: primarySQL}
+	gormCfg := primary.gormConfig()
+
+	db, err := gorm.Open(postgres.New(postgresCfg), gormCfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to database: %w", err)
+	}
+	db.ConnPool = connPool
+
+	if err := primary.registerPlugins(db); err != nil {
+		return nil, fmt.Errorf("unable to register plugins: %w", err)
+	}
+
+	if err := db.Use(&routing.Plugin{
+		ACL:         replicaACL(db),
+		BypassOptIn: cfg.DBReplicaBypassOptIn,
+		Logger:      l.ZapLogger,
+	}); err != nil {
+		return nil, fmt.Errorf("unable to register routing plugin: %w", err)
+	}
+
+	lc.Append(fx.Hook{
+		OnStart: func(_ context.Context) error {
+			primary.startPoolBackgroundJob()
+			if replica != nil {
+				replica.startPoolBackgroundJob()
+			}
+			return nil
+		},
+		OnStop: func(_ context.Context) error {
+			primary.stopPoolBackgroundJob()
+			if replica != nil {
+				replica.stopPoolBackgroundJob()
+			}
+			return nil
+		},
+	})
+
+	return db, nil
 }
 
 // NewReplica errors if DBReplicaHost is empty so callers can't silently
@@ -106,18 +195,10 @@ func NewReplica(v *validator.Validate,
 	return open(v, l, metricsWriter, lc, cfg, qc, cfg.DBReplicaHost)
 }
 
-func open(v *validator.Validate,
-	l zapgorm2.Logger,
-	metricsWriter metrics.Writer,
-	lc fx.Lifecycle,
-	cfg *internal.Config,
-	qc *querycollector.Collector,
-	host string,
-) (*gorm.DB, error) {
-	ctx := context.Background()
-	ctx, cancelFn := context.WithCancel(ctx)
+func newDatabase(cfg *internal.Config, l zapgorm2.Logger, metricsWriter metrics.Writer, qc *querycollector.Collector, host string) (*database, error) {
+	ctx, cancelFn := context.WithCancel(context.Background())
 
-	database := &database{
+	d := &database{
 		Logger:         l,
 		Host:           host,
 		User:           cfg.DBUser,
@@ -134,43 +215,57 @@ func open(v *validator.Validate,
 
 	switch {
 	case cfg.DBPassword != "":
-		database.Password = cfg.DBPassword
+		d.Password = cfg.DBPassword
 	case cfg.DBUseIAM && cfg.IsGCP():
-		database.PasswordFn = FetchGcpCloudSqlPassword
+		d.PasswordFn = FetchGcpCloudSqlPassword
 	case cfg.DBUseIAM:
-		database.PasswordFn = FetchIamTokenPassword
+		d.PasswordFn = FetchIamTokenPassword
 	}
-	if err := database.Validate(v); err != nil {
+
+	return d, nil
+}
+
+func open(v *validator.Validate,
+	l zapgorm2.Logger,
+	metricsWriter metrics.Writer,
+	lc fx.Lifecycle,
+	cfg *internal.Config,
+	qc *querycollector.Collector,
+	host string,
+) (*gorm.DB, error) {
+	d, err := newDatabase(cfg, l, metricsWriter, qc, host)
+	if err != nil {
+		return nil, err
+	}
+	if err := d.Validate(v); err != nil {
 		return nil, err
 	}
 
-	// create pool
-	pool, err := database.createPool()
+	pool, err := d.createPool()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create database pool: %w", err)
 	}
-	database.pool = pool
+	d.pool = pool
 
-	postgresCfg := database.postgresConfig(pool)
-	gormCfg := database.gormConfig()
+	postgresCfg := d.postgresConfig(pool)
+	gormCfg := d.gormConfig()
 
 	db, err := gorm.Open(postgres.New(postgresCfg), gormCfg)
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to database: %w", err)
 	}
 
-	// register plugins
-	if err := database.registerPlugins(db); err != nil {
+	if err := d.registerPlugins(db); err != nil {
 		return nil, fmt.Errorf("unable to register plugins: %w", err)
 	}
 
 	lc.Append(fx.Hook{
 		OnStart: func(_ context.Context) error {
-			database.startPoolBackgroundJob()
+			d.startPoolBackgroundJob()
 			return nil
 		},
 		OnStop: func(_ context.Context) error {
-			database.stopPoolBackgroundJob()
+			d.stopPoolBackgroundJob()
 			return nil
 		},
 	})

--- a/services/ctl-api/internal/pkg/db/psql/pool.go
+++ b/services/ctl-api/internal/pkg/db/psql/pool.go
@@ -91,14 +91,17 @@ func (d *database) createPool() (*pgxpool.Pool, error) {
 func (d *database) recordPoolMetrics() {
 	stat := d.pool.Stat()
 
-	d.MetricsWriter.Gauge("gorm_pool.conns", float64(stat.TotalConns()), []string{"conn_type:total"})
-	d.MetricsWriter.Gauge("gorm_pool.conns", float64(stat.AcquiredConns()), []string{"conn_type:acquired"})
-	d.MetricsWriter.Gauge("gorm_pool.conns", float64(stat.ConstructingConns()), []string{"conn_type:connecting"})
-	d.MetricsWriter.Gauge("gorm_pool.conns", float64(stat.IdleConns()), []string{"conn_type:idle"})
-	d.MetricsWriter.Gauge("gorm_pool.conns", float64(stat.MaxConns()), []string{"conn_type:max"})
+	role := d.Role
+	if role == "" {
+		role = "primary"
+	}
+	roleTag := "pool:" + role
 
-	avgAcquireDuration := stat.AcquireDuration() / time.Duration(stat.AcquireCount())
-	d.MetricsWriter.Timing("gorm_pool.average_acquire_duration", avgAcquireDuration, nil)
+	d.MetricsWriter.Gauge("gorm_pool.conns", float64(stat.TotalConns()), []string{"conn_type:total", roleTag})
+	d.MetricsWriter.Gauge("gorm_pool.conns", float64(stat.AcquiredConns()), []string{"conn_type:acquired", roleTag})
+	d.MetricsWriter.Gauge("gorm_pool.conns", float64(stat.ConstructingConns()), []string{"conn_type:connecting", roleTag})
+	d.MetricsWriter.Gauge("gorm_pool.conns", float64(stat.IdleConns()), []string{"conn_type:idle", roleTag})
+	d.MetricsWriter.Gauge("gorm_pool.conns", float64(stat.MaxConns()), []string{"conn_type:max", roleTag})
 }
 
 func (d *database) startPoolBackgroundJob() {

--- a/services/ctl-api/internal/pkg/db/psql/replica_acl.go
+++ b/services/ctl-api/internal/pkg/db/psql/replica_acl.go
@@ -1,0 +1,19 @@
+package psql
+
+import (
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/routing"
+)
+
+func replicaACL(db *gorm.DB) *routing.TableACL {
+	return routing.NewACLBuilder(db).
+		Allow(
+			&app.Org{},
+			&app.App{},
+			&app.Install{},
+			&app.Account{},
+		).
+		Build()
+}

--- a/services/ctl-api/internal/pkg/db/routing/acl.go
+++ b/services/ctl-api/internal/pkg/db/routing/acl.go
@@ -1,0 +1,117 @@
+package routing
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+type viewModel interface {
+	UseView() bool
+	ViewVersion() string
+}
+
+type TableACL struct {
+	Allow map[string]struct{}
+	Deny  map[string]struct{}
+}
+
+func NewTableACL(allow, deny []string) *TableACL {
+	acl := &TableACL{
+		Allow: make(map[string]struct{}, len(allow)),
+		Deny:  make(map[string]struct{}, len(deny)),
+	}
+	for _, t := range allow {
+		acl.Allow[t] = struct{}{}
+	}
+	for _, t := range deny {
+		acl.Deny[t] = struct{}{}
+	}
+	return acl
+}
+
+func (a *TableACL) AllowsReplica(table string) bool {
+	if a == nil {
+		return true
+	}
+	if table == "" {
+		return false
+	}
+	if _, denied := a.Deny[table]; denied {
+		return false
+	}
+	_, allowed := a.Allow[table]
+	return allowed
+}
+
+type ACLBuilder struct {
+	db    *gorm.DB
+	allow map[string]struct{}
+	deny  map[string]struct{}
+}
+
+func NewACLBuilder(db *gorm.DB) *ACLBuilder {
+	return &ACLBuilder{
+		db:    db,
+		allow: make(map[string]struct{}),
+		deny:  make(map[string]struct{}),
+	}
+}
+
+func (b *ACLBuilder) Allow(models ...interface{}) *ACLBuilder {
+	for _, m := range models {
+		for _, t := range tableNamesFor(b.db, m) {
+			b.allow[t] = struct{}{}
+		}
+	}
+	return b
+}
+
+func (b *ACLBuilder) Deny(models ...interface{}) *ACLBuilder {
+	for _, m := range models {
+		for _, t := range tableNamesFor(b.db, m) {
+			b.deny[t] = struct{}{}
+		}
+	}
+	return b
+}
+
+func (b *ACLBuilder) Build() *TableACL {
+	acl := &TableACL{
+		Allow: make(map[string]struct{}, len(b.allow)),
+		Deny:  make(map[string]struct{}, len(b.deny)),
+	}
+	for t := range b.allow {
+		acl.Allow[t] = struct{}{}
+	}
+	for t := range b.deny {
+		acl.Deny[t] = struct{}{}
+	}
+	return acl
+}
+
+func tableNamesFor(db *gorm.DB, model interface{}) []string {
+	base := ResolveTable(db, model)
+	if base == "" {
+		return nil
+	}
+	out := []string{base}
+	if vm, ok := model.(viewModel); ok && vm.UseView() {
+		out = append(out, fmt.Sprintf("%s_view_%s", base, vm.ViewVersion()))
+	}
+	return out
+}
+
+func ResolveTable(db *gorm.DB, model interface{}) string {
+	stmt := &gorm.Statement{DB: db}
+	if err := stmt.Parse(model); err != nil {
+		if t, ok := model.(interface{ TableName() string }); ok {
+			return t.TableName()
+		}
+		return ""
+	}
+	if stmt.Schema == nil {
+		return ""
+	}
+	return stmt.Schema.Table
+}

--- a/services/ctl-api/internal/pkg/db/routing/callback.go
+++ b/services/ctl-api/internal/pkg/db/routing/callback.go
@@ -1,0 +1,95 @@
+package routing
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+type Plugin struct {
+	ACL         *TableACL
+	BypassOptIn bool
+	Logger      *zap.Logger
+}
+
+var _ gorm.Plugin = (*Plugin)(nil)
+
+func (p *Plugin) Name() string { return "routing" }
+
+func (p *Plugin) Initialize(db *gorm.DB) error {
+	if err := db.Callback().Query().Before("*").Register("routing:decide", p.decide); err != nil {
+		return err
+	}
+	if err := db.Callback().Raw().Before("*").Register("routing:decide", p.decide); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Plugin) decide(tx *gorm.DB) {
+	if tx.Statement == nil {
+		return
+	}
+	ctx := tx.Statement.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	tx.Statement.Context = WithDecision(ctx, p.choose(ctx, tx.Statement))
+}
+
+func (p *Plugin) choose(ctx context.Context, stmt *gorm.Statement) Pool {
+	pool, reason := p.route(ctx, stmt)
+	if p.Logger != nil {
+		p.Logger.Debug("routing decision",
+			zap.String("table", stmt.Table),
+			zap.String("pool", string(pool)),
+			zap.String("reason", reason),
+		)
+	}
+	return pool
+}
+
+func (p *Plugin) route(ctx context.Context, stmt *gorm.Statement) (Pool, string) {
+	if IsForceReplica(ctx) {
+		return PoolReplica, "force_replica"
+	}
+	if IsWithoutReplica(ctx) {
+		return PoolPrimary, "without_replica"
+	}
+	if !p.ACL.AllowsReplica(stmt.Table) {
+		return PoolPrimary, "acl_blocked"
+	}
+	for _, t := range joinTables(stmt) {
+		if !p.ACL.AllowsReplica(t) {
+			return PoolPrimary, "join_acl_blocked"
+		}
+	}
+	if p.BypassOptIn {
+		return PoolReplica, "bypass_opt_in"
+	}
+	if UseReplica(ctx) {
+		return PoolReplica, "opt_in"
+	}
+	return PoolPrimary, "default_primary"
+}
+
+func joinTables(stmt *gorm.Statement) []string {
+	if len(stmt.Joins) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(stmt.Joins))
+	for _, j := range stmt.Joins {
+		out = append(out, resolveJoinTable(stmt, j.Name))
+	}
+	return out
+}
+
+func resolveJoinTable(stmt *gorm.Statement, name string) string {
+	if stmt.Schema != nil {
+		if rel, ok := stmt.Schema.Relationships.Relations[name]; ok && rel.FieldSchema != nil {
+			return rel.FieldSchema.Table
+		}
+	}
+	return name
+}

--- a/services/ctl-api/internal/pkg/db/routing/context.go
+++ b/services/ctl-api/internal/pkg/db/routing/context.go
@@ -1,0 +1,55 @@
+package routing
+
+import "context"
+
+type Pool string
+
+const (
+	PoolPrimary Pool = "primary"
+	PoolReplica Pool = "replica"
+)
+
+type (
+	replicaOptInKey  struct{}
+	replicaOptOutKey struct{}
+	replicaForceKey  struct{}
+	decisionKey      struct{}
+)
+
+func WithReplica(ctx context.Context) context.Context {
+	return context.WithValue(ctx, replicaOptInKey{}, true)
+}
+
+func UseReplica(ctx context.Context) bool {
+	v, _ := ctx.Value(replicaOptInKey{}).(bool)
+	return v
+}
+
+func WithoutReplica(ctx context.Context) context.Context {
+	return context.WithValue(ctx, replicaOptOutKey{}, true)
+}
+
+func IsWithoutReplica(ctx context.Context) bool {
+	v, _ := ctx.Value(replicaOptOutKey{}).(bool)
+	return v
+}
+
+func WithForceReplica(ctx context.Context) context.Context {
+	return context.WithValue(ctx, replicaForceKey{}, true)
+}
+
+func IsForceReplica(ctx context.Context) bool {
+	v, _ := ctx.Value(replicaForceKey{}).(bool)
+	return v
+}
+
+func WithDecision(ctx context.Context, p Pool) context.Context {
+	return context.WithValue(ctx, decisionKey{}, p)
+}
+
+func DecisionFromContext(ctx context.Context) Pool {
+	if v, ok := ctx.Value(decisionKey{}).(Pool); ok {
+		return v
+	}
+	return PoolPrimary
+}

--- a/services/ctl-api/internal/pkg/db/routing/pool.go
+++ b/services/ctl-api/internal/pkg/db/routing/pool.go
@@ -1,0 +1,57 @@
+package routing
+
+import (
+	"context"
+	"database/sql"
+
+	"gorm.io/gorm"
+)
+
+var (
+	_ gorm.ConnPool       = (*ConnPool)(nil)
+	_ gorm.TxBeginner     = (*ConnPool)(nil)
+	_ gorm.GetDBConnector = (*ConnPool)(nil)
+)
+
+type ConnPool struct {
+	primary *sql.DB
+	replica *sql.DB
+}
+
+func NewConnPool(primary, replica *sql.DB) *ConnPool {
+	return &ConnPool{
+		primary: primary,
+		replica: replica,
+	}
+}
+
+func (p *ConnPool) readDB(ctx context.Context) *sql.DB {
+	if p.replica != nil && DecisionFromContext(ctx) == PoolReplica {
+		return p.replica
+	}
+	return p.primary
+}
+
+func (p *ConnPool) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	return p.readDB(ctx).QueryContext(ctx, query, args...)
+}
+
+func (p *ConnPool) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return p.readDB(ctx).QueryRowContext(ctx, query, args...)
+}
+
+func (p *ConnPool) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	return p.primary.ExecContext(ctx, query, args...)
+}
+
+func (p *ConnPool) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return p.primary.PrepareContext(ctx, query)
+}
+
+func (p *ConnPool) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	return p.primary.BeginTx(ctx, opts)
+}
+
+func (p *ConnPool) GetDBConn() (*sql.DB, error) {
+	return p.primary, nil
+}

--- a/services/ctl-api/internal/pkg/db/routing/scope.go
+++ b/services/ctl-api/internal/pkg/db/routing/scope.go
@@ -1,0 +1,26 @@
+package routing
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+func Replica(db *gorm.DB) *gorm.DB {
+	return db.WithContext(WithReplica(stmtContext(db)))
+}
+
+func ForceReplica(db *gorm.DB) *gorm.DB {
+	return db.WithContext(WithForceReplica(stmtContext(db)))
+}
+
+func Primary(db *gorm.DB) *gorm.DB {
+	return db.WithContext(WithoutReplica(stmtContext(db)))
+}
+
+func stmtContext(db *gorm.DB) context.Context {
+	if db.Statement != nil && db.Statement.Context != nil {
+		return db.Statement.Context
+	}
+	return context.Background()
+}

--- a/services/ctl-api/internal/pkg/db/scopes/replica.go
+++ b/services/ctl-api/internal/pkg/db/scopes/replica.go
@@ -1,0 +1,31 @@
+package scopes
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/routing"
+)
+
+func WithReplica(db *gorm.DB) *gorm.DB {
+	db.Statement.Context = routing.WithReplica(stmtContext(db))
+	return db
+}
+
+func ForceReplica(db *gorm.DB) *gorm.DB {
+	db.Statement.Context = routing.WithForceReplica(stmtContext(db))
+	return db
+}
+
+func WithoutReplica(db *gorm.DB) *gorm.DB {
+	db.Statement.Context = routing.WithoutReplica(stmtContext(db))
+	return db
+}
+
+func stmtContext(db *gorm.DB) context.Context {
+	if db.Statement != nil && db.Statement.Context != nil {
+		return db.Statement.Context
+	}
+	return context.Background()
+}


### PR DESCRIPTION
### read-replica routing for GORM

This pr instroduces gorm db router that will route between our primary db versus out replica db. Included is a granular set of configurations to power a decision engine on what is routed to the replica.

DB_REPLICA_ENABLED controls whether the replica pool is routable in gorm.
DB_REPLICA_FORCE_ACL auto-routes Allow-listed tables to the replica without opt-in.

Opt-in surfaces include a global GET middleware, per-route replica.OptIn()/OptOut(), GORM scopes in scopes/replica.go, session helpers in routing/, and a @replica-read temporal codegen directive.

A per-table ACL (built from GORM models, view- and join-aware) controls eligibility, and every gorm operation now carries a pool:primary|replica metric tag so routing intent can be validated before the flag flips on.

Wires up Org/App/Install/Account in the seed ACL plus example opt-ins on GET /v1/installs/:id, the install Get activity, and GET /v1/orgs.