### PR TITLE
perf(runner): pick up jobs in milliseconds instead of waiting on a poll

### DIFF
--- a/services/ctl-api/internal/app/runners/service/get_runner_jobs.go
+++ b/services/ctl-api/internal/app/runners/service/get_runner_jobs.go
@@ -59,6 +59,8 @@ func (s *service) GetRunnerJobs(ctx *gin.Context) {
 		return
 	}
 
+	s.emitRunnerJobPickupAge(runnerJobs, pickupPathLegacy)
+
 	ctx.JSON(http.StatusOK, runnerJobs)
 }
 

--- a/services/ctl-api/internal/app/runners/service/get_runner_jobs_tail.go
+++ b/services/ctl-api/internal/app/runners/service/get_runner_jobs_tail.go
@@ -14,15 +14,16 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
 )
 
-// Long-poll tuning for job pickup. The shape mirrors log_stream_tail_logs.go.
-// Probes hit Postgres instead of ClickHouse so the fast path is cheaper, but
-// the steady-state idle rate (~1 probe/sec/subscriber) and 25s hold window
-// are deliberately the same so dashboards/alerts read consistently across the
-// two long-poll endpoints.
+// Long-poll tuning for job pickup. Pickup is event-driven: a Postgres trigger
+// (migration 112) fires NOTIFY on the queued→available transition, which the
+// pod-level RunnerJobNotifyListener fans out to parked handlers via the wake
+// registry, so the common case returns in ~ms. jobTailBackstopInterval is the
+// sparse safety poll that bounds worst-case latency when a notify is dropped
+// (listener reconnect, pod restart, RDS failover) — it is NOT the primary
+// mechanism, so it's deliberately slow (and cheaper than the old 1s loop).
 const (
 	jobTailMaxWait             = 25 * time.Second
-	jobTailMinBackoff          = 250 * time.Millisecond
-	jobTailMaxBackoff          = 1 * time.Second
+	jobTailBackstopInterval    = 5 * time.Second
 	jobTailMaxConcurrentProbes = 50
 	jobTailProbeQueryTimeout   = 2 * time.Second
 )
