### PR TITLE
fix: correctly propagate and set timeouts and cancellations.

### DIFF
--- a/services/ctl-api/internal/app/installs/signals/componentdeployapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentdeployapplyplan/signal.go
@@ -261,11 +261,12 @@ func (s *Signal) execApplyPlan(ctx workflow.Context, install *app.Install, insta
 	jobTyp := build.ComponentConfigConnection.Type.DeployJobType()
 
 	runnerJob, err := activities.AwaitCreateDeployJob(ctx, &activities.CreateDeployJobRequest{
-		RunnerID:    install.RunnerID,
-		DeployID:    installDeploy.ID,
-		Op:          op,
-		Type:        jobTyp,
-		LogStreamID: logStreamID,
+		RunnerID:        install.RunnerID,
+		DeployID:        installDeploy.ID,
+		Op:              op,
+		Type:            jobTyp,
+		LogStreamID:     logStreamID,
+		TimeoutDuration: build.ComponentConfigConnection.GetDeployTimeout(),
 		Metadata: map[string]string{
 			"install_id":           install.ID,
 			"deploy_id":            installDeploy.ID,

--- a/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
@@ -479,11 +479,12 @@ func (s *Signal) execPlan(ctx workflow.Context, install *app.Install, installDep
 
 	jobTyp := build.ComponentConfigConnection.Type.DeployPlanJobType()
 	runnerJob, err := activities.AwaitCreateDeployJob(ctx, &activities.CreateDeployJobRequest{
-		RunnerID:    install.RunnerGroup.Runners[0].ID,
-		DeployID:    installDeploy.ID,
-		Op:          op,
-		Type:        jobTyp,
-		LogStreamID: logStreamID,
+		RunnerID:        install.RunnerGroup.Runners[0].ID,
+		DeployID:        installDeploy.ID,
+		Op:              op,
+		Type:            jobTyp,
+		LogStreamID:     logStreamID,
+		TimeoutDuration: build.ComponentConfigConnection.GetDeployTimeout(),
 		Metadata: map[string]string{
 			"install_id":           install.ID,
 			"deploy_id":            installDeploy.ID,

--- a/services/ctl-api/internal/app/installs/signals/componentteardownapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentteardownapplyplan/signal.go
@@ -279,11 +279,12 @@ func (s *Signal) execApplyPlan(ctx workflow.Context, install *app.Install, insta
 	jobTyp := build.ComponentConfigConnection.Type.DeployJobType()
 
 	runnerJob, err := activities.AwaitCreateDeployJob(ctx, &activities.CreateDeployJobRequest{
-		RunnerID:    install.RunnerID,
-		DeployID:    installDeploy.ID,
-		Op:          op,
-		Type:        jobTyp,
-		LogStreamID: logStreamID,
+		RunnerID:        install.RunnerID,
+		DeployID:        installDeploy.ID,
+		Op:              op,
+		Type:            jobTyp,
+		LogStreamID:     logStreamID,
+		TimeoutDuration: build.ComponentConfigConnection.GetDeployTimeout(),
 		Metadata: map[string]string{
 			"install_id":           install.ID,
 			"deploy_id":            installDeploy.ID,

--- a/services/ctl-api/internal/app/installs/signals/componentteardownsyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentteardownsyncandplan/signal.go
@@ -495,11 +495,12 @@ func (s *Signal) execPlan(ctx workflow.Context, install *app.Install, installDep
 
 	jobTyp := build.ComponentConfigConnection.Type.DeployPlanJobType()
 	runnerJob, err := activities.AwaitCreateDeployJob(ctx, &activities.CreateDeployJobRequest{
-		RunnerID:    install.RunnerGroup.Runners[0].ID,
-		DeployID:    installDeploy.ID,
-		Op:          op,
-		Type:        jobTyp,
-		LogStreamID: logStreamID,
+		RunnerID:        install.RunnerGroup.Runners[0].ID,
+		DeployID:        installDeploy.ID,
+		Op:              op,
+		Type:            jobTyp,
+		LogStreamID:     logStreamID,
+		TimeoutDuration: build.ComponentConfigConnection.GetDeployTimeout(),
 		Metadata: map[string]string{
 			"install_id":           install.ID,
 			"deploy_id":            installDeploy.ID,

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/execute_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/execute_step.go
@@ -86,8 +86,29 @@ func (s *Signal) Execute(ctx workflow.Context) (err error) {
 	// Execute the inner signal
 	stepErr := s.executeInnerSignal(ctx, step)
 	if stepErr != nil {
-		// If the context was cancelled, Cancel() already handled status updates.
 		if ctx.Err() != nil {
+			// If Cancel() was called (via the cancel update handler), it already
+			// wrote DirectiveStop and updated status — nothing more to do.
+			// But if the context was cancelled without Cancel() (e.g., handler
+			// lifecycle stopped the workflow), write a fallback directive so the
+			// group doesn't default to StepContinue and skip the step.
+			if !s.canceled {
+				dctx, dcancel := workflow.NewDisconnectedContext(ctx)
+				defer dcancel()
+				if err := setResultDirective(dctx, s.StepID, DirectiveStop); err != nil {
+					l.Error("unable to set fallback stop directive", zap.Error(err))
+				}
+				_ = statusactivities.AwaitPkgStatusUpdateFlowStepStatus(dctx, statusactivities.UpdateStatusRequest{
+					ID: s.StepID,
+					Status: app.CompositeStatus{
+						Status:                 app.StatusError,
+						StatusHumanDescription: "step interrupted: context cancelled",
+						Metadata: map[string]any{
+							"reason": stepErr.Error(),
+						},
+					},
+				})
+			}
 			return nil
 		}
 		return s.handleStepError(ctx, l, step, flw, stepErr)

--- a/services/ctl-api/internal/pkg/workflows/job/exec.go
+++ b/services/ctl-api/internal/pkg/workflows/job/exec.go
@@ -172,6 +172,10 @@ func (j *Workflows) pollJob(ctx workflow.Context, req *ExecuteJobRequest) (app.R
 		// if the job is already timed out, there is no reason to continue.
 		now := workflow.Now(dctx)
 		if now.After(job.CreatedAt.Add(job.OverallTimeout)) {
+			// Cancel the runner job so the runner stops executing it.
+			if cancelErr := activities.AwaitPkgWorkflowsJobCancelJobByID(dctx, jobID); cancelErr != nil {
+				l.Error("unable to cancel runner job on timeout", zap.Error(cancelErr))
+			}
 			return app.RunnerJobStatusTimedOut, temporal.NewNonRetryableApplicationError("overall timeout reached", "api", fmt.Errorf("timeout"))
 		}
 

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -7094,7 +7094,7 @@ export interface components {
       vpc_nested_template_url?: string;
     };
     "service.UpdateInstallInputsRequest": {
-      deploy_dependents?: boolean;
+      deploy_dependents?: boolean | null;
       inputs: {
         [key: string]: string;
       };


### PR DESCRIPTION
This fixes a few issues where cancellations and timeouts might not correctly propagate:

1.  runner job would not be cancelled on timeout detection - this would keep the runner job running after a timeout (not 
    setting status correctly).
1. custom deploy timeouts were not set correctly.
1. A workflow could skip a step when a timeout or cancelled happened.
