### PR TITLE
fix: (dashboard) do not show "All components" for policies that never run

### DIFF
--- a/services/dashboard-ui/client/components/policies/PoliciesTable.tsx
+++ b/services/dashboard-ui/client/components/policies/PoliciesTable.tsx
@@ -100,12 +100,11 @@ export const policiesTableColumns: ColumnDef<TPolicyRow>[] = [
       if (isSandbox) {
         return <Text variant="subtext">Sandbox</Text>
       }
-      const isAllComponents =
-        !components ||
-        components.length === 0 ||
-        (components.length === 1 && components[0] === '*')
-      if (isAllComponents) {
+      if (components?.includes('*')) {
         return <Text variant="subtext">All components</Text>
+      }
+      if (!components || components.length === 0) {
+        return <Text variant="subtext">No components</Text>
       }
       return (
         <div className="flex flex-wrap gap-1">

--- a/services/dashboard-ui/client/views/app/PolicyDetail.tsx
+++ b/services/dashboard-ui/client/views/app/PolicyDetail.tsx
@@ -58,10 +58,9 @@ export const PolicyDetail = () => {
 
   const isSandboxPolicy = policy?.type === 'sandbox'
   const policyComponents = policy?.components ?? []
-  const isAllComponents =
-    !isSandboxPolicy &&
-    (policyComponents.length === 0 ||
-      (policyComponents.length === 1 && policyComponents[0] === '*'))
+  const isAllComponents = !isSandboxPolicy && policyComponents.includes('*')
+  const hasNoComponents =
+    !isSandboxPolicy && !isAllComponents && policyComponents.length === 0
 
   return (
     <PageSection>
@@ -139,6 +138,11 @@ export const PolicyDetail = () => {
               <div className="flex items-center gap-2">
                 <Icon variant="CardsIcon" size={16} />
                 <Text variant="subtext">All components</Text>
+              </div>
+            ) : hasNoComponents ? (
+              <div className="flex items-center gap-2">
+                <Icon variant="ProhibitIcon" size={16} />
+                <Text variant="subtext">No components</Text>
               </div>
             ) : (
               <div className="flex flex-col gap-2">


### PR DESCRIPTION
The policies table and policy detail view treated an empty components array the same as ["*"], both rendering "All components". But an empty components list does not apply to any component (the policy never runs), so the label was misleading.

Show "All components" only when "*" is explicitly present, and render "No components" for an empty/missing components list.