@@ -30,12 +31,9 @@ const (
 var jobTailProbeSem = make(chan struct{}, jobTailMaxConcurrentProbes)
 
 const (
-	metricJobTailProbe         = "runner_job_tail.probe"
-	metricJobTailEmptyProbeMs  = "runner_job_tail.empty_probe_ms"
-	metricJobTailHotProbeMs    = "runner_job_tail.hot_probe_ms"
-	metricJobTailOutcome       = "runner_job_tail.outcome"
-	metricJobTailSessionMs     = "runner_job_tail.session_ms"
-	metricJobTailProbesPerSess = "runner_job_tail.probes_per_session"
+	metricJobTailHotProbeMs = "runner_job_tail.hot_probe_ms"
+	metricJobTailOutcome    = "runner_job_tail.outcome"
+	metricJobTailNotifyWake = "runner_job_tail.notify_wake_probe"
 )
 
 const (
@@ -98,17 +96,18 @@ func (s *service) TailRunnerJobs(ctx *gin.Context) {
 
 	startedAt := time.Now()
 	deadline := startedAt.Add(wait)
-	backoff := jobTailMinBackoff
 	firstIter := true
-	probes := 0
+	// Subscribe BEFORE the first probe so a NOTIFY that fires between our probe
+	// and entering the select isn't missed — the buffered wake channel holds it
+	// and the next select drains it immediately.
+	wakeCh, unsubscribe := s.runnerJobWake.Subscribe(runnerID)
+	defer unsubscribe()
 
 	for {
 		probeStart := time.Now()
 		job, qerr := s.tailJobProbe(ctx.Request.Context(), runnerID, grp)
-		probes++
-		s.mw.Count(metricJobTailProbe, 1, nil)
 		if qerr != nil {
-			s.emitJobTailExit(jobTailOutcomeError, startedAt, probes)
+			s.emitJobTailExit(jobTailOutcomeError)
 			ctx.Error(errors.Wrap(qerr, "unable to probe runner job tail"))
 			return
 		}
@@ -119,51 +118,41 @@ func (s *service) TailRunnerJobs(ctx *gin.Context) {
 				s.mw.Timing(metricJobTailHotProbeMs, time.Since(probeStart), nil)
 				outcome = jobTailOutcomeHotHit
 			}
-			s.emitJobTailExit(outcome, startedAt, probes)
+			s.emitJobTailExit(outcome)
+			s.emitRunnerJobPickupAge([]*app.RunnerJob{job}, pickupPathLongPoll)
 			ctx.JSON(http.StatusOK, []*app.RunnerJob{job})
 			return
 		}
 
-		s.mw.Timing(metricJobTailEmptyProbeMs, time.Since(probeStart), nil)
 		firstIter = false
-
-		select {
-		case <-ctx.Request.Context().Done():
-			s.emitJobTailExit(jobTailOutcomeClientCancel, startedAt, probes)
-			return
-		default:
-		}
 
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
-			s.emitJobTailExit(jobTailOutcomeTimeoutEmpty, startedAt, probes)
+			s.emitJobTailExit(jobTailOutcomeTimeoutEmpty)
 			ctx.JSON(http.StatusOK, []*app.RunnerJob{})
 			return
 		}
 
-		sleep := backoff + jitter(backoff)
+		// Wait for whichever comes first: a NOTIFY wake (re-probe in ~ms), the
+		// sparse backstop tick, or the client/deadline going away. No exponential
+		// backoff — the notify carries the hot path.
+		sleep := jobTailBackstopInterval + jitter(jobTailBackstopInterval)
 		if sleep > remaining {
 			sleep = remaining
 		}
 		select {
 		case <-ctx.Request.Context().Done():
-			s.emitJobTailExit(jobTailOutcomeClientCancel, startedAt, probes)
+			s.emitJobTailExit(jobTailOutcomeClientCancel)
 			return
+		case <-wakeCh:
+			s.mw.Count(metricJobTailNotifyWake, 1, nil)
 		case <-time.After(sleep):
-		}
-
-		backoff *= 2
-		if backoff > jobTailMaxBackoff {
-			backoff = jobTailMaxBackoff
 		}
 	}
 }
 
