### PR TITLE
feat: update signal health checks to go less frequently

### DIFF
--- a/services/ctl-api/internal/app/components/signals/v2/build/signal.go
+++ b/services/ctl-api/internal/app/components/signals/v2/build/signal.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/plan"
 	orgprovision "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/provision"
+	orgreprovision "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/reprovision"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/notifications"
@@ -77,7 +78,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	}
 
 	// Ensure org is provisioned before building.
-	if err := queueclient.EnsureQueueSignal(ctx, comp.OrgID, "orgs", orgprovision.SignalType); err != nil {
+	if err := queueclient.EnsureQueueSignal(ctx, comp.OrgID, "orgs", orgprovision.SignalType, orgreprovision.SignalType); err != nil {
 		s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusError, "org provision not ready")
 		return fmt.Errorf("org provision not ready: %w", err)
 	}

--- a/services/ctl-api/internal/app/components/signals/v2/configcreated/signal.go
+++ b/services/ctl-api/internal/app/components/signals/v2/configcreated/signal.go
@@ -9,6 +9,7 @@ import (
 	buildsignal "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/v2/build"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/activities"
 	orgprovision "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/provision"
+	orgreprovision "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/v2/reprovision"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
@@ -38,7 +39,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	}
 
 	// Ensure org is provisioned before creating a build.
