### PR TITLE
chore: route lsp base image through infra-shared-ci PTC

### DIFF
--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -55,17 +55,6 @@ jobs:
       - name: Setup nuonctl
         uses: ./actions/setup-nuonctl
 
-      - name: Login to Docker Hub (optional)
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
-            echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-          else
-            echo "::warning::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN are not configured; Docker Hub pulls may hit rate limits."
-          fi
-
       - name: Setup BuildKit
         if: ${{ env.NO_REMOTE_BUILDKIT != 'true' }}
         run: CI=true nuonctl builds driver ctl-api

--- a/bins/lsp/Dockerfile
+++ b/bins/lsp/Dockerfile
@@ -109,7 +109,7 @@ COPY --from=build-linux-amd64 /out/ /
 
 # Compress, checksum, and prepare artifacts for upload
 # Go code will handle the S3 upload part
-FROM alpine:latest AS artifacts
+FROM 821160992543.dkr.ecr.us-west-2.amazonaws.com/docker.io/library/alpine:latest AS artifacts
 RUN apk add --no-cache pigz
 
 ARG BIN_NAME=nuon-lsp


### PR DESCRIPTION
Routes the one remaining external upstream pull in this repo (lsp artifacts stage, alpine:latest) through the infra-shared-ci ECR pull-through cache. Everything else already uses the public.ecr.aws/p7e3r5y0 mirror. Builds on self-hosted runners auto-login to the PTC via the promoted nuonctl.