### PR TITLE
chore(ctl-api): ensure the v2 update input workflow respects deploy deps

### DIFF
--- a/sdks/nuon-go/client/nuon_client.go
+++ b/sdks/nuon-go/client/nuon_client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-
 	"github.com/nuonco/nuon/sdks/nuon-go/client/operations"
 )
 

--- a/sdks/nuon-go/models/service_update_install_inputs_request.go
+++ b/sdks/nuon-go/models/service_update_install_inputs_request.go
@@ -20,7 +20,7 @@ import (
 type ServiceUpdateInstallInputsRequest struct {
 
 	// deploy dependents
-	DeployDependents bool `json:"deploy_dependents,omitempty"`
+	DeployDependents *bool `json:"deploy_dependents,omitempty"`
 
 	// inputs
 	// Required: true

--- a/services/ctl-api/internal/app/installs/service/update_install_input.go
+++ b/services/ctl-api/internal/app/installs/service/update_install_input.go
@@ -20,7 +20,7 @@ import (
 type UpdateInstallInputsRequest struct {
 	Inputs           map[string]*string `json:"inputs" validate:"required,gte=1"`
 	Role             string             `json:"role"`
-	DeployDependents bool               `json:"deploy_dependents"`
+	DeployDependents *bool              `json:"deploy_dependents,omitempty" swaggertype:"boolean" extensions:"x-nullable"`
 }
 
 func (c *UpdateInstallInputsRequest) Validate(v *validator.Validate) error {
@@ -111,13 +111,17 @@ func (s *service) UpdateInstallInputs(ctx *gin.Context) {
 		return
 	}
 
+	// Default to deploying dependents when the field is omitted, preserving the
+	// historical always-deploy behavior; an explicit false is now respected.
+	deployDependents := req.DeployDependents == nil || *req.DeployDependents
+
 	workflow, err := s.helpers.CreateAndStartInputUpdateWorkflow(
 		ctx,
 		install.ID,
 		*changedInputs,
 		changedInputValues,
 		req.Role,
-		req.DeployDependents,
+		deployDependents,
 	)
 	if err != nil {
 		ctx.Error(fmt.Errorf("unable to create install inputs: %w", err))

--- a/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -52,6 +53,7 @@ func InputUpdate(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRes
 
 	changedInputsRaw := generics.FromPtrStr(flw.Metadata["inputs"])
 	changedInputs := strings.Split(changedInputsRaw, ",")
+	deployDependents := generics.FromPtrStr(flw.Metadata["deploy_dependents"]) == strconv.FormatBool(true)
 
 	appConfig, err := activities.AwaitGetAppConfig(ctx, activities.GetAppConfigRequest{
 		ID: install.AppConfigID,
@@ -90,15 +92,17 @@ func InputUpdate(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRes
 	for _, comp := range getComponentsForChangedInputs(appConfig, &changedRefs) {
 		componentIDs = append(componentIDs, comp.ID)
 
-		dependentCompIDs, err := activities.AwaitGetComponentDependents(ctx, &activities.GetComponentDependentsRequest{
-			AppConfigID: appConfig.ID,
-			ComponentID: comp.ID,
-		})
-		if err != nil {
-			return nil, errors.Wrapf(err, "unable to get component dependents for %s", comp.ID)
-		}
+		if deployDependents {
+			dependentCompIDs, err := activities.AwaitGetComponentDependents(ctx, &activities.GetComponentDependentsRequest{
+				AppConfigID: appConfig.ID,
+				ComponentID: comp.ID,
+			})
+			if err != nil {
+				return nil, errors.Wrapf(err, "unable to get component dependents for %s", comp.ID)
+			}
 
-		componentIDs = append(componentIDs, dependentCompIDs...)
+			componentIDs = append(componentIDs, dependentCompIDs...)
+		}
 	}
 	componentIDs = generics.UniqueSlice(componentIDs)
 


### PR DESCRIPTION
### Description

Ensure the v2 workflow for `update-input` respects the `DeployDependents` arg from the request.