-	if err := queueclient.EnsureQueueSignal(ctx, cmp.OrgID, "orgs", orgprovision.SignalType); err != nil {
+	if err := queueclient.EnsureQueueSignal(ctx, cmp.OrgID, "orgs", orgprovision.SignalType, orgreprovision.SignalType); err != nil {
 		return fmt.Errorf("org provision not ready: %w", err)
 	}
 

--- a/services/ctl-api/internal/app/runners/helpers/create_process_queues.go
+++ b/services/ctl-api/internal/app/runners/helpers/create_process_queues.go
@@ -36,16 +36,24 @@ func (h *Helpers) CreateProcessQueues(ctx context.Context, runnerID string, proc
 		return nil, fmt.Errorf("unable to create process queue: %w", err)
 	}
 
-	// Cron emitter: process health check once per hour
+	// Cron emitter: health check interval depends on process type.
+	// Build processes are longer-lived and less latency-sensitive.
+	healthCheckSchedule := "*/5 * * * *"
+	healthCheckExpiry := 5 * time.Minute
+	if process.Type == app.RunnerProcessTypeBuild {
+		healthCheckSchedule = "*/15 * * * *"
+		healthCheckExpiry = 15 * time.Minute
+	}
+
 	if _, err := h.emitterClient.CreateEmitter(ctx, &emitterclient.CreateEmitterRequest{
 		QueueID:         q.ID,
 		Name:            fmt.Sprintf("process-%s-health-check", process.ID),
 		Description:     "Periodic process health check",
 		Mode:            app.QueueEmitterModeCron,
-		CronSchedule:    "* * * * *",
+		CronSchedule:    healthCheckSchedule,
 		JitterWindow:    time.Second * 30,
 		SignalType:      "process_healthcheck",
-		SignalExpiresIn: 5 * time.Minute,
+		SignalExpiresIn: healthCheckExpiry,
 		SignalTemplate: queuesignal.NewRaw("process_healthcheck", map[string]any{
 			"runner_id":  runnerID,
 			"process_id": process.ID,

--- a/services/ctl-api/internal/pkg/queue/client/ensure_queue_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/ensure_queue_signal.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"go.temporal.io/sdk/workflow"
 
@@ -11,27 +13,34 @@ import (
 )
 
 // EnsureQueueSignal is a workflow-level helper that checks whether the latest
-// signal of a given type for an owner has completed. If it has, it returns
-// immediately. If it is still in flight, it registers a callback and blocks
-// until the signal completes (or times out).
+// signal of any of the given types for an owner has completed. If it has, it
+// returns immediately. If it is still in flight, it registers a callback and
+// blocks until the signal completes (or times out).
 //
 // This enables dependent signals to wait for prerequisites without polling,
-// e.g. a component-build signal waiting for org-provision to finish.
-func EnsureQueueSignal(ctx workflow.Context, ownerID, ownerType string, signalType signal.SignalType) error {
-	cbID := fmt.Sprintf("ensure-%s-%s-%s", ownerType, ownerID, signalType)
+// e.g. a component-build signal waiting for org-provision or org-reprovision
+// (whichever is most recent) to finish.
+func EnsureQueueSignal(ctx workflow.Context, ownerID, ownerType string, signalTypes ...signal.SignalType) error {
+	// Build a deterministic callback ID by sorting the signal types.
+	sorted := make([]string, len(signalTypes))
+	for i, st := range signalTypes {
+		sorted[i] = string(st)
+	}
+	sort.Strings(sorted)
+	cbID := fmt.Sprintf("ensure-%s-%s-%s", ownerType, ownerID, strings.Join(sorted, "+"))
 	cbRef := callback.New(ctx, cbID)
 
 	resp, err := AwaitEnsureSignal(ctx, &EnsureSignalRequest{
-		OwnerID:    ownerID,
-		OwnerType:  ownerType,
-		SignalType: signalType,
-		Callback:   cbRef,
+		OwnerID:     ownerID,
+		OwnerType:   ownerType,
+		SignalTypes: signalTypes,
+		Callback:    cbRef,
 	})
 	if err != nil {
 		if dbgenerics.IsGormErrRecordNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("ensure signal %s for %s/%s: %w", signalType, ownerType, ownerID, err)
+		return fmt.Errorf("ensure signal %v for %s/%s: %w", signalTypes, ownerType, ownerID, err)
 	}
 
 	if resp.AlreadyComplete {
@@ -40,7 +49,7 @@ func EnsureQueueSignal(ctx workflow.Context, ownerID, ownerType string, signalTy
 
 	// Block until the handler sends a completion callback.
 	if _, err := callback.Await(ctx, cbRef); err != nil {
-		return fmt.Errorf("ensure signal %s for %s/%s failed while awaiting: %w", signalType, ownerType, ownerID, err)
+		return fmt.Errorf("ensure signal %v for %s/%s failed while awaiting: %w", signalTypes, ownerType, ownerID, err)
 	}
 
 	return nil

--- a/services/ctl-api/internal/pkg/queue/client/ensure_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/ensure_signal.go
@@ -14,9 +14,9 @@ import (
 )
 
 type EnsureSignalRequest struct {
-	OwnerID    string            `json:"owner_id" validate:"required"`
-	OwnerType  string            `json:"owner_type" validate:"required"`
-	SignalType signal.SignalType `json:"signal_type" validate:"required"`
+	OwnerID     string              `json:"owner_id" validate:"required"`
+	OwnerType   string              `json:"owner_type" validate:"required"`
+	SignalTypes []signal.SignalType `json:"signal_types" validate:"required,min=1"`
 
 	// Callback to register on the signal if it is still in flight.
 	Callback callback.Ref `json:"callback"`
@@ -36,18 +36,15 @@ type EnsureSignalResponse struct {
 // @temporal-gen-v2 activity
 // @start-to-close-timeout 1m
 func (c *Client) EnsureSignal(ctx context.Context, req *EnsureSignalRequest) (*EnsureSignalResponse, error) {
-	// Find the latest signal for this owner+type.
+	// Find the latest signal across all requested types for this owner.
 	var qs app.QueueSignal
 	res := c.db.WithContext(ctx).
-		Where(app.QueueSignal{
-			OwnerID:   req.OwnerID,
-			OwnerType: req.OwnerType,
-			Type:      req.SignalType,
-		}).
+		Where("owner_id = ? AND owner_type = ? AND type IN ?",
+			req.OwnerID, req.OwnerType, req.SignalTypes).
 		Order("created_at DESC").
 		First(&qs)
 	if res.Error != nil {
-		return nil, dbgenerics.TemporalGormError(res.Error, "no signal found for owner+type")
+		return nil, dbgenerics.TemporalGormError(res.Error, "no signal found for owner+types")
 	}
 
 	// Already succeeded — nothing to wait for.


### PR DESCRIPTION
Update health checks to run less frequently every 5 minutes for installs and every 15 for org runners.
