### PR TITLE
fix: validator: handle zero-time fires in cron min-interval probe

### DIFF
--- a/services/ctl-api/internal/pkg/validator/cron_schedule.go
+++ b/services/ctl-api/internal/pkg/validator/cron_schedule.go
@@ -51,9 +51,19 @@ func cronScheduleValidator(fl validator.FieldLevel) bool {
 func MinScheduleInterval(sched cron.Schedule) time.Duration {
 	now := time.Now().UTC()
 	prev := sched.Next(now)
+	if prev.IsZero() {
+		// schedule never fires (e.g. impossible date) — treat as infinite gap.
+		return time.Duration(1<<63 - 1)
+	}
 	min := time.Duration(1<<63 - 1)
 	for i := 0; i < minIntervalProbeFires; i++ {
 		next := sched.Next(prev)
+		if next.IsZero() {
+			// no further fires within the underlying parser's search horizon
+			// (robfig/cron caps at ~5 years). The gaps we already sampled are
+			// representative; stop probing rather than computing a bogus delta.
+			break
+		}
 		if d := next.Sub(prev); d < min {
 			min = d
 		}

--- a/services/ctl-api/internal/pkg/validator/cron_schedule_test.go
+++ b/services/ctl-api/internal/pkg/validator/cron_schedule_test.go
@@ -20,6 +20,15 @@ func TestCronSchedule_MinInterval(t *testing.T) {
 		{"weekdays 9am", "0 9 * * 1-5", false},
 		{"sunday midnight", "0 0 * * 0", false},
 		{"daily midnight", "0 0 * * *", false},
+		{"every 10m", "10,20,30,40,50 * * * *", false},
+		{"exactly 5m apart twice/hour", "0,5 * * * *", false},
+		{"5m step with offset", "2-59/5 * * * *", false},
+		{"once a day late", "59 23 * * *", false},
+		{"crosses day boundary safely", "0 0,23 * * *", false},
+		{"business hours every 5m weekdays", "*/5 9-17 * * 1-5", false},
+		{"MWF noon only", "0 12 * * 1,3,5", false},
+		{"once a year (leap day)", "0 0 29 2 *", false},
+		{"once a year (new year)", "0 0 1 1 *", false},
 
 		// fail: too frequent
 		{"every minute", "* * * * *", true},
@@ -29,6 +38,13 @@ func TestCronSchedule_MinInterval(t *testing.T) {
 		{"two fires 1 min apart", "0,1 * * * *", true},
 		{"three fires 2 min apart", "0,2,4 * * * *", true},
 		{"mostly 15m with one 1m gap", "0,15,30,45,46 * * * *", true},
+		{"uneven list with 4m gap mid-cycle", "3,13,23,37,41,53 * * * *", true},
+		{"4m apart, just under the limit", "0,4 * * * *", true},
+		{"hour-boundary 1m gap (59→00)", "0,59 * * * *", true},
+		{"step 7 wraps at hour (56→00 = 4m)", "*/7 * * * *", true},
+		{"step 3 minute (3m gap)", "*/3 * * * *", true},
+		{"two fires close, crossing hour", "55,59 * * * *", true},
+		{"frequent only during business hours", "*/3 9-17 * * *", true},
 
 		// fail: invalid syntax
 		{"invalid", "not a cron", true},


### PR DESCRIPTION
Guard MinScheduleInterval against robfig/cron's ~5y search horizon returning zero times, which previously caused infrequent schedules (e.g. Feb 29 yearly) to be wrongly rejected. Adds boundary, hour-wrap, and rare-fire test cases for confidence.