### PR TITLE
feat: gorm statement latency metric

### DIFF
--- a/services/ctl-api/internal/pkg/db/plugins/metrics/metrics_plugin.go
+++ b/services/ctl-api/internal/pkg/db/plugins/metrics/metrics_plugin.go
@@ -20,10 +20,13 @@ import (
 type contextKey string
 
 const (
-	defaultContextKey    contextKey    = "gorm_metrics_plugin"
-	targetLatency        time.Duration = time.Millisecond * 500
-	maxEventTextLen      int           = 4096
-	eventTextTruncSuffix string        = "... [truncated]"
+	defaultContextKey      contextKey    = "gorm_metrics_plugin"
+	statementStartKey      contextKey    = "gorm_metrics_plugin_statement_start"
+	statementDurationKey   contextKey    = "gorm_metrics_plugin_statement_duration"
+	targetLatency          time.Duration = time.Millisecond * 500
+	statementTargetLatency time.Duration = time.Millisecond * 200
+	maxEventTextLen        int           = 4096
+	eventTextTruncSuffix   string        = "... [truncated]"
 )
 
 var _ gorm.Plugin = (*metricsWriterPlugin)(nil)
@@ -59,19 +62,39 @@ const (
 	UpdateOperation OperationType = "update"
 	DeleteOperation OperationType = "delete"
 	RawOperation    OperationType = "raw"
+	RowOperation    OperationType = "row"
 )
 
 func (m *metricsWriterPlugin) Initialize(db *gorm.DB) error {
 	db.Callback().Create().Before("*").Register("before_all", func(tx *gorm.DB) { m.beforeAll(tx, CreateOperation) })
+	db.Callback().Create().After("gorm:save_before_associations").Before("gorm:create").Register("before_statement", m.beforeStatement)
+	db.Callback().Create().After("gorm:create").Before("gorm:save_after_associations").Register("after_statement", m.afterStatement)
 	db.Callback().Create().After("*").Register("after_all", func(tx *gorm.DB) { m.afterAll(tx, CreateOperation) })
+
 	db.Callback().Query().Before("*").Register("before_all", func(tx *gorm.DB) { m.beforeAll(tx, QueryOperation) })
+	db.Callback().Query().Before("gorm:query").Register("before_statement", m.beforeStatement)
+	db.Callback().Query().After("gorm:query").Before("gorm:preload").Register("after_statement", m.afterStatement)
 	db.Callback().Query().After("*").Register("after_all", func(tx *gorm.DB) { m.afterAll(tx, QueryOperation) })
+
 	db.Callback().Update().Before("*").Register("before_all", func(tx *gorm.DB) { m.beforeAll(tx, UpdateOperation) })
+	db.Callback().Update().After("gorm:save_before_associations").Before("gorm:update").Register("before_statement", m.beforeStatement)
+	db.Callback().Update().After("gorm:update").Before("gorm:save_after_associations").Register("after_statement", m.afterStatement)
 	db.Callback().Update().After("*").Register("after_all", func(tx *gorm.DB) { m.afterAll(tx, UpdateOperation) })
+
 	db.Callback().Delete().Before("*").Register("before_all", func(tx *gorm.DB) { m.beforeAll(tx, DeleteOperation) })
+	db.Callback().Delete().After("gorm:delete_before_associations").Before("gorm:delete").Register("before_statement", m.beforeStatement)
+	db.Callback().Delete().After("gorm:delete").Register("after_statement", m.afterStatement)
 	db.Callback().Delete().After("*").Register("after_all", func(tx *gorm.DB) { m.afterAll(tx, DeleteOperation) })
+
 	db.Callback().Raw().Before("*").Register("before_all", func(tx *gorm.DB) { m.beforeAll(tx, RawOperation) })
+	db.Callback().Raw().Before("gorm:raw").Register("before_statement", m.beforeStatement)
+	db.Callback().Raw().After("gorm:raw").Register("after_statement", m.afterStatement)
 	db.Callback().Raw().After("*").Register("after_all", func(tx *gorm.DB) { m.afterAll(tx, RawOperation) })
+
+	db.Callback().Row().Before("*").Register("before_all", func(tx *gorm.DB) { m.beforeAll(tx, RowOperation) })
+	db.Callback().Row().Before("gorm:row").Register("before_statement", m.beforeStatement)
+	db.Callback().Row().After("gorm:row").Register("after_statement", m.afterStatement)
+	db.Callback().Row().After("*").Register("after_all", func(tx *gorm.DB) { m.afterAll(tx, RowOperation) })
 
 	return nil
 }
@@ -93,6 +116,22 @@ func (m *metricsWriterPlugin) beforeAll(tx *gorm.DB, operationType OperationType
 	metrics.DBQueryCount += 1
 }
 
+// beforeStatement/afterStatement bracket the core SQL statement (the SELECT/INSERT/UPDATE/DELETE itself), excluding
+// the preload and save/delete-association phases. This isolates the single contained psql request so afterAll can
+// report gorm_statement_latency per statement rather than cumulating association/preload round-trips.
+func (m *metricsWriterPlugin) beforeStatement(tx *gorm.DB) {
+	tx.Statement.Context = context.WithValue(tx.Statement.Context, statementStartKey, time.Now())
+}
+
+func (m *metricsWriterPlugin) afterStatement(tx *gorm.DB) {
+	ctx := tx.Statement.Context
+	val := ctx.Value(statementStartKey)
+	if val == nil {
+		return
+	}
+	tx.Statement.Context = context.WithValue(ctx, statementDurationKey, time.Since(val.(time.Time)))
+}
+
 func (m *metricsWriterPlugin) afterAll(tx *gorm.DB, operationType OperationType) {
 	ctx := tx.Statement.Context
 	schema := tx.Statement.Schema
@@ -109,6 +148,12 @@ func (m *metricsWriterPlugin) afterAll(tx *gorm.DB, operationType OperationType)
 	startTS := val.(time.Time)
 	dur := time.Since(startTS)
 	withinTargetLatency := time.Since(startTS) < targetLatency
+
+	// statement latency isolates the root query (no preloads); falls back to dur for ops with no preload phase.
+	stmtDur := dur
+	if v := ctx.Value(statementDurationKey); v != nil {
+		stmtDur = v.(time.Duration)
+	}
 
 	tags := []string{
 		"table:" + tableName,
@@ -147,6 +192,7 @@ func (m *metricsWriterPlugin) afterAll(tx *gorm.DB, operationType OperationType)
 	preloadCount := float64(len(tx.Statement.Preloads))
 
 	m.metricsWriter.Timing("gorm_operation_latency", dur, tags)
+	m.metricsWriter.Timing("gorm_operation.statement_latency", stmtDur, tags)
 	m.metricsWriter.Gauge("gorm_operation.response_size", float64(respSize), tags)
 	m.metricsWriter.Gauge("gorm_operation.preload_count", preloadCount, tags)
 	m.metricsWriter.Gauge("gorm_operation.rows_affected", float64(tx.RowsAffected), tags)
@@ -167,6 +213,26 @@ func (m *metricsWriterPlugin) afterAll(tx *gorm.DB, operationType OperationType)
 
 	if m.dbType == "ch" {
 		return
+	}
+
+	// statement-level slow query: the root SQL itself exceeded target, excluding preloads.
+	if stmtDur >= statementTargetLatency {
+		stmtEventText := fmt.Sprintf("Slow gorm statement identified for table %s and endpoint %s (latency: %dms)\n\nPrepared SQL: %s\nVars: %v\n",
+			tableName,
+			metricCtx.Endpoint,
+			stmtDur.Milliseconds(),
+			tx.Statement.SQL.String(),
+			tx.Statement.Vars,
+		)
+		if len(stmtEventText) > maxEventTextLen {
+			stmtEventText = stmtEventText[:maxEventTextLen-len(eventTextTruncSuffix)] + eventTextTruncSuffix
+		}
+
+		m.metricsWriter.Event(&statsd.Event{
+			Title: fmt.Sprintf("Slow gorm statement: %s (%dms)", metricCtx.Endpoint, stmtDur.Milliseconds()),
+			Text:  stmtEventText,
+			Tags:  tags,
+		})
 	}
 
 	if dur < targetLatency {


### PR DESCRIPTION
add new gorm statement latency metric that will capture gorm request atency excluding preloads.
add new datadog event for slow statement queries that write at 200ms.