### PR TITLE
feat: render install state in kustomize manifests

### DIFF
--- a/bins/runner/internal/jobs/deploy/kubernetes_manifest/initialize.go
+++ b/bins/runner/internal/jobs/deploy/kubernetes_manifest/initialize.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	pkgctx "github.com/nuonco/nuon/bins/runner/internal/pkg/ctx"
+	"github.com/nuonco/nuon/pkg/render"
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 	"go.uber.org/zap"
 )
@@ -48,9 +49,30 @@ func (h *handler) Initialize(ctx context.Context, job *models.AppRunnerJob, jobE
 		return fmt.Errorf("error reading manifest after initializing: %w", err)
 	}
 
-	h.state.plan.KubernetesManifestDeployPlan.Manifest = string(manifestBytes)
+	manifest := string(manifestBytes)
+
+	// Interpolate {{.nuon.*}} placeholders that survived kustomize unchanged.
+	// Inline-manifest deploys never reach this branch (planner pre-renders and
+	// the early return above skips the OCI pull), so State is only ever set
+	// for the kustomize path. Older planners may not populate it; in that
+	// case we just apply the manifest as-is.
+	if planState := h.state.plan.KubernetesManifestDeployPlan.State; planState != nil {
+		stateMap, err := planState.AsMap()
+		if err != nil {
+			return fmt.Errorf("unable to flatten install state for kustomize manifest: %w", err)
+		}
+		rendered, err := render.RenderV2(manifest, stateMap)
+		if err != nil {
+			return fmt.Errorf("unable to render install state into kustomize manifest: %w", err)
+		}
+		manifest = rendered
+		l.Info("rendered install state into kustomize manifest",
+			zap.Int("rendered_size", len(rendered)))
+	}
+
+	h.state.plan.KubernetesManifestDeployPlan.Manifest = manifest
 	l.Info("manifest loaded from OCI artifact",
-		zap.Int("content_size", len(manifestBytes)))
+		zap.Int("content_size", len(manifest)))
 
 	return nil
 }

