### PR TITLE
fix(ui): don't show pending approval badge when wrkflw status is awaiting approval

### DIFF
--- a/services/dashboard-ui/client/components/workflows/WorkflowTimeline/WorkflowTimeline.tsx
+++ b/services/dashboard-ui/client/components/workflows/WorkflowTimeline/WorkflowTimeline.tsx
@@ -58,6 +58,7 @@ export const WorkflowTimeline = ({
               </Badge>
             ) : null}
             {workflow?.approval_option === 'prompt' &&
+            workflow?.status?.status !== 'approval-awaiting' &&
             getPendingApprovalCount(workflow) ? (
               <Badge size="sm" theme="warn">
                 Pending approval


### PR DESCRIPTION
Don't show "pending approval" badge on workflows when the status is "awaiting approval"