### PR TITLE
feat(api/ui): install lifecycle status, improved deprovision ux/ui

### DIFF
--- a/services/ctl-api/internal/app/install.go
+++ b/services/ctl-api/internal/app/install.go
@@ -18,14 +18,25 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/links"
 )
 
+type InstallLifecycleStatus string
+
+const (
+	InstallLifecycleStatusProvisioning   InstallLifecycleStatus = "provisioning"
+	InstallLifecycleStatusProvisioned    InstallLifecycleStatus = "provisioned"
+	InstallLifecycleStatusDeprovisioning InstallLifecycleStatus = "deprovisioning"
+	InstallLifecycleStatusDeprovisioned  InstallLifecycleStatus = "deprovisioned"
+	InstallLifecycleStatusReprovisioning InstallLifecycleStatus = "reprovisioning"
+)
+
 type Install struct {
-	ID          string                `gorm:"primary_key;check:id_checker,char_length(id)=26" json:"id,omitzero" temporaljson:"id,omitzero,omitempty"`
-	CreatedByID string                `json:"created_by_id,omitzero" gorm:"not null;default:null" temporaljson:"created_by_id,omitzero,omitempty"`
-	CreatedBy   Account               `json:"-" temporaljson:"created_by,omitzero,omitempty"`
-	CreatedAt   time.Time             `json:"created_at,omitzero" gorm:"notnull" temporaljson:"created_at,omitzero,omitempty"`
-	UpdatedAt   time.Time             `json:"updated_at,omitzero" gorm:"notnull" temporaljson:"updated_at,omitzero,omitempty"`
-	DeletedAt   soft_delete.DeletedAt `gorm:"index:idx_app_install_name,unique" json:"-" temporaljson:"deleted_at,omitzero,omitempty"`
-	Metadata    pgtype.Hstore         `json:"metadata,omitzero" gorm:"type:hstore" swaggertype:"object,string" temporaljson:"metadata,omitzero,omitempty"`
+	ID              string                `gorm:"primary_key;check:id_checker,char_length(id)=26" json:"id,omitzero" temporaljson:"id,omitzero,omitempty"`
+	CreatedByID     string                `json:"created_by_id,omitzero" gorm:"not null;default:null" temporaljson:"created_by_id,omitzero,omitempty"`
+	CreatedBy       Account               `json:"-" temporaljson:"created_by,omitzero,omitempty"`
+	CreatedAt       time.Time             `json:"created_at,omitzero" gorm:"notnull" temporaljson:"created_at,omitzero,omitempty"`
+	UpdatedAt       time.Time             `json:"updated_at,omitzero" gorm:"notnull" temporaljson:"updated_at,omitzero,omitempty"`
+	DeletedAt       soft_delete.DeletedAt `gorm:"index:idx_app_install_name,unique" json:"-" temporaljson:"deleted_at,omitzero,omitempty"`
+	Metadata        pgtype.Hstore         `json:"metadata,omitzero" gorm:"type:hstore" swaggertype:"object,string" temporaljson:"metadata,omitzero,omitempty"`
+	LifecycleStatus CompositeStatus       `json:"lifecycle_status,omitzero" gorm:"type:jsonb" swaggertype:"object" temporaljson:"lifecycle_status,omitzero,omitempty"`
 	labels.Labeled
 
 	// used for RLS

--- a/services/ctl-api/internal/app/installs/service/create_install.go
+++ b/services/ctl-api/internal/app/installs/service/create_install.go
@@ -93,6 +93,12 @@ func (s *service) CreateInstallV2(ctx *gin.Context) {
 		return
 	}
 
+	lifecycleStatus := app.NewCompositeStatus(ctx, app.Status(app.InstallLifecycleStatusProvisioning))
+	lifecycleStatus.StatusHumanDescription = "Install is being provisioned"
+	s.db.WithContext(ctx).Model(&app.Install{ID: install.ID}).Updates(map[string]any{
+		"lifecycle_status": lifecycleStatus,
+	})
+
 	// Send signals via queues
 	signalsQueueID, err := s.getInstallSignalsQueueID(ctx, install.ID)
 	if err != nil {
@@ -218,6 +224,12 @@ func (s *service) CreateInstall(ctx *gin.Context) {
 		ctx.Error(err)
 		return
 	}
+
+	lifecycleStatus := app.NewCompositeStatus(ctx, app.Status(app.InstallLifecycleStatusProvisioning))
+	lifecycleStatus.StatusHumanDescription = "Install is being provisioned"
+	s.db.WithContext(ctx).Model(&app.Install{ID: install.ID}).Updates(map[string]any{
+		"lifecycle_status": lifecycleStatus,
+	})
 
 	// Send signals via queues
 	signalsQueueID, err := s.getInstallSignalsQueueID(ctx, install.ID)

--- a/services/ctl-api/internal/app/installs/service/delete_install.go
+++ b/services/ctl-api/internal/app/installs/service/delete_install.go
@@ -48,6 +48,12 @@ func (s *service) DeleteInstall(ctx *gin.Context) {
 		return
 	}
 
+	lifecycleStatus := app.NewCompositeStatus(ctx, app.Status(app.InstallLifecycleStatusDeprovisioning))
+	lifecycleStatus.StatusHumanDescription = "Install is being deprovisioned"
+	s.db.WithContext(ctx).Model(&app.Install{ID: install.ID}).Updates(map[string]any{
+		"lifecycle_status": lifecycleStatus,
+	})
+
 	workflowsQueueID, err := s.getInstallWorkflowsQueueID(ctx, install.ID)
 	if err != nil {
 		ctx.Error(err)

--- a/services/ctl-api/internal/app/installs/service/deprovision_install.go
+++ b/services/ctl-api/internal/app/installs/service/deprovision_install.go
@@ -68,6 +68,13 @@ func (s *service) DeprovisionInstall(ctx *gin.Context) {
 		ctx.Error(err)
 		return
 	}
+
+	lifecycleStatus := app.NewCompositeStatus(ctx, app.Status(app.InstallLifecycleStatusDeprovisioning))
+	lifecycleStatus.StatusHumanDescription = "Install is being deprovisioned"
+	s.db.WithContext(ctx).Model(&app.Install{ID: install.ID}).Updates(map[string]any{
+		"lifecycle_status": lifecycleStatus,
+	})
+
 	queueID, err := s.getInstallWorkflowsQueueID(ctx, install.ID)
 	if err != nil {
 		ctx.Error(err)

--- a/services/ctl-api/internal/app/installs/signals/componentteardownapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentteardownapplyplan/signal.go
@@ -223,7 +223,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		DeployID: installDeploy.ID,
 	})
 
-	s.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusInactive, "successfully torn down")
+	s.updateDeployStatus(ctx, installDeploy.ID, app.InstallDeployStatusInactive, "successfully torn down")
 	s.updateInstallComponentStatus(ctx, installDeploy.InstallComponentID, app.InstallComponentStatusInactive, "successfully torn down")
 
 	orgEnabled, err := activities.AwaitHasFeatureByFeature(ctx, string(app.OrgFeatureStateGenV2))

--- a/services/ctl-api/internal/pkg/workflows/status/activities/update.go
+++ b/services/ctl-api/internal/pkg/workflows/status/activities/update.go
@@ -695,6 +695,30 @@ func (a *Activities) UpdateQueueStatusV2(ctx context.Context, req UpdateQueueSta
 	return a.updateStatusV2(ctx, &obj, status, getter)
 }
 
+type UpdateInstallLifecycleStatusV2Request struct {
+	InstallID         string                     `validate:"required"`
+	Status            app.InstallLifecycleStatus `validate:"required"`
+	StatusDescription string                     `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+// @by-field InstallID
+func (a *Activities) UpdateInstallLifecycleStatusV2(ctx context.Context, req UpdateInstallLifecycleStatusV2Request) error {
+	obj := app.Install{ID: req.InstallID}
+
+	getter := func(ctx context.Context) (app.CompositeStatus, error) {
+		var obj app.Install
+		if err := a.getStatus(ctx, &obj, req.InstallID); err != nil {
+			return app.CompositeStatus{}, err
+		}
+		return obj.LifecycleStatus, nil
+	}
+
+	status := app.NewCompositeStatus(ctx, app.Status(req.Status))
+	status.StatusHumanDescription = req.StatusDescription
+	return a.updateStatusCommon(ctx, &obj, status, getter, "lifecycle_status")
+}
+
 type UpdateQueueSignalStatusV2Request struct {
 	QueueSignalID     string     `validate:"required"`
 	Status            app.Status `validate:"required"`

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/update_flow_finished_at.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/update_flow_finished_at.go
@@ -17,8 +17,6 @@ type UpdateFlowFinishedAtRequest struct {
 // @temporal-gen-v2 activity
 // @by-field ID
 func (a *Activities) PkgWorkflowsFlowUpdateFlowFinishedAt(ctx context.Context, req UpdateFlowFinishedAtRequest) error {
-	// Load-then-Save so Workflow.BeforeSave fires and recomputes name to
-	// the past-tense title once finished_at is set.
 	var runner app.Workflow
 	if err := a.db.WithContext(ctx).Where("id = ?", req.ID).Take(&runner).Error; err != nil {
 		return generics.TemporalGormError(gorm.ErrRecordNotFound)
@@ -26,6 +24,52 @@ func (a *Activities) PkgWorkflowsFlowUpdateFlowFinishedAt(ctx context.Context, r
 	runner.FinishedAt = time.Now()
 	if err := a.db.WithContext(ctx).Save(&runner).Error; err != nil {
 		return generics.TemporalGormError(gorm.ErrRecordNotFound)
+	}
+
+	if runner.OwnerType == "installs" {
+		if newLifecycle := a.installLifecycleTransition(&runner); newLifecycle != nil {
+			var install app.Install
+			if err := a.db.WithContext(ctx).Where(app.Install{ID: runner.OwnerID}).First(&install).Error; err == nil {
+				existing := install.LifecycleStatus
+				existing.History = nil
+				newLifecycle.CreatedAtTS = time.Now().Unix()
+				newLifecycle.History = append([]app.CompositeStatus{existing}, install.LifecycleStatus.History...)
+				if len(newLifecycle.History) > 25 {
+					newLifecycle.History = newLifecycle.History[:25]
+				}
+				a.db.WithContext(ctx).Model(&app.Install{ID: runner.OwnerID}).Updates(map[string]any{
+					"lifecycle_status": newLifecycle,
+				})
+			}
+		}
+	}
+
+	return nil
+}
+
+func (a *Activities) installLifecycleTransition(wf *app.Workflow) *app.CompositeStatus {
+	failed := wf.Status.Status == app.StatusError || wf.Status.Status == app.StatusCancelled
+
+	switch wf.Type {
+	case app.WorkflowTypeProvision:
+		status := app.InstallLifecycleStatusProvisioned
+		description := "Install has been provisioned"
+		if failed {
+			description = "Install provision failed"
+		}
+		return &app.CompositeStatus{
+			Status:                 app.Status(status),
+			StatusHumanDescription: description,
+		}
+	case app.WorkflowTypeDeprovision:
+		description := "Install has been deprovisioned"
+		if failed {
+			description = "Install deprovision failed"
+		}
+		return &app.CompositeStatus{
+			Status:                 app.Status(app.InstallLifecycleStatusDeprovisioned),
+			StatusHumanDescription: description,
+		}
 	}
 	return nil
 }

--- a/services/dashboard-ui/client/components/common/Loading.tsx
+++ b/services/dashboard-ui/client/components/common/Loading.tsx
@@ -4,22 +4,27 @@ export const Loading = ({
   className,
   strokeWidth = 'default',
   variant = 'default',
+  size,
 }: {
   className?: string
   strokeWidth?: 'default' | 'thick'
   variant?: 'default' | 'large'
+  size?: number | string
 }) => {
+  const sizeStyle = size ? { width: Number(size), height: Number(size) } : undefined
+
   return (
     <span className="animate-pulse">
       <svg
         className={cn(
           'animate-spin',
           {
-            'h-5 w-5': variant === 'default',
-            'h-10 w-10': variant === 'large',
+            'h-5 w-5': !size && variant === 'default',
+            'h-10 w-10': !size && variant === 'large',
           },
           className
         )}
+        style={sizeStyle}
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/services/dashboard-ui/client/components/common/Status.tsx
+++ b/services/dashboard-ui/client/components/common/Status.tsx
@@ -98,15 +98,16 @@ export const Status = ({
     INDICATOR_BASE,
     INDICATOR_SIZE[variant],
     INDICATOR_THEME_CLASSES[variant][theme],
-    {
-      [`h-[${iconSize + 8}px] w-[${iconSize + 8}px]`]: variant === 'timeline',
-    }
   )
+  const indicatorStyle =
+    variant === 'timeline'
+      ? { width: iconSize + 8, height: iconSize + 8 }
+      : undefined
   const statusTextClass = STATUS_TEXT_CLASSES[variant]
 
   return (
     <span className={rootClass} {...props}>
-      <span className={indicatorClass}>
+      <span className={indicatorClass} style={indicatorStyle}>
         {iconVariant ? (
           <Icon
             className="status-icon"

--- a/services/dashboard-ui/client/components/components/ComponentsTooltip.tsx
+++ b/services/dashboard-ui/client/components/components/ComponentsTooltip.tsx
@@ -26,23 +26,65 @@ export function getContextTooltipItemsFromComponents(
   }))
 }
 
+const DEPROVISIONING_COMPONENT_SUBTITLES: Record<string, string> = {
+  executing: 'Tearing down',
+  active: 'Waiting to teardown',
+  pending: 'Tearing down',
+  success: 'Teardown complete',
+  error: 'Teardown failed',
+}
+
+const DEPROVISIONED_COMPONENT_SUBTITLES: Record<string, string> = {
+  executing: 'Torn down',
+  active: 'Torn down',
+  pending: 'Torn down',
+  success: 'Torn down',
+  inactive: 'Torn down',
+  error: 'Teardown failed',
+}
+
+function getComponentSubtitle(
+  status: string | undefined,
+  lifecycleStatus?: string
+): string {
+  if (!status) return toSentenceCase(status)
+  if (lifecycleStatus === 'deprovisioned') {
+    return DEPROVISIONED_COMPONENT_SUBTITLES[status] ?? toSentenceCase(status)
+  }
+  if (lifecycleStatus === 'deprovisioning') {
+    return DEPROVISIONING_COMPONENT_SUBTITLES[status] ?? toSentenceCase(status)
+  }
+  return toSentenceCase(status)
+}
+
 export function getContextTooltipItemsFromInstallComponents(
   components: TInstallComponent[],
-  pathname: string
+  pathname: string,
+  lifecycleStatus?: string
 ): TContextTooltipItem[] {
+  const isDeprovisioning = lifecycleStatus === 'deprovisioning'
+  const isDeprovisioned = lifecycleStatus === 'deprovisioned'
+  const STALE_STATUSES = ['active', 'pending', 'executing', 'queued', 'planning', 'syncing']
+  const effectiveStatus = (status: string | undefined) => {
+    if (!status) return status
+    if (isDeprovisioned && STALE_STATUSES.includes(status)) return 'deprovisioned'
+    if (isDeprovisioning && STALE_STATUSES.includes(status)) return 'deprovisioning'
+    return status
+  }
+
   return components?.map((comp) => ({
     id: comp?.component_id,
     href: `${pathname}/${comp?.component_id}`,
     leftContent: (
       <Status
-        status={comp?.status_v2?.status}
+        status={effectiveStatus(comp?.status_v2?.status)}
         isWithoutText
         variant="timeline"
         iconSize={16}
       />
     ),
     title: comp?.component?.name,
-    subtitle: toSentenceCase(comp?.status_v2?.status),
+    subtitle: getComponentSubtitle(comp?.status_v2?.status, lifecycleStatus),
   }))
 }
 

--- a/services/dashboard-ui/client/components/installs/DeprovisionBanner/DeprovisionBanner.stories.tsx
+++ b/services/dashboard-ui/client/components/installs/DeprovisionBanner/DeprovisionBanner.stories.tsx
@@ -1,0 +1,52 @@
+export default {
+  title: 'Installs/DeprovisionBanner',
+}
+
+import { DeprovisionBanner } from './DeprovisionBanner'
+
+const mockProvisioning = {
+  id: 'inst123',
+  name: 'test-install',
+  lifecycle_status: {
+    status: 'provisioning',
+    status_human_description: 'Install is being provisioned',
+  },
+} as any
+
+const mockDeprovisioning = {
+  id: 'inst123',
+  name: 'test-install',
+  lifecycle_status: {
+    status: 'deprovisioning',
+    status_human_description: 'Install is being deprovisioned',
+  },
+} as any
+
+const mockDeprovisioned = {
+  id: 'inst123',
+  name: 'test-install',
+  lifecycle_status: {
+    status: 'deprovisioned',
+    status_human_description: 'Install has been deprovisioned',
+  },
+} as any
+
+export const Provisioning = () => (
+  <DeprovisionBanner
+    install={mockProvisioning}
+    orgId="org123"
+    workflowId="wf123"
+  />
+)
+
+export const Deprovisioning = () => (
+  <DeprovisionBanner
+    install={mockDeprovisioning}
+    orgId="org123"
+    workflowId="wf123"
+  />
+)
+
+export const Deprovisioned = () => (
+  <DeprovisionBanner install={mockDeprovisioned} orgId="org123" />
+)

--- a/services/dashboard-ui/client/components/installs/DeprovisionBanner/DeprovisionBanner.tsx
+++ b/services/dashboard-ui/client/components/installs/DeprovisionBanner/DeprovisionBanner.tsx
@@ -1,0 +1,63 @@
+import { Banner } from '@/components/common/Banner'
+import { Icon } from '@/components/common/Icon'
+import { Link } from '@/components/common/Link'
+import { Text } from '@/components/common/Text'
+import type { TBannerTheme } from '@/components/common/Banner'
+import type { TInstall } from '@/types'
+
+export interface IDeprovisionBanner {
+  install: TInstall
+  orgId: string
+  workflowId?: string
+}
+
+const LIFECYCLE_CONFIG: Record<
+  string,
+  { heading: string; theme: TBannerTheme }
+> = {
+  provisioning: {
+    heading: 'This install is being provisioned',
+    theme: 'info',
+  },
+  deprovisioning: {
+    heading: 'This install is being deprovisioned',
+    theme: 'warn',
+  },
+  deprovisioned: {
+    heading: 'This install has been deprovisioned',
+    theme: 'warn',
+  },
+}
+
+export const DeprovisionBanner = ({
+  install,
+  orgId,
+  workflowId,
+}: IDeprovisionBanner) => {
+  const status = install?.lifecycle_status?.status ?? ''
+  const config = LIFECYCLE_CONFIG[status]
+  if (!config) return null
+
+  return (
+    <Banner theme={config.theme} className="rounded-none border-x-0 border-t-0">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-col gap-0.5">
+          <Text weight="strong">{config.heading}</Text>
+          {install?.lifecycle_status?.status_human_description && (
+            <Text variant="subtext">
+              {install.lifecycle_status.status_human_description}
+            </Text>
+          )}
+        </div>
+        {workflowId && (
+          <Link
+            href={`/${orgId}/installs/${install.id}/workflows/${workflowId}`}
+            className="flex items-center gap-1 text-sm shrink-0"
+          >
+            View workflow <Icon variant="ArrowRightIcon" size={14} />
+          </Link>
+        )}
+      </div>
+    </Banner>
+  )
+}

--- a/services/dashboard-ui/client/components/installs/DeprovisionBanner/DeprovisionBannerContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/DeprovisionBanner/DeprovisionBannerContainer.tsx
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query'
+import { useInstall } from '@/hooks/use-install'
+import { useOrg } from '@/hooks/use-org'
+import { getInstallWorkflows } from '@/lib'
+import { DeprovisionBanner } from './DeprovisionBanner'
+
+const BANNER_STATUSES = ['provisioning', 'deprovisioning', 'deprovisioned']
+
+export const DeprovisionBannerContainer = () => {
+  const { org } = useOrg()
+  const { install } = useInstall()
+
+  const lifecycleStatus = install?.lifecycle_status?.status
+  const showBanner = !!lifecycleStatus && BANNER_STATUSES.includes(lifecycleStatus)
+
+  const { data: workflows } = useQuery({
+    queryKey: ['install-workflows', org?.id, install?.id, 'lifecycle-banner'],
+    queryFn: () =>
+      getInstallWorkflows({ installId: install!.id, orgId: org!.id }),
+    enabled:
+      !!org?.id &&
+      !!install?.id &&
+      (lifecycleStatus === 'deprovisioning' ||
+        lifecycleStatus === 'provisioning'),
+  })
+
+  if (!showBanner) return null
+
+  const activeWorkflow = workflows?.data?.find((w) => !w.finished_at)
+
+  return (
+    <DeprovisionBanner
+      install={install}
+      orgId={org?.id ?? ''}
+      workflowId={activeWorkflow?.id}
+    />
+  )
+}

--- a/services/dashboard-ui/client/components/installs/DeprovisionBanner/index.ts
+++ b/services/dashboard-ui/client/components/installs/DeprovisionBanner/index.ts
@@ -1,0 +1,2 @@
+export { DeprovisionBannerContainer as DeprovisionBanner } from './DeprovisionBannerContainer'
+export { DeprovisionBanner as DeprovisionBannerComponent } from './DeprovisionBanner'

--- a/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.tsx
+++ b/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.tsx
@@ -93,6 +93,18 @@ export const InstallStatuses = ({
   stack,
   ...props
 }: IInstallStatuses) => {
+  const lifecycleStatus = install?.lifecycle_status?.status
+  const isDeprovisioning = lifecycleStatus === 'deprovisioning'
+  const isDeprovisioned = lifecycleStatus === 'deprovisioned'
+
+  const STALE_STATUSES = ['active', 'pending', 'executing', 'queued', 'planning', 'syncing']
+  const effectiveStatus = (status: string | undefined) => {
+    if (!status) return status
+    if (isDeprovisioned && STALE_STATUSES.includes(status)) return 'deprovisioned'
+    if (isDeprovisioning && STALE_STATUSES.includes(status)) return 'deprovisioning'
+    return status
+  }
+
   const driftStatus = install?.drifted_objects?.length ? 'warn' : 'active'
   const latestStackVersion = stack?.versions?.[0]
   const stackStatus = latestStackVersion?.composite_status?.status
@@ -172,11 +184,12 @@ export const InstallStatuses = ({
           title: `${install.runner_type === 'aws' ? 'AWS' : toSentenceCase(install?.runner_type)} runner`,
           subtitle: getInstallStatusTitle(
             'runner_status',
-            install?.runner_status
+            install?.runner_status,
+            install?.lifecycle_status?.status
           ),
           leftContent: (
             <Status
-              status={install?.runner_status}
+              status={effectiveStatus(install?.runner_status)}
               isWithoutText
               variant="timeline"
               iconSize={16}
@@ -186,7 +199,7 @@ export const InstallStatuses = ({
       ]}
     >
       {variant === 'icon' ? (
-        <Text theme={getStatusTheme(install.runner_status ?? '')}>
+        <Text theme={getStatusTheme(effectiveStatus(install.runner_status) ?? '')}>
           <Icon
             variant="SneakerMoveIcon"
             size={14}
@@ -194,8 +207,8 @@ export const InstallStatuses = ({
           />
         </Text>
       ) : (
-        <Status status={install.runner_status} variant="badge">
-          {isLabelHidden ? 'Runner' : install.runner_status}
+        <Status status={effectiveStatus(install.runner_status)} variant="badge">
+          {isLabelHidden ? 'Runner' : effectiveStatus(install.runner_status)}
         </Status>
       )}
     </ContextTooltip>
@@ -212,11 +225,12 @@ export const InstallStatuses = ({
           title: toSentenceCase(install?.install_sandbox_runs?.at(0)?.run_type),
           subtitle: getInstallStatusTitle(
             'sandbox_status',
-            install?.sandbox_status
+            install?.sandbox_status,
+            install?.lifecycle_status?.status
           ),
           leftContent: (
             <Status
-              status={install.sandbox_status}
+              status={effectiveStatus(install.sandbox_status)}
               isWithoutText
               variant="timeline"
               iconSize={16}
@@ -226,7 +240,7 @@ export const InstallStatuses = ({
       ]}
     >
       {variant === 'icon' ? (
-        <Text theme={getStatusTheme(install.sandbox_status ?? '')}>
+        <Text theme={getStatusTheme(effectiveStatus(install.sandbox_status) ?? '')}>
           <Icon
             variant="ShippingContainerIcon"
             size={14}
@@ -234,8 +248,8 @@ export const InstallStatuses = ({
           />
         </Text>
       ) : (
-        <Status status={install.sandbox_status} variant="badge">
-          {isLabelHidden ? 'Sandbox' : install.sandbox_status}
+        <Status status={effectiveStatus(install.sandbox_status)} variant="badge">
+          {isLabelHidden ? 'Sandbox' : effectiveStatus(install.sandbox_status)}
         </Status>
       )}
     </ContextTooltip>
@@ -245,21 +259,23 @@ export const InstallStatuses = ({
     <ComponentsTooltip
       title={getInstallStatusTitle(
         'composite_component_status',
-        install?.composite_component_status
+        install?.composite_component_status,
+        install?.lifecycle_status?.status
       )}
       componentSummaries={getContextTooltipItemsFromInstallComponents(
         install?.install_components as TInstallComponent[],
-        `/${install.org_id}/installs/${install.id}/components`
+        `/${install.org_id}/installs/${install.id}/components`,
+        install?.lifecycle_status?.status
       )}
       position={tooltipPosition}
     >
       {variant === 'icon' ? (
-        <Text theme={getStatusTheme(install.composite_component_status ?? '')}>
+        <Text theme={getStatusTheme(effectiveStatus(install.composite_component_status) ?? '')}>
           <Icon variant="CardsIcon" size={14} className="cursor-default" />
         </Text>
       ) : (
-        <Status status={install.composite_component_status} variant="badge">
-          {isLabelHidden ? 'Components' : install.composite_component_status}
+        <Status status={effectiveStatus(install.composite_component_status)} variant="badge">
+          {isLabelHidden ? 'Components' : effectiveStatus(install.composite_component_status)}
         </Status>
       )}
     </ComponentsTooltip>
@@ -318,9 +334,9 @@ export const InstallStatuses = ({
   const allStatuses = [
     install?.drifted_objects?.length ? 'warn' : 'active',
     stackStatus,
-    install?.runner_status,
-    install?.sandbox_status,
-    install?.composite_component_status,
+    effectiveStatus(install?.runner_status),
+    effectiveStatus(install?.sandbox_status),
+    effectiveStatus(install?.composite_component_status),
   ]
   const { worstStatus } = getWorstStatusTheme(allStatuses)
 
@@ -368,11 +384,11 @@ export const InstallStatuses = ({
     {
       id: 'runner',
       title: 'Runner',
-      subtitle: getInstallStatusTitle('runner_status', install?.runner_status),
+      subtitle: getInstallStatusTitle('runner_status', install?.runner_status, install?.lifecycle_status?.status),
       href: `/${install.org_id}/installs/${install.id}/runner`,
       leftContent: (
         <Status
-          status={install?.runner_status}
+          status={effectiveStatus(install?.runner_status)}
           isWithoutText
           variant="timeline"
           iconSize={16}
@@ -384,12 +400,13 @@ export const InstallStatuses = ({
       title: 'Sandbox',
       subtitle: getInstallStatusTitle(
         'sandbox_status',
-        install?.sandbox_status
+        install?.sandbox_status,
+        install?.lifecycle_status?.status
       ),
       href: `/${install.org_id}/installs/${install.id}/sandbox`,
       leftContent: (
         <Status
-          status={install?.sandbox_status}
+          status={effectiveStatus(install?.sandbox_status)}
           isWithoutText
           variant="timeline"
           iconSize={16}
@@ -401,12 +418,13 @@ export const InstallStatuses = ({
       title: 'Components',
       subtitle: getInstallStatusTitle(
         'composite_component_status',
-        install?.composite_component_status
+        install?.composite_component_status,
+        install?.lifecycle_status?.status
       ),
       href: `/${install.org_id}/installs/${install.id}/components`,
       leftContent: (
         <Status
-          status={install?.composite_component_status}
+          status={effectiveStatus(install?.composite_component_status)}
           isWithoutText
           variant="timeline"
           iconSize={16}

--- a/services/dashboard-ui/client/types/ctl-api.types.ts
+++ b/services/dashboard-ui/client/types/ctl-api.types.ts
@@ -183,6 +183,10 @@ export type TInstall = Omit<components['schemas']['app.Install'], 'sandbox'> & {
   app?: components['schemas']['app.App']
   created_by?: components['schemas']['app.Account']
   gcp_account?: { project_id?: string; region?: string }
+  lifecycle_status?: {
+    status?: string
+    status_human_description?: string
+  }
   org_id?: string
   sandbox?: TInstallSandbox
 }

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -3772,6 +3772,7 @@ export interface components {
       install_stack?: components["schemas"]["app.InstallStack"];
       install_states?: components["schemas"]["app.InstallState"][];
       labels?: components["schemas"]["github_com_nuonco_nuon_pkg_labels.Labels"];
+      lifecycle_status?: Record<string, never>;
       links?: {
         [key: string]: unknown;
       };

--- a/services/dashboard-ui/client/utils/install-utils.ts
+++ b/services/dashboard-ui/client/utils/install-utils.ts
@@ -44,7 +44,40 @@ const COMPONENTS_STATUS_TITLES: TTitleMap = {
   unknown: 'Deployment status is unknown',
 }
 
-// Helper for fallback
+const DEPROVISIONING_RUNNER_OVERRIDES: TTitleMap = {
+  active: 'Runner waiting to teardown',
+  deprovisioned: 'Runner teardown complete',
+}
+
+const DEPROVISIONED_RUNNER_OVERRIDES: TTitleMap = {
+  active: 'Runner torn down',
+  deprovisioned: 'Runner teardown complete',
+}
+
+const DEPROVISIONING_SANDBOX_OVERRIDES: TTitleMap = {
+  active: 'Sandbox waiting to teardown',
+  deprovisioned: 'Sandbox teardown complete',
+  deprovisioning: 'Sandbox tearing down',
+}
+
+const DEPROVISIONED_SANDBOX_OVERRIDES: TTitleMap = {
+  active: 'Sandbox torn down',
+  deprovisioned: 'Sandbox teardown complete',
+  deprovisioning: 'Sandbox torn down',
+}
+
+const DEPROVISIONING_COMPONENTS_OVERRIDES: TTitleMap = {
+  active: 'Components waiting to teardown',
+  pending: 'Components tearing down',
+  executing: 'Components tearing down',
+}
+
+const DEPROVISIONED_COMPONENTS_OVERRIDES: TTitleMap = {
+  active: 'Components torn down',
+  pending: 'Components torn down',
+  executing: 'Components torn down',
+}
+
 function getStatusTitle(
   map: TTitleMap,
   status: string,
@@ -79,8 +112,26 @@ export function getInstallComponentsStatusTitle(status: string): string {
 
 export function getInstallStatusTitle(
   statusKey: string,
-  status: string
+  status: string,
+  lifecycleStatus?: string
 ): string {
+  if (lifecycleStatus === 'deprovisioning' || lifecycleStatus === 'deprovisioned') {
+    const isFinished = lifecycleStatus === 'deprovisioned'
+    let override: string | undefined
+    switch (statusKey) {
+      case 'runner_status':
+        override = (isFinished ? DEPROVISIONED_RUNNER_OVERRIDES : DEPROVISIONING_RUNNER_OVERRIDES)[status]
+        break
+      case 'sandbox_status':
+        override = (isFinished ? DEPROVISIONED_SANDBOX_OVERRIDES : DEPROVISIONING_SANDBOX_OVERRIDES)[status]
+        break
+      case 'composite_component_status':
+        override = (isFinished ? DEPROVISIONED_COMPONENTS_OVERRIDES : DEPROVISIONING_COMPONENTS_OVERRIDES)[status]
+        break
+    }
+    if (override) return override
+  }
+
   switch (statusKey) {
     case 'runner_status':
       return getInstallRunnerStatusTitle(status)

--- a/services/dashboard-ui/client/utils/status-utils.test.ts
+++ b/services/dashboard-ui/client/utils/status-utils.test.ts
@@ -59,7 +59,7 @@ describe('status-utils', () => {
       expect(getStatusTheme('Not deployed')).toBe('neutral')
       expect(getStatusTheme('No build')).toBe('neutral')
       expect(getStatusTheme('not-attempted')).toBe('neutral')
-      expect(getStatusTheme('deprovisioned')).toBe('neutral')
+      expect(getStatusTheme('deprovisioned')).toBe('warn')
       expect(getStatusTheme('skeleton')).toBe('neutral')
     })
 
@@ -103,7 +103,7 @@ describe('status-utils', () => {
 
     test('should return ClockCountdown for neutral statuses', () => {
       expect(getStatusIconVariant('pending')).toBe('ClockCountdownIcon')
-      expect(getStatusIconVariant('inactive')).toBe('ClockCountdownIcon')
+      expect(getStatusIconVariant('inactive')).toBe('WarningIcon')
       expect(getStatusIconVariant('offline')).toBe('ClockCountdownIcon')
     })
 

--- a/services/dashboard-ui/client/utils/status-utils.ts
+++ b/services/dashboard-ui/client/utils/status-utils.ts
@@ -61,6 +61,8 @@ const STATUS_THEME_MAP: Record<string, TStatusTheme> = {
   retried: 'info',
   applying: 'info',
   'awaiting-user-run': 'info',
+  deprovisioning: 'info',
+  reprovisioning: 'info',
 
   // Neutral
   noop: 'neutral',
@@ -71,7 +73,7 @@ const STATUS_THEME_MAP: Record<string, TStatusTheme> = {
   'Not deployed': 'neutral',
   'No build': 'neutral',
   'not-attempted': 'neutral',
-  deprovisioned: 'neutral',
+  deprovisioned: 'warn',
   skeleton: 'neutral',
 
   // Brand
@@ -124,15 +126,17 @@ const STATUS_ICON_MAP: Record<string, TIconVariant> = {
   available: 'Loading',
   'pending-approval': 'Loading',
   info: 'Loading',
+  deprovisioning: 'Loading',
+  reprovisioning: 'Loading',
 
   // Neutral
   noop: 'ClockCountdownIcon',
-  inactive: 'ClockCountdownIcon',
+  inactive: 'WarningIcon',
   pending: 'ClockCountdownIcon',
   offline: 'ClockCountdownIcon',
   'Not deployed': 'ClockCountdownIcon',
   'No build': 'ClockCountdownIcon',
-  deprovisioned: 'ClockCountdownIcon',
+  deprovisioned: 'WarningIcon',
 
   // skipped
   'auto-skipped': 'MinusCircleIcon',

--- a/services/dashboard-ui/client/views/install/InstallLayout.tsx
+++ b/services/dashboard-ui/client/views/install/InstallLayout.tsx
@@ -7,6 +7,7 @@ import { LabeledValue } from '@/components/common/LabeledValue'
 import { Link } from '@/components/common/Link'
 import { Time } from '@/components/common/Time'
 import { Text } from '@/components/common/Text'
+import { DeprovisionBanner } from '@/components/installs/DeprovisionBanner'
 import { DriftedSummary } from '@/components/installs/DriftedSummary'
 import { InstallStatusesContainer } from '@/components/installs/InstallStatuses'
 import { InstallManagementDropdown } from '@/components/installs/management/InstallManagementDropdown'
@@ -124,6 +125,7 @@ const InstallTemplate = () => {
 
   return (
     <PageLayout>
+      <DeprovisionBanner />
       {isChildRoute ? (
         <PageContent className="border-t" variant="row">
           <SubNav


### PR DESCRIPTION
## API updates
- Added `InstallLifecycleStatus` type and `LifecycleStatus CompositeStatus JSONB` column to the Install model (auto-migrated by GORM)
- Added `UpdateInstallLifecycleStatusV2` Temporal activity for future workflow use
- Set lifecycle status to provisioning when creating an install
- Set lifecycle status to deprovisioning when deprovisioning or deleting an install
- Transition lifecycle status to provisioned or deprovisioned when the workflow finishes (with history tracking, handles error/cancelled)
- Fixed component teardown not updating status_v2 — changed to sync deploy status to install component so status_v2 reflects the actual torn-down state

## Dashboard updates
- Added lifecycle banner that shows during provisioning (blue), deprovisioning (amber), and after deprovisioned (amber) with a link to the active
  workflow — disappears once provisioned
- Added deprovision-contextual status titles for runner, sandbox, and components (e.g. "Runner waiting to teardown", "Components tearing down", "Torn
  down")
- Override stale sub-statuses (active, pending, executing) with the lifecycle status so badges and icons reflect the actual state during and after
  deprovision
- Mapped deprovisioning/reprovisioning to info theme (blue/loading) and deprovisioned to warn theme (amber/warning icon)
- Changed inactive icon from clock to warning icon
- Fixed Status timeline variant circles not rendering — dynamic Tailwind class was never generated, replaced with inline style
- Fixed Loading spinner ignoring the size prop in timeline contexts