### PR TITLE
feat: (sandbox mode): allow a custom error message on runner job configs

### DIFF
--- a/services/ctl-api/internal/app/admin-dashboard/client/types/admin.types.ts
+++ b/services/ctl-api/internal/app/admin-dashboard/client/types/admin.types.ts
@@ -264,6 +264,7 @@ export type TSandboxModeJobConfig = {
   job_type: string
   duration: number
   should_error: boolean
+  error_message?: string
   panic: boolean
   trigger_shutdown: boolean
   created_at: string

--- a/services/ctl-api/internal/app/admin-dashboard/client/views/sandbox-mode/SandboxMode.tsx
+++ b/services/ctl-api/internal/app/admin-dashboard/client/views/sandbox-mode/SandboxMode.tsx
@@ -22,6 +22,7 @@ const defaultJobForm = {
   duration_ms: 1000,
   sleep_duration_ms: 0,
   should_error: false,
+  error_message: '',
   panic: false,
   trigger_shutdown: false,
   log_template: '',
@@ -115,6 +116,7 @@ export const SandboxMode = () => {
       duration_ms: config.duration ? config.duration / 1_000_000 : 0,
       sleep_duration_ms: config.sleep_duration ? config.sleep_duration / 1_000_000 : 0,
       should_error: config.should_error ?? false,
+      error_message: config.error_message || '',
       panic: config.panic ?? false,
       trigger_shutdown: config.trigger_shutdown ?? false,
       log_template: config.log_template || '',
@@ -450,6 +452,17 @@ function JobFormPanel({
         <Field label="Should error">
           <input type="checkbox" checked={form.should_error} onChange={(e) => setForm((f) => ({ ...f, should_error: e.target.checked }))} className="mt-1" />
         </Field>
+        {form.should_error && (
+          <Field label="Error message">
+            <textarea
+              value={form.error_message}
+              onChange={(e) => setForm((f) => ({ ...f, error_message: e.target.value }))}
+              rows={3}
+              placeholder="Overrides the default &quot;sandbox error&quot;. e.g. AccessDenied: User: arn:aws:iam::123:role/nuon-runner is not authorized to perform: s3:CreateBucket on resource: arn:aws:s3:::acme-prod"
+              className="w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-800 text-sm py-1.5 px-2 font-mono"
+            />
+          </Field>
+        )}
         <Field label="Panic">
           <input type="checkbox" checked={form.panic} onChange={(e) => setForm((f) => ({ ...f, panic: e.target.checked }))} className="mt-1" />
         </Field>

--- a/services/ctl-api/internal/app/admin-dashboard/service/sandbox_mode.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/sandbox_mode.go
@@ -200,6 +200,7 @@ type upsertRunnerJobConfigRequest struct {
 	DurationMs          int64  `json:"duration_ms"`
 	SleepDurationMs     int64  `json:"sleep_duration_ms"`
 	ShouldError         bool   `json:"should_error"`
+	ErrorMessage        string `json:"error_message"`
 	Panic               bool   `json:"panic"`
 	TriggerShutdown     bool   `json:"trigger_shutdown"`
 	LogTemplate         string `json:"log_template"`
@@ -226,6 +227,7 @@ func (s *service) SandboxModeUpsertRunnerJobConfig(c *gin.Context) {
 		Duration:            time.Duration(req.DurationMs) * time.Millisecond,
 		SleepDuration:       time.Duration(req.SleepDurationMs) * time.Millisecond,
 		ShouldError:         req.ShouldError,
+		ErrorMessage:        req.ErrorMessage,
 		Panic:               req.Panic,
 		TriggerShutdown:     req.TriggerShutdown,
 		LogTemplate:         req.LogTemplate,
@@ -238,7 +240,7 @@ func (s *service) SandboxModeUpsertRunnerJobConfig(c *gin.Context) {
 	if res := s.db.WithContext(c.Request.Context()).
 		Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "job_type"}, {Name: "operation"}, {Name: "deleted_at"}},
-			DoUpdates: clause.AssignmentColumns([]string{"enabled", "duration", "sleep_duration", "should_error", "panic", "trigger_shutdown", "log_template", "plan_template", "plan_display_template", "state_template", "output_template", "updated_at"}),
+			DoUpdates: clause.AssignmentColumns([]string{"enabled", "duration", "sleep_duration", "should_error", "error_message", "panic", "trigger_shutdown", "log_template", "plan_template", "plan_display_template", "state_template", "output_template", "updated_at"}),
 		}).
 		Create(&config); res.Error != nil {
 		s.l.Error("failed to upsert runner job config", zap.Error(res.Error))

--- a/services/ctl-api/internal/app/runners/service/sandbox_config_response.go
+++ b/services/ctl-api/internal/app/runners/service/sandbox_config_response.go
@@ -85,9 +85,14 @@ func convertToSandboxConfigResponse(cfg app.SandboxModeJobConfig) SandboxConfigR
 		}
 	}
 
-	// Map failure modes to error message
+	// Map failure modes to error message. A custom ErrorMessage overrides the
+	// generic default, letting a sandbox deploy fail with a controllable string
+	// (e.g. an AWS IAM permission denial) for exercising error-parsing locally.
 	if cfg.ShouldError {
 		resp.ErrorMessage = "sandbox error"
+		if cfg.ErrorMessage != "" {
+			resp.ErrorMessage = cfg.ErrorMessage
+		}
 	}
 	if cfg.Panic {
 		resp.ErrorMessage = "sandbox: panic requested"

--- a/services/ctl-api/internal/app/sandbox_mode_job_config.go
+++ b/services/ctl-api/internal/app/sandbox_mode_job_config.go
@@ -32,6 +32,8 @@ type SandboxModeJobConfig struct {
 	Panic           bool `json:"panic"`
 	TriggerShutdown bool `json:"trigger_shutdown"`
 
+	ErrorMessage string `json:"error_message,omitempty" gorm:"default:''"`
+
 	// Template references (keys into the templates package)
 	LogTemplate         string `json:"log_template,omitempty"`
 	PlanTemplate        string `json:"plan_template,omitempty"`


### PR DESCRIPTION
Add an `ErrorMessage` field to `SandboxModeJobConfig` so a sandbox-mode runner job can fail with a controllable string instead of the generic "sandbox error". When set (and ShouldError is on), it overrides the default in the runner sandbox config response, letting various jobs fail with realistic messages (e.g. an AWS IAM permission denial) to test error-parsing pipelines locally.

Wire the field through the admin dashboard sandbox-mode job config form and BFF upsert.