### PR TITLE
feat: add stack events to the slack app

### DIFF
--- a/bins/cli/cmd/orgs.go
+++ b/bins/cli/cmd/orgs.go
@@ -319,6 +319,7 @@ EXAMPLES
       "interests": {
         "resources": {
           "installs":               {"outcome": "completion", "approval_requests": true, "approval_responses": true},
+          "stacks":                 {"outcome": "completion"},
           "components":             {"outcome": "completion", "approval_requests": true, "approval_responses": true, "drift_detected": true},
           "sandboxes":              {"outcome": "completion", "approval_requests": true, "approval_responses": true, "drift_detected": true},
           "install_configurations": {"outcome": "completion", "approval_requests": true, "approval_responses": true}

--- a/bins/cli/internal/services/orgs/subscriptiontui/tui.go
+++ b/bins/cli/internal/services/orgs/subscriptiontui/tui.go
@@ -49,6 +49,7 @@ type API interface {
 var (
 	resourceKinds = []string{
 		"installs",
+		"stacks",
 		"components",
 		"sandboxes",
 		"install_configurations",
@@ -61,6 +62,7 @@ var (
 	// multi-select blank is a valid (and idiomatic) choice.
 	resourceOps = map[string][]string{
 		"installs":               {"provision", "deprovision", "reprovision"},
+		"stacks":                 {"version_active"},
 		"components":             {"deploy", "teardown"},
 		"sandboxes":              {"provision", "reprovision", "deprovision"},
 		"install_configurations": {"inputs", "secrets"},

--- a/docs/guides/webhooks.mdx
+++ b/docs/guides/webhooks.mdx
@@ -85,6 +85,7 @@ Each resource accepts a list of sub-ops drawn from a fixed vocabulary:
 | Resource                 | Supported `ops`                                            |
 | ------------------------ | ---------------------------------------------------------- |
 | `installs`               | `provision`, `deprovision`, `reprovision`                  |
+| `stacks`                 | `version_active`                                           |
 | `components`             | `deploy`, `teardown`                                       |
 | `sandboxes`              | `provision`, `reprovision`, `deprovision`                  |
 | `install_configurations` | `inputs`, `secrets`                                        |
@@ -151,6 +152,7 @@ notifications for the four most common resources:
 {
   "resources": {
     "installs":               { "outcome": "completion", "approval_requests": true, "approval_responses": true },
+    "stacks":                 { "outcome": "completion" },
     "components":             { "outcome": "completion", "approval_requests": true, "approval_responses": true, "drift_detected": true },
     "sandboxes":              { "outcome": "completion", "approval_requests": true, "approval_responses": true, "drift_detected": true },
     "install_configurations": { "outcome": "completion", "approval_requests": true, "approval_responses": true }

--- a/services/ctl-api/internal/app/slack/service/slack_oauth_callback.go
+++ b/services/ctl-api/internal/app/slack/service/slack_oauth_callback.go
@@ -21,14 +21,26 @@ import (
 // oauthErrorPage is the HTML shown to the user in their browser when the OAuth
 // callback fails. Slack opens the redirect in a browser tab so we render a
 // human-readable page rather than a JSON error envelope.
+//
+// The body is intentionally padded past 512 bytes: Chrome (and some other
+// browsers) replace short 4xx/5xx response bodies with their own generic
+// error page, hiding the actual failure message from the user.
 var oauthErrorPage = template.Must(template.New("slack-oauth-error").Parse(`<!doctype html>
-<html><head><meta charset="utf-8"><title>Slack install failed</title>
-<style>body{font-family:system-ui,sans-serif;max-width:540px;margin:64px auto;color:#222}
-h1{font-size:20px}p{line-height:1.45}code{background:#f3f3f3;padding:2px 4px;border-radius:3px}</style>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Slack install failed</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;max-width:600px;margin:64px auto;padding:0 24px;color:#222;line-height:1.5}
+h1{font-size:22px;margin-bottom:16px;color:#b00020}
+p{margin:12px 0}
+.message{background:#fff3f3;border-left:4px solid #b00020;padding:12px 16px;border-radius:4px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;word-break:break-word}
+.hint{color:#666;font-size:14px}
+code{background:#f3f3f3;padding:2px 6px;border-radius:3px;font-size:13px}
+</style>
 </head><body>
 <h1>Slack install failed</h1>
-<p>{{.Message}}</p>
-<p>You can close this tab and retry the install from the Nuon dashboard.</p>
+<p>We couldn't complete the Slack install. The error reported by the server was:</p>
+<p class="message">{{.Message}}</p>
+<p class="hint">You can safely close this tab and retry the install from the Nuon dashboard. If the problem persists, check the <code>ctl-api</code> server logs for entries tagged <code>slack oauth</code> — the warn/error line there will have the underlying cause (e.g. redirect_uri mismatch, expired state JWT, or missing client credentials).</p>
+<p class="hint">If you need to contact support, include the timestamp of this attempt and the Slack workspace you were installing into.</p>
 </body></html>`))
 
 // SlackOAuthCallback is the redirect target for the Slack OAuth v2 install

--- a/services/ctl-api/internal/app/slack/service/subscribe_modal.go
+++ b/services/ctl-api/internal/app/slack/service/subscribe_modal.go
@@ -673,6 +673,8 @@ func resourceKindLabel(k interests.ResourceKind) string {
 	switch k {
 	case interests.ResourceInstalls:
 		return "Installs"
+	case interests.ResourceStacks:
+		return "Stacks"
 	case interests.ResourceComponents:
 		return "Components"
 	case interests.ResourceSandboxes:
@@ -710,6 +712,8 @@ func subOpLabel(op string) string {
 		return "Inactive"
 	case "run":
 		return "Run"
+	case "version_active":
+		return "Version active"
 	default:
 		return op
 	}

--- a/services/ctl-api/internal/pkg/interests/classify.go
+++ b/services/ctl-api/internal/pkg/interests/classify.go
@@ -39,6 +39,7 @@ const (
 	stepTargetInstallActionRuns        = "install_action_workflow_runs"
 	stepTargetInstallRunnerUpdate      = "install_runner_update"
 	stepTargetInstallCloudFormation    = "install_cloudformation_stack"
+	stepTargetInstallStackVersions     = "install_stack_versions"
 	stepTargetRunners                  = "runners"
 )
 
@@ -322,6 +323,13 @@ func stepResolution(stepTargetType, parentWorkflowType string) (ResourceKind, st
 
 	case stepTargetInstallActionWorkflowRun, stepTargetInstallActionRuns:
 		return ResourceActions, "run", true
+
+	case stepTargetInstallStackVersions:
+		// The await-install-stack-version-run step succeeds when the install
+		// stack version flips to active — surface that as (stacks, version_active)
+		// rather than falling through to the parent provision/reprovision
+		// workflow's sandbox-provision classification.
+		return ResourceStacks, "version_active", true
 
 	case stepTargetInstallRunnerUpdate, stepTargetInstallCloudFormation, stepTargetRunners:
 		switch parentWorkflowType {

--- a/services/ctl-api/internal/pkg/interests/defaults.go
+++ b/services/ctl-api/internal/pkg/interests/defaults.go
@@ -9,10 +9,10 @@ func AllEvents() Interests {
 }
 
 // Default returns the materialised "power user opted out of AllEvents"
-// baseline. Four resources (installs, components, sandboxes,
+// baseline. Five resources (installs, stacks, components, sandboxes,
 // install_configurations) are present with empty ops (= all sub-ops),
-// Outcome=Completion, and approval flags both true. Runners + actions are
-// absent (= off).
+// Outcome=Completion, and approval flags both true (where supported).
+// Runners + actions are absent (= off).
 //
 // Toggling "Send all events" off in the picker writes this exact shape so
 // users land on a sensible per-resource starting point instead of an empty
@@ -24,6 +24,9 @@ func Default() Interests {
 				Outcome:           OutcomeCompletion,
 				ApprovalRequests:  true,
 				ApprovalResponses: true,
+			},
+			ResourceStacks: {
+				Outcome: OutcomeCompletion,
 			},
 			ResourceComponents: {
 				Outcome:           OutcomeCompletion,

--- a/services/ctl-api/internal/pkg/interests/interests_test.go
+++ b/services/ctl-api/internal/pkg/interests/interests_test.go
@@ -668,6 +668,22 @@ func TestStepResolution(t *testing.T) {
 			wantOK:         true,
 		},
 		{
+			name:           "install stack version step inside provision → stacks.version_active",
+			stepTargetType: stepTargetInstallStackVersions,
+			parentWfType:   "provision",
+			wantResource:   ResourceStacks,
+			wantOp:         "version_active",
+			wantOK:         true,
+		},
+		{
+			name:           "install stack version step inside reprovision → stacks.version_active",
+			stepTargetType: stepTargetInstallStackVersions,
+			parentWfType:   "reprovision",
+			wantResource:   ResourceStacks,
+			wantOp:         "version_active",
+			wantOK:         true,
+		},
+		{
 			name:           "unknown step target type → not resolved",
 			stepTargetType: "install_random_thing",
 			parentWfType:   "provision",

--- a/services/ctl-api/internal/pkg/interests/types.go
+++ b/services/ctl-api/internal/pkg/interests/types.go
@@ -25,6 +25,7 @@ type ResourceKind string
 
 const (
 	ResourceInstalls              ResourceKind = "installs"
+	ResourceStacks                ResourceKind = "stacks"
 	ResourceComponents            ResourceKind = "components"
 	ResourceSandboxes             ResourceKind = "sandboxes"
 	ResourceInstallConfigurations ResourceKind = "install_configurations"
@@ -36,6 +37,7 @@ const (
 // renders rows in this order; defaults() / docs walk it.
 var AllResources = []ResourceKind{
 	ResourceInstalls,
+	ResourceStacks,
 	ResourceComponents,
 	ResourceSandboxes,
 	ResourceInstallConfigurations,
@@ -76,6 +78,7 @@ const (
 // event that only fires when the plan-only check observes actual changes.
 var SubOps = map[ResourceKind][]string{
 	ResourceInstalls:              {"provision", "deprovision", "reprovision"},
+	ResourceStacks:                {"version_active"},
 	ResourceComponents:            {"deploy", "teardown"},
 	ResourceSandboxes:             {"provision", "reprovision", "deprovision"},
 	ResourceInstallConfigurations: {"inputs", "secrets"},

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/event_targets.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/event_targets.go
@@ -84,6 +84,12 @@ func EventTargetsFromEvent(ctx context.Context, db *gorm.DB, event signal.Signal
 					t.ActionID = id
 				}
 			}
+		case string(app.WorkflowStepTargetTypeInstallStackVersions):
+			if t.InstallID == "" {
+				if id := lookupInstallIDFromStackVersion(ctx, db, data.Step.TargetID); id != "" {
+					t.InstallID = id
+				}
+			}
 		}
 
 		// Sandbox-derived install. The sandbox is owned by exactly one
@@ -151,6 +157,28 @@ func lookupInstallIDFromSandbox(ctx context.Context, db *gorm.DB, sandboxID stri
 		Table("install_sandboxes").
 		Select("install_id").
 		Where("id = ?", sandboxID).
+		Scan(&row).Error; err != nil {
+		return ""
+	}
+	return row.InstallID
+}
+
+// lookupInstallIDFromStackVersion resolves the install id behind an
+// install_stack_versions row directly via its install_id column. The
+// await-install-stack-version-run step uses this target type, so install-scoped
+// Match (specific installs / label selectors) needs this to fire for the
+// (stacks, version_active) event.
+func lookupInstallIDFromStackVersion(ctx context.Context, db *gorm.DB, stackVersionID string) string {
+	if db == nil || stackVersionID == "" {
+		return ""
+	}
+	var row struct {
+		InstallID string
+	}
+	if err := db.WithContext(ctx).
+		Table("install_stack_versions").
+		Select("install_id").
+		Where("id = ?", stackVersionID).
 		Scan(&row).Error; err != nil {
 		return ""
 	}

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/slack.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/slack.go
@@ -727,6 +727,12 @@ func (h *SlackSignalLifecycleHook) eventTargetsFromEvent(ctx context.Context, ev
 					t.ActionID = id
 				}
 			}
+		case string(app.WorkflowStepTargetTypeInstallStackVersions):
+			if t.InstallID == "" {
+				if id := h.lookupInstallIDFromStackVersion(ctx, data.Step.TargetID); id != "" {
+					t.InstallID = id
+				}
+			}
 		}
 
 		// Sandbox-derived install. The sandbox is owned by exactly one
@@ -847,6 +853,27 @@ func (l *labelLoader) fetch(ctx context.Context, table, id string) (labels.Label
 	}
 	l.cache[key] = row.Labels
 	return row.Labels, nil
+}
+
+// lookupInstallIDFromStackVersion resolves the install id behind an
+// install_stack_versions row directly via its install_id column. Used by
+// the await-install-stack-version-run step's (stacks, version_active) event
+// so install-scoped Match works.
+func (h *SlackSignalLifecycleHook) lookupInstallIDFromStackVersion(ctx context.Context, stackVersionID string) string {
+	if h.db == nil || stackVersionID == "" {
+		return ""
+	}
+	var row struct {
+		InstallID string
+	}
+	if err := h.db.WithContext(ctx).
+		Table("install_stack_versions").
+		Select("install_id").
+		Where("id = ?", stackVersionID).
+		Scan(&row).Error; err != nil {
+		return ""
+	}
+	return row.InstallID
 }
 
 func (h *SlackSignalLifecycleHook) lookupInstallIDFromDeploy(ctx context.Context, deployID string) string {

--- a/services/dashboard-ui/client/components/interests/defaults.ts
+++ b/services/dashboard-ui/client/components/interests/defaults.ts
@@ -13,6 +13,7 @@ export const allEvents = (): Interests => ({ all_events: true })
 export const defaultInterests = (): Interests => ({
   resources: {
     installs: { outcome: 'completion', approval_requests: true, approval_responses: true },
+    stacks: { outcome: 'completion' },
     components: { outcome: 'completion', approval_requests: true, approval_responses: true, drift_detected: true },
     sandboxes: { outcome: 'completion', approval_requests: true, approval_responses: true, drift_detected: true },
     install_configurations: { outcome: 'completion', approval_requests: true, approval_responses: true },

--- a/services/dashboard-ui/client/components/interests/subops.ts
+++ b/services/dashboard-ui/client/components/interests/subops.ts
@@ -13,6 +13,7 @@ import type { ResourceKind } from './types'
 
 export const SUB_OPS: Record<ResourceKind, string[]> = {
   installs: ['provision', 'deprovision', 'reprovision'],
+  stacks: ['version_active'],
   components: ['deploy', 'teardown'],
   sandboxes: ['provision', 'reprovision', 'deprovision'],
   install_configurations: ['inputs', 'secrets'],
@@ -43,6 +44,8 @@ const SUB_OP_LABELS: Record<string, string> = {
   inactive: 'Inactive',
   // actions
   run: 'Run',
+  // stacks
+  version_active: 'Version active',
 }
 
 export const labelForSubOp = (op: string): string =>

--- a/services/dashboard-ui/client/components/interests/types.ts
+++ b/services/dashboard-ui/client/components/interests/types.ts
@@ -8,6 +8,7 @@
 
 export type ResourceKind =
   | 'installs'
+  | 'stacks'
   | 'components'
   | 'sandboxes'
   | 'install_configurations'
@@ -39,6 +40,7 @@ export interface Interests {
 // UI rows render in this order; defaults() walks it.
 export const ALL_RESOURCES: ResourceKind[] = [
   'installs',
+  'stacks',
   'components',
   'sandboxes',
   'install_configurations',
@@ -49,6 +51,7 @@ export const ALL_RESOURCES: ResourceKind[] = [
 // Human label per resource. Sentence-case.
 export const RESOURCE_LABELS: Record<ResourceKind, string> = {
   installs: 'Installs',
+  stacks: 'Stacks',
   components: 'Components',
   sandboxes: 'Sandboxes',
   install_configurations: 'Install configurations',
@@ -58,6 +61,7 @@ export const RESOURCE_LABELS: Record<ResourceKind, string> = {
 
 export const RESOURCE_DESCRIPTIONS: Record<ResourceKind, string> = {
   installs: 'Install provision, deprovision, reprovision lifecycle.',
+  stacks: 'Install stack lifecycle, including when a stack version becomes active.',
   components: 'Per-component deploy and teardown. Toggle drift detected to be notified when drift is found.',
   sandboxes: 'Sandbox provision, reprovision, deprovision. Toggle drift detected to be notified when drift is found.',
   install_configurations: 'Install input updates and secret syncs.',


### PR DESCRIPTION
## Problem

Users currently can't see Stack events in the Slack integration. Provisioning the stack is currently the most opaque part of the process for the vendor, and we want to lay the foundation for a better experience that we can iterate on.

## Solution

This PR adds Stacks as a resource to the Slack integration, so that signals from stack steps are correctly classified and surfaced in Slack.

<img width="1200" height="1674" alt="Screenshot 2026-05-27 at 08 27 56" src="https://github.com/user-attachments/assets/b9c6ca5e-3f47-4f7f-ae67-da79a39ec27c" />

It _does not_ enable selecting Stacks a resource in the configuration UI. Currently, stack events can only happen within provision and reprovision workflows, and breaking out their events separately doesn't provide any value. We will flesh this out as we iterate on the Stack provisioning experience.