### PR TITLE
feat: (ctl-api) enforce 5-minute minimum interval for action and drift crons

### DIFF
--- a/services/ctl-api/internal/app/apps/service/create_app_sandbox_config.go
+++ b/services/ctl-api/internal/app/apps/service/create_app_sandbox_config.go
@@ -22,7 +22,7 @@ type CreateAppSandboxConfigRequest struct {
 	vcshelpers.VCSConfigRequest
 
 	TerraformVersion             string  `json:"terraform_version" validate:"required"`
-	DriftSchedule                *string `json:"drift_schedule,omitempty"`
+	DriftSchedule                *string `json:"drift_schedule,omitempty" validate:"omitempty,cron_schedule"`
 	MaxAutoRetries               *int    `json:"max_auto_retries,omitempty"`
 	SkipNoops                    *bool   `json:"skip_noops,omitempty"`
 	AutoApproveOnPoliciesPassing *bool   `json:"auto_approve_on_policies_passing,omitempty"`

--- a/services/ctl-api/internal/app/components/service/create_helm_component_config.go
+++ b/services/ctl-api/internal/app/components/service/create_helm_component_config.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
-	"github.com/robfig/cron"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
@@ -39,7 +38,7 @@ type CreateHelmComponentConfigRequest struct {
 	Dependencies   []string                      `json:"dependencies"`
 	References     []string                      `json:"references"`
 	Checksum       string                        `json:"checksum"`
-	DriftSchedule  *string                       `json:"drift_schedule,omitempty"`
+	DriftSchedule  *string                       `json:"drift_schedule,omitempty" validate:"omitempty,cron_schedule"`
 	OperationRoles map[app.OperationType]*string `json:"operation_roles,omitempty"`
 }
 
@@ -234,10 +233,6 @@ func (s *service) createHelmComponentConfig(ctx context.Context, cmpID string, r
 		OperationRoles:               operationRoles,
 	}
 	if req.DriftSchedule != nil {
-		_, err := cron.ParseStandard(*req.DriftSchedule)
-		if err != nil {
-			return nil, fmt.Errorf("invalid drift schedule: must be a valid cron expression: %s . Error: %s", *req.DriftSchedule, err.Error())
-		}
 		componentConfigConnection.DriftSchedule = *req.DriftSchedule
 	}
 

--- a/services/ctl-api/internal/app/components/service/create_kubernetes_manifest_component_config.go
+++ b/services/ctl-api/internal/app/components/service/create_kubernetes_manifest_component_config.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
-	"github.com/robfig/cron"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
@@ -33,7 +32,7 @@ type CreateKubernetesManifestComponentConfigRequest struct {
 	MaxAutoRetries               *int    `json:"max_auto_retries,omitempty"`
 	SkipNoops                    *bool   `json:"skip_noops,omitempty"`
 	AutoApproveOnPoliciesPassing *bool   `json:"auto_approve_on_policies_passing,omitempty"`
-	DriftSchedule                *string `json:"drift_schedule,omitempty"`
+	DriftSchedule                *string `json:"drift_schedule,omitempty" validate:"omitempty,cron_schedule"`
 
 	// Kustomize configuration (mutually exclusive with Manifest)
 	Kustomize *KustomizeConfigRequest `json:"kustomize,omitempty"`
@@ -260,12 +259,7 @@ func (s *service) createKubernetesManifestComponentConfig(
 	}
 
 	if req.DriftSchedule != nil {
-		_, err := cron.ParseStandard(*req.DriftSchedule)
-		if err != nil {
-			return nil, fmt.Errorf("invalid drift schedule: must be a valid cron expression: %s . Error: %s", *req.DriftSchedule, err.Error())
-		}
 		componentConfigConnection.DriftSchedule = *req.DriftSchedule
-
 	}
 
 	if res := s.db.WithContext(ctx).Create(&componentConfigConnection); res.Error != nil {

--- a/services/ctl-api/internal/app/components/service/create_pulumi_component_config.go
+++ b/services/ctl-api/internal/app/components/service/create_pulumi_component_config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/lib/pq"
-	"github.com/robfig/cron"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
@@ -35,7 +34,7 @@ type CreatePulumiComponentConfigRequest struct {
 	Dependencies   []string                      `json:"dependencies"`
 	References     []string                      `json:"references"`
 	Checksum       string                        `json:"checksum"`
-	DriftSchedule  *string                       `json:"drift_schedule,omitempty"`
+	DriftSchedule  *string                       `json:"drift_schedule,omitempty" validate:"omitempty,cron_schedule"`
 	OperationRoles map[app.OperationType]*string `json:"operation_roles,omitempty"`
 }
 
@@ -210,10 +209,6 @@ func (s *service) createPulumiComponentConfig(ctx context.Context, cmpID string,
 		OperationRoles:               operationRoles,
 	}
 	if req.DriftSchedule != nil {
-		_, err := cron.ParseStandard(*req.DriftSchedule)
-		if err != nil {
-			return nil, fmt.Errorf("invalid drift schedule: must be a valid cron expression: %s . Error: %s", *req.DriftSchedule, err.Error())
-		}
 		componentConfigConnection.DriftSchedule = *req.DriftSchedule
 	}
 	if res := s.db.WithContext(ctx).Create(&componentConfigConnection); res.Error != nil {

--- a/services/ctl-api/internal/app/components/service/create_terraform_module_component_config.go
+++ b/services/ctl-api/internal/app/components/service/create_terraform_module_component_config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
-	"github.com/robfig/cron"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
@@ -37,7 +36,7 @@ type CreateTerraformModuleComponentConfigRequest struct {
 	Dependencies   []string                      `json:"dependencies"`
 	References     []string                      `json:"references"`
 	Checksum       string                        `json:"checksum"`
-	DriftSchedule  *string                       `json:"drift_schedule,omitempty"`
+	DriftSchedule  *string                       `json:"drift_schedule,omitempty" validate:"omitempty,cron_schedule"`
 	OperationRoles map[app.OperationType]*string `json:"operation_roles,omitempty"`
 }
 
@@ -249,10 +248,6 @@ func (s *service) createTerraformModuleComponentConfig(ctx context.Context, cmpI
 		OperationRoles:                 operationRoles,
 	}
 	if req.DriftSchedule != nil {
-		_, err := cron.ParseStandard(*req.DriftSchedule)
-		if err != nil {
-			return nil, fmt.Errorf("invalid drift schedule: must be a valid cron expression: %s . Error: %s", *req.DriftSchedule, err.Error())
-		}
 		componentConfigConnection.DriftSchedule = *req.DriftSchedule
 	}
 	if res := s.db.WithContext(ctx).Create(&componentConfigConnection); res.Error != nil {

--- a/services/ctl-api/internal/pkg/config/syncer/actions.go
+++ b/services/ctl-api/internal/pkg/config/syncer/actions.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	actionshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/actions/helpers"
 	vcshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/vcs/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/config/syncer/validation"
 )
 
 // ensureAction creates an action workflow if it doesn't exist, using the shared helpers
@@ -100,6 +101,12 @@ func (s *syncer) syncAction(ctx context.Context, action *config.ActionConfig) er
 	// Build triggers
 	triggers := make([]app.ActionWorkflowTriggerConfig, 0, len(action.Triggers))
 	for _, trigger := range action.Triggers {
+		if err := validation.ValidateCronSchedule(trigger.CronSchedule); err != nil {
+			return sync.SyncErr{
+				Resource:    fmt.Sprintf("action-%s", action.Name),
+				Description: err.Error(),
+			}
+		}
 		triggers = append(triggers, app.ActionWorkflowTriggerConfig{
 			Index:        int(trigger.Index),
 			Type:         app.ActionWorkflowTriggerType(trigger.Type),

--- a/services/ctl-api/internal/pkg/config/syncer/sandbox/sync.go
+++ b/services/ctl-api/internal/pkg/config/syncer/sandbox/sync.go
@@ -32,6 +32,15 @@ func Sync(ctx context.Context, db *gorm.DB, cfg *config.AppConfig, appID, appCon
 		}
 	}
 
+	if cfg.Sandbox.DriftSchedule != nil {
+		if err := validation.ValidateCronSchedule(*cfg.Sandbox.DriftSchedule); err != nil {
+			return sync.SyncErr{
+				Resource:    "app-sandbox",
+				Description: err.Error(),
+			}
+		}
+	}
+
 	// Get the app with preloaded org and VCS connections
 	var parentApp app.App
 	res := db.WithContext(ctx).

--- a/services/ctl-api/internal/pkg/config/syncer/validation/cron.go
+++ b/services/ctl-api/internal/pkg/config/syncer/validation/cron.go
@@ -3,23 +3,33 @@ package validation
 import (
 	"fmt"
 
-	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/robfig/cron"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
 
 // ValidateCronSchedule validates a cron expression string.
-// Returns an error if the cron expression is invalid.
+// Returns an error if the cron expression is invalid or fires more frequently
+// than validatorPkg.MinCronInterval.
 // Duplicates logic from services/ctl-api/internal/pkg/validator/cron_schedule.go
 func ValidateCronSchedule(cronExpr string) error {
 	if cronExpr == "" {
 		return nil // Empty is allowed (optional field)
 	}
 
-	_, err := cron.ParseStandard(cronExpr)
+	sched, err := cron.ParseStandard(cronExpr)
 	if err != nil {
 		return stderr.ErrUser{
 			Err:         fmt.Errorf("invalid cron expression: %w", err),
 			Description: fmt.Sprintf("Cron expression '%s' is invalid. Must be a valid cron format (e.g., '0 0 * * *' for daily at midnight)", cronExpr),
+		}
+	}
+
+	if minInterval := validatorPkg.MinScheduleInterval(sched); minInterval < validatorPkg.MinCronInterval {
+		return stderr.ErrUser{
+			Err:         fmt.Errorf("cron schedule fires too frequently: %s", minInterval),
+			Description: fmt.Sprintf("Cron expression '%s' fires every %s, which is more often than the allowed minimum of %s.", cronExpr, minInterval, validatorPkg.MinCronInterval),
 		}
 	}
 

--- a/services/ctl-api/internal/pkg/validator/cron_schedule.go
+++ b/services/ctl-api/internal/pkg/validator/cron_schedule.go
@@ -1,9 +1,21 @@
 package validator
 
 import (
+	"time"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/robfig/cron"
 )
+
+// MinCronInterval is the minimum allowed interval between consecutive fires of
+// any user-defined cron schedule (e.g. action triggers, drift scans).
+const MinCronInterval = 5 * time.Minute
+
+// minIntervalProbeFires is the number of consecutive scheduled fires we walk
+// when computing the smallest interval a schedule produces. Crons can have
+// variable gaps (e.g. weekday-only or "0,15,30,45,46 * * * *"), so we sample
+// enough fires to surface the shortest gap in the cycle.
+const minIntervalProbeFires = 200
 
 type cronScheduleString struct {
 	Val string `validate:"cron_schedule"`
@@ -23,6 +35,29 @@ func cronScheduleValidator(fl validator.FieldLevel) bool {
 		return true
 	}
 
-	_, err := cron.ParseStandard(cronExpr)
-	return err == nil
+	sched, err := cron.ParseStandard(cronExpr)
+	if err != nil {
+		return false
+	}
+
+	return MinScheduleInterval(sched) >= MinCronInterval
+}
+
+// MinScheduleInterval returns the smallest gap between two consecutive fires
+// of the given schedule, sampled over the next minIntervalProbeFires fires.
+//
+// Exposed so callers outside the struct-tag flow (e.g. the syncer-side
+// `ValidateCronSchedule` helper) can apply the same rule without re-parsing.
+func MinScheduleInterval(sched cron.Schedule) time.Duration {
+	now := time.Now().UTC()
+	prev := sched.Next(now)
+	min := time.Duration(1<<63 - 1)
+	for i := 0; i < minIntervalProbeFires; i++ {
+		next := sched.Next(prev)
+		if d := next.Sub(prev); d < min {
+			min = d
+		}
+		prev = next
+	}
+	return min
 }

--- a/services/ctl-api/internal/pkg/validator/cron_schedule_test.go
+++ b/services/ctl-api/internal/pkg/validator/cron_schedule_test.go
@@ -1,0 +1,49 @@
+package validator
+
+import (
+	"testing"
+)
+
+func TestCronSchedule_MinInterval(t *testing.T) {
+	v := New()
+
+	cases := []struct {
+		name    string
+		expr    string
+		wantErr bool
+	}{
+		// pass
+		{"empty", "", false},
+		{"every 5 min", "*/5 * * * *", false},
+		{"hourly on 0", "0 * * * *", false},
+		{"every 15 min", "*/15 * * * *", false},
+		{"weekdays 9am", "0 9 * * 1-5", false},
+		{"sunday midnight", "0 0 * * 0", false},
+		{"daily midnight", "0 0 * * *", false},
+
+		// fail: too frequent
+		{"every minute", "* * * * *", true},
+		{"every 1 min explicit", "*/1 * * * *", true},
+		{"every 2 min", "*/2 * * * *", true},
+		{"every 4 min", "*/4 * * * *", true},
+		{"two fires 1 min apart", "0,1 * * * *", true},
+		{"three fires 2 min apart", "0,2,4 * * * *", true},
+		{"mostly 15m with one 1m gap", "0,15,30,45,46 * * * *", true},
+
+		// fail: invalid syntax
+		{"invalid", "not a cron", true},
+		{"too few fields", "* * *", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CronSchedule(v, tc.expr)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for %q, got nil", tc.expr)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error for %q, got %v", tc.expr, err)
+			}
+		})
+	}
+}

--- a/services/ctl-api/internal/pkg/validator/validate.go
+++ b/services/ctl-api/internal/pkg/validator/validate.go
@@ -20,6 +20,8 @@ func FormatValidationError(err error) error {
 				fieldErr = fmt.Sprintf("%s: Name must contain only lowercase letters, numbers, underscores, dots, and curly braces (for interpolation)", e.Field())
 			case "entity_name":
 				fieldErr = fmt.Sprintf("%s: Name must contain only lowercase letters, numbers, underscores, and hyphens", e.Field())
+			case "cron_schedule":
+				fieldErr = fmt.Sprintf("%s: must be a valid cron expression that fires no more often than every %s", e.Field(), MinCronInterval)
 			default:
 				fieldErr = fmt.Sprintf("%s: %s", e.Field(), e.Error())
 			}


### PR DESCRIPTION
Adds a `MinCronInterval` (5m) check to the shared `cron_schedule` validator so action triggers, component drift schedules, and sandbox drift schedules are all rejected when they would fire more often than once every 5 minutes.

- Extend `cronScheduleValidator` to walk the next 200 fires and reject when the smallest interval is below `MinCronInterval`. Using this approach as crons schedules can fire on uneven intervals.
- Tag `DriftSchedule` on terraform/helm/pulumi/k8s component configs and on the app sandbox config with 'omitempty,cron_schedule' and drop the inline cron.ParseStandard blocks now covered by struct validation.
- Mirror the rule in syncer/validation.ValidateCronSchedule, and call it from the action and sandbox syncer paths which write directly to the DB without going through the HTTP validators.
- Add unit tests for the validator covering pass cases (>= 5m), too-frequent schedules (incl. mixed-interval crons with one short gap), and bad syntax.