### PR TITLE
refactor(ui): install managed by config overrides

### DIFF
--- a/services/dashboard-ui/client/components/common/form/Toggle.tsx
+++ b/services/dashboard-ui/client/components/common/form/Toggle.tsx
@@ -27,11 +27,11 @@ export const Toggle = ({
       aria-label={label}
       disabled={disabled}
       className={cn(
-        'flex gap-2 cursor-pointer text-left items-center',
-        disabled && 'opacity-50 cursor-not-allowed',
+        'flex gap-2 text-left items-center',
+        disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
         className
       )}
-      onClick={() => !disabled && onChange(!checked)}
+      onClick={() => onChange(!checked)}
       {...props}
     >
       <span className="relative shrink-0 h-[20px] w-[24px]">

--- a/services/dashboard-ui/client/components/installs/management/EditInputs/EditInputs.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditInputs/EditInputs.tsx
@@ -1,6 +1,4 @@
-import { useRef, useState, type ReactNode } from 'react'
 import { Banner } from '@/components/common/Banner'
-import { Button } from '@/components/common/Button'
 import { CheckboxInput } from '@/components/common/form/CheckboxInput'
 import { Input } from '@/components/common/form/Input'
 import { Icon } from '@/components/common/Icon'
@@ -9,75 +7,6 @@ import { Text } from '@/components/common/Text'
 import { Modal, type IModal } from '@/components/surfaces/Modal'
 import { UpdateInstallForm } from '@/components/installs/forms/UpdateInstallForm'
 import type { TAppConfig, TInstall } from '@/types'
-
-interface IConfirmUpdateModal extends IModal {
-  isInstallManagedByConfig: boolean
-  onConfirm: () => void
-  onCancel: () => void
-}
-
-export const ConfirmUpdateModal = ({
-  isInstallManagedByConfig,
-  onConfirm,
-  onCancel,
-  ...props
-}: IConfirmUpdateModal) => {
-  if (!isInstallManagedByConfig) {
-    onConfirm()
-    return null
-  }
-
-  return (
-    <Modal
-      heading={
-        <Text
-          flex
-          className="gap-4"
-          variant="h3"
-          weight="strong"
-          theme="warn"
-        >
-          <Icon variant="WarningIcon" size="24" />
-          Override changes to this install?
-        </Text>
-      }
-      primaryActionTrigger={{
-        children: 'Confirm override',
-        onClick: onConfirm,
-        variant: 'primary',
-      }}
-      {...props}
-    >
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-col gap-4">
-          <Text variant="body" weight="strong">
-            You are about to update an Install managed by a Config file.
-          </Text>
-          <Text variant="body">
-            If you proceed, the config file syncing will be disabled. Are you
-            sure you want to continue?
-          </Text>
-        </div>
-
-        <Banner theme="info">
-          <Text variant="body">
-            <strong>Tip:</strong> Use the management menu to enable Install
-            Config syncing again.
-          </Text>
-        </Banner>
-
-        <div className="flex gap-3 justify-end">
-          <Button
-            onClick={onCancel}
-            variant="ghost"
-          >
-            Cancel
-          </Button>
-        </div>
-      </div>
-    </Modal>
-  )
-}
 
 interface IEditInputsFormModal extends IModal {
   install: TInstall

--- a/services/dashboard-ui/client/components/installs/management/EditInputs/EditInputsContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditInputs/EditInputsContainer.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
+import { Tooltip } from '@/components/common/Tooltip'
 import { Toast } from '@/components/surfaces/Toast'
 import type { IModal } from '@/components/surfaces/Modal'
 import { useInstall } from '@/hooks/use-install'
@@ -11,40 +12,10 @@ import { useOrg } from '@/hooks/use-org'
 import { useToast } from '@/hooks/use-toast'
 import { useSurfaces } from '@/hooks/use-surfaces'
 import { getAppConfig, updateInstall, updateInstallInputs } from '@/lib'
-import { ConfirmUpdateModal, EditInputsFormModal } from './EditInputs'
+import { EditInputsFormModal } from './EditInputs'
 
 interface IEditInputs {
   showNameField?: boolean
-}
-
-export const ConfirmUpdateModalContainer = ({
-  onConfirm,
-  onCancel,
-  ...props
-}: {
-  onConfirm: () => void
-  onCancel: () => void
-} & IModal) => {
-  const { install } = useInstall()
-  const { removeModal } = useSurfaces()
-
-  const isInstallManagedByConfig =
-    install?.metadata?.managed_by === 'nuon/cli/install-config'
-
-  return (
-    <ConfirmUpdateModal
-      isInstallManagedByConfig={isInstallManagedByConfig}
-      onConfirm={() => {
-        onConfirm()
-        removeModal(props.modalId)
-      }}
-      onCancel={() => {
-        onCancel()
-        removeModal(props.modalId)
-      }}
-      {...props}
-    />
-  )
 }
 
 export const EditInputsFormModalContainer = ({ showNameField, ...props }: IEditInputs & Omit<IModal, 'onSubmit'>) => {
@@ -106,14 +77,10 @@ export const EditInputsFormModalContainer = ({ showNameField, ...props }: IEditI
   const { mutateAsync, isPending: isUpdatingInputs, error: actionError } = useMutation({
     mutationFn: async (formData: FormData) => {
       const nameChanged = showNameField && installName !== (install?.name ?? '')
-      const needsManagedByUpdate = install?.metadata?.managed_by === 'nuon/cli/install-config'
 
-      if (nameChanged || needsManagedByUpdate) {
+      if (nameChanged) {
         await updateInstall({
-          body: {
-            ...(nameChanged && { name: installName }),
-            ...(needsManagedByUpdate && { metadata: { managed_by: 'nuon/dashboard' } }),
-          },
+          body: { name: installName },
           installId: install.id,
           orgId: org.id,
         })
@@ -218,6 +185,8 @@ export const EditInputsFormModalContainer = ({ showNameField, ...props }: IEditI
   )
 }
 
+const MANAGED_BY_CONFIG_TIP = 'Managed by config. Disable config sync to edit.'
+
 export const EditInputsButton = ({
   showNameField,
   ...props
@@ -225,40 +194,27 @@ export const EditInputsButton = ({
   const { install } = useInstall()
   const { addModal } = useSurfaces()
 
-  const showConfirmModal = () => {
-    const confirmModal = (
-      <ConfirmUpdateModalContainer
-        onConfirm={() => {
-          const editModal = <EditInputsFormModalContainer showNameField={showNameField} />
-          addModal(editModal)
-        }}
-        onCancel={() => {}}
-      />
-    )
-    addModal(confirmModal)
-  }
+  const isManagedByConfig = install?.metadata?.managed_by === 'nuon/cli/install-config'
 
-  const showEditModal = () => {
+  const handleClick = () => {
     const editModal = <EditInputsFormModalContainer showNameField={showNameField} />
     addModal(editModal)
   }
 
-  const handleClick = () => {
-    const isInstallManagedByConfig =
-      install?.metadata?.managed_by === 'nuon/cli/install-config'
-
-    if (isInstallManagedByConfig) {
-      showConfirmModal()
-    } else {
-      showEditModal()
-    }
+  if (isManagedByConfig) {
+    return (
+      <Tooltip tipContent={MANAGED_BY_CONFIG_TIP} position="left" tipContentClassName="!whitespace-normal !w-auto max-w-[200px] text-xs" className="w-full">
+        <Button disabled className="pointer-events-none" {...props}>
+          {props?.isMenuButton ? null : <Icon variant="PencilSimpleLineIcon" />}
+          {showNameField ? 'Edit install' : 'Edit inputs'}
+          {props?.isMenuButton ? <Icon variant="PencilSimpleLineIcon" /> : null}
+        </Button>
+      </Tooltip>
+    )
   }
 
   return (
-    <Button
-      onClick={handleClick}
-      {...props}
-    >
+    <Button onClick={handleClick} {...props}>
       {props?.isMenuButton ? null : <Icon variant="PencilSimpleLineIcon" />}
       {showNameField ? 'Edit install' : 'Edit inputs'}
       {props?.isMenuButton ? <Icon variant="PencilSimpleLineIcon" /> : null}

--- a/services/dashboard-ui/client/components/installs/management/EditInputs/index.ts
+++ b/services/dashboard-ui/client/components/installs/management/EditInputs/index.ts
@@ -1,9 +1,5 @@
 export {
-  ConfirmUpdateModalContainer as ConfirmUpdateModal,
   EditInputsFormModalContainer as EditInputsFormModal,
   EditInputsButton,
 } from './EditInputsContainer'
-export {
-  ConfirmUpdateModal as ConfirmUpdateModalComponent,
-  EditInputsFormModal as EditInputsFormModalComponent,
-} from './EditInputs'
+export { EditInputsFormModal as EditInputsFormModalComponent } from './EditInputs'

--- a/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabelsContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabelsContainer.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
+import { Tooltip } from '@/components/common/Tooltip'
 import { Toast } from '@/components/surfaces/Toast'
 import type { IModal } from '@/components/surfaces/Modal'
 import { useOrg } from '@/hooks/use-org'
@@ -10,6 +11,8 @@ import { useToast } from '@/hooks/use-toast'
 import { useSurfaces } from '@/hooks/use-surfaces'
 import { addInstallLabels, removeInstallLabels } from '@/lib'
 import { EditLabelsModal } from './EditLabels'
+
+const MANAGED_BY_CONFIG_TIP = 'Managed by config. Disable config sync to edit.'
 
 export const EditLabelsModalContainer = ({ ...props }: IModal) => {
   const { removeModal } = useSurfaces()
@@ -73,15 +76,28 @@ export const EditLabelsModalContainer = ({ ...props }: IModal) => {
 
 export const EditLabelsButton = ({ ...props }: IButtonAsButton) => {
   const { addModal } = useSurfaces()
+  const { install } = useInstall()
+
+  const isManagedByConfig = install?.metadata?.managed_by === 'nuon/cli/install-config'
+
+  const handleClick = () => {
+    const modal = <EditLabelsModalContainer />
+    addModal(modal)
+  }
+
+  if (isManagedByConfig) {
+    return (
+      <Tooltip tipContent={MANAGED_BY_CONFIG_TIP} position="left" tipContentClassName="!whitespace-normal !w-auto max-w-[200px] text-xs" className="w-full">
+        <Button disabled className="pointer-events-none" {...props}>
+          Edit labels
+          <Icon variant="TagIcon" />
+        </Button>
+      </Tooltip>
+    )
+  }
 
   return (
-    <Button
-      onClick={() => {
-        const modal = <EditLabelsModalContainer />
-        addModal(modal)
-      }}
-      {...props}
-    >
+    <Button onClick={handleClick} {...props}>
       Edit labels
       <Icon variant="TagIcon" />
     </Button>

--- a/services/dashboard-ui/client/components/installs/management/EditStackOverrides/EditStackOverridesContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditStackOverrides/EditStackOverridesContainer.tsx
@@ -2,6 +2,7 @@ import { useQuery, useMutation } from '@tanstack/react-query'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
+import { Tooltip } from '@/components/common/Tooltip'
 import { Toast } from '@/components/surfaces/Toast'
 import type { IModal } from '@/components/surfaces/Modal'
 import { useOrg } from '@/hooks/use-org'
@@ -11,32 +12,11 @@ import { useSurfaces } from '@/hooks/use-surfaces'
 import {
   getAppConfig,
   createInstallConfig,
-  updateInstall,
   updateInstallConfig,
 } from '@/lib'
-import { ConfirmOverrideModal } from '../EnableAutoApprove/EnableAutoApprove'
 import { EditStackOverridesModal } from './EditStackOverrides'
 
-const ConfirmOverrideModalContainer = ({ onConfirm, ...props }: { onConfirm: () => void } & IModal) => {
-  const { removeModal } = useSurfaces()
-  const { install } = useInstall()
-
-  const isInstallManagedByConfig = install?.metadata?.managed_by === 'nuon/cli/install-config'
-
-  if (!isInstallManagedByConfig) {
-    return null
-  }
-
-  return (
-    <ConfirmOverrideModal
-      onConfirm={() => {
-        onConfirm()
-        removeModal(props.modalId)
-      }}
-      {...props}
-    />
-  )
-}
+const MANAGED_BY_CONFIG_TIP = 'Managed by config. Disable config sync to edit.'
 
 export const EditStackOverridesModalContainer = ({
   ...props
@@ -72,14 +52,6 @@ export const EditStackOverridesModalContainer = ({
         parameters?: Record<string, string>
       }>
     }) => {
-      if (install?.metadata?.managed_by === 'nuon/cli/install-config') {
-        await updateInstall({
-          orgId: org.id,
-          installId: install.id,
-          body: { metadata: { managed_by: 'nuon/dashboard' } },
-        })
-      }
-
       if (hasInstallConfig) {
         return updateInstallConfig({
           orgId: org.id,
@@ -144,30 +116,26 @@ export const EditStackOverridesButton = ({
   const { addModal } = useSurfaces()
   const { install } = useInstall()
 
-  const isInstallManagedByConfig = install?.metadata?.managed_by === 'nuon/cli/install-config'
+  const isManagedByConfig = install?.metadata?.managed_by === 'nuon/cli/install-config'
 
   const handleClick = () => {
-    if (isInstallManagedByConfig) {
-      const overrideModal = (
-        <ConfirmOverrideModalContainer
-          onConfirm={() => {
-            const mainModal = <EditStackOverridesModalContainer />
-            addModal(mainModal)
-          }}
-        />
-      )
-      addModal(overrideModal)
-    } else {
-      const modal = <EditStackOverridesModalContainer />
-      addModal(modal)
-    }
+    const modal = <EditStackOverridesModalContainer />
+    addModal(modal)
+  }
+
+  if (isManagedByConfig) {
+    return (
+      <Tooltip tipContent={MANAGED_BY_CONFIG_TIP} position="left" tipContentClassName="!whitespace-normal !w-auto max-w-[200px] text-xs" className="w-full">
+        <Button disabled className="pointer-events-none" {...props}>
+          <Icon variant="StackSimpleIcon" />
+          Edit stack overrides
+        </Button>
+      </Tooltip>
+    )
   }
 
   return (
-    <Button
-      onClick={handleClick}
-      {...props}
-    >
+    <Button onClick={handleClick} {...props}>
       <Icon variant="StackSimpleIcon" />
       Edit stack overrides
     </Button>

--- a/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/AutoApproveToggle.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/AutoApproveToggle.tsx
@@ -1,10 +1,10 @@
 import { Toggle } from '@/components/common/form/Toggle'
+import { Tooltip } from '@/components/common/Tooltip'
 import { useInstall } from '@/hooks/use-install'
 import { useSurfaces } from '@/hooks/use-surfaces'
-import {
-  ConfirmOverrideModalContainer,
-  EnableAutoApproveModalContainer,
-} from './EnableAutoApproveContainer'
+import { EnableAutoApproveModalContainer } from './EnableAutoApproveContainer'
+
+const MANAGED_BY_CONFIG_TIP = 'Managed by config. Disable config sync to edit.'
 
 export const AutoApproveToggle = () => {
   const { addModal } = useSurfaces()
@@ -14,31 +14,30 @@ export const AutoApproveToggle = () => {
   const isApproveAll =
     hasInstallConfig &&
     install?.install_config?.approval_option === 'approve-all'
-  const isInstallManagedByConfig =
+  const isManagedByConfig =
     install?.metadata?.managed_by === 'nuon/cli/install-config'
 
   const handleChange = () => {
-    if (isInstallManagedByConfig) {
-      const overrideModal = (
-        <ConfirmOverrideModalContainer
-          onConfirm={() => {
-            const mainModal = <EnableAutoApproveModalContainer />
-            addModal(mainModal)
-          }}
-        />
-      )
-      addModal(overrideModal)
-    } else {
-      const modal = <EnableAutoApproveModalContainer />
-      addModal(modal)
-    }
+    const modal = <EnableAutoApproveModalContainer />
+    addModal(modal)
   }
 
-  return (
+  const toggle = (
     <Toggle
       checked={isApproveAll}
       onChange={handleChange}
+      disabled={isManagedByConfig}
       label="Auto approval"
     />
   )
+
+  if (isManagedByConfig) {
+    return (
+      <Tooltip tipContent={MANAGED_BY_CONFIG_TIP} position="left" tipContentClassName="!whitespace-normal !w-auto max-w-[200px] text-xs">
+        {toggle}
+      </Tooltip>
+    )
+  }
+
+  return toggle
 }

--- a/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/EnableAutoApprove.stories.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/EnableAutoApprove.stories.tsx
@@ -3,7 +3,7 @@ export default {
 }
 
 import { ModalStory } from '@/components/__stories__/helpers'
-import { EnableAutoApproveModal, ConfirmOverrideModal } from './EnableAutoApprove'
+import { EnableAutoApproveModal } from './EnableAutoApprove'
 
 const noop = () => {}
 
@@ -34,11 +34,5 @@ export const Success = () => (
 export const WithError = () => (
   <ModalStory>
     <EnableAutoApproveModal isPending={false} error={{ error: 'Something went wrong' }} isApproveAll={false} isSuccess={false} onSubmit={noop} />
-  </ModalStory>
-)
-
-export const ConfirmOverride = () => (
-  <ModalStory>
-    <ConfirmOverrideModal onConfirm={noop} />
   </ModalStory>
 )

--- a/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/EnableAutoApprove.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/EnableAutoApprove.tsx
@@ -3,54 +3,6 @@ import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
 import { Modal, type IModal } from '@/components/surfaces/Modal'
 
-interface IConfirmOverrideModal extends IModal {
-  onConfirm: () => void
-}
-
-export const ConfirmOverrideModal = ({
-  onConfirm,
-  ...props
-}: IConfirmOverrideModal) => {
-  return (
-    <Modal
-      heading={
-        <Text
-          flex
-          className="gap-4"
-          variant="h3"
-          weight="strong"
-          theme="warn"
-        >
-          <Icon variant="WarningIcon" size="24" />
-          Override changes to this install?
-        </Text>
-      }
-      primaryActionTrigger={{
-        children: 'Confirm override',
-        onClick: onConfirm,
-        variant: 'primary',
-      }}
-      {...props}
-    >
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-2">
-          <Text variant="base" weight="strong">
-            You are about to update an Install managed by a Config file.
-          </Text>
-          <Text variant="body">
-            If you proceed, the config file syncing will be disabled. Are you sure you want to continue?
-          </Text>
-        </div>
-        <Banner theme="info">
-          <Text variant="body">
-            <strong>Tip:</strong> Use the management menu to enable Install Config syncing again.
-          </Text>
-        </Banner>
-      </div>
-    </Modal>
-  )
-}
-
 interface IEnableAutoApproveModal extends Omit<IModal, 'onSubmit'> {
   isPending: boolean
   error: any

--- a/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/EnableAutoApproveContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/EnableAutoApproveContainer.tsx
@@ -2,39 +2,19 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
+import { Tooltip } from '@/components/common/Tooltip'
 import { Toast } from '@/components/surfaces/Toast'
 import type { IModal } from '@/components/surfaces/Modal'
 import { useOrg } from '@/hooks/use-org'
 import { useInstall } from '@/hooks/use-install'
 import { useToast } from '@/hooks/use-toast'
 import { useSurfaces } from '@/hooks/use-surfaces'
-import { updateInstall, createInstallConfig, updateInstallConfig } from '@/lib'
-import { ConfirmOverrideModal, EnableAutoApproveModal } from './EnableAutoApprove'
+import { createInstallConfig, updateInstallConfig } from '@/lib'
+import { EnableAutoApproveModal } from './EnableAutoApprove'
 
-interface IEnableAutoApprove {}
+const MANAGED_BY_CONFIG_TIP = 'Managed by config. Disable config sync to edit.'
 
-export const ConfirmOverrideModalContainer = ({ onConfirm, ...props }: { onConfirm: () => void } & IModal) => {
-  const { removeModal } = useSurfaces()
-  const { install } = useInstall()
-
-  const isInstallManagedByConfig = install?.metadata?.managed_by === 'nuon/cli/install-config'
-
-  if (!isInstallManagedByConfig) {
-    return null
-  }
-
-  return (
-    <ConfirmOverrideModal
-      onConfirm={() => {
-        onConfirm()
-        removeModal(props.modalId)
-      }}
-      {...props}
-    />
-  )
-}
-
-export const EnableAutoApproveModalContainer = ({ ...props }: IEnableAutoApprove & Omit<IModal, 'onSubmit'>) => {
+export const EnableAutoApproveModalContainer = ({ ...props }: Omit<IModal, 'onSubmit'>) => {
   const queryClient = useQueryClient()
   const { removeModal } = useSurfaces()
   const { org } = useOrg()
@@ -46,14 +26,6 @@ export const EnableAutoApproveModalContainer = ({ ...props }: IEnableAutoApprove
 
   const { mutate, isPending: isLoading, data, error } = useMutation({
     mutationFn: async () => {
-      if (install?.metadata?.managed_by === 'nuon/cli/install-config') {
-        await updateInstall({
-          orgId: org.id,
-          installId: install.id,
-          body: { metadata: { managed_by: 'nuon/dashboard' } },
-        })
-      }
-
       if (hasInstallConfig) {
         return updateInstallConfig({
           orgId: org.id,
@@ -101,39 +73,35 @@ export const EnableAutoApproveModalContainer = ({ ...props }: IEnableAutoApprove
 
 export const EnableAutoApproveButton = ({
   ...props
-}: IEnableAutoApprove & IButtonAsButton) => {
+}: IButtonAsButton) => {
   const { addModal } = useSurfaces()
   const { install } = useInstall()
 
   const hasInstallConfig = Boolean(install?.install_config)
   const isApproveAll = hasInstallConfig && install?.install_config?.approval_option === 'approve-all'
-  const isInstallManagedByConfig = install?.metadata?.managed_by === 'nuon/cli/install-config'
+  const isManagedByConfig = install?.metadata?.managed_by === 'nuon/cli/install-config'
 
   const buttonText = isApproveAll ? 'Disable auto approval' : 'Enable auto approval'
   const buttonIcon = isApproveAll ? 'ToggleRightIcon' : 'ToggleLeftIcon'
 
   const handleClick = () => {
-    if (isInstallManagedByConfig) {
-      const overrideModal = (
-        <ConfirmOverrideModalContainer
-          onConfirm={() => {
-            const mainModal = <EnableAutoApproveModalContainer />
-            addModal(mainModal)
-          }}
-        />
-      )
-      addModal(overrideModal)
-    } else {
-      const modal = <EnableAutoApproveModalContainer />
-      addModal(modal)
-    }
+    const modal = <EnableAutoApproveModalContainer />
+    addModal(modal)
+  }
+
+  if (isManagedByConfig) {
+    return (
+      <Tooltip tipContent={MANAGED_BY_CONFIG_TIP} position="left" tipContentClassName="!whitespace-normal !w-auto max-w-[200px] text-xs" className="w-full">
+        <Button disabled className="pointer-events-none" {...props}>
+          {buttonText}
+          <Icon variant={buttonIcon} />
+        </Button>
+      </Tooltip>
+    )
   }
 
   return (
-    <Button
-      onClick={handleClick}
-      {...props}
-    >
+    <Button onClick={handleClick} {...props}>
       {buttonText}
       <Icon variant={buttonIcon} />
     </Button>

--- a/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/index.ts
+++ b/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/index.ts
@@ -1,10 +1,6 @@
 export {
-  ConfirmOverrideModalContainer as ConfirmOverrideModal,
   EnableAutoApproveModalContainer as EnableAutoApproveModal,
   EnableAutoApproveButton,
 } from './EnableAutoApproveContainer'
-export {
-  ConfirmOverrideModal as ConfirmOverrideModalComponent,
-  EnableAutoApproveModal as EnableAutoApproveModalComponent,
-} from './EnableAutoApprove'
+export { EnableAutoApproveModal as EnableAutoApproveModalComponent } from './EnableAutoApprove'
 export { AutoApproveToggle } from './AutoApproveToggle'

--- a/services/dashboard-ui/client/components/installs/management/EnableConfigSync/EnableConfigSync.stories.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EnableConfigSync/EnableConfigSync.stories.tsx
@@ -3,30 +3,36 @@ export default {
 }
 
 import { ModalStory } from '@/components/__stories__/helpers'
-import { EnableConfigSyncModal } from './EnableConfigSync'
+import { EnableConfigSyncModal, DisableConfigSyncModal } from './EnableConfigSync'
 
 const noop = () => {}
 
-export const EnableDefault = () => (
+export const Enable = () => (
   <ModalStory>
-    <EnableConfigSyncModal isManagedByConfig={false} isPending={false} error={null} onSubmit={noop} />
+    <EnableConfigSyncModal isPending={false} error={null} onSubmit={noop} />
   </ModalStory>
 )
 
-export const DisableDefault = () => (
+export const EnableLoading = () => (
   <ModalStory>
-    <EnableConfigSyncModal isManagedByConfig={true} isPending={false} error={null} onSubmit={noop} />
+    <EnableConfigSyncModal isPending={true} error={null} onSubmit={noop} />
   </ModalStory>
 )
 
-export const Loading = () => (
+export const EnableError = () => (
   <ModalStory>
-    <EnableConfigSyncModal isManagedByConfig={false} isPending={true} error={null} onSubmit={noop} />
+    <EnableConfigSyncModal isPending={false} error={{ error: 'Something went wrong' }} onSubmit={noop} />
   </ModalStory>
 )
 
-export const WithError = () => (
+export const Disable = () => (
   <ModalStory>
-    <EnableConfigSyncModal isManagedByConfig={false} isPending={false} error={{ error: 'Something went wrong' }} onSubmit={noop} />
+    <DisableConfigSyncModal installName="prod-acme" isPending={false} error={null} onSubmit={noop} />
+  </ModalStory>
+)
+
+export const DisableError = () => (
+  <ModalStory>
+    <DisableConfigSyncModal installName="prod-acme" isPending={false} error={{ error: 'Something went wrong' }} onSubmit={noop} />
   </ModalStory>
 )

--- a/services/dashboard-ui/client/components/installs/management/EnableConfigSync/EnableConfigSync.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EnableConfigSync/EnableConfigSync.tsx
@@ -1,48 +1,117 @@
+import { useState } from 'react'
 import { Banner } from '@/components/common/Banner'
 import { Icon } from '@/components/common/Icon'
+import { Input } from '@/components/common/form/Input'
 import { Text } from '@/components/common/Text'
 import { Modal, type IModal } from '@/components/surfaces/Modal'
 
+interface IDisableConfigSyncModal extends Omit<IModal, 'onSubmit'> {
+  installName: string
+  isPending: boolean
+  error: any
+  onSubmit: () => void
+}
+
+export const DisableConfigSyncModal = ({
+  installName,
+  isPending,
+  error,
+  onSubmit,
+  ...props
+}: IDisableConfigSyncModal) => {
+  const [confirmName, setConfirmName] = useState('')
+
+  const isConfirmValid = confirmName === installName
+  const canSubmit = isConfirmValid && !isPending
+
+  return (
+    <Modal
+      heading={
+        <Text flex className="gap-4" variant="h3" weight="strong" theme="warn">
+          <Icon variant="FileCloudIcon" size="24" />
+          Disable config sync?
+        </Text>
+      }
+      primaryActionTrigger={{
+        children: isPending ? (
+          <span className="flex items-center gap-2">
+            <Icon variant="Loading" /> Disabling...
+          </span>
+        ) : (
+          <span className="flex items-center gap-2">
+            <Icon variant="ToggleRightIcon" /> Disable config sync
+          </span>
+        ),
+        onClick: onSubmit,
+        disabled: !canSubmit,
+        variant: 'danger',
+      }}
+      {...props}
+    >
+      <div className="flex flex-col gap-4">
+        {error ? (
+          <Banner theme="error">
+            {error?.error || 'An error happened, please refresh the page and try again.'}
+          </Banner>
+        ) : null}
+
+        <Banner theme="warn">
+          <Text variant="body">
+            <strong>Warning:</strong> Disabling config sync will stop future syncs from the install config file. Settings will need to be managed manually from the dashboard.
+          </Text>
+        </Banner>
+
+        <div className="flex flex-col gap-2">
+          <Text variant="body">
+            To verify, type{' '}
+            <span className="font-mono font-medium text-red-800 dark:text-red-400 bg-red-50 dark:bg-red-900/20 px-1 py-0.5 rounded">
+              {installName}
+            </span>{' '}
+            below.
+          </Text>
+          <Input
+            id="confirm-install-name"
+            placeholder="install name"
+            type="text"
+            value={confirmName}
+            onChange={(e) => setConfirmName(e.target.value)}
+            error={confirmName.length > 0 && !isConfirmValid}
+            errorMessage={confirmName.length > 0 && !isConfirmValid ? "Install name doesn't match" : undefined}
+          />
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
 interface IEnableConfigSyncModal extends Omit<IModal, 'onSubmit'> {
-  isManagedByConfig: boolean
   isPending: boolean
   error: any
   onSubmit: () => void
 }
 
 export const EnableConfigSyncModal = ({
-  isManagedByConfig,
   isPending,
   error,
   onSubmit,
   ...props
 }: IEnableConfigSyncModal) => {
-  const buttonText = isManagedByConfig ? 'Disable Install Config Sync' : 'Enable Install Config Sync'
-  const modalHeading = isManagedByConfig ? 'Disable Install Config Sync?' : 'Enable Install Config Sync?'
-
   return (
     <Modal
       heading={
-        <Text
-          flex
-          className="gap-4"
-          variant="h3"
-          weight="strong"
-        >
+        <Text flex className="gap-4" variant="h3" weight="strong">
           <Icon variant="FileCloudIcon" size="24" />
-          {modalHeading}
+          Enable config sync?
         </Text>
       }
       primaryActionTrigger={{
         children: isPending ? (
           <span className="flex items-center gap-2">
-            <Icon variant="Loading" />
-            {isManagedByConfig ? 'Disabling...' : 'Enabling...'}
+            <Icon variant="Loading" /> Enabling...
           </span>
         ) : (
           <span className="flex items-center gap-2">
-            <Icon variant={isManagedByConfig ? 'ToggleRightIcon' : 'ToggleLeftIcon'} />
-            {buttonText}
+            <Icon variant="ToggleLeftIcon" /> Enable config sync
           </span>
         ),
         onClick: onSubmit,
@@ -51,7 +120,7 @@ export const EnableConfigSyncModal = ({
       }}
       {...props}
     >
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-4">
         {error ? (
           <Banner theme="error">
             {error?.error || 'An error happened, please refresh the page and try again.'}
@@ -59,13 +128,7 @@ export const EnableConfigSyncModal = ({
         ) : null}
 
         <Text variant="base">
-          This Install can be managed via an Install Config file only after marking it as managed by Install Config.
-        </Text>
-
-        <Text variant="base">
-          {isManagedByConfig
-            ? 'Disabling this will stop any future syncs from the Install Config file.'
-            : 'Enable this to allow syncing from an Install Config file.'}
+          Enable this to allow syncing settings from an install config file.
         </Text>
       </div>
     </Modal>

--- a/services/dashboard-ui/client/components/installs/management/EnableConfigSync/EnableConfigSyncContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EnableConfigSync/EnableConfigSyncContainer.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
@@ -9,44 +9,75 @@ import { useOrg } from '@/hooks/use-org'
 import { useToast } from '@/hooks/use-toast'
 import { useSurfaces } from '@/hooks/use-surfaces'
 import { updateInstall } from '@/lib'
-import { EnableConfigSyncModal } from './EnableConfigSync'
+import { DisableConfigSyncModal, EnableConfigSyncModal } from './EnableConfigSync'
 
-interface IEnableConfigSync {}
-
-export const EnableConfigSyncModalContainer = ({ ...props }: IEnableConfigSync & Omit<IModal, 'onSubmit'>) => {
+const DisableConfigSyncModalContainer = ({ ...props }: Omit<IModal, 'onSubmit'>) => {
+  const queryClient = useQueryClient()
   const { org } = useOrg()
   const { install } = useInstall()
   const { removeModal } = useSurfaces()
   const { addToast } = useToast()
 
-  const hasManagedBy = Boolean(install?.metadata?.managed_by)
-  const isManagedByConfig =
-    hasManagedBy && install?.metadata?.managed_by === 'nuon/cli/install-config'
-
-  const { mutate, isPending: isLoading, error } = useMutation({
+  const { mutate, isPending, error } = useMutation({
     mutationFn: () =>
       updateInstall({
         orgId: org.id,
         installId: install.id,
-        body: {
-          metadata: {
-            managed_by: isManagedByConfig
-              ? 'nuon/dashboard'
-              : 'nuon/cli/install-config',
-          },
-        },
+        body: { metadata: { managed_by: 'nuon/dashboard' } },
       }),
     onSuccess: () => {
+      removeModal(props.modalId)
+      queryClient.invalidateQueries({ queryKey: ['install', org.id, install.id] })
       addToast(
-        <Toast heading="Config sync updated" theme="success">
-          <Text>
-            Config sync has been {isManagedByConfig ? 'disabled' : 'enabled'} for {install.name}.
-          </Text>
+        <Toast heading="Config sync disabled" theme="success">
+          <Text>Config sync has been disabled for {install.name}.</Text>
         </Toast>
       )
-      removeModal(props.modalId)
     },
-    onError: (error) => {
+    onError: () => {
+      addToast(
+        <Toast heading="Config sync update failed" theme="error">
+          <Text>Unable to update config sync for {install.name}.</Text>
+        </Toast>
+      )
+    },
+  })
+
+  return (
+    <DisableConfigSyncModal
+      installName={install?.name ?? ''}
+      isPending={isPending}
+      error={error}
+      onSubmit={() => mutate()}
+      {...props}
+    />
+  )
+}
+
+const EnableConfigSyncModalContainer = ({ ...props }: Omit<IModal, 'onSubmit'>) => {
+  const queryClient = useQueryClient()
+  const { org } = useOrg()
+  const { install } = useInstall()
+  const { removeModal } = useSurfaces()
+  const { addToast } = useToast()
+
+  const { mutate, isPending, error } = useMutation({
+    mutationFn: () =>
+      updateInstall({
+        orgId: org.id,
+        installId: install.id,
+        body: { metadata: { managed_by: 'nuon/cli/install-config' } },
+      }),
+    onSuccess: () => {
+      removeModal(props.modalId)
+      queryClient.invalidateQueries({ queryKey: ['install', org.id, install.id] })
+      addToast(
+        <Toast heading="Config sync enabled" theme="success">
+          <Text>Config sync has been enabled for {install.name}.</Text>
+        </Toast>
+      )
+    },
+    onError: () => {
       addToast(
         <Toast heading="Config sync update failed" theme="error">
           <Text>Unable to update config sync for {install.name}.</Text>
@@ -57,8 +88,7 @@ export const EnableConfigSyncModalContainer = ({ ...props }: IEnableConfigSync &
 
   return (
     <EnableConfigSyncModal
-      isManagedByConfig={isManagedByConfig}
-      isPending={isLoading}
+      isPending={isPending}
       error={error}
       onSubmit={() => mutate()}
       {...props}
@@ -66,25 +96,23 @@ export const EnableConfigSyncModalContainer = ({ ...props }: IEnableConfigSync &
   )
 }
 
-export const EnableConfigSyncButton = ({ ...props }: IEnableConfigSync & IButtonAsButton) => {
+export const EnableConfigSyncButton = ({ ...props }: IButtonAsButton) => {
   const { install } = useInstall()
   const { addModal } = useSurfaces()
-  const modal = <EnableConfigSyncModalContainer />
 
-  const hasManagedBy = Boolean(install?.metadata?.managed_by)
-  const isManagedByConfig =
-    hasManagedBy && install?.metadata?.managed_by === 'nuon/cli/install-config'
+  const isManagedByConfig = install?.metadata?.managed_by === 'nuon/cli/install-config'
 
-  const buttonText = isManagedByConfig ? 'Disable install config sync' : 'Enable install config sync'
+  const handleClick = () => {
+    if (isManagedByConfig) {
+      addModal(<DisableConfigSyncModalContainer />)
+    } else {
+      addModal(<EnableConfigSyncModalContainer />)
+    }
+  }
 
   return (
-    <Button
-      onClick={() => {
-        addModal(modal)
-      }}
-      {...props}
-    >
-      {buttonText}
+    <Button onClick={handleClick} {...props}>
+      {isManagedByConfig ? 'Disable config sync' : 'Enable config sync'}
       <Icon variant="FileCloudIcon" />
     </Button>
   )

--- a/services/dashboard-ui/client/components/installs/management/EnableConfigSync/index.ts
+++ b/services/dashboard-ui/client/components/installs/management/EnableConfigSync/index.ts
@@ -1,2 +1,2 @@
-export { EnableConfigSyncModalContainer as EnableConfigSyncModal, EnableConfigSyncButton } from './EnableConfigSyncContainer'
-export { EnableConfigSyncModal as EnableConfigSyncModalComponent } from './EnableConfigSync'
+export { EnableConfigSyncButton } from './EnableConfigSyncContainer'
+export { EnableConfigSyncModal as EnableConfigSyncModalComponent, DisableConfigSyncModal as DisableConfigSyncModalComponent } from './EnableConfigSync'


### PR DESCRIPTION
This PR removes the ability to override an install config by making edits in the dashboard. If an install is managed by a config then all setting edit options are disabled and the config sync must be explicitly disabled to edit the install settings from the dashboard. Disabling config sync is treated like a destructive action now and uses the destructive pattern.