### PR TITLE
fix: (policies) reject component-scoped policies with empty components

### DIFF
--- a/pkg/config/app_policies.go
+++ b/pkg/config/app_policies.go
@@ -223,7 +223,7 @@ func (a AppPolicy) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Example("./disallow-ingress-nginx-custom-snippets.yaml").
 		Example("./block-mutable-tags.rego").
 		Field("components").Short("target components").
-		Long("List of component names this policy applies to. Use [\"*\"] to apply to all components of the specified type. If empty, doesn't apply to any component. Ignored when type is 'sandbox'.").
+		Long("List of component names this policy applies to. Use [\"*\"] to apply to all components of the specified type, or list specific component names. Required for component-scoped policy types - an empty list is rejected. Ignored when type is 'sandbox'.").
 		Example("*").
 		Example("rds_cluster")
 }

--- a/pkg/config/validate/validate_policies.go
+++ b/pkg/config/validate/validate_policies.go
@@ -64,8 +64,12 @@ func ValidatePoliciesWithLogger(a *config.AppConfig, l *zap.Logger) error {
 			return err
 		}
 
-		if err := validatePolicyComponents(policy.Components); err != nil {
-			policyLogger.Error("invalid policy components", zap.Error(err), zap.Strings("components", policy.Components))
+		policyName := policy.Name
+		if policyName == "" {
+			policyName = fmt.Sprintf("#%d", idx)
+		}
+		if err := validatePolicyComponents(policyName, policy.Type, policy.Components); err != nil {
+			policyLogger.Error("invalid policy components", zap.Error(err), zap.String("policy_name", policyName), zap.Strings("components", policy.Components))
 			return err
 		}
 
@@ -134,8 +138,31 @@ func validatePolicyTypeEngineCompatibility(policyType config.AppPolicyType, engi
 	return nil
 }
 
-func validatePolicyComponents(components []string) error {
+// componentScopedPolicyType reports whether a policy type is evaluated per
+// component and therefore requires a non-empty components list. Sandbox and
+// kubernetes_cluster policies are not component-scoped and ignore components.
+func componentScopedPolicyType(policyType config.AppPolicyType) bool {
+	switch policyType {
+	case config.AppPolicyTypeTerraformModule,
+		config.AppPolicyTypeHelmChart,
+		config.AppPolicyTypeKubernetesManifest,
+		config.AppPolicyTypeDockerBuild,
+		config.AppPolicyTypeContainerImage,
+		config.AppPolicyTypePulumi:
+		return true
+	default:
+		return false
+	}
+}
+
+func validatePolicyComponents(policyName string, policyType config.AppPolicyType, components []string) error {
 	if len(components) == 0 {
+		// Component-scoped policies with an empty components list never run,
+		// which silently disables them. Require an explicit target (["*"] for
+		// all components of the type, or specific component names).
+		if componentScopedPolicyType(policyType) {
+			return fmt.Errorf("policy %q (type %s) requires a non-empty components list; use [\"*\"] to apply to all components of this type or list specific component names", policyName, policyType)
+		}
 		return nil
 	}
 

--- a/pkg/config/validate/validate_policies.go
+++ b/pkg/config/validate/validate_policies.go
@@ -68,7 +68,7 @@ func ValidatePoliciesWithLogger(a *config.AppConfig, l *zap.Logger) error {
 		if policyName == "" {
 			policyName = fmt.Sprintf("#%d", idx)
 		}
-		if err := validatePolicyComponents(policyName, policy.Type, policy.Components); err != nil {
+		if err := ValidatePolicyComponents(policyName, policy.Type, policy.Components); err != nil {
 			policyLogger.Error("invalid policy components", zap.Error(err), zap.String("policy_name", policyName), zap.Strings("components", policy.Components))
 			return err
 		}
@@ -155,7 +155,10 @@ func componentScopedPolicyType(policyType config.AppPolicyType) bool {
 	}
 }
 
-func validatePolicyComponents(policyName string, policyType config.AppPolicyType, components []string) error {
+// ValidatePolicyComponents validates the components list for a single policy.
+// It is shared by config validation (nuon CLI sync) and the ctl-api create
+// endpoint so both enforce the same rules.
+func ValidatePolicyComponents(policyName string, policyType config.AppPolicyType, components []string) error {
 	if len(components) == 0 {
 		// Component-scoped policies with an empty components list never run,
 		// which silently disables them. Require an explicit target (["*"] for

--- a/pkg/config/validate/validate_policies_test.go
+++ b/pkg/config/validate/validate_policies_test.go
@@ -101,7 +101,7 @@ func TestValidatePolicyComponents(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := validatePolicyComponents(name, test.policyType, test.components)
+			err := ValidatePolicyComponents(name, test.policyType, test.components)
 			assert.Equal(t, (err != nil), test.expected, "Expected error: %v, got: %v", test.expected, err)
 		})
 	}

--- a/pkg/config/validate/validate_policies_test.go
+++ b/pkg/config/validate/validate_policies_test.go
@@ -79,20 +79,29 @@ func TestValidatePolicyTypeEngineCompatibility(t *testing.T) {
 
 func TestValidatePolicyComponents(t *testing.T) {
 	tests := map[string]struct {
+		policyType config.AppPolicyType
 		components []string
 		expected   bool
 	}{
-		"empty":                {[]string{}, false},
-		"single_component":     {[]string{"rds_cluster"}, false},
-		"multiple_components":  {[]string{"rds_cluster", "vpc"}, false},
-		"wildcard_only":        {[]string{"*"}, false},
-		"wildcard_with_others": {[]string{"*", "rds_cluster"}, true},
-		"empty_component_name": {[]string{"rds_cluster", ""}, true},
+		// component-scoped types must declare components - empty silently disables them
+		"terraform_empty_error":     {config.AppPolicyTypeTerraformModule, []string{}, true},
+		"terraform_nil_error":       {config.AppPolicyTypeTerraformModule, nil, true},
+		"helm_empty_error":          {config.AppPolicyTypeHelmChart, []string{}, true},
+		"container_image_empty_err": {config.AppPolicyTypeContainerImage, []string{}, true},
+		// non component-scoped types ignore components and may be empty
+		"sandbox_empty_ok":            {config.AppPolicyTypeSandbox, []string{}, false},
+		"kubernetes_cluster_empty_ok": {config.AppPolicyTypeKubernetesCluster, []string{}, false},
+		// populated lists validate the same regardless of type
+		"single_component":     {config.AppPolicyTypeTerraformModule, []string{"rds_cluster"}, false},
+		"multiple_components":  {config.AppPolicyTypeTerraformModule, []string{"rds_cluster", "vpc"}, false},
+		"wildcard_only":        {config.AppPolicyTypeTerraformModule, []string{"*"}, false},
+		"wildcard_with_others": {config.AppPolicyTypeTerraformModule, []string{"*", "rds_cluster"}, true},
+		"empty_component_name": {config.AppPolicyTypeTerraformModule, []string{"rds_cluster", ""}, true},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := validatePolicyComponents(test.components)
+			err := validatePolicyComponents(name, test.policyType, test.components)
 			assert.Equal(t, (err != nil), test.expected, "Expected error: %v, got: %v", test.expected, err)
 		})
 	}

--- a/services/ctl-api/internal/app/apps/service/create_app_policies_config.go
+++ b/services/ctl-api/internal/app/apps/service/create_app_policies_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/pkg/config"
+	"github.com/nuonco/nuon/pkg/config/validate"
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
@@ -54,11 +55,22 @@ func (c *CreateAppPoliciesConfigRequest) Validate(v *validator.Validate) error {
 		return validatorPkg.FormatValidationError(err)
 	}
 
-	for _, policy := range c.Policies {
+	for idx, policy := range c.Policies {
 		if !generics.SliceContains(policy.Type, app.AllPolicyTypes) {
 			return stderr.ErrUser{
 				Err:         fmt.Errorf("policy type must be one of (%s)", strings.Join(generics.ToStringSlice(app.AllPolicyTypes), ",")),
 				Description: "invalid policy type " + string(policy.Type),
+			}
+		}
+
+		policyName := policy.Name
+		if policyName == "" {
+			policyName = fmt.Sprintf("#%d", idx)
+		}
+		if err := validate.ValidatePolicyComponents(policyName, policy.Type, policy.Components); err != nil {
+			return stderr.ErrUser{
+				Err:         err,
+				Description: err.Error(),
 			}
 		}
 	}


### PR DESCRIPTION
A component-scoped policy (`terraform_module`, `helm_chart`, `kubernetes_manifest`, `docker_build`, `container_image`, `pulumi`) with an empty components list is never evaluated at runtime, silently disabling it. The dashboard, however, renders such policies as `"All components"`, so users believed they were active when they never ran.

Add config validation that rejects an empty components list for these types, requiring an explicit target (`["*"]` for all components of the type, or specific component names). Sandbox policies are unaffected since they ignore components.