### PR TITLE
feat: Add CompositeError to install component deploy jobs

### DIFF
--- a/bins/runner/internal/jobs/deploy/terraform/exec.go
+++ b/bins/runner/internal/jobs/deploy/terraform/exec.go
@@ -120,6 +120,11 @@ func (p *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 
 	if err != nil {
 		l.Error("terraform run errored", zap.Error(err))
+		// Persist the full, untruncated terraform error onto the job execution
+		// result so ctl-api can parse it into a structured composite error
+		// (e.g. a missing AWS IAM permission). The per-execution status
+		// description is capped, so this is the authoritative error message.
+		p.writeErrorResult(ctx, fmt.Sprintf("terraform %s", job.Operation), err)
 		return fmt.Errorf("unable to execute %s run: %w", job.Operation, err)
 	}
 

--- a/services/ctl-api/internal/app/install_deploy.go
+++ b/services/ctl-api/internal/app/install_deploy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/indexes"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
@@ -89,6 +90,11 @@ type InstallDeploy struct {
 	StatusDescription string              `json:"status_description,omitzero" gorm:"notnull" temporaljson:"status_description,omitzero,omitempty"`
 	Type              InstallDeployType   `json:"install_deploy_type,omitzero" temporaljson:"type,omitzero,omitempty"`
 	StatusV2          CompositeStatus     `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
+
+	// CompositeError holds a typed, structured error (e.g. a missing AWS IAM
+	// permission) frozen at write time when a deploy plan/apply fails. It is
+	// nil for successful or non-enriched failures.
+	CompositeError *compositeerrors.CompositeErrorData `json:"composite_error,omitempty" gorm:"type:jsonb" temporaljson:"composite_error,omitzero,omitempty"`
 
 	// DEPRECATED: use WorkflowID
 	InstallWorkflowID *string   `json:"install_workflow_id,omitzero" gorm:"default null" temporaljson:"install_sandbox_id,omitzero,omitempty"`

--- a/services/ctl-api/internal/app/installs/deployerrors/aws_permission_error.go
+++ b/services/ctl-api/internal/app/installs/deployerrors/aws_permission_error.go
@@ -1,0 +1,118 @@
+// Package deployerrors holds the typed CompositeError implementations produced
+// by component deploy (plan + apply) flows. It lives next to the installs
+// domain that consumes it rather than in a central error catalog: each domain
+// owns the custom errors it knows how to produce and parse.
+package deployerrors
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+// AWSPermissionErrorType is the discriminator for AWS IAM permission failures
+// surfaced from a terraform plan/apply during a component deploy.
+const AWSPermissionErrorType compositeerrors.Type = "terraform.aws_permission"
+
+// AWSPermissionError is the typed payload for an AWS API call that failed with
+// AccessDenied / UnauthorizedOperation because the deploy's IAM principal is
+// missing a permission. It implements compositeerrors.CompositeError so it can
+// be returned like any error and frozen onto the owning deploy row.
+type AWSPermissionError struct {
+	// Action is the IAM action the caller lacked, e.g. "ec2:CreateVpc",
+	// "s3:CreateBucket".
+	Action string `json:"action"`
+
+	// Resource is the ARN (or wildcard) the call targeted, when known.
+	Resource string `json:"resource,omitempty"`
+
+	// Principal is the IAM principal ARN the call was made as, when known.
+	Principal string `json:"principal,omitempty"`
+
+	// AWSErrorCode is the API error code we matched on (AccessDenied,
+	// UnauthorizedOperation, AccessDeniedException, AuthorizationError).
+	AWSErrorCode string `json:"aws_error_code,omitempty"`
+
+	// RawMessage is the AWS-emitted error line we extracted the fields from.
+	RawMessage string `json:"raw_message,omitempty"`
+}
+
+var _ compositeerrors.CompositeError = (*AWSPermissionError)(nil)
+
+// Error returns the one-line headline shown to users.
+func (e *AWSPermissionError) Error() string {
+	if e.Action != "" {
+		return fmt.Sprintf("Missing AWS IAM permission: %s", e.Action)
+	}
+	return "Missing AWS IAM permission"
+}
+
+func (e *AWSPermissionError) Type() compositeerrors.Type { return AWSPermissionErrorType }
+func (e *AWSPermissionError) Severity() compositeerrors.Severity {
+	return compositeerrors.SeverityError
+}
+
+// Sections returns the structured detail rendered in the dashboard: what AWS
+// said, the principal/resource context, and a copy-pasteable IAM policy
+// statement granting the missing action.
+func (e *AWSPermissionError) Sections() []compositeerrors.Section {
+	sections := []compositeerrors.Section{
+		{
+			Heading: "Why",
+			Body:    "The IAM principal used by this deployment is missing a permission required to perform the operation. Grant the permission to the principal and retry.",
+		},
+	}
+
+	if e.RawMessage != "" {
+		sections = append(sections, compositeerrors.Section{
+			Heading: "AWS response",
+			Body:    "```\n" + e.RawMessage + "\n```",
+		})
+	}
+
+	if e.Principal != "" || e.Resource != "" {
+		var b strings.Builder
+		if e.Principal != "" {
+			fmt.Fprintf(&b, "Principal: `%s`\n", e.Principal)
+		}
+		if e.Resource != "" {
+			fmt.Fprintf(&b, "Resource: `%s`\n", e.Resource)
+		}
+		sections = append(sections, compositeerrors.Section{
+			Heading: "Context",
+			Body:    strings.TrimRight(b.String(), "\n"),
+		})
+	}
+
+	if e.Action != "" {
+		sections = append(sections, compositeerrors.Section{
+			Heading: "How to fix",
+			Body:    "Add the following to the role used by this deployment:\n\n```json\n" + e.policyStatementJSON() + "\n```",
+		})
+	}
+
+	return sections
+}
+
+// policyStatementJSON renders a minimal IAM policy statement granting the
+// missing action on the resource (or "*" if the resource isn't known).
+func (e *AWSPermissionError) policyStatementJSON() string {
+	resource := e.Resource
+	if resource == "" {
+		resource = "*"
+	}
+	stmt := map[string]any{
+		"Version": "2012-10-17",
+		"Statement": []map[string]any{
+			{
+				"Effect":   "Allow",
+				"Action":   []string{e.Action},
+				"Resource": resource,
+			},
+		},
+	}
+	b, _ := json.MarshalIndent(stmt, "", "  ")
+	return string(b)
+}

--- a/services/ctl-api/internal/app/installs/deployerrors/aws_permission_error.go
+++ b/services/ctl-api/internal/app/installs/deployerrors/aws_permission_error.go
@@ -16,6 +16,10 @@ import (
 // surfaced from a terraform plan/apply during a component deploy.
 const AWSPermissionErrorType compositeerrors.Type = "terraform.aws_permission"
 
+// defaultIAMPolicyVersion is the IAM policy language version embedded in the
+// remediation policy statement we recommend to users.
+const defaultIAMPolicyVersion string = "2012-10-17"
+
 // AWSPermissionError is the typed payload for an AWS API call that failed with
 // AccessDenied / UnauthorizedOperation because the deploy's IAM principal is
 // missing a permission. It implements compositeerrors.CompositeError so it can
@@ -61,7 +65,7 @@ func (e *AWSPermissionError) Sections() []compositeerrors.Section {
 	sections := []compositeerrors.Section{
 		{
 			Heading: "Why",
-			Body:    "The IAM principal used by this deployment is missing a permission required to perform the operation. Grant the permission to the principal and retry.",
+			Body:    "The IAM principal used by this deployment was denied a permission required to perform the operation. This usually means the permission is not granted, but it can also be an explicit deny, a service control policy (SCP), or a permissions boundary. Grant or unblock the permission for the principal and retry.",
 		},
 	}
 
@@ -73,16 +77,16 @@ func (e *AWSPermissionError) Sections() []compositeerrors.Section {
 	}
 
 	if e.Principal != "" || e.Resource != "" {
-		var b strings.Builder
+		var lines []string
 		if e.Principal != "" {
-			fmt.Fprintf(&b, "Principal: `%s`\n", e.Principal)
+			lines = append(lines, fmt.Sprintf("Principal: `%s`", e.Principal))
 		}
 		if e.Resource != "" {
-			fmt.Fprintf(&b, "Resource: `%s`\n", e.Resource)
+			lines = append(lines, fmt.Sprintf("Resource: `%s`", e.Resource))
 		}
 		sections = append(sections, compositeerrors.Section{
 			Heading: "Context",
-			Body:    strings.TrimRight(b.String(), "\n"),
+			Body:    strings.Join(lines, "\n\n"),
 		})
 	}
 
@@ -104,7 +108,7 @@ func (e *AWSPermissionError) policyStatementJSON() string {
 		resource = "*"
 	}
 	stmt := map[string]any{
-		"Version": "2012-10-17",
+		"Version": defaultIAMPolicyVersion,
 		"Statement": []map[string]any{
 			{
 				"Effect":   "Allow",

--- a/services/ctl-api/internal/app/installs/deployerrors/parse.go
+++ b/services/ctl-api/internal/app/installs/deployerrors/parse.go
@@ -1,0 +1,103 @@
+package deployerrors
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+// awsPermissionPatterns are attempted in order. Each must define a named
+// "action" group, and may define "principal" / "resource" / "code" groups.
+var awsPermissionPatterns = []*regexp.Regexp{
+	// Classic AccessDenied with principal + action + resource, e.g.
+	// "AccessDenied: User: arn:aws:iam::123:role/nuon-runner is not authorized
+	//  to perform: s3:CreateBucket on resource: arn:aws:s3:::acme-prod-assets"
+	regexp.MustCompile(
+		`(?P<code>AccessDenied(?:Exception)?|AuthorizationError):\s*(?:User|Principal):\s*(?P<principal>arn:[^\s]+)\s+is not authorized to perform:\s*(?P<action>[a-zA-Z0-9-]+:[a-zA-Z0-9*]+)(?:\s+on\s+resource:\s*(?P<resource>\S+))?`,
+	),
+	// Same shape without an explicit error-code prefix (some SDK clients).
+	regexp.MustCompile(
+		`(?:User|Principal):\s*(?P<principal>arn:[^\s]+)\s+is not authorized to perform:\s*(?P<action>[a-zA-Z0-9-]+:[a-zA-Z0-9*]+)(?:\s+on\s+resource:\s*(?P<resource>\S+))?`,
+	),
+	// EC2-style UnauthorizedOperation, where the action lives in a separate
+	// sentence: "UnauthorizedOperation: ... Operation: ec2:CreateVpc"
+	regexp.MustCompile(
+		`(?P<code>UnauthorizedOperation):[^\n]*?(?:Operation|operation):\s*(?P<action>[a-zA-Z0-9-]+:[a-zA-Z0-9*]+)`,
+	),
+}
+
+// Parse inspects raw terraform plan/apply error output and returns a typed
+// AWSPermissionError when it recognises an AWS IAM permission failure. It
+// returns nil when there is no confident match, so callers fall back to the
+// existing plain-string status description.
+func Parse(raw string) compositeerrors.CompositeError {
+	if !strings.Contains(raw, "AccessDenied") &&
+		!strings.Contains(raw, "UnauthorizedOperation") &&
+		!strings.Contains(raw, "not authorized to perform") &&
+		!strings.Contains(raw, "AuthorizationError") {
+		return nil
+	}
+
+	for _, re := range awsPermissionPatterns {
+		match := re.FindStringSubmatch(raw)
+		if match == nil {
+			continue
+		}
+		fields := groupMap(re, match)
+		action := fields["action"]
+		if action == "" {
+			continue
+		}
+
+		return &AWSPermissionError{
+			Action:       action,
+			Resource:     trimTrailingPunct(fields["resource"]),
+			Principal:    fields["principal"],
+			AWSErrorCode: fields["code"],
+			RawMessage:   extractRelevantLine(raw, match[0]),
+		}
+	}
+
+	return nil
+}
+
+func groupMap(re *regexp.Regexp, match []string) map[string]string {
+	out := map[string]string{}
+	for i, name := range re.SubexpNames() {
+		if name == "" {
+			continue
+		}
+		if i < len(match) {
+			out[name] = match[i]
+		}
+	}
+	return out
+}
+
+// trimTrailingPunct strips trailing punctuation that often glues to ARNs when
+// AWS embeds them in sentences.
+func trimTrailingPunct(s string) string {
+	return strings.TrimRight(s, ".,;:")
+}
+
+// extractRelevantLine returns the line containing the match, trimmed of the
+// terraform "│ " box-drawing prefix when present.
+func extractRelevantLine(raw, matchStr string) string {
+	needle := firstNChars(matchStr, 50)
+	for _, line := range strings.Split(raw, "\n") {
+		if strings.Contains(line, needle) {
+			t := strings.TrimSpace(line)
+			t = strings.TrimPrefix(t, "│")
+			return strings.TrimSpace(t)
+		}
+	}
+	return strings.TrimSpace(matchStr)
+}
+
+func firstNChars(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/services/ctl-api/internal/app/installs/deployerrors/parse_test.go
+++ b/services/ctl-api/internal/app/installs/deployerrors/parse_test.go
@@ -46,6 +46,46 @@ func TestParse_AccessDenied(t *testing.T) {
 	}
 }
 
+func TestParse_AccessDeniedException_PassRole(t *testing.T) {
+	ce := Parse(readFixture(t, "iam_passrole_access_denied_exception.txt"))
+	if ce == nil {
+		t.Fatal("expected a composite error, got nil")
+	}
+	e := ce.(*AWSPermissionError)
+	if e.Action != "iam:PassRole" {
+		t.Errorf("action = %q, want iam:PassRole", e.Action)
+	}
+	if e.AWSErrorCode != "AccessDeniedException" {
+		t.Errorf("code = %q, want AccessDeniedException", e.AWSErrorCode)
+	}
+	if e.Principal != "arn:aws:sts::123456789012:assumed-role/nuon-runner/session" {
+		t.Errorf("principal = %q", e.Principal)
+	}
+	if e.Resource != "arn:aws:iam::123456789012:role/acme-task-role" {
+		t.Errorf("resource = %q", e.Resource)
+	}
+}
+
+func TestParse_NoErrorCodePrefix(t *testing.T) {
+	// Some SDK clients emit the "is not authorized to perform" sentence with no
+	// AccessDenied/Exception code prefix.
+	raw := "User: arn:aws:sts::123:assumed-role/foo/bar is not authorized to perform: iam:PassRole on resource: arn:aws:iam::123:role/baz"
+	ce := Parse(raw)
+	if ce == nil {
+		t.Fatal("expected a composite error, got nil")
+	}
+	e := ce.(*AWSPermissionError)
+	if e.Action != "iam:PassRole" {
+		t.Errorf("action = %q, want iam:PassRole", e.Action)
+	}
+	if e.AWSErrorCode != "" {
+		t.Errorf("code = %q, want empty (no prefix)", e.AWSErrorCode)
+	}
+	if e.Resource != "arn:aws:iam::123:role/baz" {
+		t.Errorf("resource = %q", e.Resource)
+	}
+}
+
 func TestParse_UnauthorizedOperation(t *testing.T) {
 	ce := Parse(readFixture(t, "ec2_unauthorized_operation.txt"))
 	if ce == nil {

--- a/services/ctl-api/internal/app/installs/deployerrors/parse_test.go
+++ b/services/ctl-api/internal/app/installs/deployerrors/parse_test.go
@@ -1,0 +1,116 @@
+package deployerrors
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func readFixture(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("unable to read fixture %s: %v", name, err)
+	}
+	return string(b)
+}
+
+func TestParse_AccessDenied(t *testing.T) {
+	ce := Parse(readFixture(t, "terraform_apply_access_denied.txt"))
+	if ce == nil {
+		t.Fatal("expected a composite error, got nil")
+	}
+
+	e, ok := ce.(*AWSPermissionError)
+	if !ok {
+		t.Fatalf("expected *AWSPermissionError, got %T", ce)
+	}
+	if e.Action != "s3:CreateBucket" {
+		t.Errorf("action = %q, want s3:CreateBucket", e.Action)
+	}
+	if e.AWSErrorCode != "AccessDenied" {
+		t.Errorf("code = %q, want AccessDenied", e.AWSErrorCode)
+	}
+	if e.Principal != "arn:aws:iam::123456789012:role/nuon-runner" {
+		t.Errorf("principal = %q", e.Principal)
+	}
+	if e.Resource != "arn:aws:s3:::acme-prod-assets" {
+		t.Errorf("resource = %q", e.Resource)
+	}
+	if ce.Error() != "Missing AWS IAM permission: s3:CreateBucket" {
+		t.Errorf("headline = %q", ce.Error())
+	}
+	if len(ce.Sections()) == 0 {
+		t.Error("expected sections, got none")
+	}
+}
+
+func TestParse_UnauthorizedOperation(t *testing.T) {
+	ce := Parse(readFixture(t, "ec2_unauthorized_operation.txt"))
+	if ce == nil {
+		t.Fatal("expected a composite error, got nil")
+	}
+	e := ce.(*AWSPermissionError)
+	if e.Action != "ec2:CreateVpc" {
+		t.Errorf("action = %q, want ec2:CreateVpc", e.Action)
+	}
+	if e.AWSErrorCode != "UnauthorizedOperation" {
+		t.Errorf("code = %q, want UnauthorizedOperation", e.AWSErrorCode)
+	}
+}
+
+func TestSections_FullyPopulated(t *testing.T) {
+	e := &AWSPermissionError{
+		Action:       "s3:CreateBucket",
+		Resource:     "arn:aws:s3:::acme-prod-assets",
+		Principal:    "arn:aws:iam::123456789012:role/nuon-runner",
+		AWSErrorCode: "AccessDenied",
+		RawMessage:   "AccessDenied: ... is not authorized to perform: s3:CreateBucket",
+	}
+
+	headings := map[string]string{}
+	for _, s := range e.Sections() {
+		headings[s.Heading] = s.Body
+	}
+
+	for _, want := range []string{"Why", "AWS response", "Context", "How to fix"} {
+		if _, ok := headings[want]; !ok {
+			t.Errorf("missing section %q; got sections %v", want, headings)
+		}
+	}
+
+	// The "How to fix" section must embed a valid IAM policy granting the action.
+	fix := headings["How to fix"]
+	if !strings.Contains(fix, "s3:CreateBucket") || !strings.Contains(fix, "arn:aws:s3:::acme-prod-assets") {
+		t.Errorf("How to fix section missing action/resource: %q", fix)
+	}
+	if !strings.Contains(headings["Context"], "arn:aws:iam::123456789012:role/nuon-runner") {
+		t.Errorf("Context section missing principal: %q", headings["Context"])
+	}
+}
+
+func TestSections_MinimalOmitsOptionalSections(t *testing.T) {
+	e := &AWSPermissionError{} // no action/resource/principal/raw
+
+	headings := map[string]bool{}
+	for _, s := range e.Sections() {
+		headings[s.Heading] = true
+	}
+	if headings["AWS response"] || headings["Context"] || headings["How to fix"] {
+		t.Errorf("expected only the Why section for an empty error, got %v", headings)
+	}
+}
+
+func TestParse_NoMatch(t *testing.T) {
+	cases := []string{
+		"",
+		"Error: creating EC2 VPC: InvalidParameterValue: bad CIDR",
+		"plan job failed",
+	}
+	for _, in := range cases {
+		if ce := Parse(in); ce != nil {
+			t.Errorf("Parse(%q) = %v, want nil", in, ce)
+		}
+	}
+}

--- a/services/ctl-api/internal/app/installs/deployerrors/testdata/ec2_unauthorized_operation.txt
+++ b/services/ctl-api/internal/app/installs/deployerrors/testdata/ec2_unauthorized_operation.txt
@@ -1,0 +1,10 @@
+module.network.aws_vpc.main: Creating...
+╷
+│ Error: creating EC2 VPC: UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message: aBcDeFgHiJkLmNoPqRsTuVwXyZ012345 Operation: ec2:CreateVpc
+│ 	status code: 403, request id: 11112222-aaaa-bbbb-cccc-333344445555
+│
+│   with module.network.aws_vpc.main,
+│   on .terraform/modules/network/vpc.tf line 8, in resource "aws_vpc" "main":
+│    8: resource "aws_vpc" "main" {
+│
+╵

--- a/services/ctl-api/internal/app/installs/deployerrors/testdata/iam_passrole_access_denied_exception.txt
+++ b/services/ctl-api/internal/app/installs/deployerrors/testdata/iam_passrole_access_denied_exception.txt
@@ -1,0 +1,10 @@
+module.app.aws_iam_role.task: Creating...
+╷
+│ Error: creating ECS Service (acme-api): AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/nuon-runner/session is not authorized to perform: iam:PassRole on resource: arn:aws:iam::123456789012:role/acme-task-role
+│ 	status code: 403, request id: A1B2C3D4-5678
+│
+│   with module.app.aws_ecs_service.api,
+│   on main.tf line 88, in resource "aws_ecs_service" "api":
+│   88: resource "aws_ecs_service" "api" {
+│
+╵

--- a/services/ctl-api/internal/app/installs/deployerrors/testdata/terraform_apply_access_denied.txt
+++ b/services/ctl-api/internal/app/installs/deployerrors/testdata/terraform_apply_access_denied.txt
@@ -1,0 +1,10 @@
+module.app.aws_s3_bucket.assets: Creating...
+╷
+│ Error: creating S3 Bucket (acme-prod-assets): AccessDenied: User: arn:aws:iam::123456789012:role/nuon-runner is not authorized to perform: s3:CreateBucket on resource: arn:aws:s3:::acme-prod-assets because no identity-based policy allows the s3:CreateBucket action
+│ 	status code: 403, request id: D5E6F7G8H9, host id: abcDEF/123==
+│
+│   with module.app.aws_s3_bucket.assets,
+│   on main.tf line 42, in resource "aws_s3_bucket" "assets":
+│   42: resource "aws_s3_bucket" "assets" {
+│
+╵

--- a/services/ctl-api/internal/app/installs/signals/componentdeployapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentdeployapplyplan/signal.go
@@ -372,11 +372,13 @@ func (s *Signal) execApplyPlan(ctx workflow.Context, install *app.Install, insta
 		msg := job.JobErrorMessage(err, "apply job failed")
 		s.updateDeployStatus(ctx, installDeploy.ID, app.InstallDeployStatusError, msg)
 		if s.runnerJobID != "" {
-			_ = activities.AwaitRecordDeployCompositeError(ctx, activities.RecordDeployCompositeErrorRequest{
+			if rerr := activities.AwaitRecordDeployCompositeError(ctx, activities.RecordDeployCompositeErrorRequest{
 				DeployID:        installDeploy.ID,
 				RunnerJobID:     s.runnerJobID,
 				FallbackMessage: msg,
-			})
+			}); rerr != nil {
+				l.Warn("unable to record deploy composite error", zap.Error(rerr))
+			}
 		}
 		l.Error("job did not succeed", zap.Error(err))
 		return fmt.Errorf("unable to get install: %w", err)

--- a/services/ctl-api/internal/app/installs/signals/componentdeployapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentdeployapplyplan/signal.go
@@ -369,7 +369,15 @@ func (s *Signal) execApplyPlan(ctx workflow.Context, install *app.Install, insta
 		WorkflowID: fmt.Sprintf("queue-signal-%s-execute-job-%s", install.ID, runnerJob.ID),
 	})
 	if err != nil {
-		s.updateDeployStatus(ctx, installDeploy.ID, app.InstallDeployStatusError, job.JobErrorMessage(err, "apply job failed"))
+		msg := job.JobErrorMessage(err, "apply job failed")
+		s.updateDeployStatus(ctx, installDeploy.ID, app.InstallDeployStatusError, msg)
+		if s.runnerJobID != "" {
+			_ = activities.AwaitRecordDeployCompositeError(ctx, activities.RecordDeployCompositeErrorRequest{
+				DeployID:        installDeploy.ID,
+				RunnerJobID:     s.runnerJobID,
+				FallbackMessage: msg,
+			})
+		}
 		l.Error("job did not succeed", zap.Error(err))
 		return fmt.Errorf("unable to get install: %w", err)
 	}

--- a/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
@@ -557,7 +557,15 @@ func (s *Signal) execPlan(ctx workflow.Context, install *app.Install, installDep
 		WorkflowID: fmt.Sprintf("queue-signal-%s-execute-job-%s", install.ID, runnerJob.ID),
 	})
 	if err != nil {
-		s.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusError, job.JobErrorMessage(err, "plan job failed"))
+		msg := job.JobErrorMessage(err, "plan job failed")
+		s.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusError, msg)
+		if s.runnerJobID != "" {
+			_ = activities.AwaitRecordDeployCompositeError(ctx, activities.RecordDeployCompositeErrorRequest{
+				DeployID:        installDeploy.ID,
+				RunnerJobID:     s.runnerJobID,
+				FallbackMessage: msg,
+			})
+		}
 		l.Error("job did not succeed", zap.Error(err))
 		return fmt.Errorf("unable to get install: %w", err)
 	}

--- a/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
@@ -560,11 +560,13 @@ func (s *Signal) execPlan(ctx workflow.Context, install *app.Install, installDep
 		msg := job.JobErrorMessage(err, "plan job failed")
 		s.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusError, msg)
 		if s.runnerJobID != "" {
-			_ = activities.AwaitRecordDeployCompositeError(ctx, activities.RecordDeployCompositeErrorRequest{
+			if rerr := activities.AwaitRecordDeployCompositeError(ctx, activities.RecordDeployCompositeErrorRequest{
 				DeployID:        installDeploy.ID,
 				RunnerJobID:     s.runnerJobID,
 				FallbackMessage: msg,
-			})
+			}); rerr != nil {
+				l.Warn("unable to record deploy composite error", zap.Error(rerr))
+			}
 		}
 		l.Error("job did not succeed", zap.Error(err))
 		return fmt.Errorf("unable to get install: %w", err)

--- a/services/ctl-api/internal/app/installs/signals/componentteardownapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentteardownapplyplan/signal.go
@@ -387,7 +387,17 @@ func (s *Signal) execApplyPlan(ctx workflow.Context, install *app.Install, insta
 		WorkflowID: fmt.Sprintf("queue-signal-%s-execute-job-%s", install.ID, runnerJob.ID),
 	})
 	if err != nil {
-		s.updateDeployStatus(ctx, installDeploy.ID, app.InstallDeployStatusError, job.JobErrorMessage(err, "teardown apply job failed"))
+		msg := job.JobErrorMessage(err, "teardown apply job failed")
+		s.updateDeployStatus(ctx, installDeploy.ID, app.InstallDeployStatusError, msg)
+		if s.runnerJobID != "" {
+			if rerr := activities.AwaitRecordDeployCompositeError(ctx, activities.RecordDeployCompositeErrorRequest{
+				DeployID:        installDeploy.ID,
+				RunnerJobID:     s.runnerJobID,
+				FallbackMessage: msg,
+			}); rerr != nil {
+				l.Warn("unable to record deploy composite error", zap.Error(rerr))
+			}
+		}
 		l.Error("job did not succeed", zap.Error(err))
 		return fmt.Errorf("unable to get install: %w", err)
 	}

--- a/services/ctl-api/internal/app/installs/signals/componentteardownsyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentteardownsyncandplan/signal.go
@@ -563,7 +563,17 @@ func (s *Signal) execPlan(ctx workflow.Context, install *app.Install, installDep
 		WorkflowID: fmt.Sprintf("queue-signal-%s-execute-job-%s", install.ID, runnerJob.ID),
 	})
 	if err != nil {
-		s.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusError, job.JobErrorMessage(err, "teardown plan job failed"))
+		msg := job.JobErrorMessage(err, "teardown plan job failed")
+		s.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusError, msg)
+		if s.runnerJobID != "" {
+			if rerr := activities.AwaitRecordDeployCompositeError(ctx, activities.RecordDeployCompositeErrorRequest{
+				DeployID:        installDeploy.ID,
+				RunnerJobID:     s.runnerJobID,
+				FallbackMessage: msg,
+			}); rerr != nil {
+				l.Warn("unable to record deploy composite error", zap.Error(rerr))
+			}
+		}
 		l.Error("job did not succeed", zap.Error(err))
 		return fmt.Errorf("unable to get install: %w", err)
 	}

--- a/services/ctl-api/internal/app/installs/worker/activities/record_deploy_composite_error.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/record_deploy_composite_error.go
@@ -1,0 +1,93 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/deployerrors"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+type RecordDeployCompositeErrorRequest struct {
+	DeployID    string `validate:"required"`
+	RunnerJobID string `validate:"required"`
+
+	// FallbackMessage is the (possibly truncated) status description the
+	// signal already has from the failed job. It is parsed when the runner
+	// job execution result carries no untruncated error message.
+	FallbackMessage string
+}
+
+// RecordDeployCompositeError parses the failed deploy's terraform output for a
+// recognised structured error (currently AWS IAM permission failures) and, when
+// matched, freezes it onto the InstallDeploy as a CompositeError.
+//
+// It prefers the untruncated message stored on the runner job execution result
+// (error_metadata["message"]) and falls back to the caller-supplied message.
+// This activity is best-effort: a parse miss or a missing result is not an
+// error, it simply leaves the deploy's plain-string status description in place.
+//
+// @temporal-gen-v2 activity
+// @max-retries 1
+func (a *Activities) RecordDeployCompositeError(ctx context.Context, req RecordDeployCompositeErrorRequest) error {
+	l := temporalzap.GetActivityLogger(ctx)
+	l = l.With(
+		zap.String("deploy_id", req.DeployID),
+		zap.String("runner_job_id", req.RunnerJobID),
+	)
+
+	raw := req.FallbackMessage
+	if msg := a.latestJobErrorMessage(ctx, req.RunnerJobID); msg != "" {
+		raw = msg
+	}
+
+	ce := deployerrors.Parse(raw)
+	if ce == nil {
+		l.Info("no structured composite error recognised for deploy failure")
+		return nil
+	}
+
+	data := compositeerrors.New(ce)
+	res := a.db.WithContext(ctx).
+		Model(&app.InstallDeploy{ID: req.DeployID}).
+		Select("composite_error").
+		Updates(app.InstallDeploy{CompositeError: data})
+	if res.Error != nil {
+		return fmt.Errorf("unable to record deploy composite error: %w", res.Error)
+	}
+
+	l.Info("recorded composite error on deploy", zap.String("composite_error_type", string(data.Type)))
+	return nil
+}
+
+// latestJobErrorMessage returns the untruncated error message recorded on the
+// most recent runner job execution result for the job, or "" when none exists.
+// It walks the RunnerJob -> Executions -> Result association chain (the
+// executions table is indexed on (runner_job_id, created_at)).
+func (a *Activities) latestJobErrorMessage(ctx context.Context, runnerJobID string) string {
+	var job app.RunnerJob
+	res := a.db.WithContext(ctx).
+		Preload("Executions", func(db *gorm.DB) *gorm.DB {
+			return db.Order("runner_job_executions.created_at DESC").Limit(1)
+		}).
+		Preload("Executions.Result").
+		Where(app.RunnerJob{ID: runnerJobID}).
+		First(&job)
+	if res.Error != nil {
+		return ""
+	}
+
+	if len(job.Executions) == 0 || job.Executions[0].Result == nil {
+		return ""
+	}
+
+	if msg, ok := job.Executions[0].Result.ErrorMetadata["message"]; ok && msg != nil {
+		return *msg
+	}
+	return ""
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/record_deploy_composite_error.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/record_deploy_composite_error.go
@@ -48,7 +48,7 @@ func (a *Activities) RecordDeployCompositeError(ctx context.Context, req RecordD
 
 	ce := deployerrors.Parse(raw)
 	if ce == nil {
-		l.Info("no structured composite error recognised for deploy failure")
+		l.Debug("no structured composite error recognised for deploy failure")
 		return nil
 	}
 
@@ -59,6 +59,9 @@ func (a *Activities) RecordDeployCompositeError(ctx context.Context, req RecordD
 		Updates(app.InstallDeploy{CompositeError: data})
 	if res.Error != nil {
 		return fmt.Errorf("unable to record deploy composite error: %w", res.Error)
+	}
+	if res.RowsAffected < 1 {
+		return fmt.Errorf("no deploy found for id %s: %w", req.DeployID, gorm.ErrRecordNotFound)
 	}
 
 	l.Info("recorded composite error on deploy", zap.String("composite_error_type", string(data.Type)))
@@ -73,7 +76,7 @@ func (a *Activities) latestJobErrorMessage(ctx context.Context, runnerJobID stri
 	var job app.RunnerJob
 	res := a.db.WithContext(ctx).
 		Preload("Executions", func(db *gorm.DB) *gorm.DB {
-			return db.Order("runner_job_executions.created_at DESC").Limit(1)
+			return db.Order("runner_job_executions.created_at DESC, runner_job_executions.id DESC").Limit(1)
 		}).
 		Preload("Executions.Result").
 		Where(app.RunnerJob{ID: runnerJobID}).

--- a/services/dashboard-ui/client/components/common/Banner.tsx
+++ b/services/dashboard-ui/client/components/common/Banner.tsx
@@ -54,7 +54,7 @@ export const Banner = ({
       {...props}
     >
       <div className="flex mt-0.5 self-start">{ICONS[theme]}</div>
-      <div className="!w-full">
+      <div className="min-w-0 flex-1">
         {typeof children === 'string' ? (
           <Text weight="strong">{children}</Text>
         ) : (

--- a/services/dashboard-ui/client/components/common/CompositeError/CompositeError.stories.tsx
+++ b/services/dashboard-ui/client/components/common/CompositeError/CompositeError.stories.tsx
@@ -1,0 +1,45 @@
+import { CompositeError } from './CompositeError'
+import type { TCompositeError } from '@/types'
+
+export default {
+  title: 'Common/CompositeError',
+}
+
+const awsPermissionError: TCompositeError = {
+  type: 'aws_permission_error',
+  severity: 'error',
+  message: 'Deploy failed because the install role is missing required AWS IAM permissions.',
+  sections: [
+    {
+      heading: 'Missing permissions',
+      body: '- `ec2:CreateSecurityGroup`\n- `ec2:AuthorizeSecurityGroupIngress`',
+    },
+    {
+      heading: 'How to fix',
+      body: 'Add the missing actions to the install role policy, then retry the deploy.',
+    },
+  ],
+}
+
+export const Default = () => <CompositeError error={awsPermissionError} />
+
+export const NoSections = () => (
+  <CompositeError
+    error={{
+      type: 'aws_permission_error',
+      severity: 'error',
+      message: 'The install role is not authorized to perform this Terraform operation.',
+    }}
+  />
+)
+
+export const Warning = () => (
+  <CompositeError
+    error={{
+      type: 'aws_permission_error',
+      severity: 'warning',
+      message: 'Some optional permissions are missing and may limit functionality.',
+      sections: [{ heading: 'Details', body: 'Missing `s3:GetBucketTagging`.' }],
+    }}
+  />
+)

--- a/services/dashboard-ui/client/components/common/CompositeError/CompositeError.tsx
+++ b/services/dashboard-ui/client/components/common/CompositeError/CompositeError.tsx
@@ -1,0 +1,47 @@
+import { Badge } from '@/components/common/Badge'
+import { Banner } from '@/components/common/Banner'
+import { Markdown } from '@/components/common/Markdown'
+import { Text } from '@/components/common/Text'
+import type { TCompositeError, TCompositeErrorSeverity, TTheme } from '@/types'
+
+interface ICompositeError {
+  error: TCompositeError
+}
+
+const SEVERITY_THEME: Record<TCompositeErrorSeverity, TTheme> = {
+  fatal: 'error',
+  error: 'error',
+  warning: 'warn',
+  info: 'info',
+}
+
+export const CompositeError = ({ error }: ICompositeError) => {
+  const theme = SEVERITY_THEME[error?.severity] ?? 'error'
+  const sections = Array.isArray(error?.sections) ? error.sections : []
+
+  return (
+    <Banner theme={theme}>
+      <div className="flex w-full min-w-0 flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Text weight="strong">{error?.message}</Text>
+          {error?.type ? (
+            <Badge variant="code" size="sm" theme={theme}>
+              {error.type}
+            </Badge>
+          ) : null}
+        </div>
+
+        {sections.map((section, i) => (
+          <div key={i} className="flex min-w-0 flex-col gap-1">
+            {section?.heading ? (
+              <Text variant="subtext" weight="strong">
+                {section.heading}
+              </Text>
+            ) : null}
+            <Markdown content={section?.body} />
+          </div>
+        ))}
+      </div>
+    </Banner>
+  )
+}

--- a/services/dashboard-ui/client/components/common/CompositeError/index.ts
+++ b/services/dashboard-ui/client/components/common/CompositeError/index.ts
@@ -1,0 +1,1 @@
+export { CompositeError } from './CompositeError'

--- a/services/dashboard-ui/client/components/workflows/step-details/deploy-details/DeployStepDetails/DeployStepDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/deploy-details/DeployStepDetails/DeployStepDetails.tsx
@@ -1,4 +1,5 @@
 import { Plan } from '@/components/approvals/Plan'
+import { CompositeError } from '@/components/common/CompositeError'
 import { Duration } from '@/components/common/Duration'
 import { EmptyState } from '@/components/common/EmptyState'
 import { Icon } from '@/components/common/Icon'
@@ -85,6 +86,9 @@ export const DeployStepDetails = ({
           </Text>
         ) : null}
       </div>
+      {deploy?.composite_error ? (
+        <CompositeError error={deploy.composite_error} />
+      ) : null}
       {step?.execution_type === 'approval' ? (
         <ApprovalStepTabs step={step} deploy={deploy} />
       ) : (

--- a/services/dashboard-ui/client/types/ctl-api.types.ts
+++ b/services/dashboard-ui/client/types/ctl-api.types.ts
@@ -210,6 +210,14 @@ export type TInstallComponentOutputs = Record<string, string>
 export type TInstallConfig = components['schemas']['app.InstallConfig']
 export type TInstallAuditLog = components['schemas']['app.InstallAuditLog']
 export type TDriftedObject = components['schemas']['app.DriftedObject']
+// composite errors
+export type TCompositeErrorSeverity =
+  components['schemas']['compositeerrors.Severity']
+export type TCompositeErrorSection =
+  components['schemas']['compositeerrors.Section']
+export type TCompositeError =
+  components['schemas']['compositeerrors.CompositeErrorData']
+
 // deploys
 export type TInstallDeploy = components['schemas']['app.InstallDeploy'] & {
   org_id: string

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -4015,6 +4015,12 @@ export interface components {
       component_config_version?: number;
       component_id?: string;
       component_name?: string;
+      /**
+       * @description CompositeError holds a typed, structured error (e.g. a missing AWS IAM
+       * permission) frozen at write time when a deploy plan/apply fails. It is
+       * nil for successful or non-enriched failures.
+       */
+      composite_error?: components["schemas"]["compositeerrors.CompositeErrorData"];
       created_at?: string;
       created_by?: components["schemas"]["app.Account"];
       created_by_id?: string;
@@ -5633,6 +5639,19 @@ export interface components {
       is_private?: boolean;
       name?: string;
     };
+    "compositeerrors.CompositeErrorData": {
+      data?: number[];
+      message?: string;
+      sections?: components["schemas"]["compositeerrors.Section"][];
+      severity?: components["schemas"]["compositeerrors.Severity"];
+      type?: string;
+    };
+    "compositeerrors.Section": {
+      body?: string;
+      heading?: string;
+    };
+    /** @enum {string} */
+    "compositeerrors.Severity": "fatal" | "error" | "warning" | "info";
     /** @enum {string} */
     "config.AppPolicyEngine": "kyverno" | "opa";
     /** @enum {string} */

--- a/services/dashboard-ui/client/views/install/DeployDetail.tsx
+++ b/services/dashboard-ui/client/views/install/DeployDetail.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { ApprovalBanner } from '@/components/approvals/ApprovalBanner'
 import { Plan } from '@/components/approvals/Plan'
 import { DeployHeader } from '@/components/deploys/DeployHeader'
+import { CompositeError } from '@/components/common/CompositeError'
 import { SSELogs, LogsSkeleton } from '@/components/log-stream/SSELogs'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
@@ -86,6 +87,10 @@ const DeployDetailContent = ({ componentId }: { componentId: string }) => {
       />
 
       <DeployHeader component={component} workflow={workflow} stepId={step?.id} />
+
+      {deploy?.composite_error ? (
+        <CompositeError error={deploy.composite_error} />
+      ) : null}
 
       {pendingApproval && !isAutoApprove ? (
         <div className="flex flex-col gap-4">

--- a/services/dashboard-ui/client/views/install/DeployLayout.tsx
+++ b/services/dashboard-ui/client/views/install/DeployLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import { ApprovalBanner } from '@/components/approvals/ApprovalBanner'
+import { CompositeError } from '@/components/common/CompositeError'
 import { DeployHeader } from '@/components/deploys/DeployHeader'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
@@ -130,6 +131,10 @@ const DeployLayoutInner = () => {
       />
 
       <DeployHeader component={component} workflow={workflow} stepId={step?.id} />
+
+      {deploy?.composite_error ? (
+        <CompositeError error={deploy.composite_error} />
+      ) : null}
 
       {pendingApproval && !isAutoApprove ? (
         <ApprovalBanner step={step} />


### PR DESCRIPTION
This PR adds composite error support to deploy jobs for install components. 

Currently only terraform permission related errors have been wired up to be extracted out and shown to users. We detect AWS permission errors in case of Component Plan and Deploy jobs. I'll follow up with wiring this to also detect AWS permission errors in case of Sandbox Plan and Apply steps as well as for Action runs.

In the UI, we have added a new component for `CompositeError` and we render it on deploy job's detail page, as well as on step details page.

<img width="2172" height="948" alt="Screenshot 2026-06-09 at 9 31 05 PM" src="https://github.com/user-attachments/assets/e485d4bc-9ee5-4dc6-878c-0c614a62ee43" />