-func (s *service) emitJobTailExit(result string, startedAt time.Time, probes int) {
-	tags := []string{"result:" + result}
-	s.mw.Count(metricJobTailOutcome, 1, tags)
-	s.mw.Timing(metricJobTailSessionMs, time.Since(startedAt), tags)
-	s.mw.Distribution(metricJobTailProbesPerSess, float64(probes), tags)
+func (s *service) emitJobTailExit(result string) {
+	s.mw.Count(metricJobTailOutcome, 1, []string{"result:" + result})
 }
 
 // tailJobProbe runs a single bounded Postgres query for the next available

--- a/services/ctl-api/internal/app/runners/service/runner_job_notify_listener.go
+++ b/services/ctl-api/internal/app/runners/service/runner_job_notify_listener.go
@@ -1,0 +1,167 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/pkg/metrics"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/psql"
+)
+
+const (
+	runnerJobNotifyChannel = "runner_job_available_v1"
+
+	// listenerSessionMaxAge tears down and reopens the listener connection well
+	// inside the pool's 5m MaxConnLifetime and the ~15m IAM token window, so the
+	// listener never runs on an aged or stale-auth connection. Reopening re-runs
+	// the IAM token fetch in psql.NewPrimaryListenerConn.
+	listenerSessionMaxAge = 4*time.Minute + 30*time.Second
+	listenerMinReconnect  = 250 * time.Millisecond
+	listenerMaxReconnect  = 10 * time.Second
+)
+
+type runnerJobNotifyPayload struct {
+	RunnerID string `json:"runner_id"`
+	JobID    string `json:"job_id"`
+	Group    string `json:"group"`
+}
+
+// RunnerJobNotifyListener holds one primary-DB LISTEN connection per pod and
+// fans NOTIFY events out to parked TailRunnerJobs handlers via the wake
+// registry. It is intentionally best-effort: the long-poll handler keeps a poll
+// backstop, so a dropped notify (reconnect, pod restart, RDS failover) only
+// costs latency, never correctness.
+type RunnerJobNotifyListener struct {
+	cfg      *internal.Config
+	l        *zap.Logger
+	mw       metrics.Writer
+	registry *RunnerJobWakeRegistry
+
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+type RunnerJobNotifyListenerParams struct {
+	fx.In
+
+	Cfg      *internal.Config
+	L        *zap.Logger
+	MW       metrics.Writer
+	Registry *RunnerJobWakeRegistry
+}
+
+// StartRunnerJobNotifyListener constructs the listener and binds its lifecycle
+// to fx. Wired via fx.Invoke so the listener starts eagerly without anything
+// having to depend on it.
+func StartRunnerJobNotifyListener(p RunnerJobNotifyListenerParams, lc fx.Lifecycle) *RunnerJobNotifyListener {
+	rl := &RunnerJobNotifyListener{
+		cfg:      p.Cfg,
+		l:        p.L.With(zap.String("component", "runner_job_notify_listener")),
+		mw:       p.MW,
+		registry: p.Registry,
+		done:     make(chan struct{}),
+	}
+
+	lc.Append(fx.Hook{
+		OnStart: func(_ context.Context) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			rl.cancel = cancel
+			go rl.run(ctx)
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			if rl.cancel != nil {
+				rl.cancel()
+			}
+			select {
+			case <-rl.done:
+			case <-ctx.Done():
+			}
+			return nil
+		},
+	})
+
+	return rl
+}
+
+func (rl *RunnerJobNotifyListener) run(ctx context.Context) {
+	defer close(rl.done)
+
+	backoff := listenerMinReconnect
+	for ctx.Err() == nil {
+		clean, err := rl.listenOnce(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+
+		if clean {
+			// Scheduled session rotation (age-out), not a fault: reset backoff
+			// and reconnect promptly.
+			backoff = listenerMinReconnect
+		} else {
+			rl.l.Warn("notify listener disconnected, reconnecting", zap.Error(err))
+			rl.mw.Count("runner_job_tail.listener_error", 1, nil)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff + jitter(backoff)):
+		}
+
+		if !clean {
+			backoff *= 2
+			if backoff > listenerMaxReconnect {
+				backoff = listenerMaxReconnect
+			}
+		}
+	}
+}
+
+// listenOnce opens a connection, LISTENs, and pumps notifications until the
+// session ages out or the connection drops. It returns clean=true when the exit
+// was our own scheduled age-out (parent ctx still live), so the caller can treat
+// it as a routine rotation rather than an error.
+func (rl *RunnerJobNotifyListener) listenOnce(parent context.Context) (clean bool, err error) {
+	ctx, cancel := context.WithTimeout(parent, listenerSessionMaxAge+jitter(30*time.Second))
+	defer cancel()
+
+	conn, err := psql.NewPrimaryListenerConn(ctx, rl.cfg)
+	if err != nil {
+		return false, err
+	}
+	defer conn.Close(context.Background())
+
+	if _, err := conn.Exec(ctx, "LISTEN "+runnerJobNotifyChannel); err != nil {
+		return false, err
+	}
+
+	rl.mw.Gauge("runner_job_tail.listener_up", 1, nil)
+	defer rl.mw.Gauge("runner_job_tail.listener_up", 0, nil)
+	rl.l.Info("notify listener connected")
+
+	for {
+		n, err := conn.WaitForNotification(ctx)
+		if err != nil {
+			// Our own session-age deadline elapsed while the service is still
+			// running → routine rotation, not a fault.
+			if parent.Err() == nil && ctx.Err() != nil {
+				return true, nil
+			}
+			return false, err
+		}
+
+		var payload runnerJobNotifyPayload
+		if jerr := json.Unmarshal([]byte(n.Payload), &payload); jerr != nil || payload.RunnerID == "" {
+			rl.mw.Count("runner_job_tail.notify_payload_invalid", 1, nil)
+			continue
+		}
+
+		rl.registry.Wake(payload.RunnerID)
+	}
+}

