### PR TITLE
chore(cli): `nuon installs inputs` commands

### DIFF
--- a/bins/cli/cmd/installs.go
+++ b/bins/cli/cmd/installs.go
@@ -401,6 +401,47 @@ The --stack, --sandbox, and --component-id flags are mutually exclusive.`,
 	currentInputs.MarkFlagRequired("install-id")
 	installsCmds.AddCommand(currentInputs)
 
+	inputsCmd := &cobra.Command{
+		Use:   "inputs",
+		Short: "Manage install inputs",
+		Long:  "View and set the app input values for an install",
+	}
+	inputsCmd.PersistentFlags().StringVarP(&id, "install-id", "i", "", "The ID or name of the install")
+
+	inputsGetCmd := &cobra.Command{
+		Use:     "get",
+		Aliases: []string{"list"},
+		Short:   "View install inputs",
+		Long:    "View the install's current input values alongside their declared defaults",
+		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
+			svc := installs.New(c.apiClient, c.cfg)
+			return svc.GetInputs(cmd.Context(), id, PrintJSON)
+		}),
+	}
+	inputsCmd.AddCommand(inputsGetCmd)
+
+	inputsSetCmd := &cobra.Command{
+		Use:   "set [key=value ...]",
+		Short: "Set install inputs",
+		Long: `Set one or more install input values.
+
+Accepts a list of inputs in key=value format, e.g.:
+
+  nuon installs inputs set foo=bar baz=qux
+
+The current inputs are fetched first so changed values can be shown. Setting an
+input that is not declared on the app raises an error.`,
+		Args: cobra.MinimumNArgs(1),
+		Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
+			svc := installs.New(c.apiClient, c.cfg)
+			return svc.SetInputs(cmd.Context(), id, args, deployDependents, PrintJSON)
+		}),
+	}
+	inputsSetCmd.Flags().BoolVar(&deployDependents, "deploy-dependents", true, "Deploy components that depend on the updated inputs")
+	inputsCmd.AddCommand(inputsSetCmd)
+
+	installsCmds.AddCommand(inputsCmd)
+
 	selectInstallCmd := &cobra.Command{
 		Use:         "select",
 		Short:       "Select your current install",

--- a/bins/cli/internal/services/installs/inputs.go
+++ b/bins/cli/internal/services/installs/inputs.go
@@ -1,0 +1,229 @@
+package installs
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nuonco/nuon/sdks/nuon-go/models"
+
+	"github.com/nuonco/nuon/bins/cli/internal/config"
+	"github.com/nuonco/nuon/bins/cli/internal/lookup"
+	"github.com/nuonco/nuon/bins/cli/internal/ui"
+	"github.com/nuonco/nuon/pkg/cli/styles"
+)
+
+// inputDef describes a single declared app input, with its default value.
+type inputDef struct {
+	name      string
+	def       string
+	sensitive bool
+}
+
+// loadInputDefs fetches the install's app input config and returns the
+// declared inputs (name + default) along with the resolved install ID.
+func (s *Service) loadInputDefs(ctx context.Context, installID string) (string, []inputDef, error) {
+	installID, err := lookup.InstallID(ctx, s.api, installID)
+	if err != nil {
+		return "", nil, err
+	}
+
+	install, err := s.api.GetInstall(ctx, installID)
+	if err != nil {
+		return "", nil, err
+	}
+
+	cfg, err := s.api.GetAppInputLatestConfig(ctx, install.AppID)
+	if err != nil {
+		return "", nil, err
+	}
+
+	defs := make([]inputDef, 0, len(cfg.Inputs))
+	for _, in := range cfg.Inputs {
+		defs = append(defs, inputDef{
+			name:      in.Name,
+			def:       in.Default,
+			sensitive: in.Sensitive,
+		})
+	}
+	sort.Slice(defs, func(i, j int) bool {
+		return defs[i].name < defs[j].name
+	})
+	return installID, defs, nil
+}
+
+// GetInputs prints the install's current inputs alongside their declared
+// defaults.
+func (s *Service) GetInputs(ctx context.Context, installID string, asJSON bool) error {
+	installID, defs, err := s.loadInputDefs(ctx, installID)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+
+	current, err := s.api.GetInstallCurrentInputs(ctx, installID)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+
+	if asJSON {
+		ui.PrintJSON(current)
+		return nil
+	}
+
+	values := redactedValues(current)
+
+	view := ui.NewGetView()
+	data := [][]string{{"", "VALUE", "DEFAULT"}}
+	for _, d := range defs {
+		val, ok := values[d.name]
+		if !ok {
+			val = "-"
+		}
+		def := d.def
+		if def == "" {
+			def = "-"
+		}
+		data = append(data, []string{styles.TextPrimary.Render(d.name), val, def})
+	}
+	view.Render(data)
+	return nil
+}
+
+// SetInputs patches install inputs from a list of key=value pairs. It fetches
+// the current inputs first so it can show which values changed, and validates
+// that each key refers to a declared input.
+func (s *Service) SetInputs(ctx context.Context, installID string, args []string, deployDependents bool, asJSON bool) error {
+	updates, err := parseInputArgs(args)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+
+	installID, defs, err := s.loadInputDefs(ctx, installID)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+
+	known := make(map[string]inputDef, len(defs))
+	for _, d := range defs {
+		known[d.name] = d
+	}
+
+	var unknown []string
+	for k := range updates {
+		if _, ok := known[k]; !ok {
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return ui.PrintError(fmt.Errorf("unknown input(s): %s", strings.Join(unknown, ", ")))
+	}
+
+	current, err := s.api.GetInstallCurrentInputs(ctx, installID)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+	prevValues := currentValues(current)
+	prevRedacted := redactedValues(current)
+
+	// The update endpoint expects the full set of inputs, so start from the
+	// existing values and merge in only the keys that are being changed.
+	merged := make(map[string]string, len(prevValues)+len(updates))
+	for k, v := range prevValues {
+		merged[k] = v
+	}
+
+	// Track which inputs actually changed (new value differs from the
+	// original), so we can render an accurate CHANGED column.
+	changed := make(map[string]bool, len(updates))
+	for k, v := range updates {
+		prev, ok := prevValues[k]
+		if !ok || prev != v {
+			changed[k] = true
+		}
+		merged[k] = v
+	}
+
+	request := &models.ServiceUpdateInstallInputsRequest{
+		Inputs:           merged,
+		DeployDependents: &deployDependents,
+	}
+	if config.Debug() {
+		ui.PrintJSON(request)
+	}
+
+	resp, err := s.api.UpdateInstallInputs(ctx, installID, request)
+	if err != nil {
+		return ui.PrintJSONError(err)
+	}
+
+	if asJSON {
+		ui.PrintJSON(resp)
+		return nil
+	}
+
+	keys := make([]string, 0, len(updates))
+	for k := range updates {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	view := ui.NewGetView()
+	data := [][]string{{"", "PREVIOUS", "NEW", "CHANGED"}}
+	for _, k := range keys {
+		newVal := updates[k]
+		displayNew := newVal
+		displayPrev, hadPrev := prevRedacted[k]
+		if !hadPrev {
+			displayPrev = "-"
+		}
+		if known[k].sensitive {
+			displayNew = "********"
+		}
+		changedStr := "no"
+		if changed[k] {
+			// Highlight changes: red for the old value, green for the new.
+			displayPrev = styles.TextError.Render(displayPrev)
+			displayNew = styles.TextSuccess.Render(displayNew)
+			changedStr = styles.TextSuccess.Render("yes")
+		}
+		data = append(data, []string{styles.TextPrimary.Render(k), displayPrev, displayNew, changedStr})
+	}
+	view.Render(data)
+	return nil
+}
+
+// currentValues returns the non-redacted values map from a current-inputs
+// response, falling back to an empty map.
+func currentValues(in *models.AppInstallInputs) map[string]string {
+	if in == nil || in.Values == nil {
+		return map[string]string{}
+	}
+	return in.Values
+}
+
+// redactedValues returns the redacted values map, falling back to an empty map.
+func redactedValues(in *models.AppInstallInputs) map[string]string {
+	if in == nil || in.RedactedValues == nil {
+		return map[string]string{}
+	}
+	return in.RedactedValues
+}
+
+// parseInputArgs parses a list of key=value pairs into a map. It errors on
+// malformed entries.
+func parseInputArgs(args []string) (map[string]string, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("no inputs provided; expected key=value pairs")
+	}
+	out := make(map[string]string, len(args))
+	for _, arg := range args {
+		k, v, ok := strings.Cut(arg, "=")
+		if !ok || k == "" {
+			return nil, fmt.Errorf("invalid input %q; expected key=value", arg)
+		}
+		out[k] = v
+	}
+	return out, nil
+}

--- a/bins/cli/internal/ui/bubbles/table.go
+++ b/bins/cli/internal/ui/bubbles/table.go
@@ -104,7 +104,8 @@ func calculateColumnWidth(data [][]string, columnIndex int) int {
 
 	for _, row := range data {
 		if columnIndex < len(row) {
-			cellWidth := len(row[columnIndex])
+			// Use lipgloss.Width so ANSI color codes don't inflate the width.
+			cellWidth := lipgloss.Width(row[columnIndex])
 			if cellWidth > maxWidth {
 				maxWidth = cellWidth
 			}


### PR DESCRIPTION
### Description

New command group: `nuon installs inputs`

Intended to subsume:

- `nuon installs current-inputs`
- `nuon installs update-input`

Full replacement for those commands. 

Additionally: we'll add a TUI at `nuon installs inputs edit` for interactive editing.

The major difference here is that the `set` command that replaces `update-input` accepts a subset of the values and merges with the current values to send a `PATCH` the endpoint will accept (it expects the full set).

```
nuon-dev installs inputs --help

  View and set the app input values for an install

  USAGE

    nuon installs inputs [command] [--flags]

  COMMANDS

    get                            View install inputs
    set [key=value ...] [--flags]  Set install inputs

  FLAGS

    -f --config                    Path to custom config file. Can also be set using the NUON_CONFIG_FILE env var. (~/.nuon)
    -C --config-file               Path to custom config file. Can also be set using the NUON_CONFIG_FILE env var. (~/.nuon)
    -h --help                      Help for inputs
    -i --install-id                The ID or name of the install
    -j --json                      Print output as json
```

> [!NOTE]
> In the near future, we will alias and eventually remove `update-input` and `current-inputs`. 
