### PR TITLE
fix: role param Default must be string to match AllowedValues

### DIFF
--- a/services/ctl-api/internal/pkg/stacks/cloudformation/resource_role.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/resource_role.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"strconv"
 
 	"github.com/awslabs/goformation/v7/cloudformation"
 	"github.com/awslabs/goformation/v7/cloudformation/iam"
@@ -166,7 +167,7 @@ func (a *Templates) getRolePolicy(role app.AppAWSIAMRoleConfig, policy app.AppAW
 func (a *Templates) getRoleParameters(role app.AppAWSIAMRoleConfig, defaultValue bool) cloudformation.Parameter {
 	return cloudformation.Parameter{
 		Type:    "String",
-		Default: defaultValue,
+		Default: strconv.FormatBool(defaultValue),
 		AllowedValues: []any{
 			"true",
 			"false",


### PR DESCRIPTION
getRoleParameters set Default to a Go bool on a Type:String parameter whose AllowedValues are strings ("true"/"false"). Serialized as JSON boolean true, CloudFormation rejects it (Default not in AllowedValues) — surfacing as invalid params + no default selected when launching the stack. Affects every role toggle (EnableRunnerProvision/Deprovision/Maintenance, break-glass, custom roles). Fix: serialize Default as a string via strconv.FormatBool.