### PR TITLE
chore: cleanup general queue configuration

### DIFF
--- a/services/ctl-api/internal/app/general/service/restart_event_loops_workflow.go
+++ b/services/ctl-api/internal/app/general/service/restart_event_loops_workflow.go
@@ -1,14 +1,14 @@
 package service
 
 import (
-	"errors"
-	"io"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/general/signals"
-	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/general/signals/v2/promotion"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
 
 type RestartGeneralEventLoopRequest struct{}
@@ -20,21 +20,22 @@ type RestartGeneralEventLoopRequest struct{}
 // @Tags					general/admin
 // @Accept					json
 // @Produce				json
-// @Success				201	{string}	ok
+// @Success				200	{object}	app.EmptyResponse
 // @Router					/v1/general/restart-event-loop [post]
 func (s *service) RestartGeneralEventLoop(ctx *gin.Context) {
-	var req RestartGeneralEventLoopRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
-		ctx.Error(stderr.NewInvalidRequest(err))
+	q, err := s.generalHelpers.EnsureGeneralQueue(ctx)
+	if err != nil {
+		ctx.Error(fmt.Errorf("unable to ensure general queue: %w", err))
 		return
 	}
 
-	s.evClient.Send(ctx, "general", &signals.Signal{
-		Type: signals.OperationRestart,
-	})
+	if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+		QueueID: q.ID,
+		Signal:  &promotion.Signal{},
+	}); err != nil {
+		ctx.Error(fmt.Errorf("unable to enqueue promotion signal: %w", err))
+		return
+	}
 
-	ctx.JSON(http.StatusCreated, map[string]string{
-		"status": "ok",
-		"type":   string(signals.OperationRestart),
-	})
+	ctx.JSON(http.StatusOK, app.EmptyResponse{})
 }

--- a/services/ctl-api/internal/app/general/signals/v2/promotion/signal.go
+++ b/services/ctl-api/internal/app/general/signals/v2/promotion/signal.go
@@ -3,6 +3,8 @@ package promotion
 import (
 	"fmt"
 
+	enumsv1 "go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
@@ -62,5 +64,42 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		)
 	}
 
+	// Start (or replace) the enqueuer sweep cron workflow.
+	startSweepWorkflow(ctx)
+
+	// Start (or replace) the general metrics cron workflow.
+	startMetricsWorkflow(ctx)
+
 	return nil
+}
+
+func startSweepWorkflow(ctx workflow.Context) {
+	cwo := workflow.ChildWorkflowOptions{
+		WorkflowID:            "enqueuer-sweep",
+		CronSchedule:          "* * * * *",
+		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+		ParentClosePolicy:     enumsv1.PARENT_CLOSE_POLICY_ABANDON,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 0,
+		},
+	}
+	ctx = workflow.WithChildOptions(ctx, cwo)
+
+	type sweepReq struct{}
+	workflow.ExecuteChildWorkflow(ctx, "EnqueuerSweep", sweepReq{})
+}
+
+func startMetricsWorkflow(ctx workflow.Context) {
+	cwo := workflow.ChildWorkflowOptions{
+		WorkflowID:            "general-metrics-cron",
+		CronSchedule:          "*/1 * * * *",
+		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+		ParentClosePolicy:     enumsv1.PARENT_CLOSE_POLICY_ABANDON,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 0,
+		},
+	}
+	ctx = workflow.WithChildOptions(ctx, cwo)
+
+	workflow.ExecuteChildWorkflow(ctx, "Metrics")
 }

--- a/services/ctl-api/internal/app/general/signals/v2/promotion/signal.go
+++ b/services/ctl-api/internal/app/general/signals/v2/promotion/signal.go
@@ -3,8 +3,6 @@ package promotion
 import (
 	"fmt"
 
-	enumsv1 "go.temporal.io/api/enums/v1"
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
@@ -64,42 +62,18 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		)
 	}
 
-	// Start (or replace) the enqueuer sweep cron workflow.
-	startSweepWorkflow(ctx)
-
-	// Start (or replace) the general metrics cron workflow.
-	startMetricsWorkflow(ctx)
+	// Start (or replace) the enqueuer sweep and metrics cron workflows
+	// as top-level Temporal cron workflows via the client.
+	cronResp, err := generalactivities.AwaitEnsureCronWorkflows(ctx, generalactivities.EnsureCronWorkflowsRequest{})
+	if err != nil {
+		return fmt.Errorf("ensure cron workflows: %w", err)
+	}
+	if l != nil {
+		l.Info("ensured cron workflows",
+			zap.Bool("sweep_started", cronResp.SweepStarted),
+			zap.Bool("metrics_started", cronResp.MetricsStarted),
+		)
+	}
 
 	return nil
