### PR TITLE
fix: restore queue callback await timeout to 30m

### DIFF
--- a/services/ctl-api/internal/pkg/callback/await.go
+++ b/services/ctl-api/internal/pkg/callback/await.go
@@ -8,7 +8,9 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-const defaultAwaitTimeout = 5 * time.Minute
+// TODO: restored to the pre-#1531 value; replace with per-signal derived
+// timeouts (SignalWithTimeout) so long deploys use their configured budget.
+const defaultAwaitTimeout = 30 * time.Minute
 
 // Result is the payload sent by the handler on completion.
 type Result struct {


### PR DESCRIPTION
#1531 lowered callback.defaultAwaitTimeout 30m->5m, failing any deploy/build await >5m ("callback timeout: signal not received within 5m0s"); the deploy path nests several callback.Await layers on this default. Restores the pre-#1531 30m. Proper fix (per-signal SignalWithTimeout/DeriveTimeout so each layer uses its configured budget) tracked as follow-up.