### PR TITLE
feat(slack): redesign workflow notification cards

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,7 @@ require (
 	github.com/pulumi/pulumi/sdk/v3 v3.155.0
 	github.com/sagikazarmark/slog-shim v0.1.0
 	github.com/segmentio/analytics-go/v3 v3.3.0
+	github.com/slack-go/slack v0.24.0
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -147,7 +148,6 @@ require (
 	go.uber.org/fx v1.23.0
 	go.uber.org/zap v1.27.1
 	golang.design/x/clipboard v0.7.1
-	golang.org/x/net v0.52.0
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.79.3
@@ -316,6 +316,7 @@ require (
 	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect
 	golang.org/x/image v0.28.0 // indirect
 	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect
+	golang.org/x/net v0.52.0 // indirect
 	google.golang.org/genproto v0.0.0-20250303144028-a0af3efb3deb // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2138,8 +2138,8 @@ github.com/go-swagger/go-swagger v0.33.0/go.mod h1:wJK762cSroJbM7hgJtKtbZxfevB3R
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
-github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
-github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
@@ -2870,6 +2870,8 @@ github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af h1:Sp5TG9f7K39yf
 github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
+github.com/slack-go/slack v0.24.0 h1:oMz5WcCBVTkxpBxeA8QVxxK70R+XV/a0qNka6TRNGHQ=
+github.com/slack-go/slack v0.24.0/go.mod h1:H0yR/YBuRJ39RkE+JpV/d/oEsbanzTRowR82bCN0cEs=
 github.com/someshkoli/go-toml/v2 v2.0.0-20260106110510-b42197d17bf7 h1:RVsTEfqivFX/5V7+bPEsYyxfklvAdJcD0FFNJr0MUUs=
 github.com/someshkoli/go-toml/v2 v2.0.0-20260106110510-b42197d17bf7/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/someshkoli/helm-diff/v3 v3.0.0-20250909140920-ea5d6a9f37b9 h1:zA0E5M9f2r8/vuDEBQV71RXzcTu85mD0hV4jmPyUiF0=

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/slack.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/slack.go
@@ -514,28 +514,29 @@ func (h *SlackSignalLifecycleHook) postOrThread(
 		}
 	}
 
-	// Skip child replies for workflow-kind events. The parent message
-	// itself already renders the workflow's headline + latest status, so
-	// a threaded reply with the same content ("Running runbook —
-	// Started" / "Succeeded") is redundant noise. Step events still post
-	// as children.
-	if rendered.event.Kind == slackrender.KindWorkflow {
-		return nil
+	// Post the child as a threaded reply — but only for step / approval
+	// events. Workflow-kind events are already represented by the parent
+	// card (a reply with the same "Provisioning install — Started /
+	// Succeeded" content would be redundant noise); they still fall
+	// through to refresh the parent rollup below so the workflow's final
+	// state lands on the card.
+	if rendered.event.Kind != slackrender.KindWorkflow {
+		childMsg := slackrender.BuildChildMessage(rendered.event)
+		if _, err := h.slackClient.PostMessage(ctx, install.BotAccessToken, slackclient.PostMessageRequest{
+			Channel:  sub.ChannelID,
+			Text:     childMsg.Text,
+			Blocks:   childMsg.Blocks,
+			ThreadTS: parentTS,
+		}); err != nil {
+			return fmt.Errorf("post slack threaded reply: %w", err)
+		}
 	}
 
-	// Post the child as a threaded reply.
-	childMsg := slackrender.BuildChildMessage(rendered.event)
-	if _, err := h.slackClient.PostMessage(ctx, install.BotAccessToken, slackclient.PostMessageRequest{
-		Channel:  sub.ChannelID,
-		Text:     childMsg.Text,
-		Blocks:   childMsg.Blocks,
-		ThreadTS: parentTS,
-	}); err != nil {
-		return fmt.Errorf("post slack threaded reply: %w", err)
-	}
-
-	// Best-effort: edit the parent with the freshest rollup. Failure here
-	// is logged but never returned — the child already landed.
+	// Best-effort: edit the parent with the freshest rollup so it reflects
+	// the latest step (while running) and the terminal workflow status (on
+	// the workflow's succeeded / failed event). Skipped when the parent was
+	// just created this call (found == false) — it already carries the
+	// current state. Failure here is logged but never returned.
 	if found {
 		rollup := slackrender.BuildParentRollup(rendered.event, startedAt)
 		if _, err := h.slackClient.UpdateMessage(ctx, install.BotAccessToken, slackclient.UpdateMessageRequest{

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/slackrender/message.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/slackrender/message.go
@@ -4,91 +4,259 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/slack-go/slack"
 )
 
 // Message is the rendered output of a Build* call: a fallback text string
-// (used by Slack when blocks aren't supported) and the structured blocks
-// posted as the message body.
+// (used by Slack when blocks aren't supported) and the typed Block Kit
+// blocks posted as the message body. Blocks are built with the slack-go
+// SDK so their shape is validated by the type system rather than
+// hand-assembled maps.
 type Message struct {
 	Text   string
-	Blocks []any
+	Blocks []slack.Block
 }
 
-// LinkChip is a (label, url) pair rendered as a clickable mrkdwn chip in
-// the trailing context block.
+// LinkChip is a (label, url) pair rendered either as a context link or an
+// actions button.
 type LinkChip struct {
 	Label string
 	URL   string
 }
 
-// BuildParentMessage renders the workflow's parent post — emitted on the
-// first event for a workflow. The parent's shape (headline + status +
-// footer + links) is identical to BuildParentRollup so the post never
-// visually grows or rearranges across edits.
+// kv is a single label/value pair rendered as a field in a fielded section.
+type kv struct {
+	k string
+	v string
+}
+
+const headerMaxLen = 150
+
+// BuildParentMessage renders the workflow's parent post — a fielded "card"
+// emitted on the first event for a workflow. Its shape is identical to
+// BuildParentRollup so the post never visually rearranges across edits.
 //
 // startedAt is the workflow's first-event timestamp. When zero, the
-// "running 5m" / "ran 5m" line is omitted.
+// Duration field is omitted.
 func BuildParentMessage(e Event, startedAt time.Time) Message {
 	return buildParent(e, startedAt, time.Now())
 }
 
-// BuildParentRollup renders the parent post on every subsequent edit.
+// BuildParentRollup renders the parent card on every subsequent edit.
 // Identical layout to BuildParentMessage by design.
 func BuildParentRollup(e Event, startedAt time.Time) Message {
 	return buildParent(e, startedAt, time.Now())
 }
 
-// BuildChildMessage renders the per-event threaded reply.
-func BuildChildMessage(e Event) Message {
-	headline := childHeadline(e)
-	statusLine := childStatusLine(e)
-	footer := childFooterParts(e)
-	links := buildLinks(e)
+// buildParent assembles the parent / rollup card: a header, a fielded
+// section (status / duration / install / org / by), an optional error
+// block, and an "Open in Nuon" button.
+func buildParent(e Event, startedAt, now time.Time) Message {
+	blocks := []slack.Block{headerBlock(parentHeaderText(e))}
 
-	return Message{
-		Text:   plainHeadline(e, false),
-		Blocks: buildBlocks(headline, statusLine, footer, links),
+	if fields := parentFields(e, startedAt, now); len(fields) > 0 {
+		blocks = append(blocks, slack.NewDividerBlock(), fieldsSection(fields))
 	}
+	if step := parentLatestStep(e); step != "" {
+		blocks = append(blocks, slack.NewDividerBlock(), mrkdwnSection(step))
+	}
+	if errBlock, ok := errorSection(e); ok {
+		blocks = append(blocks, errBlock)
+	}
+	if actions, ok := actionsBlock(buildLinks(e)); ok {
+		blocks = append(blocks, actions)
+	}
+
+	return Message{Text: plainHeadline(e, true), Blocks: blocks}
 }
 
-// BuildFlatMessage renders a defensive single-block fallback for events
-// without a workflow id (e.g. install-created). Same shape as the child.
+// parentHeaderText renders the big plain-text header: entity icon +
+// workflow title, with the runbook subject appended for runbook runs.
+func parentHeaderText(e Event) string {
+	parts := nonEmpty(workflowSubjectIcon(e), workflowHeaderTitle(e))
+	text := strings.TrimSpace(strings.Join(parts, " "))
+	if subj := workflowSubjectLabel(e); subj != "" {
+		text = text + " · " + subj
+	}
+	return text
+}
+
+// parentFields builds the two-column field grid. The workflow type is
+// intentionally omitted — the header already conveys it.
+//
+// State is the workflow-level status (In progress → Succeeded / Failed),
+// kept distinct from the per-step status so the card never reads as
+// "Succeeded" mid-run just because the latest step finished. The latest
+// step itself renders as a full-width section below the grid (see
+// parentLatestStep) so long step names get room.
+func parentFields(e Event, startedAt, now time.Time) []kv {
+	fields := []kv{}
+	emoji, label := parentState(e)
+	fields = append(fields, kv{"State", emoji + " " + label})
+	if d := elapsedValue(startedAt, now); d != "" {
+		fields = append(fields, kv{"Duration", d})
+	}
+	if name := installName(e); name != "" {
+		fields = append(fields, kv{"Install", slackEscape(name)})
+	}
+	if name := orgName(e); name != "" {
+		fields = append(fields, kv{"Org", slackEscape(name)})
+	}
+	if e.Workflow.CreatedByEmail != "" {
+		fields = append(fields, kv{"By", slackEscape(e.Workflow.CreatedByEmail)})
+	}
+	return fields
+}
+
+// parentState resolves the workflow-level status for the parent card. Only
+// a terminal workflow-kind event yields a terminal state; every step event
+// (and the workflow "started") reads as "In progress", because steps only
+// flow while the workflow is mid-run.
+func parentState(e Event) (string, string) {
+	if e.Kind == KindWorkflow {
+		switch e.Transition {
+		case TransitionSucceeded:
+			return statusEmoji(TransitionSucceeded), "Succeeded"
+		case TransitionFailed:
+			return statusEmoji(TransitionFailed), "Failed"
+		case TransitionCancelled:
+			return statusEmoji(TransitionCancelled), "Cancelled"
+		}
+	}
+	return "⏳", "In progress"
+}
+
+// parentLatestStep renders the full-width "latest step" section line for
+// the parent card: a bold step name (which can be long) followed by its
+// status on the same line. Empty for workflow-kind events, which carry no
+// step.
+func parentLatestStep(e Event) string {
+	if e.Kind != KindWorkflowStep && e.Kind != KindWorkflowStepApproval {
+		return ""
+	}
+	if e.Step == nil {
+		return ""
+	}
+	title := headerTitle(e)
+	if subj := subjectLabel(e); subj != "" && !strings.EqualFold(subj, title) {
+		title = title + " — " + subj
+	}
+	v := "*" + slackEscape(title) + "*  " + statusEmoji(e.Transition) + " " + transitionPhrase(e.Transition)
+	if rb := approvalRespondedBy(e); rb != "" {
+		v = v + " by " + slackEscape(rb)
+	}
+	return v
+}
+
+// BuildChildMessage renders the per-event threaded reply: a tight two-line
+// block. Org / install are intentionally omitted — every reply in the
+// thread is the same install, so repeating them is noise; the parent card
+// already carries them.
+func BuildChildMessage(e Event) Message {
+	blocks := []slack.Block{mrkdwnSection(childHeadline(e))}
+	if ctx, ok := contextBlock(childContextParts(e), childLinks(e)); ok {
+		blocks = append(blocks, ctx)
+	}
+	return Message{Text: plainHeadline(e, false), Blocks: blocks}
+}
+
+// childHeadline renders the reply's lead line: status emoji + bold title +
+// optional subject. The status emoji leads so the outcome is scannable
+// down the thread gutter.
+func childHeadline(e Event) string {
+	emoji := statusEmoji(e.Transition)
+	title := headerTitle(e)
+	headline := strings.TrimSpace(emoji + "  *" + slackEscape(title) + "*")
+	if subj := subjectLabel(e); subj != "" && !strings.EqualFold(subj, title) {
+		headline = headline + " — " + slackEscape(subj)
+	}
+	return headline
+}
+
+// childContextParts builds the small grey sub-line: status phrase,
+// duration, and any error. No org / install (redundant in-thread).
+func childContextParts(e Event) []string {
+	parts := []string{}
+	if phrase := transitionPhrase(e.Transition); phrase != "" {
+		if rb := approvalRespondedBy(e); rb != "" {
+			phrase = phrase + " by " + rb
+		}
+		parts = append(parts, phrase)
+	}
+	if e.Outcome != nil && e.Outcome.DurationMs > 0 {
+		parts = append(parts, humanDurationMs(e.Outcome.DurationMs))
+	}
+	if e.Outcome != nil && e.Outcome.Error != "" {
+		parts = append(parts, "error: "+trimContext(e.Outcome.Error, 220))
+	}
+	return parts
+}
+
+// childLinks prefers the most step-specific link (component → sandbox →
+// workflow) so the reply jumps the reader to the thing that changed.
+func childLinks(e Event) []LinkChip {
+	links := []LinkChip{}
+	if e.Links == nil {
+		return links
+	}
+	if l := firstNonEmptyLink(e.Links,
+		func(l *ContextLinks) string { return l.Component },
+		func(l *ContextLinks) string { return l.Sandbox },
+		func(l *ContextLinks) string { return l.Workflow },
+	); l != "" {
+		links = append(links, LinkChip{Label: "Open ↗", URL: l})
+	}
+	if e.Kind == KindWorkflowStepApproval && e.Links.Approval != "" {
+		links = append(links, LinkChip{Label: "View approval ↗", URL: e.Links.Approval})
+	}
+	return links
+}
+
+// BuildFlatMessage renders a self-contained top-level message for events
+// without a workflow id (e.g. install-created). Unlike a thread reply it
+// keeps the org / install context, since it stands alone.
 func BuildFlatMessage(e Event) Message {
-	return BuildChildMessage(e)
+	blocks := []slack.Block{mrkdwnSection(childHeadline(e))}
+	parts := childContextParts(e)
+	if name := orgName(e); name != "" {
+		parts = append([]string{"org: " + slackEscape(name)}, parts...)
+	}
+	if name := installName(e); name != "" {
+		parts = append([]string{"install: " + slackEscape(name)}, parts...)
+	}
+	if ctx, ok := contextBlock(parts, buildLinks(e)); ok {
+		blocks = append(blocks, ctx)
+	}
+	return Message{Text: plainHeadline(e, false), Blocks: blocks}
 }
 
-// BuildDriftDetectedMessage renders a standalone (non-threaded) drift
-// notification.
+// BuildDriftDetectedMessage renders a standalone (non-threaded) drift card.
 //
 // Drift workflows produce no useful "running drift check" signal for
 // subscribers — the only event that matters is "drift was actually
 // detected on resource X". So drift events are deliberately NOT anchored
-// under a parent post; each detection is its own top-level message that
-// links directly to the affected component or sandbox.
-//
-// Headline: "🌊 Drift detected — <component name>" for component drift,
-// "🌊 Drift detected on sandbox" for sandbox drift. Footer carries the
-// org / install chips. The link chip points at the most specific
-// resource available (component → sandbox → install).
+// under a parent post; each detection is its own top-level card that links
+// directly to the affected component or sandbox.
 func BuildDriftDetectedMessage(e Event) Message {
-	headline := driftHeadline(e)
-	footer := driftFooterParts(e)
-	links := driftLinks(e)
-
-	return Message{
-		Text:   plainDriftHeadline(e),
-		Blocks: buildBlocks(headline, "", footer, links),
+	blocks := []slack.Block{headerBlock(driftHeaderText(e))}
+	if fields := driftFields(e); len(fields) > 0 {
+		blocks = append(blocks, slack.NewDividerBlock(), fieldsSection(fields))
 	}
+	if actions, ok := actionsBlock(driftLinks(e)); ok {
+		blocks = append(blocks, actions)
+	}
+	return Message{Text: plainDriftHeadline(e), Blocks: blocks}
 }
 
-// driftHeadline renders the bold section line for a drift-detected event.
-func driftHeadline(e Event) string {
-	subject := driftSubject(e)
-	headline := "🌊 *Drift detected*"
-	if subject != "" {
-		headline = headline + " — " + slackEscape(subject)
+// driftHeaderText renders the drift card header: "🌊 Drift detected" with
+// the component subject appended when resolved.
+func driftHeaderText(e Event) string {
+	text := "🌊 Drift detected"
+	if subject := driftSubject(e); subject != "" {
+		text = text + " · " + subject
 	}
-	return headline
+	return text
 }
 
 // driftSubject resolves the subject (component name or sandbox literal)
@@ -101,37 +269,28 @@ func driftSubject(e Event) string {
 	case TargetTypeInstallDeploys:
 		return e.Step.ComponentName
 	case TargetTypeInstallSandboxRuns:
-		// There's no SandboxName on the step ref (only id), and there's
-		// one sandbox per install, so the install chip in the footer is
-		// already enough disambiguation. Use a generic "sandbox" label.
 		return "sandbox"
 	}
 	return ""
 }
 
-// driftFooterParts builds the small grey context block for drift events:
-// org and install chips only. Workflow / elapsed / status are
-// intentionally omitted — drift events are point-in-time observations,
-// not lifecycle transitions, so the usual "running 5m" / status emoji
-// content would be noise.
-func driftFooterParts(e Event) []string {
-	parts := []string{}
-	if e.OrgName != "" {
-		parts = append(parts, "org: "+e.OrgName)
-	} else if e.OrgID != "" {
-		parts = append(parts, "org: "+truncateID(e.OrgID, 10))
+// driftFields builds the drift card's field grid: component / install / org.
+func driftFields(e Event) []kv {
+	fields := []kv{}
+	if subject := driftSubject(e); subject != "" {
+		fields = append(fields, kv{"Component", slackEscape(subject)})
 	}
-	if e.Workflow.OwnerType == OwnerTypeInstalls && e.Workflow.OwnerName != "" {
-		parts = append(parts, "install: "+e.Workflow.OwnerName)
-	} else if e.Workflow.OwnerType == OwnerTypeInstalls && e.Workflow.OwnerID != "" {
-		parts = append(parts, "install: "+truncateID(e.Workflow.OwnerID, 10))
+	if name := installName(e); name != "" {
+		fields = append(fields, kv{"Install", slackEscape(name)})
 	}
-	return parts
+	if name := orgName(e); name != "" {
+		fields = append(fields, kv{"Org", slackEscape(name)})
+	}
+	return fields
 }
 
-// driftLinks returns the link chips for a drift event. Prefer the most
-// specific resource link — component → sandbox → install — so the click
-// lands the reader directly on the thing that drifted.
+// driftLinks returns the drift card button target — the most specific
+// resource available (component → sandbox → install).
 func driftLinks(e Event) []LinkChip {
 	links := []LinkChip{}
 	if e.Links == nil {
@@ -158,43 +317,9 @@ func plainDriftHeadline(e Event) string {
 	return "🌊 Drift detected — " + subject
 }
 
-// buildParent assembles the parent / rollup blocks.
-func buildParent(e Event, startedAt, now time.Time) Message {
-	headline := parentHeadline(e)
-	statusLine := parentStatusLine(e, startedAt, now)
-	footer := parentFooterParts(e, startedAt, now)
-	links := buildLinks(e)
-
-	return Message{
-		Text:   plainHeadline(e, true),
-		Blocks: buildBlocks(headline, statusLine, footer, links),
-	}
-}
-
-// parentHeadline renders the bolded section line — entity icon +
-// sentence-case title. The install/owner name and workflow type are
-// intentionally NOT appended here: both already appear as chips in the
-// context block below, and inlining them turns the headline into noise
-// like "Workflow step — bdoans _(provision)_".
-//
-// The parent message is rewritten on every event (BuildParentRollup), so
-// the title must anchor on the workflow's identity rather than the
-// triggering event's step — otherwise the parent's headline swaps to the
-// latest step name and readers lose the "what workflow am I in" anchor.
-func parentHeadline(e Event) string {
-	icon := workflowSubjectIcon(e)
-	title := workflowHeaderTitle(e)
-	headline := strings.TrimSpace(strings.Join(nonEmpty(icon, title), " "))
-	headline = "*" + slackEscape(headline) + "*"
-	if subj := workflowSubjectLabel(e); subj != "" {
-		headline = headline + " — " + slackEscape(subj)
-	}
-	return headline
-}
-
 // workflowSubjectLabel returns a workflow-scoped subject for the parent
-// headline. For runbook_run workflows that is the runbook's name; other
-// workflow types return "" so the headline stays the workflow title alone.
+// header. For runbook_run workflows that is the runbook's name; other
+// workflow types return "" so the header stays the workflow title alone.
 func workflowSubjectLabel(e Event) string {
 	if e.Workflow.Type == WorkflowTypeRunbookRun && e.Workflow.RunbookName != "" {
 		return e.Workflow.RunbookName
@@ -202,7 +327,7 @@ func workflowSubjectLabel(e Event) string {
 	return ""
 }
 
-// workflowHeaderTitle returns the title for the parent message — always
+// workflowHeaderTitle returns the title for the parent card — always
 // derived from the workflow type, ignoring any step in the event.
 func workflowHeaderTitle(e Event) string {
 	if title := titleFromWorkflowType(e.Workflow.Type); title != "" {
@@ -214,7 +339,7 @@ func workflowHeaderTitle(e Event) string {
 	return "Workflow"
 }
 
-// workflowSubjectIcon returns the icon for the parent message — always
+// workflowSubjectIcon returns the icon for the parent card — always
 // derived from the workflow type, ignoring any step in the event.
 func workflowSubjectIcon(e Event) string {
 	switch e.Workflow.Type {
@@ -241,94 +366,8 @@ func workflowSubjectIcon(e Event) string {
 	return ""
 }
 
-// parentStatusLine renders the second line in the section block: the
-// freshest transition. The step name is intentionally NOT repeated here
-// because it is now the headline.
-func parentStatusLine(e Event, startedAt, now time.Time) string {
-	if e.Transition == "" {
-		return ""
-	}
-	parts := []string{"latest:", statusPart(e)}
-	if rb := approvalRespondedBy(e); rb != "" {
-		parts = append(parts, "by "+slackEscape(rb))
-	}
-	return strings.Join(parts, " ")
-}
-
-// parentFooterParts builds the small grey context block: org / install /
-// workflow chips, then a "running 5m" / "ran 5m" elapsed line, then any
-// error.
-func parentFooterParts(e Event, startedAt, now time.Time) []string {
-	parts := []string{}
-	if e.OrgName != "" {
-		parts = append(parts, "org: "+e.OrgName)
-	} else if e.OrgID != "" {
-		parts = append(parts, "org: "+truncateID(e.OrgID, 10))
-	}
-	if e.Workflow.OwnerType == OwnerTypeInstalls && e.Workflow.OwnerName != "" {
-		parts = append(parts, "install: "+e.Workflow.OwnerName)
-	} else if e.Workflow.OwnerType == OwnerTypeInstalls && e.Workflow.OwnerID != "" {
-		parts = append(parts, "install: "+truncateID(e.Workflow.OwnerID, 10))
-	}
-	if e.Workflow.Type != "" {
-		parts = append(parts, "workflow: "+e.Workflow.Type)
-	}
-	if e.Workflow.CreatedByEmail != "" {
-		parts = append(parts, "by: "+slackEscape(e.Workflow.CreatedByEmail))
-	}
-	if elapsed := buildElapsed(e, startedAt, now); elapsed != "" {
-		parts = append(parts, elapsed)
-	}
-	if e.Outcome != nil && e.Outcome.Error != "" {
-		parts = append(parts, "error: "+trimContext(e.Outcome.Error, 220))
-	}
-	return parts
-}
-
-// childHeadline renders a child's bolded section line.
-func childHeadline(e Event) string {
-	icon := subjectIcon(e)
-	title := headerTitle(e)
-	headline := strings.TrimSpace(strings.Join(nonEmpty(icon, title), " "))
-	if subj := subjectLabel(e); subj != "" && !strings.EqualFold(subj, title) {
-		headline = headline + " — " + subj
-	}
-	return "*" + slackEscape(headline) + "*"
-}
-
-// childStatusLine renders the per-event status sub-line. The step name
-// is intentionally NOT repeated here because it is now the headline.
-func childStatusLine(e Event) string {
-	if e.Transition == "" {
-		return ""
-	}
-	parts := []string{statusPart(e)}
-	if rb := approvalRespondedBy(e); rb != "" {
-		parts = append(parts, "by "+slackEscape(rb))
-	}
-	return strings.Join(parts, " · ")
-}
-
-// childFooterParts builds the small grey context block for child posts.
-func childFooterParts(e Event) []string {
-	parts := []string{}
-	if e.OrgName != "" {
-		parts = append(parts, "org: "+e.OrgName)
-	}
-	if e.Workflow.OwnerType == OwnerTypeInstalls && e.Workflow.OwnerName != "" {
-		parts = append(parts, "install: "+e.Workflow.OwnerName)
-	}
-	if e.Outcome != nil && e.Outcome.DurationMs > 0 {
-		parts = append(parts, humanDurationMs(e.Outcome.DurationMs))
-	}
-	if e.Outcome != nil && e.Outcome.Error != "" {
-		parts = append(parts, "error: "+trimContext(e.Outcome.Error, 220))
-	}
-	return parts
-}
-
-// buildLinks resolves the right-side link chips for the context block:
-// "Open in Nuon" + (for approvals) "view approval".
+// buildLinks resolves the parent card's button(s): "Open in Nuon" +
+// (for approvals) "View approval".
 func buildLinks(e Event) []LinkChip {
 	links := []LinkChip{}
 	if e.Links == nil {
@@ -342,15 +381,29 @@ func buildLinks(e Event) []LinkChip {
 		links = append(links, LinkChip{Label: "Open in Nuon", URL: l})
 	}
 	if e.Kind == KindWorkflowStepApproval && e.Links.Approval != "" {
-		links = append(links, LinkChip{Label: "view approval", URL: e.Links.Approval})
+		links = append(links, LinkChip{Label: "View approval", URL: e.Links.Approval})
 	}
 	return links
 }
 
-// statusPart renders the "<emoji> <phrase>" status segment used by every
-// per-event line.
-func statusPart(e Event) string {
-	return fmt.Sprintf("%s %s", statusEmoji(e.Transition), transitionPhrase(e.Transition))
+// installName resolves the install owner's display name, falling back to a
+// truncated id.
+func installName(e Event) string {
+	if e.Workflow.OwnerType != OwnerTypeInstalls {
+		return ""
+	}
+	if e.Workflow.OwnerName != "" {
+		return e.Workflow.OwnerName
+	}
+	return truncateID(e.Workflow.OwnerID, 10)
+}
+
+// orgName resolves the org's display name, falling back to a truncated id.
+func orgName(e Event) string {
+	if e.OrgName != "" {
+		return e.OrgName
+	}
+	return truncateID(e.OrgID, 10)
 }
 
 // statusEmoji maps the transition to a single-glyph prefix.
@@ -375,51 +428,9 @@ func statusEmoji(transition string) string {
 	}
 }
 
-// subjectIcon returns the entity-kind glyph that prefixes the headline.
-func subjectIcon(e Event) string {
-	if (e.Kind == KindWorkflowStep || e.Kind == KindWorkflowStepApproval) && e.Step != nil {
-		switch e.Step.TargetType {
-		case TargetTypeInstallDeploys:
-			return "🧩"
-		case TargetTypeInstallSandboxRuns:
-			return "📦"
-		case TargetTypeInstallActionWorkflowRuns:
-			return "🏃"
-		case TargetTypeInstallCloudFormationStack,
-			TargetTypeInstallRunnerUpdate:
-			return "🏗"
-		}
-	}
-	switch e.Workflow.Type {
-	case WorkflowTypeProvision,
-		WorkflowTypeReprovision,
-		WorkflowTypeDeprovision,
-		WorkflowTypeInputUpdate,
-		WorkflowTypeSyncSecrets:
-		return "🏗"
-	case WorkflowTypeDeprovisionSandbox,
-		WorkflowTypeReprovisionSandbox:
-		return "📦"
-	case WorkflowTypeManualDeploy,
-		WorkflowTypeDeployComponents,
-		WorkflowTypeTeardownComponent,
-		WorkflowTypeTeardownComponents,
-		WorkflowTypeDriftRun:
-		return "🧩"
-	case WorkflowTypeActionWorkflowRun:
-		return "🏃"
-	case WorkflowTypeRunbookRun:
-		return "📒"
-	}
-	return ""
-}
-
-// subjectLabel resolves the entity name (component name, action name)
-// that the event is acting on. Used to suffix the headline so a reader
-// sees "Deploying component — api" instead of just "Deploying
-// component". The install owner name is intentionally NOT used as a
-// fallback — it already appears as a chip in the context block, and
-// inlining it just made the headline noisy ("Workflow step — bdoans").
+// subjectLabel resolves the entity name (component name, action name) that
+// the event is acting on. The install owner name is intentionally NOT used
+// as a fallback — it already appears on the parent card.
 func subjectLabel(e Event) string {
 	if (e.Kind == KindWorkflowStep || e.Kind == KindWorkflowStepApproval) && e.Step != nil {
 		switch e.Step.TargetType {
@@ -440,8 +451,8 @@ func subjectLabel(e Event) string {
 	return ""
 }
 
-// approvalRespondedBy returns the responder display string for an
-// approval response event, empty otherwise.
+// approvalRespondedBy returns the responder display string for an approval
+// response event, empty otherwise.
 func approvalRespondedBy(e Event) string {
 	if e.Approval == nil {
 		return ""
@@ -449,20 +460,16 @@ func approvalRespondedBy(e Event) string {
 	return strings.TrimSpace(e.Approval.RespondedBy)
 }
 
-// buildElapsed produces a "running 5m" / "ran 5m" segment. Returns ""
+// elapsedValue formats the workflow elapsed time as a short phrase, empty
 // when startedAt is zero.
-func buildElapsed(e Event, startedAt, now time.Time) string {
+func elapsedValue(startedAt, now time.Time) string {
 	if startedAt.IsZero() {
 		return ""
 	}
 	if now.IsZero() {
 		now = time.Now()
 	}
-	verb := "running"
-	if e.IsTerminal() {
-		verb = "ran"
-	}
-	return fmt.Sprintf("%s %s", verb, humanElapsed(now.Sub(startedAt)))
+	return humanElapsed(now.Sub(startedAt))
 }
 
 // humanElapsed formats a duration as a short human-readable phrase.
@@ -532,8 +539,17 @@ func truncateID(id string, n int) string {
 	return string(r[:n]) + "…"
 }
 
-// firstNonEmptyLink walks a chain of getters and returns the first non-empty
-// link.
+// truncateHeader caps header text at Slack's 150-char plain_text limit.
+func truncateHeader(s string) string {
+	r := []rune(s)
+	if len(r) <= headerMaxLen {
+		return s
+	}
+	return string(r[:headerMaxLen-1]) + "…"
+}
+
+// firstNonEmptyLink walks a chain of getters and returns the first
+// non-empty link.
 func firstNonEmptyLink(links *ContextLinks, getters ...func(*ContextLinks) string) string {
 	if links == nil {
 		return ""
@@ -557,16 +573,26 @@ func nonEmpty(parts ...string) []string {
 	return out
 }
 
-// plainHeadline renders the message-text fallback (used when blocks
-// aren't rendered).
+// plainHeadline renders the message-text fallback (used when blocks aren't
+// rendered).
 func plainHeadline(e Event, parent bool) string {
 	parts := []string{}
-	if icon := subjectIcon(e); icon != "" {
-		parts = append(parts, icon)
-	}
-	parts = append(parts, headerTitle(e))
-	if subj := subjectLabel(e); subj != "" {
-		parts = append(parts, "—", subj)
+	if parent {
+		if icon := workflowSubjectIcon(e); icon != "" {
+			parts = append(parts, icon)
+		}
+		parts = append(parts, workflowHeaderTitle(e))
+		if subj := workflowSubjectLabel(e); subj != "" {
+			parts = append(parts, "·", subj)
+		}
+	} else {
+		if icon := subjectIcon(e); icon != "" {
+			parts = append(parts, icon)
+		}
+		parts = append(parts, headerTitle(e))
+		if subj := subjectLabel(e); subj != "" {
+			parts = append(parts, "—", subj)
+		}
 	}
 	if e.Transition != "" {
 		parts = append(parts, "·", transitionPhrase(e.Transition))
@@ -574,53 +600,114 @@ func plainHeadline(e Event, parent bool) string {
 	return strings.Join(parts, " ")
 }
 
-// buildBlocks constructs the canonical two-block Slack message body:
-//
-//	SECTION: bold headline
-//	  (optional second mrkdwn line: status / latest line)
-//	CONTEXT: small grey footer parts joined by " · " + link chips
-//
-// All link chips render as separate context elements so Slack groups them
-// inline (slackbot inlines everything; we keep them split — see ctl-api
-// AGENTS.md for the rationale).
-func buildBlocks(headlineLine, statusLine string, footerParts []string, links []LinkChip) []any {
-	sectionText := headlineLine
-	if statusLine != "" {
-		sectionText = sectionText + "\n" + statusLine
+// subjectIcon returns the entity-kind glyph used by the plain-text
+// fallback for step events.
+func subjectIcon(e Event) string {
+	if (e.Kind == KindWorkflowStep || e.Kind == KindWorkflowStepApproval) && e.Step != nil {
+		switch e.Step.TargetType {
+		case TargetTypeInstallDeploys:
+			return "🧩"
+		case TargetTypeInstallSandboxRuns:
+			return "📦"
+		case TargetTypeInstallActionWorkflowRuns:
+			return "🏃"
+		case TargetTypeInstallCloudFormationStack,
+			TargetTypeInstallRunnerUpdate:
+			return "🏗"
+		}
 	}
-	blocks := []any{
-		map[string]any{
-			"type": "section",
-			"text": map[string]any{
-				"type": "mrkdwn",
-				"text": sectionText,
-			},
-		},
-	}
+	return workflowSubjectIcon(e)
+}
 
-	contextElements := []any{}
-	if len(footerParts) > 0 {
-		contextElements = append(contextElements, map[string]any{
-			"type": "mrkdwn",
-			"text": slackEscape(strings.Join(footerParts, " · ")),
-		})
+// --- Block Kit builders (slack-go typed) ---
+
+// headerBlock builds a large plain_text header block.
+func headerBlock(text string) *slack.HeaderBlock {
+	return slack.NewHeaderBlock(slack.NewTextBlockObject(slack.PlainTextType, truncateHeader(text), true, false))
+}
+
+// mrkdwnSection builds a single-text mrkdwn section block.
+func mrkdwnSection(text string) *slack.SectionBlock {
+	return slack.NewSectionBlock(slack.NewTextBlockObject(slack.MarkdownType, text, false, false), nil, nil)
+}
+
+// fieldsSection builds a section with a two-column mrkdwn field grid. Each
+// pair renders as a bold label above its value.
+func fieldsSection(pairs []kv) *slack.SectionBlock {
+	fields := make([]*slack.TextBlockObject, 0, len(pairs))
+	for _, p := range pairs {
+		fields = append(fields, slack.NewTextBlockObject(slack.MarkdownType, "*"+p.k+"*\n"+p.v, false, false))
+	}
+	return slack.NewSectionBlock(nil, fields, nil)
+}
+
+// errorSection builds the full-width error block for terminal failures.
+func errorSection(e Event) (*slack.SectionBlock, bool) {
+	if e.Outcome == nil || e.Outcome.Error == "" {
+		return nil, false
+	}
+	return mrkdwnSection("*Error*\n```" + trimContext(e.Outcome.Error, 500) + "```"), true
+}
+
+// contextBlock builds the small grey context line: footer parts joined by
+// " · " followed by link chips. Returns ok=false when empty.
+func contextBlock(parts []string, links []LinkChip) (*slack.ContextBlock, bool) {
+	elements := []slack.MixedElement{}
+	if len(parts) > 0 {
+		elements = append(elements, slack.NewTextBlockObject(slack.MarkdownType, slackEscape(strings.Join(parts, " · ")), false, false))
 	}
 	for _, link := range links {
 		if link.URL == "" {
 			continue
 		}
-		contextElements = append(contextElements, map[string]any{
-			"type": "mrkdwn",
-			"text": fmt.Sprintf("<%s|%s>", link.URL, link.Label),
-		})
+		elements = append(elements, slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("<%s|%s>", link.URL, link.Label), false, false))
 	}
-	if len(contextElements) > 0 {
-		blocks = append(blocks, map[string]any{
-			"type":     "context",
-			"elements": contextElements,
-		})
+	if len(elements) == 0 {
+		return nil, false
 	}
-	return blocks
+	return slack.NewContextBlock("", elements...), true
+}
+
+// actionsBlock builds an actions block of URL buttons. URL buttons
+// navigate without dispatching an interaction payload, so they need no
+// interactivity endpoint. Returns ok=false when there are no links.
+func actionsBlock(links []LinkChip) (*slack.ActionBlock, bool) {
+	elements := []slack.BlockElement{}
+	for _, link := range links {
+		if link.URL == "" {
+			continue
+		}
+		btn := slack.NewButtonBlockElement(
+			buttonActionID(link.Label),
+			"",
+			slack.NewTextBlockObject(slack.PlainTextType, link.Label, true, false),
+		)
+		btn.URL = link.URL
+		elements = append(elements, btn)
+	}
+	if len(elements) == 0 {
+		return nil, false
+	}
+	return slack.NewActionBlock("", elements...), true
+}
+
+// buttonActionID derives a stable action_id from a button label. URL
+// buttons don't dispatch interactions, but Slack still requires the field.
+func buttonActionID(label string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(label) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == ' ' || r == '_' || r == '-':
+			b.WriteByte('_')
+		}
+	}
+	id := strings.Trim(b.String(), "_")
+	if id == "" {
+		return "action"
+	}
+	return id
 }
 
 // slackEscape escapes the three characters Slack treats specially in

--- a/services/ctl-api/internal/pkg/slack/client/client.go
+++ b/services/ctl-api/internal/pkg/slack/client/client.go
@@ -23,6 +23,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/slack-go/slack"
 )
 
 // BaseURL is the public Slack Web API endpoint. Tests override this.
@@ -140,7 +142,7 @@ func (c *Client) OAuthV2Access(ctx context.Context, req OAuthV2AccessRequest) (*
 type PostMessageRequest struct {
 	Channel  string         `json:"channel"`
 	Text     string         `json:"text,omitempty"`
-	Blocks   []any          `json:"blocks,omitempty"`
+	Blocks   []slack.Block  `json:"blocks,omitempty"`
 	ThreadTS string         `json:"thread_ts,omitempty"`
 	Metadata map[string]any `json:"metadata,omitempty"`
 }
@@ -167,10 +169,10 @@ func (c *Client) PostMessage(ctx context.Context, botToken string, req PostMessa
 
 // UpdateMessageRequest mutates a previously posted message.
 type UpdateMessageRequest struct {
-	Channel string `json:"channel"`
-	TS      string `json:"ts"`
-	Text    string `json:"text,omitempty"`
-	Blocks  []any  `json:"blocks,omitempty"`
+	Channel string        `json:"channel"`
+	TS      string        `json:"ts"`
+	Text    string        `json:"text,omitempty"`
+	Blocks  []slack.Block `json:"blocks,omitempty"`
 }
 
 // UpdateMessageResponse mirrors chat.update's response.


### PR DESCRIPTION
Card-style Slack notifications (header + fields + buttons) built with slack-go typed blocks; parent shows workflow State + latest step, cleaner threaded replies.