### PR TITLE
feat: input update step type for runbooks

### DIFF
--- a/pkg/config/runbook_config.go
+++ b/pkg/config/runbook_config.go
@@ -18,6 +18,7 @@ const (
 	RunbookStepTypeComponentDeploy    RunbookStepType = "component_deploy"
 	RunbookStepTypeComponentTearDown  RunbookStepType = "component_tear_down"
 	RunbookStepTypeAction             RunbookStepType = "action"
+	RunbookStepTypeInputUpdate        RunbookStepType = "input_update"
 	RunbookStepTypeSandboxReprovision RunbookStepType = "sandbox_reprovision"
 	RunbookStepTypeSandboxDeprovision RunbookStepType = "sandbox_deprovision"
 
@@ -59,6 +60,17 @@ type RunbookStepConfig struct {
 	// and do NOT redeploy components on top.
 	SkipComponentDeploys bool `mapstructure:"skip_component_deploys,omitempty" toml:"skip_component_deploys,omitempty"`
 
+	// For type = "input_update" — map of input-name → templated value to apply
+	// to the install. Values support the same Go-template features as action
+	// command / inline_contents (e.g. {{.component.x.output.y}}).
+	Inputs map[string]string `mapstructure:"inputs,omitempty" toml:"inputs,omitempty" features:"template"`
+
+	// For type = "input_update" — when true, only update inputs without
+	// redeploying components that depend on them. Mirrors the dashboard's
+	// "Deploy dependents" checkbox (inverted polarity so the Go zero value
+	// preserves the default of deploying dependents).
+	SkipDeployDependents bool `mapstructure:"skip_deploy_dependents,omitempty" toml:"skip_deploy_dependents,omitempty"`
+
 	// For type = "action" — reference existing action
 	ActionName string `mapstructure:"action_name,omitempty" toml:"action_name,omitempty"`
 
@@ -94,10 +106,11 @@ func (r RunbookStepConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Example("deploy-database").
 		Example("run-migrations").
 		Field("type").Short("type of step").Required().
-		Long("One of: 'component_deploy' (deploy a component; 'deploy' is accepted as a legacy alias), 'component_tear_down' (tear down a component), 'action' (run an action), 'sandbox_reprovision', or 'sandbox_deprovision' (run the corresponding sandbox lifecycle plan + apply)").
+		Long("One of: 'component_deploy' (deploy a component; 'deploy' is accepted as a legacy alias), 'component_tear_down' (tear down a component), 'action' (run an action), 'input_update' (update install inputs and optionally redeploy affected components), 'sandbox_reprovision', or 'sandbox_deprovision' (run the corresponding sandbox lifecycle plan + apply)").
 		Example("component_deploy").
 		Example("component_tear_down").
 		Example("action").
+		Example("input_update").
 		Example("sandbox_reprovision").
 		Field("component_name").Short("component to deploy or tear down (for component steps)").
 		Long("Name of the component to deploy or tear down. Required when type is 'component_deploy' or 'component_tear_down'").
@@ -127,7 +140,11 @@ func (r RunbookStepConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Field("role").Short("IAM role for inline action execution").
 		Long("IAM role name to use when executing the inline action step").
 		Field("skip_component_deploys").Short("skip component deployments after sandbox reprovision").
-		Long("Only applies to 'sandbox_reprovision' steps. When true, only the sandbox infrastructure is reprovisioned and components are NOT redeployed on top. Matches the dashboard's 'Skip component deployments' option")
+		Long("Only applies to 'sandbox_reprovision' steps. When true, only the sandbox infrastructure is reprovisioned and components are NOT redeployed on top. Matches the dashboard's 'Skip component deployments' option").
+		Field("inputs").Short("install inputs to update (for input_update steps)").
+		Long("Map of input-name to value. Values support Go templating (e.g. {{.component.x.output.y}}). Required when type is 'input_update'. Customer-sourced (install_stack) inputs cannot be updated this way").
+		Field("skip_deploy_dependents").Short("skip redeploying components after updating inputs").
+		Long("Only applies to 'input_update' steps. When true, only the install inputs are updated and components depending on those inputs are NOT redeployed. Mirrors the dashboard's 'Deploy dependents' checkbox (inverted polarity — the default is to deploy dependents)")
 }
 
 func (r *RunbookConfig) parse() error {

--- a/pkg/config/sync/apisyncer/runbooks_sync.go
+++ b/pkg/config/sync/apisyncer/runbooks_sync.go
@@ -68,6 +68,8 @@ func (s *syncer) syncRunbook(ctx context.Context, resource string, runbook *conf
 			DeployDependents:     step.DeployDependents,
 			TearDownDependents:   step.TearDownDependents,
 			SkipComponentDeploys: step.SkipComponentDeploys,
+			Inputs:               step.Inputs,
+			SkipDeployDependents: step.SkipDeployDependents,
 			ActionName:           step.ActionName,
 			Command:              step.Command,
 			InlineContents:       step.InlineContents,

--- a/sdks/nuon-go/models/app_runbook_step_config.go
+++ b/sdks/nuon-go/models/app_runbook_step_config.go
@@ -47,6 +47,12 @@ type AppRunbookStepConfig struct {
 	// inline contents
 	InlineContents string `json:"inline_contents,omitempty"`
 
+	// input_update fields. Inputs is a map of input-name → templated value to
+	// apply to the install. SkipDeployDependents inverts the dashboard's
+	// "Deploy dependents" checkbox so the Go zero value preserves the default
+	// (deploy dependents on input update).
+	Inputs map[string]string `json:"inputs,omitempty"`
+
 	// name
 	Name string `json:"name,omitempty"`
 
@@ -58,6 +64,9 @@ type AppRunbookStepConfig struct {
 
 	// sandbox lifecycle fields
 	SkipComponentDeploys bool `json:"skip_component_deploys,omitempty"`
+
+	// skip deploy dependents
+	SkipDeployDependents bool `json:"skip_deploy_dependents,omitempty"`
 
 	// tear down dependents
 	TearDownDependents bool `json:"tear_down_dependents,omitempty"`

--- a/sdks/nuon-go/models/service_create_runbook_step_config_request.go
+++ b/sdks/nuon-go/models/service_create_runbook_step_config_request.go
@@ -40,6 +40,9 @@ type ServiceCreateRunbookStepConfigRequest struct {
 	// inline contents
 	InlineContents string `json:"inline_contents,omitempty"`
 
+	// inputs
+	Inputs map[string]string `json:"inputs,omitempty"`
+
 	// name
 	// Required: true
 	Name *string `json:"name"`
@@ -49,6 +52,9 @@ type ServiceCreateRunbookStepConfigRequest struct {
 
 	// skip component deploys
 	SkipComponentDeploys bool `json:"skip_component_deploys,omitempty"`
+
+	// skip deploy dependents
+	SkipDeployDependents bool `json:"skip_deploy_dependents,omitempty"`
 
 	// tear down dependents
 	TearDownDependents bool `json:"tear_down_dependents,omitempty"`

--- a/services/ctl-api/internal/app/installs/helpers/apply_input_patch.go
+++ b/services/ctl-api/internal/app/installs/helpers/apply_input_patch.go
@@ -1,0 +1,158 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+)
+
+// ApplyInputPatchResult captures the output of applying a partial input update.
+type ApplyInputPatchResult struct {
+	// InstallInputs is the freshly persisted InstallInputs row (Values cleared,
+	// matching the HTTP handler's response shape).
+	InstallInputs *app.InstallInputs
+	// ChangedNames is the list of input names whose values changed.
+	ChangedNames []string
+	// ChangedValuesJSON is a JSON snapshot of old→new values for audit logging
+	// (sensitive inputs are masked).
+	ChangedValuesJSON string
+}
+
+// ApplyInstallInputPatch merges a partial input patch over the install's
+// current inputs, validates the merged set against the pinned app input
+// config, persists a new InstallInputs row, and returns the changed input
+// names + audit values.
+//
+// Shared by the PATCH /v1/installs/{id}/inputs HTTP handler and the runbook
+// input_update step. Callers are responsible for starting any workflow that
+// reacts to the change.
+func (h *Helpers) ApplyInstallInputPatch(
+	ctx context.Context,
+	install *app.Install,
+	patch map[string]*string,
+) (*ApplyInputPatchResult, error) {
+	if len(install.App.AppInputConfigs) < 1 {
+		return nil, stderr.ErrUser{
+			Err:         fmt.Errorf("no app input configs defined on app"),
+			Description: "no app input configs defined",
+		}
+	}
+
+	latestInstallInputs := app.InstallInputs{}
+	if err := h.db.WithContext(ctx).
+		Where("install_id = ?", install.ID).
+		Order("created_at DESC").
+		First(&latestInstallInputs).Error; err != nil {
+		return nil, fmt.Errorf("unable to get latest install inputs: %w", err)
+	}
+
+	pinnedAppInputConfig, err := h.GetPinnedAppInputConfig(ctx, install.AppID, install.AppConfigID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get pinned app input config: %w", err)
+	}
+	if pinnedAppInputConfig == nil {
+		return nil, stderr.ErrUser{
+			Err:         fmt.Errorf("invalid install inputs provided"),
+			Description: "inputs provided on install, that are not defined on the app",
+		}
+	}
+
+	if err := validateVendorSourceInputs(pinnedAppInputConfig, patch); err != nil {
+		return nil, err
+	}
+
+	merged := MergeInstallInputs(latestInstallInputs.Values, patch, pinnedAppInputConfig)
+	if err := h.ValidateInstallInputs(ctx, pinnedAppInputConfig, merged); err != nil {
+		return nil, err
+	}
+
+	changed, err := ComputeChangedInputs(
+		latestInstallInputs.Values,
+		patch,
+		pinnedAppInputConfig.AppInputs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to compute changed inputs: %w", err)
+	}
+
+	obj := &app.InstallInputs{
+		AppInputConfigID: pinnedAppInputConfig.ID,
+		InstallID:        install.ID,
+		Values:           pgtype.Hstore(merged),
+	}
+	if err := h.db.WithContext(ctx).Create(&obj).Error; err != nil {
+		return nil, fmt.Errorf("unable to create install inputs: %w", err)
+	}
+
+	// Re-fetch so we return the latest row with its generated fields, then clear
+	// Values for the response (matching the HTTP handler's contract).
+	persisted := app.InstallInputs{}
+	if err := h.db.WithContext(ctx).
+		Where("install_id = ?", install.ID).
+		Order("created_at DESC").
+		First(&persisted).Error; err != nil {
+		return nil, fmt.Errorf("unable to get latest install inputs after create: %w", err)
+	}
+	persisted.Values = nil
+
+	return &ApplyInputPatchResult{
+		InstallInputs:     &persisted,
+		ChangedNames:      changed.Names,
+		ChangedValuesJSON: changed.ChangedValuesJSON,
+	}, nil
+}
+
+// MergeInstallInputs overlays the provided subset onto the install's existing
+// input values and drops any inputs no longer defined in the pinned app input
+// config.
+func MergeInstallInputs(existing map[string]*string, patch map[string]*string, appInputConfig *app.AppInputConfig) map[string]*string {
+	merged := map[string]*string{}
+	for k, v := range existing {
+		merged[k] = v
+	}
+	for k, v := range patch {
+		merged[k] = v
+	}
+
+	appInputNames := map[string]struct{}{}
+	for _, input := range appInputConfig.AppInputs {
+		appInputNames[input.Name] = struct{}{}
+	}
+	for k := range merged {
+		if _, ok := appInputNames[k]; !ok {
+			delete(merged, k)
+		}
+	}
+
+	return merged
+}
+
+func validateVendorSourceInputs(appInputConfig *app.AppInputConfig, inputs map[string]*string) error {
+	appInputSources := map[string]app.AppInputSource{}
+	for _, input := range appInputConfig.AppInputs {
+		appInputSources[input.Name] = input.Source
+	}
+
+	for name := range inputs {
+		source, ok := appInputSources[name]
+		if !ok {
+			return stderr.ErrUser{
+				Err:         fmt.Errorf("input %s is not defined in app input config", name),
+				Description: "input " + name + " does not exist in the app inputs",
+			}
+		}
+
+		if source == app.AppInputSourceCustomer {
+			return stderr.ErrUser{
+				Err:         fmt.Errorf("%s has source install_stack, cannot be updated via api", name),
+				Description: name + " has source install_stack and cannot be updated via the api",
+			}
+		}
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/app/installs/service/update_install_inputs.go
+++ b/services/ctl-api/internal/app/installs/service/update_install_inputs.go
@@ -7,10 +7,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
-	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/updated"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	executeflow "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeflow"
@@ -67,58 +65,9 @@ func (s *service) UpdateInstallInputs(ctx *gin.Context) {
 		return
 	}
 
-	if len(install.App.AppInputConfigs) < 1 {
-		ctx.Error(stderr.ErrUser{
-			Err:         fmt.Errorf("no app input configs defined on app"),
-			Description: "no app input configs defined",
-		})
-		return
-	}
-
-	latestLatestInstallInputs, err := s.getLatestInstallInputs(ctx, install.ID)
+	patchResult, err := s.helpers.ApplyInstallInputPatch(ctx, install, req.Inputs)
 	if err != nil {
-		ctx.Error(fmt.Errorf("unable to get latest install inputs: %w", err))
-		return
-	}
-
-	pinnedAppInputConfig, err := s.helpers.GetPinnedAppInputConfig(ctx, install.AppID, install.AppConfigID)
-	if err != nil {
-		ctx.Error(fmt.Errorf("unable to get latest app input config: %w", err))
-		return
-	}
-	if pinnedAppInputConfig == nil {
-		ctx.Error(stderr.ErrUser{
-			Err:         fmt.Errorf("invalid install inputs provided"),
-			Description: "inputs provided on install, that are not defined on the app",
-		})
-		return
-	}
-
-	// Reject any install_stack (customer) sourced inputs in the provided subset.
-	// This intentionally operates ONLY on the subset the caller sent — existing
-	// customer-sourced values carried over by the merge are preserved, not re-validated.
-	if err := s.validateVendorSourceInputs(pinnedAppInputConfig, req.Inputs); err != nil {
 		ctx.Error(err)
-		return
-	}
-
-	// Merge the provided subset over the install's current inputs, then validate the
-	// full resulting set so required inputs remain satisfied after a partial update.
-	merged := mergeInstallInputs(latestLatestInstallInputs.Values, req.Inputs, pinnedAppInputConfig)
-	if err := s.helpers.ValidateInstallInputs(ctx, pinnedAppInputConfig, merged); err != nil {
-		ctx.Error(err)
-		return
-	}
-
-	inputs, changedInputs, changedInputValues, err := s.newInstallInputs(
-		ctx,
-		latestLatestInstallInputs,
-		pinnedAppInputConfig,
-		merged,
-		req,
-	)
-	if err != nil {
-		ctx.Error(fmt.Errorf("unable to create install inputs: %w", err))
 		return
 	}
 
@@ -129,8 +78,8 @@ func (s *service) UpdateInstallInputs(ctx *gin.Context) {
 	workflow, err := s.helpers.CreateAndStartInputUpdateWorkflow(
 		ctx,
 		install.ID,
-		*changedInputs,
-		changedInputValues,
+		patchResult.ChangedNames,
+		patchResult.ChangedValuesJSON,
 		req.Role,
 		deployDependents,
 	)
@@ -163,8 +112,8 @@ func (s *service) UpdateInstallInputs(ctx *gin.Context) {
 		return
 	}
 
-	inputs.WorkflowID = &workflow.ID
-	ctx.JSON(http.StatusOK, inputs)
+	patchResult.InstallInputs.WorkflowID = &workflow.ID
+	ctx.JSON(http.StatusOK, patchResult.InstallInputs)
 }
 
 func (s *service) getLatestInstallInputs(ctx context.Context, installID string) (*app.InstallInputs, error) {
@@ -192,92 +141,4 @@ func (s *service) getLatestAppInputConfig(ctx context.Context, appID string) (*a
 	}
 
 	return &appInputConfig, nil
-}
-
-func (s *service) newInstallInputs(
-	ctx context.Context,
-	installInputs *app.InstallInputs,
-	appInputConfig *app.AppInputConfig,
-	merged map[string]*string,
-	req UpdateInstallInputsRequest,
-) (*app.InstallInputs, *[]string, string, error) {
-	changed, err := helpers.ComputeChangedInputs(
-		installInputs.Values,
-		req.Inputs,
-		appInputConfig.AppInputs,
-	)
-	if err != nil {
-		return nil, nil, "", fmt.Errorf("unable to compute changed inputs: %w", err)
-	}
-
-	// this update will be tied to the latest AppInputConfigID for the app
-	obj := &app.InstallInputs{
-		AppInputConfigID: appInputConfig.ID,
-		InstallID:        installInputs.InstallID,
-		Values:           pgtype.Hstore(merged),
-	}
-	res := s.db.WithContext(ctx).Create(&obj)
-	if res.Error != nil {
-		return nil, nil, "", fmt.Errorf("unable to create install inputs: %w", res.Error)
-	}
-
-	latestInstallInputs, err := s.getLatestInstallInputs(ctx, installInputs.InstallID)
-	if err != nil {
-		return nil, nil, "", fmt.Errorf("unable to get latest install inputs: %w", err)
-	}
-
-	latestInstallInputs.Values = nil
-
-	return latestInstallInputs, &changed.Names, changed.ChangedValuesJSON, nil
-}
-
-// mergeInstallInputs overlays the provided subset onto the install's existing input
-// values and drops any inputs no longer defined in the pinned app input config.
-func mergeInstallInputs(existing map[string]*string, patch map[string]*string, appInputConfig *app.AppInputConfig) map[string]*string {
-	merged := map[string]*string{}
-	for k, v := range existing {
-		merged[k] = v
-	}
-	for k, v := range patch {
-		merged[k] = v
-	}
-
-	appInputNames := map[string]struct{}{}
-	for _, input := range appInputConfig.AppInputs {
-		appInputNames[input.Name] = struct{}{}
-	}
-	for k := range merged {
-		if _, ok := appInputNames[k]; !ok {
-			delete(merged, k)
-		}
-	}
-
-	return merged
-}
-
-func (s *service) validateVendorSourceInputs(appInputConfig *app.AppInputConfig, inputs map[string]*string) error {
-	appInputSources := map[string]app.AppInputSource{}
-	for _, input := range appInputConfig.AppInputs {
-		appInputSources[input.Name] = input.Source
-	}
-
-	for name := range inputs {
-		source, ok := appInputSources[name]
-		if !ok {
-			return stderr.ErrUser{
-				Err:         fmt.Errorf("input %s is not defined in app input config", name),
-				Description: "input " + name + " does not exist in the app inputs",
-			}
-		}
-
-		// Reject customer sourced inputs
-		if source == app.AppInputSourceCustomer {
-			return stderr.ErrUser{
-				Err:         fmt.Errorf("%s has source install_stack, cannot be updated via api", name),
-				Description: name + " has source install_stack and cannot be updated via the api",
-			}
-		}
-	}
-
-	return nil
 }

--- a/services/ctl-api/internal/app/installs/worker/activities/apply_input_patch.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/apply_input_patch.go
@@ -1,0 +1,46 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+type ApplyInstallInputPatchRequest struct {
+	InstallID string             `validate:"required"`
+	Patch     map[string]*string `validate:"required"`
+}
+
+type ApplyInstallInputPatchResponse struct {
+	InstallInputsID   string   `json:"install_inputs_id"`
+	ChangedNames      []string `json:"changed_names"`
+	ChangedValuesJSON string   `json:"changed_values_json"`
+}
+
+// ApplyInstallInputPatch merges the patch over the install's current inputs,
+// validates the result, and persists a new InstallInputs row. Returns the list
+// of input names whose values changed so the caller can drive the input-update
+// step sequence.
+//
+// @temporal-gen-v2 activity
+func (a *Activities) ApplyInstallInputPatch(ctx context.Context, req *ApplyInstallInputPatchRequest) (*ApplyInstallInputPatchResponse, error) {
+	var install app.Install
+	if err := a.db.WithContext(ctx).
+		Preload("App.AppInputConfigs").
+		Where("id = ?", req.InstallID).
+		First(&install).Error; err != nil {
+		return nil, fmt.Errorf("unable to load install %s: %w", req.InstallID, err)
+	}
+
+	result, err := a.helpers.ApplyInstallInputPatch(ctx, &install, req.Patch)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ApplyInstallInputPatchResponse{
+		InstallInputsID:   result.InstallInputs.ID,
+		ChangedNames:      result.ChangedNames,
+		ChangedValuesJSON: result.ChangedValuesJSON,
+	}, nil
+}

--- a/services/ctl-api/internal/app/installs/workflows/v2/run_runbook.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/run_runbook.go
@@ -124,6 +124,13 @@ func RunRunbook(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResu
 			}
 			steps = append(steps, actionStep)
 
+		case app.RunbookStepTypeInputUpdate:
+			inputSteps, err := runbookInputUpdateSteps(ctx, &stepCfg, sg, flw, install)
+			if err != nil {
+				return nil, errors.Wrapf(err, "unable to generate input_update step %s", stepCfg.Name)
+			}
+			steps = append(steps, inputSteps...)
+
 		case app.RunbookStepTypeSandboxReprovision,
 			app.RunbookStepTypeSandboxDeprovision:
 			sbxSteps, err := runbookSandboxLifecycleSteps(ctx, installID, &stepCfg, flw, sg, install)
@@ -481,4 +488,43 @@ func runbookSandboxLifecycleSteps(ctx workflow.Context, installID string, stepCf
 	result = append(result, deploySteps...)
 
 	return result, nil
+}
+
+// runbookInputUpdateSteps applies the step's input patch to the install and
+// generates the same step sequence the dashboard's PATCH /v1/installs/{id}/inputs
+// triggers (state-refresh + pre/post-update lifecycle actions + affected
+// component deploys, or sandbox reprovision when the sandbox references the
+// changed inputs).
+func runbookInputUpdateSteps(
+	ctx workflow.Context,
+	stepCfg *app.RunbookStepConfig,
+	sg *stepGroup,
+	flw *app.Workflow,
+	install *app.Install,
+) ([]*app.WorkflowStep, error) {
+	if len(stepCfg.Inputs) == 0 {
+		return nil, errors.Errorf("input_update step %q has no inputs", stepCfg.Name)
+	}
+
+	// Apply the patch and persist a new InstallInputs row.
+	patchResp, err := activities.AwaitApplyInstallInputPatch(ctx, &activities.ApplyInstallInputPatchRequest{
+		InstallID: install.ID,
+		Patch:     map[string]*string(stepCfg.Inputs),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to apply install input patch")
+	}
+
+	// Nothing to do when no values actually changed — skip the deploy/state
+	// refresh churn rather than emit a no-op step sequence.
+	if len(patchResp.ChangedNames) == 0 {
+		return nil, nil
+	}
+
+	return inputUpdateSteps(ctx, sg, inputUpdateStepsArgs{
+		Install:          install,
+		Flw:              flw,
+		ChangedInputs:    patchResp.ChangedNames,
+		DeployDependents: !stepCfg.SkipDeployDependents,
+	})
 }

--- a/services/ctl-api/internal/app/installs/workflows/v2/shared_input_update.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/shared_input_update.go
@@ -1,0 +1,172 @@
+package v2
+
+import (
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/pkg/errors"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/pkg/config/refs"
+	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/generatestate"
+	statepartialgenerate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/state/statepartialgenerate"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
+)
+
+// inputUpdateStepsArgs is the input set required to generate the step sequence
+// for an install-input update. Shared by the dashboard-triggered InputUpdate
+// workflow and the runbook input_update step.
+type inputUpdateStepsArgs struct {
+	Install          *app.Install
+	Flw              *app.Workflow
+	ChangedInputs    []string
+	DeployDependents bool
+}
+
+// inputUpdateSteps generates the full step sequence for applying an install
+// input update: state-refresh, pre-update lifecycle actions, affected-component
+// deploys (or sandbox reprovision when sandbox refs the changed inputs),
+// and post-update lifecycle actions.
+//
+// Callers own the *stepGroup and the surrounding []*app.WorkflowStep slice;
+// this function appends to that slice and returns the result.
+func inputUpdateSteps(ctx workflow.Context, sg *stepGroup, args inputUpdateStepsArgs) ([]*app.WorkflowStep, error) {
+	install := args.Install
+	flw := args.Flw
+	installID := install.ID
+
+	steps := make([]*app.WorkflowStep, 0)
+
+	sg.nextGroup() // refresh inputs partial in state
+	orgEnabled, err := activities.AwaitHasFeatureByFeature(ctx, string(app.OrgFeatureStateGenV2))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to check state-gen-v2 feature")
+	}
+	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
+	var stateSignal signal.Signal
+	if stateGenV2 {
+		stateSignal = &statepartialgenerate.Signal{
+			InstallID:       installID,
+			Targets:         statemanager.TargetsForHint(statemanager.HintInputsUpdated, ""),
+			TriggeredByID:   installID,
+			TriggeredByType: "installs",
+		}
+	} else {
+		stateSignal = &generatestate.Signal{InstallID: installID}
+	}
+	step, err := sg.installSignalStep(ctx, installID, "update install state inputs", pgtype.Hstore{}, stateSignal, flw.PlanOnly, WithSkippable(false))
+	if err != nil {
+		return nil, err
+	}
+	steps = append(steps, step)
+
+	appConfig, err := activities.AwaitGetAppConfig(ctx, activities.GetAppConfigRequest{
+		ID: install.AppConfigID,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to get app config for install %s", installID)
+	}
+
+	awData, err := activities.AwaitGetActionWorkflows(ctx, &activities.GetActionWorkflows{
+		InstallID: installID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflows")
+	}
+
+	lifecycleSteps, err := getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePreUpdateInputs, sg, appConfig, awData)
+	if err != nil {
+		return nil, err
+	}
+	steps = append(steps, lifecycleSteps...)
+
+	var changedRefs []refs.Ref
+	for _, input := range args.ChangedInputs {
+		changedRefs = append(changedRefs, refs.Ref{
+			Name: input,
+			Type: refs.RefTypeInputs,
+		})
+		changedRefs = append(changedRefs, refs.Ref{
+			Name: input,
+			Type: refs.RefTypeInstallInputs,
+		})
+	}
+
+	// Get all components that reference the changed inputs
+	var componentIDs []string
+	for _, comp := range getComponentsForChangedInputs(appConfig, &changedRefs) {
+		componentIDs = append(componentIDs, comp.ID)
+
+		if args.DeployDependents {
+			dependentCompIDs, err := activities.AwaitGetComponentDependents(ctx, &activities.GetComponentDependentsRequest{
+				AppConfigID: appConfig.ID,
+				ComponentID: comp.ID,
+			})
+			if err != nil {
+				return nil, errors.Wrapf(err, "unable to get component dependents for %s", comp.ID)
+			}
+
+			componentIDs = append(componentIDs, dependentCompIDs...)
+		}
+	}
+	componentIDs = generics.UniqueSlice(componentIDs)
+
+	// Check if sandbox config references contain any of the changed inputs
+	sandboxNeedsReprovision, err := checkSandboxNeedsReprovision(ctx, appConfig, &changedRefs)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to check if sandbox needs reprovision")
+	}
+
+	// If sandbox needs reprovision, emit sandbox reprovision steps in place of component deploys
+	if sandboxNeedsReprovision {
+		sandboxSteps, err := getSandboxReprovisionSteps(ctx, install, installID, flw, sg, appConfig, awData)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to get sandbox reprovision steps")
+		}
+		steps = append(steps, sandboxSteps...)
+	} else {
+		deploySteps, err := getComponentDeploySteps(ctx, installID, flw, componentIDs, sg, appConfig, awData)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to get component deploy steps")
+		}
+		steps = append(steps, deploySteps...)
+	}
+
+	lifecycleSteps, err = getLifecycleActionsSteps(ctx, installID, flw, app.ActionWorkflowTriggerTypePostUpdateInputs, sg, appConfig, awData)
+	if err != nil {
+		return nil, err
+	}
+	steps = append(steps, lifecycleSteps...)
+
+	return steps, nil
+}
+
+func getComponentsForChangedInputs(appConfig *app.AppConfig, changedRefs *[]refs.Ref) []app.Component {
+	components := make([]app.Component, 0)
+
+	for _, conConfigs := range appConfig.ComponentConfigConnections {
+		for _, ref := range conConfigs.Refs {
+			for _, changedRef := range *changedRefs {
+				if ref.Name == changedRef.Name && ref.Type == changedRef.Type {
+					components = append(components, conConfigs.Component)
+				}
+			}
+		}
+	}
+	return components
+}
+
+// checkSandboxNeedsReprovision checks if the sandbox configuration references any of the changed inputs
+func checkSandboxNeedsReprovision(ctx workflow.Context, appCfg *app.AppConfig, changedRefs *[]refs.Ref) (bool, error) {
+	for _, sandboxRef := range appCfg.SandboxConfig.Refs {
+		for _, changedRef := range *changedRefs {
+			if sandboxRef.Name == changedRef.Name && sandboxRef.Type == changedRef.Type {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
@@ -4,18 +4,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/pkg/config/refs"
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/generatestate"
-	statepartialgenerate "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/state/statepartialgenerate"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
-	statemanager "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
 )
 
 func InputUpdate(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResult, error) {
@@ -25,38 +20,16 @@ func InputUpdate(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRes
 		return nil, errors.Wrap(err, "unable to get install")
 	}
 
-	sg := newStepGroup(flw)
-	steps := make([]*app.WorkflowStep, 0)
-
-	sg.nextGroup() // refresh inputs partial in state
-	orgEnabled, err := activities.AwaitHasFeatureByFeature(ctx, string(app.OrgFeatureStateGenV2))
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to check state-gen-v2 feature")
-	}
-	stateGenV2 := statemanager.UseStateGenV2(orgEnabled, install.Metadata)
-	var stateSignal signal.Signal
-	if stateGenV2 {
-		stateSignal = &statepartialgenerate.Signal{
-			InstallID:       installID,
-			Targets:         statemanager.TargetsForHint(statemanager.HintInputsUpdated, ""),
-			TriggeredByID:   installID,
-			TriggeredByType: "installs",
-		}
-	} else {
-		stateSignal = &generatestate.Signal{InstallID: installID}
-	}
-	step, err := sg.installSignalStep(ctx, installID, "update install state inputs", pgtype.Hstore{}, stateSignal, flw.PlanOnly, WithSkippable(false))
-	if err != nil {
-		return nil, err
-	}
-	steps = append(steps, step)
-
 	changedInputsRaw := generics.FromPtrStr(flw.Metadata["inputs"])
 	changedInputs := strings.Split(changedInputsRaw, ",")
 	deployDependents := generics.FromPtrStr(flw.Metadata["deploy_dependents"]) == strconv.FormatBool(true)
 
-	appConfig, err := activities.AwaitGetAppConfig(ctx, activities.GetAppConfigRequest{
-		ID: install.AppConfigID,
+	sg := newStepGroup(flw)
+	steps, err := inputUpdateSteps(ctx, sg, inputUpdateStepsArgs{
+		Install:          install,
+		Flw:              flw,
+		ChangedInputs:    changedInputs,
+		DeployDependents: deployDependents,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to get app config for install %s", installID)
@@ -136,33 +109,4 @@ func InputUpdate(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRes
 	steps = append(steps, lifecycleSteps...)
 
 	return sg.Result(steps), nil
-}
-
-func getComponentsForChangedInputs(appConfig *app.AppConfig, changedRefs *[]refs.Ref) []app.Component {
-	components := make([]app.Component, 0)
-
-	for _, conConfigs := range appConfig.ComponentConfigConnections {
-		for _, ref := range conConfigs.Refs {
-			for _, changedRef := range *changedRefs {
-				if ref.Name == changedRef.Name && ref.Type == changedRef.Type {
-					components = append(components, conConfigs.Component)
-				}
-			}
-		}
-	}
-	return components
-}
-
-// checkSandboxNeedsReprovision checks if the sandbox configuration references any of the changed inputs
-func checkSandboxNeedsReprovision(ctx workflow.Context, appCfg *app.AppConfig, changedRefs *[]refs.Ref) (bool, error) {
-	// Check if any of the sandbox's references match the changed inputs
-	for _, sandboxRef := range appCfg.SandboxConfig.Refs {
-		for _, changedRef := range *changedRefs {
-			if sandboxRef.Name == changedRef.Name && sandboxRef.Type == changedRef.Type {
-				return true, nil
-			}
-		}
-	}
-
-	return false, nil
 }

--- a/services/ctl-api/internal/app/runbook_step_config.go
+++ b/services/ctl-api/internal/app/runbook_step_config.go
@@ -20,6 +20,7 @@ const (
 	RunbookStepTypeComponentDeploy    RunbookStepType = "component_deploy"
 	RunbookStepTypeComponentTearDown  RunbookStepType = "component_tear_down"
 	RunbookStepTypeAction             RunbookStepType = "action"
+	RunbookStepTypeInputUpdate        RunbookStepType = "input_update"
 	RunbookStepTypeSandboxReprovision RunbookStepType = "sandbox_reprovision"
 	RunbookStepTypeSandboxDeprovision RunbookStepType = "sandbox_deprovision"
 
@@ -54,6 +55,13 @@ type RunbookStepConfig struct {
 
 	// sandbox lifecycle fields
 	SkipComponentDeploys bool `json:"skip_component_deploys,omitzero" gorm:"default:false" temporaljson:"skip_component_deploys,omitzero,omitempty"`
+
+	// input_update fields. Inputs is a map of input-name → templated value to
+	// apply to the install. SkipDeployDependents inverts the dashboard's
+	// "Deploy dependents" checkbox so the Go zero value preserves the default
+	// (deploy dependents on input update).
+	Inputs               pgtype.Hstore `json:"inputs,omitzero" gorm:"type:hstore" swaggertype:"object,string" temporaljson:"inputs,omitzero,omitempty"`
+	SkipDeployDependents bool          `json:"skip_deploy_dependents,omitzero" gorm:"default:false" temporaljson:"skip_deploy_dependents,omitzero,omitempty"`
 
 	// action reference field
 	ActionWorkflowID generics.NullString `json:"action_workflow_id,omitzero" swaggertype:"string" temporaljson:"action_workflow_id,omitzero,omitempty"`

--- a/services/ctl-api/internal/app/runbooks/service/create_runbook_config.go
+++ b/services/ctl-api/internal/app/runbooks/service/create_runbook_config.go
@@ -46,6 +46,8 @@ type CreateRunbookStepConfigRequest struct {
 	EnvVars                  map[string]string `json:"env_vars,omitempty"`
 	Timeout                  int64             `json:"timeout,omitempty"`
 	Role                     string            `json:"role,omitempty"`
+	Inputs                   map[string]string `json:"inputs,omitempty"`
+	SkipDeployDependents     bool              `json:"skip_deploy_dependents,omitempty"`
 }
 
 // @ID				CreateRunbookConfig
@@ -111,11 +113,22 @@ func (s *service) CreateRunbookConfig(ctx *gin.Context) {
 		case app.RunbookStepTypeComponentDeploy,
 			app.RunbookStepTypeComponentTearDown,
 			app.RunbookStepTypeAction,
+			app.RunbookStepTypeInputUpdate,
 			app.RunbookStepTypeSandboxReprovision,
 			app.RunbookStepTypeSandboxDeprovision:
 		default:
 			ctx.Error(fmt.Errorf("invalid step type %q for step %s", stepReq.Type, stepReq.Name))
 			return
+		}
+
+		if stepType == app.RunbookStepTypeInputUpdate && len(stepReq.Inputs) == 0 {
+			ctx.Error(fmt.Errorf("step %s of type input_update requires non-empty inputs", stepReq.Name))
+			return
+		}
+
+		inputs := pgtype.Hstore{}
+		for k, v := range stepReq.Inputs {
+			inputs[k] = &v
 		}
 
 		envVars := pgtype.Hstore{}
@@ -131,6 +144,8 @@ func (s *service) CreateRunbookConfig(ctx *gin.Context) {
 			DeployDependents:     stepReq.DeployDependents || stepReq.DeployDependenciesLegacy,
 			TearDownDependents:   stepReq.TearDownDependents,
 			SkipComponentDeploys: stepReq.SkipComponentDeploys,
+			Inputs:               inputs,
+			SkipDeployDependents: stepReq.SkipDeployDependents,
 			Command:              stepReq.Command,
 			InlineContents:       stepReq.InlineContents,
 			EnvVars:              envVars,

--- a/services/dashboard-ui/client/components/runbooks/RunbookStep.tsx
+++ b/services/dashboard-ui/client/components/runbooks/RunbookStep.tsx
@@ -28,6 +28,8 @@ export const RunbookStep = ({ index, step, actionBasePath }: IRunbookStep) => {
                 ? 'RocketIcon'
                 : step.type === 'component_tear_down'
                   ? 'TrashIcon'
+                : step.type === 'input_update'
+                  ? 'PencilIcon'
                 : step.type === 'sandbox_reprovision' ||
                     step.type === 'sandbox_deprovision'
                   ? 'CubeIcon'
@@ -72,6 +74,12 @@ export const RunbookStep = ({ index, step, actionBasePath }: IRunbookStep) => {
               <Text variant="subtext">{step.skip_component_deploys ? 'Yes' : 'No'}</Text>
             </div>
           ) : null}
+          {step.type === 'input_update' ? (
+            <div className="flex items-center py-2 gap-4">
+              <Text variant="subtext" theme="neutral" className="w-48 shrink-0">Deploy dependents</Text>
+              <Text variant="subtext">{step.skip_deploy_dependents ? 'No' : 'Yes'}</Text>
+            </div>
+          ) : null}
           {step.action_workflow_id ? (
             <div className="flex items-center py-2 gap-4">
               <Text variant="subtext" theme="neutral" className="w-48 shrink-0">Action ID</Text>
@@ -110,6 +118,15 @@ export const RunbookStep = ({ index, step, actionBasePath }: IRunbookStep) => {
           <div className="flex flex-col gap-2">
             <Text weight="strong">Environment variables</Text>
             <KeyValueList values={objectToKeyValueArray(step.env_vars)} />
+          </div>
+        ) : null}
+
+        {step.type === 'input_update' &&
+        step.inputs &&
+        Object.keys(step.inputs).length > 0 ? (
+          <div className="flex flex-col gap-2">
+            <Text weight="strong">Inputs</Text>
+            <KeyValueList values={objectToKeyValueArray(step.inputs)} />
           </div>
         ) : null}
         {actionBasePath && step.action_workflow_id ? (

--- a/services/dashboard-ui/client/lib/ctl-api/apps/runbooks/get-runbooks.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/runbooks/get-runbooks.ts
@@ -58,6 +58,8 @@ export type TRunbookStep = {
   deploy_dependents?: boolean
   tear_down_dependents?: boolean
   skip_component_deploys?: boolean
+  inputs?: Record<string, string>
+  skip_deploy_dependents?: boolean
   action_workflow_id?: string
   command?: string
   inline_contents?: string

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -4853,11 +4853,21 @@ export interface components {
       id?: string;
       idx?: number;
       inline_contents?: string;
+      /**
+       * @description input_update fields. Inputs is a map of input-name → templated value to
+       * apply to the install. SkipDeployDependents inverts the dashboard's
+       * "Deploy dependents" checkbox so the Go zero value preserves the default
+       * (deploy dependents on input update).
+       */
+      inputs?: {
+        [key: string]: string;
+      };
       name?: string;
       role?: string;
       runbook_config_id?: string;
       /** @description sandbox lifecycle fields */
       skip_component_deploys?: boolean;
+      skip_deploy_dependents?: boolean;
       tear_down_dependents?: boolean;
       timeout?: number;
       type?: string;
@@ -7023,9 +7033,13 @@ export interface components {
       };
       idx?: number;
       inline_contents?: string;
+      inputs?: {
+        [key: string]: string;
+      };
       name: string;
       role?: string;
       skip_component_deploys?: boolean;
+      skip_deploy_dependents?: boolean;
       tear_down_dependents?: boolean;
       timeout?: number;
       type: string;


### PR DESCRIPTION
## Summary

This PR adds an input update step to runbooks, along with some refactoring to ensure the steps have consistent behavior in their "home" workflow and in runbook workflows.

### Input update steps

You can add a step of type `input_update` to a runbook. It allows updating one or more inputs, and controllering whether affected component's dependents are updated (consistent with the update input UI behavior.)

```toml
[[steps]]
name   = "Update image tag"
type   = "input_update"
inputs = { image = "kennethreitz/httpbin", tag = "latest" }
```