-}
-
-func startSweepWorkflow(ctx workflow.Context) {
-	cwo := workflow.ChildWorkflowOptions{
-		WorkflowID:            "enqueuer-sweep",
-		CronSchedule:          "* * * * *",
-		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
-		ParentClosePolicy:     enumsv1.PARENT_CLOSE_POLICY_ABANDON,
-		RetryPolicy: &temporal.RetryPolicy{
-			MaximumAttempts: 0,
-		},
-	}
-	ctx = workflow.WithChildOptions(ctx, cwo)
-
-	type sweepReq struct{}
-	workflow.ExecuteChildWorkflow(ctx, "EnqueuerSweep", sweepReq{})
-}
-
-func startMetricsWorkflow(ctx workflow.Context) {
-	cwo := workflow.ChildWorkflowOptions{
-		WorkflowID:            "general-metrics-cron",
-		CronSchedule:          "*/1 * * * *",
-		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
-		ParentClosePolicy:     enumsv1.PARENT_CLOSE_POLICY_ABANDON,
-		RetryPolicy: &temporal.RetryPolicy{
-			MaximumAttempts: 0,
-		},
-	}
-	ctx = workflow.WithChildOptions(ctx, cwo)
-
-	workflow.ExecuteChildWorkflow(ctx, "Metrics")
 }

--- a/services/ctl-api/internal/app/general/worker/activities/ensure_cron_workflows.go
+++ b/services/ctl-api/internal/app/general/worker/activities/ensure_cron_workflows.go
@@ -1,0 +1,64 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	enumsv1 "go.temporal.io/api/enums/v1"
+	tclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/pkg/workflows"
+)
+
+type EnsureCronWorkflowsRequest struct{}
+
+type EnsureCronWorkflowsResponse struct {
+	SweepStarted   bool `json:"sweep_started"`
+	MetricsStarted bool `json:"metrics_started"`
+}
+
+// EnsureCronWorkflows starts (or replaces) the enqueuer-sweep and
+// general-metrics-cron workflows as top-level Temporal cron workflows.
+//
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 2m
+func (a *Activities) EnsureCronWorkflows(ctx context.Context, _ EnsureCronWorkflowsRequest) (*EnsureCronWorkflowsResponse, error) {
+	resp := &EnsureCronWorkflowsResponse{}
+
+	// Start (or replace) the enqueuer sweep cron.
+	sweepOpts := tclient.StartWorkflowOptions{
+		ID:                    "enqueuer-sweep",
+		TaskQueue:             workflows.APITaskQueue,
+		CronSchedule:          "* * * * *",
+		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 0,
+		},
+	}
+	type sweepReq struct{}
+	if _, err := a.tClient.ExecuteWorkflowInNamespace(ctx, "general", sweepOpts, "EnqueuerSweep", sweepReq{}); err != nil {
+		return nil, fmt.Errorf("unable to start enqueuer sweep workflow: %w", err)
+	}
+	resp.SweepStarted = true
+	a.logger.Info("enqueuer sweep cron started/replaced", zap.String("workflow-id", "enqueuer-sweep"))
+
+	// Start (or replace) the general metrics cron.
+	metricsOpts := tclient.StartWorkflowOptions{
+		ID:                    "general-metrics-cron",
+		TaskQueue:             workflows.APITaskQueue,
+		CronSchedule:          "*/1 * * * *",
+		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 0,
+		},
+	}
+	if _, err := a.tClient.ExecuteWorkflowInNamespace(ctx, "general", metricsOpts, "Metrics"); err != nil {
+		return nil, fmt.Errorf("unable to start general metrics workflow: %w", err)
+	}
+	resp.MetricsStarted = true
+	a.logger.Info("general metrics cron started/replaced", zap.String("workflow-id", "general-metrics-cron"))
+
+	return resp, nil
+}

--- a/services/ctl-api/internal/app/general/worker/event_loop_workflow.go
+++ b/services/ctl-api/internal/app/general/worker/event_loop_workflow.go
@@ -34,7 +34,6 @@ func (w *Workflows) EventLoop(ctx workflow.Context, req eventloop.EventLoopReque
 		},
 		StartupHook: func(ctx workflow.Context, req eventloop.EventLoopRequest) error {
 			w.startPurgeStaleDataWorkflow(ctx)
-			w.startMetricsWorkflow(ctx)
 			w.startRestartOrgRunnersWorkflow(ctx)
 			w.startRestartOrgEventLoopsWorkflow(ctx)
 			return nil


### PR DESCRIPTION
There are a few background processes that need to be run with the control-plane. This PR updates the endpoints in the 
general namespace to run those via queues and remove some old compatibility issues.
