### PR TITLE
perf(queue): cheaper exists check in ensure-active loops

### DIFF
--- a/services/ctl-api/internal/pkg/queue/activities/queue_exists.go
+++ b/services/ctl-api/internal/pkg/queue/activities/queue_exists.go
@@ -1,0 +1,26 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+)
+
+// @temporal-gen-v2 activity
+// @as-wrapper
+// @wrapper-prefix QueueInternal
+// @by-field queueID
+// @start-to-close-timeout 1m
+func (a *Activities) queueExists(ctx context.Context, queueID string) (bool, error) {
+	var count int64
+	if res := a.db.WithContext(ctx).
+		Model(&app.Queue{}).
+		Where(app.Queue{ID: queueID}).
+		Limit(1).
+		Count(&count); res.Error != nil {
+		return false, generics.TemporalGormError(res.Error, "unable to check queue existence")
+	}
+
+	return count > 0, nil
+}

--- a/services/ctl-api/internal/pkg/queue/emitter/ensure_queue_active.go
+++ b/services/ctl-api/internal/pkg/queue/emitter/ensure_queue_active.go
@@ -4,7 +4,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	queueactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
 )
@@ -12,14 +11,13 @@ import (
 func (e *emitterWorkflow) ensureQueueActive(ctx workflow.Context) error {
 	l, _ := log.WorkflowLogger(ctx)
 
-	_, err := queueactivities.AwaitGetQueueByQueueID(ctx, e.queueID)
+	exists, err := queueactivities.AwaitQueueExistsByQueueID(ctx, e.queueID)
 	if err != nil {
-		if generics.IsGormErrRecordNotFound(err) {
-			l.Warn("queue not found, stopping emitter", zap.String("queue-id", e.queueID))
-			e.stopped = true
-			return nil
-		}
 		return err
+	}
+	if !exists {
+		l.Warn("queue not found, stopping emitter", zap.String("queue-id", e.queueID))
+		e.stopped = true
 	}
 
 	return nil

--- a/services/ctl-api/internal/pkg/queue/ensure_active.go
+++ b/services/ctl-api/internal/pkg/queue/ensure_active.go
@@ -4,7 +4,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
 )
@@ -15,14 +14,13 @@ func (q *queue) ensureActive(ctx workflow.Context) error {
 		return err
 	}
 
-	_, err = activities.AwaitGetQueueByQueueID(ctx, q.queueID)
+	exists, err := activities.AwaitQueueExistsByQueueID(ctx, q.queueID)
 	if err != nil {
-		if generics.IsGormErrRecordNotFound(err) {
-			l.Warn("queue not found, stopping workflow", zap.String("queue-id", q.queueID))
-			q.stopped = true
-			return nil
-		}
 		return err
+	}
+	if !exists {
+		l.Warn("queue not found, stopping workflow", zap.String("queue-id", q.queueID))
+		q.stopped = true
 	}
 
 	return nil


### PR DESCRIPTION
Replaces full `AwaitGetQueueByQueueID` row fetch + JSON round-trip with a `bool` existence activity in the two hot-loop callers that discard the result. Cuts the #1 worker CPU consumer and a large chunk of `gorm.DB.First` + reflect2 JSON allocations.