### PR TITLE
fix: azure runner use binary health probes and don't shutdown immediately

### DIFF
--- a/bins/runner/internal/jobs/management/vm_shutdown/exec.go
+++ b/bins/runner/internal/jobs/management/vm_shutdown/exec.go
@@ -32,7 +32,7 @@ func (h *handler) finishJob(ctx context.Context, job *models.AppRunnerJob, jobEx
 		}
 
 		// On Azure, don't power the VM off. An instance refresh in Azure takes 10m+ to complete.
-		// Keep the VM on and let the Azure control planereplace it.
+		// Keep the VM on and let the Azure control plane replace it.
 		if h.settings.Platform == "azure" {
 			l.Info("draining health probe; letting azure vmss repair (replace) the instance")
 			h.health.SetUnhealthy()

--- a/bins/runner/internal/jobs/management/vm_shutdown/exec.go
+++ b/bins/runner/internal/jobs/management/vm_shutdown/exec.go
@@ -34,7 +34,7 @@ func (h *handler) finishJob(ctx context.Context, job *models.AppRunnerJob, jobEx
 		// On Azure, don't power the VM off. An instance refresh in Azure takes 10m+ to complete.
 		// Keep the VM on and let the Azure control plane replace it.
 		if h.settings.Platform == "azure" {
-			l.Info("draining health probe; letting azure vmss repair (replace) the instance")
+			l.Info("vm shutdown - marking vm as unhealthy; letting azure vmss replace the instance")
 			h.health.SetUnhealthy()
 			return nil
 		}

--- a/bins/runner/internal/jobs/management/vm_shutdown/exec.go
+++ b/bins/runner/internal/jobs/management/vm_shutdown/exec.go
@@ -31,10 +31,23 @@ func (h *handler) finishJob(ctx context.Context, job *models.AppRunnerJob, jobEx
 			return err
 		}
 
+		// On Azure, don't power the VM off. A Stopped instance keeps its
+		// last-known Healthy state and resets the repair grace period, so it
+		// lingers instead of being recycled. Instead, fail the health probe and
+		// let the VMSS Application Health extension mark the instance Unhealthy —
+		// automaticRepairsPolicy then deletes and recreates it. The mng process
+		// stays up serving 503 so the probe keeps failing until Azure replaces
+		// the instance.
+		if h.settings.Platform == "azure" {
+			l.Info("draining health probe; letting azure vmss repair (replace) the instance")
+			h.health.SetUnhealthy()
+			return nil
+		}
+
 		// NOTE(fd): this shuts down so quickly we do lose the tail end of the logs.
 		// executes an os shutdown ↴ via dbus w/ a shell fallback w/ a sudo shell fallback
-		err = pkgshutdown.Shutdown(ctx, l, h.v)
-		if err != nil {
+		if err := pkgshutdown.Shutdown(ctx, l, h.v); err != nil {
+			l.Error("failed to shut down vm", zap.Error(err))
 		}
 	}
 

--- a/bins/runner/internal/jobs/management/vm_shutdown/exec.go
+++ b/bins/runner/internal/jobs/management/vm_shutdown/exec.go
@@ -31,13 +31,8 @@ func (h *handler) finishJob(ctx context.Context, job *models.AppRunnerJob, jobEx
 			return err
 		}
 
-		// On Azure, don't power the VM off. A Stopped instance keeps its
-		// last-known Healthy state and resets the repair grace period, so it
-		// lingers instead of being recycled. Instead, fail the health probe and
-		// let the VMSS Application Health extension mark the instance Unhealthy —
-		// automaticRepairsPolicy then deletes and recreates it. The mng process
-		// stays up serving 503 so the probe keeps failing until Azure replaces
-		// the instance.
+		// On Azure, don't power the VM off. An instance refresh in Azure takes 10m+ to complete.
+		// Keep the VM on and let the Azure control planereplace it.
 		if h.settings.Platform == "azure" {
 			l.Info("draining health probe; letting azure vmss repair (replace) the instance")
 			h.health.SetUnhealthy()

--- a/bins/runner/internal/jobs/management/vm_shutdown/handler.go
+++ b/bins/runner/internal/jobs/management/vm_shutdown/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nuonco/nuon/bins/runner/internal/jobs"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/errs"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/health"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/settings"
 )
 
@@ -20,6 +21,7 @@ type handler struct {
 	settings    *settings.Settings
 	shutdowner  fx.Shutdowner
 	errRecorder *errs.Recorder
+	health      *health.Server
 }
 
 var _ jobs.JobHandler = (*handler)(nil)
@@ -32,6 +34,7 @@ type HandlerParams struct {
 	Settings    *settings.Settings
 	Shutdowner  fx.Shutdowner
 	ErrRecorder *errs.Recorder
+	Health      *health.Server
 }
 
 func New(params HandlerParams) *handler {
@@ -41,6 +44,7 @@ func New(params HandlerParams) *handler {
 		settings:    params.Settings,
 		shutdowner:  params.Shutdowner,
 		errRecorder: params.ErrRecorder,
+		health:      params.Health,
 	}
 }
 

--- a/bins/runner/internal/pkg/health/livez.go
+++ b/bins/runner/internal/pkg/health/livez.go
@@ -3,14 +3,7 @@
 // Azure VMSS automatic instance repair needs an application-level health
 // signal. The VMSS Application Health extension probes this endpoint; while the
 // mng process is up it returns 200 and the instance is Healthy.
-//
-// Unlike the AWS ASG EC2 health check, Azure does NOT mark a powered-off
-// instance Unhealthy — a Stopped/deallocated VM retains its last-known health
-// state (Healthy) and is never repaired. So before the runner powers the VM
-// off on shutdown (see vm_shutdown), it calls SetUnhealthy to make this probe
-// fail while the VM is still running. The extension then marks the instance
-// Unhealthy and automaticRepairsPolicy replaces it — the Azure analog to the
-// AWS behavior that brings a shut-down runner back automatically.
+
 package health
 
 import (
@@ -53,8 +46,7 @@ func New(params Params) (*Server, error) {
 
 	s.srv = &http.Server{
 		// Bind to loopback only: the Azure VMSS Application Health extension
-		// runs inside the guest and probes 127.0.0.1, so the endpoint never
-		// needs to be reachable off-host.
+		// runs inside the vm and probes 127.0.0.1
 		Addr:              fmt.Sprintf("127.0.0.1:%d", params.Cfg.HealthPort),
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
@@ -94,9 +86,7 @@ func (s *Server) handleLivez(w http.ResponseWriter, _ *http.Request) {
 
 // SetUnhealthy flips the /livez probe to fail (503) so the Azure VMSS
 // Application Health extension marks the instance Unhealthy and automatic
-// instance repair replaces it. Called right before a VM shutdown so the
-// instance is recycled rather than left Stopped — a Stopped instance keeps its
-// last-known Healthy state and is never repaired.
+// instance repair replaces it.
 func (s *Server) SetUnhealthy() {
 	s.unhealthy.Store(true)
 	s.l.Info("health probe set to unhealthy")

--- a/bins/runner/internal/pkg/health/livez.go
+++ b/bins/runner/internal/pkg/health/livez.go
@@ -1,17 +1,23 @@
-// Package health serves a minimal /healthz endpoint from the mng process.
+// Package health serves a minimal /livez endpoint from the mng process.
 //
 // Azure VMSS automatic instance repair needs an application-level health
 // signal. The VMSS Application Health extension probes this endpoint; while the
-// mng process is up it returns 200, and when the runner powers the VM off (see
-// process.ShutdownPoller) the probe fails, the instance is marked unhealthy,
-// and the VMSS repairs it. This mirrors the AWS ASG EC2 health check, which is
-// what brings a shut-down AWS runner back automatically.
+// mng process is up it returns 200 and the instance is Healthy.
+//
+// Unlike the AWS ASG EC2 health check, Azure does NOT mark a powered-off
+// instance Unhealthy — a Stopped/deallocated VM retains its last-known health
+// state (Healthy) and is never repaired. So before the runner powers the VM
+// off on shutdown (see vm_shutdown), it calls SetUnhealthy to make this probe
+// fail while the VM is still running. The extension then marks the instance
+// Unhealthy and automaticRepairsPolicy replaces it — the Azure analog to the
+// AWS behavior that brings a shut-down runner back automatically.
 package health
 
 import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/sourcegraph/conc"
@@ -30,29 +36,28 @@ type Params struct {
 }
 
 type Server struct {
-	l   *zap.Logger
-	srv *http.Server
-	wg  *conc.WaitGroup
+	l         *zap.Logger
+	srv       *http.Server
+	wg        *conc.WaitGroup
+	unhealthy atomic.Bool
 }
 
 func New(params Params) (*Server, error) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/livez", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
-	})
-
 	s := &Server{
-		l: params.L,
-		srv: &http.Server{
-			// Bind to loopback only: the Azure VMSS Application Health
-			// extension runs inside the guest and probes 127.0.0.1, so the
-			// endpoint never needs to be reachable off-host.
-			Addr:              fmt.Sprintf("127.0.0.1:%d", params.Cfg.HealthPort),
-			Handler:           mux,
-			ReadHeaderTimeout: 5 * time.Second,
-		},
+		l:  params.L,
 		wg: conc.NewWaitGroup(),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/livez", s.handleLivez)
+
+	s.srv = &http.Server{
+		// Bind to loopback only: the Azure VMSS Application Health extension
+		// runs inside the guest and probes 127.0.0.1, so the endpoint never
+		// needs to be reachable off-host.
+		Addr:              fmt.Sprintf("127.0.0.1:%d", params.Cfg.HealthPort),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	params.LC.Append(fx.Hook{
@@ -75,4 +80,24 @@ func New(params Params) (*Server, error) {
 	})
 
 	return s, nil
+}
+
+func (s *Server) handleLivez(w http.ResponseWriter, _ *http.Request) {
+	if s.unhealthy.Load() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("unhealthy"))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+// SetUnhealthy flips the /livez probe to fail (503) so the Azure VMSS
+// Application Health extension marks the instance Unhealthy and automatic
+// instance repair replaces it. Called right before a VM shutdown so the
+// instance is recycled rather than left Stopped — a Stopped instance keeps its
+// last-known Healthy state and is never repaired.
+func (s *Server) SetUnhealthy() {
+	s.unhealthy.Store(true)
+	s.l.Info("health probe set to unhealthy")
 }

--- a/bins/runner/internal/pkg/health/livez.go
+++ b/bins/runner/internal/pkg/health/livez.go
@@ -3,7 +3,6 @@
 // Azure VMSS automatic instance repair needs an application-level health
 // signal. The VMSS Application Health extension probes this endpoint; while the
 // mng process is up it returns 200 and the instance is Healthy.
-
 package health
 
 import (

--- a/bins/runner/internal/pkg/process/shutdown_poller.go
+++ b/bins/runner/internal/pkg/process/shutdown_poller.go
@@ -144,7 +144,7 @@ func (sp *ShutdownPoller) check(ctx context.Context) {
 				// On Azure, don't power the VM off. An instance refresh in Azure takes 10m+ to complete.
 				// Keep the VM on and let the Azure control plane replace it.
 				if sp.settings.Platform == "azure" {
-					sp.l.Info("mng process shutdown on azure: draining health probe, letting vmss replace the instance")
+					sp.l.Info("mng process shutdown - marking vm as unhealthy; letting azure vmss replace the instance")
 					if sp.health != nil {
 						sp.health.SetUnhealthy()
 					}

--- a/bins/runner/internal/pkg/process/shutdown_poller.go
+++ b/bins/runner/internal/pkg/process/shutdown_poller.go
@@ -144,16 +144,21 @@ func (sp *ShutdownPoller) check(ctx context.Context) {
 				// On Azure, don't power the VM off. An instance refresh in Azure takes 10m+ to complete.
 				// Keep the VM on and let the Azure control plane replace it.
 				if sp.settings.Platform == "azure" {
-					sp.l.Info("mng process shutdown - marking vm as unhealthy; letting azure vmss replace the instance")
 					if sp.health != nil {
+						sp.l.Info("mng process shutdown - marking vm as unhealthy; letting azure vmss replace the instance")
 						sp.health.SetUnhealthy()
+						return
 					}
-					return
-				}
-
-				sp.l.Info("mng process shutdown: powering off VM")
-				if err := pkgshutdown.Shutdown(ctx, sp.l, sp.v); err != nil {
-					sp.l.Warn("VM shutdown failed", zap.Error(err))
+					// should never happen: the mng process always wires the health server. fall back to poweroff.
+					sp.l.Error("mng process shutdown on azure but health server is nil; falling back to vm poweroff")
+					if err := pkgshutdown.Shutdown(ctx, sp.l, sp.v); err != nil {
+						sp.l.Warn("VM shutdown failed", zap.Error(err))
+					}
+				} else {
+					sp.l.Info("mng process shutdown: powering off VM")
+					if err := pkgshutdown.Shutdown(ctx, sp.l, sp.v); err != nil {
+						sp.l.Warn("VM shutdown failed", zap.Error(err))
+					}
 				}
 			}
 

--- a/bins/runner/internal/pkg/process/shutdown_poller.go
+++ b/bins/runner/internal/pkg/process/shutdown_poller.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/bins/runner/internal"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/health"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/settings"
 	pkgshutdown "github.com/nuonco/nuon/bins/runner/internal/pkg/shutdown"
 	nuonrunner "github.com/nuonco/nuon/sdks/nuon-runner-go"
@@ -32,6 +33,9 @@ type ShutdownPollerParams struct {
 	Settings   *settings.Settings
 	Shutdowner fx.Shutdowner
 	V          *validator.Validate
+
+	// only provided in the mng process; nil in the install/run process.
+	Health *health.Server `optional:"true"`
 }
 
 type ShutdownPoller struct {
@@ -40,6 +44,8 @@ type ShutdownPoller struct {
 	v          *validator.Validate
 	registrar  *Registrar
 	shutdowner fx.Shutdowner
+	settings   *settings.Settings
+	health     *health.Server
 
 	podShutdown *podShutdown
 
@@ -57,6 +63,8 @@ func NewShutdownPoller(params ShutdownPollerParams) *ShutdownPoller {
 		v:           params.V,
 		registrar:   params.Registrar,
 		shutdowner:  params.Shutdowner,
+		settings:    params.Settings,
+		health:      params.Health,
 		podShutdown: newPodShutdown(params.Cfg, params.Settings, params.L),
 		ctx:         ctx,
 		cancelFn:    cancelFn,
@@ -133,6 +141,16 @@ func (sp *ShutdownPoller) check(ctx context.Context) {
 			}
 
 			if sp.registrar.ProcessType() == "mng" {
+				// On Azure, don't power the VM off. An instance refresh in Azure takes 10m+ to complete.
+				// Keep the VM on and let the Azure control plane replace it.
+				if sp.settings.Platform == "azure" {
+					sp.l.Info("mng process shutdown on azure: draining health probe, letting vmss replace the instance")
+					if sp.health != nil {
+						sp.health.SetUnhealthy()
+					}
+					return
+				}
+
 				sp.l.Info("mng process shutdown: powering off VM")
 				if err := pkgshutdown.Shutdown(ctx, sp.l, sp.v); err != nil {
 					sp.l.Warn("VM shutdown failed", zap.Error(err))

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_runner.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_runner.go
@@ -199,9 +199,10 @@ func (t *Templates) getDefaultRunnerTemplate() map[string]any {
 										"typeHandlerVersion":      "1.0", // Binary Health States (v1.0): a 200 from the probe
 										"autoUpgradeMinorVersion": true,
 										"settings": map[string]any{
-											"protocol":    "http",
-											"port":        9999,
-											"requestPath": "/livez",
+											"protocol":       "http",
+											"port":           9999,
+											"requestPath":    "/livez",
+											"numberOfProbes": 3, // Require 3 consecutive failing probes
 										},
 									},
 								},

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_runner.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_runner.go
@@ -196,7 +196,7 @@ func (t *Templates) getDefaultRunnerTemplate() map[string]any {
 									"properties": map[string]any{
 										"publisher":               "Microsoft.ManagedServices",
 										"type":                    "ApplicationHealthLinux",
-										"typeHandlerVersion":      "2.0",
+										"typeHandlerVersion":      "1.0", // Binary Health States (v1.0): a 200 from the probe
 										"autoUpgradeMinorVersion": true,
 										"settings": map[string]any{
 											"protocol":    "http",


### PR DESCRIPTION
A shutdown on the runner in Azure will replace the instance, but it takes 10+ minutes to do. 

Here we:
* Swap the health probes to binary mode (dumb 200 OK healthchecks)
* Don't call shutdown ourselves on Azure runners
* Instead mark the azure healthcheck as unhealthy and leave the runner up
* Allow the Azure control plane to replace the VM (in its own sweet time)