### PR TITLE
feat: udpate-input support for --deploy-dependents

### DIFF
--- a/bins/cli/cmd/installs.go
+++ b/bins/cli/cmd/installs.go
@@ -28,6 +28,7 @@ func (c *cli) installsCmd() *cobra.Command {
 		labelArgs        []string
 		noSelect         bool
 		deployDeps       bool
+		deployDependents bool
 		offset           int
 		limit            int
 		planOnly         bool
@@ -513,13 +514,14 @@ The --stack, --sandbox, and --component-id flags are mutually exclusive.`,
 		Long:  "Update an install input value",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			svc := installs.New(c.apiClient, c.cfg)
-			return svc.UpdateInput(cmd.Context(), id, inputs, PrintJSON)
+			return svc.UpdateInput(cmd.Context(), id, inputs, deployDependents, PrintJSON)
 		}),
 	}
 	updateInputCmd.Flags().StringVarP(&id, "install-id", "i", "", "The ID of the install you want to update")
 	updateInputCmd.MarkFlagRequired("install-id")
 	updateInputCmd.Flags().StringSliceVar(&inputs, "inputs", []string{}, "The app input values for the install")
 	updateInputCmd.MarkFlagRequired("inputs")
+	updateInputCmd.Flags().BoolVar(&deployDependents, "deploy-dependents", true, "Deploy components that depend on the updated inputs")
 	installsCmds.AddCommand(updateInputCmd)
 
 	deprovisionInstallSandboxCmd := &cobra.Command{

--- a/bins/cli/internal/services/installs/update_input.go
+++ b/bins/cli/internal/services/installs/update_input.go
@@ -6,18 +6,24 @@ import (
 
 	"github.com/nuonco/nuon/sdks/nuon-go/models"
 
+	"github.com/nuonco/nuon/bins/cli/internal/config"
 	"github.com/nuonco/nuon/bins/cli/internal/ui"
 )
 
-func (s *Service) UpdateInput(ctx context.Context, installID string, inputs []string, printJSON bool) error {
+func (s *Service) UpdateInput(ctx context.Context, installID string, inputs []string, deployDependents bool, printJSON bool) error {
 	inputsMap := make(map[string]string)
 	for _, kv := range inputs {
 		kvT := strings.Split(kv, "=")
 		inputsMap[kvT[0]] = kvT[1]
 	}
-	installInput, err := s.api.UpdateInstallInputs(ctx, installID, &models.ServiceUpdateInstallInputsRequest{
-		Inputs: inputsMap,
-	})
+	request := &models.ServiceUpdateInstallInputsRequest{
+		Inputs:           inputsMap,
+		DeployDependents: &deployDependents,
+	}
+	if config.Debug() {
+		ui.PrintJSON(request)
+	}
+	installInput, err := s.api.UpdateInstallInputs(ctx, installID, request)
 	if err != nil {
 		return ui.PrintJSONError(err)
 	}


### PR DESCRIPTION
### Description

Add a flag, `--deploy-dependents`, to `nuon installs update-input`.


### Notes

Depends on https://github.com/nuonco/nuon/pull/1563