### PR TITLE
chore: fix issue where a queue signal not found

### DIFF
--- a/sdks/nuon-go/client/nuon_client.go
+++ b/sdks/nuon-go/client/nuon_client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+
 	"github.com/nuonco/nuon/sdks/nuon-go/client/operations"
 )
 

--- a/sdks/nuon-go/models/app_queue_signal.go
+++ b/sdks/nuon-go/models/app_queue_signal.go
@@ -8,6 +8,7 @@ package models
 import (
 	"context"
 	stderrors "errors"
+	"strconv"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -19,12 +20,11 @@ import (
 // swagger:model app.QueueSignal
 type AppQueueSignal struct {
 
-	// Callback describes where to send a Temporal signal when this queue signal
-	// completes. When set, the handler signals the parent workflow on completion
-	// instead of requiring the parent to block on a heartbeating AwaitSignal activity.
-	Callback struct {
-		CallbackRef
-	} `json:"callback,omitempty"`
+	// callback
+	Callback *CallbackRef `json:"callback,omitempty"`
+
+	// callbacks
+	Callbacks []*CallbackRef `json:"callbacks"`
 
 	// created at
 	CreatedAt string `json:"created_at,omitempty"`
@@ -89,6 +89,10 @@ func (m *AppQueueSignal) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateCallbacks(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateQueue(formats); err != nil {
 		res = append(res, err)
 	}
@@ -118,6 +122,51 @@ func (m *AppQueueSignal) Validate(formats strfmt.Registry) error {
 func (m *AppQueueSignal) validateCallback(formats strfmt.Registry) error {
 	if swag.IsZero(m.Callback) { // not required
 		return nil
+	}
+
+	if m.Callback != nil {
+		if err := m.Callback.Validate(formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("callback")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("callback")
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *AppQueueSignal) validateCallbacks(formats strfmt.Registry) error {
+	if swag.IsZero(m.Callbacks) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.Callbacks); i++ {
+		if swag.IsZero(m.Callbacks[i]) { // not required
+			continue
+		}
+
+		if m.Callbacks[i] != nil {
+			if err := m.Callbacks[i].Validate(formats); err != nil {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
+					return ve.ValidateName("callbacks" + "." + strconv.Itoa(i))
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
+					return ce.ValidateName("callbacks" + "." + strconv.Itoa(i))
+				}
+
+				return err
+			}
+		}
+
 	}
 
 	return nil
@@ -246,6 +295,10 @@ func (m *AppQueueSignal) ContextValidate(ctx context.Context, formats strfmt.Reg
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateCallbacks(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateQueue(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -273,6 +326,55 @@ func (m *AppQueueSignal) ContextValidate(ctx context.Context, formats strfmt.Reg
 }
 
 func (m *AppQueueSignal) contextValidateCallback(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Callback != nil {
+
+		if swag.IsZero(m.Callback) { // not required
+			return nil
+		}
+
+		if err := m.Callback.ContextValidate(ctx, formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("callback")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("callback")
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *AppQueueSignal) contextValidateCallbacks(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Callbacks); i++ {
+
+		if m.Callbacks[i] != nil {
+
+			if swag.IsZero(m.Callbacks[i]) { // not required
+				return nil
+			}
+
+			if err := m.Callbacks[i].ContextValidate(ctx, formats); err != nil {
+				ve := new(errors.Validation)
+				if stderrors.As(err, &ve) {
+					return ve.ValidateName("callbacks" + "." + strconv.Itoa(i))
+				}
+				ce := new(errors.CompositeError)
+				if stderrors.As(err, &ce) {
+					return ce.ValidateName("callbacks" + "." + strconv.Itoa(i))
+				}
+
+				return err
+			}
+		}
+
+	}
 
 	return nil
 }

--- a/services/ctl-api/internal/pkg/queue/client/ensure_queue_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/ensure_queue_signal.go
@@ -6,6 +6,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/callback"
+	dbgenerics "github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 )
 
@@ -27,6 +28,9 @@ func EnsureQueueSignal(ctx workflow.Context, ownerID, ownerType string, signalTy
 		Callback:   cbRef,
 	})
 	if err != nil {
+		if dbgenerics.IsGormErrRecordNotFound(err) {
+			return nil
+		}
 		return fmt.Errorf("ensure signal %s for %s/%s: %w", signalType, ownerType, ownerID, err)
 	}
 

--- a/services/ctl-api/internal/pkg/queue/client/ensure_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/ensure_signal.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/callback"
+	dbgenerics "github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 )
 
@@ -46,7 +47,7 @@ func (c *Client) EnsureSignal(ctx context.Context, req *EnsureSignalRequest) (*E
 		Order("created_at DESC").
 		First(&qs)
 	if res.Error != nil {
-		return nil, errors.Wrap(res.Error, "no signal found for owner+type")
+		return nil, dbgenerics.TemporalGormError(res.Error, "no signal found for owner+type")
 	}
 
 	// Already succeeded — nothing to wait for.


### PR DESCRIPTION
When using a queue signal to await for control flow, fixes an issue where the signal being deleted could cause problems.
