### PR TITLE
chore: stop executing when a queue signal is deleted

### DIFF
--- a/services/ctl-api/internal/pkg/queue/handler/run.go
+++ b/services/ctl-api/internal/pkg/queue/handler/run.go
@@ -5,7 +5,9 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/pkg/generics"
+	dbgenerics "github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 )
 
@@ -13,6 +15,16 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
 		return false, err
+	}
+
+	// Check that the signal still exists before doing any work.
+	// If it was deleted, terminate the workflow without continue-as-new.
+	if _, err := activities.AwaitGetQueueSignalByQueueSignalID(ctx, h.queueSignalID); err != nil {
+		if dbgenerics.IsGormErrRecordNotFound(err) {
+			l.Warn("queue signal not found, terminating handler")
+			return true, nil
+		}
+		return false, errors.Wrap(err, "unable to fetch queue signal")
 	}
 
 	if err := h.registerHandlers(ctx); err != nil {


### PR DESCRIPTION
This removes a situation where a handler can continue once a queue signal is deleted.
