### PR TITLE
ci: skip artifact push for fork PRs

### DIFF
--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -42,6 +42,8 @@ jobs:
       NO_REMOTE_BUILDKIT: ${{ contains(github.event.pull_request.labels.*.name, 'no-remote-buildkit') }}
       DISABLE_GITHUB_OIDC: ${{ inputs.disable_github_oidc }}
       GEN_API_TYPES: ${{ contains(github.event.pull_request.labels.*.name, 'gen-api-types') }}
+      # Fork PRs don't push artifacts (security).
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
       - uses: FranzDiebold/github-env-vars-action@v2
 
@@ -87,7 +89,8 @@ jobs:
           CI=true nuonctl builds release \
             ${{inputs.service}} \
             --tag=${{inputs.tag}} \
-            --no-cache=${{ env.NO_CACHE == 'true' || inputs.is_promotion }}
+            --no-cache=${{ env.NO_CACHE == 'true' || inputs.is_promotion }} \
+            --push=${{ env.IS_FORK_PR != 'true' }}
         # --write-cache=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         env:
           BUILD_PROMOTION: ${{ inputs.is_promotion }}


### PR DESCRIPTION
## Summary

Followup to #1489. With OIDC disabled, ECR works for fork PRs via the runner's instance profile — but GAR has no such fallback (`bins/nuonctl/internal/pkg/gar/token.go` is hardcoded to GitHub OIDC, and GitHub strips `id-token: write` from fork PRs).

Pass `--push=false` to `nuonctl builds release` for fork PRs so the build still runs as a compile-check + test signal, but doesn't try to publish to ECR/GAR.

This is also the security-correct posture: a fork PR shouldn't be able to push artifacts to your registries.

## Test plan

- [x] Re-run #1375 after merge; Tests + Build steps complete (build runs, no publish)
- [x] Intra-org PR still pushes as before (IS_FORK_PR=false)