### PR TITLE
feat: collect first/last name on org invites and pass name to Loops

### DIFF
--- a/bins/cli/cmd/orgs.go
+++ b/bins/cli/cmd/orgs.go
@@ -15,6 +15,8 @@ func (c *cli) orgsCmd() *cobra.Command {
 		limit        int
 		search       string
 		email        string
+		firstName    string
+		lastName     string
 		noSelect     bool
 		connectionID string
 	)
@@ -184,10 +186,12 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Long:  "Invite a user by email to org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			svc := orgs.New(c.apiClient, c.cfg)
-			return svc.CreateInvite(cmd.Context(), email, PrintJSON)
+			return svc.CreateInvite(cmd.Context(), email, firstName, lastName, PrintJSON)
 		}),
 	}
 	createInviteCmd.Flags().StringVarP(&email, "email", "e", "", "Email of user to invite")
+	createInviteCmd.Flags().StringVar(&firstName, "first-name", "", "First name of user to invite")
+	createInviteCmd.Flags().StringVar(&lastName, "last-name", "", "Last name of user to invite")
 	orgsCmd.AddCommand(createInviteCmd)
 
 	listInvitesCmd := &cobra.Command{

--- a/bins/cli/internal/services/orgs/create_invite.go
+++ b/bins/cli/internal/services/orgs/create_invite.go
@@ -8,14 +8,16 @@ import (
 	"github.com/nuonco/nuon/sdks/nuon-go/models"
 )
 
-func (s *Service) CreateInvite(ctx context.Context, email string, asJSON bool) error {
+func (s *Service) CreateInvite(ctx context.Context, email, firstName, lastName string, asJSON bool) error {
 	view := ui.NewGetView()
 	if email == "" {
 		return view.Error(fmt.Errorf("email is required"))
 	}
 
 	invite, err := s.api.CreateOrgInvite(ctx, &models.ServiceCreateOrgInviteRequest{
-		Email: &email,
+		Email:     &email,
+		FirstName: firstName,
+		LastName:  lastName,
 	})
 	if err != nil {
 		return view.Error(err)
@@ -30,11 +32,15 @@ func (s *Service) CreateInvite(ctx context.Context, email string, asJSON bool) e
 		{
 			"ID",
 			"EMAIL",
+			"FIRST NAME",
+			"LAST NAME",
 			"STATUS",
 		},
 		{
 			invite.ID,
 			invite.Email,
+			invite.FirstName,
+			invite.LastName,
 			string(invite.Status),
 		},
 	}

--- a/sdks/nuon-go/models/app_org_invite.go
+++ b/sdks/nuon-go/models/app_org_invite.go
@@ -28,8 +28,14 @@ type AppOrgInvite struct {
 	// email
 	Email string `json:"email,omitempty"`
 
+	// first name
+	FirstName string `json:"first_name,omitempty"`
+
 	// id
 	ID string `json:"id,omitempty"`
+
+	// last name
+	LastName string `json:"last_name,omitempty"`
 
 	// parent relationship
 	OrgID string `json:"org_id,omitempty"`

--- a/sdks/nuon-go/models/service_create_org_invite_request.go
+++ b/sdks/nuon-go/models/service_create_org_invite_request.go
@@ -24,6 +24,12 @@ type ServiceCreateOrgInviteRequest struct {
 	// Required: true
 	Email *string `json:"email"`
 
+	// first name
+	FirstName string `json:"first_name,omitempty"`
+
+	// last name
+	LastName string `json:"last_name,omitempty"`
+
 	// role type
 	RoleType AppRoleType `json:"role_type,omitempty"`
 }

--- a/services/ctl-api/internal/app/org_invite.go
+++ b/services/ctl-api/internal/app/org_invite.go
@@ -31,10 +31,12 @@ type OrgInvite struct {
 	OrgID string `json:"org_id,omitzero" gorm:"notnull;index:idx_invite_org_email,unique" temporaljson:"org_id,omitzero,omitempty"`
 	Org   Org    `gorm:"constraint:OnDelete:CASCADE;" json:"-" temporaljson:"org,omitzero,omitempty"`
 
-	Email    string          `gorm:"notnull;default null;index:idx_invite_org_email,unique" json:"email,omitzero" temporaljson:"email,omitzero,omitempty"`
-	Status   OrgInviteStatus `json:"status,omitzero" gorm:"notnull;default null" temporaljson:"status,omitzero,omitempty"`
-	StatusV2 CompositeStatus `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
-	RoleType RoleType        `json:"role_type,omitzero" temporaljson:"role_type,omitzero,omitempty"`
+	Email     string          `gorm:"notnull;default null;index:idx_invite_org_email,unique" json:"email,omitzero" temporaljson:"email,omitzero,omitempty"`
+	FirstName string          `gorm:"default null" json:"first_name,omitzero" temporaljson:"first_name,omitzero,omitempty"`
+	LastName  string          `gorm:"default null" json:"last_name,omitzero" temporaljson:"last_name,omitzero,omitempty"`
+	Status    OrgInviteStatus `json:"status,omitzero" gorm:"notnull;default null" temporaljson:"status,omitzero,omitempty"`
+	StatusV2  CompositeStatus `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
+	RoleType  RoleType        `json:"role_type,omitzero" temporaljson:"role_type,omitzero,omitempty"`
 }
 
 func (o *OrgInvite) Indexes(db *gorm.DB) []migrations.Index {

--- a/services/ctl-api/internal/app/orgs/service/create_invite.go
+++ b/services/ctl-api/internal/app/orgs/service/create_invite.go
@@ -16,8 +16,10 @@ import (
 )
 
 type CreateOrgInviteRequest struct {
-	Email    string       `json:"email" validate:"required"`
-	RoleType app.RoleType `json:"role_type,omitempty"`
+	Email     string       `json:"email" validate:"required"`
+	FirstName string       `json:"first_name,omitempty"`
+	LastName  string       `json:"last_name,omitempty"`
+	RoleType  app.RoleType `json:"role_type,omitempty"`
 }
 
 // @ID						CreateOrgInvite
@@ -82,7 +84,7 @@ func (s *service) CreateOrgInvite(ctx *gin.Context) {
 		return
 	}
 
-	invite, err := s.createInvite(ctx, org.ID, req.Email, roleType)
+	invite, err := s.createInvite(ctx, org.ID, req.Email, req.FirstName, req.LastName, roleType)
 	if err != nil {
 		ctx.Error(fmt.Errorf("unable to create invite: %w", err))
 		return
@@ -111,12 +113,14 @@ func (s *service) CreateOrgInvite(ctx *gin.Context) {
 	})
 }
 
-func (s *service) createInvite(ctx context.Context, orgID, email string, roleType app.RoleType) (*app.OrgInvite, error) {
+func (s *service) createInvite(ctx context.Context, orgID, email, firstName, lastName string, roleType app.RoleType) (*app.OrgInvite, error) {
 	invite := app.OrgInvite{
-		OrgID:    orgID,
-		Email:    email,
-		Status:   app.OrgInviteStatusPending,
-		RoleType: roleType,
+		OrgID:     orgID,
+		Email:     email,
+		FirstName: firstName,
+		LastName:  lastName,
+		Status:    app.OrgInviteStatusPending,
+		RoleType:  roleType,
 	}
 
 	err := s.db.WithContext(ctx).

--- a/services/ctl-api/internal/app/orgs/signals/created/signal.go
+++ b/services/ctl-api/internal/app/orgs/signals/created/signal.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/notifications"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
@@ -49,6 +50,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		"org_name":   org.Name,
 		"created_by": org.CreatedBy.Email,
 		"email":      org.CreatedBy.Email,
+		"name":       identityName(&org.CreatedBy),
 		// TODO: Add org_url - requires app URL config which is not available in signal context
 	})
 
@@ -81,6 +83,21 @@ func (s *Signal) sendNotification(ctx workflow.Context, typ notifications.Type, 
 			zap.Error(err),
 			zap.String("type", typ.String()))
 	}
+}
+
+// identityName returns the first non-empty profile name from the account's
+// identity provider records, or an empty string if none is set. Loops falls
+// back to a default greeting when the name variable is empty.
+func identityName(account *app.Account) string {
+	if account == nil {
+		return ""
+	}
+	for _, identity := range account.Identities {
+		if identity.Name != "" {
+			return identity.Name
+		}
+	}
+	return ""
 }
 
 func hasTag(tags []string, target string) bool {

--- a/services/ctl-api/internal/app/orgs/signals/invite_created/signal.go
+++ b/services/ctl-api/internal/app/orgs/signals/invite_created/signal.go
@@ -52,6 +52,8 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		"org_name":   org.Name,
 		"created_by": orgInvite.CreatedBy.Email,
 		"login_url":  s.LoginURL,
+		"first_name": orgInvite.FirstName,
+		"last_name":  orgInvite.LastName,
 	}
 
 	if err := sharedactivities.AwaitSendEmail(ctx, sharedactivities.SendNotificationRequest{OrgID: s.OrgID, Type: notifications.NotificationsTypeOrgInvite, Vars: vars}); err != nil {

--- a/services/ctl-api/internal/app/orgs/worker/activities/get.go
+++ b/services/ctl-api/internal/app/orgs/worker/activities/get.go
@@ -27,6 +27,7 @@ func (a *Activities) getOrg(ctx context.Context, orgID string) (*app.Org, error)
 	res := a.db.WithContext(ctx).
 		Preload("NotificationsConfig").
 		Preload("CreatedBy").
+		Preload("CreatedBy.Identities").
 		Preload("Apps").
 		Preload("Apps.Installs").
 		Preload("RunnerGroup.Runners").

--- a/services/dashboard-ui/client/components/team/InviteUser/InviteUser.tsx
+++ b/services/dashboard-ui/client/components/team/InviteUser/InviteUser.tsx
@@ -18,9 +18,16 @@ export const InviteUserModal = ({
   hasSupportRole: boolean
   isPending: boolean
   error: TAPIError | null
-  onSubmit: (params: { email: string; roleType: string }) => void
+  onSubmit: (params: {
+    email: string
+    firstName: string
+    lastName: string
+    roleType: string
+  }) => void
 } & Omit<IModal, 'onSubmit'>) => {
   const [email, setEmail] = useState('')
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
   const [roleType, setRoleType] = useState('org_admin')
 
   return (
@@ -42,8 +49,8 @@ export const InviteUserModal = ({
             Invite user
           </span>
         ),
-        disabled: !email || isPending,
-        onClick: () => onSubmit({ email, roleType }),
+        disabled: !email || !firstName || !lastName || isPending,
+        onClick: () => onSubmit({ email, firstName, lastName, roleType }),
         variant: 'primary',
       }}
       {...props}
@@ -54,6 +61,28 @@ export const InviteUserModal = ({
             {error?.error || 'Unable to invite user to organization'}
           </Banner>
         ) : null}
+        <div className="flex gap-4">
+          <div className="flex flex-1 flex-col gap-2">
+            <Label htmlFor="invite-first-name">First name</Label>
+            <Input
+              id="invite-first-name"
+              placeholder="Ada"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              required
+            />
+          </div>
+          <div className="flex flex-1 flex-col gap-2">
+            <Label htmlFor="invite-last-name">Last name</Label>
+            <Input
+              id="invite-last-name"
+              placeholder="Lovelace"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              required
+            />
+          </div>
+        </div>
         <div className="flex flex-col gap-2">
           <Label htmlFor="invite-email">
             Email address of the user you want to invite

--- a/services/dashboard-ui/client/components/team/InviteUser/InviteUserContainer.tsx
+++ b/services/dashboard-ui/client/components/team/InviteUser/InviteUserContainer.tsx
@@ -18,9 +18,24 @@ const InviteUserModalContainer = (props: Record<string, any>) => {
   const hasSupportRole = !!org?.features?.['support-role']
 
   const { mutate, isPending, error } = useMutation({
-    mutationFn: ({ email, roleType }: { email: string; roleType: string }) =>
+    mutationFn: ({
+      email,
+      firstName,
+      lastName,
+      roleType,
+    }: {
+      email: string
+      firstName: string
+      lastName: string
+      roleType: string
+    }) =>
       inviteUser({
-        body: { email, ...(hasSupportRole ? { role_type: roleType } : {}) },
+        body: {
+          email,
+          first_name: firstName,
+          last_name: lastName,
+          ...(hasSupportRole ? { role_type: roleType } : {}),
+        },
         orgId: org.id,
       }),
     onSuccess: (_data, { email }) => {
@@ -46,7 +61,9 @@ const InviteUserModalContainer = (props: Record<string, any>) => {
       hasSupportRole={hasSupportRole}
       isPending={isPending}
       error={error}
-      onSubmit={({ email, roleType }) => mutate({ email, roleType })}
+      onSubmit={({ email, firstName, lastName, roleType }) =>
+        mutate({ email, firstName, lastName, roleType })
+      }
       {...props}
     />
   )

--- a/services/dashboard-ui/client/lib/ctl-api/orgs/invite-user.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/orgs/invite-user.ts
@@ -3,6 +3,8 @@ import type { TOrgInvite } from '@/types'
 
 export type TInviteUserBody = {
   email: string
+  first_name?: string
+  last_name?: string
   role_type?: string
 }
 


### PR DESCRIPTION
Add first_name/last_name to the invite team member modal (required in the UI) and persist them on the OrgInvite model. The invite_created signal now sends first_name/last_name to Loops, and the org-created signal sends the creator's identity-provider name. API fields are optional for backward compatibility; Loops handles the fallback when a name is absent.

Surfaces updated: dashboard modal, CLI (--first-name/--last-name), API request, OrgInvite model + Get preload, and the nuon-go SDK models.