### PR TITLE
feat(cli): nuon installs labels command group

### DIFF
--- a/bins/cli/cmd/installs.go
+++ b/bins/cli/cmd/installs.go
@@ -1062,30 +1062,66 @@ By default, launches an interactive TUI to browse and execute actions.`,
 
 	installsCmds.AddCommand(actionsCmd)
 
-	labelCmd := &cobra.Command{
-		Use:   "label",
-		Short: "Add, remove, or view labels on an install",
-		Long: `Add, remove, or view labels on an install.
+	labelsCmd := &cobra.Command{
+		Use:   "labels",
+		Short: "List, set, or unset labels on an install",
+		Long: `List, set, or unset labels on an install.
 
-Labels are key-value strings. Pass kubectl-style positional args:
-  KEY=VALUE   add or overwrite a label
-  KEY-        remove a label
+Labels are key-value strings used to organize and filter installs.`,
+	}
 
-With no args, prints the install's current labels.
+	labelsListCmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List the labels on an install",
+		Long: `List the labels on an install.
 
 Examples:
-  nuon installs label --install-id inst_abc env=prod team=platform
-  nuon installs label --install-id inst_abc env-
-  nuon installs label --install-id inst_abc env=prod owner-
-  nuon installs label --install-id inst_abc`,
-		Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
+  nuon installs labels list --install-id inst_abc`,
+		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			svc := installs.New(c.apiClient, c.cfg)
-			return svc.Label(cmd.Context(), id, args, PrintJSON)
+			return svc.LabelsList(cmd.Context(), id, PrintJSON)
 		}),
 	}
-	labelCmd.Flags().StringVarP(&id, "install-id", "i", "", "The ID or name of the install you want to label")
-	labelCmd.MarkFlagRequired("install-id")
-	installsCmds.AddCommand(labelCmd)
+	labelsListCmd.Flags().StringVarP(&id, "install-id", "i", "", "The ID or name of the install")
+	labelsListCmd.MarkFlagRequired("install-id")
+	labelsCmd.AddCommand(labelsListCmd)
+
+	labelsSetCmd := &cobra.Command{
+		Use:   "set",
+		Short: "Set (add or overwrite) labels on an install",
+		Long: `Set labels on an install. Pass kubectl-style positional args:
+  KEY=VALUE   add or overwrite a label
+
+Examples:
+  nuon installs labels set --install-id inst_abc env=prod team=platform`,
+		Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
+			svc := installs.New(c.apiClient, c.cfg)
+			return svc.LabelsSet(cmd.Context(), id, args, PrintJSON)
+		}),
+	}
+	labelsSetCmd.Flags().StringVarP(&id, "install-id", "i", "", "The ID or name of the install")
+	labelsSetCmd.MarkFlagRequired("install-id")
+	labelsCmd.AddCommand(labelsSetCmd)
+
+	labelsUnsetCmd := &cobra.Command{
+		Use:   "unset",
+		Short: "Unset (remove) labels on an install",
+		Long: `Unset labels on an install. Pass one or more bare keys to remove:
+  KEY   remove a label
+
+Examples:
+  nuon installs labels unset --install-id inst_abc env team`,
+		Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
+			svc := installs.New(c.apiClient, c.cfg)
+			return svc.LabelsUnset(cmd.Context(), id, args, PrintJSON)
+		}),
+	}
+	labelsUnsetCmd.Flags().StringVarP(&id, "install-id", "i", "", "The ID or name of the install")
+	labelsUnsetCmd.MarkFlagRequired("install-id")
+	labelsCmd.AddCommand(labelsUnsetCmd)
+
+	installsCmds.AddCommand(labelsCmd)
 
 	return installsCmds
 }

--- a/bins/cli/internal/services/installs/labels.go
+++ b/bins/cli/internal/services/installs/labels.go
@@ -5,33 +5,18 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/nuonco/nuon/pkg/cli/styles"
+
 	"github.com/nuonco/nuon/bins/cli/internal/lookup"
 	"github.com/nuonco/nuon/bins/cli/internal/services/labels"
 	"github.com/nuonco/nuon/bins/cli/internal/ui"
 )
 
-// Label adds or removes labels on an install. Pass kubectl-style args:
-// "key=value" to set, "key-" to remove. With no args, prints current labels.
-func (s *Service) Label(ctx context.Context, installIDOrName string, args []string, asJSON bool) error {
+// LabelsList prints the labels on an install.
+func (s *Service) LabelsList(ctx context.Context, installIDOrName string, asJSON bool) error {
 	installID, err := lookup.InstallID(ctx, s.api, installIDOrName)
 	if err != nil {
 		return ui.PrintError(err)
-	}
-
-	set, remove, err := labels.ParseArgs(args)
-	if err != nil {
-		return ui.PrintError(err)
-	}
-
-	if len(set) > 0 {
-		if _, err := s.api.AddInstallLabels(ctx, installID, set); err != nil {
-			return ui.PrintError(fmt.Errorf("unable to add labels: %w", err))
-		}
-	}
-	if len(remove) > 0 {
-		if _, err := s.api.RemoveInstallLabels(ctx, installID, remove); err != nil {
-			return ui.PrintError(fmt.Errorf("unable to remove labels: %w", err))
-		}
 	}
 
 	install, err := s.api.GetInstall(ctx, installID)
@@ -44,25 +29,99 @@ func (s *Service) Label(ctx context.Context, installIDOrName string, args []stri
 		return nil
 	}
 
-	if len(set) > 0 || len(remove) > 0 {
-		fmt.Printf("install/%s labeled\n", install.ID)
-	}
-	printLabels(install.ID, install.Labels)
+	renderLabels(install.ID, install.Labels)
 	return nil
 }
 
-func printLabels(id string, lbls map[string]string) {
+// LabelsSet adds or overwrites labels on an install. Args are kubectl-style
+// "key=value" pairs.
+func (s *Service) LabelsSet(ctx context.Context, installIDOrName string, args []string, asJSON bool) error {
+	installID, err := lookup.InstallID(ctx, s.api, installIDOrName)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+
+	set, remove, err := labels.ParseArgs(args)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+	if len(remove) > 0 {
+		return ui.PrintError(fmt.Errorf("use 'nuon installs labels unset' to remove labels"))
+	}
+	if len(set) == 0 {
+		return ui.PrintError(fmt.Errorf("provide at least one label as key=value"))
+	}
+
+	if _, err := s.api.AddInstallLabels(ctx, installID, set); err != nil {
+		return ui.PrintError(fmt.Errorf("unable to set labels: %w", err))
+	}
+
+	install, err := s.api.GetInstall(ctx, installID)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+
+	if asJSON {
+		ui.PrintJSON(map[string]any{"id": install.ID, "labels": install.Labels})
+		return nil
+	}
+
+	ui.PrintSuccess(fmt.Sprintf("install/%s labeled", install.ID))
+	renderLabels(install.ID, install.Labels)
+	return nil
+}
+
+// LabelsUnset removes labels from an install by key.
+func (s *Service) LabelsUnset(ctx context.Context, installIDOrName string, args []string, asJSON bool) error {
+	installID, err := lookup.InstallID(ctx, s.api, installIDOrName)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+
+	keys, err := labels.ParseKeys(args)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+	if len(keys) == 0 {
+		return ui.PrintError(fmt.Errorf("provide at least one label key to unset"))
+	}
+
+	if _, err := s.api.RemoveInstallLabels(ctx, installID, keys); err != nil {
+		return ui.PrintError(fmt.Errorf("unable to unset labels: %w", err))
+	}
+
+	install, err := s.api.GetInstall(ctx, installID)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+
+	if asJSON {
+		ui.PrintJSON(map[string]any{"id": install.ID, "labels": install.Labels})
+		return nil
+	}
+
+	ui.PrintSuccess(fmt.Sprintf("install/%s labels removed", install.ID))
+	renderLabels(install.ID, install.Labels)
+	return nil
+}
+
+// renderLabels prints an install's labels as a styled KEY/VALUE table.
+func renderLabels(id string, lbls map[string]string) {
 	if len(lbls) == 0 {
-		fmt.Printf("%s: (no labels)\n", id)
+		fmt.Printf("%s %s\n", styles.TextBold.Render(id), styles.TextSubtle.Render("(no labels)"))
 		return
 	}
+
 	keys := make([]string, 0, len(lbls))
 	for k := range lbls {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	fmt.Printf("%s:\n", id)
+
+	view := ui.NewListView()
+	data := [][]string{{"KEY", "VALUE"}}
 	for _, k := range keys {
-		fmt.Printf("  %s=%s\n", k, lbls[k])
+		data = append(data, []string{k, lbls[k]})
 	}
+	view.Render(data)
 }

--- a/bins/cli/internal/services/labels/parse.go
+++ b/bins/cli/internal/services/labels/parse.go
@@ -39,3 +39,23 @@ func ParseArgs(args []string) (set map[string]string, remove []string, err error
 	}
 	return set, remove, nil
 }
+
+// ParseKeys validates bare label keys (used by `unset`). It rejects empty keys
+// and any "key=value" form, since a value has no meaning when removing a label.
+//
+//	"key"       -> "key"
+//	"key=value" -> error
+func ParseKeys(args []string) ([]string, error) {
+	keys := make([]string, 0, len(args))
+	for _, a := range args {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if strings.Contains(a, "=") {
+			return nil, fmt.Errorf("invalid label key %q (provide a bare key, not key=value)", a)
+		}
+		keys = append(keys, strings.TrimSuffix(a, "-"))
+	}
+	return keys, nil
+}


### PR DESCRIPTION
```
  List, set, or unset labels on an install.

  Labels are key-value strings used to organize and filter installs.

  USAGE

    nuon installs labels [command] [--flags]

  COMMANDS

    list [--flags]    List the labels on an install
    set [--flags]     Set (add or overwrite) labels on an install
    unset [--flags]   Unset (remove) labels on an install
```
