### PR TITLE
feat: subscribe to everything except chosen labels

### DIFF
--- a/bins/cli/internal/services/orgs/subscriptiontui/tui.go
+++ b/bins/cli/internal/services/orgs/subscriptiontui/tui.go
@@ -149,11 +149,16 @@ func newResourceState(kind string) *resourceState {
 //   - matchModeSkip / matchModeAny: nothing else read.
 //   - matchModeSpecific: ids populated by the data-driven entity picker
 //     in pickers.go.
-//   - matchModeLabels: selectorRaw parsed by labels.ParseLabelsQuery.
+//   - matchModeLabels: selectorRaw parsed into MatchLabels and
+//     excludeRaw into NotMatchLabels. Either may be empty as long as
+//     at least one is non-empty — mirrors the Slack/dashboard
+//     "include" + "exclude" inputs so "everything except env=stage"
+//     works without enumerating positives.
 type kindMatchState struct {
 	mode        string
 	ids         []string
 	selectorRaw string
+	excludeRaw  string
 }
 
 // Run walks the user through an interactive picker that produces the two
@@ -349,9 +354,13 @@ func buildPhase1Groups(
 
 		groups = append(groups, huh.NewGroup(
 			huh.NewInput().
-				Title(fmt.Sprintf("%s — label selector", k)).
-				Description("key=value pairs, comma-separated (e.g. env=prod,team=*). Required for the Labels mode.").
+				Title(fmt.Sprintf("%s — include label selector", k)).
+				Description("key=value pairs, comma-separated (e.g. env=prod,team=*). Leave blank to match everything except the excludes.").
 				Value(&st.selectorRaw),
+			huh.NewInput().
+				Title(fmt.Sprintf("%s — exclude label selector", k)).
+				Description("key=value pairs whose match removes an entity (e.g. env=stage). Optional; at least one of include/exclude is required for the Labels mode.").
+				Value(&st.excludeRaw),
 		).WithHideFunc(func() bool { return !*scoped || st.mode != matchModeLabels }))
 	}
 
@@ -403,7 +412,10 @@ func buildInterests(allEvents bool, resources map[string]*resourceState) any {
 //   - skip:     omit the kind (nil pointer)
 //   - any:      &TargetMatch{} — empty filter, server treats as "any"
 //   - specific: &TargetMatch{IDs: ...}
-//   - labels:   &TargetMatch{Selector: &Selector{MatchLabels: ...}}
+//   - labels:   &TargetMatch{Selector: ...} with the parsed include
+//     selector in MatchLabels and the parsed exclude selector in
+//     NotMatchLabels. Either map may be empty as long as at least one
+//     of them is non-empty.
 func buildMatch(scoped bool, kindStates map[string]*kindMatchState) (*labels.SubscriptionMatch, error) {
 	if !scoped {
 		return nil, nil
@@ -430,11 +442,19 @@ func buildMatch(scoped bool, kindStates map[string]*kindMatchState) (*labels.Sub
 			}
 			tm = &labels.TargetMatch{IDs: st.ids}
 		case matchModeLabels:
-			lbls := labels.ParseLabelsQuery(st.selectorRaw)
-			if len(lbls) == 0 {
-				return nil, fmt.Errorf("%s match mode is labels but no key=value pairs were given", kind)
+			inc := labels.ParseLabelsQuery(st.selectorRaw)
+			exc := labels.ParseLabelsQuery(st.excludeRaw)
+			if len(inc) == 0 && len(exc) == 0 {
+				return nil, fmt.Errorf("%s match mode is labels but no include/exclude key=value pairs were given", kind)
 			}
-			tm = &labels.TargetMatch{Selector: &labels.Selector{MatchLabels: lbls}}
+			sel := &labels.Selector{}
+			if len(inc) > 0 {
+				sel.MatchLabels = inc
+			}
+			if len(exc) > 0 {
+				sel.NotMatchLabels = exc
+			}
+			tm = &labels.TargetMatch{Selector: sel}
 		default:
 			return nil, fmt.Errorf("unknown %s match mode %q", kind, st.mode)
 		}

--- a/pkg/labels/scopes.go
+++ b/pkg/labels/scopes.go
@@ -46,3 +46,31 @@ func WithLabels(column string, lbls Labels) func(*gorm.DB) *gorm.DB {
 		return db
 	}
 }
+
+// WithoutLabels is the negative counterpart of WithLabels. It filters rows
+// where the JSONB column does NOT match any of the specified key-value pairs.
+// A value of "*" rejects rows where the key is present at all
+// (jsonb_exists). Other values reject only rows where the exact pair is set.
+// Each NotMatchLabels entry is independent; a row is excluded if ANY entry
+// matches it (mirrors Selector.Matches in-Go semantics).
+// Returns a no-op scope if lbls is nil or empty.
+func WithoutLabels(column string, lbls Labels) func(*gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		if len(lbls) == 0 {
+			return db
+		}
+		for k, v := range lbls {
+			if v == "*" {
+				db = db.Where("NOT jsonb_exists("+column+", ?)", k)
+				continue
+			}
+			pair, err := json.Marshal(Labels{k: v})
+			if err != nil {
+				_ = db.AddError(err)
+				return db
+			}
+			db = db.Where("NOT ("+column+" @> ?::jsonb)", string(pair))
+		}
+		return db
+	}
+}

--- a/pkg/labels/selector.go
+++ b/pkg/labels/selector.go
@@ -12,16 +12,23 @@ import (
 // "key must exist" (mirrors the wildcard semantics of WithLabels' jsonb_exists
 // branch in scopes.go); any other value requires exact equality (mirrors @>).
 //
+// NotMatchLabels expresses negation with the same value semantics: an entry
+// rejects sets where the key is present and matches (exact value or wildcard
+// existence). It exists so users can say "everything except env=stage" without
+// having to enumerate every other env value or label every install.
+//
 // Callers represent "match everything" as a *nil* Selector, never as
 // Selector{MatchLabels: nil} — see Validate.
 type Selector struct {
-	MatchLabels Labels `json:"match_labels"`
+	MatchLabels    Labels `json:"match_labels,omitempty"`
+	NotMatchLabels Labels `json:"not_match_labels,omitempty"`
 }
 
-// Matches returns true iff every entry in MatchLabels is satisfied by set.
-// Empty MatchLabels matches everything; callers should not construct such a
-// Selector (Validate rejects it) but the matcher is permissive so dispatch
-// never silently drops events on stale data.
+// Matches returns true iff every entry in MatchLabels is satisfied by set
+// AND no entry in NotMatchLabels is satisfied by set. Empty MatchLabels and
+// empty NotMatchLabels both mean "no constraint of that polarity"; callers
+// should not construct such a Selector (Validate rejects it) but the matcher
+// is permissive so dispatch never silently drops events on stale data.
 func (s *Selector) Matches(set Labels) bool {
 	if s == nil {
 		return true
@@ -38,24 +45,43 @@ func (s *Selector) Matches(set Labels) bool {
 			return false
 		}
 	}
+	for k, v := range s.NotMatchLabels {
+		got, ok := set[k]
+		if !ok {
+			// key absent → exclusion not triggered for this entry
+			continue
+		}
+		if v == "*" {
+			// key-existence exclusion: present → reject
+			return false
+		}
+		if got == v {
+			return false
+		}
+	}
 	return true
 }
 
 // Validate enforces the invariant that a *non-nil* Selector carries at least
-// one constraint. The "match everything" case is expressed by a nil pointer at
-// the call site (TargetMatch.Selector == nil), not by an empty MatchLabels
-// map — this keeps the dispatch / preview / canonical-key code paths from
-// having to special-case an ambiguous shape.
+// one constraint (positive or negative). The "match everything" case is
+// expressed by a nil pointer at the call site (TargetMatch.Selector == nil),
+// not by empty maps — this keeps the dispatch / preview / canonical-key code
+// paths from having to special-case an ambiguous shape.
 func (s *Selector) Validate() error {
 	if s == nil {
 		return errors.New("selector is nil")
 	}
-	if len(s.MatchLabels) == 0 {
-		return errors.New("selector match_labels must be non-empty (use a nil *Selector for match-all)")
+	if len(s.MatchLabels) == 0 && len(s.NotMatchLabels) == 0 {
+		return errors.New("selector must have at least one of match_labels or not_match_labels (use a nil *Selector for match-all)")
 	}
 	for k := range s.MatchLabels {
 		if strings.TrimSpace(k) == "" {
 			return errors.New("selector match_labels has blank key")
+		}
+	}
+	for k := range s.NotMatchLabels {
+		if strings.TrimSpace(k) == "" {
+			return errors.New("selector not_match_labels has blank key")
 		}
 	}
 	return nil
@@ -68,17 +94,24 @@ func (s *Selector) Canonical() string {
 	if s == nil {
 		return ""
 	}
-	keys := make([]string, 0, len(s.MatchLabels))
-	for k := range s.MatchLabels {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	pairs := make([][2]string, len(keys))
-	for i, k := range keys {
-		pairs[i] = [2]string{k, s.MatchLabels[k]}
+	sortedPairs := func(m Labels) [][2]string {
+		keys := make([]string, 0, len(m))
+		for k := range m {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		pairs := make([][2]string, len(keys))
+		for i, k := range keys {
+			pairs[i] = [2]string{k, m[k]}
+		}
+		return pairs
 	}
 	b, _ := json.Marshal(struct {
-		MatchLabels [][2]string `json:"match_labels"`
-	}{MatchLabels: pairs})
+		MatchLabels    [][2]string `json:"match_labels"`
+		NotMatchLabels [][2]string `json:"not_match_labels,omitempty"`
+	}{
+		MatchLabels:    sortedPairs(s.MatchLabels),
+		NotMatchLabels: sortedPairs(s.NotMatchLabels),
+	})
 	return string(b)
 }

--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -77,6 +77,60 @@ func TestSelector_Matches(t *testing.T) {
 			set:  nil,
 			want: false,
 		},
+		{
+			name: "not-match excludes set with matching key+value",
+			sel:  &Selector{NotMatchLabels: Labels{"env": "stage"}},
+			set:  Labels{"env": "stage"},
+			want: false,
+		},
+		{
+			name: "not-match allows set with different value for same key",
+			sel:  &Selector{NotMatchLabels: Labels{"env": "stage"}},
+			set:  Labels{"env": "prod"},
+			want: true,
+		},
+		{
+			name: "not-match allows set without the key",
+			sel:  &Selector{NotMatchLabels: Labels{"env": "stage"}},
+			set:  Labels{"team": "platform"},
+			want: true,
+		},
+		{
+			name: "not-match wildcard excludes set with key present",
+			sel:  &Selector{NotMatchLabels: Labels{"env": "*"}},
+			set:  Labels{"env": "anything"},
+			want: false,
+		},
+		{
+			name: "not-match wildcard allows set with key absent",
+			sel:  &Selector{NotMatchLabels: Labels{"env": "*"}},
+			set:  Labels{"team": "platform"},
+			want: true,
+		},
+		{
+			name: "include AND exclude combined: include hit + exclude not triggered",
+			sel:  &Selector{MatchLabels: Labels{"team": "platform"}, NotMatchLabels: Labels{"env": "stage"}},
+			set:  Labels{"team": "platform", "env": "prod"},
+			want: true,
+		},
+		{
+			name: "include AND exclude combined: include hit but exclude triggered",
+			sel:  &Selector{MatchLabels: Labels{"team": "platform"}, NotMatchLabels: Labels{"env": "stage"}},
+			set:  Labels{"team": "platform", "env": "stage"},
+			want: false,
+		},
+		{
+			name: "only NotMatchLabels: empty set is allowed (env=stage exclusion not triggered)",
+			sel:  &Selector{NotMatchLabels: Labels{"env": "stage"}},
+			set:  Labels{},
+			want: true,
+		},
+		{
+			name: "multiple NotMatchLabels: any match excludes",
+			sel:  &Selector{NotMatchLabels: Labels{"env": "stage", "tier": "experimental"}},
+			set:  Labels{"env": "prod", "tier": "experimental"},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -114,6 +168,21 @@ func TestSelector_Validate(t *testing.T) {
 			name:    "blank key rejected",
 			sel:     &Selector{MatchLabels: Labels{"": "prod"}},
 			wantErr: true,
+		},
+		{
+			name:    "blank NotMatchLabels key rejected",
+			sel:     &Selector{NotMatchLabels: Labels{"": "stage"}},
+			wantErr: true,
+		},
+		{
+			name:    "only NotMatchLabels is valid",
+			sel:     &Selector{NotMatchLabels: Labels{"env": "stage"}},
+			wantErr: false,
+		},
+		{
+			name:    "MatchLabels + NotMatchLabels both populated is valid",
+			sel:     &Selector{MatchLabels: Labels{"team": "platform"}, NotMatchLabels: Labels{"env": "stage"}},
+			wantErr: false,
 		},
 		{
 			name:    "whitespace-only key rejected",
@@ -172,5 +241,23 @@ func TestSelector_Canonical_DistinguishesValues(t *testing.T) {
 	b := &Selector{MatchLabels: Labels{"env": "stage"}}
 	if a.Canonical() == b.Canonical() {
 		t.Errorf("Canonical should differ for different values")
+	}
+}
+
+func TestSelector_Canonical_DistinguishesIncludeFromExclude(t *testing.T) {
+	include := &Selector{MatchLabels: Labels{"env": "stage"}}
+	exclude := &Selector{NotMatchLabels: Labels{"env": "stage"}}
+	if include.Canonical() == exclude.Canonical() {
+		t.Errorf("Canonical of include vs exclude must differ:\n  include=%s\n  exclude=%s",
+			include.Canonical(), exclude.Canonical())
+	}
+}
+
+func TestSelector_Canonical_NotMatchLabelsStable(t *testing.T) {
+	a := &Selector{NotMatchLabels: Labels{"env": "stage", "tier": "experimental"}}
+	b := &Selector{NotMatchLabels: Labels{"tier": "experimental", "env": "stage"}}
+	if a.Canonical() != b.Canonical() {
+		t.Errorf("Canonical not stable across NotMatchLabels map order:\n  a=%s\n  b=%s",
+			a.Canonical(), b.Canonical())
 	}
 }

--- a/services/ctl-api/internal/app/slack/service/subscribe_modal.go
+++ b/services/ctl-api/internal/app/slack/service/subscribe_modal.go
@@ -70,8 +70,14 @@ const (
 	subscribeEntitiesActionIDActions    = "nuon_subscribe_entities_actions"
 
 	// Labels selector textinput. Only rendered when predicate=Labels.
-	subscribeLabelsBlockID  = "nuon_subscribe_labels_block"
-	subscribeLabelsActionID = "nuon_subscribe_labels"
+	// subscribeLabelsBlockID drives the positive (include) selector;
+	// subscribeExcludeLabelsBlockID drives NotMatchLabels so users can
+	// say "everything except env=stage" without enumerating every other
+	// env value.
+	subscribeLabelsBlockID         = "nuon_subscribe_labels_block"
+	subscribeLabelsActionID        = "nuon_subscribe_labels"
+	subscribeExcludeLabelsBlockID  = "nuon_subscribe_exclude_labels_block"
+	subscribeExcludeLabelsActionID = "nuon_subscribe_exclude_labels"
 
 	subscribeNotifBlockID  = "nuon_subscribe_notif_block"
 	subscribeNotifActionID = "nuon_subscribe_notif"
@@ -244,6 +250,13 @@ type subscribeModalRenderState struct {
 	// selector textinput when Predicate==predicateOptionLabels. Parsed
 	// lazily via labels.ParseLabelsQuery on submission and on preview.
 	LabelsRaw string
+
+	// ExcludeLabelsRaw is the verbatim text from the exclusion selector
+	// textinput (same predicate). Parsed into Selector.NotMatchLabels so
+	// "everything except env=stage" works without enumerating positives.
+	// Either LabelsRaw or ExcludeLabelsRaw (or both) may be empty; at
+	// least one must be non-empty for the Labels predicate to validate.
+	ExcludeLabelsRaw string
 
 	Notif string // notifOptionAll | notifOptionSpecific
 
@@ -563,11 +576,34 @@ func buildSubscribeModalView(
 			blocks = append(blocks, map[string]any{
 				"type":     "input",
 				"block_id": subscribeLabelsBlockID,
-				"label":    map[string]any{"type": "plain_text", "text": "Label selector"},
+				"label":    map[string]any{"type": "plain_text", "text": "Include labels"},
+				"hint":     map[string]any{"type": "plain_text", "text": "Leave empty to include everything (combine with Exclude labels below)."},
+				"optional": true,
 				"element":  labelsInput,
 				// dispatch_action so the preview re-runs on enter; we
 				// also re-run on every other dispatch_action that
 				// re-renders the modal.
+				"dispatch_action": true,
+			})
+
+			excludeInput := map[string]any{
+				"type":      "plain_text_input",
+				"action_id": subscribeExcludeLabelsActionID,
+				"placeholder": map[string]any{
+					"type": "plain_text",
+					"text": "env=stage, tier=experimental",
+				},
+			}
+			if render.ExcludeLabelsRaw != "" {
+				excludeInput["initial_value"] = render.ExcludeLabelsRaw
+			}
+			blocks = append(blocks, map[string]any{
+				"type":            "input",
+				"block_id":        subscribeExcludeLabelsBlockID,
+				"label":           map[string]any{"type": "plain_text", "text": "Exclude labels"},
+				"hint":            map[string]any{"type": "plain_text", "text": "Skip events for entities matching these labels (e.g. env=stage)."},
+				"optional":        true,
+				"element":         excludeInput,
 				"dispatch_action": true,
 			})
 		}
@@ -1293,6 +1329,7 @@ func (s *service) renderStateFromSubscription(
 		case tm.Selector != nil:
 			rs.Predicate = predicateOptionLabels
 			rs.LabelsRaw = labelsToQueryString(tm.Selector.MatchLabels)
+			rs.ExcludeLabelsRaw = labelsToQueryString(tm.Selector.NotMatchLabels)
 		default:
 			rs.Predicate = predicateOptionAny
 		}
@@ -1346,7 +1383,14 @@ func describeMatch(m *labels.SubscriptionMatch) string {
 	}
 	switch {
 	case tm.Selector != nil:
-		return "by labels: " + labelsToQueryString(tm.Selector.MatchLabels)
+		parts := make([]string, 0, 2)
+		if inc := labelsToQueryString(tm.Selector.MatchLabels); inc != "" {
+			parts = append(parts, inc)
+		}
+		if exc := labelsToQueryString(tm.Selector.NotMatchLabels); exc != "" {
+			parts = append(parts, "not "+exc)
+		}
+		return "by labels: " + strings.Join(parts, "; ")
 	case len(tm.IDs) > 0:
 		const maxIDs = 3
 		shown := tm.IDs
@@ -1716,11 +1760,12 @@ func buildSubscriptionMatchFromRender(render subscribeModalRenderState) (*labels
 		}
 		tm = &labels.TargetMatch{IDs: append([]string(nil), render.EntityIDs...)}
 	case predicateOptionLabels:
-		parsed := labels.ParseLabelsQuery(render.LabelsRaw)
-		if len(parsed) == 0 {
-			return nil, subscribeLabelsBlockID, "Enter a label selector like env=prod, owner=*."
+		includeLbls := labels.ParseLabelsQuery(render.LabelsRaw)
+		excludeLbls := labels.ParseLabelsQuery(render.ExcludeLabelsRaw)
+		if len(includeLbls) == 0 && len(excludeLbls) == 0 {
+			return nil, subscribeLabelsBlockID, "Enter a label selector (include or exclude) like env=prod or env=stage."
 		}
-		sel := &labels.Selector{MatchLabels: parsed}
+		sel := &labels.Selector{MatchLabels: includeLbls, NotMatchLabels: excludeLbls}
 		if err := sel.Validate(); err != nil {
 			return nil, subscribeLabelsBlockID, "Invalid label selector: " + err.Error()
 		}
@@ -1923,11 +1968,15 @@ func (s *service) maybePreview(
 		}
 		tm = &labels.TargetMatch{IDs: append([]string(nil), render.EntityIDs...)}
 	case predicateOptionLabels:
-		parsed := labels.ParseLabelsQuery(render.LabelsRaw)
-		if len(parsed) == 0 {
+		includeLbls := labels.ParseLabelsQuery(render.LabelsRaw)
+		excludeLbls := labels.ParseLabelsQuery(render.ExcludeLabelsRaw)
+		if len(includeLbls) == 0 && len(excludeLbls) == 0 {
 			return &subscribePreview{Kind: kind}
 		}
-		tm = &labels.TargetMatch{Selector: &labels.Selector{MatchLabels: parsed}}
+		tm = &labels.TargetMatch{Selector: &labels.Selector{
+			MatchLabels:    includeLbls,
+			NotMatchLabels: excludeLbls,
+		}}
 	default:
 		return nil
 	}
@@ -1969,7 +2018,10 @@ func (s *service) previewMatched(
 	case len(t.IDs) > 0:
 		tx = tx.Where("id IN ?", t.IDs)
 	case t.Selector != nil:
-		tx = tx.Scopes(labels.WithLabels("labels", t.Selector.MatchLabels))
+		tx = tx.Scopes(
+			labels.WithLabels("labels", t.Selector.MatchLabels),
+			labels.WithoutLabels("labels", t.Selector.NotMatchLabels),
+		)
 	}
 
 	// First the total count, then the truncated name list.
@@ -2129,13 +2181,14 @@ func readSubscribeRenderStateFromPayload(payload slackInteractionPayload) subscr
 	predicateOpt := pickValue(subscribePredicateBlockID, subscribePredicateActionID, "selected_option")
 
 	rs := subscribeModalRenderState{
-		OrgLinkID:  pickValue(subscribeOrgBlockID, subscribeOrgActionID, "selected_option"),
-		Match:      matchOpt,
-		TargetKind: targetKindFromString(kindOpt),
-		Predicate:  predicateOpt,
-		LabelsRaw:  pickPlainText(subscribeLabelsBlockID, subscribeLabelsActionID),
-		Notif:      pickValue(subscribeNotifBlockID, subscribeNotifActionID, "selected_option"),
-		Resources:  readResourceRenderStateFromValues(values, pickValue, pickMultiValues),
+		OrgLinkID:        pickValue(subscribeOrgBlockID, subscribeOrgActionID, "selected_option"),
+		Match:            matchOpt,
+		TargetKind:       targetKindFromString(kindOpt),
+		Predicate:        predicateOpt,
+		LabelsRaw:        pickPlainText(subscribeLabelsBlockID, subscribeLabelsActionID),
+		ExcludeLabelsRaw: pickPlainText(subscribeExcludeLabelsBlockID, subscribeExcludeLabelsActionID),
+		Notif:            pickValue(subscribeNotifBlockID, subscribeNotifActionID, "selected_option"),
+		Resources:        readResourceRenderStateFromValues(values, pickValue, pickMultiValues),
 	}
 
 	// Read app picker selection. Slack only emits this block when it

--- a/services/dashboard-ui/client/components/match/MatchPicker.stories.tsx
+++ b/services/dashboard-ui/client/components/match/MatchPicker.stories.tsx
@@ -43,6 +43,33 @@ export const PreselectedComponentsByLabels = () => (
   />
 )
 
+// Preselected installs by exclusion only — "everything except env=stage".
+// Include textinput stays empty, exclude textinput is pre-filled.
+export const PreselectedInstallsExcludeOnly = () => (
+  <Story
+    initial={{
+      installs: {
+        selector: { not_match_labels: { env: 'stage' } },
+      },
+    }}
+  />
+)
+
+// Preselected installs by both include + exclude — production tier=critical
+// installs except the canary ones.
+export const PreselectedInstallsIncludeAndExclude = () => (
+  <Story
+    initial={{
+      installs: {
+        selector: {
+          match_labels: { env: 'prod' },
+          not_match_labels: { canary: '*' },
+        },
+      },
+    }}
+  />
+)
+
 // Preselected actions with empty TargetMatch{} — predicate radio lands on
 // "Any" so toggling kinds doesn't surprise the user.
 export const PreselectedActionsAny = () => (

--- a/services/dashboard-ui/client/components/match/MatchPicker.tsx
+++ b/services/dashboard-ui/client/components/match/MatchPicker.tsx
@@ -36,7 +36,8 @@ type MatchMode = 'all' | 'specific'
 //     Match by:       ◉ Any ○ Specific ○ Labels
 //     (Specific)      [ entity multi-select scoped to the picked app
 //                       — installs stay org-scoped ]
-//     (Labels)        [ "env=prod, tier=critical, owner=*" text input ]
+//     (Labels)        [ "env=prod, tier=critical, owner=*" include input ]
+//                     [ "env=stage" exclude input — "everything except…" ]
 //
 // `value` is the exact wire shape persisted to the slack_channel_subscriptions
 // row's `match` JSONB column. Undefined => org-wide subscription.
@@ -67,11 +68,17 @@ export const MatchPicker = ({
     const tm = value?.[initialKind]
     return labelsToQueryString(tm?.selector?.match_labels)
   }, [value, initialKind])
+  const initialExcludeLabels = useMemo(() => {
+    const tm = value?.[initialKind]
+    return labelsToQueryString(tm?.selector?.not_match_labels)
+  }, [value, initialKind])
 
   const [mode, setMode] = useState<MatchMode>(initialMode)
   const [kind, setKind] = useState<TargetKind>(initialKind)
   const [predicate, setPredicate] = useState<Predicate>(initialPredicate)
   const [labelsRaw, setLabelsRaw] = useState<string>(initialLabels)
+  const [excludeLabelsRaw, setExcludeLabelsRaw] =
+    useState<string>(initialExcludeLabels)
   // appId is only meaningful when kind ∈ {components, actions} and
   // predicate is 'specific'. It's a UX gate, not part of the wire format
   // — the picked entity ids are globally unique so SubscriptionMatch
@@ -116,17 +123,22 @@ export const MatchPicker = ({
       return
     }
     // labels
-    const parsed = parseLabelsQuery(labelsRaw)
-    // Empty selector is invalid (server-side Validate rejects it); we
-    // still emit the empty-selector shape so the submit-time validator
-    // can surface the error rather than silently keeping the previous
-    // match.
-    onChange({ [kind]: { selector: { match_labels: parsed } } })
+    const include = parseLabelsQuery(labelsRaw)
+    const exclude = parseLabelsQuery(excludeLabelsRaw)
+    // Mirror the Slack modal: emit only the populated halves so the
+    // wire payload stays minimal. Empty include+exclude is invalid
+    // (server-side Validate rejects it); we still emit the empty
+    // shape so the submit-time validator can surface the error rather
+    // than silently keeping the previous match.
+    const selector: { match_labels?: typeof include; not_match_labels?: typeof exclude } = {}
+    if (Object.keys(include).length > 0) selector.match_labels = include
+    if (Object.keys(exclude).length > 0) selector.not_match_labels = exclude
+    onChange({ [kind]: { selector } })
     // We intentionally exclude `value` and `onChange` from deps to avoid
     // an infinite loop — onChange is called with the derived value, which
     // the parent re-passes as `value`. Including either would re-fire the
     // effect on every parent render.
-  }, [mode, kind, predicate, labelsRaw])
+  }, [mode, kind, predicate, labelsRaw, excludeLabelsRaw])
 
   // Switching kind clears the entity ids to mirror the Slack modal's
   // clearStaleSpecificFields behaviour — ids belong to the previous
@@ -138,6 +150,7 @@ export const MatchPicker = ({
     setKind(next)
     setAppId(undefined)
     setLabelsRaw('')
+    setExcludeLabelsRaw('')
   }
 
   // Switching the app inside components/actions invalidates the
@@ -263,22 +276,41 @@ export const MatchPicker = ({
           ) : null}
 
           {predicate === 'labels' ? (
-            <div className="flex flex-col gap-2">
-              <Input
-                labelProps={{ labelText: 'Label selector' }}
-                placeholder="env=prod, tier=critical, owner=*"
-                value={labelsRaw}
-                onChange={(e) => setLabelsRaw(e.target.value)}
-                disabled={disabled}
-              />
-              <Text variant="subtext" theme="neutral">
-                Comma-separated key=value pairs. Use <code>key=*</code> (or just
-                <code> key</code>) to match any value for a key.
-              </Text>
-              {labelsRaw.trim().length > 0 &&
-              Object.keys(parseLabelsQuery(labelsRaw)).length === 0 ? (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-2">
+                <Input
+                  labelProps={{ labelText: 'Include labels' }}
+                  placeholder="env=prod, tier=critical, owner=*"
+                  value={labelsRaw}
+                  onChange={(e) => setLabelsRaw(e.target.value)}
+                  disabled={disabled}
+                />
+                <Text variant="subtext" theme="neutral">
+                  Match {TARGET_KIND_LABELS_PLURAL[kind]} where every listed key
+                  matches. Use <code>key=*</code> (or just <code>key</code>) to
+                  match any value for a key. Leave blank to match everything
+                  except the exclusions below.
+                </Text>
+              </div>
+              <div className="flex flex-col gap-2">
+                <Input
+                  labelProps={{ labelText: 'Exclude labels' }}
+                  placeholder="env=stage"
+                  value={excludeLabelsRaw}
+                  onChange={(e) => setExcludeLabelsRaw(e.target.value)}
+                  disabled={disabled}
+                />
+                <Text variant="subtext" theme="neutral">
+                  Drop {TARGET_KIND_LABELS_PLURAL[kind]} where any listed key
+                  matches — e.g. <code>env=stage</code> to skip stage installs
+                  without enumerating every prod env value.
+                </Text>
+              </div>
+              {labelsRaw.trim().length === 0 &&
+              excludeLabelsRaw.trim().length === 0 ? (
                 <Banner theme="warn">
-                  Add at least one key (e.g. <code>env=prod</code>) — an empty
+                  Add at least one include or exclude key (e.g.{' '}
+                  <code>env=prod</code> or <code>env=stage</code>) — an empty
                   selector matches nothing.
                 </Banner>
               ) : null}
@@ -301,7 +333,7 @@ const derivePredicate = (
 ): Predicate => {
   const tm = m?.[kind]
   if (!tm) return 'any'
-  if (tm.selector?.match_labels) return 'labels'
+  if (tm.selector?.match_labels || tm.selector?.not_match_labels) return 'labels'
   if (tm.ids && tm.ids.length > 0) return 'specific'
   return 'any'
 }

--- a/services/dashboard-ui/client/components/match/parse.test.ts
+++ b/services/dashboard-ui/client/components/match/parse.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { labelsToQueryString, parseLabelsQuery } from './parse'
+import { describeMatch } from './types'
 
 describe('parseLabelsQuery', () => {
   test('empty input returns empty map', () => {
@@ -86,5 +87,65 @@ describe('labelsToQueryString', () => {
 
   test('wildcard value renders as k=*', () => {
     expect(labelsToQueryString({ env: '*' })).toBe('env=*')
+  })
+})
+
+describe('describeMatch', () => {
+  test('undefined => Org-wide', () => {
+    expect(describeMatch(undefined)).toBe('Org-wide')
+  })
+
+  test('no populated kind => Org-wide', () => {
+    expect(describeMatch({})).toBe('Org-wide')
+  })
+
+  test('include labels only', () => {
+    expect(
+      describeMatch({
+        installs: { selector: { match_labels: { env: 'prod', tier: '*' } } },
+      })
+    ).toBe('Installs: env=prod, tier=*')
+  })
+
+  test('exclude labels only renders with "not " prefix', () => {
+    expect(
+      describeMatch({
+        installs: { selector: { not_match_labels: { env: 'stage' } } },
+      })
+    ).toBe('Installs: not env=stage')
+  })
+
+  test('include + exclude joined with semicolon', () => {
+    expect(
+      describeMatch({
+        components: {
+          selector: {
+            match_labels: { env: 'prod' },
+            not_match_labels: { canary: '*' },
+          },
+        },
+      })
+    ).toBe('Components: env=prod; not canary=*')
+  })
+
+  test('ids fall back to count-noun summary', () => {
+    expect(describeMatch({ installs: { ids: ['a', 'b', 'c'] } })).toBe(
+      '3 installs'
+    )
+    expect(describeMatch({ installs: { ids: ['a'] } })).toBe('1 install')
+  })
+
+  test('empty TargetMatch{} renders as Any', () => {
+    expect(describeMatch({ actions: {} })).toBe('Any actions')
+  })
+
+  test('empty selector maps fall through to Any (matches nothing summary)', () => {
+    // describeMatch treats empty selectors as no labels; falls through
+    // to ids → empty → Any. The server rejects this shape on submit.
+    expect(
+      describeMatch({
+        installs: { selector: { match_labels: {}, not_match_labels: {} } },
+      })
+    ).toBe('Any installs')
   })
 })

--- a/services/dashboard-ui/client/components/match/types.ts
+++ b/services/dashboard-ui/client/components/match/types.ts
@@ -25,11 +25,16 @@ export type Labels = Record<string, string>
 // dispatch layer, not of label matching.
 export type TargetKind = 'installs' | 'components' | 'actions'
 
-// Selector mirrors pkg/labels.Selector. MatchLabels values may be a
-// literal (`env=prod`) or the wildcard `"*"` (matches any value for the
-// key — the bare-key form `env` round-trips as `env=*`).
+// Selector mirrors pkg/labels.Selector. Both MatchLabels and
+// NotMatchLabels values may be a literal (`env=prod`) or the wildcard
+// `"*"` (matches any value for the key — the bare-key form `env`
+// round-trips as `env=*`). NotMatchLabels lets users say "everything
+// except env=stage" without enumerating every other env value;
+// composition rule is AND across both maps (entity matches iff every
+// key in match_labels matches AND no key in not_match_labels matches).
 export interface Selector {
   match_labels?: Labels
+  not_match_labels?: Labels
 }
 
 // TargetMatch filters one entity kind. An empty TargetMatch ({}) is
@@ -106,7 +111,9 @@ export const firstPopulatedKind = (
 // dashboard table and the Slack modal use the same vocabulary.
 //
 //   - undefined  / no kind populated → "Org-wide"
-//   - selector                       → "Components: env=prod, owner=*"
+//   - include only                   → "Components: env=prod, owner=*"
+//   - exclude only                   → "Components: not env=stage"
+//   - both                           → "Components: env=prod; not env=stage"
 //   - ids                            → "3 installs"
 //   - empty TargetMatch{}            → "Any installs"
 export const describeMatch = (m: SubscriptionMatch | undefined): string => {
@@ -114,8 +121,16 @@ export const describeMatch = (m: SubscriptionMatch | undefined): string => {
   if (!m || !kind) return 'Org-wide'
   const tm = m[kind]
   if (!tm) return 'Org-wide'
-  if (tm.selector?.match_labels && Object.keys(tm.selector.match_labels).length > 0) {
-    return `${TARGET_KIND_LABELS[kind]}: ${labelsToQueryString(tm.selector.match_labels)}`
+  const sel = tm.selector
+  const inc = sel?.match_labels
+  const exc = sel?.not_match_labels
+  const incNonEmpty = inc && Object.keys(inc).length > 0
+  const excNonEmpty = exc && Object.keys(exc).length > 0
+  if (incNonEmpty || excNonEmpty) {
+    const parts: string[] = []
+    if (incNonEmpty) parts.push(labelsToQueryString(inc))
+    if (excNonEmpty) parts.push(`not ${labelsToQueryString(exc)}`)
+    return `${TARGET_KIND_LABELS[kind]}: ${parts.join('; ')}`
   }
   if (tm.ids && tm.ids.length > 0) {
     const noun =


### PR DESCRIPTION
## Summary

Slack channel subscriptions and webhooks can now exclude entities by label. A subscription scoped to "by labels" accepts both an include selector and an exclude selector, so "everything except env=stage" no longer requires labeling every prod install.

## What you can do after this PR

**Skip a slice of entities by label.** The labels predicate gains an exclude selector that drops any entity whose labels match. The exclude rule uses the same `key=value`, `key=*`, comma-separated grammar as include.

**Either side can be blank.** Mixing the two means "include these and drop those." Leaving include blank means "everything except these." Leaving exclude blank is the existing include-only behavior.

**Available everywhere.** The exclude input shows up in the Slack `/nuon subscribe` modal, the Slack subscription forms in the dashboard, the webhook create/edit forms in the dashboard, and the interactive `nuon webhooks create/update` picker. Webhook delivery and Slack delivery share the same match code path, so scripted webhook subscriptions can already use the exclude shape in the subscription JSON.

## What stays the same

Existing subscriptions match the same entities. Org-wide subscriptions, id lists, and include-only label selectors dispatch exactly as before. No data migration is needed.

## Mechanics worth flagging for review

The canonical text used by the per-subscription uniqueness index now includes the exclude map, so two subscriptions that differ only in exclusions count as distinct. The matching predicate, the dispatch-time preview, and the database scope are all symmetric: an exclude entry with value `*` rejects any row where the key exists, exact values reject only the matching pair, and multiple entries are ORed together.
