### PR TITLE
chore: improve workflow performance with local-activities / batching

### DIFF
--- a/services/ctl-api/internal/app/installs/worker/activities/get_install_components_batch.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/get_install_components_batch.go
@@ -1,0 +1,38 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+type GetInstallComponentsBatchRequest struct {
+	InstallID    string   `validate:"required"`
+	ComponentIDs []string `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) GetInstallComponentsBatch(ctx context.Context, req GetInstallComponentsBatchRequest) (map[string]*app.InstallComponent, error) {
+	var components []app.InstallComponent
+	res := a.db.WithContext(ctx).
+		Preload("Component").
+		Preload("Component.Dependencies").
+		Preload("TerraformWorkspace").
+		Preload("InstallDeploys", func(db *gorm.DB) *gorm.DB {
+			return db.Order("install_deploys.created_at DESC").Limit(1)
+		}).
+		Where("install_id = ? AND component_id IN ?", req.InstallID, req.ComponentIDs).
+		Find(&components)
+	if res.Error != nil {
+		return nil, fmt.Errorf("unable to get install components: %w", res.Error)
+	}
+
+	result := make(map[string]*app.InstallComponent, len(components))
+	for i := range components {
+		result[components[i].ComponentID] = &components[i]
+	}
+	return result, nil
+}

--- a/services/ctl-api/internal/app/installs/workflows/v2/deprovision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/deprovision.go
@@ -96,7 +96,7 @@ func Deprovision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRes
 	step, err = sg.installSignalStep(ctx, installID, "deprovision sandbox apply", pgtype.Hstore{}, &deprovisionsandboxapplyplan.Signal{
 		InstallSandboxID: sandbox.ID,
 		InstallID:        installID,
-	}, flw.PlanOnly)
+	}, flw.PlanOnly, WithMaxAutoRetries(install.AppSandboxConfig.GetMaxAutoRetries()))
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/deprovision_sandbox.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/deprovision_sandbox.go
@@ -89,7 +89,7 @@ func DeprovisionSandbox(ctx workflow.Context, flw *app.Workflow) (*app.GenerateS
 	step, err = sg.installSignalStep(ctx, installID, "deprovision sandbox apply plan", pgtype.Hstore{}, &deprovisionsandboxapplyplan.Signal{
 		InstallSandboxID: sandbox.ID,
 		InstallID:        installID,
-	}, flw.PlanOnly)
+	}, flw.PlanOnly, WithMaxAutoRetries(install.AppSandboxConfig.GetMaxAutoRetries()))
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/manual_deploy.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/manual_deploy.go
@@ -144,7 +144,7 @@ func ManualDeploySteps(ctx workflow.Context, flw *app.Workflow) (*app.GenerateSt
 			ComponentID:        comp.ID,
 			FlowID:             "",
 			SandboxMode:        false,
-		}, flw.PlanOnly)
+		}, flw.PlanOnly, WithMaxAutoRetries(componentMaxAutoRetries(appCfg, comp.ID)))
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to create image sync")
 		}

--- a/services/ctl-api/internal/app/installs/workflows/v2/provision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/provision.go
@@ -151,7 +151,7 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 		step, err = sg.installSignalStep(ctx, installID, "provision sandbox apply plan", pgtype.Hstore{}, &provisionsandboxapplyplan.Signal{
 			InstallSandboxID: sandboxID,
 			InstallID:        installID,
-		}, flw.PlanOnly)
+		}, flw.PlanOnly, WithMaxAutoRetries(install.AppSandboxConfig.GetMaxAutoRetries()))
 		if err != nil {
 			return nil, err
 		}

--- a/services/ctl-api/internal/app/installs/workflows/v2/reprovision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/reprovision.go
@@ -154,7 +154,7 @@ func Reprovision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRes
 		step, err = sg.installSignalStep(ctx, installID, "reprovision sandbox apply plan", pgtype.Hstore{}, &reprovisionsandboxapplyplan.Signal{
 			InstallSandboxID: sandbox.ID,
 			InstallID:        installID,
-		}, flw.PlanOnly)
+		}, flw.PlanOnly, WithMaxAutoRetries(install.AppSandboxConfig.GetMaxAutoRetries()))
 		if err != nil {
 			return nil, err
 		}

--- a/services/ctl-api/internal/app/installs/workflows/v2/reprovision_sandbox.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/reprovision_sandbox.go
@@ -103,7 +103,7 @@ func getSandboxReprovisionSteps(ctx workflow.Context, install *app.Install, inst
 	step, err = sg.installSignalStep(ctx, installID, "reprovision sandbox apply", pgtype.Hstore{}, &reprovisionsandboxapplyplan.Signal{
 		InstallSandboxID: sandbox.ID,
 		InstallID:        installID,
-	}, flw.PlanOnly)
+	}, flw.PlanOnly, WithMaxAutoRetries(install.AppSandboxConfig.GetMaxAutoRetries()))
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/workflows/v2/shared.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/shared.go
@@ -44,6 +44,26 @@ func WithGroupIdx(n int) WorkflowStepOptions {
 	}
 }
 
+// componentMaxAutoRetries looks up the max auto retries for a component from
+// the pre-fetched app config, avoiding redundant activity calls.
+func componentMaxAutoRetries(appCfg *app.AppConfig, componentID string) int {
+	for _, ccc := range appCfg.ComponentConfigConnections {
+		if ccc.ComponentID == componentID {
+			return ccc.GetMaxAutoRetries()
+		}
+	}
+	return 0
+}
+
+func WithMaxAutoRetries(n int) WorkflowStepOptions {
+	return func(s *app.WorkflowStep) {
+		if s.Status.Metadata == nil {
+			s.Status.Metadata = make(map[string]any)
+		}
+		s.Status.Metadata["max_auto_retries"] = n
+	}
+}
+
 func WithExecutionType(executionType app.WorkflowStepExecutionType) WorkflowStepOptions {
 	return func(s *app.WorkflowStep) {
 		s.ExecutionType = executionType
@@ -142,16 +162,21 @@ func installSignalStep(ctx workflow.Context, installID, name string, metadata pg
 
 	step.Timeout = signal.DeriveTimeout(sig)
 
-	if mar, ok := sig.(signal.SignalWithMaxAutoRetries); ok {
-		maxAutoRetries := mar.MaxAutoRetries(ctx)
-		if step.Status.Metadata == nil {
-			step.Status.Metadata = make(map[string]any)
-		}
-		step.Status.Metadata["max_auto_retries"] = maxAutoRetries
-	}
-
+	// Apply options first so WithMaxAutoRetries can set the metadata before
+	// we decide whether to call the (expensive) MaxAutoRetries activity.
 	for _, o := range opts {
 		o(step)
+	}
+
+	// Only call MaxAutoRetries if not already provided via WithMaxAutoRetries.
+	if _, alreadySet := step.Status.Metadata["max_auto_retries"]; !alreadySet {
+		if mar, ok := sig.(signal.SignalWithMaxAutoRetries); ok {
+			maxAutoRetries := mar.MaxAutoRetries(ctx)
+			if step.Status.Metadata == nil {
+				step.Status.Metadata = make(map[string]any)
+			}
+			step.Status.Metadata["max_auto_retries"] = maxAutoRetries
+		}
 	}
 
 	return step, nil

--- a/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
@@ -152,6 +152,16 @@ func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Wo
 		components[ccc.ComponentID] = ccc.Component
 	}
 
+	// Batch fetch all install components in one activity call instead of
+	// fetching them individually per component in the loop below.
+	installComps, err := activities.AwaitGetInstallComponentsBatch(ctx, activities.GetInstallComponentsBatchRequest{
+		InstallID:    installID,
+		ComponentIDs: componentIDs,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to batch get install components")
+	}
+
 	for i, compID := range componentIDs {
 		// Yield to the Temporal scheduler periodically to avoid deadlock detection
 		// when generating steps for many components (TMPRL1101).
@@ -166,17 +176,8 @@ func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Wo
 			return nil, errors.Errorf("component %s not found in app config", compID)
 		}
 
-		// Resolve install component ID
-		installComp, err := activities.AwaitGetInstallComponent(ctx, activities.GetInstallComponentRequest{
-			InstallID:   installID,
-			ComponentID: compID,
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to get install component")
-		}
-
 		var installComponentID string
-		if installComp != nil {
+		if installComp, ok := installComps[compID]; ok && installComp != nil {
 			installComponentID = installComp.ID
 		}
 
@@ -219,7 +220,7 @@ func getComponentDeploySteps(ctx workflow.Context, installID string, flw *app.Wo
 				InstallComponentID: installComponentID,
 				InstallID:          installID,
 				ComponentID:        comp.ID,
-			}, flw.PlanOnly)
+			}, flw.PlanOnly, WithMaxAutoRetries(componentMaxAutoRetries(appCfg, comp.ID)))
 			if err != nil {
 				return nil, errors.Wrap(err, "unable to create image sync")
 			}

--- a/services/ctl-api/internal/app/installs/workflows/v2/teardown_component.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/teardown_component.go
@@ -108,7 +108,7 @@ func TeardownComponent(ctx workflow.Context, flw *app.Workflow) (*app.GenerateSt
 			ComponentID:        compIDStr,
 			FlowID:             "",
 			SandboxMode:        false,
-		}, flw.PlanOnly)
+		}, flw.PlanOnly, WithMaxAutoRetries(componentMaxAutoRetries(appCfg, compIDStr)))
 		if err != nil {
 			return nil, err
 		}

--- a/services/ctl-api/internal/app/installs/workflows/v2/teardown_components.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/teardown_components.go
@@ -159,7 +159,7 @@ func teardownComponents(ctx workflow.Context, flw *app.Workflow, sg *stepGroup, 
 			ComponentID:        compID,
 			FlowID:             "",
 			SandboxMode:        false,
-		}, flw.PlanOnly)
+		}, flw.PlanOnly, WithMaxAutoRetries(componentMaxAutoRetries(appCfg, compID)))
 		if err != nil {
 			return nil, err
 		}

--- a/services/ctl-api/internal/pkg/queue/activities/local.go
+++ b/services/ctl-api/internal/pkg/queue/activities/local.go
@@ -1,0 +1,72 @@
+package activities
+
+import (
+	"time"
+
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+var defaultLocalActivityOpts = workflow.LocalActivityOptions{
+	ScheduleToCloseTimeout: 10 * time.Second,
+	RetryPolicy: &temporal.RetryPolicy{
+		MaximumAttempts: 1,
+	},
+}
+
+func withLocalOpts(ctx workflow.Context) workflow.Context {
+	return workflow.WithLocalActivityOptions(ctx, defaultLocalActivityOpts)
+}
+
+// LocalAwaitGetQueueSignalByQueueSignalID fetches a queue signal by ID as a local activity.
+func LocalAwaitGetQueueSignalByQueueSignalID(ctx workflow.Context, queueSignalID string) (*app.QueueSignal, error) {
+	var result *app.QueueSignal
+	err := workflow.ExecuteLocalActivity(withLocalOpts(ctx),
+		(*Activities).QueueInternalGetQueueSignal,
+		GetQueueSignalRequest{QueueSignalID: queueSignalID},
+	).Get(ctx, &result)
+	return result, err
+}
+
+// LocalAwaitGetQueueSignalSignalByQueueSignalID deserializes a signal from the DB as a local activity.
+func LocalAwaitGetQueueSignalSignalByQueueSignalID(ctx workflow.Context, queueSignalID string) (signal.Signal, error) {
+	var result signal.Signal
+	err := workflow.ExecuteLocalActivity(withLocalOpts(ctx),
+		(*Activities).QueueInternalGetQueueSignalSignal,
+		GetQueueSignalSignalRequest{QueueSignalID: queueSignalID},
+	).Get(ctx, &result)
+	return result, err
+}
+
+// LocalAwaitUpdateQueueSignalRunID persists handler run ID as a local activity.
+func LocalAwaitUpdateQueueSignalRunID(ctx workflow.Context, req *UpdateQueueSignalRunIDRequest) error {
+	return workflow.ExecuteLocalActivity(withLocalOpts(ctx),
+		(*Activities).UpdateQueueSignalRunID, req,
+	).Get(ctx, nil)
+}
+
+// LocalAwaitIncrementQueueSignalExecutionCount increments execution count as a local activity.
+func LocalAwaitIncrementQueueSignalExecutionCount(ctx workflow.Context, req *IncrementQueueSignalExecutionCountRequest) error {
+	return workflow.ExecuteLocalActivity(withLocalOpts(ctx),
+		(*Activities).IncrementQueueSignalExecutionCount, req,
+	).Get(ctx, nil)
+}
+
+// LocalAwaitCheckCANRequested checks for CAN hint in queue metadata as a local activity.
+func LocalAwaitCheckCANRequested(ctx workflow.Context, req CheckCANRequestedRequest) (bool, error) {
+	var result bool
+	err := workflow.ExecuteLocalActivity(withLocalOpts(ctx),
+		(*Activities).QueueInternalCheckCANRequested, req,
+	).Get(ctx, &result)
+	return result, err
+}
+
+// LocalAwaitClearCANRequested clears CAN hint from queue metadata as a local activity.
+func LocalAwaitClearCANRequested(ctx workflow.Context, req ClearCANRequestedRequest) error {
+	return workflow.ExecuteLocalActivity(withLocalOpts(ctx),
+		(*Activities).QueueInternalClearCANRequested, req,
+	).Get(ctx, nil)
+}

--- a/services/ctl-api/internal/pkg/queue/can_listener.go
+++ b/services/ctl-api/internal/pkg/queue/can_listener.go
@@ -84,7 +84,7 @@ func (q *queue) runCANCheck(ctx workflow.Context, l *zap.Logger) (bool, *CheckCA
 	}
 
 	// Check 2: restart_hint set in queue metadata.
-	requested, err := activities.AwaitCheckCANRequested(ctx, activities.CheckCANRequestedRequest{
+	requested, err := activities.LocalAwaitCheckCANRequested(ctx, activities.CheckCANRequestedRequest{
 		QueueID: q.queueID,
 	})
 	if err != nil {
@@ -110,7 +110,7 @@ func (q *queue) runCANCheck(ctx workflow.Context, l *zap.Logger) (bool, *CheckCA
 			l.Info("continue-as-new requested via metadata, clearing hint")
 		}
 		// Clear the hint so subsequent checks don't re-trigger.
-		if clearErr := activities.AwaitClearCANRequested(ctx, activities.ClearCANRequestedRequest{
+		if clearErr := activities.LocalAwaitClearCANRequested(ctx, activities.ClearCANRequestedRequest{
 			QueueID: q.queueID,
 		}); clearErr != nil && l != nil {
 			l.Warn("unable to clear restart_hint", zap.Error(clearErr))

--- a/services/ctl-api/internal/pkg/queue/direct_execute.go
+++ b/services/ctl-api/internal/pkg/queue/direct_execute.go
@@ -40,7 +40,7 @@ func (q *queue) directExecuteHandler(ctx workflow.Context, req DirectExecuteRequ
 
 	l.Info("direct executing queue signal", zap.String("queue-signal-id", req.QueueSignalID))
 
-	queueSignal, err := activities.AwaitGetQueueSignalByQueueSignalID(ctx, req.QueueSignalID)
+	queueSignal, err := activities.LocalAwaitGetQueueSignalByQueueSignalID(ctx, req.QueueSignalID)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get queue signal")
 	}
@@ -63,7 +63,7 @@ func (q *queue) directExecuteHandler(ctx workflow.Context, req DirectExecuteRequ
 	// process immediately, bypassing the channel
 	signalErr := q.processQueueSignal(ctx, l, queueSignal, queueRef)
 	if signalErr != nil {
-		if statusErr := statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+		if statusErr := statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 			QueueSignalID: queueSignal.ID,
 			Status:        app.StatusError,
 		}); statusErr != nil {

--- a/services/ctl-api/internal/pkg/queue/handle_signal.go
+++ b/services/ctl-api/internal/pkg/queue/handle_signal.go
@@ -27,7 +27,7 @@ func (q *queue) handleQueueSignal(ctx workflow.Context, queueRef QueueRef) error
 	}
 
 	l.Info("starting processing of queue signal")
-	queueSignal, err := activities.AwaitGetQueueSignalByQueueSignalID(ctx, queueRef.ID)
+	queueSignal, err := activities.LocalAwaitGetQueueSignalByQueueSignalID(ctx, queueRef.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get queue signal")
 	}
@@ -45,7 +45,7 @@ func (q *queue) handleQueueSignal(ctx workflow.Context, queueRef QueueRef) error
 		l.Info("emitter signals disabled globally, skipping",
 			zap.String("queue-signal-id", queueSignal.ID),
 			zap.String("queue-id", queueSignal.QueueID))
-		_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+		_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 			QueueSignalID:     queueSignal.ID,
 			Status:            app.StatusCancelled,
 			StatusDescription: "emitter signals disabled",
@@ -61,7 +61,7 @@ func (q *queue) handleQueueSignal(ctx workflow.Context, queueRef QueueRef) error
 	}
 
 	// Mark the signal as dequeued with timestamp
-	_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+	_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 		QueueSignalID: queueSignal.ID,
 		Status:        app.StatusInProgress,
 		Metadata: map[string]any{
@@ -73,7 +73,7 @@ func (q *queue) handleQueueSignal(ctx workflow.Context, queueRef QueueRef) error
 	signalErr = q.processQueueSignal(ctx, l, queueSignal, queueRef)
 	if signalErr != nil {
 		// Persist error status so callers don't block forever
-		if statusErr := statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+		if statusErr := statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 			QueueSignalID: queueSignal.ID,
 			Status:        app.StatusError,
 		}); statusErr != nil {
@@ -103,7 +103,7 @@ func (q *queue) processQueueSignal(ctx workflow.Context, l *zap.Logger, queueSig
 	}
 
 	// Persist the handler's RunID for recovery.
-	_ = activities.AwaitUpdateQueueSignalRunID(ctx, &activities.UpdateQueueSignalRunIDRequest{
+	_ = activities.LocalAwaitUpdateQueueSignalRunID(ctx, &activities.UpdateQueueSignalRunIDRequest{
 		QueueSignalID: queueSignal.ID,
 		RunID:         readyResp.RunID,
 	})

--- a/services/ctl-api/internal/pkg/queue/handler/cancel.go
+++ b/services/ctl-api/internal/pkg/queue/handler/cancel.go
@@ -61,7 +61,7 @@ func (h *handler) cancelHandler(ctx workflow.Context, req *CancelRequest) (*Canc
 	if cancelCallbackInvoked {
 		statusReq.StatusDescription = "cancel-callback-invoked"
 	}
-	_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusReq)
+	_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusReq)
 
 	dur := workflow.Now(ctx).Sub(start)
 	h.runAfterPhaseSafe(ctx, event, signal.SignalPhaseOutcome{

--- a/services/ctl-api/internal/pkg/queue/handler/completion.go
+++ b/services/ctl-api/internal/pkg/queue/handler/completion.go
@@ -17,7 +17,7 @@ func (h *handler) sendCompletionCallbacks(ctx workflow.Context) {
 	l, _ := log.WorkflowLogger(ctx)
 
 	// Reload from DB to pick up callbacks added after init (e.g. by EnsureSignal).
-	qs, err := activities.AwaitGetQueueSignalByQueueSignalID(ctx, h.queueSignalID)
+	qs, err := activities.LocalAwaitGetQueueSignalByQueueSignalID(ctx, h.queueSignalID)
 	if err == nil {
 		h.callbacks = qs.Callbacks
 		// Merge legacy single Callback if set.

--- a/services/ctl-api/internal/pkg/queue/handler/execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/execute.go
@@ -40,7 +40,7 @@ func (h *handler) executeHandler(ctx workflow.Context, cb callback.Ref) (resp *E
 	}()
 
 	// Increment execution count to track how many times this signal has been executed.
-	_ = activities.AwaitIncrementQueueSignalExecutionCount(ctx, &activities.IncrementQueueSignalExecutionCountRequest{
+	_ = activities.LocalAwaitIncrementQueueSignalExecutionCount(ctx, &activities.IncrementQueueSignalExecutionCountRequest{
 		QueueSignalID: h.queueSignalID,
 	})
 
@@ -59,7 +59,7 @@ func (h *handler) executeHandler(ctx workflow.Context, cb callback.Ref) (resp *E
 	decision := h.runBeforePhase(ctx, event)
 	if !decision.Allow {
 		blockedErr := &signal.SignalErrExecute{Err: errors.New("blocked by lifecycle hook: " + decision.Reason)}
-		_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+		_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 			QueueSignalID:     h.queueSignalID,
 			Status:            app.StatusError,
 			StatusDescription: blockedErr.Error(),
@@ -77,7 +77,7 @@ func (h *handler) executeHandler(ctx workflow.Context, cb callback.Ref) (resp *E
 	defer cancel()
 
 	start := workflow.Now(ctx)
-	_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+	_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 		QueueSignalID: h.queueSignalID,
 		Status:        app.StatusInProgress,
 		Metadata: map[string]any{
@@ -97,7 +97,7 @@ func (h *handler) executeHandler(ctx workflow.Context, cb callback.Ref) (resp *E
 		// If the signal panicked, write error status here (outside the panic boundary).
 		var panicErr *signal.SignalErrPanic
 		if errors.As(err, &panicErr) {
-			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+			_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 				QueueSignalID:     h.queueSignalID,
 				Status:            app.StatusError,
 				StatusDescription: panicErr.Error(),
@@ -117,7 +117,7 @@ func (h *handler) executeHandler(ctx workflow.Context, cb callback.Ref) (resp *E
 
 		execErr := &signal.SignalErrExecute{Err: err}
 		humanDesc := signal.HumanError(err)
-		_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+		_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 			QueueSignalID:     h.queueSignalID,
 			Status:            app.StatusError,
 			StatusDescription: humanDesc,
@@ -133,7 +133,7 @@ func (h *handler) executeHandler(ctx workflow.Context, cb callback.Ref) (resp *E
 	}
 
 	// persist success status to DB
-	_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+	_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 		QueueSignalID: h.queueSignalID,
 		Status:        app.StatusSuccess,
 		Metadata: map[string]any{

--- a/services/ctl-api/internal/pkg/queue/handler/run.go
+++ b/services/ctl-api/internal/pkg/queue/handler/run.go
@@ -25,7 +25,9 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 
 	// Check that the signal still exists before doing any work.
 	// If it was deleted, terminate the workflow without continue-as-new.
-	if _, err := activities.AwaitGetQueueSignalByQueueSignalID(ctx, h.queueSignalID); err != nil {
+	// We pass the fetched signal into initializeState to avoid a redundant DB fetch.
+	qs, err := activities.LocalAwaitGetQueueSignalByQueueSignalID(ctx, h.queueSignalID)
+	if err != nil {
 		if dbgenerics.IsGormErrRecordNotFound(err) {
 			l.Warn("queue signal not found, terminating handler")
 			return true, nil
@@ -37,7 +39,7 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 		return false, err
 	}
 
-	if err := h.initializeState(ctx); err != nil {
+	if err := h.initializeState(ctx, qs); err != nil {
 		return false, errors.Wrap(err, "unable to initialize state")
 	}
 
@@ -55,7 +57,10 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 	// The alive checker combines both existence and expiry checks in a single
 	// DB query to avoid redundant round-trips.
 	var mgrOpts []workflowmanager.Option
-	mgrOpts = append(mgrOpts, workflowmanager.WithCheckInterval(3*time.Minute))
+	// Handler signals have explicit callbacks for completion, so the alive
+	// checker only needs to detect deletion/expiry. A longer interval reduces
+	// local activity overhead for long-running signals.
+	mgrOpts = append(mgrOpts, workflowmanager.WithCheckInterval(5*time.Minute))
 
 	// don't continue-as-new mid-phase: it orphans the in-flight update and the
 	// successor run fails the signal while the work is still alive.
@@ -71,7 +76,7 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 	}
 
 	mgrOpts = append(mgrOpts, workflowmanager.WithAliveChecker(func(gCtx workflow.Context) (bool, error) {
-		qs, err := activities.AwaitGetQueueSignalByQueueSignalID(gCtx, h.queueSignalID)
+		qs, err := activities.LocalAwaitGetQueueSignalByQueueSignalID(gCtx, h.queueSignalID)
 		if err != nil {
 			if dbgenerics.IsGormErrRecordNotFound(err) {
 				l.Warn("queue signal deleted, terminating orphaned handler")
@@ -87,7 +92,7 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 		return true, nil
 	}))
 	mgrOpts = append(mgrOpts, workflowmanager.WithOnStopped(func(gCtx workflow.Context) {
-		_ = statusactivities.AwaitUpdateQueueSignalStatusV2(gCtx, statusactivities.UpdateQueueSignalStatusV2Request{
+		_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(gCtx, statusactivities.UpdateQueueSignalStatusV2Request{
 			QueueSignalID:     h.queueSignalID,
 			Status:            app.StatusError,
 			StatusDescription: "signal expired or deleted",

--- a/services/ctl-api/internal/pkg/queue/handler/state.go
+++ b/services/ctl-api/internal/pkg/queue/handler/state.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"time"
 
-	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -13,15 +12,10 @@ import (
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
-func (h *handler) initializeState(ctx workflow.Context) error {
-	queueSignal, err := activities.AwaitGetQueueSignalByQueueSignalID(ctx, h.queueSignalID)
-	if err != nil {
-		return errors.Wrap(err, "unable to get queue signal")
-	}
-
+func (h *handler) initializeState(ctx workflow.Context, queueSignal *app.QueueSignal) error {
 	// If the signal has an expiry time and we're past it, terminate without processing.
 	if queueSignal.ExpiresAt != nil && workflow.Now(ctx).After(*queueSignal.ExpiresAt) {
-		_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+		_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 			QueueSignalID:     h.queueSignalID,
 			Status:            app.StatusError,
 			StatusDescription: "signal expired",
@@ -47,7 +41,7 @@ func (h *handler) initializeState(ctx workflow.Context) error {
 		_, valFinished := meta["validate_finished_at"]
 		if valStarted && !valFinished {
 			desc := "previous execution was abandoned (crashed mid-validate), marking as failed"
-			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+			_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 				QueueSignalID:     h.queueSignalID,
 				Status:            app.StatusError,
 				StatusDescription: desc,
@@ -63,7 +57,7 @@ func (h *handler) initializeState(ctx workflow.Context) error {
 		_, execFinished := meta["execute_finished_at"]
 		if execStarted && !execFinished {
 			desc := "previous execution was abandoned (crashed mid-execute), marking as failed"
-			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+			_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 				QueueSignalID:     h.queueSignalID,
 				Status:            app.StatusError,
 				StatusDescription: desc,
@@ -76,17 +70,20 @@ func (h *handler) initializeState(ctx workflow.Context) error {
 		}
 	}
 
-	sig, err := activities.AwaitGetQueueSignalSignalByQueueSignalID(ctx, h.queueSignalID)
+	// The Signal field has temporaljson:"-" so it's stripped during activity
+	// serialization. We must fetch it via a separate local activity that
+	// deserializes from DB using the catalog.
+	sig, err := activities.LocalAwaitGetQueueSignalSignalByQueueSignalID(ctx, h.queueSignalID)
 	if err != nil {
 		if catalog.IsSignalTypeNotRegistered(err) {
-			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+			_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 				QueueSignalID:     h.queueSignalID,
 				Status:            app.StatusPending,
 				StatusDescription: "signal type not registered in current build; parked for redeploy",
 			})
 			return nil
 		}
-		return errors.Wrap(err, "unable to get signal")
+		return err
 	}
 	h.sig = sig
 
@@ -117,7 +114,7 @@ func (h *handler) initializeState(ctx workflow.Context) error {
 
 	if err := signal.ApplyInit(h.sig, ctx); err != nil {
 		initErr := &signal.SignalErrInit{Err: err}
-		_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+		_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 			QueueSignalID:     h.queueSignalID,
 			Status:            app.StatusError,
 			StatusDescription: initErr.Error(),

--- a/services/ctl-api/internal/pkg/queue/handler/validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/validate.go
@@ -48,7 +48,7 @@ func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *
 	}
 
 	// mark the signal as in-progress in the DB
-	_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+	_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 		QueueSignalID: h.queueSignalID,
 		Status:        app.StatusInProgress,
 		Metadata: map[string]any{
@@ -62,7 +62,7 @@ func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *
 	decision := h.runBeforePhase(ctx, event)
 	if !decision.Allow {
 		blockedErr := &signal.SignalErrValidate{Err: errors.New("blocked by lifecycle hook: " + decision.Reason)}
-		_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+		_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 			QueueSignalID:     h.queueSignalID,
 			Status:            app.StatusError,
 			StatusDescription: blockedErr.Error(),
@@ -85,7 +85,7 @@ func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *
 		// If the signal panicked, write error status here (outside the panic boundary).
 		var panicErr *signal.SignalErrPanic
 		if errors.As(err, &panicErr) {
-			_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+			_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 				QueueSignalID:     h.queueSignalID,
 				Status:            app.StatusError,
 				StatusDescription: panicErr.Error(),
@@ -99,7 +99,7 @@ func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *
 
 		validateErr := &signal.SignalErrValidate{Err: err}
 		humanDesc := signal.HumanError(err)
-		_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+		_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 			QueueSignalID:     h.queueSignalID,
 			Status:            app.StatusError,
 			StatusDescription: humanDesc,
@@ -115,7 +115,7 @@ func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *
 	}
 
 	// record validate completion timestamp
-	_ = statusactivities.AwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+	_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
 		QueueSignalID: h.queueSignalID,
 		Status:        app.StatusInProgress,
 		Metadata: map[string]any{

--- a/services/ctl-api/internal/pkg/workflows/status/activities/local.go
+++ b/services/ctl-api/internal/pkg/workflows/status/activities/local.go
@@ -1,0 +1,26 @@
+package statusactivities
+
+import (
+	"time"
+
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+var defaultLocalActivityOpts = workflow.LocalActivityOptions{
+	ScheduleToCloseTimeout: 10 * time.Second,
+	RetryPolicy: &temporal.RetryPolicy{
+		MaximumAttempts: 1,
+	},
+}
+
+func withLocalOpts(ctx workflow.Context) workflow.Context {
+	return workflow.WithLocalActivityOptions(ctx, defaultLocalActivityOpts)
+}
+
+// LocalAwaitUpdateQueueSignalStatusV2 updates queue signal status as a local activity.
+func LocalAwaitUpdateQueueSignalStatusV2(ctx workflow.Context, input UpdateQueueSignalStatusV2Request) error {
+	return workflow.ExecuteLocalActivity(withLocalOpts(ctx),
+		(*Activities).UpdateQueueSignalStatusV2, input,
+	).Get(ctx, nil)
+}

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -5409,8 +5409,11 @@ export interface components {
       parameters?: {
         [key: string]: string;
       };
+      status?: components["schemas"]["config.CustomNestedStackStatus"];
       template_url?: string;
     };
+    /** @enum {string} */
+    "config.CustomNestedStackStatus": "pending" | "ready" | "error";
     "config.HelmRepoConfig": {
       chart?: string;
       repoURL?: string;
@@ -7094,7 +7097,7 @@ export interface components {
       vpc_nested_template_url?: string;
     };
     "service.UpdateInstallInputsRequest": {
-      deploy_dependents?: boolean;
+      deploy_dependents?: boolean | null;
       inputs: {
         [key: string]: string;
       };


### PR DESCRIPTION
This speeds up initial workflow generation by up to ~200% in some cases. There are several optimizations here:

1. The queue system moves to using local activities, dropping hits to the temporal server.
2. We now batch things in workflow generation such as fetching install components.
3. Timeout configuration accepts an install.
4. We now remove some redundant app config calls.