### PR TITLE
chore: improve cancellation, queue signal metrics

### DIFF
--- a/services/ctl-api/internal/app/general/worker/activities/get_queue_signal_not_enqueued_metrics.go
+++ b/services/ctl-api/internal/app/general/worker/activities/get_queue_signal_not_enqueued_metrics.go
@@ -1,0 +1,36 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+type NotEnqueuedByType struct {
+	Type  string `gorm:"column:type"`
+	Count int64  `gorm:"column:count"`
+}
+
+type QueueSignalNotEnqueuedMetrics struct {
+	NotEnqueuedByType []NotEnqueuedByType
+}
+
+type GetQueueSignalNotEnqueuedMetricsRequest struct{}
+
+// @temporal-gen-v2 activity
+func (a *Activities) GetQueueSignalNotEnqueuedMetrics(ctx context.Context, req GetQueueSignalNotEnqueuedMetricsRequest) (*QueueSignalNotEnqueuedMetrics, error) {
+	return a.getQueueSignalNotEnqueuedMetrics(ctx, a.db)
+}
+
+func (a *Activities) getQueueSignalNotEnqueuedMetrics(ctx context.Context, db *gorm.DB) (*QueueSignalNotEnqueuedMetrics, error) {
+	var m QueueSignalNotEnqueuedMetrics
+
+	if res := db.WithContext(ctx).
+		Raw(`SELECT type, count(*) as count FROM queue_signals WHERE enqueued = false GROUP BY type`).
+		Scan(&m.NotEnqueuedByType); res.Error != nil {
+		return nil, fmt.Errorf("unable to count not enqueued signals by type: %w", res.Error)
+	}
+
+	return &m, nil
+}

--- a/services/ctl-api/internal/app/general/worker/metrics_workflow.go
+++ b/services/ctl-api/internal/app/general/worker/metrics_workflow.go
@@ -62,26 +62,30 @@ func (w *Workflows) Metrics(ctx workflow.Context) error {
 		"clickhouse_parts_active_stats": func(ctx workflow.Context) error {
 			return w.writeCHPartStats(ctx)
 		},
-		"temporal_orgs": func(ctx workflow.Context) error {
-			return w.temporalNamespaceMetrics(ctx, "orgs")
-		},
-		"temporal_apps": func(ctx workflow.Context) error {
-			return w.temporalNamespaceMetrics(ctx, "apps")
-		},
-		"temporal_components": func(ctx workflow.Context) error {
-			return w.temporalNamespaceMetrics(ctx, "components")
-		},
-		"temporal_installs": func(ctx workflow.Context) error {
-			return w.temporalNamespaceMetrics(ctx, "installs")
-		},
-		"temporal_releases": func(ctx workflow.Context) error {
-			return w.temporalNamespaceMetrics(ctx, "releases")
-		},
-		"temporal_runners": func(ctx workflow.Context) error {
-			return w.temporalNamespaceMetrics(ctx, "runners")
-		},
+		// TODO: temporarily disabled — GetNamespaceMetrics is timing out
+		// "temporal_orgs": func(ctx workflow.Context) error {
+		// 	return w.temporalNamespaceMetrics(ctx, "orgs")
+		// },
+		// "temporal_apps": func(ctx workflow.Context) error {
+		// 	return w.temporalNamespaceMetrics(ctx, "apps")
+		// },
+		// "temporal_components": func(ctx workflow.Context) error {
+		// 	return w.temporalNamespaceMetrics(ctx, "components")
+		// },
+		// "temporal_installs": func(ctx workflow.Context) error {
+		// 	return w.temporalNamespaceMetrics(ctx, "installs")
+		// },
+		// "temporal_releases": func(ctx workflow.Context) error {
+		// 	return w.temporalNamespaceMetrics(ctx, "releases")
+		// },
+		// "temporal_runners": func(ctx workflow.Context) error {
+		// 	return w.temporalNamespaceMetrics(ctx, "runners")
+		// },
 		"queue_signal_enqueue": func(ctx workflow.Context) error {
 			return w.writeQueueSignalEnqueueMetrics(ctx)
+		},
+		"queue_signal_not_enqueued": func(ctx workflow.Context) error {
+			return w.writeQueueSignalNotEnqueuedMetrics(ctx)
 		},
 	}
 
