### PR TITLE
chore: properly wire timeouts between steps, groups and signals

### DIFF
--- a/services/ctl-api/internal/app/apps/signals/branches/builds/execute.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/builds/execute.go
@@ -259,7 +259,7 @@ func (s *Signal) dispatchAndAwaitGroup(ctx workflow.Context, group *app.Workflow
 		return fmt.Errorf("unable to enqueue group signal: %w", err)
 	}
 
-	_, err = callback.Await(ctx, cb)
+	_, err = callback.AwaitWithTimeout(ctx, cb, callback.FallbackAwaitTimeout)
 	if err != nil {
 		if ctx.Err() != nil {
 			cancelCtx, cancelCtxCancel := workflow.NewDisconnectedContext(ctx)
@@ -362,7 +362,7 @@ func (s *Signal) sandboxBuildForInstall(ctx workflow.Context, l log.Logger, inst
 			"install_component_id", installComponentID,
 			"queue_signal_id", enqueueResp.QueueSignalID)
 
-		if _, err = callback.Await(ctx, cb); err != nil {
+		if _, err = callback.AwaitWithTimeout(ctx, cb, callback.FallbackAwaitTimeout); err != nil {
 			return fmt.Errorf("install %s component %s: sandbox deploy failed: %w", installID, componentID, err)
 		}
 

--- a/services/ctl-api/internal/app/apps/signals/branches/deploygrouptoqueue/execute.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/deploygrouptoqueue/execute.go
@@ -156,7 +156,7 @@ func (s *Signal) deployComponentToInstall(ctx workflow.Context, logger log.Logge
 		"queue_signal_id", enqueueResp.QueueSignalID,
 	)
 
-	_, err = callback.Await(ctx, cb)
+	_, err = callback.AwaitWithTimeout(ctx, cb, callback.FallbackAwaitTimeout)
 	if err != nil {
 		return fmt.Errorf("deploy failed: %w", err)
 	}

--- a/services/ctl-api/internal/app/apps/signals/branches/run/execute.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/run/execute.go
@@ -69,7 +69,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	)
 
 	// Await the execute-workflow signal completion
-	if _, err = callback.Await(ctx, cb); err != nil {
+	if _, err = callback.AwaitWithTimeout(ctx, cb, callback.FallbackAwaitTimeout); err != nil {
 		logger.Error("workflow execution failed", "error", err)
 		if _, updateErr := activities.AwaitUpdateAppBranchRunStatus(ctx, &activities.UpdateAppBranchRunStatusRequest{
 			RunID:        run.ID,

--- a/services/ctl-api/internal/app/installs/helpers/stategen/stategen.go
+++ b/services/ctl-api/internal/app/installs/helpers/stategen/stategen.go
@@ -1,8 +1,6 @@
 package stategen
 
 import (
-	"time"
-
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
@@ -53,7 +51,7 @@ func HintOrGenerate(ctx workflow.Context, req Request) error {
 			}
 			// state-manager queue missing — fall through to legacy generation
 		} else {
-			if _, err := callback.AwaitWithTimeout(ctx, cb, 30*time.Minute); err != nil {
+			if _, err := callback.AwaitWithTimeout(ctx, cb, callback.ShortTimeout); err != nil {
 				return errors.Wrap(err, "unable to await state generation")
 			}
 			return nil

--- a/services/ctl-api/internal/app/installs/helpers/stategen/stategen.go
+++ b/services/ctl-api/internal/app/installs/helpers/stategen/stategen.go
@@ -1,6 +1,8 @@
 package stategen
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
@@ -51,7 +53,7 @@ func HintOrGenerate(ctx workflow.Context, req Request) error {
 			}
 			// state-manager queue missing — fall through to legacy generation
 		} else {
-			if _, err := callback.Await(ctx, cb); err != nil {
+			if _, err := callback.AwaitWithTimeout(ctx, cb, 30*time.Minute); err != nil {
 				return errors.Wrap(err, "unable to await state generation")
 			}
 			return nil

--- a/services/ctl-api/internal/app/installs/signals/driftdetected/dispatch.go
+++ b/services/ctl-api/internal/app/installs/signals/driftdetected/dispatch.go
@@ -1,8 +1,6 @@
 package driftdetected
 
 import (
-	"time"
-
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
@@ -33,7 +31,7 @@ func Dispatch(ctx workflow.Context, sig *Signal) error {
 		return errors.Wrap(err, "unable to enqueue drift-detected signal")
 	}
 
-	if _, err := callback.AwaitWithTimeout(ctx, cb, 5*time.Minute); err != nil {
+	if _, err := callback.AwaitWithTimeout(ctx, cb, callback.DriftDetectionTimeout); err != nil {
 		return errors.Wrap(err, "drift-detected signal failed")
 	}
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/driftdetected/dispatch.go
+++ b/services/ctl-api/internal/app/installs/signals/driftdetected/dispatch.go
@@ -1,6 +1,8 @@
 package driftdetected
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
@@ -31,7 +33,7 @@ func Dispatch(ctx workflow.Context, sig *Signal) error {
 		return errors.Wrap(err, "unable to enqueue drift-detected signal")
 	}
 
-	if _, err := callback.Await(ctx, cb); err != nil {
+	if _, err := callback.AwaitWithTimeout(ctx, cb, 5*time.Minute); err != nil {
 		return errors.Wrap(err, "drift-detected signal failed")
 	}
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/workflowstepapprovalrequest/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/workflowstepapprovalrequest/signal.go
@@ -1,6 +1,8 @@
 package workflowstepapprovalrequest
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
@@ -152,7 +154,7 @@ func Dispatch(ctx workflow.Context, sig *Signal) error {
 		return errors.Wrap(err, "unable to enqueue workflow-step-approval-request signal")
 	}
 
-	if _, err := callback.Await(ctx, cb); err != nil {
+	if _, err := callback.AwaitWithTimeout(ctx, cb, 5*time.Minute); err != nil {
 		return errors.Wrap(err, "workflow-step-approval-request signal failed")
 	}
 	return nil

--- a/services/ctl-api/internal/app/installs/signals/workflowstepapprovalrequest/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/workflowstepapprovalrequest/signal.go
@@ -1,8 +1,6 @@
 package workflowstepapprovalrequest
 
 import (
-	"time"
-
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
@@ -154,7 +152,7 @@ func Dispatch(ctx workflow.Context, sig *Signal) error {
 		return errors.Wrap(err, "unable to enqueue workflow-step-approval-request signal")
 	}
 
-	if _, err := callback.AwaitWithTimeout(ctx, cb, 5*time.Minute); err != nil {
+	if _, err := callback.AwaitWithTimeout(ctx, cb, callback.HumanGatedTimeout); err != nil {
 		return errors.Wrap(err, "workflow-step-approval-request signal failed")
 	}
 	return nil

--- a/services/ctl-api/internal/app/onboarding/signals/create_app/execute.go
+++ b/services/ctl-api/internal/app/onboarding/signals/create_app/execute.go
@@ -118,7 +118,7 @@ func (s *Signal) executeCreateApp(ctx workflow.Context, logger interface{ Info(s
 
 		// Wait for the branch run to complete so app config (input_config) is ready
 		// before advancing. Without this, the install step loads before inputs exist.
-		_, err = callback.Await(ctx, cb)
+		_, err = callback.AwaitWithTimeout(ctx, cb, callback.FallbackAwaitTimeout)
 		if err != nil {
 			return fmt.Errorf("app branch run failed: %w", err)
 		}

--- a/services/ctl-api/internal/pkg/callback/await.go
+++ b/services/ctl-api/internal/pkg/callback/await.go
@@ -8,8 +8,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-const defaultAwaitTimeout = 30 * time.Minute
-
 // FallbackAwaitTimeout caps a human-gated wait that has no configured timeout.
 const FallbackAwaitTimeout = 30 * 24 * time.Hour
 
@@ -17,12 +15,6 @@ const FallbackAwaitTimeout = 30 * 24 * time.Hour
 type Result struct {
 	Status            string `json:"status"`
 	StatusDescription string `json:"status_description,omitempty"`
-}
-
-// Await waits for a completion signal on the Ref's signal channel using the
-// default timeout.
-func Await(ctx workflow.Context, ref Ref) (*Result, error) {
-	return AwaitWithTimeout(ctx, ref, defaultAwaitTimeout)
 }
 
 // AwaitWithTimeout waits for a completion signal on the Ref's signal channel.

--- a/services/ctl-api/internal/pkg/callback/await.go
+++ b/services/ctl-api/internal/pkg/callback/await.go
@@ -8,8 +8,27 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-// FallbackAwaitTimeout caps a human-gated wait that has no configured timeout.
-const FallbackAwaitTimeout = 30 * 24 * time.Hour
+const (
+	// QuickTimeout is for fast infrastructure operations: validation, no-op
+	// signals, DB-row creation. If these take longer than 5 minutes something
+	// is stuck.
+	QuickTimeout = 5 * time.Minute
+
+	// DriftDetectionTimeout is for drift-detection signals which are lightweight
+	// but fan out through the webhook/Slack pipeline.
+	DriftDetectionTimeout = 15 * time.Minute
+
+	// ShortTimeout is for operations expected to complete within minutes:
+	// state generation, lightweight queue signals.
+	ShortTimeout = 30 * time.Minute
+
+	// HumanGatedTimeout is for operations that require human interaction:
+	// approval workflows, user-initiated stack runs.
+	HumanGatedTimeout = 180 * 24 * time.Hour
+
+	// FallbackAwaitTimeout caps a wait that has no configured timeout.
+	FallbackAwaitTimeout = 30 * 24 * time.Hour
+)
 
 // Result is the payload sent by the handler on completion.
 type Result struct {

--- a/services/ctl-api/internal/pkg/flow/group_dispatch.go
+++ b/services/ctl-api/internal/pkg/flow/group_dispatch.go
@@ -95,7 +95,7 @@ func DispatchGroupSignal(ctx workflow.Context, cfg StepConfig, group *app.Workfl
 	}
 
 	// Legacy fallback: no StepGroupID, use framework-level finished handler.
-	_, err = callback.Await(ctx, cb)
+	_, err = callback.AwaitWithTimeout(ctx, cb, callback.FallbackAwaitTimeout)
 	if err != nil {
 		if ctx.Err() != nil {
 			cancelCtx, cancelCtxCancel := workflow.NewDisconnectedContext(ctx)

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/execute_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/execute_step.go
@@ -241,7 +241,11 @@ func (s *Signal) executeInnerSignal(ctx workflow.Context, step *app.WorkflowStep
 		"queue_signal_id", enqueueResp.QueueSignalID,
 	)
 
-	_, err = callback.Await(ctx, cb)
+	stepTimeout := step.Timeout
+	if stepTimeout <= 0 {
+		stepTimeout = callback.FallbackAwaitTimeout
+	}
+	_, err = callback.AwaitWithTimeout(ctx, cb, stepTimeout)
 	if err != nil {
 		return errors.Wrapf(err, "queue signal execution failed for step %s", step.Name)
 	}

--- a/services/ctl-api/internal/pkg/flow/step_dispatch.go
+++ b/services/ctl-api/internal/pkg/flow/step_dispatch.go
@@ -83,7 +83,12 @@ func DispatchStepSignal(ctx workflow.Context, cfg StepConfig, step *app.Workflow
 	}
 
 	// Wait for completion via signal channel — zero activity overhead, zero heartbeats.
-	_, err = callback.Await(ctx, cb)
+	// Bound by the step's derived timeout so we don't wait 30 days on a misconfigured step.
+	stepTimeout := step.Timeout
+	if stepTimeout <= 0 {
+		stepTimeout = callback.FallbackAwaitTimeout
+	}
+	_, err = callback.AwaitWithTimeout(ctx, cb, stepTimeout)
 	if err != nil {
 		// If the parent workflow was cancelled, propagate cancellation to the step signal
 		if ctx.Err() != nil {

--- a/services/ctl-api/internal/pkg/flow/step_generate_signal.go
+++ b/services/ctl-api/internal/pkg/flow/step_generate_signal.go
@@ -13,6 +13,8 @@ package flow
 //  6. Persist groups and steps to DB.
 
 import (
+	"time"
+
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/pkg/errors"
@@ -191,10 +193,33 @@ func persistGenerateResult(ctx workflow.Context, flw *app.Workflow, result *app.
 			groupIDByIdx[g.GroupIdx] = g.ID
 		}
 
+		// Derive group timeouts from their steps.
+		// Sequential groups: sum of step timeouts.
+		// Parallel groups: max of step timeouts.
+		groupParallel := make(map[int]bool, len(groups))
+		for _, g := range groups {
+			groupParallel[g.GroupIdx] = g.Parallel
+		}
+		groupTimeouts := make(map[int]time.Duration, len(groups))
+		for _, step := range steps {
+			t := step.Timeout
+			if t <= 0 {
+				continue
+			}
+			if groupParallel[step.GroupIdx] {
+				if t > groupTimeouts[step.GroupIdx] {
+					groupTimeouts[step.GroupIdx] = t
+				}
+			} else {
+				groupTimeouts[step.GroupIdx] += t
+			}
+		}
+
 		groupsReq := activities.CreateFlowStepGroupsRequest{
 			Groups: make([]activities.CreateFlowStepGroup, 0, len(groups)),
 		}
 		for _, g := range groups {
+			g.Timeout = groupTimeouts[g.GroupIdx]
 			groupsReq.Groups = append(groupsReq.Groups, activities.CreateFlowStepGroup{
 				ID:         g.ID,
 				WorkflowID: flw.ID,
@@ -202,6 +227,7 @@ func persistGenerateResult(ctx workflow.Context, flw *app.Workflow, result *app.
 				Parallel:   g.Parallel,
 				Name:       g.Name,
 				Status:     g.Status,
+				Timeout:    g.Timeout,
 			})
 		}
 		if _, err := activities.AwaitPkgWorkflowsFlowCreateFlowStepGroups(ctx, groupsReq); err != nil {

--- a/services/ctl-api/internal/pkg/queue/client/ensure_queue_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/ensure_queue_signal.go
@@ -48,7 +48,7 @@ func EnsureQueueSignal(ctx workflow.Context, ownerID, ownerType string, signalTy
 	}
 
 	// Block until the handler sends a completion callback.
-	if _, err := callback.Await(ctx, cbRef); err != nil {
+	if _, err := callback.AwaitWithTimeout(ctx, cbRef, callback.FallbackAwaitTimeout); err != nil {
 		return fmt.Errorf("ensure signal %v for %s/%s failed while awaiting: %w", signalTypes, ownerType, ownerID, err)
 	}
 

--- a/services/ctl-api/internal/pkg/queue/handle_signal.go
+++ b/services/ctl-api/internal/pkg/queue/handle_signal.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
 	handleractivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
@@ -121,11 +122,13 @@ func (q *queue) processQueueSignal(ctx workflow.Context, l *zap.Logger, queueSig
 		return errors.Wrap(err, "unable to send validate update")
 	}
 
-	if _, err := callback.Await(ctx, validateCB); err != nil {
+	if _, err := callback.AwaitWithTimeout(ctx, validateCB, 5*time.Minute); err != nil {
 		return errors.Wrap(err, "validate failed")
 	}
 
 	// 3. Execute: send update (accepted-only), wait for callback.
+	// Derive the timeout from the signal so long-running signals get the full budget.
+	executeTimeout := signal.DeriveTimeout(queueSignal.Signal.Signal)
 	executeCB := callback.New(ctx, queueSignal.ID+"-execute")
 	l.Info("sending execute update")
 	if err := handleractivities.AwaitUpdateWorkflowExecute(ctx, handleractivities.UpdateWorkflowExecuteRequest{
@@ -138,7 +141,7 @@ func (q *queue) processQueueSignal(ctx workflow.Context, l *zap.Logger, queueSig
 		return errors.Wrap(err, "unable to send execute update")
 	}
 
-	if _, err := callback.Await(ctx, executeCB); err != nil {
+	if _, err := callback.AwaitWithTimeout(ctx, executeCB, executeTimeout); err != nil {
 		return errors.Wrap(err, "execute failed")
 	}
 

--- a/services/ctl-api/internal/pkg/queue/handle_signal.go
+++ b/services/ctl-api/internal/pkg/queue/handle_signal.go
@@ -122,7 +122,7 @@ func (q *queue) processQueueSignal(ctx workflow.Context, l *zap.Logger, queueSig
 		return errors.Wrap(err, "unable to send validate update")
 	}
 
-	if _, err := callback.AwaitWithTimeout(ctx, validateCB, 5*time.Minute); err != nil {
+	if _, err := callback.AwaitWithTimeout(ctx, validateCB, callback.QuickTimeout); err != nil {
 		return errors.Wrap(err, "validate failed")
 	}
 

--- a/services/ctl-api/internal/pkg/workflows/job/exec.go
+++ b/services/ctl-api/internal/pkg/workflows/job/exec.go
@@ -57,7 +57,8 @@ func (w *Workflows) ExecuteJob(ctx workflow.Context, req *ExecuteJobRequest) (ap
 
 	if queueSignalID != "" {
 		// Queue path: await signal completion via callback.
-		if _, err := callback.Await(ctx, cb); err != nil {
+		// Bound by the workflow's execution timeout (1h), but be explicit.
+		if _, err := callback.AwaitWithTimeout(ctx, cb, time.Hour); err != nil {
 			return app.RunnerJobStatusUnknown, errors.Wrap(err, "queue signal failed")
 		}
 	} else {


### PR DESCRIPTION
We were inadvertently using a fallback timeout of 30 minutes in some places. This updates the timeouts to propagate 
correctly:

1. step-groups correctly calculate the aggregate timeout they need to set.
1. steps propagate the timeout from inner signals.
1. jobs correctly set timeouts.
1. no more `Await` method, and we enforce callers pass in a timeout.

There are some places we were setting smaller timeouts than needed, or larger timeouts than needed.
