### PR TITLE
fix: set status for drift scans

### DIFF
--- a/services/ctl-api/internal/pkg/flow/checks/planonly/check.go
+++ b/services/ctl-api/internal/pkg/flow/checks/planonly/check.go
@@ -41,6 +41,11 @@ func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workf
 
 	return directive.CheckResult{
 		Directive: directive.StepContinue,
+		// handlePlanOnlyApproval already wrote the step's authoritative status
+		// (Approved) and the step-target status (Drifted / NoDrift). Set Status
+		// here so applyCheckResult does not default to StatusError and overwrite
+		// the row we just persisted.
+		Status: app.WorkflowStepApprovalStatusApproved,
 		Reason: directive.CheckReason{
 			Check:   "plan-only",
 			Summary: summary,


### PR DESCRIPTION
## Problem

Drift scans (plan-only workflows) were leaving the step row in `error` status whe drift was detected 


## Fix

Set `Status: app.WorkflowStepApprovalStatusApproved` on the returned `CheckResult`, matching how the policy auto-approve path already does it. `applyCheckResult` then no longer defaults to error, and the row stays consistent with what `handlePlanOnlyApproval` wrote.

Applies to both drifted and no-drift outcomes of plan-only workflows.
