### PR TITLE
fix: context propagation into signal handler

### DIFF
--- a/services/ctl-api/internal/app/components/worker/activities/create_component_build_record.go
+++ b/services/ctl-api/internal/app/components/worker/activities/create_component_build_record.go
@@ -11,7 +11,6 @@ import (
 type CreateComponentBuildRecordRequest struct {
 	ComponentID string `validate:"required"`
 	OrgID       string `validate:"required"`
-	CreatedByID string
 
 	// GitRef overrides useLatest when set. Used to pin a build to the branch's specific commit.
 	GitRef *string
@@ -25,9 +24,6 @@ type CreateComponentBuildRecordRequest struct {
 // @temporal-gen-v2 activity
 func (a *Activities) CreateComponentBuildRecord(ctx context.Context, req CreateComponentBuildRecordRequest) (*app.ComponentBuild, error) {
 	ctx = cctx.SetOrgIDContext(ctx, req.OrgID)
-	if req.CreatedByID != "" {
-		ctx = cctx.SetAccountIDContext(ctx, req.CreatedByID)
-	}
 
 	useLatest := req.GitRef == nil
 	build, err := a.helpers.CreateComponentBuild(ctx, req.ComponentID, useLatest, req.GitRef)

--- a/services/ctl-api/internal/app/components/worker/activities/create_component_build_record.go
+++ b/services/ctl-api/internal/app/components/worker/activities/create_component_build_record.go
@@ -11,7 +11,7 @@ import (
 type CreateComponentBuildRecordRequest struct {
 	ComponentID string `validate:"required"`
 	OrgID       string `validate:"required"`
-	CreatedByID string `validate:"required"`
+	CreatedByID string
 
 	// GitRef overrides useLatest when set. Used to pin a build to the branch's specific commit.
 	GitRef *string
@@ -25,7 +25,9 @@ type CreateComponentBuildRecordRequest struct {
 // @temporal-gen-v2 activity
 func (a *Activities) CreateComponentBuildRecord(ctx context.Context, req CreateComponentBuildRecordRequest) (*app.ComponentBuild, error) {
 	ctx = cctx.SetOrgIDContext(ctx, req.OrgID)
-	ctx = cctx.SetAccountIDContext(ctx, req.CreatedByID)
+	if req.CreatedByID != "" {
+		ctx = cctx.SetAccountIDContext(ctx, req.CreatedByID)
+	}
 
 	useLatest := req.GitRef == nil
 	build, err := a.helpers.CreateComponentBuild(ctx, req.ComponentID, useLatest, req.GitRef)

--- a/services/ctl-api/internal/pkg/queue/handler/execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/execute.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/callback"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/queuecctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
@@ -72,6 +73,11 @@ func (h *handler) executeHandler(ctx workflow.Context, cb callback.Ref) (resp *E
 	}
 
 	execCtx, cancel := workflow.WithCancel(ctx)
+
+	// Restore the enqueuer's identity onto the execution context.
+	if h.queueSignal != nil {
+		execCtx = queuecctx.ApplyWorkflow(execCtx, h.queueSignal.SignalContext)
+	}
 	h.executingCtx = execCtx
 	h.executingCancel = cancel
 	defer cancel()

--- a/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx.go
+++ b/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx.go
@@ -3,6 +3,8 @@ package queuecctx
 import (
 	"context"
 
+	"go.temporal.io/sdk/workflow"
+
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	qcctx "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/cctx"
 )
@@ -34,6 +36,23 @@ func Apply(ctx context.Context, sc qcctx.SignalContext) context.Context {
 	}
 	if sc.TraceID != "" {
 		ctx = cctx.SetTraceIDContext(ctx, sc.TraceID)
+	}
+	return ctx
+}
+
+// ApplyWorkflow is the workflow.Context analog of Apply. It restores the
+// captured per-signal context values onto a workflow.Context so that the
+// signal's Execute (and any activities it schedules via the Temporal
+// propagator) see the enqueuer's identity rather than the queue workflow's.
+func ApplyWorkflow(ctx workflow.Context, sc qcctx.SignalContext) workflow.Context {
+	if sc.AccountID != "" {
+		ctx = cctx.SetAccountIDWorkflowContext(ctx, sc.AccountID)
+	}
+	if sc.OrgID != "" {
+		ctx = cctx.SetOrgIDWorkflowContext(ctx, sc.OrgID)
+	}
+	if sc.TraceID != "" {
+		ctx = cctx.SetTraceIDWorkflowContext(ctx, sc.TraceID)
 	}
 	return ctx
 }


### PR DESCRIPTION
Queue workflow does not propagate signal context to handler workflow which causes improper information in handler workflow context.
It also propagates queue workflow context further which could cause incorrect ctx values inside handler values.

This pr applies signal context before creating handler workflow so correct ctx values are propagated further.