### PR TITLE
refactor(ui): better handling of stale sse endpoints

### DIFF
--- a/services/dashboard-ui/client/hooks/use-resource-sse.tsx
+++ b/services/dashboard-ui/client/hooks/use-resource-sse.tsx
@@ -2,6 +2,13 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import { useToast } from '@/hooks/use-toast'
 import { Text } from '@/components/common/Text'
 import { Toast } from '@/components/surfaces/Toast'
+import {
+  ensureActivityTracking,
+  isRecentlyActive,
+  onNextActivity,
+} from '@/lib/user-activity'
+
+const RECENT_ACTIVITY_WINDOW_MS = 5 * 60_000
 
 type SSEEventHandler = (event: MessageEvent) => void
 
@@ -15,10 +22,13 @@ interface UseResourceSSEOptions {
 export function useResourceSSE({ url, enabled, onMessage, listeners }: UseResourceSSEOptions) {
   const { addToast } = useToast()
   const [connected, setConnected] = useState(false)
+  const [suspended, setSuspended] = useState(false)
   const eventSourceRef = useRef<EventSource | null>(null)
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const reconnectAttemptRef = useRef(0)
   const finishedRef = useRef(false)
+  const expiredRef = useRef(false)
+  const resumeCleanupRef = useRef<(() => void) | null>(null)
   const onMessageRef = useRef(onMessage)
   onMessageRef.current = onMessage
   const listenersRef = useRef(listeners)
@@ -33,11 +43,23 @@ export function useResourceSSE({ url, enabled, onMessage, listeners }: UseResour
       clearTimeout(reconnectTimeoutRef.current)
       reconnectTimeoutRef.current = null
     }
+    if (resumeCleanupRef.current) {
+      resumeCleanupRef.current()
+      resumeCleanupRef.current = null
+    }
+    setSuspended(false)
     setConnected(false)
   }, [])
 
   const connect = useCallback(() => {
     if (!url || eventSourceRef.current) return
+
+    if (resumeCleanupRef.current) {
+      resumeCleanupRef.current()
+      resumeCleanupRef.current = null
+    }
+    setSuspended(false)
+    expiredRef.current = false
 
     const eventSource = new EventSource(url)
     eventSourceRef.current = eventSource
@@ -56,6 +78,10 @@ export function useResourceSSE({ url, enabled, onMessage, listeners }: UseResour
 
     eventSource.addEventListener('finished', () => {
       finishedRef.current = true
+    })
+
+    eventSource.addEventListener('expired', () => {
+      expiredRef.current = true
     })
 
     eventSource.addEventListener('fetch-error', (event: MessageEvent) => {
@@ -80,6 +106,18 @@ export function useResourceSSE({ url, enabled, onMessage, listeners }: UseResour
       // fallback polling takes over instead of reconnecting forever.
       if (finishedRef.current) return
 
+      // The server expires streams after a max lifetime. If the user hasn't
+      // interacted recently, suspend until their next interaction instead of
+      // reconnecting — an unattended visible tab shouldn't poll at full rate.
+      if (expiredRef.current && !isRecentlyActive(RECENT_ACTIVITY_WINDOW_MS)) {
+        setSuspended(true)
+        resumeCleanupRef.current = onNextActivity(() => {
+          resumeCleanupRef.current = null
+          connect()
+        })
+        return
+      }
+
       const backoffDelay = Math.min(1000 * Math.pow(2, reconnectAttemptRef.current), 30000)
       reconnectAttemptRef.current += 1
 
@@ -95,12 +133,29 @@ export function useResourceSSE({ url, enabled, onMessage, listeners }: UseResour
   }, [url])
 
   useEffect(() => {
+    ensureActivityTracking()
     finishedRef.current = false
-    if (enabled && url) {
+    if (enabled && url && document.visibilityState !== 'hidden') {
       connect()
     }
     return () => disconnect()
   }, [enabled, url, connect, disconnect])
 
-  return { connected, disconnect }
+  // Hidden tabs disconnect so the BFF stops polling ctl-api for them. On
+  // return, the focus refetch covers the gap and the fresh stream sends a
+  // full snapshot on its first tick.
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        disconnect()
+      } else if (enabled && url && !finishedRef.current) {
+        reconnectAttemptRef.current = 0
+        connect()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange)
+  }, [enabled, url, connect, disconnect])
+
+  return { connected, suspended, disconnect }
 }

--- a/services/dashboard-ui/client/hooks/use-sse-resource-query.ts
+++ b/services/dashboard-ui/client/hooks/use-sse-resource-query.ts
@@ -55,7 +55,7 @@ export function useSSEResourceQuery<TData>({
     [queryClient, eventName, onPrimaryEvent, extraListeners, ...queryKey]
   )
 
-  const { connected: sseConnected, disconnect } = useResourceSSE({
+  const { connected: sseConnected, suspended: sseSuspended, disconnect } = useResourceSSE({
     url: sseUrl,
     enabled: sseEnabled ?? shouldPoll,
     listeners,
@@ -67,7 +67,8 @@ export function useSSEResourceQuery<TData>({
     refetchInterval: (query) => {
       if (sseConnected) return false
       if (!shouldPoll) return false
-      return isFinished?.(query.state.data) ? finishedPollMs : fallbackPollMs
+      if (isFinished?.(query.state.data)) return finishedPollMs
+      return sseSuspended ? finishedPollMs : fallbackPollMs
     },
     enabled,
   })

--- a/services/dashboard-ui/client/hooks/use-sse-timeline-query.ts
+++ b/services/dashboard-ui/client/hooks/use-sse-timeline-query.ts
@@ -3,6 +3,8 @@ import { useQuery, useQueryClient, type QueryKey } from '@tanstack/react-query'
 import { useResourceSSE } from '@/hooks/use-resource-sse'
 import { createSSEQueryListener, type TSSEListenerMap } from '@/lib/sse-listeners'
 
+const SUSPENDED_POLL_MS = 30_000
+
 interface IUseSSETimelineQuery<TData> {
   sseUrl: string | undefined
   queryKey: QueryKey
@@ -36,7 +38,7 @@ export function useSSETimelineQuery<TData>({
     [queryClient, eventName, transform, extraListeners, ...queryKey]
   )
 
-  const { connected: sseConnected } = useResourceSSE({
+  const { connected: sseConnected, suspended: sseSuspended } = useResourceSSE({
     url: sseUrl,
     enabled: shouldPoll,
     listeners,
@@ -46,7 +48,12 @@ export function useSSETimelineQuery<TData>({
     queryKey,
     queryFn,
     refetchOnMount: 'always',
-    refetchInterval: shouldPoll && !sseConnected ? pollInterval : false,
+    refetchInterval:
+      !shouldPoll || sseConnected
+        ? false
+        : sseSuspended
+          ? SUSPENDED_POLL_MS
+          : pollInterval,
     enabled,
   })
 

--- a/services/dashboard-ui/client/lib/user-activity.ts
+++ b/services/dashboard-ui/client/lib/user-activity.ts
@@ -1,0 +1,42 @@
+const ACTIVITY_EVENTS = [
+  'pointerdown',
+  'pointermove',
+  'keydown',
+  'wheel',
+  'touchstart',
+] as const
+
+let lastActivityAt = Date.now()
+let tracking = false
+
+const markActivity = () => {
+  lastActivityAt = Date.now()
+}
+
+export function ensureActivityTracking() {
+  if (tracking || typeof window === 'undefined') return
+  tracking = true
+  for (const event of ACTIVITY_EVENTS) {
+    window.addEventListener(event, markActivity, { passive: true })
+  }
+}
+
+export function isRecentlyActive(windowMs: number) {
+  return Date.now() - lastActivityAt < windowMs
+}
+
+export function onNextActivity(callback: () => void) {
+  const handler = () => {
+    cleanup()
+    callback()
+  }
+  const cleanup = () => {
+    for (const event of ACTIVITY_EVENTS) {
+      window.removeEventListener(event, handler)
+    }
+  }
+  for (const event of ACTIVITY_EVENTS) {
+    window.addEventListener(event, handler, { passive: true })
+  }
+  return cleanup
+}

--- a/services/dashboard-ui/server/internal/handlers/sse.go
+++ b/services/dashboard-ui/server/internal/handlers/sse.go
@@ -24,6 +24,7 @@ const (
 	sseFinishedPollInterval  = 30 * time.Second
 	sseErrorRetryDelay       = 5 * time.Second
 	sseFinishedGracePeriod   = 2 * time.Minute
+	sseMaxStreamLifetime     = 30 * time.Minute
 )
 
 var terminalStatuses = map[string]bool{
@@ -105,7 +106,11 @@ type sseStreamConfig struct {
 	ErrorRetryDelay time.Duration
 	// FinishedGracePeriod of zero means the stream never self-closes.
 	FinishedGracePeriod time.Duration
-	Log                 *zap.Logger
+	// MaxLifetime defaults to sseMaxStreamLifetime. The stream emits an
+	// expired event and closes once exceeded; the client decides whether to
+	// reconnect based on recent user activity.
+	MaxLifetime time.Duration
+	Log         *zap.Logger
 }
 
 // runSSEStream writes SSE headers and runs the poll loop: fetch, emit events
@@ -121,6 +126,9 @@ func runSSEStream(c *gin.Context, cfg sseStreamConfig) {
 	if cfg.ErrorRetryDelay == 0 {
 		cfg.ErrorRetryDelay = sseErrorRetryDelay
 	}
+	if cfg.MaxLifetime == 0 {
+		cfg.MaxLifetime = sseMaxStreamLifetime
+	}
 
 	c.Writer.Header().Set("Content-Type", "text/event-stream")
 	c.Writer.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
@@ -131,6 +139,7 @@ func runSSEStream(c *gin.Context, cfg sseStreamConfig) {
 
 	ctx := c.Request.Context()
 	hashes := map[string]string{}
+	start := time.Now()
 	var finishedAt time.Time
 
 	sendEvent := func(ev sseEvent) {
@@ -147,6 +156,11 @@ func runSSEStream(c *gin.Context, cfg sseStreamConfig) {
 		case <-ctx.Done():
 			return
 		default:
+		}
+
+		if time.Since(start) >= cfg.MaxLifetime {
+			sendEvent(sseEvent{Name: "expired", Data: []byte("true")})
+			return
 		}
 
 		res, fetchErr := cfg.Fetch(ctx)

--- a/services/dashboard-ui/server/internal/handlers/sse_test.go
+++ b/services/dashboard-ui/server/internal/handlers/sse_test.go
@@ -201,6 +201,23 @@ func TestRunSSEStreamUnnamedEvent(t *testing.T) {
 	}
 }
 
+func TestRunSSEStreamMaxLifetime(t *testing.T) {
+	// 200 steps at 1ms polls comfortably outlast a 20ms lifetime; the stream
+	// must expire on its own before the script exhausts.
+	steps := make([]sseScriptStep, 200)
+	for i := range steps {
+		steps[i] = sseScriptStep{res: sseFetchResult{Events: []sseEvent{event("build", `{"v":1}`)}}}
+	}
+
+	body := runScriptedStream(t, steps, func(cfg *sseStreamConfig) {
+		cfg.MaxLifetime = 20 * time.Millisecond
+	})
+
+	if got := strings.Count(body, "event: expired\ndata: true"); got != 1 {
+		t.Errorf("expired events = %d, want 1\nbody:\n%s", got, body)
+	}
+}
+
 func TestRunSSEStreamKeepalive(t *testing.T) {
 	body := runScriptedStream(t, []sseScriptStep{
 		{res: sseFetchResult{Events: []sseEvent{event("build", `{"v":1}`)}}},


### PR DESCRIPTION
- Hidden tabs disconnect SSE (and reconnect on return) — use-resource-sse.tsx
- BFF closes every SSE stream after 30 min with an expired event — sse.go + test
- New shared user-activity tracker — lib/user-activity.ts
- On expired: reconnect only if user active in last 5 min, else suspend until next interaction — use-resource-sse.tsx
- While suspended, fallback polling slows to 30s — use-sse-resource-query.ts, use-sse-timeline-query.ts