### PR TITLE
feat: add sandbox operations to runbooks

### DIFF
--- a/pkg/config/runbook_config.go
+++ b/pkg/config/runbook_config.go
@@ -14,8 +14,11 @@ import (
 type RunbookStepType string
 
 const (
-	RunbookStepTypeDeploy RunbookStepType = "deploy"
-	RunbookStepTypeAction RunbookStepType = "action"
+	RunbookStepTypeDeploy             RunbookStepType = "deploy"
+	RunbookStepTypeAction             RunbookStepType = "action"
+	RunbookStepTypeSandboxProvision   RunbookStepType = "sandbox_provision"
+	RunbookStepTypeSandboxReprovision RunbookStepType = "sandbox_reprovision"
+	RunbookStepTypeSandboxDeprovision RunbookStepType = "sandbox_deprovision"
 )
 
 type RunbookConfig struct {
@@ -36,6 +39,10 @@ type RunbookStepConfig struct {
 	// For type = "deploy"
 	ComponentName      string `mapstructure:"component_name,omitempty" toml:"component_name,omitempty"`
 	DeployDependencies bool   `mapstructure:"deploy_dependencies,omitempty" toml:"deploy_dependencies,omitempty"`
+
+	// For type = "sandbox_provision" / "sandbox_reprovision" — when true, only run the sandbox infra
+	// plan + apply and do NOT redeploy components on top.
+	SkipComponentDeploys bool `mapstructure:"skip_component_deploys,omitempty" toml:"skip_component_deploys,omitempty"`
 
 	// For type = "action" — reference existing action
 	ActionName string `mapstructure:"action_name,omitempty" toml:"action_name,omitempty"`
@@ -70,9 +77,10 @@ func (r RunbookStepConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Example("deploy-database").
 		Example("run-migrations").
 		Field("type").Short("type of step").Required().
-		Long("Either 'deploy' for deploying a component, or 'action' for running an action").
+		Long("One of: 'deploy' (deploy a component), 'action' (run an action), 'sandbox_provision', 'sandbox_reprovision', or 'sandbox_deprovision' (run the corresponding sandbox lifecycle plan + apply)").
 		Example("deploy").
 		Example("action").
+		Example("sandbox_reprovision").
 		Field("component_name").Short("component to deploy (for deploy steps)").
 		Long("Name of the component to deploy. Required when type is 'deploy'").
 		Example("database").
@@ -95,7 +103,9 @@ func (r RunbookStepConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Example("30s").
 		Example("5m").
 		Field("role").Short("IAM role for inline action execution").
-		Long("IAM role name to use when executing the inline action step")
+		Long("IAM role name to use when executing the inline action step").
+		Field("skip_component_deploys").Short("skip component deployments after sandbox reprovision/provision").
+		Long("Only applies to 'sandbox_provision' and 'sandbox_reprovision' steps. When true, only the sandbox infrastructure is (re)provisioned and components are NOT redeployed on top. Matches the dashboard's 'Skip component deployments' option")
 }
 
 func (r *RunbookConfig) parse() error {

--- a/pkg/config/runbook_config.go
+++ b/pkg/config/runbook_config.go
@@ -16,7 +16,6 @@ type RunbookStepType string
 const (
 	RunbookStepTypeDeploy             RunbookStepType = "deploy"
 	RunbookStepTypeAction             RunbookStepType = "action"
-	RunbookStepTypeSandboxProvision   RunbookStepType = "sandbox_provision"
 	RunbookStepTypeSandboxReprovision RunbookStepType = "sandbox_reprovision"
 	RunbookStepTypeSandboxDeprovision RunbookStepType = "sandbox_deprovision"
 )
@@ -40,8 +39,8 @@ type RunbookStepConfig struct {
 	ComponentName      string `mapstructure:"component_name,omitempty" toml:"component_name,omitempty"`
 	DeployDependencies bool   `mapstructure:"deploy_dependencies,omitempty" toml:"deploy_dependencies,omitempty"`
 
-	// For type = "sandbox_provision" / "sandbox_reprovision" — when true, only run the sandbox infra
-	// plan + apply and do NOT redeploy components on top.
+	// For type = "sandbox_reprovision" — when true, only run the sandbox infra plan + apply
+	// and do NOT redeploy components on top.
 	SkipComponentDeploys bool `mapstructure:"skip_component_deploys,omitempty" toml:"skip_component_deploys,omitempty"`
 
 	// For type = "action" — reference existing action
@@ -77,7 +76,7 @@ func (r RunbookStepConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Example("deploy-database").
 		Example("run-migrations").
 		Field("type").Short("type of step").Required().
-		Long("One of: 'deploy' (deploy a component), 'action' (run an action), 'sandbox_provision', 'sandbox_reprovision', or 'sandbox_deprovision' (run the corresponding sandbox lifecycle plan + apply)").
+		Long("One of: 'deploy' (deploy a component), 'action' (run an action), 'sandbox_reprovision', or 'sandbox_deprovision' (run the corresponding sandbox lifecycle plan + apply)").
 		Example("deploy").
 		Example("action").
 		Example("sandbox_reprovision").
@@ -104,8 +103,8 @@ func (r RunbookStepConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Example("5m").
 		Field("role").Short("IAM role for inline action execution").
 		Long("IAM role name to use when executing the inline action step").
-		Field("skip_component_deploys").Short("skip component deployments after sandbox reprovision/provision").
-		Long("Only applies to 'sandbox_provision' and 'sandbox_reprovision' steps. When true, only the sandbox infrastructure is (re)provisioned and components are NOT redeployed on top. Matches the dashboard's 'Skip component deployments' option")
+		Field("skip_component_deploys").Short("skip component deployments after sandbox reprovision").
+		Long("Only applies to 'sandbox_reprovision' steps. When true, only the sandbox infrastructure is reprovisioned and components are NOT redeployed on top. Matches the dashboard's 'Skip component deployments' option")
 }
 
 func (r *RunbookConfig) parse() error {

--- a/pkg/config/runbook_config_test.go
+++ b/pkg/config/runbook_config_test.go
@@ -31,7 +31,6 @@ func TestRunbookConfig_Parse(t *testing.T) {
 					Timeout:        "2m",
 					EnvVarMap:      map[string]string{"API_URL": "https://example.com"},
 				},
-				{Name: "sbx-provision", Type: RunbookStepTypeSandboxProvision},
 				{Name: "sbx-reprovision", Type: RunbookStepTypeSandboxReprovision, Role: "custom-role"},
 				{Name: "sbx-deprovision", Type: RunbookStepTypeSandboxDeprovision},
 			},
@@ -87,7 +86,6 @@ func TestRunbookConfig_Parse(t *testing.T) {
 func TestRunbookStepType_Constants(t *testing.T) {
 	require.Equal(t, RunbookStepType("deploy"), RunbookStepTypeDeploy)
 	require.Equal(t, RunbookStepType("action"), RunbookStepTypeAction)
-	require.Equal(t, RunbookStepType("sandbox_provision"), RunbookStepTypeSandboxProvision)
 	require.Equal(t, RunbookStepType("sandbox_reprovision"), RunbookStepTypeSandboxReprovision)
 	require.Equal(t, RunbookStepType("sandbox_deprovision"), RunbookStepTypeSandboxDeprovision)
 }

--- a/pkg/config/runbook_config_test.go
+++ b/pkg/config/runbook_config_test.go
@@ -31,6 +31,9 @@ func TestRunbookConfig_Parse(t *testing.T) {
 					Timeout:        "2m",
 					EnvVarMap:      map[string]string{"API_URL": "https://example.com"},
 				},
+				{Name: "sbx-provision", Type: RunbookStepTypeSandboxProvision},
+				{Name: "sbx-reprovision", Type: RunbookStepTypeSandboxReprovision, Role: "custom-role"},
+				{Name: "sbx-deprovision", Type: RunbookStepTypeSandboxDeprovision},
 			},
 		}
 
@@ -84,4 +87,7 @@ func TestRunbookConfig_Parse(t *testing.T) {
 func TestRunbookStepType_Constants(t *testing.T) {
 	require.Equal(t, RunbookStepType("deploy"), RunbookStepTypeDeploy)
 	require.Equal(t, RunbookStepType("action"), RunbookStepTypeAction)
+	require.Equal(t, RunbookStepType("sandbox_provision"), RunbookStepTypeSandboxProvision)
+	require.Equal(t, RunbookStepType("sandbox_reprovision"), RunbookStepTypeSandboxReprovision)
+	require.Equal(t, RunbookStepType("sandbox_deprovision"), RunbookStepTypeSandboxDeprovision)
 }

--- a/pkg/config/sync/apisyncer/runbooks_sync.go
+++ b/pkg/config/sync/apisyncer/runbooks_sync.go
@@ -65,6 +65,7 @@ func (s *syncer) syncRunbook(ctx context.Context, resource string, runbook *conf
 			Idx:                int64(idx),
 			ComponentName:      step.ComponentName,
 			DeployDependencies: step.DeployDependencies,
+			SkipComponentDeploys: step.SkipComponentDeploys,
 			ActionName:         step.ActionName,
 			Command:            step.Command,
 			InlineContents:     step.InlineContents,

--- a/pkg/config/sync/apisyncer/runbooks_sync.go
+++ b/pkg/config/sync/apisyncer/runbooks_sync.go
@@ -60,18 +60,18 @@ func (s *syncer) syncRunbook(ctx context.Context, resource string, runbook *conf
 		}
 
 		request.Steps = append(request.Steps, &models.ServiceCreateRunbookStepConfigRequest{
-			Name:               generics.ToPtr(step.Name),
-			Type:               generics.ToPtr(string(step.Type)),
-			Idx:                int64(idx),
-			ComponentName:      step.ComponentName,
-			DeployDependencies: step.DeployDependencies,
+			Name:                 generics.ToPtr(step.Name),
+			Type:                 generics.ToPtr(string(step.Type)),
+			Idx:                  int64(idx),
+			ComponentName:        step.ComponentName,
+			DeployDependencies:   step.DeployDependencies,
 			SkipComponentDeploys: step.SkipComponentDeploys,
-			ActionName:         step.ActionName,
-			Command:            step.Command,
-			InlineContents:     step.InlineContents,
-			EnvVars:            step.EnvVarMap,
-			Timeout:            timeout.Nanoseconds(),
-			Role:               step.Role,
+			ActionName:           step.ActionName,
+			Command:              step.Command,
+			InlineContents:       step.InlineContents,
+			EnvVars:              step.EnvVarMap,
+			Timeout:              timeout.Nanoseconds(),
+			Role:                 step.Role,
 		})
 	}
 

--- a/sdks/nuon-go/models/app_runbook_step_config.go
+++ b/sdks/nuon-go/models/app_runbook_step_config.go
@@ -56,6 +56,9 @@ type AppRunbookStepConfig struct {
 	// runbook config id
 	RunbookConfigID string `json:"runbook_config_id,omitempty"`
 
+	// sandbox lifecycle fields
+	SkipComponentDeploys bool `json:"skip_component_deploys,omitempty"`
+
 	// timeout
 	Timeout int64 `json:"timeout,omitempty"`
 

--- a/sdks/nuon-go/models/service_create_runbook_step_config_request.go
+++ b/sdks/nuon-go/models/service_create_runbook_step_config_request.go
@@ -47,6 +47,9 @@ type ServiceCreateRunbookStepConfigRequest struct {
 	// role
 	Role string `json:"role,omitempty"`
 
+	// skip component deploys
+	SkipComponentDeploys bool `json:"skip_component_deploys,omitempty"`
+
 	// timeout
 	Timeout int64 `json:"timeout,omitempty"`
 

--- a/services/ctl-api/internal/app/installs/workflows/v2/run_runbook.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/run_runbook.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/pkg/errors"
@@ -13,10 +14,17 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/componentdeployapplyplan"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/componentsyncimage"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/deprovisionsandboxapplyplan"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/deprovisionsandboxplan"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/executeactionworkflow"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/generatestate"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/provisionsandboxapplyplan"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/provisionsandboxplan"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/reprovisionsandboxapplyplan"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/reprovisionsandboxplan"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	dbgenerics "github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
 )
 
@@ -81,6 +89,15 @@ func RunRunbook(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResu
 				return nil, errors.Wrapf(err, "unable to generate action step %s", stepCfg.Name)
 			}
 			steps = append(steps, actionStep)
+
+		case app.RunbookStepTypeSandboxProvision,
+			app.RunbookStepTypeSandboxReprovision,
+			app.RunbookStepTypeSandboxDeprovision:
+			sbxSteps, err := runbookSandboxLifecycleSteps(ctx, installID, &stepCfg, flw, sg, install)
+			if err != nil {
+				return nil, errors.Wrapf(err, "unable to generate sandbox %s step %s", stepCfg.Type, stepCfg.Name)
+			}
+			steps = append(steps, sbxSteps...)
 		}
 	}
 
@@ -250,4 +267,84 @@ func runbookActionStep(ctx workflow.Context, installID string, stepCfg *app.Runb
 	}
 
 	return sg.installSignalStep(ctx, installID, fmt.Sprintf("action: %s", stepCfg.Name), pgtype.Hstore{}, sig, false)
+}
+
+func runbookSandboxLifecycleSteps(ctx workflow.Context, installID string, stepCfg *app.RunbookStepConfig, flw *app.Workflow, sg *stepGroup, install *app.Install) ([]*app.WorkflowStep, error) {
+	sandbox, err := activities.AwaitGetInstallSandboxByInstallID(ctx, installID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get install sandbox")
+	}
+
+	role := stepCfg.Role
+	if role == "" {
+		role = flw.Role
+	}
+
+	var (
+		planLabel   string
+		applyLabel  string
+		planSignal  signal.Signal
+		applySignal signal.Signal
+	)
+	switch stepCfg.Type {
+	case app.RunbookStepTypeSandboxProvision:
+		planLabel = fmt.Sprintf("sandbox provision plan: %s", stepCfg.Name)
+		applyLabel = fmt.Sprintf("sandbox provision apply: %s", stepCfg.Name)
+		planSignal = &provisionsandboxplan.Signal{InstallSandboxID: sandbox.ID, InstallID: installID, Role: role}
+		applySignal = &provisionsandboxapplyplan.Signal{InstallSandboxID: sandbox.ID, InstallID: installID}
+	case app.RunbookStepTypeSandboxReprovision:
+		planLabel = fmt.Sprintf("sandbox reprovision plan: %s", stepCfg.Name)
+		applyLabel = fmt.Sprintf("sandbox reprovision apply: %s", stepCfg.Name)
+		planSignal = &reprovisionsandboxplan.Signal{InstallSandboxID: sandbox.ID, InstallID: installID, Role: role}
+		applySignal = &reprovisionsandboxapplyplan.Signal{InstallSandboxID: sandbox.ID, InstallID: installID}
+	case app.RunbookStepTypeSandboxDeprovision:
+		planLabel = fmt.Sprintf("sandbox deprovision plan: %s", stepCfg.Name)
+		applyLabel = fmt.Sprintf("sandbox deprovision apply: %s", stepCfg.Name)
+		planSignal = &deprovisionsandboxplan.Signal{InstallSandboxID: sandbox.ID, InstallID: installID, Role: role}
+		applySignal = &deprovisionsandboxapplyplan.Signal{InstallSandboxID: sandbox.ID, InstallID: installID}
+	default:
+		return nil, errors.Errorf("unsupported sandbox lifecycle step type %q", stepCfg.Type)
+	}
+
+	sg.nextGroupNamed(fmt.Sprintf("sandbox %s: %s", strings.TrimPrefix(string(stepCfg.Type), "sandbox_"), stepCfg.Name))
+
+	result := make([]*app.WorkflowStep, 0, 2)
+	planStep, err := sg.installSignalStep(ctx, installID, planLabel, pgtype.Hstore{}, planSignal, flw.PlanOnly, WithSkippable(false))
+	if err != nil {
+		return nil, err
+	}
+	result = append(result, planStep)
+
+	if flw.PlanOnly {
+		return result, nil
+	}
+
+	applyStep, err := sg.installSignalStep(ctx, installID, applyLabel, pgtype.Hstore{}, applySignal, flw.PlanOnly, WithMaxAutoRetries(install.AppSandboxConfig.GetMaxAutoRetries()))
+	if err != nil {
+		return nil, err
+	}
+	result = append(result, applyStep)
+
+	// Optionally redeploy all components after a sandbox (re)provision, mirroring the standalone workflows.
+	// Deprovision never deploys; SkipComponentDeploys lets the runbook author opt out.
+	if stepCfg.SkipComponentDeploys || stepCfg.Type == app.RunbookStepTypeSandboxDeprovision {
+		return result, nil
+	}
+
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get app config")
+	}
+	awData, err := activities.AwaitGetActionWorkflows(ctx, &activities.GetActionWorkflows{InstallID: installID})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflows")
+	}
+
+	deploySteps, err := deployAllComponents(ctx, installID, flw, sg, appCfg, awData)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to generate component deploy steps")
+	}
+	result = append(result, deploySteps...)
+
+	return result, nil
 }

--- a/services/ctl-api/internal/app/installs/workflows/v2/run_runbook.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/run_runbook.go
@@ -18,8 +18,6 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/deprovisionsandboxplan"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/executeactionworkflow"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/generatestate"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/provisionsandboxapplyplan"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/provisionsandboxplan"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/reprovisionsandboxapplyplan"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/reprovisionsandboxplan"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
@@ -90,8 +88,7 @@ func RunRunbook(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResu
 			}
 			steps = append(steps, actionStep)
 
-		case app.RunbookStepTypeSandboxProvision,
-			app.RunbookStepTypeSandboxReprovision,
+		case app.RunbookStepTypeSandboxReprovision,
 			app.RunbookStepTypeSandboxDeprovision:
 			sbxSteps, err := runbookSandboxLifecycleSteps(ctx, installID, &stepCfg, flw, sg, install)
 			if err != nil {
@@ -287,11 +284,6 @@ func runbookSandboxLifecycleSteps(ctx workflow.Context, installID string, stepCf
 		applySignal signal.Signal
 	)
 	switch stepCfg.Type {
-	case app.RunbookStepTypeSandboxProvision:
-		planLabel = fmt.Sprintf("sandbox provision plan: %s", stepCfg.Name)
-		applyLabel = fmt.Sprintf("sandbox provision apply: %s", stepCfg.Name)
-		planSignal = &provisionsandboxplan.Signal{InstallSandboxID: sandbox.ID, InstallID: installID, Role: role}
-		applySignal = &provisionsandboxapplyplan.Signal{InstallSandboxID: sandbox.ID, InstallID: installID}
 	case app.RunbookStepTypeSandboxReprovision:
 		planLabel = fmt.Sprintf("sandbox reprovision plan: %s", stepCfg.Name)
 		applyLabel = fmt.Sprintf("sandbox reprovision apply: %s", stepCfg.Name)

--- a/services/ctl-api/internal/app/runbook_step_config.go
+++ b/services/ctl-api/internal/app/runbook_step_config.go
@@ -19,7 +19,6 @@ type RunbookStepType string
 const (
 	RunbookStepTypeDeploy             RunbookStepType = "deploy"
 	RunbookStepTypeAction             RunbookStepType = "action"
-	RunbookStepTypeSandboxProvision   RunbookStepType = "sandbox_provision"
 	RunbookStepTypeSandboxReprovision RunbookStepType = "sandbox_reprovision"
 	RunbookStepTypeSandboxDeprovision RunbookStepType = "sandbox_deprovision"
 )

--- a/services/ctl-api/internal/app/runbook_step_config.go
+++ b/services/ctl-api/internal/app/runbook_step_config.go
@@ -17,8 +17,11 @@ import (
 type RunbookStepType string
 
 const (
-	RunbookStepTypeDeploy RunbookStepType = "deploy"
-	RunbookStepTypeAction RunbookStepType = "action"
+	RunbookStepTypeDeploy             RunbookStepType = "deploy"
+	RunbookStepTypeAction             RunbookStepType = "action"
+	RunbookStepTypeSandboxProvision   RunbookStepType = "sandbox_provision"
+	RunbookStepTypeSandboxReprovision RunbookStepType = "sandbox_reprovision"
+	RunbookStepTypeSandboxDeprovision RunbookStepType = "sandbox_deprovision"
 )
 
 type RunbookStepConfig struct {
@@ -42,6 +45,9 @@ type RunbookStepConfig struct {
 	// deploy fields
 	ComponentName      string `json:"component_name,omitzero" temporaljson:"component_name,omitzero,omitempty"`
 	DeployDependencies bool   `json:"deploy_dependencies,omitzero" gorm:"default:false" temporaljson:"deploy_dependencies,omitzero,omitempty"`
+
+	// sandbox lifecycle fields
+	SkipComponentDeploys bool `json:"skip_component_deploys,omitzero" gorm:"default:false" temporaljson:"skip_component_deploys,omitzero,omitempty"`
 
 	// action reference field
 	ActionWorkflowID generics.NullString `json:"action_workflow_id,omitzero" swaggertype:"string" temporaljson:"action_workflow_id,omitzero,omitempty"`

--- a/services/ctl-api/internal/app/runbooks/service/create_runbook_config.go
+++ b/services/ctl-api/internal/app/runbooks/service/create_runbook_config.go
@@ -20,18 +20,18 @@ type CreateRunbookConfigRequest struct {
 }
 
 type CreateRunbookStepConfigRequest struct {
-	Name               string            `json:"name" validate:"required"`
-	Type               string            `json:"type" validate:"required"`
-	Idx                int64             `json:"idx"`
-	ComponentName      string            `json:"component_name,omitempty"`
-	DeployDependencies bool              `json:"deploy_dependencies,omitempty"`
+	Name                 string            `json:"name" validate:"required"`
+	Type                 string            `json:"type" validate:"required"`
+	Idx                  int64             `json:"idx"`
+	ComponentName        string            `json:"component_name,omitempty"`
+	DeployDependencies   bool              `json:"deploy_dependencies,omitempty"`
 	SkipComponentDeploys bool              `json:"skip_component_deploys,omitempty"`
-	ActionName         string            `json:"action_name,omitempty"`
-	Command            string            `json:"command,omitempty"`
-	InlineContents     string            `json:"inline_contents,omitempty"`
-	EnvVars            map[string]string `json:"env_vars,omitempty"`
-	Timeout            int64             `json:"timeout,omitempty"`
-	Role               string            `json:"role,omitempty"`
+	ActionName           string            `json:"action_name,omitempty"`
+	Command              string            `json:"command,omitempty"`
+	InlineContents       string            `json:"inline_contents,omitempty"`
+	EnvVars              map[string]string `json:"env_vars,omitempty"`
+	Timeout              int64             `json:"timeout,omitempty"`
+	Role                 string            `json:"role,omitempty"`
 }
 
 // @ID				CreateRunbookConfig
@@ -105,17 +105,17 @@ func (s *service) CreateRunbookConfig(ctx *gin.Context) {
 		}
 
 		stepCfg := app.RunbookStepConfig{
-			Idx:                idx,
-			Name:               stepReq.Name,
-			Type:               stepType,
-			ComponentName:      stepReq.ComponentName,
-			DeployDependencies: stepReq.DeployDependencies,
+			Idx:                  idx,
+			Name:                 stepReq.Name,
+			Type:                 stepType,
+			ComponentName:        stepReq.ComponentName,
+			DeployDependencies:   stepReq.DeployDependencies,
 			SkipComponentDeploys: stepReq.SkipComponentDeploys,
-			Command:            stepReq.Command,
-			InlineContents:     stepReq.InlineContents,
-			EnvVars:            envVars,
-			Timeout:            time.Duration(stepReq.Timeout),
-			Role:               stepReq.Role,
+			Command:              stepReq.Command,
+			InlineContents:       stepReq.InlineContents,
+			EnvVars:              envVars,
+			Timeout:              time.Duration(stepReq.Timeout),
+			Role:                 stepReq.Role,
 		}
 
 		// Resolve action_name to ActionWorkflowID

--- a/services/ctl-api/internal/app/runbooks/service/create_runbook_config.go
+++ b/services/ctl-api/internal/app/runbooks/service/create_runbook_config.go
@@ -25,6 +25,7 @@ type CreateRunbookStepConfigRequest struct {
 	Idx                int64             `json:"idx"`
 	ComponentName      string            `json:"component_name,omitempty"`
 	DeployDependencies bool              `json:"deploy_dependencies,omitempty"`
+	SkipComponentDeploys bool              `json:"skip_component_deploys,omitempty"`
 	ActionName         string            `json:"action_name,omitempty"`
 	Command            string            `json:"command,omitempty"`
 	InlineContents     string            `json:"inline_contents,omitempty"`
@@ -87,6 +88,18 @@ func (s *service) CreateRunbookConfig(ctx *gin.Context) {
 
 	steps := make([]app.RunbookStepConfig, 0, len(req.Steps))
 	for idx, stepReq := range req.Steps {
+		stepType := app.RunbookStepType(stepReq.Type)
+		switch stepType {
+		case app.RunbookStepTypeDeploy,
+			app.RunbookStepTypeAction,
+			app.RunbookStepTypeSandboxProvision,
+			app.RunbookStepTypeSandboxReprovision,
+			app.RunbookStepTypeSandboxDeprovision:
+		default:
+			ctx.Error(fmt.Errorf("invalid step type %q for step %s", stepReq.Type, stepReq.Name))
+			return
+		}
+
 		envVars := pgtype.Hstore{}
 		for k, v := range stepReq.EnvVars {
 			envVars[k] = &v
@@ -95,9 +108,10 @@ func (s *service) CreateRunbookConfig(ctx *gin.Context) {
 		stepCfg := app.RunbookStepConfig{
 			Idx:                idx,
 			Name:               stepReq.Name,
-			Type:               app.RunbookStepType(stepReq.Type),
+			Type:               stepType,
 			ComponentName:      stepReq.ComponentName,
 			DeployDependencies: stepReq.DeployDependencies,
+			SkipComponentDeploys: stepReq.SkipComponentDeploys,
 			Command:            stepReq.Command,
 			InlineContents:     stepReq.InlineContents,
 			EnvVars:            envVars,

--- a/services/ctl-api/internal/app/runbooks/service/create_runbook_config.go
+++ b/services/ctl-api/internal/app/runbooks/service/create_runbook_config.go
@@ -92,7 +92,6 @@ func (s *service) CreateRunbookConfig(ctx *gin.Context) {
 		switch stepType {
 		case app.RunbookStepTypeDeploy,
 			app.RunbookStepTypeAction,
-			app.RunbookStepTypeSandboxProvision,
 			app.RunbookStepTypeSandboxReprovision,
 			app.RunbookStepTypeSandboxDeprovision:
 		default:

--- a/services/dashboard-ui/client/components/runbooks/RunbookStep.tsx
+++ b/services/dashboard-ui/client/components/runbooks/RunbookStep.tsx
@@ -5,7 +5,6 @@ import { Expand } from '@/components/common/Expand'
 import { Icon } from '@/components/common/Icon'
 import { ID } from '@/components/common/ID'
 import { KeyValueList } from '@/components/common/KeyValueList'
-import { LabeledValue } from '@/components/common/LabeledValue'
 import { Link } from '@/components/common/Link'
 import { Text } from '@/components/common/Text'
 import type { TRunbookStep } from '@/lib/ctl-api/apps/runbooks/get-runbooks'
@@ -24,7 +23,15 @@ export const RunbookStep = ({ index, step, actionBasePath }: IRunbookStep) => {
       heading={
         <span className="flex items-center gap-2">
           <Icon
-            variant={step.type === 'deploy' ? 'RocketIcon' : 'TerminalIcon'}
+            variant={
+              step.type === 'deploy'
+                ? 'RocketIcon'
+                : step.type === 'sandbox_provision' ||
+                    step.type === 'sandbox_reprovision' ||
+                    step.type === 'sandbox_deprovision'
+                  ? 'CubeIcon'
+                  : 'TerminalIcon'
+            }
             size={16}
           />
           <Text weight="strong">
@@ -39,39 +46,43 @@ export const RunbookStep = ({ index, step, actionBasePath }: IRunbookStep) => {
       isOpen
     >
       <div className="flex flex-col gap-4 p-4 border-t">
-        <div className="flex flex-wrap gap-4">
+        <div className="flex flex-col divide-y">
           {step.component_name ? (
-            <LabeledValue label="Component">
+            <div className="flex items-center py-2 gap-4">
+              <Text variant="subtext" theme="neutral" className="w-48 shrink-0">Component</Text>
               <Text variant="subtext">{step.component_name}</Text>
-            </LabeledValue>
+            </div>
           ) : null}
           {step.type === 'deploy' ? (
-            <LabeledValue label="Deploy dependencies">
-              <Badge
-                variant="code"
-                size="sm"
-                theme={step.deploy_dependencies ? 'info' : 'neutral'}
-              >
-                {step.deploy_dependencies ? 'Yes' : 'No'}
-              </Badge>
-            </LabeledValue>
+            <div className="flex items-center py-2 gap-4">
+              <Text variant="subtext" theme="neutral" className="w-48 shrink-0">Deploy dependencies</Text>
+              <Text variant="subtext">{step.deploy_dependencies ? 'Yes' : 'No'}</Text>
+            </div>
+          ) : null}
+          {step.type === 'sandbox_provision' ||
+          step.type === 'sandbox_reprovision' ? (
+            <div className="flex items-center py-2 gap-4">
+              <Text variant="subtext" theme="neutral" className="w-48 shrink-0">Skip component deploys</Text>
+              <Text variant="subtext">{step.skip_component_deploys ? 'Yes' : 'No'}</Text>
+            </div>
           ) : null}
           {step.action_workflow_id ? (
-            <LabeledValue label="Action ID">
-              <span className="flex items-center gap-2">
-                <ID>{step.action_workflow_id}</ID>
-              </span>
-            </LabeledValue>
+            <div className="flex items-center py-2 gap-4">
+              <Text variant="subtext" theme="neutral" className="w-48 shrink-0">Action ID</Text>
+              <ID>{step.action_workflow_id}</ID>
+            </div>
           ) : null}
           {step.role ? (
-            <LabeledValue label="Role">
+            <div className="flex items-center py-2 gap-4">
+              <Text variant="subtext" theme="neutral" className="w-48 shrink-0">Role</Text>
               <Text variant="subtext">{step.role}</Text>
-            </LabeledValue>
+            </div>
           ) : null}
           {step.timeout ? (
-            <LabeledValue label="Timeout">
+            <div className="flex items-center py-2 gap-4">
+              <Text variant="subtext" theme="neutral" className="w-48 shrink-0">Timeout</Text>
               <Duration nanoseconds={step.timeout} variant="subtext" />
-            </LabeledValue>
+            </div>
           ) : null}
         </div>
 

--- a/services/dashboard-ui/client/components/runbooks/RunbookStep.tsx
+++ b/services/dashboard-ui/client/components/runbooks/RunbookStep.tsx
@@ -26,8 +26,7 @@ export const RunbookStep = ({ index, step, actionBasePath }: IRunbookStep) => {
             variant={
               step.type === 'deploy'
                 ? 'RocketIcon'
-                : step.type === 'sandbox_provision' ||
-                    step.type === 'sandbox_reprovision' ||
+                : step.type === 'sandbox_reprovision' ||
                     step.type === 'sandbox_deprovision'
                   ? 'CubeIcon'
                   : 'TerminalIcon'
@@ -59,8 +58,7 @@ export const RunbookStep = ({ index, step, actionBasePath }: IRunbookStep) => {
               <Text variant="subtext">{step.deploy_dependencies ? 'Yes' : 'No'}</Text>
             </div>
           ) : null}
-          {step.type === 'sandbox_provision' ||
-          step.type === 'sandbox_reprovision' ? (
+          {step.type === 'sandbox_reprovision' ? (
             <div className="flex items-center py-2 gap-4">
               <Text variant="subtext" theme="neutral" className="w-48 shrink-0">Skip component deploys</Text>
               <Text variant="subtext">{step.skip_component_deploys ? 'Yes' : 'No'}</Text>

--- a/services/dashboard-ui/client/components/runbooks/RunbookStepCard/RunbookStepCard.tsx
+++ b/services/dashboard-ui/client/components/runbooks/RunbookStepCard/RunbookStepCard.tsx
@@ -79,6 +79,12 @@ export const RunbookStepCard = ({
 }: IRunbookStepCard) => {
   const isDeploy = step.step_target_type === 'install_deploys'
   const isActionRun = step.step_target_type === 'install_action_workflow_runs'
+  const isSandboxRun = step.step_target_type === 'install_sandbox_runs'
+  const targetLabel = isDeploy
+    ? 'deploy'
+    : isSandboxRun
+      ? 'sandbox run'
+      : 'action run'
   const actionRun = isActionRun ? (targetData as TInstallActionRun) : undefined
   const envVarEntries = Object.entries(actionRun?.run_env_vars ?? {})
   const stepStatus =
@@ -168,7 +174,7 @@ export const RunbookStepCard = ({
             id={`step-data-${step.id}`}
             heading={
               <Text family="mono" variant="subtext">
-                View {isDeploy ? 'deploy' : 'action run'} JSON
+                View {targetLabel} JSON
               </Text>
             }
           >

--- a/services/dashboard-ui/client/lib/ctl-api/apps/runbooks/get-runbooks.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/runbooks/get-runbooks.ts
@@ -43,6 +43,7 @@ export type TRunbookStep = {
   type?: string
   component_name?: string
   deploy_dependencies?: boolean
+  skip_component_deploys?: boolean
   action_workflow_id?: string
   command?: string
   inline_contents?: string

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -4650,6 +4650,8 @@ export interface components {
       name?: string;
       role?: string;
       runbook_config_id?: string;
+      /** @description sandbox lifecycle fields */
+      skip_component_deploys?: boolean;
       timeout?: number;
       type?: string;
       updated_at?: string;
@@ -6740,6 +6742,7 @@ export interface components {
       inline_contents?: string;
       name: string;
       role?: string;
+      skip_component_deploys?: boolean;
       timeout?: number;
       type: string;
     };


### PR DESCRIPTION
## Summary

We want to be able to include sandbox operations in runbooks. This PR adds support for 3 new runbook step types.

### sandbox_reprovision

Can be used to reprovision a sandbox as part of a runbook run. If excluded, `role` default to the runbook's role, and `skip_component_deploys` defaults to `false`.

```toml
[[steps]]
name = "Reprovision sandbox"
type = "sandbox_reprovision"
role = "arn:aws:iam::{{ .install_stack.outputs.account_id }}:role/{{.nuon.install.id}}-provision"
skip_component_deploys = true
```

### sandbox_deprovision

Can be used to deprovision a sandbox as part of a runbook run.  If scluded `role` defaults to the runbook role.

```toml
[[steps]]
name = "Deprovision sandbox "
type = "sandbox_deprovision"
role = "arn:aws:iam::{{ .install_stack.outputs.account_id }}:role/{{.nuon.install.id}}-deprovision"
```