--- a/services/ctl-api/internal/app/runners/service/runner_job_pickup_age.go
+++ b/services/ctl-api/internal/app/runners/service/runner_job_pickup_age.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"time"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// metricRunnerJobPickupAgeMs records how long a job sat available before a
+// runner picked it up, tagged by which pickup path served it. It is emitted on
+// both the legacy 5s-poll endpoint and the long-poll/NOTIFY tail endpoint so the
+// two can be compared directly: with the long-poll flag on, a freshly-available
+// job is handed back in ~ms; on the legacy path it waits out the runner's
+// idle-poll interval (up to ~5s).
+const metricRunnerJobPickupAgeMs = "runner_job.pickup_age_ms"
+
+const (
+	pickupPathLongPoll = "longpoll"
+	pickupPathLegacy   = "legacy"
+)
+
+// emitRunnerJobPickupAge emits the pickup-age timing for each available job
+// being handed back to a runner. The baseline is CreatedAt: interactive jobs
+// (actions, sandbox, notebook cells) are born `available`, so CreatedAt is the
+// instant the job became pickable and the timing is exact pickup latency. Jobs
+// that queue before becoming available will read slightly high (the wait
+// includes queue time).
+//
+// Caveat: the legacy endpoint can return the same still-available job on
+// successive polls until the runner claims it, so a backlogged job may be
+// sampled more than once — this only ever inflates the legacy distribution,
+// never the long-poll one (which returns a job once on its NOTIFY wake).
+func (s *service) emitRunnerJobPickupAge(jobs []*app.RunnerJob, path string) {
+	now := time.Now()
+	for _, j := range jobs {
+		if j == nil || j.Status != app.RunnerJobStatusAvailable {
+			continue
+		}
+		s.mw.Timing(metricRunnerJobPickupAgeMs, now.Sub(j.CreatedAt), []string{
+			"pickup_path:" + path,
+		})
+	}
+}

