### PR TITLE
feat(ui): add support for stratus card in markdown

### DIFF
--- a/docs/guides/using-readmes.mdx
+++ b/docs/guides/using-readmes.mdx
@@ -341,6 +341,26 @@ A flexbox layout container for arranging other elements.
 Attributes: `gap` (number), `align`, `justify`, `wrap` (`"true"` or `"false"`,
 defaults to true).
 
+### Card
+
+Wraps content in a styled card container with border, padding, and shadow.
+
+```markdown README.md
+<nuon-card>
+
+## Quick reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REPLICAS` | `2` | Number of API server replicas |
+| `LOG_LEVEL` | `info` | Application log level |
+
+</nuon-card>
+```
+
+Attributes:
+- `class` — optional CSS class name for custom styling
+
 ### Tabs
 
 Renders tabbed content sections. Wrap `<nuon-tab>` elements inside a

--- a/services/dashboard-ui/client/components/common/Markdown/Markdown.stories.tsx
+++ b/services/dashboard-ui/client/components/common/Markdown/Markdown.stories.tsx
@@ -1152,6 +1152,48 @@ In a group:
     </div>
 
     <div className="space-y-4">
+      <h4 className="text-sm font-medium">Card</h4>
+      <p className="text-xs text-gray-500 dark:text-gray-500">
+        Use {'<nuon-card>'} to wrap content in a styled card container.
+      </p>
+      <div className="p-4 border rounded-lg">
+        <Markdown
+          content={`<nuon-card>
+
+## Environment status
+
+<nuon-group gap="2" align="center">
+  <nuon-badge theme="success">Production</nuon-badge>
+  <nuon-badge theme="warn">Staging</nuon-badge>
+  <nuon-badge theme="error">Development</nuon-badge>
+</nuon-group>
+
+</nuon-card>
+
+Cards in a group:
+
+<nuon-group gap="4">
+  <nuon-card>
+
+**Step 1:** Create an install
+
+  </nuon-card>
+  <nuon-card>
+
+**Step 2:** Deploy components
+
+  </nuon-card>
+  <nuon-card>
+
+**Step 3:** Verify health
+
+  </nuon-card>
+</nuon-group>`}
+        />
+      </div>
+    </div>
+
+    <div className="space-y-4">
       <h4 className="text-sm font-medium">Combined example</h4>
       <div className="p-4 border rounded-lg">
         <Markdown

--- a/services/dashboard-ui/client/components/common/Markdown/nuon-components.tsx
+++ b/services/dashboard-ui/client/components/common/Markdown/nuon-components.tsx
@@ -10,6 +10,7 @@ import { SandboxCard } from '@/components/sandbox/SandboxCard'
 import { RunnerCard } from '@/components/runners/RunnerCard'
 import { StackCard } from '@/components/stacks/StackCard'
 import { Group } from '@/components/common/Group'
+import { Card } from '@/components/common/Card'
 import { ViewStateButton } from '@/components/installs/management/ViewState'
 
 export type MarkdownMode = 'app' | 'install'
@@ -107,6 +108,13 @@ const registry: Record<string, NuonComponent> = {
       align: attrs.align,
       justify: attrs.justify,
       wrap: attrs.wrap === 'false' ? false : true,
+    }),
+  },
+  'nuon-card': {
+    component: Card,
+    mapProps: (attrs) => ({
+      children: attrs.children,
+      className: attrs.class,
     }),
   },
 }


### PR DESCRIPTION
 Add support for `<nuon-card></nuon-card>` display component to the README markdown rendering.