--- a/docs/guides/kubernetes-manifest-components.mdx
+++ b/docs/guides/kubernetes-manifest-components.mdx
@@ -186,6 +186,66 @@ spec:
     targetPort: 8080
 ```
 
+## Kustomize
+
+In addition to inline manifests, Kubernetes manifest components can be sourced from a [Kustomize](https://kustomize.io) overlay in a Git repo. Use this when you want to assemble your manifests from a base + overlays, layer in patches, or share manifests across multiple components.
+
+### Pointing a component at a Kustomize overlay
+
+A Kustomize-backed component references the repo holding the overlay (either `public_repo` for a public GitHub repo, or `connected_repo` for a Nuon-connected private repo) and a `kustomize.path` relative to the source root.
+
+```toml components/kustomize-demo.toml
+name = "kustomize-demo"
+type = "kubernetes_manifest"
+
+namespace = "kustomize-demo"
+
+[public_repo]
+repo = "nuonco/example-app-configs"
+directory = "gke-simple/src/components/kustomize-demo"
+branch = "main"
+
+[kustomize]
+path = "."
+```
+
+The directory at `directory` must contain a standard `kustomization.yaml`. Nuon runs `kustomize build` on it during deploy.
+
+```yaml gke-simple/src/components/kustomize-demo/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - deployment.yaml
+```
+
+### State interpolation in Kustomize trees
+
+Kustomize-backed components support the same `{{.nuon.*}}` template variables as inline manifests. Placeholders are rendered on the runner, against the live install state, **after** `kustomize build` produces the final manifest. This means you can reference install IDs, app metadata, install stack outputs, and other component outputs directly from any YAML file inside your Kustomize overlay.
+
+```yaml gke-simple/src/components/kustomize-demo/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: install-info
+  namespace: kustomize-demo
+  annotations:
+    nuon.co/rendered-install-id: "{{.nuon.install.id}}"
+data:
+  install_id: "{{.nuon.install.id}}"
+  install_name: "{{.nuon.install.name}}"
+  app_id: "{{.nuon.app.id}}"
+  project_id: "{{.nuon.install_stack.outputs.project_id}}"
+```
+
+After a deploy, the rendered ConfigMap on the cluster will have the placeholders replaced with the install's actual values — for example, `install_id: inl...`, `project_id: nuon-gcp-support`.
+
+<Note>
+Kustomize-backed manifests are interpolated on the runner, not in the planner. This keeps the Temporal workflow payload small even for large Kustomize trees. Inline manifests, by contrast, are still rendered in the planner.
+</Note>
+
 ## Nuon Managed Sandbox Components
 
 The `aws-eks-sandbox` [managed Sandbox](/concepts/sandboxes#nuon-managed-sandboxes) ships with standard components that your Kubernetes manifests can leverage:

--- a/pkg/plans/types/kubernetes_manifest_deploy_plan.go
+++ b/pkg/plans/types/kubernetes_manifest_deploy_plan.go
@@ -5,6 +5,7 @@ import (
 	azurecredentials "github.com/nuonco/nuon/pkg/azure/credentials"
 	gcpcredentials "github.com/nuonco/nuon/pkg/gcp/credentials"
 	"github.com/nuonco/nuon/pkg/kube"
+	"github.com/nuonco/nuon/pkg/types/state"
 )
 
 type KubernetesManifestDeployPlan struct {
@@ -24,6 +25,13 @@ type KubernetesManifestDeployPlan struct {
 
 	// OCIArtifact reference (set during plan creation, used by runner to pull manifest)
 	OCIArtifact *OCIArtifactReference `json:"oci_artifact,omitempty"`
+
+	// State carries the install state the runner needs to interpolate
+	// nuon template placeholders into the kustomize-produced manifest.yaml
+	// after pulling the OCI artifact. Nil for inline-manifest deploys,
+	// which are pre-rendered planner-side and short-circuit the OCI pull
+	// on the runner. Same shape as SandboxRunPlan.State.
+	State *state.State `json:"state,omitempty"`
 }
 
 // OCIArtifactReference points to the packaged manifest artifact

--- a/sdks/nuon-go/models/plantypes_kubernetes_manifest_deploy_plan.go
+++ b/sdks/nuon-go/models/plantypes_kubernetes_manifest_deploy_plan.go
@@ -45,6 +45,15 @@ type PlantypesKubernetesManifestDeployPlan struct {
 	OciArtifact struct {
 		PlantypesOCIArtifactReference
 	} `json:"oci_artifact,omitempty"`
+
+	// State carries the install state the runner needs to interpolate
+	// nuon template placeholders into the kustomize-produced manifest.yaml
+	// after pulling the OCI artifact. Nil for inline-manifest deploys,
+	// which are pre-rendered planner-side and short-circuit the OCI pull
+	// on the runner. Same shape as SandboxRunPlan.State.
+	State struct {
+		GithubComNuoncoNuonPkgTypesStateState
+	} `json:"state,omitempty"`
 }
 
 // Validate validates this plantypes kubernetes manifest deploy plan
@@ -68,6 +77,10 @@ func (m *PlantypesKubernetesManifestDeployPlan) Validate(formats strfmt.Registry
 	}
 
 	if err := m.validateOciArtifact(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -162,6 +175,14 @@ func (m *PlantypesKubernetesManifestDeployPlan) validateOciArtifact(formats strf
 	return nil
 }
 
+func (m *PlantypesKubernetesManifestDeployPlan) validateState(formats strfmt.Registry) error {
+	if swag.IsZero(m.State) { // not required
+		return nil
+	}
+
+	return nil
+}
+
 // ContextValidate validate this plantypes kubernetes manifest deploy plan based on the context it is used
 func (m *PlantypesKubernetesManifestDeployPlan) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
@@ -183,6 +204,10 @@ func (m *PlantypesKubernetesManifestDeployPlan) ContextValidate(ctx context.Cont
 	}
 
 	if err := m.contextValidateOciArtifact(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateState(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -273,6 +298,11 @@ func (m *PlantypesKubernetesManifestDeployPlan) contextValidateGcpAuth(ctx conte
 }
 
 func (m *PlantypesKubernetesManifestDeployPlan) contextValidateOciArtifact(ctx context.Context, formats strfmt.Registry) error {
+
+	return nil
+}
+
+func (m *PlantypesKubernetesManifestDeployPlan) contextValidateState(ctx context.Context, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/sdks/nuon-runner-go/models/plantypes_kubernetes_manifest_deploy_plan.go
+++ b/sdks/nuon-runner-go/models/plantypes_kubernetes_manifest_deploy_plan.go
@@ -45,6 +45,15 @@ type PlantypesKubernetesManifestDeployPlan struct {
 	OciArtifact struct {
 		PlantypesOCIArtifactReference
 	} `json:"oci_artifact,omitempty"`
+
+	// State carries the install state the runner needs to interpolate
+	// nuon template placeholders into the kustomize-produced manifest.yaml
+	// after pulling the OCI artifact. Nil for inline-manifest deploys,
+	// which are pre-rendered planner-side and short-circuit the OCI pull
+	// on the runner. Same shape as SandboxRunPlan.State.
+	State struct {
+		GithubComNuoncoNuonPkgTypesStateState
+	} `json:"state,omitempty"`
 }
 
 // Validate validates this plantypes kubernetes manifest deploy plan
@@ -68,6 +77,10 @@ func (m *PlantypesKubernetesManifestDeployPlan) Validate(formats strfmt.Registry
 	}
 
 	if err := m.validateOciArtifact(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -162,6 +175,14 @@ func (m *PlantypesKubernetesManifestDeployPlan) validateOciArtifact(formats strf
 	return nil
 }
 
+func (m *PlantypesKubernetesManifestDeployPlan) validateState(formats strfmt.Registry) error {
+	if swag.IsZero(m.State) { // not required
+		return nil
+	}
+
+	return nil
+}
+
 // ContextValidate validate this plantypes kubernetes manifest deploy plan based on the context it is used
 func (m *PlantypesKubernetesManifestDeployPlan) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
@@ -183,6 +204,10 @@ func (m *PlantypesKubernetesManifestDeployPlan) ContextValidate(ctx context.Cont
 	}
 
 	if err := m.contextValidateOciArtifact(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateState(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -273,6 +298,11 @@ func (m *PlantypesKubernetesManifestDeployPlan) contextValidateGcpAuth(ctx conte
 }
 
 func (m *PlantypesKubernetesManifestDeployPlan) contextValidateOciArtifact(ctx context.Context, formats strfmt.Registry) error {
+
+	return nil
+}
+
+func (m *PlantypesKubernetesManifestDeployPlan) contextValidateState(ctx context.Context, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_kubernetes_manifest_deploy.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_kubernetes_manifest_deploy.go
@@ -15,7 +15,7 @@ import (
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/pkg/render"
 	types "github.com/nuonco/nuon/pkg/types/approvals"
-	"github.com/nuonco/nuon/pkg/types/state"
+	statepkg "github.com/nuonco/nuon/pkg/types/state"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
@@ -26,7 +26,7 @@ func (p *Planner) createKubernetesManifestDeployPlan(
 	req *CreateDeployPlanRequest,
 	appCfg *app.AppConfig,
 	stack *app.InstallStack,
-	state *state.State,
+	state *statepkg.State,
 	installDeploy *app.InstallDeploy,
 ) (*plantypes.KubernetesManifestDeployPlan, error) {
 	l, err := log.WorkflowLogger(ctx)
@@ -106,6 +106,16 @@ func (p *Planner) createKubernetesManifestDeployPlan(
 		return nil, errors.Wrap(err, "unable to get cluster info")
 	}
 
+	// Ship the install state to the runner only when the manifest will be
+	// loaded from the OCI artifact (kustomize path — inline manifests are
+	// already pre-rendered above and the runner short-circuits the OCI pull
+	// when plan.Manifest is non-empty). This lets the runner interpolate
+	// {{.nuon.*}} placeholders that survived kustomize unchanged.
+	var planState *statepkg.State
+	if renderedManifest == "" {
+		planState = state
+	}
+
 	return &plantypes.KubernetesManifestDeployPlan{
 		ClusterInfo: clusterInfo,
 		Namespace:   renderedNamespace,
@@ -115,6 +125,7 @@ func (p *Planner) createKubernetesManifestDeployPlan(
 			Tag:    ociArtifact.Tag,
 			Digest: ociArtifact.Digest,
 		},
+		State:     planState,
 		AWSAuth:   cloudAuth.AWS,
 		AzureAuth: cloudAuth.Azure,
 		GCPAuth:   cloudAuth.GCP,

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -5798,6 +5798,14 @@ export interface components {
       namespace?: string;
       /** @description OCIArtifact reference (set during plan creation, used by runner to pull manifest) */
       oci_artifact?: components["schemas"]["plantypes.OCIArtifactReference"];
+      /**
+       * @description State carries the install state the runner needs to interpolate
+       * nuon template placeholders into the kustomize-produced manifest.yaml
+       * after pulling the OCI artifact. Nil for inline-manifest deploys,
+       * which are pre-rendered planner-side and short-circuit the OCI pull
+       * on the runner. Same shape as SandboxRunPlan.State.
+       */
+      state?: components["schemas"]["github_com_nuonco_nuon_pkg_types_state.State"];
     };
     "plantypes.KubernetesSandboxMode": {
       plan_contents?: string;


### PR DESCRIPTION
Kustomize-backed Kubernetes manifest components can now use the same `{{.nuon.*}}` template variables that inline manifests and Helm charts already support.

## What you can do after this PR

**Reference install state from any file inside a Kustomize tree.** You can drop `{{.nuon.install.id}}`, `{{.nuon.app.id}}`, `{{.nuon.install_stack.outputs.*}}`, and any other Nuon context variable into a base, overlay, or patch. The placeholders get rendered against the live install state during deploy, with the install's actual values landing on the cluster.

## Mechanics worth flagging for review

Kustomize manifests are rendered on the runner instead of in the planner. The planner attaches install state to the deploy plan, and the runner reads it and templates the unpacked manifest before applying. Inline manifests still render in the planner. The split keeps the Temporal workflow payload small even for large Kustomize trees, which is why we hadn't done this before.

The same pattern is already in use for sandbox runs, where the deploy plan carries an install state blob the runner consumes. This change reuses that shape rather than introducing a new one.

## Docs

The Kubernetes manifest components guide picks up a new Kustomize section covering how to point a component at an overlay and how state interpolation works inside it.
