### PR TITLE
fix(dashboard): only show retry/skip on the latest attempt of a retried workflow step

### DIFF
--- a/services/dashboard-ui/client/components/admin/sections/AdminOrgSection/AdminOrgSection.tsx
+++ b/services/dashboard-ui/client/components/admin/sections/AdminOrgSection/AdminOrgSection.tsx
@@ -46,6 +46,9 @@ export const AdminOrgSection = ({
   runnerLoading,
 }: IAdminOrgSection) => {
   const runnerId = runner?.id ?? ''
+  // Destructive org-level actions require typing the org's name (falling back
+  // to the org id) so admins must explicitly confirm the exact target org.
+  const orgConfirmText = org?.name || orgId
 
   const metadata = (
     <AdminMetadataPanel>
@@ -198,7 +201,7 @@ export const AdminOrgSection = ({
           variant="danger"
           requiresConfirmation
           requiresInput
-          inputText="yesimsure"
+          inputText={orgConfirmText}
           confirmationText="WARNING: This will deprovision ALL infrastructure for this organization including runners and installs. Database records will be preserved. This may take a while to complete."
         />
         <AdminActionCard
@@ -208,7 +211,7 @@ export const AdminOrgSection = ({
           variant="danger"
           requiresConfirmation
           requiresInput
-          inputText="yesimsure"
+          inputText={orgConfirmText}
           confirmationText="WARNING: This will permanently delete ALL install records for this organization. Any running infrastructure will be orphaned and must be cleaned up manually (e.g. via aws-nuke). This action CANNOT be undone. Only use this when installs are broken beyond repair."
         />
         <AdminActionCard
@@ -218,7 +221,7 @@ export const AdminOrgSection = ({
           variant="danger"
           requiresConfirmation
           requiresInput
-          inputText="yesimsure"
+          inputText={orgConfirmText}
           confirmationText="WARNING: This will permanently delete the organization record and all its roles. Any running infrastructure will be orphaned and must be cleaned up manually. This action CANNOT be undone."
         />
       </AdminActionGroup>

--- a/services/dashboard-ui/client/components/workflows/WorkflowSteps/WorkflowSteps.tsx
+++ b/services/dashboard-ui/client/components/workflows/WorkflowSteps/WorkflowSteps.tsx
@@ -11,7 +11,7 @@ import { StepButtons } from '@/components/workflows/step-details/StepButtons'
 import { StepDetailPanelButton } from '@/components/workflows/step-details/StepDetailPanel'
 import { StepTitle } from '@/components/workflows/step-details/StepTitle'
 import type { TWorkflowStep } from '@/types'
-import { getStepBadge } from '@/utils/workflow-utils'
+import { getStepBadge, getStepKind } from '@/utils/workflow-utils'
 
 export interface IWorkflowSteps {
   approvalPrompt?: boolean
@@ -34,6 +34,14 @@ export const WorkflowSteps = ({
     .filter((step) => step.execution_type !== 'hidden')
     .filter((step) => step.name.includes(searchName))
 
+  // Retrying a step appends a new attempt row that shares the same logical
+  // "kind" (group + name) as the prior attempts. Only the latest attempt of a
+  // kind should expose retry/skip controls, so track the last index per kind.
+  const lastIdxByKind = new Map<string, number>()
+  filteredSteps.forEach((step, idx) => {
+    lastIdxByKind.set(getStepKind(step), idx)
+  })
+
   return (
     <div className="flex flex-col gap-6">
       <SearchInput
@@ -43,8 +51,9 @@ export const WorkflowSteps = ({
       />
       <div className="flex flex-col gap-4">
         {filteredSteps.length ? (
-          filteredSteps.map((step) => {
+          filteredSteps.map((step, idx) => {
             const badgeConfig = getStepBadge(step, approvalPrompt, planOnly)
+            const isLatestAttempt = lastIdxByKind.get(getStepKind(step)) === idx
 
             return (
               <div
@@ -78,7 +87,11 @@ export const WorkflowSteps = ({
                   ) : null}
                 </div>
 
-                <StepButtons isApproveAll={!approvalPrompt} step={step} />
+                <StepButtons
+                  isApproveAll={!approvalPrompt}
+                  showRetry={isLatestAttempt}
+                  step={step}
+                />
               </div>
             )
           })

--- a/services/dashboard-ui/client/components/workflows/step-details/StepButtons.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/StepButtons.tsx
@@ -13,17 +13,20 @@ import { SkipStepButton } from './SkipStep'
 export const StepButtons = ({
   buttonSize = 'sm',
   isApproveAll = false,
+  showRetry = true,
   step,
 }: {
   buttonSize?: TButtonSize
   isApproveAll?: boolean
+  // Only the latest attempt of a retried step should expose retry/skip controls.
+  showRetry?: boolean
   step: TWorkflowStep
 }) => {
   const { hasResponded } = useRespondedApprovals()
   const { approval, retry } = getStepButtons(step)
   return (
     <div className="md:ml-auto flex items-center gap-4">
-      {retry ? (
+      {retry && showRetry ? (
         <>
           {step?.skippable ? (
             <SkipStepButton size={buttonSize} variant="danger" step={step} />

--- a/services/dashboard-ui/client/utils/workflow-utils.ts
+++ b/services/dashboard-ui/client/utils/workflow-utils.ts
@@ -101,6 +101,16 @@ export function getStepBadge(
 
   return status && WORKFLOW_BADGE_MAP[status] ? WORKFLOW_BADGE_MAP[status] : {}
 }
+/**
+ * A step's logical "kind" — stable across retry attempts. Retrying a step
+ * creates a new step row that shares the same group and name as the prior
+ * attempt(s), so callers can group attempts together (e.g. to only show retry
+ * controls on the latest attempt of a kind).
+ */
+export function getStepKind(step: TWorkflowStep): string {
+  return `${step?.group_idx ?? ''}:${step?.step_target_type ?? ''}:${step?.name ?? step?.id ?? ''}`
+}
+
 export type TStepButtonsCfg = {
   cancel: boolean
   approval: boolean
@@ -109,7 +119,9 @@ export type TStepButtonsCfg = {
 
 export function getStepButtons(step: TWorkflowStep): TStepButtonsCfg {
   const status = step?.status?.status
-  const isFailedAwaitingRetry = status === 'failed-pending-retry'
+  // A step that has already been superseded by a newer retry attempt
+  // (`retried === true`) should never offer retry/skip controls.
+  const isFailedAwaitingRetry = status === 'failed-pending-retry' && !step?.retried
   const isRetryableError = status === 'error' && !!step?.retryable && !step?.retried && !step?.status?.metadata?.retries_exhausted && step?.status?.metadata?.retry_type !== 'auto'
   return {
     retry: isFailedAwaitingRetry || isRetryableError,


### PR DESCRIPTION
## Only show retry/skip on the latest attempt of a retried workflow step

### Summary
When a workflow step fails and is retried, the backend appends a **new attempt row** rather than replacing the old one — so the steps list can show multiple rows for the same logical step. Previously every one of those rows could render "Skip step" / "Retry step", including already-superseded attempts. This scopes the retry/skip controls to the **latest attempt** of each step, so only the live attempt is actionable.

### Changes
- `utils/workflow-utils.ts`
  - Added `getStepKind(step)` — a stable identity across retry attempts (`group_idx` + `step_target_type` + `name`, falling back to `id`).
  - Hardened `getStepButtons`: a step already superseded by a newer retry (`retried === true`) no longer offers retry/skip, including the `failed-pending-retry` case.
- `WorkflowSteps.tsx`
  - Computes the last index per step "kind" and passes `showRetry` so only the most recent attempt of a kind renders the retry/skip controls.
- `StepButtons.tsx`
  - New `showRetry` prop (default `true`) gating the retry/skip block; approval buttons unaffected.

### Behavior
- Single attempt → unchanged (retry/skip shown when applicable).
- Retried step → older attempts show their status/"Retried" badge but no retry/skip buttons; only the newest attempt is actionable.

### Also included
- **Admin org safety:** destructive org-level actions (Deprovision org, Forget all org installs, Forget org) now require typing the exact **org name** to confirm instead of a generic `yesimsure` (falls back to org ID if the name is empty).

### Test plan
- [x] Retry a failing step and confirm only the newest attempt row shows Skip/Retry; older attempts show the "Retried" badge with no buttons.
- [x] Confirm a never-retried failed step still shows Retry/Skip.
- [x] Confirm approval buttons are unaffected.
- [x] In admin controls, trigger **Forget org** and verify Confirm is enabled only after typing the org name.