### PR TITLE
fix: ensure PATCH -ing install inputs accepts a subset of inputs

### DIFF
--- a/bins/cli/internal/services/installs/app_install_syncer.go
+++ b/bins/cli/internal/services/installs/app_install_syncer.go
@@ -313,30 +313,23 @@ func (s *appInstallSyncer) syncExistingInstall(
 		}
 	}
 
-	// Use the current inputs as defaults, for missing values in the current inputs.
-	installCfg.InputGroups = append([]config.InputGroup{{
-		Inputs: currInputs.Values,
-	}}, installCfg.InputGroups...)
-
-	installCfgInputs := installCfg.FlattenedInputs()
-
+	// Only send the inputs explicitly defined in the install config file. The API
+	// merges them with the install's existing values server-side, so we don't
+	// re-send the full set — in particular install_stack sourced inputs, which the
+	// API rejects. definedInputs was computed above from the config file.
 	hasInputChanged := false
-	if len(installCfgInputs) != len(currInputs.Values) {
-		hasInputChanged = true
-	} else {
-		// length is same, go through each input to see if any have changed.
-		for k, v := range installCfgInputs {
-			if currInputs.Values[k] != v {
-				hasInputChanged = true
-				break
-			}
+	for k, v := range definedInputs {
+		if cur, ok := currInputs.Values[k]; !ok || cur != v {
+			hasInputChanged = true
+			break
 		}
 	}
 
-	// If inputs have divereged, update the install inputs.
+	// If any defined input has diverged from the install's current value, update
+	// the install inputs.
 	if hasInputChanged {
 		installInputs, err := s.api.UpdateInstallInputs(ctx, appInstall.ID, &models.ServiceUpdateInstallInputsRequest{
-			Inputs: installCfgInputs,
+			Inputs: definedInputs,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("error updating inputs for install %s: %w", appInstall.Name, err)

--- a/bins/cli/internal/services/installs/inputs.go
+++ b/bins/cli/internal/services/installs/inputs.go
@@ -127,26 +127,24 @@ func (s *Service) SetInputs(ctx context.Context, installID string, args []string
 	prevValues := currentValues(current)
 	prevRedacted := redactedValues(current)
 
-	// The update endpoint expects the full set of inputs, so start from the
-	// existing values and merge in only the keys that are being changed.
-	merged := make(map[string]string, len(prevValues)+len(updates))
-	for k, v := range prevValues {
-		merged[k] = v
-	}
-
-	// Track which inputs actually changed (new value differs from the
-	// original), so we can render an accurate CHANGED column.
+	// The update endpoint accepts a partial set of inputs and merges them with
+	// the install's existing values server-side, so we only send the subset the
+	// caller is changing. This also avoids re-sending install_stack sourced inputs,
+	// which the API rejects.
+	//
+	// We still fetched the current inputs above to track which keys actually
+	// changed (new value differs from the original), so we can render an accurate
+	// CHANGED column.
 	changed := make(map[string]bool, len(updates))
 	for k, v := range updates {
 		prev, ok := prevValues[k]
 		if !ok || prev != v {
 			changed[k] = true
 		}
-		merged[k] = v
 	}
 
 	request := &models.ServiceUpdateInstallInputsRequest{
-		Inputs:           merged,
+		Inputs:           updates,
 		DeployDependents: &deployDependents,
 	}
 	if config.Debug() {
@@ -155,7 +153,10 @@ func (s *Service) SetInputs(ctx context.Context, installID string, args []string
 
 	resp, err := s.api.UpdateInstallInputs(ctx, installID, request)
 	if err != nil {
-		return ui.PrintJSONError(err)
+		if asJSON {
+			return ui.PrintJSONError(err)
+		}
+		return ui.PrintError(err)
 	}
 
 	if asJSON {

--- a/services/ctl-api/docs/public/descriptions/update_install_inputs.md
+++ b/services/ctl-api/docs/public/descriptions/update_install_inputs.md
@@ -1,1 +1,5 @@
 Update input values for an install.
+
+This endpoint accepts a partial subset of inputs and merges them with the install's existing
+inputs, so callers only need to send the inputs they want to change. Inputs sourced from the
+`install_stack` (customer source) are managed by the install stack and are rejected if supplied.

--- a/services/ctl-api/internal/app/installs/service/update_install_inputs.go
+++ b/services/ctl-api/internal/app/installs/service/update_install_inputs.go
@@ -86,16 +86,26 @@ func (s *service) UpdateInstallInputs(ctx *gin.Context) {
 		ctx.Error(fmt.Errorf("unable to get latest app input config: %w", err))
 		return
 	}
+	if pinnedAppInputConfig == nil {
+		ctx.Error(stderr.ErrUser{
+			Err:         fmt.Errorf("invalid install inputs provided"),
+			Description: "inputs provided on install, that are not defined on the app",
+		})
+		return
+	}
 
-	err = s.helpers.ValidateInstallInputs(ctx, pinnedAppInputConfig, req.Inputs)
-	if err != nil {
+	// Reject any install_stack (customer) sourced inputs in the provided subset.
+	// This intentionally operates ONLY on the subset the caller sent — existing
+	// customer-sourced values carried over by the merge are preserved, not re-validated.
+	if err := s.validateVendorSourceInputs(pinnedAppInputConfig, req.Inputs); err != nil {
 		ctx.Error(err)
 		return
 	}
 
-	// Validate that only vendor inputs are being updated
-	err = s.validateVendorSourceInputs(pinnedAppInputConfig, req.Inputs)
-	if err != nil {
+	// Merge the provided subset over the install's current inputs, then validate the
+	// full resulting set so required inputs remain satisfied after a partial update.
+	merged := mergeInstallInputs(latestLatestInstallInputs.Values, req.Inputs, pinnedAppInputConfig)
+	if err := s.helpers.ValidateInstallInputs(ctx, pinnedAppInputConfig, merged); err != nil {
 		ctx.Error(err)
 		return
 	}
@@ -104,6 +114,7 @@ func (s *service) UpdateInstallInputs(ctx *gin.Context) {
 		ctx,
 		latestLatestInstallInputs,
 		pinnedAppInputConfig,
+		merged,
 		req,
 	)
 	if err != nil {
@@ -187,23 +198,9 @@ func (s *service) newInstallInputs(
 	ctx context.Context,
 	installInputs *app.InstallInputs,
 	appInputConfig *app.AppInputConfig,
+	merged map[string]*string,
 	req UpdateInstallInputsRequest,
 ) (*app.InstallInputs, *[]string, string, error) {
-	inputs := map[string]*string{}
-	for k, v := range installInputs.Values {
-		inputs[k] = v
-	}
-
-	for k, v := range req.Inputs {
-		inputs[k] = v
-	}
-
-	// create a lookup for the latest app input config
-	appInputNames := map[string]struct{}{}
-	for _, input := range appInputConfig.AppInputs {
-		appInputNames[input.Name] = struct{}{}
-	}
-
 	changed, err := helpers.ComputeChangedInputs(
 		installInputs.Values,
 		req.Inputs,
@@ -213,20 +210,11 @@ func (s *service) newInstallInputs(
 		return nil, nil, "", fmt.Errorf("unable to compute changed inputs: %w", err)
 	}
 
-	// remove inputs not in the latest app input config
-	for k := range inputs {
-		_, ok := appInputNames[k]
-		if !ok {
-			delete(inputs, k)
-			continue
-		}
-	}
-
 	// this update will be tied to the latest AppInputConfigID for the app
 	obj := &app.InstallInputs{
 		AppInputConfigID: appInputConfig.ID,
 		InstallID:        installInputs.InstallID,
-		Values:           pgtype.Hstore(inputs),
+		Values:           pgtype.Hstore(merged),
 	}
 	res := s.db.WithContext(ctx).Create(&obj)
 	if res.Error != nil {
@@ -243,6 +231,30 @@ func (s *service) newInstallInputs(
 	return latestInstallInputs, &changed.Names, changed.ChangedValuesJSON, nil
 }
 
+// mergeInstallInputs overlays the provided subset onto the install's existing input
+// values and drops any inputs no longer defined in the pinned app input config.
+func mergeInstallInputs(existing map[string]*string, patch map[string]*string, appInputConfig *app.AppInputConfig) map[string]*string {
+	merged := map[string]*string{}
+	for k, v := range existing {
+		merged[k] = v
+	}
+	for k, v := range patch {
+		merged[k] = v
+	}
+
+	appInputNames := map[string]struct{}{}
+	for _, input := range appInputConfig.AppInputs {
+		appInputNames[input.Name] = struct{}{}
+	}
+	for k := range merged {
+		if _, ok := appInputNames[k]; !ok {
+			delete(merged, k)
+		}
+	}
+
+	return merged
+}
+
 func (s *service) validateVendorSourceInputs(appInputConfig *app.AppInputConfig, inputs map[string]*string) error {
 	appInputSources := map[string]app.AppInputSource{}
 	for _, input := range appInputConfig.AppInputs {
@@ -252,12 +264,18 @@ func (s *service) validateVendorSourceInputs(appInputConfig *app.AppInputConfig,
 	for name := range inputs {
 		source, ok := appInputSources[name]
 		if !ok {
-			return fmt.Errorf("input %s is not defined in app input config", name)
+			return stderr.ErrUser{
+				Err:         fmt.Errorf("input %s is not defined in app input config", name),
+				Description: "input " + name + " does not exist in the app inputs",
+			}
 		}
 
 		// Reject customer sourced inputs
 		if source == app.AppInputSourceCustomer {
-			return fmt.Errorf("%s has source install_stack, cannot be updated via api", name)
+			return stderr.ErrUser{
+				Err:         fmt.Errorf("%s has source install_stack, cannot be updated via api", name),
+				Description: name + " has source install_stack and cannot be updated via the api",
+			}
 		}
 	}
 

--- a/services/ctl-api/internal/app/installs/service/update_install_inputs_test.go
+++ b/services/ctl-api/internal/app/installs/service/update_install_inputs_test.go
@@ -59,6 +59,113 @@ func (s *InstallsServiceTestSuite) TestUpdateInstallInputsSuccess() {
 	assert.Equal(s.T(), install.ID, dbWorkflow.OwnerID)
 }
 
+// TestUpdateInstallInputsPartialMerge verifies the endpoint behaves as a true PATCH:
+// a caller can send a subset of inputs, and the endpoint merges it with the install's
+// existing inputs. Previously this failed because the request had to carry every required
+// input.
+func (s *InstallsServiceTestSuite) TestUpdateInstallInputsPartialMerge() {
+	install := s.createTestInstall()
+
+	var inputCfg app.AppInputConfig
+	require.NoError(s.T(), s.deps.DB.
+		Preload("AppInputs").
+		Where("app_id = ?", s.testApp.ID).
+		Order("created_at DESC").
+		First(&inputCfg).Error)
+	require.NotEmpty(s.T(), inputCfg.AppInputs)
+	groupID := inputCfg.AppInputs[0].AppInputGroupID
+
+	// The seeded config has a single (non-required) "region" input. Add a second
+	// required vendor input and a customer (install_stack) sourced input so we can
+	// exercise a partial update that omits a required input and preserves the
+	// install_stack value.
+	requiredVendor := &app.AppInput{
+		AppInputConfigID: inputCfg.ID,
+		AppInputGroupID:  groupID,
+		Name:             "size",
+		DisplayName:      "Size",
+		Type:             app.AppInputTypeString,
+		Required:         true,
+		Source:           app.AppInputSourceVendor,
+	}
+	require.NoError(s.T(), s.deps.DB.Create(requiredVendor).Error)
+	customerInput := &app.AppInput{
+		AppInputConfigID: inputCfg.ID,
+		AppInputGroupID:  groupID,
+		Name:             "vpc_id",
+		DisplayName:      "VPC ID",
+		Type:             app.AppInputTypeString,
+		Source:           app.AppInputSourceCustomer,
+	}
+	require.NoError(s.T(), s.deps.DB.Create(customerInput).Error)
+
+	// Seed existing inputs covering all three, including the install_stack value.
+	s.deps.Seeder.CreateInstallInputs(s.ctx, s.T(), install.ID, inputCfg.ID, map[string]*string{
+		"region": strPtr("us-west-2"),
+		"size":   strPtr("large"),
+		"vpc_id": strPtr("vpc-123"),
+	})
+
+	// Patch ONLY region — "size" is required but omitted, which previously failed.
+	body := UpdateInstallInputsRequest{
+		Inputs: map[string]*string{
+			"region": strPtr("us-east-1"),
+		},
+	}
+	path := fmt.Sprintf("/v1/installs/%s/inputs", install.ID)
+	rr := s.makeRequest(http.MethodPatch, path, body)
+	require.Equal(s.T(), http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	// The new record reflects the merge: region updated, size + vpc_id preserved.
+	var dbInputs app.InstallInputs
+	require.NoError(s.T(), s.deps.DB.
+		Where("install_id = ?", install.ID).
+		Order("created_at DESC").
+		First(&dbInputs).Error)
+	assert.Equal(s.T(), "us-east-1", *dbInputs.Values["region"])
+	assert.Equal(s.T(), "large", *dbInputs.Values["size"])
+	assert.Equal(s.T(), "vpc-123", *dbInputs.Values["vpc_id"])
+}
+
+// TestUpdateInstallInputsRejectsInstallStackInput verifies that supplying a value for an
+// install_stack (customer) sourced input is rejected, even when it is part of an otherwise
+// valid partial update.
+func (s *InstallsServiceTestSuite) TestUpdateInstallInputsRejectsInstallStackInput() {
+	install := s.createTestInstall()
+
+	var inputCfg app.AppInputConfig
+	require.NoError(s.T(), s.deps.DB.
+		Preload("AppInputs").
+		Where("app_id = ?", s.testApp.ID).
+		Order("created_at DESC").
+		First(&inputCfg).Error)
+	require.NotEmpty(s.T(), inputCfg.AppInputs)
+	groupID := inputCfg.AppInputs[0].AppInputGroupID
+
+	customerInput := &app.AppInput{
+		AppInputConfigID: inputCfg.ID,
+		AppInputGroupID:  groupID,
+		Name:             "vpc_id",
+		DisplayName:      "VPC ID",
+		Type:             app.AppInputTypeString,
+		Source:           app.AppInputSourceCustomer,
+	}
+	require.NoError(s.T(), s.deps.DB.Create(customerInput).Error)
+
+	s.deps.Seeder.CreateInstallInputs(s.ctx, s.T(), install.ID, inputCfg.ID, map[string]*string{
+		"region": strPtr("us-west-2"),
+	})
+
+	body := UpdateInstallInputsRequest{
+		Inputs: map[string]*string{
+			"vpc_id": strPtr("vpc-999"),
+		},
+	}
+	path := fmt.Sprintf("/v1/installs/%s/inputs", install.ID)
+	rr := s.makeRequest(http.MethodPatch, path, body)
+	assert.Equal(s.T(), http.StatusBadRequest, rr.Code, "body: %s", rr.Body.String())
+}
+
 func (s *InstallsServiceTestSuite) TestUpdateInstallInputsNoExistingInputs() {
 	install := s.createTestInstall()
 


### PR DESCRIPTION
### Description

1. Update `PATCH /v1/installs/{install_id}/inputs` to accept a subset of inputs.
1. Update `nuon installs inputs set` to send only a subset of inputs.
1. Update `nuon installs sync` to send only the inputs configured in the install toml file.

### Motivation

`PATCH /v1/installs/{install_id}/inputs` is defined as a `PATCH` but was effectively acting as a `PUT`, meaning: it
required the full set of inputs on every request. As a result, all of our clients are composing a full payload by merging
the users's changes with the current inputs.

As a result, validation was touching every input and rejecting the request when the app defines a `user_configurable` input
whose source is `install_stack`.

This is problematic because it means any app that defines such an input cannot be updated.
