### PR TITLE
fix: space group-retry step clones by 100 to avoid idx collision

### DIFF
--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/clone_group.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/clone_group.go
@@ -154,7 +154,7 @@ func (s *Signal) cloneGroupForRetry(ctx workflow.Context, groupIdx int) error {
 				"retry_idx":       newGroupRetryIdx,
 				"group_retry_idx": newGroupRetryIdx,
 			}),
-			Idx:                 maxIdx + 100 + i,
+			Idx:                 maxIdx + 100*(i+1),
 			ExecutionType:       step.ExecutionType,
 			Metadata:            step.Metadata,
 			Retryable:           step.Retryable,

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/retry_group.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/retry_group.go
@@ -127,7 +127,7 @@ func (s *Signal) retryGroup(ctx workflow.Context, l *zap.Logger) error {
 				"group_retry_idx": newGroupRetryIdx,
 				"retry_type":      "auto",
 			}),
-			Idx:            maxIdx + 100 + i,
+			Idx:            maxIdx + 100*(i+1),
 			ExecutionType:  step.ExecutionType,
 			Metadata:       step.Metadata,
 			Retryable:      step.Retryable,


### PR DESCRIPTION
Group-retry cloned steps with `maxIdx + 100 + i` (consecutive idx). Originals are spaced by 100, so an individual step retry (`idx+1`) lands on the next sibling's idx; the executor orders by `(idx, created_at)` and runs the sibling instead. Bites when a previously-passing non-last step fails on a re-run (e.g. `sync and plan` inside a retried group). Fix: clone with `maxIdx + 100*(i+1)` so clones keep the 100 spacing.