--- a/services/ctl-api/internal/app/runners/service/runner_job_wake.go
+++ b/services/ctl-api/internal/app/runners/service/runner_job_wake.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"hash/fnv"
+	"sync"
+)
+
+// runnerJobWakeShards bounds lock contention on the registry: Subscribe/Wake
+// take only their runner's shard lock, so a burst of NOTIFY-driven wakes for
+// different runners doesn't serialize on a single global mutex.
+const runnerJobWakeShards = 32
+
+type runnerJobWakeShard struct {
+	mu      sync.Mutex
+	waiters map[string]map[chan struct{}]struct{}
+}
+
+// RunnerJobWakeRegistry fans a single pod-level NOTIFY listener out to the
+// parked TailRunnerJobs handlers on this pod, keyed by runner_id. The wake
+// carries no job data — it only tells a parked handler to re-probe Postgres —
+// so a missed or spurious wake is harmless (the handler's poll backstop and
+// authoritative re-query cover correctness).
+type RunnerJobWakeRegistry struct {
+	shards [runnerJobWakeShards]*runnerJobWakeShard
+}
+
+func NewRunnerJobWakeRegistry() *RunnerJobWakeRegistry {
+	r := &RunnerJobWakeRegistry{}
+	for i := range r.shards {
+		r.shards[i] = &runnerJobWakeShard{
+			waiters: make(map[string]map[chan struct{}]struct{}),
+		}
+	}
+	return r
+}
+
+func (r *RunnerJobWakeRegistry) shardFor(runnerID string) *runnerJobWakeShard {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(runnerID))
+	return r.shards[h.Sum32()%runnerJobWakeShards]
+}
+
+// Subscribe registers a waiter for a runner's job-available wakeups. The
+// returned channel is buffered (cap 1) and coalescing: Wake does a non-blocking
+// send, so a waiter that hasn't drained its previous signal isn't blocked on.
+// Callers MUST invoke the returned unsubscribe func (defer) to avoid leaking
+// the waiter.
+func (r *RunnerJobWakeRegistry) Subscribe(runnerID string) (<-chan struct{}, func()) {
+	ch := make(chan struct{}, 1)
+	sh := r.shardFor(runnerID)
+
+	sh.mu.Lock()
+	set := sh.waiters[runnerID]
+	if set == nil {
+		set = make(map[chan struct{}]struct{})
+		sh.waiters[runnerID] = set
+	}
+	set[ch] = struct{}{}
+	sh.mu.Unlock()
+
+	var once sync.Once
+	unsubscribe := func() {
+		once.Do(func() {
+			sh.mu.Lock()
+			if cur := sh.waiters[runnerID]; cur != nil {
+				delete(cur, ch)
+				if len(cur) == 0 {
+					delete(sh.waiters, runnerID)
+				}
+			}
+			sh.mu.Unlock()
+		})
+	}
+
+	return ch, unsubscribe
+}
+
+// Wake signals every current waiter for a runner to re-probe and returns how
+// many waiters were signalled (0 means no parked request for this runner lives
+// on this pod). Non-blocking and coalescing.
+func (r *RunnerJobWakeRegistry) Wake(runnerID string) int {
+	sh := r.shardFor(runnerID)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+
+	set := sh.waiters[runnerID]
+	for ch := range set {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+	return len(set)
+}

--- a/services/ctl-api/internal/app/runners/service/service.go
+++ b/services/ctl-api/internal/app/runners/service/service.go
@@ -37,6 +37,7 @@ type Params struct {
 	Heartbeater          *heartbeater.Heartbeater
 	FeaturesClient       *features.Features
 	TemporalClient       temporalclient.Client
+	RunnerJobWake        *RunnerJobWakeRegistry
 }
 
 type service struct {
@@ -53,6 +54,7 @@ type service struct {
 	heartbeater          *heartbeater.Heartbeater
 	featuresClient       *features.Features
 	temporalClient       temporalclient.Client
+	runnerJobWake        *RunnerJobWakeRegistry
 	// logStreamCache hits in front of getLogStream on the OTLP ingest
 	// hot path. The fields the writer reads (OwnerType, ParentLogStreamID)
 	// are effectively immutable for the life of the stream, so a 5min TTL
@@ -370,6 +372,7 @@ func New(params Params) *service {
 		heartbeater:          params.Heartbeater,
 		featuresClient:       params.FeaturesClient,
 		temporalClient:       params.TemporalClient,
+		runnerJobWake:        params.RunnerJobWake,
 		logStreamCache:       expirable.NewLRU[string, *app.LogStream](logStreamCacheSize, nil, logStreamCacheTTL),
 	}
 }

--- a/services/ctl-api/internal/app/runners/signals/processjob/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/processjob/signal.go
@@ -111,37 +111,36 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 	return nil
 }
 
+// InlineValidate marks process_job's Validate as inline and activity-free
+// (the runner/active-process/job checks moved to Execute), so the handler can
+// skip the validate-phase abandonment stamps on the dispatch hot path.
+func (s *Signal) InlineValidate() bool {
+	return true
+}
+
 func (s *Signal) Execute(ctx workflow.Context) error {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
 		return err
 	}
 
-	l.Info("fetching runner to ensure it is healthy")
-	runner, err := activities.AwaitGet(ctx, activities.GetRequest{
+	l.Info("fetching runner and job to ensure runner is healthy")
+	execData, err := activities.AwaitGetRunnerJobForExecution(ctx, activities.GetRunnerJobForExecutionRequest{
 		RunnerID: s.RunnerID,
+		JobID:    s.JobID,
 	})
 	if err != nil {
-		s.updateJobStatus(ctx, s.JobID, app.RunnerJobStatusNotAttempted, "unable to fetch runner from database")
-		return fmt.Errorf("unable to get runner: %w", err)
+		s.updateJobStatus(ctx, s.JobID, app.RunnerJobStatusNotAttempted, "unable to fetch runner and job from database")
+		return fmt.Errorf("unable to get runner job execution data: %w", err)
 	}
+	runner := execData.Runner
+	runnerJob := execData.Job
 
 	// Check if runner has any active process
-	resp, err := activities.AwaitHasActiveRunnerProcess(ctx, activities.HasActiveRunnerProcessRequest{
-		RunnerID: s.RunnerID,
-	})
-	if err != nil || !resp.HasActive {
+	if !execData.HasActiveProcess {
 		l.Warn("runner has no active process, not attempting")
 		s.updateJobStatus(ctx, s.JobID, app.RunnerJobStatusNotAttempted, "no active runner process available")
 		return errors.New("runner has no active process")
-	}
-
-	runnerJob, err := activities.AwaitGetJob(ctx, activities.GetJobRequest{
-		ID: s.JobID,
-	})
-	if err != nil {
-		s.updateJobStatus(ctx, s.JobID, app.RunnerJobStatusNotAttempted, "unable to get job from database")
-		return fmt.Errorf("unable to update runner job: %w", err)
 	}
 
 	if runnerJob.Status == app.RunnerJobStatusCancelled {

--- a/services/ctl-api/internal/app/runners/worker/activities/get_runner_job_for_execution.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_runner_job_for_execution.go
@@ -1,0 +1,52 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+type GetRunnerJobForExecutionRequest struct {
+	RunnerID string `validate:"required"`
+	JobID    string `validate:"required"`
+}
+
+type GetRunnerJobForExecutionResponse struct {
+	Runner           *app.Runner
+	Job              *app.RunnerJob
+	HasActiveProcess bool
+}
+
+// GetRunnerJobForExecution coalesces the three reads the process_job execute
+// phase needs — runner, active-process check, and job — into a single activity.
+// Done separately these were three serial Temporal round-trips on the dispatch
+// hot path right before started_at is stamped; folding them into one round-trip
+// shaves that latency for every job.
+//
+// @temporal-gen-v2 activity
+func (a *Activities) GetRunnerJobForExecution(ctx context.Context, req GetRunnerJobForExecutionRequest) (*GetRunnerJobForExecutionResponse, error) {
+	runner, err := a.getRunner(ctx, req.RunnerID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get runner: %w", err)
+	}
+
+	var activeCount int64
+	if err := a.db.WithContext(ctx).
+		Model(&app.RunnerProcess{}).
+		Where("runner_id = ? AND composite_status->>'status' = ?", req.RunnerID, string(app.RunnerProcessStatusActive)).
+		Count(&activeCount).Error; err != nil {
+		return nil, fmt.Errorf("unable to check active runner process: %w", err)
+	}
+
+	job, err := a.getRunnerJob(ctx, req.JobID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get runner job: %w", err)
+	}
+
+	return &GetRunnerJobForExecutionResponse{
+		Runner:           runner,
+		Job:              job,
+		HasActiveProcess: activeCount > 0,
+	}, nil
+}

--- a/services/ctl-api/internal/fxmodules/services.go
+++ b/services/ctl-api/internal/fxmodules/services.go
@@ -57,6 +57,8 @@ var sharedServices = fx.Options(
 	fx.Provide(api.AsService(runnerauthservice.New)),
 	fx.Provide(heartbeater.New),
 	fx.Provide(runnersservice.NewRunnerHeartbeatCache),
+	fx.Provide(runnersservice.NewRunnerJobWakeRegistry),
+	fx.Invoke(runnersservice.StartRunnerJobNotifyListener),
 	fx.Provide(api.AsService(runnersservice.New)),
 	fx.Provide(api.AsService(slackservice.New)),
 	fx.Provide(api.AsService(vcsservice.New)),

--- a/services/ctl-api/internal/pkg/db/psql/listener_conn.go
+++ b/services/ctl-api/internal/pkg/db/psql/listener_conn.go
@@ -1,0 +1,61 @@
+package psql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+// NewPrimaryListenerConn opens a single dedicated, non-pooled connection to the
+// PRIMARY database, suitable for LISTEN/NOTIFY. The caller owns the connection
+// and must Close it.
+//
+// This deliberately bypasses the pgxpool: a LISTEN binds to a session and pins
+// a connection for its lifetime, which is the wrong thing to take from a shared
+// pool. Because RDS IAM auth tokens rotate (~15m) and pooled connections are
+// recycled on a 5m lifetime, callers should periodically tear this connection
+// down and re-open via this function rather than holding it open indefinitely —
+// each reopen re-runs the IAM token fetch below.
+func NewPrimaryListenerConn(ctx context.Context, cfg *internal.Config) (*pgx.Conn, error) {
+	d := &database{
+		Host:    cfg.DBHost,
+		User:    cfg.DBUser,
+		Name:    cfg.DBName,
+		Port:    cfg.DBPort,
+		SSLMode: cfg.DBSSLMode,
+		Region:  cfg.DBRegion,
+	}
+	switch {
+	case cfg.DBPassword != "":
+		d.Password = cfg.DBPassword
+	case cfg.DBUseIAM && cfg.IsGCP():
+		d.PasswordFn = FetchGcpCloudSqlPassword
+	case cfg.DBUseIAM:
+		d.PasswordFn = FetchIamTokenPassword
+	}
+
+	connCfg, err := d.connCfg()
+	if err != nil {
+		return nil, fmt.Errorf("unable to build listener conn config: %w", err)
+	}
+
+	// connCfg() omits password from the DSN when a PasswordFn is set (mirrors
+	// the pool's beforeConnect hook); inject the freshly-fetched token here.
+	if d.PasswordFn != nil {
+		pw, err := d.PasswordFn(ctx, *d)
+		if err != nil {
+			return nil, fmt.Errorf("unable to fetch listener db password: %w", err)
+		}
+		connCfg.Password = pw
+	}
+
+	conn, err := pgx.ConnectConfig(ctx, connCfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open listener connection: %w", err)
+	}
+
+	return conn, nil
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/112_runner_job_available_notify_trigger.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/112_runner_job_available_notify_trigger.go
@@ -1,0 +1,20 @@
+package migrations
+
+import (
+	"context"
+	_ "embed"
+
+	"gorm.io/gorm"
+)
+
+//go:embed 112_runner_job_available_notify_trigger.sql
+var RunnerJobAvailableNotifyTriggerSQL string
+
+func (m *Migrations) Migration112RunnerJobAvailableNotifyTrigger(ctx context.Context, db *gorm.DB) error {
+	if res := db.WithContext(ctx).
+		Exec(RunnerJobAvailableNotifyTriggerSQL); res.Error != nil {
+		return res.Error
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/112_runner_job_available_notify_trigger.sql
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/112_runner_job_available_notify_trigger.sql
@@ -1,0 +1,34 @@
+-- Emit a Postgres NOTIFY whenever a runner job becomes available so the
+-- long-poll job-pickup endpoint (TailRunnerJobs) can wake parked runners in
+-- ~ms instead of waiting out its poll backstop. The notification carries no
+-- correctness: the endpoint always re-queries Postgres on wake, and keeps a
+-- sparse poll as a backstop, so a dropped notify (listener reconnecting, pod
+-- restart, RDS failover) only costs latency, never a stranded job.
+--
+-- The function fires for both INSERT (job born available) and the
+-- queued -> available UPDATE. Logic lives in the body (not a WHEN clause) so a
+-- single trigger can cover INSERT OR UPDATE without referencing OLD on INSERT.
+
+CREATE OR REPLACE FUNCTION notify_runner_job_available() RETURNS trigger AS $$
+BEGIN
+  IF NEW.status = 'available'
+     AND (TG_OP = 'INSERT' OR OLD.status IS DISTINCT FROM NEW.status) THEN
+    PERFORM pg_notify(
+      'runner_job_available_v1',
+      json_build_object(
+        'runner_id', NEW.runner_id,
+        'job_id', NEW.id,
+        'group', NEW."group"
+      )::text
+    );
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS runner_job_available_notify ON runner_jobs;
+
+CREATE TRIGGER runner_job_available_notify
+AFTER INSERT OR UPDATE OF status ON runner_jobs
+FOR EACH ROW
+EXECUTE FUNCTION notify_runner_job_available();

--- a/services/ctl-api/internal/pkg/db/psql/migrations/all.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/all.go
@@ -120,5 +120,9 @@ func (m *Migrations) All() []migrations.Migration {
 			Name: "111-backfill-lifecycle-phase",
 			Fn:   m.Migration111BackfillLifecyclePhase,
 		},
+		{
+			Name: "112-runner-job-available-notify-trigger",
+			Fn:   m.Migration112RunnerJobAvailableNotifyTrigger,
+		},
 	}
 }

--- a/services/ctl-api/internal/pkg/queue/handler/validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/validate.go
@@ -48,13 +48,15 @@ func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *
 	}
 
 	// mark the signal as in-progress in the DB
-	_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
-		QueueSignalID: h.queueSignalID,
-		Status:        app.StatusInProgress,
-		Metadata: map[string]any{
-			"validate_started_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
-		},
-	})
+	if !h.skipValidateStamps() {
+		_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+			QueueSignalID: h.queueSignalID,
+			Status:        app.StatusInProgress,
+			Metadata: map[string]any{
+				"validate_started_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
+			},
+		})
+	}
 
 	event := h.buildSignalPhaseEvent(signal.SignalPhaseValidate)
 
@@ -115,15 +117,28 @@ func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *
 	}
 
 	// record validate completion timestamp
-	_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
-		QueueSignalID: h.queueSignalID,
-		Status:        app.StatusInProgress,
-		Metadata: map[string]any{
-			"validate_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
-		},
-	})
+	if !h.skipValidateStamps() {
+		_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
+			QueueSignalID: h.queueSignalID,
+			Status:        app.StatusInProgress,
+			Metadata: map[string]any{
+				"validate_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
+			},
+		})
+	}
 
 	return nil, nil
