### PR TITLE
fix: enqueue app provision signals on create

### DIFF
--- a/services/ctl-api/internal/app/apps/service/create_app.go
+++ b/services/ctl-api/internal/app/apps/service/create_app.go
@@ -77,6 +77,11 @@ func (s *service) CreateApp(ctx *gin.Context) {
 		return
 	}
 
+	if err := s.onAppCreated(ctx, app.ID); err != nil {
+		ctx.Error(fmt.Errorf("unable to dispatch app created signals: %w", err))
+		return
+	}
+
 	// Update user journey for first app creation
 	if err := s.accountsHelpers.UpdateUserJourneyStepForFirstAppCreate(ctx, user.ID, app.ID); err != nil {
 		// Log error but don't fail app creation

--- a/services/ctl-api/internal/app/apps/service/on_app_created.go
+++ b/services/ctl-api/internal/app/apps/service/on_app_created.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	createdsignal "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/signals/created"
+	polldependencies "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/signals/polldependencies"
+	provision "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/signals/provision"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+)
+
+// onAppCreated enqueues the created, provision and poll-dependencies signals on
+// the app queue so a newly created app gets provisioned.
+func (s *service) onAppCreated(ctx context.Context, appID string) error {
+	q, err := s.queueClient.GetQueueByOwner(ctx, appID, "apps")
+	if err != nil {
+		return fmt.Errorf("unable to get app queue: %w", err)
+	}
+
+	if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+		QueueID:   q.ID,
+		OwnerID:   appID,
+		OwnerType: "apps",
+		Signal:    &createdsignal.Signal{AppID: appID},
+	}); err != nil {
+		return fmt.Errorf("unable to enqueue created signal: %w", err)
+	}
+
+	if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+		QueueID:   q.ID,
+		OwnerID:   appID,
+		OwnerType: "apps",
+		Signal:    &provision.Signal{AppID: appID},
+	}); err != nil {
+		return fmt.Errorf("unable to enqueue provision signal: %w", err)
+	}
+
+	if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+		QueueID:   q.ID,
+		OwnerID:   appID,
+		OwnerType: "apps",
+		Signal:    &polldependencies.Signal{AppID: appID},
+	}); err != nil {
+		return fmt.Errorf("unable to enqueue poll dependencies signal: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
App creation stopped triggering provisioning after #1532 removed the legacy event-loop sends (OperationCreated/OperationProvision/OperationPollDependencies) without a queue-signal replacement. Apps got stuck at "queued / waiting for queue to provision app" forever.

Adds onAppCreated, mirroring onComponentCreated: enqueues created, provision and poll-dependencies signals on the app queue after create.