### PR TITLE
chore(cli): address user-configurable inputs on install sync

### DIFF
--- a/bins/cli/internal/services/installs/app_install_syncer.go
+++ b/bins/cli/internal/services/installs/app_install_syncer.go
@@ -3,6 +3,7 @@ package installs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"time"
@@ -212,12 +213,25 @@ func (s *appInstallSyncer) syncExistingInstall(
 	}
 
 	definedInputs := installCfg.FlattenedInputs()
+	var inputErrs []error
 	for _, ic := range appConfig.Input.Inputs {
-		if ic.Required {
-			if _, ok := definedInputs[ic.Name]; !ok {
-				return nil, fmt.Errorf("missing required input %s", ic.Name)
+		_, defined := definedInputs[ic.Name]
+
+		// user_configurable (source=customer) inputs are owned by the customer/install
+		// stack, not the install config, so they cannot be set via sync.
+		if ic.Source == string(models.AppAppInputSourceCustomer) {
+			if defined {
+				inputErrs = append(inputErrs, fmt.Errorf("refusing to set user_configurable input %s", ic.Name))
 			}
+			continue
 		}
+
+		if ic.Required && !defined {
+			inputErrs = append(inputErrs, fmt.Errorf("missing required input %s", ic.Name))
+		}
+	}
+	if len(inputErrs) > 0 {
+		return nil, fmt.Errorf("\n%w", errors.Join(inputErrs...))
 	}
 
 	upstreamRawConfig, err := s.api.GenerateCLIInstallConfig(ctx, appInstall.ID)


### PR DESCRIPTION
The `nuon installs sync` command was not taking `user-configurable`
inputs into account during validation. As a result, we were requiring
values for them so validation failed in the CLI. But if we send them,
validation will fail in the API.

The solution is to omit them from the required/set validation.

Additionally, we were "failing fast" but it's a better experience to
collect all failures and print them to the console at once instead of
requiring iterative editing of the file to identify each individual
error.

### Screenshots

<img width="716" height="132" alt="image" src="https://github.com/user-attachments/assets/c24a4b34-27f3-4c22-8315-684b69e2e3cc" />


<img width="757" height="230" alt="image" src="https://github.com/user-attachments/assets/a77f7e35-c675-41f5-b1a9-93edf1ae73e7" />


<img width="756" height="210" alt="image" src="https://github.com/user-attachments/assets/48da1a42-60f2-4dbb-8d36-a3e550aedd55" />