+}
+
+// skipValidateStamps reports whether the validate-phase abandonment stamps
+// should be skipped for this handler's signal. Signals that implement
+// SignalWithInlineValidate (idempotent, activity-free Validate) opt out: the
+// stamps can never detect a real mid-validate abandonment for them and only add
+// status-write round-trips to the dispatch hot path. Error-path status writes
+// are unaffected — only the two success-path metadata stamps are skipped.
+func (h *handler) skipValidateStamps() bool {
+	iv, ok := h.sig.(signal.SignalWithInlineValidate)
+	return ok && iv.InlineValidate()
 }
 
 // runSignalValidate calls the user-provided signal Validate in a panic-safe boundary.

--- a/services/ctl-api/internal/pkg/queue/signal/interfaces.go
+++ b/services/ctl-api/internal/pkg/queue/signal/interfaces.go
@@ -97,6 +97,19 @@ type SignalWithRetryGroup interface {
 	RetryGroup() bool
 }
 
+// SignalWithInlineValidate is implemented by signals whose Validate phase runs
+// entirely inline on the workflow task — no activities, no awaits — performing
+// only idempotent, side-effect-free checks (e.g. required-field validation).
+// For such signals the handler skips the validate-phase abandonment stamps
+// (validate_started_at / validate_finished_at): an inline Validate runs to
+// completion within a single workflow task, so it can never be abandoned
+// mid-phase and re-running it on recovery is safe. The stamps then serve no
+// purpose and only add status-write round-trips to the dispatch hot path.
+// Note: Validate still runs in full — only the two success-path stamps are skipped.
+type SignalWithInlineValidate interface {
+	InlineValidate() bool
+}
+
 // ---------------------------------------------------------------------------
 // Step Execution Capabilities
 // ---------------------------------------------------------------------------


### PR DESCRIPTION

## Summary

Newly available runner jobs reach the runner faster. Orgs on the long-poll flag
get millisecond pickup instead of waiting out a poll interval, and a leaner
dispatch handshake speeds up every job regardless of the flag.

## Behind the long-poll flag

**Jobs reach the runner almost immediately.** A Postgres trigger fires the
instant a job becomes available and wakes the runner's parked request, so
interactive work (actions, sandbox runs, notebook cells) starts without the poll
delay (up to ~5s). Orgs without the flag keep using the existing poll endpoint.

## For every org

**Faster dispatch handshake.** The checks run right before a job is marked
started are folded into one round trip, and validate-phase status stamps are
skipped for signals that validate inline.

**Measurable in DataDog.** A pickup-age timing is emitted on both pickup paths,
tagged by path, so the win is comparable.

## What stays the same

Pickup stays correct if a notification is dropped (listener reconnect, pod
restart, database failover): the long-poll endpoint re-queries on wake and keeps
a sparse poll as a backstop.
