### PR TITLE
docs(035): add skip_noops and auto_approve_on_policies_passing

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -279,6 +279,7 @@
         "icon": "clock-rotate-left",
         "pages": [
           "updates/updates",
+          "updates/035-cancel-workflows-trace-view-and-slack",
           "updates/034-aws-terraform-install-stack",
           "updates/033-Workflow-Policy-and-improved-cloud-support",
           "updates/032-extensions-and-roles",

--- a/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
+++ b/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
@@ -30,14 +30,6 @@ Drift checks now emit a dedicated `drift.detected` event whenever a plan-only ch
 
 A new install-scoped sandbox drift cron complements the existing per-component drift check, so sandbox infrastructure is now polled on the same schedule as your app components.
 
-## Slack app
-
-Nuon now ships with a first-class Slack integration. Connect a workspace to your org and subscribe channels to workflow, approval, runner, and drift events — the same event taxonomy that powers webhooks, delivered as readable Slack messages.
-
-{/* TODO: add screenshot of Slack notifications */}
-
-New orgs are auto-linked to a configured workspace at creation time, so customers get notifications out of the box.
-
 ## Component dependency graph
 
 Installs now render a full dependency graph of their [components](/concepts/components), including transitive dependencies. Use it to understand blast radius before approving a deploy, or to debug why a component is waiting.

--- a/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
+++ b/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
@@ -47,7 +47,7 @@ Installs now render a full dependency graph of their [components](/concepts/comp
 - `skip_noops` — when a plan comes back with no changes, skip the deploy step entirely instead of running (or waiting on approval for) a no-op.
 - `auto_approve_on_policies_passing` — automatically approve a deploy when its policy checks pass, so only deploys that fail policy require manual sign-off.
 
-Both default to off and can be set per component or on the sandbox.
+Both default to off and can be set on a [Helm](/config-ref/helm), [Terraform](/config-ref/terraform), [Docker build](/config-ref/docker-build), or [Kubernetes manifest](/config-ref/kubernetes-manifest) component, or on the [sandbox](/config-ref/sandbox).
 
 ```toml
 skip_noops                       = true

--- a/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
+++ b/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
@@ -6,36 +6,6 @@ boost: 0.3
 
 _May 21, 2026_
 
-## Cancel active workflows
-
-You can now cancel in-flight [workflows](/concepts/workflows) directly from the dashboard. Stuck deploys, runaway sandboxes, and approval-blocked flows no longer require a wait or a support ticket — open the workflow and hit cancel.
-
-{/* TODO: add screenshot of cancel workflow UI */}
-
-A new `POST /v1/installs/{install_id}/workflows/cancel` API endpoint backs the same behavior for scripted use.
-
-## Trace timeline view
-
-The workflow detail page now renders as a split trace view — a fixed step tree on the left and a timeline bar chart on the right — so you can see at a glance where time was spent across a run.
-
-{/* TODO: add screenshot of trace timeline view */}
-
-- Indent guides make parent/child relationships obvious in deeply nested flows.
-- Log filters are consolidated into a severity dropdown plus a combined filter, with a new tool filter for narrowing to a specific integration.
-- System logs are included by default, and trace logs stream live over SSE.
-
-## Drift detection notifications
-
-Drift checks now emit a dedicated `drift.detected` event whenever a plan-only check finds non-no-op changes. Subscribe webhook or Slack consumers to the new event to get notified the moment drift appears — independently of any deploy outcome. See [Webhooks](/guides/webhooks) for the event payload.
-
-A new install-scoped sandbox drift cron complements the existing per-component drift check, so sandbox infrastructure is now polled on the same schedule as your app components.
-
-## Component dependency graph
-
-Installs now render a full dependency graph of their [components](/concepts/components), including transitive dependencies. Use it to understand blast radius before approving a deploy, or to debug why a component is waiting.
-
-{/* TODO: add screenshot of component dep graph */}
-
 ## Sandbox auto-retries
 
 [Sandboxes](/concepts/sandboxes) now support `max_auto_retries` in their config, matching the behavior already available on components. Transient sandbox failures self-heal without manual re-runs, and a configurable cap prevents genuinely broken sandboxes from looping forever.
@@ -60,7 +30,7 @@ Org [webhooks](/guides/webhooks) now accept a structured `interests` filter so e
 
 ## Nuon CLI
 
-- New `nuon-ext-replay-stack` extension for replaying install stack runs from the CLI.
+- New **`nuon-ext-replay-stack`** [CLI extension](/guides/cli-extensions) — a recovery tool for an install stuck at the **awaiting phone-home** step. If an install stack's phone-home payload was received but the stack version never activated, reprovision the install and run the extension to replay the stored payload to the new phone-home URL, letting the install complete.
 
 ## API
 

--- a/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
+++ b/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
@@ -1,0 +1,107 @@
+---
+title: '035 - Cancel workflows, trace timeline, and Slack'
+description: 'Cancel in-flight workflows, view runs as a trace timeline, subscribe to drift detection events over webhooks and the new Slack app, and more.'
+boost: 0.3
+---
+
+_May 21, 2026_
+
+## Cancel active workflows
+
+You can now cancel in-flight [workflows](/concepts/workflows) directly from the dashboard. Stuck deploys, runaway sandboxes, and approval-blocked flows no longer require a wait or a support ticket — open the workflow and hit cancel.
+
+{/* TODO: add screenshot of cancel workflow UI */}
+
+A new `POST /v1/installs/{install_id}/workflows/cancel` API endpoint backs the same behavior for scripted use.
+
+## Trace timeline view
+
+The workflow detail page now renders as a split trace view — a fixed step tree on the left and a timeline bar chart on the right — so you can see at a glance where time was spent across a run.
+
+{/* TODO: add screenshot of trace timeline view */}
+
+- Indent guides make parent/child relationships obvious in deeply nested flows.
+- Log filters are consolidated into a severity dropdown plus a combined filter, with a new tool filter for narrowing to a specific integration.
+- System logs are included by default, and trace logs stream live over SSE.
+
+## Drift detection notifications
+
+Drift checks now emit a dedicated `drift.detected` event whenever a plan-only check finds non-no-op changes. Subscribe webhook or Slack consumers to the new event to get notified the moment drift appears — independently of any deploy outcome. See [Webhooks](/guides/webhooks) for the event payload.
+
+A new install-scoped sandbox drift cron complements the existing per-component drift check, so sandbox infrastructure is now polled on the same schedule as your app components.
+
+## Slack app
+
+Nuon now ships with a first-class Slack integration. Connect a workspace to your org and subscribe channels to workflow, approval, runner, and drift events — the same event taxonomy that powers webhooks, delivered as readable Slack messages.
+
+{/* TODO: add screenshot of Slack notifications */}
+
+New orgs are auto-linked to a configured workspace at creation time, so customers get notifications out of the box.
+
+## Component dependency graph
+
+Installs now render a full dependency graph of their [components](/concepts/components), including transitive dependencies. Use it to understand blast radius before approving a deploy, or to debug why a component is waiting.
+
+{/* TODO: add screenshot of component dep graph */}
+
+## Sandbox auto-retries
+
+[Sandboxes](/concepts/sandboxes) now support `max_auto_retries` in their config, matching the behavior already available on components. Transient sandbox failures self-heal without manual re-runs, and a configurable cap prevents genuinely broken sandboxes from looping forever.
+
+## Skip no-op deploys and auto-approve on passing policies
+
+[Components](/concepts/components) and [sandboxes](/concepts/sandboxes) gained two new deploy-control fields in their config:
+
+- `skip_noops` — when a plan comes back with no changes, skip the deploy step entirely instead of running (or waiting on approval for) a no-op.
+- `auto_approve_on_policies_passing` — automatically approve a deploy when its policy checks pass, so only deploys that fail policy require manual sign-off.
+
+Both default to off and can be set per component or on the sandbox.
+
+```toml
+skip_noops                       = true
+auto_approve_on_policies_passing = true
+```
+
+## Per-webhook event filters
+
+Org [webhooks](/guides/webhooks) now accept a structured `interests` filter so each subscription can opt into a subset of events — by resource (workflow, step, approval, runner), operation, outcome, or approval state — instead of receiving every lifecycle event. Existing subscriptions default to `all_events: true` and continue to behave exactly as before.
+
+## Runner authentication on AWS
+
+[Runners on AWS](/architecture/runner-auth) now default to instance identity document (IID) authentication. New runners pick it up automatically; existing runners are unaffected. This aligns AWS with the zero-trust auth posture already used on GCP and Azure.
+
+## Updates
+
+- **Policy reports** redesigned for faster scanning of evaluations across installs.
+- **Install navbar** updated with clearer sections and quicker access to runner, components, and workflows.
+- **App branches** UI is now generally available behind a feature flag, with a refreshed design.
+- **Architecture diagram export** — download a PNG of the install's architecture diagram from the dashboard.
+- **Search installs by runner ID** from the installs list and via the API.
+- **State download and copy** — pull component state directly from the workflow step panel.
+- **Diff rendering** handles long lines and overflow more gracefully; overflow highlights are clearer.
+- **Workflow badges** refreshed with new statuses and consistent colors across the dashboard.
+- **Live updates** — the workflow detail, log viewer, timeline, resource pages, and org status bar now stream over SSE instead of polling.
+- **Keyboard shortcuts** for common dashboard navigation actions.
+- **Onboarding** flow now validates org details before provisioning.
+- **Plan approvals** are now delivered as queue signals, improving reliability when a runner is briefly unavailable.
+
+## Bug fixes
+
+- Fixed an auto-approval bug where plan-only mode could incorrectly auto-approve plans.
+- Fixed the action run cancel button on the workflow detail page.
+- Fixed missing install inputs when no vendor inputs were defined.
+- Fixed Terraform provider mirror builds for orgs that also use `docker_build` components.
+- Fixed `nuon orgs connect-github` CLI callback path so the GitHub App flow completes correctly.
+- Fixed `nuon ext list` to include locally-installed extensions; removed the `NUON_PREVIEW` requirement for `nuon ext`.
+- Fixed log panel "copy link" and SSE log loading on already-closed streams.
+- Fixed VM shutdown, signal re-enqueue, and "approve all" edge cases.
+- Fixed `time.Duration` fields in the API and SDK to serialize as documented.
+
+## Nuon CLI
+
+- New `nuon-ext-replay-stack` extension for replaying install stack runs from the CLI.
+
+## API
+
+- `POST /v1/installs/{install_id}/workflows/cancel` — cancel active workflows for an install.
+- Active workflows and pending approvals are now excluded from responses for deleted installs.

--- a/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
+++ b/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
@@ -66,37 +66,6 @@ auto_approve_on_policies_passing = true
 
 Org [webhooks](/guides/webhooks) now accept a structured `interests` filter so each subscription can opt into a subset of events — by resource (workflow, step, approval, runner), operation, outcome, or approval state — instead of receiving every lifecycle event. Existing subscriptions default to `all_events: true` and continue to behave exactly as before.
 
-## Runner authentication on AWS
-
-[Runners on AWS](/architecture/runner-auth) now default to instance identity document (IID) authentication. New runners pick it up automatically; existing runners are unaffected. This aligns AWS with the zero-trust auth posture already used on GCP and Azure.
-
-## Updates
-
-- **Policy reports** redesigned for faster scanning of evaluations across installs.
-- **Install navbar** updated with clearer sections and quicker access to runner, components, and workflows.
-- **App branches** UI is now generally available behind a feature flag, with a refreshed design.
-- **Architecture diagram export** — download a PNG of the install's architecture diagram from the dashboard.
-- **Search installs by runner ID** from the installs list and via the API.
-- **State download and copy** — pull component state directly from the workflow step panel.
-- **Diff rendering** handles long lines and overflow more gracefully; overflow highlights are clearer.
-- **Workflow badges** refreshed with new statuses and consistent colors across the dashboard.
-- **Live updates** — the workflow detail, log viewer, timeline, resource pages, and org status bar now stream over SSE instead of polling.
-- **Keyboard shortcuts** for common dashboard navigation actions.
-- **Onboarding** flow now validates org details before provisioning.
-- **Plan approvals** are now delivered as queue signals, improving reliability when a runner is briefly unavailable.
-
-## Bug fixes
-
-- Fixed an auto-approval bug where plan-only mode could incorrectly auto-approve plans.
-- Fixed the action run cancel button on the workflow detail page.
-- Fixed missing install inputs when no vendor inputs were defined.
-- Fixed Terraform provider mirror builds for orgs that also use `docker_build` components.
-- Fixed `nuon orgs connect-github` CLI callback path so the GitHub App flow completes correctly.
-- Fixed `nuon ext list` to include locally-installed extensions; removed the `NUON_PREVIEW` requirement for `nuon ext`.
-- Fixed log panel "copy link" and SSE log loading on already-closed streams.
-- Fixed VM shutdown, signal re-enqueue, and "approve all" edge cases.
-- Fixed `time.Duration` fields in the API and SDK to serialize as documented.
-
 ## Nuon CLI
 
 - New `nuon-ext-replay-stack` extension for replaying install stack runs from the CLI.


### PR DESCRIPTION
Document two per-component/sandbox deploy-control config fields shipped after 034 (committed May 15, PR #1337, live at v0.19.974) that were missed in the changelog:

- skip_noops — skip the deploy step when a plan is a no-op
- auto_approve_on_policies_passing — auto-approve a deploy when policy checks pass