### PR TITLE
chore(ctl-api): org runner resource request mod for stage

### DIFF
--- a/services/ctl-api/internal/app/runners/worker/kuberunner/values.go
+++ b/services/ctl-api/internal/app/runners/worker/kuberunner/values.go
@@ -121,7 +121,7 @@ func (a *Activities) getValues(req *InstallOrUpgradeRequest) helmValues {
 		Resources: resourceValues{
 			Requests: resourceRequests{
 				CPU:    "750m",
-				Memory: "1.5Gi",
+				Memory: "1000Mi",
 			},
 		},
 	}


### PR DESCRIPTION
again, this is a floor. each runner pod runs on a dedicated node. these
values work for a t3a.small (for stage) and allow room for the
daemonsets that run alongside it.
