### PR TITLE
revert: "fix: (queue/handler) terminate handler properly when previous run was abandoned"

### DIFF
--- a/services/ctl-api/internal/pkg/queue/handler/state.go
+++ b/services/ctl-api/internal/pkg/queue/handler/state.go
@@ -39,39 +39,34 @@ func (h *handler) initializeState(ctx workflow.Context) error {
 	if meta := queueSignal.Status.Metadata; meta != nil {
 		// If init previously failed, the signal is already in a terminal error state.
 		if _, initFailed := meta["init_failed_at"]; initFailed {
-			h.setFinished(app.StatusError, "previous init failed; signal already in terminal state")
 			return nil
 		}
 
 		_, valStarted := meta["validate_started_at"]
 		_, valFinished := meta["validate_finished_at"]
 		if valStarted && !valFinished {
-			desc := "previous execution was abandoned (crashed mid-validate), marking as failed"
 			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 				QueueSignalID:     h.queueSignalID,
 				Status:            app.StatusError,
-				StatusDescription: desc,
+				StatusDescription: "previous execution was abandoned (crashed mid-validate), marking as failed",
 				Metadata: map[string]any{
 					"validate_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
 				},
 			})
-			h.setFinished(app.StatusError, desc)
 			return nil
 		}
 
 		_, execStarted := meta["execute_started_at"]
 		_, execFinished := meta["execute_finished_at"]
 		if execStarted && !execFinished {
-			desc := "previous execution was abandoned (crashed mid-execute), marking as failed"
 			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 				QueueSignalID:     h.queueSignalID,
 				Status:            app.StatusError,
-				StatusDescription: desc,
+				StatusDescription: "previous execution was abandoned (crashed mid-execute), marking as failed",
 				Metadata: map[string]any{
 					"execute_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
 				},
 			})
-			h.setFinished(app.StatusError, desc)
 			return nil
 		}
 	}


### PR DESCRIPTION
Reverts nuonco/nuon#1494

We think this may be preventing workflows from being canceled. 