### PR TITLE
docs: fix error in new secrets guide

### DIFF
--- a/docs/guides/configuring-inputs-and-secrets.mdx
+++ b/docs/guides/configuring-inputs-and-secrets.mdx
@@ -114,15 +114,15 @@ description  = "Base64 encoded GitHub App Key"
 required     = true
 format       = "base64"
 
-[[kubernetes_sync_targets]]
+[[secret.kubernetes_sync_targets]]
 namespaces = ["api", "workers"]
 name      = "github"
 key       = "app-key"
 ```
 
-Setting `[[kubernetes_sync_targets]]` syncs the secret as a Kubernetes Secret object after sandbox provisioning, using
+Setting `[[secret.kubernetes_sync_targets]]` syncs the secret as a Kubernetes Secret object after sandbox provisioning, using
 the details provided. This approach allows for easy definition of secrets in whatever shape is desired and enables
-reflection of secrets across different namespaces. We support multiple `kubernetes_sync_targets` entries.
+reflection of secrets across different namespaces. We support multiple `[[secret.kubernetes_sync_targets]]` entries.
 
 We also support the following method which is less flexible:
 


### PR DESCRIPTION
* added missing secret prefix to kubernetes_sync_targets table header