### PR TITLE
docs(035): Runbooks & rendered READMEs changelog + Runbooks guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -279,6 +279,7 @@
         "icon": "clock-rotate-left",
         "pages": [
           "updates/updates",
+          "updates/035-cancel-workflows-trace-view-and-slack",
           "updates/034-aws-terraform-install-stack",
           "updates/033-Workflow-Policy-and-improved-cloud-support",
           "updates/032-extensions-and-roles",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -144,6 +144,7 @@
               "guides/configuring-sandboxes",
               "guides/using-variables",
               "guides/using-readmes",
+              "guides/runbooks",
               "guides/vcs",
               {
                 "group": "Components",
@@ -279,7 +280,7 @@
         "icon": "clock-rotate-left",
         "pages": [
           "updates/updates",
-          "updates/035-cancel-workflows-trace-view-and-slack",
+          "updates/035-runbooks-and-readmes",
           "updates/034-aws-terraform-install-stack",
           "updates/033-Workflow-Policy-and-improved-cloud-support",
           "updates/032-extensions-and-roles",

--- a/docs/guides/runbooks.mdx
+++ b/docs/guides/runbooks.mdx
@@ -5,9 +5,9 @@ icon: "list-checks"
 keywords: ["runbooks", "runbook", "runbook TOML", "configure runbooks", "runbook steps", "deploy step", "action step", "operational procedures", "version upgrade", "database migration", "nuon runbooks"]
 ---
 
-Runbooks let you define a named, ordered sequence of steps and run it against an install on demand. Use them for the multi-step operations that would otherwise be run by hand — version upgrades, database migrations, data backfills, and recovery procedures.
+Runbooks turn a multi-step operational procedure into a single, repeatable artifact you run against an install on demand — much like a notebook turns an analysis into ordered, re-runnable cells. Instead of performing version upgrades, database migrations, data backfills, or recovery steps by hand each time, you define the sequence once and run it consistently across every install.
 
-Each step is either a **deploy** (deploy a component) or an **action** (run an [action](/guides/actions), or an inline ad-hoc command). Steps execute in order, and a runbook run shows up in the install's workflow history just like any other operation.
+Each step is either a **deploy** (deploy a component) or an **action** (run an [action](/guides/actions), or an inline ad-hoc command). Steps run in order, and every run is recorded in the install's workflow history — its steps, logs, and outcome — so you have a durable, auditable record of what ran, when, and against which install.
 
 ## Where runbooks live
 

--- a/docs/guides/runbooks.mdx
+++ b/docs/guides/runbooks.mdx
@@ -1,0 +1,90 @@
+---
+title: "Configure runbooks"
+description: "Define named, multi-step procedures and run them against your installs on demand."
+icon: "list-checks"
+keywords: ["runbooks", "runbook", "runbook TOML", "configure runbooks", "runbook steps", "deploy step", "action step", "operational procedures", "version upgrade", "database migration", "nuon runbooks"]
+---
+
+Runbooks let you define a named, ordered sequence of steps and run it against an install on demand. Use them for the multi-step operations that would otherwise be run by hand — version upgrades, database migrations, data backfills, and recovery procedures.
+
+Each step is either a **deploy** (deploy a component) or an **action** (run an [action](/guides/actions), or an inline ad-hoc command). Steps execute in order, and a runbook run shows up in the install's workflow history just like any other operation.
+
+## Where runbooks live
+
+Define runbooks as TOML files in a `runbooks/` directory in your app config. Each file is one runbook:
+
+```
+my-app/
+├── metadata.toml
+├── components/
+├── actions/
+└── runbooks/
+    └── v2.3-update.toml
+```
+
+They sync with the rest of your config via `nuon sync`.
+
+## Example
+
+```toml
+name        = "v2.3-update"
+description = "Apply the v2.3 schema migration, then roll out the API."
+readme      = "./runbooks/v2.3-update.md"
+
+[[steps]]
+name        = "migrate-db"
+type        = "action"
+action_name = "database-migration"
+
+[[steps]]
+name           = "deploy-api"
+type           = "deploy"
+component_name = "api-server"
+deploy_dependencies = true
+
+[[steps]]
+name    = "smoke-test"
+type    = "action"
+command = "./scripts/smoke-test.sh"
+timeout = "5m"
+```
+
+## Configuration reference
+
+### Runbook
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Name shown in the **Runbooks** tab and used to identify the runbook during sync. |
+| `description` | string | No | Short description of what the runbook does. |
+| `readme` | string | No | Markdown documentation for the runbook. Supports Go templating and external file sources (HTTP(S) URLs, git, or local paths). |
+| `labels` | map | No | Key/value labels for organizing runbooks. |
+| `steps` | array | Yes | Ordered list of steps to execute. See below. |
+
+### Step (`[[steps]]`)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Step name shown in the workflow UI and runbook detail page. |
+| `type` | string | Yes | `deploy` or `action`. |
+| `component_name` | string | deploy steps | Component to deploy. Required when `type = "deploy"`. |
+| `deploy_dependencies` | bool | No | When true, also deploys the component's transitive dependencies in order. |
+| `action_name` | string | action steps | Name of an existing [action](/guides/actions) to run. Mutually exclusive with the inline fields below. |
+| `command` | string | action steps | Shell command for an inline ad-hoc action. Supports Go templating. |
+| `inline_contents` | string | action steps | Inline script contents, or a reference to an external file. Supports templating and external sources. |
+| `env_vars` | map | No | Environment variables for an inline action step. |
+| `timeout` | string | No | Maximum execution time for an inline action step (Go duration, e.g. `30s`, `5m`). |
+| `role` | string | No | IAM role to assume when executing an inline action step. |
+
+An action step uses **either** `action_name` (to run a previously defined action) **or** the inline fields (`command` / `inline_contents`) to define an ad-hoc action — not both.
+
+## Running a runbook
+
+Trigger and watch runbook runs from the **Runbooks** tab in the [dashboard](https://app.nuon.co/), or from the CLI:
+
+```sh
+# View runbooks for an install
+nuon runbooks --install-id <install-id>
+```
+
+Each run is recorded in the install's workflow history, so you can review the steps, logs, and outcome of any past runbook execution.

--- a/docs/guides/runbooks.mdx
+++ b/docs/guides/runbooks.mdx
@@ -5,9 +5,9 @@ icon: "list-checks"
 keywords: ["runbooks", "runbook", "runbook TOML", "configure runbooks", "runbook steps", "deploy step", "action step", "operational procedures", "version upgrade", "database migration", "nuon runbooks"]
 ---
 
-Runbooks turn a multi-step operational procedure into a single, repeatable artifact you run against an install on demand — much like a notebook turns an analysis into ordered, re-runnable cells. Instead of performing version upgrades, database migrations, data backfills, or recovery steps by hand each time, you define the sequence once and run it consistently across every install.
+Runbooks turn a multi-step operational procedure into a single, repeatable artifact you run against an install on demand, much like a notebook turns an analysis into ordered, re-runnable cells. Instead of performing version upgrades, database migrations, data backfills, or recovery steps by hand each time, you define the sequence once and run it consistently across every install.
 
-Each step is either a **deploy** (deploy a component) or an **action** (run an [action](/guides/actions), or an inline ad-hoc command). Steps run in order, and every run is recorded in the install's workflow history — its steps, logs, and outcome — so you have a durable, auditable record of what ran, when, and against which install.
+Each step is either a **deploy** (deploy a component) or an **action** (run an [action](/guides/actions), or an inline ad-hoc command). Steps run in order, and every run is recorded in the install's workflow history (its steps, logs, and outcome), so you have a durable, auditable record of what ran, when, and against which install.
 
 ## Where runbooks live
 
@@ -76,7 +76,7 @@ timeout = "5m"
 | `timeout` | string | No | Maximum execution time for an inline action step (Go duration, e.g. `30s`, `5m`). |
 | `role` | string | No | IAM role to assume when executing an inline action step. |
 
-An action step uses **either** `action_name` (to run a previously defined action) **or** the inline fields (`command` / `inline_contents`) to define an ad-hoc action — not both.
+An action step uses **either** `action_name` (to run a previously defined action) **or** the inline fields (`command` / `inline_contents`) to define an ad-hoc action, not both.
 
 ## Running a runbook
 

--- a/docs/guides/using-readmes.mdx
+++ b/docs/guides/using-readmes.mdx
@@ -543,7 +543,7 @@ Attributes: `name`, `id`.
 ### Run runbook
 
 Renders a card with a button that opens the run runbook confirmation modal.
-Reference by `name` or `id`.
+Reference a [runbook](/guides/runbooks) by `name` or `id`.
 
 ```markdown README.md
 <nuon-run-runbook name="restart-service"></nuon-run-runbook>

--- a/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
+++ b/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
@@ -30,14 +30,6 @@ Drift checks now emit a dedicated `drift.detected` event whenever a plan-only ch
 
 A new install-scoped sandbox drift cron complements the existing per-component drift check, so sandbox infrastructure is now polled on the same schedule as your app components.
 
-## Slack app
-
-Nuon now ships with a first-class Slack integration. Connect a workspace to your org and subscribe channels to workflow, approval, runner, and drift events — the same event taxonomy that powers webhooks, delivered as readable Slack messages.
-
-{/* TODO: add screenshot of Slack notifications */}
-
-New orgs are auto-linked to a configured workspace at creation time, so customers get notifications out of the box.
-
 ## Component dependency graph
 
 Installs now render a full dependency graph of their [components](/concepts/components), including transitive dependencies. Use it to understand blast radius before approving a deploy, or to debug why a component is waiting.

--- a/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
+++ b/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
@@ -47,7 +47,7 @@ Installs now render a full dependency graph of their [components](/concepts/comp
 - `skip_noops` — when a plan comes back with no changes, skip the deploy step entirely instead of running (or waiting on approval for) a no-op.
 - `auto_approve_on_policies_passing` — automatically approve a deploy when its policy checks pass, so only deploys that fail policy require manual sign-off.
 
-Both default to off and can be set per component or on the sandbox.
+Both default to off and can be set on a [Helm](/config-ref/helm), [Terraform](/config-ref/terraform), [Docker build](/config-ref/docker-build), or [Kubernetes manifest](/config-ref/kubernetes-manifest) component, or on the [sandbox](/config-ref/sandbox).
 
 ```toml
 skip_noops                       = true

--- a/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
+++ b/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
@@ -6,36 +6,6 @@ boost: 0.3
 
 _May 21, 2026_
 
-## Cancel active workflows
-
-You can now cancel in-flight [workflows](/concepts/workflows) directly from the dashboard. Stuck deploys, runaway sandboxes, and approval-blocked flows no longer require a wait or a support ticket — open the workflow and hit cancel.
-
-{/* TODO: add screenshot of cancel workflow UI */}
-
-A new `POST /v1/installs/{install_id}/workflows/cancel` API endpoint backs the same behavior for scripted use.
-
-## Trace timeline view
-
-The workflow detail page now renders as a split trace view — a fixed step tree on the left and a timeline bar chart on the right — so you can see at a glance where time was spent across a run.
-
-{/* TODO: add screenshot of trace timeline view */}
-
-- Indent guides make parent/child relationships obvious in deeply nested flows.
-- Log filters are consolidated into a severity dropdown plus a combined filter, with a new tool filter for narrowing to a specific integration.
-- System logs are included by default, and trace logs stream live over SSE.
-
-## Drift detection notifications
-
-Drift checks now emit a dedicated `drift.detected` event whenever a plan-only check finds non-no-op changes. Subscribe webhook or Slack consumers to the new event to get notified the moment drift appears — independently of any deploy outcome. See [Webhooks](/guides/webhooks) for the event payload.
-
-A new install-scoped sandbox drift cron complements the existing per-component drift check, so sandbox infrastructure is now polled on the same schedule as your app components.
-
-## Component dependency graph
-
-Installs now render a full dependency graph of their [components](/concepts/components), including transitive dependencies. Use it to understand blast radius before approving a deploy, or to debug why a component is waiting.
-
-{/* TODO: add screenshot of component dep graph */}
-
 ## Sandbox auto-retries
 
 [Sandboxes](/concepts/sandboxes) now support `max_auto_retries` in their config, matching the behavior already available on components. Transient sandbox failures self-heal without manual re-runs, and a configurable cap prevents genuinely broken sandboxes from looping forever.
@@ -60,7 +30,7 @@ Org [webhooks](/guides/webhooks) now accept a structured `interests` filter so e
 
 ## Nuon CLI
 
-- New `nuon-ext-replay-stack` extension for replaying install stack runs from the CLI.
+- New **`nuon-ext-replay-stack`** [CLI extension](/guides/cli-extensions) — a recovery tool for an install stuck at the **awaiting phone-home** step. If an install stack's phone-home payload was received but the stack version never activated, reprovision the install and run the extension to replay the stored payload to the new phone-home URL, letting the install complete.
 
 ## API
 

--- a/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
+++ b/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
@@ -1,0 +1,107 @@
+---
+title: '035 - Cancel workflows, trace timeline, and Slack'
+description: 'Cancel in-flight workflows, view runs as a trace timeline, subscribe to drift detection events over webhooks and the new Slack app, and more.'
+boost: 0.3
+---
+
+_May 21, 2026_
+
+## Cancel active workflows
+
+You can now cancel in-flight [workflows](/concepts/workflows) directly from the dashboard. Stuck deploys, runaway sandboxes, and approval-blocked flows no longer require a wait or a support ticket — open the workflow and hit cancel.
+
+{/* TODO: add screenshot of cancel workflow UI */}
+
+A new `POST /v1/installs/{install_id}/workflows/cancel` API endpoint backs the same behavior for scripted use.
+
+## Trace timeline view
+
+The workflow detail page now renders as a split trace view — a fixed step tree on the left and a timeline bar chart on the right — so you can see at a glance where time was spent across a run.
+
+{/* TODO: add screenshot of trace timeline view */}
+
+- Indent guides make parent/child relationships obvious in deeply nested flows.
+- Log filters are consolidated into a severity dropdown plus a combined filter, with a new tool filter for narrowing to a specific integration.
+- System logs are included by default, and trace logs stream live over SSE.
+
+## Drift detection notifications
+
+Drift checks now emit a dedicated `drift.detected` event whenever a plan-only check finds non-no-op changes. Subscribe webhook or Slack consumers to the new event to get notified the moment drift appears — independently of any deploy outcome. See [Webhooks](/guides/webhooks) for the event payload.
+
+A new install-scoped sandbox drift cron complements the existing per-component drift check, so sandbox infrastructure is now polled on the same schedule as your app components.
+
+## Slack app
+
+Nuon now ships with a first-class Slack integration. Connect a workspace to your org and subscribe channels to workflow, approval, runner, and drift events — the same event taxonomy that powers webhooks, delivered as readable Slack messages.
+
+{/* TODO: add screenshot of Slack notifications */}
+
+New orgs are auto-linked to a configured workspace at creation time, so customers get notifications out of the box.
+
+## Component dependency graph
+
+Installs now render a full dependency graph of their [components](/concepts/components), including transitive dependencies. Use it to understand blast radius before approving a deploy, or to debug why a component is waiting.
+
+{/* TODO: add screenshot of component dep graph */}
+
+## Sandbox auto-retries
+
+[Sandboxes](/concepts/sandboxes) now support `max_auto_retries` in their config, matching the behavior already available on components. Transient sandbox failures self-heal without manual re-runs, and a configurable cap prevents genuinely broken sandboxes from looping forever.
+
+## Skip no-op deploys and auto-approve on passing policies
+
+[Components](/concepts/components) and [sandboxes](/concepts/sandboxes) gained two new deploy-control fields in their config:
+
+- `skip_noops` — when a plan comes back with no changes, skip the deploy step entirely instead of running (or waiting on approval for) a no-op.
+- `auto_approve_on_policies_passing` — automatically approve a deploy when its policy checks pass, so only deploys that fail policy require manual sign-off.
+
+Both default to off and can be set per component or on the sandbox.
+
+```toml
+skip_noops                       = true
+auto_approve_on_policies_passing = true
+```
+
+## Per-webhook event filters
+
+Org [webhooks](/guides/webhooks) now accept a structured `interests` filter so each subscription can opt into a subset of events — by resource (workflow, step, approval, runner), operation, outcome, or approval state — instead of receiving every lifecycle event. Existing subscriptions default to `all_events: true` and continue to behave exactly as before.
+
+## Runner authentication on AWS
+
+[Runners on AWS](/architecture/runner-auth) now default to instance identity document (IID) authentication. New runners pick it up automatically; existing runners are unaffected. This aligns AWS with the zero-trust auth posture already used on GCP and Azure.
+
+## Updates
+
+- **Policy reports** redesigned for faster scanning of evaluations across installs.
+- **Install navbar** updated with clearer sections and quicker access to runner, components, and workflows.
+- **App branches** UI is now generally available behind a feature flag, with a refreshed design.
+- **Architecture diagram export** — download a PNG of the install's architecture diagram from the dashboard.
+- **Search installs by runner ID** from the installs list and via the API.
+- **State download and copy** — pull component state directly from the workflow step panel.
+- **Diff rendering** handles long lines and overflow more gracefully; overflow highlights are clearer.
+- **Workflow badges** refreshed with new statuses and consistent colors across the dashboard.
+- **Live updates** — the workflow detail, log viewer, timeline, resource pages, and org status bar now stream over SSE instead of polling.
+- **Keyboard shortcuts** for common dashboard navigation actions.
+- **Onboarding** flow now validates org details before provisioning.
+- **Plan approvals** are now delivered as queue signals, improving reliability when a runner is briefly unavailable.
+
+## Bug fixes
+
+- Fixed an auto-approval bug where plan-only mode could incorrectly auto-approve plans.
+- Fixed the action run cancel button on the workflow detail page.
+- Fixed missing install inputs when no vendor inputs were defined.
+- Fixed Terraform provider mirror builds for orgs that also use `docker_build` components.
+- Fixed `nuon orgs connect-github` CLI callback path so the GitHub App flow completes correctly.
+- Fixed `nuon ext list` to include locally-installed extensions; removed the `NUON_PREVIEW` requirement for `nuon ext`.
+- Fixed log panel "copy link" and SSE log loading on already-closed streams.
+- Fixed VM shutdown, signal re-enqueue, and "approve all" edge cases.
+- Fixed `time.Duration` fields in the API and SDK to serialize as documented.
+
+## Nuon CLI
+
+- New `nuon-ext-replay-stack` extension for replaying install stack runs from the CLI.
+
+## API
+
+- `POST /v1/installs/{install_id}/workflows/cancel` — cancel active workflows for an install.
+- Active workflows and pending approvals are now excluded from responses for deleted installs.

--- a/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
+++ b/docs/updates/035-cancel-workflows-trace-view-and-slack.mdx
@@ -66,37 +66,6 @@ auto_approve_on_policies_passing = true
 
 Org [webhooks](/guides/webhooks) now accept a structured `interests` filter so each subscription can opt into a subset of events — by resource (workflow, step, approval, runner), operation, outcome, or approval state — instead of receiving every lifecycle event. Existing subscriptions default to `all_events: true` and continue to behave exactly as before.
 
-## Runner authentication on AWS
-
-[Runners on AWS](/architecture/runner-auth) now default to instance identity document (IID) authentication. New runners pick it up automatically; existing runners are unaffected. This aligns AWS with the zero-trust auth posture already used on GCP and Azure.
-
-## Updates
-
-- **Policy reports** redesigned for faster scanning of evaluations across installs.
-- **Install navbar** updated with clearer sections and quicker access to runner, components, and workflows.
-- **App branches** UI is now generally available behind a feature flag, with a refreshed design.
-- **Architecture diagram export** — download a PNG of the install's architecture diagram from the dashboard.
-- **Search installs by runner ID** from the installs list and via the API.
-- **State download and copy** — pull component state directly from the workflow step panel.
-- **Diff rendering** handles long lines and overflow more gracefully; overflow highlights are clearer.
-- **Workflow badges** refreshed with new statuses and consistent colors across the dashboard.
-- **Live updates** — the workflow detail, log viewer, timeline, resource pages, and org status bar now stream over SSE instead of polling.
-- **Keyboard shortcuts** for common dashboard navigation actions.
-- **Onboarding** flow now validates org details before provisioning.
-- **Plan approvals** are now delivered as queue signals, improving reliability when a runner is briefly unavailable.
-
-## Bug fixes
-
-- Fixed an auto-approval bug where plan-only mode could incorrectly auto-approve plans.
-- Fixed the action run cancel button on the workflow detail page.
-- Fixed missing install inputs when no vendor inputs were defined.
-- Fixed Terraform provider mirror builds for orgs that also use `docker_build` components.
-- Fixed `nuon orgs connect-github` CLI callback path so the GitHub App flow completes correctly.
-- Fixed `nuon ext list` to include locally-installed extensions; removed the `NUON_PREVIEW` requirement for `nuon ext`.
-- Fixed log panel "copy link" and SSE log loading on already-closed streams.
-- Fixed VM shutdown, signal re-enqueue, and "approve all" edge cases.
-- Fixed `time.Duration` fields in the API and SDK to serialize as documented.
-
 ## Nuon CLI
 
 - New `nuon-ext-replay-stack` extension for replaying install stack runs from the CLI.

--- a/docs/updates/035-runbooks-and-readmes.mdx
+++ b/docs/updates/035-runbooks-and-readmes.mdx
@@ -8,7 +8,7 @@ _May 21, 2026_
 
 ## Runbooks
 
-Runbooks let you define a named, ordered sequence of steps and run it against an install on demand — version upgrades, database migrations, recovery procedures, and other multi-step operations that used to be run by hand.
+Runbooks let you define a named, ordered sequence of steps and run it against an install on demand: version upgrades, database migrations, recovery procedures, and other multi-step operations that used to be run by hand.
 
 Define runbooks as TOML files in a `runbooks/` directory in your app config. Each step is either a **deploy** (deploy a component, optionally with its dependencies) or an **action** (run an existing action, or an inline ad-hoc command):
 
@@ -30,7 +30,7 @@ Trigger and watch runs from the new **Runbooks** tab in the dashboard, or from t
 
 ## Rendered READMEs
 
-An install's README can now be fetched **fully rendered for that install** through the API. The README's Go template expressions are evaluated against the install's live values, so the API returns the resolved documentation — real URLs, IDs, and outputs — instead of the raw template source.
+An install's README can now be fetched **fully rendered for that install** through the API. The README's Go template expressions are evaluated against the install's live values, so the API returns the resolved documentation (real URLs, IDs, and outputs) instead of the raw template source.
 
 READMEs are authored as Markdown on the app (the `readme` field in `metadata.toml`) and on individual [runbooks](/guides/runbooks), and support Go templating (e.g. `{{ .nuon.install.outputs.* }}`) plus external file sources (HTTP(S), git, or local paths). See [Using READMEs](/guides/using-readmes).
 
@@ -42,8 +42,8 @@ READMEs are authored as Markdown on the app (the `readme` field in `metadata.tom
 
 [Components](/concepts/components) and [sandboxes](/concepts/sandboxes) gained two new deploy-control fields in their config:
 
-- `skip_noops` — when a plan comes back with no changes, skip the deploy step entirely instead of running (or waiting on approval for) a no-op.
-- `auto_approve_on_policies_passing` — automatically approve a deploy when its policy checks pass, so only deploys that fail policy require manual sign-off.
+- `skip_noops`: when a plan comes back with no changes, skip the deploy step entirely instead of running (or waiting on approval for) a no-op.
+- `auto_approve_on_policies_passing`: automatically approve a deploy when its policy checks pass, so only deploys that fail policy require manual sign-off.
 
 Both default to off and can be set on a [Helm](/config-ref/helm), [Terraform](/config-ref/terraform), [Docker build](/config-ref/docker-build), or [Kubernetes manifest](/config-ref/kubernetes-manifest) component, or on the [sandbox](/config-ref/sandbox).
 
@@ -54,13 +54,13 @@ auto_approve_on_policies_passing = true
 
 ## Per-webhook event filters
 
-Org [webhooks](/guides/webhooks) now accept a structured `interests` filter so each subscription can opt into a subset of events — by resource (workflow, step, approval, runner), operation, outcome, or approval state — instead of receiving every lifecycle event. Existing subscriptions default to `all_events: true` and continue to behave exactly as before.
+Org [webhooks](/guides/webhooks) now accept a structured `interests` filter so each subscription can opt into a subset of events, scoped by resource (workflow, step, approval, runner), operation, outcome, or approval state, instead of receiving every lifecycle event. Existing subscriptions default to `all_events: true` and continue to behave exactly as before.
 
 ## Nuon CLI
 
-- New **`nuon-ext-replay-stack`** [CLI extension](/guides/cli-extensions) — a recovery tool for an install stuck at the **awaiting phone-home** step. If an install stack's phone-home payload was received but the stack version never activated, reprovision the install and run the extension to replay the stored payload to the new phone-home URL, letting the install complete.
+- New **`nuon-ext-replay-stack`** [CLI extension](/guides/cli-extensions): a recovery tool for an install stuck at the **awaiting phone-home** step. If an install stack's phone-home payload was received but the stack version never activated, reprovision the install and run the extension to replay the stored payload to the new phone-home URL, letting the install complete.
 
 ## API
 
-- `POST /v1/installs/{install_id}/workflows/cancel` — cancel active workflows for an install.
+- `POST /v1/installs/{install_id}/workflows/cancel`: cancel active workflows for an install.
 - Active workflows and pending approvals are now excluded from responses for deleted installs.

--- a/docs/updates/035-runbooks-and-readmes.mdx
+++ b/docs/updates/035-runbooks-and-readmes.mdx
@@ -30,9 +30,9 @@ Trigger and watch runs from the new **Runbooks** tab in the dashboard, or from t
 
 ## Rendered READMEs
 
-An install's README can now be fetched **fully rendered with that install's live template values** through the API, so the documentation a customer sees reflects their actual deployment — real URLs, IDs, and outputs rather than `{{ ... }}` placeholders.
+An install's README can now be fetched **fully rendered for that install** through the API. The README's Go template expressions are evaluated against the install's live values, so the API returns the resolved documentation — real URLs, IDs, and outputs — instead of the raw template source.
 
-READMEs are authored as Markdown on the app (the `readme` field in `metadata.toml`) and on individual [runbooks](/guides/runbooks), and support Go templating plus external file sources (HTTP(S), git, or local paths). See [Using READMEs](/guides/using-readmes).
+READMEs are authored as Markdown on the app (the `readme` field in `metadata.toml`) and on individual [runbooks](/guides/runbooks), and support Go templating (e.g. `{{ .nuon.install.outputs.* }}`) plus external file sources (HTTP(S), git, or local paths). See [Using READMEs](/guides/using-readmes).
 
 ## Sandbox auto-retries
 

--- a/docs/updates/035-runbooks-and-readmes.mdx
+++ b/docs/updates/035-runbooks-and-readmes.mdx
@@ -1,10 +1,38 @@
 ---
-title: '035 - Cancel workflows, trace timeline, and Slack'
-description: 'Cancel in-flight workflows, view runs as a trace timeline, subscribe to drift detection events over webhooks and the new Slack app, and more.'
+title: '035 - Runbooks and rendered READMEs'
+description: 'Define and run multi-step runbooks against installs, fetch install READMEs rendered with live template values, plus deploy controls, webhook event filters, and more.'
 boost: 0.3
 ---
 
 _May 21, 2026_
+
+## Runbooks
+
+Runbooks let you define a named, ordered sequence of steps and run it against an install on demand — version upgrades, database migrations, recovery procedures, and other multi-step operations that used to be run by hand.
+
+Define runbooks as TOML files in a `runbooks/` directory in your app config. Each step is either a **deploy** (deploy a component, optionally with its dependencies) or an **action** (run an existing action, or an inline ad-hoc command):
+
+```toml
+name = "v2.3-update"
+
+[[steps]]
+name           = "migrate-db"
+type           = "action"
+action_name    = "database-migration"
+
+[[steps]]
+name           = "deploy-api"
+type           = "deploy"
+component_name = "api-server"
+```
+
+Trigger and watch runs from the new **Runbooks** tab in the dashboard, or from the CLI with `nuon runbooks --install-id <id>`. See the [Runbooks guide](/guides/runbooks) for the full configuration reference.
+
+## Rendered READMEs
+
+An install's README can now be fetched **fully rendered with that install's live template values** through the API, so the documentation a customer sees reflects their actual deployment — real URLs, IDs, and outputs rather than `{{ ... }}` placeholders.
+
+READMEs are authored as Markdown on the app (the `readme` field in `metadata.toml`) and on individual [runbooks](/guides/runbooks), and support Go templating plus external file sources (HTTP(S), git, or local paths). See [Using READMEs](/guides/using-readmes).
 
 ## Sandbox auto-retries
 

--- a/docs/updates/updates.mdx
+++ b/docs/updates/updates.mdx
@@ -7,6 +7,9 @@ boost: 0.4
 <Note>Nuon issues new Releases frequently, so we recommend you visit the Changelog regularly.</Note>
 
 <CardGroup cols={2}>
+  <Card title="035 - Runbooks and rendered READMEs" icon="list-check" href="/updates/035-runbooks-and-readmes">
+    Define and run multi-step runbooks against installs, and fetch install READMEs rendered with live template values.
+  </Card>
   <Card title="034 - Slack Integration, Webhooks, and AWS Terraform Stacks" icon="slack" href="/updates/034-aws-terraform-install-stack">
     Slack notifications, org-scoped webhooks, and Terraform stacks for AWS.
   </Card>

--- a/services/dashboard-ui/client/content/dashboard-announcements.json
+++ b/services/dashboard-ui/client/content/dashboard-announcements.json
@@ -1,12 +1,12 @@
 {
   "announcements": [
     {
-      "id": "slack-webhooks-aws-tf-034",
-      "title": "Slack Integration, Webhooks, and AWS Terraform Stacks",
-      "date": "May 12, 2026",
-      "description": "Slack notifications, org-scoped webhooks, and Terraform stacks for AWS.",
+      "id": "runbooks-readmes-035",
+      "title": "Runbooks and rendered READMEs",
+      "date": "May 21, 2026",
+      "description": "Define and run multi-step runbooks against installs, and fetch install READMEs rendered with live values.",
       "ctaText": "Learn more",
-      "ctaUrl": "https://docs.nuon.co/updates/034-aws-terraform-install-stack",
+      "ctaUrl": "https://docs.nuon.co/updates/035-runbooks-and-readmes",
       "dismissible": false
     }
   ]


### PR DESCRIPTION
## What

Reworks the **035** changelog to focus on the two headline features promoted since 034, and adds the missing Runbooks documentation.

### Changelog (`updates/035-runbooks-and-readmes.mdx`)
- **Runbooks** (PR #1458, May 27) — named, ordered deploy/action procedures defined in a `runbooks/` directory, run from the dashboard Runbooks tab or `nuon runbooks`.
- **Rendered READMEs** (PRs #1332–1351, May 14–15) — install READMEs fetched fully rendered with the install's live template values.
- Retitled, rewrote the description, renamed the file (URL is now `/updates/035-runbooks-and-readmes`), and updated `docs.json`.
- Retained the other curated post-034 items (sandbox auto-retries, skip-noop/policy auto-approve, per-webhook filters, CLI recovery, API) below the headline sections.

### New guide (`guides/runbooks.mdx`)
No runbooks doc existed. Adds directory layout, full config reference (runbook + step fields), and how to run. Registered in nav next to "Using READMEs."

Supersedes #1543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)