### PR TITLE
ci: disable github OIDC, rely on self-hosted runner instance role

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -123,7 +123,7 @@ jobs:
       prod: true
       stage: false
       is_promotion: true
-      disable_github_oidc: ${{ github.repository != 'nuonco/nuon' }}
+      disable_github_oidc: true
     secrets: inherit
 
   bump_tag:

--- a/.github/workflows/promote_from_branch.yml
+++ b/.github/workflows/promote_from_branch.yml
@@ -92,7 +92,7 @@ jobs:
       prod: true
       stage: true
       is_promotion: true
-      disable_github_oidc: ${{ github.repository != 'nuonco/nuon' }}
+      disable_github_oidc: true
     secrets: inherit
 
   bump_tag:

--- a/.github/workflows/promote_single_service.yml
+++ b/.github/workflows/promote_single_service.yml
@@ -93,7 +93,7 @@ jobs:
       prod: true
       stage: false
       is_promotion: true
-      disable_github_oidc: ${{ github.repository != 'nuonco/nuon' }}
+      disable_github_oidc: true
     secrets: inherit
 
   lsp:
@@ -108,7 +108,7 @@ jobs:
       prod: true
       stage: false
       is_promotion: true
-      disable_github_oidc: ${{ github.repository != 'nuonco/nuon' }}
+      disable_github_oidc: true
     secrets: inherit
 
   bump_tag:

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -77,7 +77,7 @@ jobs:
     env:
       NO_CACHE: ${{ contains(github.event.pull_request.labels.*.name, 'no-cache') }}
       NO_REMOTE_BUILDKIT: ${{ contains(github.event.pull_request.labels.*.name, 'no-remote-buildkit') }}
-      DISABLE_GITHUB_OIDC: ${{ github.repository != 'nuonco/nuon' }}
+      DISABLE_GITHUB_OIDC: true
     steps:
       - uses: FranzDiebold/github-env-vars-action@v2
       - name: Checkout repo
@@ -107,7 +107,7 @@ jobs:
       prod: false
       stage: ${{ github.event_name != 'pull_request' || needs.prepare.outputs.auto_deploy == 'true'}}
       tag: ${{ needs.prepare.outputs.git_ref }}
-      disable_github_oidc: ${{ github.repository != 'nuonco/nuon' }}
+      disable_github_oidc: true
     secrets: inherit
 
   update_status:

--- a/bins/cli/AGENTS.md
+++ b/bins/cli/AGENTS.md
@@ -424,3 +424,4 @@ NUON_NO_TTY=true nuon <command>   # Explicit disable
 CI=true nuon <command>             # CI simulation
 nuon <command> | cat               # Pipe (auto-detected)
 ```
+

--- a/bins/runner/AGENTS.md
+++ b/bins/runner/AGENTS.md
@@ -353,3 +353,4 @@ The `--with-binary` flow is the recommended path for Azure VM runners. It:
 
 The Runner is the critical execution component that enables Nuon to securely deploy and manage applications within
 customer infrastructure while maintaining the security and isolation requirements of enterprise customers.
+


### PR DESCRIPTION
## Summary

Fork PRs (e.g. #1375) fail in the test step with `GitHub OIDC environment variables not set` because GitHub strips `id-token: write` for cross-repo PRs. Since all our CI runs on self-hosted runners with an instance profile that can already chain `sts:AssumeRole` into `gha-artifacts` and the per-service roles, we don't need OIDC at all.

Sets `disable_github_oidc: true` unconditionally across `services.yml`, `promote.yml`, `promote_from_branch.yml`, and `promote_single_service.yml` so the non-OIDC `AssumeRole` path is used everywhere.

## Test plan

- [x] Watch this PR's own services run finish green
- [x] Re-run #1375 (fork PR) after merge and confirm tests start