### PR TITLE
fix: (ctl-api) add queue_signals index for owner_id+type lookups

### DIFF
--- a/services/ctl-api/internal/app/queue_signal.go
+++ b/services/ctl-api/internal/app/queue_signal.go
@@ -78,6 +78,15 @@ func (r *QueueSignal) Indexes(db *gorm.DB) []migrations.Index {
 			},
 		},
 		{
+			Name: indexes.Name(db, &QueueSignal{}, "owner_id_type_deleted_at_created_at"),
+			Columns: []string{
+				"owner_id",
+				"type",
+				"deleted_at",
+				"created_at",
+			},
+		},
+		{
 			Name: indexes.Name(db, &QueueSignal{}, "owner_type_owner_id_deleted_at"),
 			Columns: []string{
 				"owner_type",


### PR DESCRIPTION
`findQueueSignalByOwner` in flow/client filters by (owner_id, type, deleted_at) only now, after the recent change where we dropped `owner_type` as it is not required to uniquely identify a signal. But the existing composite indexes (all of which lead with owner_type) cannot serve it. 

Add an index on (owner_id, type, deleted_at, created_at) to restore fast lookups for the workflow cancel/skip/retry/approve/pause/unpause endpoints.