### PR TITLE
fix: (ctl-api) move dependency checks from /livez to /readyz

### DIFF
--- a/services/ctl-api/internal/health/health_test.go
+++ b/services/ctl-api/internal/health/health_test.go
@@ -107,8 +107,22 @@ func (s *HealthTestSuite) makeRequest(method, path string) *httptest.ResponseRec
 	return rr
 }
 
-func (s *HealthTestSuite) TestLivezReturnsValidResponse() {
+func (s *HealthTestSuite) TestLivezReturnsOK() {
 	rr := s.makeRequest(http.MethodGet, "/livez")
+
+	require.Equal(s.T(), http.StatusOK, rr.Code)
+
+	var response map[string]any
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	require.NoError(s.T(), err)
+
+	status, ok := response["status"].(string)
+	require.True(s.T(), ok, "response should have status field")
+	require.Equal(s.T(), "ok", status)
+}
+
+func (s *HealthTestSuite) TestReadyzReturnsValidResponse() {
+	rr := s.makeRequest(http.MethodGet, "/readyz")
 
 	// Should return 200 OK or 207 Multi-Status (degraded)
 	require.Contains(s.T(), []int{http.StatusOK, http.StatusMultiStatus}, rr.Code)
@@ -125,20 +139,6 @@ func (s *HealthTestSuite) TestLivezReturnsValidResponse() {
 	// Response should have degraded array
 	_, ok = response["degraded"].([]any)
 	require.True(s.T(), ok, "response should have degraded field")
-}
-
-func (s *HealthTestSuite) TestReadyzReturnsOK() {
-	rr := s.makeRequest(http.MethodGet, "/readyz")
-
-	require.Equal(s.T(), http.StatusOK, rr.Code)
-
-	var response map[string]any
-	err := json.Unmarshal(rr.Body.Bytes(), &response)
-	require.NoError(s.T(), err)
-
-	status, ok := response["status"].(string)
-	require.True(s.T(), ok, "response should have status field")
-	require.Equal(s.T(), "ok", status)
 }
 
 func (s *HealthTestSuite) TestVersionReturnsVersionInfo() {

--- a/services/ctl-api/internal/health/livez.go
+++ b/services/ctl-api/internal/health/livez.go
@@ -1,142 +1,18 @@
 package health
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"go.temporal.io/sdk/client"
-
-	"github.com/nuonco/nuon/pkg/metrics"
-	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 )
 
+// GetLivezHandler reports whether the process is alive and the HTTP
+// server can answer. It must remain dependency-free; failing this
+// triggers a pod restart.
 func (s *Service) GetLivezHandler(ctx *gin.Context) {
-	// ping psql
-	sqlDB, err := s.db.DB()
-	if err != nil {
-		ctx.Error(stderr.ErrSystem{
-			Err:         err,
-			Description: "unable to get psql connection",
-		})
-		return
-	}
-	if err := sqlDB.PingContext(ctx); err != nil {
-		s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
-			"system": "psql",
-			"status": "unable_to_ping",
-		}))
-		ctx.Error(stderr.ErrSystem{
-			Err:         err,
-			Description: "unable to ping psql db",
-		})
-		return
-	}
-	s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
-		"system": "psql",
+	ctx.JSON(http.StatusOK, map[string]any{
 		"status": "ok",
-	}))
-
-	degraded := make([]string, 0)
-
-	// ping ch
-	chDB, err := s.chDB.DB()
-	if err != nil {
-		degraded = append(degraded, "ch")
-		s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
-			"system": "ch",
-			"status": "unable_to_connect",
-		}))
-	} else {
-		// attempt to ping clickhouse, if we get a connection
-		if err := chDB.PingContext(ctx); err != nil {
-			degraded = append(degraded, "ch")
-			s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
-				"system": "ch",
-				"status": "unable_to_ping",
-			}))
-		} else {
-			// Only increment OK metric if ping succeeded
-			s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
-				"system": "ch",
-				"status": "ok",
-			}))
-		}
-
-		// Check for read-only replicas (only if connection was successful)
-		rows, err := chDB.Query("SELECT table FROM system.replicas WHERE database = 'ctl_api' AND is_readonly = 1")
-		if err != nil {
-			degraded = append(degraded, "ch")
-			s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
-				"system": "ch",
-				"status": "unable_to_connect",
-			}))
-		} else {
-			defer rows.Close()
-
-			var tables []string
-			var tableName string // Variable to scan each row into
-
-			for rows.Next() {
-				err := rows.Scan(&tableName)
-				if err != nil {
-					// Handle scan error
-					degraded = append(degraded, "ch")
-					s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
-						"system": "ch",
-						"status": "scan_error",
-					}))
-					break
-				}
-				tables = append(tables, tableName)
-			}
-
-			// NOTE(fd): we check for iteration errors (but why?)
-			if err = rows.Err(); err != nil {
-				degraded = append(degraded, "ch")
-				s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
-					"system": "ch",
-					"status": "iteration_error",
-				}))
-			}
-
-			rowCount := len(tables)
-			if rowCount > 0 {
-				degraded = append(degraded, "ch")
-				s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
-					"system": "ch",
-					"status": "readonly_replicas_found",
-				}))
-				for i, table := range tables {
-					ctx.Header(fmt.Sprintf("x-ch-table-in-read-only-%d", i), table)
-				}
-			}
-		}
-	}
-
-	// ping temporal
-	_, err = s.tclient.CheckHealth(ctx, &client.CheckHealthRequest{})
-	if err != nil {
-		degraded = append(degraded, "temporal")
-		s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
-			"system": "temporal",
-			"status": "unable_to_ping",
-		}))
-	}
-	s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
-		"system": "temporal",
-		"status": "ok",
-	}))
-
-	statusCode := http.StatusOK
-	status := "ok"
-	if len(degraded) > 0 {
-		status = "degraded"
-		statusCode = http.StatusMultiStatus
-	}
-
-	ctx.JSON(statusCode, map[string]any{
-		"status":   status,
-		"degraded": degraded,
+		// only for backward compatibility, until dashboard migrates to /readyz
+		"degraded": []string{},
 	})
 }