@@ -224,6 +228,21 @@ func (w *Workflows) writeQueueSignalEnqueueMetrics(ctx workflow.Context) error {
 
 	for _, t := range m.UnenqueuedByType {
 		w.mw.Gauge(ctx, "queue_signals.unenqueued",
+			float64(t.Count),
+			metrics.ToTags(map[string]string{"general": "true", "signal_type": t.Type})...)
+	}
+
+	return nil
+}
+
+func (w *Workflows) writeQueueSignalNotEnqueuedMetrics(ctx workflow.Context) error {
+	m, err := activities.AwaitGetQueueSignalNotEnqueuedMetrics(ctx, activities.GetQueueSignalNotEnqueuedMetricsRequest{})
+	if err != nil {
+		return errors.Wrap(err, "unable to get queue signal not enqueued metrics")
+	}
+
+	for _, t := range m.NotEnqueuedByType {
+		w.mw.Gauge(ctx, "queue_signals.not_enqueued",
 			float64(t.Count),
 			metrics.ToTags(map[string]string{"general": "true", "signal_type": t.Type})...)
 	}

--- a/services/ctl-api/internal/app/installs/service/cancel_workflow.go
+++ b/services/ctl-api/internal/app/installs/service/cancel_workflow.go
@@ -105,11 +105,12 @@ func (s *service) cancelSingleWorkflow(ctx *gin.Context, orgID, workflowID strin
 		return fmt.Errorf("workflow is not cancelable (status: %s)", wf.Status.Status)
 	}
 
-	if err := s.cancelWorkflow(ctx, wf.ID); err != nil {
-		return fmt.Errorf("unable to cancel workflow: %w", err)
-	}
-
+	// If the workflow hasn't started yet, cancel it directly in the DB —
+	// there is no signal to cancel.
 	if wf.Status.Status == app.StatusPending {
+		if err := s.cancelWorkflow(ctx, wf.ID); err != nil {
+			return fmt.Errorf("unable to cancel workflow: %w", err)
+		}
 		return nil
 	}
 
@@ -119,17 +120,12 @@ func (s *service) cancelSingleWorkflow(ctx *gin.Context, orgID, workflowID strin
 	}
 
 	if useQueues {
-		step := s.findCancelableStep(wf)
-		if step != nil {
-			if _, err := s.flowsClient.CancelStep(ctx, &flowclient.CancelStepRequest{
-				InstallWorkflowID: wf.ID,
-				StepID:            step.ID,
-			}); err != nil {
-				s.l.Warn("failed to cancel step via queues, workflow already marked cancelled",
-					zap.String("workflow_id", wf.ID),
-					zap.String("step_id", step.ID),
-					zap.Error(err))
-			}
+		if _, err := s.flowsClient.CancelWorkflow(ctx, &flowclient.CancelWorkflowRequest{
+			InstallWorkflowID: wf.ID,
+		}); err != nil {
+			s.l.Warn("failed to cancel workflow via queues",
+				zap.String("workflow_id", wf.ID),
+				zap.Error(err))
 		}
 	} else {
 		id := worker.ExecuteWorkflowIDCallback(signals.RequestSignal{

--- a/services/ctl-api/internal/app/queue_signal.go
+++ b/services/ctl-api/internal/app/queue_signal.go
@@ -128,6 +128,13 @@ func (r *QueueSignal) Indexes(db *gorm.DB) []migrations.Index {
 			},
 			Option: "WHERE deleted_at = 0 AND enqueued = false",
 		},
+		{
+			Name: indexes.Name(db, &QueueSignal{}, "not_enqueued_type"),
+			Columns: []string{
+				"type",
+			},
+			Option: "WHERE enqueued = false",
+		},
 	}
 }
 

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
@@ -159,6 +159,15 @@ func (s *Signal) handle(ctx workflow.Context, startFromGroupIdx int) error {
 	if flw.Status.Status == app.StatusCancelled {
 		return errors.New("workflow already cancelled")
 	}
+	// Restore cancel flag from persisted metadata. The in-memory
+	// cancelRequested flag is lost across ContinueAsNew boundaries, but
+	// cancel_requested_at in the DB survives.
+	if flw.Status.Metadata != nil {
+		if _, ok := flw.Status.Metadata["cancel_requested_at"]; ok {
+			s.cancelRequested = true
+			return nil
+		}
+	}
 
 	defer func() {
 		if errors.Is(ctx.Err(), workflow.ErrCanceled) {

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
@@ -81,13 +81,16 @@ func (s *Signal) Cancel(ctx workflow.Context) error {
 		client.AwaitCancelSignal(cancelCtx, s.activeGroupQueueSignalID)
 	}
 
-	// Mark the workflow as finished + cancelled.
+	// Mark the workflow as finished + cancelled with durable metadata.
 	_ = workflowactivities.AwaitPkgWorkflowsFlowUpdateFlowFinishedAtByID(cancelCtx, s.WorkflowID)
 	_ = statusactivities.AwaitPkgStatusUpdateFlowStatus(cancelCtx, statusactivities.UpdateStatusRequest{
 		ID: s.WorkflowID,
 		Status: app.CompositeStatus{
 			Status:                 app.StatusCancelled,
 			StatusHumanDescription: "workflow cancelled",
+			Metadata: map[string]any{
+				"cancel_requested_at": workflow.Now(cancelCtx).Unix(),
+			},
 		},
 	})
 

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/update_cancel_workflow.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/update_cancel_workflow.go
@@ -20,21 +20,28 @@ type CancelWorkflowResponse struct {
 func (s *Signal) cancelWorkflowHandler(ctx workflow.Context) (*CancelWorkflowResponse, error) {
 	s.cancelRequested = true
 
+	// Persist cancel_requested_at in metadata so downstream signals (groups,
+	// steps) can detect cancellation even if the in-memory flag hasn't
+	// propagated yet. This survives ContinueAsNew and is the durable
+	// source of truth for cancellation.
+	_ = statusactivities.AwaitPkgStatusUpdateFlowStatus(ctx, statusactivities.UpdateStatusRequest{
+		ID: s.WorkflowID,
+		Status: app.CompositeStatus{
+			Status:                 app.StatusCancelled,
+			StatusHumanDescription: "workflow cancelled",
+			Metadata: map[string]any{
+				"cancel_requested_at": workflow.Now(ctx).Unix(),
+			},
+		},
+	})
+
 	// Cancel the active group signal. This triggers the group's Cancel()
 	// method which propagates to step signals and their inner signals.
 	if s.activeGroupQueueSignalID != "" {
 		client.AwaitCancelSignal(ctx, s.activeGroupQueueSignalID)
 	}
 
-	// Mark the workflow as cancelled.
 	_ = workflowactivities.AwaitPkgWorkflowsFlowUpdateFlowFinishedAtByID(ctx, s.WorkflowID)
-	_ = statusactivities.AwaitPkgStatusUpdateFlowStatus(ctx, statusactivities.UpdateStatusRequest{
-		ID: s.WorkflowID,
-		Status: app.CompositeStatus{
-			Status:                 app.StatusCancelled,
-			StatusHumanDescription: "workflow cancelled",
-		},
-	})
 
 	return &CancelWorkflowResponse{WorkflowID: s.WorkflowID}, nil
 }

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/execute_sequential.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/execute_sequential.go
@@ -12,6 +12,15 @@ import (
 // here — the single authoritative place for clone decisions.
 func (s *Signal) executeSequential(ctx workflow.Context, l *zap.Logger) error {
 	for {
+		// Check if cancellation was requested before dispatching the next
+		// step. This closes the race window where the cancel signal is
+		// still propagating through the queue infrastructure but the
+		// in-memory flag or the DB metadata already reflect it.
+		if s.cancelRequested || s.isWorkflowCancelled(ctx) {
+			s.cancelRequested = true
+			return s.writeStepGroupDirective(ctx, directive.GroupStop)
+		}
+
 		steps, err := s.getGroupSteps(ctx)
 		if err != nil {
 			return err
@@ -50,6 +59,7 @@ func (s *Signal) executeSequential(ctx workflow.Context, l *zap.Logger) error {
 			return s.writeStepGroupDirective(ctx, directive.GroupStop)
 
 		case directive.StepRetryGroup:
+			s.cancelRemainingSteps(ctx, l, steps, step.ID, app.StatusDiscarded)
 			return s.writeStepGroupDirective(ctx, directive.GroupRetryGroup)
 
 		case directive.StepSkipGroup:

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/signal.go
@@ -244,6 +244,25 @@ func (s *Signal) writeWorkflowDirective(ctx workflow.Context, d string) error {
 	})
 }
 
+// isWorkflowCancelled checks the workflow's persisted status for cancellation.
+// This is a durable check that works even if the in-memory cancelRequested flag
+// hasn't been set (e.g., cancel propagation is still in flight).
+func (s *Signal) isWorkflowCancelled(ctx workflow.Context) bool {
+	flw, err := activities.AwaitPkgWorkflowsFlowGetFlowByID(ctx, s.WorkflowID)
+	if err != nil {
+		return false
+	}
+	if flw.Status.Status == app.StatusCancelled {
+		return true
+	}
+	if flw.Status.Metadata != nil {
+		if _, ok := flw.Status.Metadata["cancel_requested_at"]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 func isTerminalStatus(status app.Status) bool {
 	switch status {
 	case app.StatusSuccess, app.StatusAutoSkipped, app.StatusUserSkipped,


### PR DESCRIPTION
This PR fixes a few issues:

1. we were not actually emitting some metrics, because our temporal metrics loops were timing out. We no longer need them, so cancelling for now.
2. we emit aggregate data on metric enqueuing now
3. fixes a long-standing bug where a cancellation could be ignored, due to a race. We fix this by testing for a cancellation requested between each step in a group, and each group in a workflow.
4. fixes an issue where we do not cancel remaining steps in a group, when retrying a group.