### PR TITLE
chore: set a floor for org runner resource requests

### DIFF
--- a/bins/runner/bundle/helm/templates/deployment.tpl
+++ b/bins/runner/bundle/helm/templates/deployment.tpl
@@ -38,6 +38,10 @@ spec:
           command:
             - /bin/runner
             - org
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" . }}

--- a/bins/runner/bundle/helm/values.yaml
+++ b/bins/runner/bundle/helm/values.yaml
@@ -23,15 +23,10 @@ autoscaling:
   targetCPUUtilizationPercentage: 100
   targetMemoryUtilizationPercentage: 100
 
-# limits should be based on the instance_types
-# docs: https://karpenter.sh/v0.37/reference/instance-types/#t3amedium
 resources:
   requests:
-    cpu: 1500m
-    memory: 1536Mi
-  limit:
-    cpu: 1750m
-    memory: 3072Mi
+    cpu: 750m
+    memory: 1.5Gi
 
 node_pool:
   # if we want the deployment to create and run on its own NodePool, we must enable this

--- a/services/ctl-api/internal/app/runners/worker/kuberunner/values.go
+++ b/services/ctl-api/internal/app/runners/worker/kuberunner/values.go
@@ -39,6 +39,15 @@ type nodePoolValues struct {
 	NodeClassRef nodeClassRefValues `mapstructure:"node_class_ref"`
 }
 
+type resourceRequests struct {
+	CPU    string `mapstructure:"cpu"`
+	Memory string `mapstructure:"memory"`
+}
+
+type resourceValues struct {
+	Requests resourceRequests `mapstructure:"requests"`
+}
+
 type helmValues struct {
 	Image helmValuesImage `mapstructure:"image"`
 	Env   helmValuesEnv   `mapstructure:"env"`
@@ -46,6 +55,7 @@ type helmValues struct {
 	ServiceAccount serviceAccountValues `mapstructure:"serviceAccount"`
 	PodLabels      map[string]string    `mapstructure:"podLabels"`
 	NodePool       nodePoolValues       `mapstructure:"node_pool"`
+	Resources      resourceValues       `mapstructure:"resources"`
 }
 
 func (a *Activities) getValues(req *InstallOrUpgradeRequest) helmValues {
@@ -107,6 +117,12 @@ func (a *Activities) getValues(req *InstallOrUpgradeRequest) helmValues {
 				Name: req.InstanceTypeName,
 			},
 			NodeClassRef: nodeClassRef,
+		},
+		Resources: resourceValues{
+			Requests: resourceRequests{
+				CPU:    "750m",
+				Memory: "1.5Gi",
+			},
 		},
 	}
 }


### PR DESCRIPTION
### Description

the reasoning here is that these org runners run in a kubernetes
cluster. on byoc deployments for which we enable datadog, if we do _not_
set resource requests, we get some relatively "loud"/common events which
can cloud histograms.

this change is introduced in an effort to reduce these events and, in
turn, reduce costs; however slightly.

values are based on nuon cloud's stage deployment which deploys the 
runners to a t3a.small. there are no limits because each org runner gets its 
own node.