### PR TITLE
fix: generate state in beginning of update inputs workflow

### DIFF
--- a/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
@@ -19,6 +19,10 @@ import (
 
 func InputUpdate(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResult, error) {
 	installID := generics.FromPtrStr(flw.Metadata["install_id"])
+	install, err := activities.AwaitGetByInstallID(ctx, installID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get install")
+	}
 
 	sg := newStepGroup(flw)
 	steps := make([]*app.WorkflowStep, 0)
@@ -48,11 +52,6 @@ func InputUpdate(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRes
 
 	changedInputsRaw := generics.FromPtrStr(flw.Metadata["inputs"])
 	changedInputs := strings.Split(changedInputsRaw, ",")
-
-	install, err := activities.AwaitGetByInstallID(ctx, installID)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get install")
-	}
 
 	appConfig, err := activities.AwaitGetAppConfig(ctx, activities.GetAppConfigRequest{
 		ID: install.AppConfigID,

--- a/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
@@ -21,8 +21,30 @@ func InputUpdate(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRes
 	installID := generics.FromPtrStr(flw.Metadata["install_id"])
 
 	sg := newStepGroup(flw)
-
 	steps := make([]*app.WorkflowStep, 0)
+
+	sg.nextGroup() // refresh inputs partial in state
+	orgEnabled, err := activities.AwaitHasFeatureByFeature(ctx, string(app.OrgFeatureStateGenV2))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to check state-gen-v2 feature")
+	}
+	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
+	var stateSignal signal.Signal
+	if stateGenV2 {
+		stateSignal = &statepartialgenerate.Signal{
+			InstallID:       installID,
+			Targets:         statemanager.TargetsForHint(statemanager.HintInputsUpdated, ""),
+			TriggeredByID:   installID,
+			TriggeredByType: "installs",
+		}
+	} else {
+		stateSignal = &generatestate.Signal{InstallID: installID}
+	}
+	step, err := sg.installSignalStep(ctx, installID, "update install state inputs", pgtype.Hstore{}, stateSignal, flw.PlanOnly, WithSkippable(false))
+	if err != nil {
+		return nil, err
+	}
+	steps = append(steps, step)
 
 	changedInputsRaw := generics.FromPtrStr(flw.Metadata["inputs"])
 	changedInputs := strings.Split(changedInputsRaw, ",")
@@ -107,29 +129,6 @@ func InputUpdate(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRes
 		return nil, err
 	}
 	steps = append(steps, lifecycleSteps...)
-
-	sg.nextGroup() // refresh inputs partial in state
-	orgEnabled, err := activities.AwaitHasFeatureByFeature(ctx, string(app.OrgFeatureStateGenV2))
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to check state-gen-v2 feature")
-	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	var stateSignal signal.Signal
-	if stateGenV2 {
-		stateSignal = &statepartialgenerate.Signal{
-			InstallID:       installID,
-			Targets:         statemanager.TargetsForHint(statemanager.HintInputsUpdated, ""),
-			TriggeredByID:   installID,
-			TriggeredByType: "installs",
-		}
-	} else {
-		stateSignal = &generatestate.Signal{InstallID: installID}
-	}
-	step, err := sg.installSignalStep(ctx, installID, "update install state inputs", pgtype.Hstore{}, stateSignal, flw.PlanOnly, WithSkippable(false))
-	if err != nil {
-		return nil, err
-	}
-	steps = append(steps, step)
 
 	return sg.Result(steps), nil
 }


### PR DESCRIPTION
missing state generation causes component to use stale state, till we land state gen ve we need to generate state before starting any workflow step