### PR TITLE
refactor(ui): edit labels in install quick menu

### DIFF
--- a/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabelsContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabelsContainer.tsx
@@ -47,6 +47,7 @@ export const EditLabelsModalContainer = ({ ...props }: IModal) => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['install', install.id] })
+      queryClient.invalidateQueries({ queryKey: ['installs'] })
       addToast(
         <Toast heading="Labels updated" theme="success">
           <Text>Labels updated for {install.name}.</Text>

--- a/services/dashboard-ui/client/components/installs/management/QuickManagementDropdown/QuickManagementDropdown.tsx
+++ b/services/dashboard-ui/client/components/installs/management/QuickManagementDropdown/QuickManagementDropdown.tsx
@@ -7,6 +7,7 @@ import { Text } from '@/components/common/Text'
 import { InstallProvider } from '@/providers/install-provider'
 import { SurfacesProvider } from '@/providers/surfaces-provider'
 import type { TInstall } from '@/types'
+import { EditLabelsButton } from '../EditLabels'
 import { EditInputsButton } from '../EditInputs'
 import { ViewCurrentInputsButton } from '../ViewCurrentInputs'
 import { EnableAutoApproveButton } from '../EnableAutoApprove'
@@ -30,6 +31,7 @@ const QuickManagementMenu = ({ orgId, installId }: IQuickManagementMenu) => {
       <Text variant="label" theme="neutral">
         Settings
       </Text>
+      <EditLabelsButton isMenuButton />
       <EditInputsButton isMenuButton />
       <ViewCurrentInputsButton isMenuButton />
       <Button href={`/${orgId}/installs/${installId}/state`} isMenuButton>


### PR DESCRIPTION
Adds "Edit labels" to the install quick menu. Refresh installs query when labels are updated.