### PR TITLE
feat(dashboard): show plan tab only when a plan exists

### DIFF
--- a/pkg/metrics/dogstatsd.go
+++ b/pkg/metrics/dogstatsd.go
@@ -150,6 +150,27 @@ func (w *writer) Timing(name string, value time.Duration, tags []string) {
 	w.handleErr(client.Timing(name, value, allTags, defaultRate))
 }
 
+func (w *writer) Distribution(name string, value float64, tags []string) {
+	allTags := append(w.Tags, tags...)
+	if w.Disable {
+		l := w.Log.With(
+			zap.String("metric_type", "distribution"),
+			zap.String("is_metric", "true"))
+		allAttrs := w.tagsToZapFields(allTags)
+		allAttrs = append(allAttrs, zap.Float64("value", value))
+		l.Debug(fmt.Sprintf("metric.distribution.%s", name), allAttrs...)
+		return
+	}
+
+	client, err := w.getClient()
+	if err != nil {
+		w.handleErr(err)
+		return
+	}
+
+	w.handleErr(client.Distribution(name, value, allTags, defaultRate))
+}
+
 func (w *writer) Event(ev *statsd.Event) {
 	if w.Disable {
 		allTags := w.tagsToZapFields(ev.Tags)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -25,6 +25,11 @@ type Writer interface {
 	Timing(name string, value time.Duration, tags []string)
 	Gauge(name string, value float64, tags []string)
 	Count(name string, value int64, tags []string)
+	// Distribution sends a single value into a Datadog distribution
+	// metric. Use this for non-duration sample distributions (e.g. row
+	// counts, queue depths) where you want percentile rollups aggregated
+	// across hosts. For latencies prefer Timing.
+	Distribution(name string, value float64, tags []string)
 
 	// datadog specific
 	Event(e *statsd.Event)

--- a/services/ctl-api/internal/app/runners/service/log_stream_read_logs.go
+++ b/services/ctl-api/internal/app/runners/service/log_stream_read_logs.go
@@ -21,6 +21,54 @@ const (
 	nestedAttributeRegex string = `^(?:[a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?)$` // https://regex101.com/r/179bxx/1
 )
 
+// metricReadFreshnessLagMs — temporary rollout metric to compare the
+// flag-off legacy poll path against `log_tail.hot_probe_ms` on the
+// flag-on path. For every response with rows, we emit `time.Since(newest
+// row timestamp)` — i.e. how stale the freshest row we just returned to
+// the user is. On the `mode:poll` slice (BFF 1s-tick live tail) p50
+// can't drop below ~500ms by construction because of the polling floor;
+// `log_tail.hot_probe_ms` p50 sits in the 300–500ms range with no such
+// floor. That gap is the rollout argument expressed in milliseconds.
+// Delete once log-tail-long-poll has rolled out broadly enough that we
+// no longer need the comparison.
+const metricReadFreshnessLagMs = "log_read.freshness_lag_ms"
+
+// readMode classifies a legacy read so the comparison against the tail
+// endpoint isn't muddied by search/download/backfill traffic. Only
+// `mode:poll` is apples-to-apples with the tail endpoint's role.
+const (
+	readModePoll     = "poll"     // empty cursor, no filters, ASC — the BFF live-tail loop
+	readModeBackfill = "backfill" // non-empty cursor, no filters — paging through history
+	readModeFiltered = "filtered" // any filter set, or order=desc — search / ad-hoc
+)
+
+func classifyReadMode(cursor int64, order string, f logFilters) string {
+	if order != "asc" || hasAnyFilter(f) {
+		return readModeFiltered
+	}
+	if cursor > 0 {
+		return readModeBackfill
+	}
+	return readModePoll
+}
+
+func hasAnyFilter(f logFilters) bool {
+	return len(f.serviceNames) > 0 ||
+		len(f.scopeNames) > 0 ||
+		len(f.severityTexts) > 0 ||
+		f.tool != "" ||
+		f.helmReleaseName != "" ||
+		f.helmOperation != "" ||
+		f.tfWorkspaceID != "" ||
+		f.tfOperation != "" ||
+		f.k8sKind != "" ||
+		f.k8sNamespace != "" ||
+		f.k8sName != "" ||
+		f.traceID != "" ||
+		f.spanID != "" ||
+		f.bodyContains != ""
+}
+
 // logFilters holds optional filter values parsed from query parameters.
 //
 // Top-level columns are filtered with normal SQL clauses. Map columns
@@ -201,6 +249,18 @@ func (s *service) LogStreamReadLogs(ctx *gin.Context) {
 	if readErr != nil {
 		ctx.Error(errors.Wrap(readErr, "unable to read runner logs"))
 		return
+	}
+
+	// Emit freshness lag of the newest returned row. ASC orders newest
+	// last, DESC orders newest first; either way it's the timestamp the
+	// user perceives as "most recent visible log" right now.
+	if len(logs) > 0 {
+		newest := logs[len(logs)-1]
+		if order == "desc" {
+			newest = logs[0]
+		}
+		s.mw.Timing(metricReadFreshnessLagMs, time.Since(newest.Timestamp),
+			[]string{"mode:" + classifyReadMode(cursor, order, filters)})
 	}
 
 	// Set headers

--- a/services/ctl-api/internal/app/runners/service/log_stream_tail_logs.go
+++ b/services/ctl-api/internal/app/runners/service/log_stream_tail_logs.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 
-	"github.com/nuonco/nuon/pkg/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
@@ -44,15 +43,16 @@ const (
 // long-pollers don't hold a slot, only callers actively querying CH.
 var tailProbeSem = make(chan struct{}, tailMaxConcurrentProbes)
 
-// Metric names. All three are tagged with `org_id` so per-org rollout
-// (per the feature flag) shows up clearly on dashboards.
+// Metric names. Emitted untagged — per-org slicing is rarely the right
+// debug path here (CH latency doesn't vary by org, and "which org spiked"
+// is easier to answer from ctl-api logs than from metric cardinality).
 const (
-	// metricTailProbe — how many CH probes is this feature generating
-	// per org? Cost / load guardrail. The 250ms→1s expo backoff puts
-	// the steady-state per-idle-subscriber rate at ~1 qps; if real
-	// numbers run materially hotter (e.g. rows trickle in just often
-	// enough to keep resetting the backoff) this is where it shows
-	// before CH does.
+	// metricTailProbe — how many CH probes is this feature generating?
+	// Cost / load guardrail. The 250ms→1s expo backoff puts the
+	// steady-state per-idle-subscriber rate at ~1 qps; if real numbers
+	// run materially hotter (e.g. rows trickle in just often enough to
+	// keep resetting the backoff) this is where it shows before CH
+	// does.
 	metricTailProbe = "log_tail.probe"
 	// metricTailEmptyProbeMs — when CH had nothing to return, how
 	// long did the round-trip cost? Health of the idle path. Should
@@ -60,13 +60,52 @@ const (
 	// work on empty probes (sort-key pruning regressed, async_insert
 	// backed up). Early-warning metric.
 	metricTailEmptyProbeMs = "log_tail.empty_probe_ms"
-	// metricTailFirstByteMs — the actual UX metric. From the moment
-	// the BFF issued the request, how long until the user saw a line
-	// of output? On a live job this should sit near tailMinBackoff
-	// (250ms) + the CH read. If p50 isn't materially better than the
-	// legacy 1s-poll path, the feature isn't doing its job and we
-	// should reconsider before broader rollout.
-	metricTailFirstByteMs = "log_tail.first_byte_ms"
+	// metricTailHotProbeMs — SLO metric. Time of the probe when iteration
+	// 1 already had rows, i.e. content was in CH when the BFF asked. Pure
+	// CH+JSON cost, no long-poll backoff mixed in. If this climbs while
+	// metricTailEmptyProbeMs is flat, the tail query shape regressed
+	// (sort-key pruning broke, cursor stopped being strictly-greater).
+	metricTailHotProbeMs = "log_tail.hot_probe_ms"
+	// metricTailOutcome — one count per session exit, tagged with
+	// `result:<hot_hit|idle_then_hit|timeout_empty|client_cancel|error>`.
+	// Replaces the bimodal log_tail.first_byte_ms histogram: hot/idle
+	// counts now come from this and hot-path latency comes from
+	// metricTailHotProbeMs. Critically also surfaces three outcomes we
+	// had no signal for before: how often we hit the 30s long-poll cap,
+	// how often the client (BFF) gave up early, and CH probe error rate.
+	metricTailOutcome = "log_tail.outcome"
+	// metricTailSessionMs — wall time of a tail request from entry to
+	// exit, tagged with `result:`. Captures the full user-facing wait
+	// including long-poll backoffs, which neither hot_probe_ms nor
+	// empty_probe_ms see. Read together with metricTailOutcome to compare
+	// "time-to-first-byte on a hit" against "30s long-poll caps" without
+	// mixing them on the same histogram.
+	metricTailSessionMs = "log_tail.session_ms"
+	// metricTailProbesPerSession — number of CH probes a single tail
+	// session issued before it exited, tagged with `result:`. A hit on
+	// probe 1 = 1; a 30s timeout typically ~5–6 (250ms→1s expo backoff).
+	// Distribution rather than count so the dashboard can show p50/p95
+	// per outcome and we can catch tight stream backoffs without
+	// reading the loop code.
+	metricTailProbesPerSession = "log_tail.probes_per_session"
+	// metricTailRowsPerResponse — rows returned to the client on a
+	// response-producing exit (hot_hit, idle_then_hit, timeout_empty=0).
+	// Emitted only when we actually return a body, so error/cancel
+	// paths don't show up as misleading "0 rows" responses on the
+	// distribution. Drives the "are we returning chunked-tiny vs
+	// page-saturating batches" view.
+	metricTailRowsPerResponse = "log_tail.rows_per_response"
+)
+
+// Outcome label values for metricTailOutcome. Kept as constants so all
+// emission sites stay aligned and a typo in one place doesn't silently
+// create a phantom outcome bucket on dashboards.
+const (
+	tailOutcomeHotHit       = "hot_hit"
+	tailOutcomeIdleThenHit  = "idle_then_hit"
+	tailOutcomeTimeoutEmpty = "timeout_empty"
+	tailOutcomeClientCancel = "client_cancel"
+	tailOutcomeError        = "error"
 )
 
 // LogStreamTailLogsResponse is the wire shape returned by the tail endpoint.
@@ -144,23 +183,31 @@ func (s *service) LogStreamTailLogs(ctx *gin.Context) {
 		}
 	}
 
-	tags := metrics.ToTags(map[string]string{"org_id": orgID})
-
 	startedAt := time.Now()
 	deadline := startedAt.Add(wait)
 
 	backoff := tailMinBackoff
+	firstIter := true
+	probes := 0
 	for {
 		probeStart := time.Now()
 		logs, next, hasMore, qerr := s.tailProbe(ctx.Request.Context(), orgID, logStreamID, cursor)
-		s.mw.Count(metricTailProbe, 1, tags)
+		probes++
+		s.mw.Count(metricTailProbe, 1, nil)
 		if qerr != nil {
+			s.emitTailExit(tailOutcomeError, startedAt, probes)
 			ctx.Error(errors.Wrap(qerr, "unable to probe log tail"))
 			return
 		}
 
 		if len(logs) > 0 {
-			s.mw.Timing(metricTailFirstByteMs, time.Since(startedAt), tags)
+			outcome := tailOutcomeIdleThenHit
+			if firstIter {
+				s.mw.Timing(metricTailHotProbeMs, time.Since(probeStart), nil)
+				outcome = tailOutcomeHotHit
+			}
+			s.emitTailExit(outcome, startedAt, probes)
+			s.mw.Distribution(metricTailRowsPerResponse, float64(len(logs)), nil)
 			ctx.JSON(http.StatusOK, LogStreamTailLogsResponse{
 				Logs:    logs,
 				Next:    next,
@@ -169,18 +216,22 @@ func (s *service) LogStreamTailLogs(ctx *gin.Context) {
 			return
 		}
 
-		s.mw.Timing(metricTailEmptyProbeMs, time.Since(probeStart), tags)
+		s.mw.Timing(metricTailEmptyProbeMs, time.Since(probeStart), nil)
+		firstIter = false
 
 		// Drop out at the wait deadline (or when the client closes the
 		// connection). Returning an empty payload is the long-poll
 		// equivalent of "still nothing, ask again".
 		select {
 		case <-ctx.Request.Context().Done():
+			s.emitTailExit(tailOutcomeClientCancel, startedAt, probes)
 			return
 		default:
 		}
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
+			s.emitTailExit(tailOutcomeTimeoutEmpty, startedAt, probes)
+			s.mw.Distribution(metricTailRowsPerResponse, 0, nil)
 			ctx.JSON(http.StatusOK, LogStreamTailLogsResponse{
 				Logs:    []app.OtelLogRecord{},
 				Next:    encodeTailCursor(cursor),
@@ -195,6 +246,7 @@ func (s *service) LogStreamTailLogs(ctx *gin.Context) {
 		}
 		select {
 		case <-ctx.Request.Context().Done():
+			s.emitTailExit(tailOutcomeClientCancel, startedAt, probes)
 			return
 		case <-time.After(sleep):
 		}
@@ -206,6 +258,18 @@ func (s *service) LogStreamTailLogs(ctx *gin.Context) {
 			backoff = tailMaxBackoff
 		}
 	}
+}
+
+// emitTailExit fires the three per-session exit metrics (outcome,
+// session_ms, probes_per_session) with a consistent `result:` label.
+// rows_per_response is emitted separately at the (only two) response-
+// producing call sites so error/cancel paths don't pollute the
+// distribution with phantom zeros.
+func (s *service) emitTailExit(result string, startedAt time.Time, probes int) {
+	tags := []string{"result:" + result}
+	s.mw.Count(metricTailOutcome, 1, tags)
+	s.mw.Timing(metricTailSessionMs, time.Since(startedAt), tags)
+	s.mw.Distribution(metricTailProbesPerSession, float64(probes), tags)
 }
 
 // tailCursor encodes the (timestamp, id) tiebreak used to paginate

--- a/services/dashboard-ui/client/components/workflows/step-details/StepDetailPanel/StepDetailPanelContainer.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/StepDetailPanel/StepDetailPanelContainer.tsx
@@ -2,6 +2,7 @@ import { useSearchParams } from 'react-router'
 import { useEffect, useRef, type ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Button } from '@/components/common/Button'
+import { EmptyState } from '@/components/common/EmptyState'
 import { Icon } from '@/components/common/Icon'
 import type { IPanel } from '@/components/surfaces/Panel'
 import { useOrg } from '@/hooks/use-org'
@@ -38,6 +39,16 @@ export function getStepPanelDetails(step: TWorkflowStep): ReactNode {
   if (step.step_target_type === 'install_stack_versions') return <StackStepDetails />
   if (step.step_target_type === 'runners') return <RunnerStepDetails />
   if (step.step_target_type === 'install_workflow_steps') return <SyncSecretsStepDetails />
+  // step_target_type only lands once the runner picks up the step;
+  // hold the panel body with a placeholder until then. The container
+  // fast-polls in this window so the gap is ~1-2s.
+  return (
+    <EmptyState
+      variant="history"
+      emptyTitle="Waiting for step to start"
+      emptyMessage="Details will appear here as soon as the runner picks up this step."
+    />
+  )
 }
 
 export interface IStepDetailPanelContainer extends IPanel {
@@ -69,6 +80,9 @@ export const StepDetailPanelContainer = ({
     refetchInterval: (query) => {
       if (!shouldPoll) return false
       if (query.state.data?.finished) return 30_000
+      // Fast-poll while waiting for runner pickup so the holding state
+      // in `getStepPanelDetails` flips to the real detail quickly.
+      if (!query.state.data?.step_target_type) return 1_500
       return pollInterval
     },
     initialData: initStep,

--- a/services/dashboard-ui/client/components/workflows/step-details/action-run-details/ActionRunHeader/ActionRunHeader.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/action-run-details/ActionRunHeader/ActionRunHeader.tsx
@@ -26,20 +26,24 @@ export const ActionRunHeader = ({
             Action run
           </Text>
 
-          <Text variant="subtext">
-            <Link
-              href={`/${orgId}/installs/${step?.owner_id}/actions/${actionRun?.config?.action_workflow_id}`}
-            >
-              View action <Icon variant="CaretRightIcon" />
-            </Link>
-          </Text>
-          <Text variant="subtext">
-            <Link
-              href={`/${orgId}/installs/${step?.owner_id}/actions/${actionRun?.config?.action_workflow_id}/runs/${actionRun?.id}`}
-            >
-              View run details <Icon variant="CaretRightIcon" />
-            </Link>
-          </Text>
+          {step?.owner_id && actionRun?.config?.action_workflow_id ? (
+            <Text variant="subtext">
+              <Link
+                href={`/${orgId}/installs/${step.owner_id}/actions/${actionRun.config.action_workflow_id}`}
+              >
+                View action <Icon variant="CaretRightIcon" />
+              </Link>
+            </Text>
+          ) : null}
+          {step?.owner_id && actionRun?.config?.action_workflow_id && actionRun?.id ? (
+            <Text variant="subtext">
+              <Link
+                href={`/${orgId}/installs/${step.owner_id}/actions/${actionRun.config.action_workflow_id}/runs/${actionRun.id}`}
+              >
+                View run details <Icon variant="CaretRightIcon" />
+              </Link>
+            </Text>
+          ) : null}
         </>
       )}
     </div>

--- a/services/dashboard-ui/client/components/workflows/step-details/action-run-details/ActionRunLogs.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/action-run-details/ActionRunLogs.tsx
@@ -1,3 +1,4 @@
+import { EmptyState } from '@/components/common/EmptyState'
 import { KeyValueList } from '@/components/common/KeyValueList'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Tabs } from '@/components/common/Tabs'
@@ -13,7 +14,16 @@ import type { IActionRunLogs } from './types'
 
 export const ActionRunLogs = ({ actionRun, isAdhoc }: IActionRunLogs) => {
   if (!actionRun?.log_stream) {
-    return null
+    return (
+      <div className="flex flex-col gap-2">
+        {isAdhoc && <Text weight="strong">Action logs</Text>}
+        <EmptyState
+          variant="history"
+          emptyTitle="Waiting for logs"
+          emptyMessage="Logs will appear here as soon as the runner starts streaming them."
+        />
+      </div>
+    )
   }
 
   return (

--- a/services/dashboard-ui/client/components/workflows/step-details/action-run-details/ActionRunStepDetails/ActionRunStepDetailsContainer.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/action-run-details/ActionRunStepDetails/ActionRunStepDetailsContainer.tsx
@@ -16,6 +16,10 @@ export const ActionRunStepDetailsContainer = ({ step }: IActionRunDetails) => {
     queryKey: ['action-run', org?.id, step?.owner_id, step?.step_target_id],
     queryFn: () => getInstallActionRun({ orgId: org!.id, installId: step!.owner_id, runId: step!.step_target_id }),
     enabled: !!org?.id && !!step?.owner_id && !!step?.step_target_id,
+    refetchInterval: (query) => {
+      if (!query.state.data?.log_stream) return 1_500
+      return false
+    },
   })
 
   const createdBy = actionRun?.created_by

--- a/services/dashboard-ui/client/components/workflows/step-details/deploy-details/DeployStepDetails/DeployStepDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/deploy-details/DeployStepDetails/DeployStepDetails.tsx
@@ -1,5 +1,6 @@
 import { Plan } from '@/components/approvals/Plan'
 import { Duration } from '@/components/common/Duration'
+import { EmptyState } from '@/components/common/EmptyState'
 import { Icon } from '@/components/common/Icon'
 import { Link } from '@/components/common/Link'
 import { Skeleton } from '@/components/common/Skeleton'
@@ -11,7 +12,7 @@ import { TraceView } from '@/components/spans/TraceView'
 import { LogStreamProvider } from '@/providers/log-stream-provider'
 import { LogViewerProvider } from '@/providers/log-viewer-provider'
 import type { TDeploy, TWorkflowStep } from '@/types'
-import { DeployApply, DeployLogsSkeleton } from '../DeployApply'
+import { DeployApply } from '../DeployApply'
 
 export interface IDeployStepDetails {
   step?: TWorkflowStep
@@ -42,22 +43,25 @@ export const DeployStepDetails = ({
             <Text variant="base" weight="strong">
               {deploy?.component_name} deployment
             </Text>
-            <Text variant="subtext">
-              <Link
-                href={`/${orgId}/installs/${step?.owner_id}/components/${deploy?.component_id}`}
-              >
-                View component <Icon variant="CaretRightIcon" />
-              </Link>
-            </Text>
+            {deploy?.component_id ? (
+              <Text variant="subtext">
+                <Link
+                  href={`/${orgId}/installs/${step?.owner_id}/components/${deploy.component_id}`}
+                >
+                  View component <Icon variant="CaretRightIcon" />
+                </Link>
+              </Text>
+            ) : null}
 
-            <Text variant="subtext">
-              <Link
-                href={`/${orgId}/installs/${step?.owner_id}/components/${deploy?.component_id}/deploys/${deploy?.id}`}
-              >
-                View deploy logs <Icon variant="CaretRightIcon" />
-              </Link>
-            </Text>
-
+            {deploy?.component_id && deploy?.id ? (
+              <Text variant="subtext">
+                <Link
+                  href={`/${orgId}/installs/${step?.owner_id}/components/${deploy.component_id}/deploys/${deploy.id}`}
+                >
+                  View deploy logs <Icon variant="CaretRightIcon" />
+                </Link>
+              </Text>
+            ) : null}
           </>
         )}
       </div>
@@ -82,43 +86,67 @@ export const DeployStepDetails = ({
         ) : null}
       </div>
       {step?.execution_type === 'approval' ? (
-        deploy?.log_stream ? (
-          <LogStreamProvider logStreamId={deploy.log_stream.id}>
-            <LogViewerProvider>
-              <Tabs
-                tabs={{
-                  plan: (
-                    <div className="mt-4">
-                      <Plan step={step} />
-                    </div>
-                  ),
-                  logs: <SSELogs />,
-                  trace: (
-                    <TraceView
-                      logStreamId={deploy.log_stream.id}
-                      shouldPoll={deploy.log_stream.open}
-                    />
-                  ),
-                }}
-              />
-            </LogViewerProvider>
-          </LogStreamProvider>
-        ) : (
-          <Tabs
-            tabs={{
-              plan: (
-                <div className="mt-4">
-                  <Plan step={step} />
-                </div>
-              ),
-              logs: <DeployLogsSkeleton />,
-            }}
-          />
-        )
+        <ApprovalStepTabs step={step} deploy={deploy} />
       ) : (
         <DeployApply initDeploy={deploy} />
       )}
     </div>
+  )
+}
+
+// Plan tab is only rendered once the runner has produced an approval
+// (step.approval set). When present it's the first tab so finished
+// approval steps land on Plan; otherwise Logs is first.
+const ApprovalStepTabs = ({
+  step,
+  deploy,
+}: {
+  step: TWorkflowStep
+  deploy?: TDeploy
+}) => {
+  const hasPlan = !!step?.approval
+  const hasLogStream = !!deploy?.log_stream
+
+  const logsTab = hasLogStream ? (
+    <SSELogs />
+  ) : (
+    <EmptyState
+      variant="history"
+      emptyTitle="Waiting for logs"
+      emptyMessage="Logs will appear here as soon as the runner starts streaming them."
+    />
+  )
+
+  const traceTab = hasLogStream ? (
+    <TraceView
+      logStreamId={deploy!.log_stream!.id}
+      shouldPoll={deploy!.log_stream!.open}
+    />
+  ) : null
+
+  const tabs: Record<string, React.ReactNode> = hasPlan
+    ? {
+        plan: (
+          <div className="mt-4">
+            <Plan step={step} />
+          </div>
+        ),
+        logs: logsTab,
+        ...(traceTab ? { trace: traceTab } : {}),
+      }
+    : {
+        logs: logsTab,
+        ...(traceTab ? { trace: traceTab } : {}),
+      }
+
+  const tabsEl = <Tabs tabs={tabs} />
+
+  if (!hasLogStream) return tabsEl
+
+  return (
+    <LogStreamProvider logStreamId={deploy!.log_stream!.id}>
+      <LogViewerProvider>{tabsEl}</LogViewerProvider>
+    </LogStreamProvider>
   )
 }
 

--- a/services/dashboard-ui/client/components/workflows/step-details/sandbox-run-details/SandboxRunStepDetails/SandboxRunStepDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/sandbox-run-details/SandboxRunStepDetails/SandboxRunStepDetails.tsx
@@ -1,5 +1,6 @@
 import { Plan } from '@/components/approvals/Plan'
 import { Duration } from '@/components/common/Duration'
+import { EmptyState } from '@/components/common/EmptyState'
 import { Icon } from '@/components/common/Icon'
 import { Link } from '@/components/common/Link'
 import { Tabs } from '@/components/common/Tabs'
@@ -36,20 +37,23 @@ export const SandboxRunStepDetails = ({
           Sandox run
         </Text>
 
-        <Text variant="subtext">
-          <Link href={`/${orgId}/installs/${step?.owner_id}/sandbox`}>
-            View sandbox <Icon variant="CaretRightIcon" />
-          </Link>
-        </Text>
+        {step?.owner_id ? (
+          <Text variant="subtext">
+            <Link href={`/${orgId}/installs/${step.owner_id}/sandbox`}>
+              View sandbox <Icon variant="CaretRightIcon" />
+            </Link>
+          </Text>
+        ) : null}
 
-        <Text variant="subtext">
-          <Link
-            href={`/${orgId}/installs/${step?.owner_id}/sandbox/runs/${step?.step_target_id}`}
-          >
-            View run logs <Icon variant="CaretRightIcon" />
-          </Link>
-        </Text>
-
+        {step?.owner_id && step?.step_target_id ? (
+          <Text variant="subtext">
+            <Link
+              href={`/${orgId}/installs/${step.owner_id}/sandbox/runs/${step.step_target_id}`}
+            >
+              View run logs <Icon variant="CaretRightIcon" />
+            </Link>
+          </Text>
+        ) : null}
       </div>
       <div className="flex flex-wrap gap-x-4 gap-y-1 items-center">
         {sandboxRun?.created_at ? (
@@ -73,39 +77,7 @@ export const SandboxRunStepDetails = ({
       </div>
 
       {step?.execution_type === 'approval' ? (
-        sandboxRun?.log_stream ? (
-          <LogStreamProvider logStreamId={sandboxRun.log_stream.id}>
-            <LogViewerProvider>
-              <Tabs
-                tabs={{
-                  plan: (
-                    <div className="mt-4">
-                      <Plan step={step} />
-                    </div>
-                  ),
-                  logs: <SSELogs />,
-                  trace: (
-                    <TraceView
-                      logStreamId={sandboxRun.log_stream.id}
-                      shouldPoll={sandboxRun.log_stream.open}
-                    />
-                  ),
-                }}
-              />
-            </LogViewerProvider>
-          </LogStreamProvider>
-        ) : (
-          <Tabs
-            tabs={{
-              plan: (
-                <div className="mt-4">
-                  <Plan step={step} />
-                </div>
-              ),
-              logs: <SandboxRunLogsSkeleton />,
-            }}
-          />
-        )
+        <ApprovalStepTabs step={step} sandboxRun={sandboxRun} />
       ) : isLoading && !sandboxRun ? (
         <div className="flex flex-col gap-4">
           <SandboxRunApplySkeleton />
@@ -115,5 +87,61 @@ export const SandboxRunStepDetails = ({
         <SandboxRunApply step={step} sandboxRun={sandboxRun} />
       )}
     </div>
+  )
+}
+
+// Plan tab is only rendered once the runner has produced an approval
+// (step.approval set). When present it's the first tab so finished
+// approval steps land on Plan; otherwise Logs is first.
+const ApprovalStepTabs = ({
+  step,
+  sandboxRun,
+}: {
+  step: TWorkflowStep
+  sandboxRun?: TSandboxRun
+}) => {
+  const hasPlan = !!step?.approval
+  const hasLogStream = !!sandboxRun?.log_stream
+
+  const logsTab = hasLogStream ? (
+    <SSELogs />
+  ) : (
+    <EmptyState
+      variant="history"
+      emptyTitle="Waiting for logs"
+      emptyMessage="Logs will appear here as soon as the runner starts streaming them."
+    />
+  )
+
+  const traceTab = hasLogStream ? (
+    <TraceView
+      logStreamId={sandboxRun!.log_stream!.id}
+      shouldPoll={sandboxRun!.log_stream!.open}
+    />
+  ) : null
+
+  const tabs: Record<string, React.ReactNode> = hasPlan
+    ? {
+        plan: (
+          <div className="mt-4">
+            <Plan step={step} />
+          </div>
+        ),
+        logs: logsTab,
+        ...(traceTab ? { trace: traceTab } : {}),
+      }
+    : {
+        logs: logsTab,
+        ...(traceTab ? { trace: traceTab } : {}),
+      }
+
+  const tabsEl = <Tabs tabs={tabs} />
+
+  if (!hasLogStream) return tabsEl
+
+  return (
+    <LogStreamProvider logStreamId={sandboxRun!.log_stream!.id}>
+      <LogViewerProvider>{tabsEl}</LogViewerProvider>
+    </LogStreamProvider>
   )
 }


### PR DESCRIPTION
## Summary
For deploy and sandbox approval steps the plan tab now only renders when a plan exists, so running steps land on logs instead of an empty plan view. Opening the step detail panel also shows logs as soon as the runner picks the step up, with no reload.

## What you can do after this PR

- **Land on the right tab for an approval step.** The plan tab only appears once a plan is attached. Finished steps still default to plan; running steps default to logs.
- **Open a step detail panel and see logs without refreshing.** The panel opens immediately with a "waiting for step to start" placeholder, fast-polls until the runner takes the step, and swaps in the live log stream the moment it is open. Deploys, sandbox runs, and adhoc and standard action runs all behave this way.
- **Click view-deploy and view-sandbox-run links only when they go somewhere.** Action run header links are hidden until the underlying ids resolve, so no more landing on `/components/undefined/deploys/undefined`.

## Mechanics worth flagging
Log tail metrics on ctl-api now report `session_ms`, `probes_per_session`, and `rows_per_response` distributions; the legacy read path emits a `mode` tag plus `freshness_lag_ms` so the existing UX can be compared against the long-poll rollout. Per-org cardinality is dropped from log-tail metrics.
