### PR TITLE
feat: configurable runner instance type via runner.toml

### DIFF
--- a/docs/config-ref/runner.mdx
+++ b/docs/config-ref/runner.mdx
@@ -15,6 +15,7 @@ title: 'Runner'
 | **`env_vars`**<br/>object | environment variables Map of environment variables to pass to the runner as key-value pairs | **Optional** | `"DEBUG=true"`, `"LOG_LEVEL=info"` |
 | **`helm_driver`**<br/>string | Helm driver configuration Specifies the backend driver for Helm operations (e.g., 'configmap', 'secret') | **Optional** | `"configmap"`, `"secret"` |
 | **`init_script_url`**<br/>string | initialization script URL URL to a script that runs during runner initialization. Supports HTTP(S), git, file, and relative paths (./). Examples: https://example.com/script.sh, ./scripts/init.sh, g... | **Optional** | `"https://raw.githubusercontent.com/nuonco/runner/refs/heads/main/scripts/aws/init-mng-v2.sh"` |
+| **`instance_type`**<br/>string | machine/instance type for the install runner Cloud machine/instance type used for the install runner host. Cloud-specific value mapped per runner_type (e.g. an EC2 instance type for aws). Defaults ... | **Optional** | `"t3a.medium"`, `"t3.large"` |
 | **`env_var`**<br/>[array](#env_var) | deprecated: use env_vars map instead Deprecated: Array of name/value pairs for environment variables. Use the env_vars map instead | **Optional** | - |
 
 ### `env_var`

--- a/pkg/config/app_runner.go
+++ b/pkg/config/app_runner.go
@@ -20,6 +20,9 @@ type AppRunnerConfig struct {
 
 	InitScriptURL string `mapstructure:"init_script_url" toml:"init_script_url"`
 
+	// InstanceType sets the cloud machine/instance type for the install runner host.
+	InstanceType string `mapstructure:"instance_type,omitempty" toml:"instance_type,omitempty"`
+
 	// Deprecated
 	EnvVars []EnvironmentVariable `mapstructure:"env_var,omitempty" toml:"env_var"`
 }
@@ -42,6 +45,10 @@ func (a AppRunnerConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Field("init_script_url").Short("initialization script URL").
 		Long("URL to a script that runs during runner initialization. Supports HTTP(S), git, file, and relative paths (./). Examples: https://example.com/script.sh, ./scripts/init.sh, git::https://github.com/org/repo//script.sh, file:///path/to/script.sh").
 		Example("https://raw.githubusercontent.com/nuonco/runner/refs/heads/main/scripts/aws/init-mng-v2.sh").
+		Field("instance_type").Short("machine/instance type for the install runner").
+		Long("Cloud machine/instance type used for the install runner host. Cloud-specific value mapped per runner_type (e.g. an EC2 instance type for aws). Defaults to the platform default when unset").
+		Example("t3a.medium").
+		Example("t3.large").
 		Field("env_var").Short("deprecated: use env_vars map instead").
 		Long("Deprecated: Array of name/value pairs for environment variables. Use the env_vars map instead")
 }

--- a/pkg/config/sync/apisyncer/runner_sync.go
+++ b/pkg/config/sync/apisyncer/runner_sync.go
@@ -13,6 +13,7 @@ func (s *syncer) syncAppRunner(ctx context.Context, resource string) error {
 		EnvVars:       s.cfg.Runner.EnvVarMap,
 		HelmDriver:    models.AppAppRunnerConfigHelmDriverType(s.cfg.Runner.HelmDriver),
 		InitScriptURL: s.cfg.Runner.InitScriptURL,
+		InstanceType:  s.cfg.Runner.InstanceType,
 		Type:          models.NewAppAppRunnerType(models.AppAppRunnerType(s.cfg.Runner.RunnerType)),
 	})
 	if err != nil {

--- a/sdks/nuon-go/models/app_app_runner_config.go
+++ b/sdks/nuon-go/models/app_app_runner_config.go
@@ -49,6 +49,9 @@ type AppAppRunnerConfig struct {
 	// takes a URL to a bash script ⤵  which will be `curl | bash`-ed on the VM. usually via user-data or equivalent.
 	InitScript string `json:"init_script,omitempty"`
 
+	// InstanceType is the cloud machine/instance type for the install runner host, mapped per cloud platform.
+	InstanceType string `json:"instance_type,omitempty"`
+
 	// org id
 	OrgID string `json:"org_id,omitempty"`
 

--- a/sdks/nuon-go/models/service_create_app_runner_config_request.go
+++ b/sdks/nuon-go/models/service_create_app_runner_config_request.go
@@ -26,6 +26,9 @@ type ServiceCreateAppRunnerConfigRequest struct {
 	// env vars
 	EnvVars map[string]string `json:"env_vars,omitempty"`
 
+	// instance type
+	InstanceType string `json:"instance_type,omitempty"`
+
 	// helm driver
 	HelmDriver AppAppRunnerConfigHelmDriverType `json:"helm_driver,omitempty"`
 

--- a/sdks/nuon-go/models/service_create_app_runner_config_request.go
+++ b/sdks/nuon-go/models/service_create_app_runner_config_request.go
@@ -26,14 +26,14 @@ type ServiceCreateAppRunnerConfigRequest struct {
 	// env vars
 	EnvVars map[string]string `json:"env_vars,omitempty"`
 
-	// instance type
-	InstanceType string `json:"instance_type,omitempty"`
-
 	// helm driver
 	HelmDriver AppAppRunnerConfigHelmDriverType `json:"helm_driver,omitempty"`
 
 	// init script url
 	InitScriptURL string `json:"init_script_url,omitempty"`
+
+	// instance type
+	InstanceType string `json:"instance_type,omitempty"`
 
 	// type
 	// Required: true

--- a/services/ctl-api/internal/app/app_runner_config.go
+++ b/services/ctl-api/internal/app/app_runner_config.go
@@ -81,6 +81,9 @@ type AppRunnerConfig struct {
 
 	// takes a URL to a bash script ⤵  which will be `curl | bash`-ed on the VM. usually via user-data or equivalent.
 	InitScriptURL string `json:"init_script,omitzero" gorm:"default null" temporaljson:"init_script,omitzero,omitempty" features:"get,omitzero"`
+
+	// InstanceType is the cloud machine/instance type for the install runner host, mapped per cloud platform.
+	InstanceType string `json:"instance_type,omitzero" gorm:"default null" temporaljson:"instance_type,omitzero,omitempty"`
 }
 
 func (a *AppRunnerConfig) Indexes(db *gorm.DB) []migrations.Index {

--- a/services/ctl-api/internal/app/apps/service/create_app_runner_config.go
+++ b/services/ctl-api/internal/app/apps/service/create_app_runner_config.go
@@ -19,6 +19,7 @@ type CreateAppRunnerConfigRequest struct {
 	EnvVars       map[string]*string                `json:"env_vars"`
 	HelmDriver    app.AppRunnerConfigHelmDriverType `json:"helm_driver"`
 	InitScriptURL string                            `json:"init_script_url"`
+	InstanceType  string                            `json:"instance_type"`
 
 	AppConfigID string `json:"app_config_id"`
 }
@@ -77,6 +78,7 @@ func (s *service) createAppRunnerConfig(ctx context.Context, appID string, req *
 		HelmDriver:    req.HelmDriver,
 		EnvVars:       pgtype.Hstore(req.EnvVars),
 		InitScriptURL: req.InitScriptURL,
+		InstanceType:  req.InstanceType,
 		Type:          req.Type,
 	}
 	res := s.db.WithContext(ctx).

--- a/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
@@ -140,6 +140,13 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return errors.Wrap(err, "unable to get runner")
 	}
 
+	// instance type comes from the latest synced runner config so reprovision picks up changes
+	instanceType := cfg.RunnerConfig.InstanceType
+	if instanceType == "" {
+		instanceType = app.DefaultInstanceTypeForPlatform(cfg.RunnerConfig.CloudPlatform)
+	}
+	runner.RunnerGroup.Settings.AWSInstanceType = instanceType
+
 	// need to generate a token
 	region := ""
 	switch {

--- a/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
+++ b/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
@@ -103,6 +103,13 @@ func (w *Workflows) GenerateInstallStackVersion(ctx workflow.Context, sreq Gener
 		return errors.Wrap(err, "unable to get runner")
 	}
 
+	// instance type comes from the latest synced runner config so reprovision picks up changes
+	instanceType := cfg.RunnerConfig.InstanceType
+	if instanceType == "" {
+		instanceType = app.DefaultInstanceTypeForPlatform(cfg.RunnerConfig.CloudPlatform)
+	}
+	runner.RunnerGroup.Settings.AWSInstanceType = instanceType
+
 	// need to generate a token
 	region := ""
 	switch {

--- a/services/ctl-api/internal/app/runner_group_settings.go
+++ b/services/ctl-api/internal/app/runner_group_settings.go
@@ -19,8 +19,22 @@ import (
 )
 
 const (
-	DefaultAWSInstanceType = "t3a.medium"
+	DefaultAWSInstanceType   = "t3a.medium"
+	DefaultGCPInstanceType   = "e2-medium"
+	DefaultAzureInstanceType = "Standard_B2s"
 )
+
+// DefaultInstanceTypeForPlatform returns the default runner machine/instance type for a cloud platform.
+func DefaultInstanceTypeForPlatform(platform CloudPlatform) string {
+	switch platform {
+	case CloudPlatformGCP:
+		return DefaultGCPInstanceType
+	case CloudPlatformAzure:
+		return DefaultAzureInstanceType
+	default:
+		return DefaultAWSInstanceType
+	}
+}
 
 type RunnerAWSAuthMethod string
 

--- a/services/ctl-api/internal/app/runner_group_settings.go
+++ b/services/ctl-api/internal/app/runner_group_settings.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/viewsql"
 )
 
+// Default runner machine/instance types per cloud platform.
 const (
 	DefaultAWSInstanceType   = "t3a.medium"
 	DefaultGCPInstanceType   = "e2-medium"

--- a/services/ctl-api/internal/app/runners/helpers/create_runner_group.go
+++ b/services/ctl-api/internal/app/runners/helpers/create_runner_group.go
@@ -48,6 +48,11 @@ func (h *Helpers) CreateInstallRunnerGroup(ctx context.Context, install *app.Ins
 		sandboxMode = install.SandboxMode.Bool
 	}
 
+	instanceType := install.AppRunnerConfig.InstanceType
+	if instanceType == "" {
+		instanceType = app.DefaultInstanceTypeForPlatform(install.AppRunnerConfig.CloudPlatform)
+	}
+
 	groups := append(app.CommonRunnerGroupSettingsGroups[:], app.DefaultInstallRunnerGroupSettingsGroups[:]...)
 	runnerGroup := app.RunnerGroup{
 		OwnerID:   install.ID,
@@ -76,7 +81,7 @@ func (h *Helpers) CreateInstallRunnerGroup(ctx context.Context, install *app.Ins
 			EnableMetrics:   false,
 			EnableSentry:    true,
 			Groups:          groups,
-			AWSInstanceType: "t3a.medium",
+			AWSInstanceType: instanceType,
 			Metadata: pgtype.Hstore(map[string]*string{
 				"org.id":          generics.ToPtr(install.OrgID),
 				"org.name":        generics.ToPtr(install.Org.Name),

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
@@ -30,7 +30,7 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 
 	// Top-level Runner parameters: exposed on the parent stack so customers can
 	// override the defaults; the runner ASG nested stack references these.
-	runnerParams := t.getRunnerParameters()
+	runnerParams := t.getRunnerParameters(inp)
 	maps.Copy(tmpl.Parameters, runnerParams)
 
 	// When using local runners (dev mode), skip the ASG and runner-EC2-specific

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
@@ -2,12 +2,14 @@ package cloudformation
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/awslabs/goformation/v7/cloudformation"
 	nestedcloudformation "github.com/awslabs/goformation/v7/cloudformation/cloudformation"
 
 	"github.com/awslabs/goformation/v7/cloudformation/tags"
 	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
 )
 
@@ -84,20 +86,32 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 // the runner. These are exposed at the parent stack so customers can override
 // the defaults when creating/updating the stack; the nested runner ASG stack
 // references them via Ref().
-func (a *Templates) getRunnerParameters() map[string]cloudformation.Parameter {
+func (a *Templates) getRunnerParameters(inp *stacks.TemplateInput) map[string]cloudformation.Parameter {
+	instanceType := inp.Settings.AWSInstanceType
+	if instanceType == "" {
+		instanceType = app.DefaultAWSInstanceType
+	}
+
+	// Always allow the configured instance type so a custom value from
+	// runner.toml is never rejected by the AllowedValues constraint.
+	allowedInstanceTypes := []interface{}{
+		"t3.medium",
+		"t3.large",
+		"t3a.medium",
+		"t3a.large",
+		"c4.large",
+		"c5.large",
+	}
+	if !slices.Contains(allowedInstanceTypes, interface{}(instanceType)) {
+		allowedInstanceTypes = append(allowedInstanceTypes, instanceType)
+	}
+
 	return map[string]cloudformation.Parameter{
 		"RunnerInstanceType": {
-			Type:        "String",
-			Description: generics.ToPtr("EC2 instance type for the runner"),
-			Default:     "t3a.medium",
-			AllowedValues: []interface{}{
-				"t3.medium",
-				"t3.large",
-				"t3a.medium",
-				"t3a.large",
-				"c4.large",
-				"c5.large",
-			},
+			Type:          "String",
+			Description:   generics.ToPtr("EC2 instance type for the runner"),
+			Default:       instanceType,
+			AllowedValues: allowedInstanceTypes,
 		},
 		"RunnerRootVolumeSize": {
 			Type:        "Number",

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg_test.go
@@ -1,0 +1,44 @@
+package cloudformation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
+)
+
+func TestGetRunnerParameters_InstanceType(t *testing.T) {
+	tpl := &Templates{}
+
+	t.Run("defaults to t3a.medium when unset", func(t *testing.T) {
+		inp := &stacks.TemplateInput{Settings: &app.RunnerGroupSettings{}}
+		params := tpl.getRunnerParameters(inp)
+
+		p := params["RunnerInstanceType"]
+		assert.Equal(t, app.DefaultAWSInstanceType, p.Default)
+		assert.Contains(t, p.AllowedValues, interface{}(app.DefaultAWSInstanceType))
+	})
+
+	t.Run("uses configured value already in the allowed list", func(t *testing.T) {
+		inp := &stacks.TemplateInput{Settings: &app.RunnerGroupSettings{AWSInstanceType: "t3.large"}}
+		params := tpl.getRunnerParameters(inp)
+
+		p := params["RunnerInstanceType"]
+		assert.Equal(t, "t3.large", p.Default)
+		assert.Contains(t, p.AllowedValues, interface{}("t3.large"))
+		assert.Len(t, p.AllowedValues, 6, "value already present should not be appended")
+	})
+
+	t.Run("auto-adds a custom value to allowed values", func(t *testing.T) {
+		inp := &stacks.TemplateInput{Settings: &app.RunnerGroupSettings{AWSInstanceType: "m5.xlarge"}}
+		params := tpl.getRunnerParameters(inp)
+
+		p := params["RunnerInstanceType"]
+		assert.Equal(t, "m5.xlarge", p.Default)
+		require.Contains(t, p.AllowedValues, interface{}("m5.xlarge"))
+		assert.Len(t, p.AllowedValues, 7, "custom value should be appended once")
+	})
+}

--- a/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
@@ -170,6 +170,26 @@ func TestRenderGCPAccountInjection(t *testing.T) {
 	})
 }
 
+func TestRenderMachineType(t *testing.T) {
+	t.Run("with instance type set", func(t *testing.T) {
+		inp := testInput()
+		inp.Settings.AWSInstanceType = "e2-medium"
+		out, _, err := Render(inp)
+		require.NoError(t, err)
+
+		tfvars := extractTfvars(t, out)
+		assert.Contains(t, tfvars, `runner_machine_type      = "e2-medium"`)
+	})
+
+	t.Run("without instance type", func(t *testing.T) {
+		out, _, err := Render(testInput())
+		require.NoError(t, err)
+
+		tfvars := extractTfvars(t, out)
+		assert.NotContains(t, tfvars, "runner_machine_type")
+	})
+}
+
 func TestRenderPermissions(t *testing.T) {
 	t.Run("without break glass", func(t *testing.T) {
 		out, _, err := Render(testInput())

--- a/services/ctl-api/internal/pkg/stacks/gcp/tmpl.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/tmpl.go
@@ -17,6 +17,9 @@ runner_api_token         = "{{.APIToken}}"
 {{- end}}
 runner_id                = "{{.Runner.ID}}"
 runner_init_script_url   = "{{.RunnerInitScriptURL}}"
+{{- if .Settings.AWSInstanceType}}
+runner_machine_type      = "{{.Settings.AWSInstanceType}}"
+{{- end}}
 phone_home_url           = "{{.CloudFormationStackVersion.PhoneHomeURL}}"
 provision_permissions    = {{.ProvisionPermissions}}
 maintenance_permissions  = {{.MaintenancePermissions}}


### PR DESCRIPTION
Adds `instance_type` to runner.toml; flows to the runner group and AWS/GCP/Azure stacks with per-cloud defaults.