### PR TITLE
chore(cli): runners of type aws require the init script url to be set

### DIFF
--- a/pkg/config/app_runner.go
+++ b/pkg/config/app_runner.go
@@ -59,20 +59,26 @@ func (a *AppRunnerConfig) parse() error {
 		}
 	}
 
-	if a.Source == "" {
-		return nil
-	}
+	if a.Source != "" {
+		obj, err := source.LoadSource(a.Source)
+		if err != nil {
+			return ErrConfig{
+				Description: fmt.Sprintf("unable to load source %s", a.Source),
+				Err:         err,
+			}
+		}
 
-	obj, err := source.LoadSource(a.Source)
-	if err != nil {
-		return ErrConfig{
-			Description: fmt.Sprintf("unable to load source %s", a.Source),
-			Err:         err,
+		if err := mapstructure.Decode(obj, &a); err != nil {
+			return err
 		}
 	}
 
-	if err := mapstructure.Decode(obj, &a); err != nil {
-		return err
+	if a.RunnerType == "aws" && a.InitScriptURL == "" {
+		return ErrConfig{
+			Description: "init_script_url is required when runner_type is aws",
+			Err:         fmt.Errorf("init_script_url is required when runner_type is aws"),
+		}
 	}
+
 	return nil
 }

--- a/pkg/config/app_runner_test.go
+++ b/pkg/config/app_runner_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppRunnerConfig_Parse_AWS_RequiresInitScriptURL(t *testing.T) {
+	cfg := &AppRunnerConfig{
+		RunnerType: "aws",
+	}
+	err := cfg.parse()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "init_script_url is required when runner_type is aws")
+}
+
+func TestAppRunnerConfig_Parse_AWS_WithInitScriptURL(t *testing.T) {
+	cfg := &AppRunnerConfig{
+		RunnerType:    "aws",
+		InitScriptURL: "https://example.com/init.sh",
+	}
+	require.NoError(t, cfg.parse())
+}
+
+func TestAppRunnerConfig_Parse_NonAWS_NoInitScriptURL(t *testing.T) {
+	cfg := &AppRunnerConfig{
+		RunnerType: "azure",
+	}
+	require.NoError(t, cfg.parse())
+}


### PR DESCRIPTION
### Description

This makes the init_script_url required so it's never absent so we never fall back to a default.

Why tho: it is imprudent to have a fallback in the Runner ASG CloudFormation if we want to version and vendor the runner init script.

### Notes

We could also forgo this approach and allow a fallback to a default _in code_ but not in the template. We can add an env_var for a default init script url in the ctl-api config which would automatically be used in (re) provision. For BYOC, this env var would be an input.

Why tho: the configurable default would allow app authors to not have to think about the init script url which is desirable now that the vast majorify of patterns have been established.