--- a/services/ctl-api/internal/health/readyz.go
+++ b/services/ctl-api/internal/health/readyz.go
@@ -1,13 +1,146 @@
 package health
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"go.temporal.io/sdk/client"
+
+	"github.com/nuonco/nuon/pkg/metrics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 )
 
+// GetReadyzHandler reports whether the process is ready to serve
+// traffic by checking external dependencies (psql, clickhouse,
+// temporal). Returns 207 Multi-Status with a degraded list when any
+// dependency is unhappy.
 func (s *Service) GetReadyzHandler(ctx *gin.Context) {
-	ctx.JSON(http.StatusOK, map[string]interface{}{
+	// ping psql
+	sqlDB, err := s.db.DB()
+	if err != nil {
+		ctx.Error(stderr.ErrSystem{
+			Err:         err,
+			Description: "unable to get psql connection",
+		})
+		return
+	}
+	if err := sqlDB.PingContext(ctx); err != nil {
+		s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
+			"system": "psql",
+			"status": "unable_to_ping",
+		}))
+		ctx.Error(stderr.ErrSystem{
+			Err:         err,
+			Description: "unable to ping psql db",
+		})
+		return
+	}
+	s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
+		"system": "psql",
 		"status": "ok",
+	}))
+
+	degraded := make([]string, 0)
+
+	// ping ch
+	chDB, err := s.chDB.DB()
+	if err != nil {
+		degraded = append(degraded, "ch")
+		s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
+			"system": "ch",
+			"status": "unable_to_connect",
+		}))
+	} else {
+		// attempt to ping clickhouse, if we get a connection
+		if err := chDB.PingContext(ctx); err != nil {
+			degraded = append(degraded, "ch")
+			s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
+				"system": "ch",
+				"status": "unable_to_ping",
+			}))
+		} else {
+			// Only increment OK metric if ping succeeded
+			s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
+				"system": "ch",
+				"status": "ok",
+			}))
+		}
+
+		// Check for read-only replicas (only if connection was successful)
+		rows, err := chDB.Query("SELECT table FROM system.replicas WHERE database = 'ctl_api' AND is_readonly = 1")
+		if err != nil {
+			degraded = append(degraded, "ch")
+			s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
+				"system": "ch",
+				"status": "unable_to_connect",
+			}))
+		} else {
+			defer rows.Close()
+
+			var tables []string
+			var tableName string // Variable to scan each row into
+
+			for rows.Next() {
+				err := rows.Scan(&tableName)
+				if err != nil {
+					// Handle scan error
+					degraded = append(degraded, "ch")
+					s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
+						"system": "ch",
+						"status": "scan_error",
+					}))
+					break
+				}
+				tables = append(tables, tableName)
+			}
+
+			// NOTE(fd): we check for iteration errors (but why?)
+			if err = rows.Err(); err != nil {
+				degraded = append(degraded, "ch")
+				s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
+					"system": "ch",
+					"status": "iteration_error",
+				}))
+			}
+
+			rowCount := len(tables)
+			if rowCount > 0 {
+				degraded = append(degraded, "ch")
+				s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
+					"system": "ch",
+					"status": "readonly_replicas_found",
+				}))
+				for i, table := range tables {
+					ctx.Header(fmt.Sprintf("x-ch-table-in-read-only-%d", i), table)
+				}
+			}
+		}
+	}
+
+	// ping temporal
+	_, err = s.tclient.CheckHealth(ctx, &client.CheckHealthRequest{})
+	if err != nil {
+		degraded = append(degraded, "temporal")
+		s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
+			"system": "temporal",
+			"status": "unable_to_ping",
+		}))
+	}
+	s.mw.Incr("healthcheck.check", metrics.ToTags(map[string]string{
+		"system": "temporal",
+		"status": "ok",
+	}))
+
+	statusCode := http.StatusOK
+	status := "ok"
+	if len(degraded) > 0 {
+		status = "degraded"
+		statusCode = http.StatusMultiStatus
+	}
+
+	ctx.JSON(statusCode, map[string]any{
+		"status":   status,
+		"degraded": degraded,
 	})
 }

--- a/services/dashboard-ui/client/lib/ctl-api/general/get-api-health.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/general/get-api-health.ts
@@ -4,6 +4,6 @@ import type { TAPIHealth } from '@/types'
 export async function getAPIHealth() {
   return api<TAPIHealth>({
     pathVersion: '',
-    path: 'livez',
+    path: 'readyz',
   })
 }


### PR DESCRIPTION
The `/livez` handler was pinging Postgres, ClickHouse (incl. a replica scan), and Temporal on every probe. Any dependency latency spike could potentially kill ctl-api pods, as the endpoint is used in K8s as a liveness probe.

This conflated liveness with readiness. Per the K8s contract:

- `/livez` failure: pod restart (must be dependency-free)
- `/readyz` failure: pod removed from Service (drains traffic)

Swap the handlers:

- `/livez` now returns `200 OK` immediately (dependency-free). Response shape (status + degraded) is preserved.
- `/readyz` now owns the psql + clickhouse + temporal checks and returns `207 Multi-Status` with a degraded list when any dependency is unhealthy.

Existing `healthcheck.check` metrics keep emitting from `/readyz`.