### PR TITLE
refactor(api): optimize workflow step preloads

### DIFF
--- a/services/ctl-api/internal/app/installs/service/get_org_pending_approvals.go
+++ b/services/ctl-api/internal/app/installs/service/get_org_pending_approvals.go
@@ -48,6 +48,7 @@ func (s *service) getOrgPendingApprovals(ctx *gin.Context, orgID string) ([]app.
 	viewName := "install_workflow_step_approvals_pending_v1"
 	var approvals []app.WorkflowStepApproval
 	res := s.db.WithContext(ctx).
+		Omit("contents").
 		Scopes(scopes.WithOverrideTable(viewName), scopes.WithOffsetPagination).
 		Joins("LEFT JOIN installs ON installs.id = "+viewName+".owner_id AND "+viewName+".owner_type = 'installs'").
 		Where("("+viewName+".owner_type != 'installs' OR installs.deleted_at = 0)").

--- a/services/ctl-api/internal/app/installs/service/get_org_pending_approvals_test.go
+++ b/services/ctl-api/internal/app/installs/service/get_org_pending_approvals_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -122,6 +123,28 @@ func (s *InstallsServiceTestSuite) TestGetOrgPendingApprovals() {
 			assert.Equal(s.T(), tc.wantInResult, found, "approval %s: wantInResult=%v", approval.ID, tc.wantInResult)
 		})
 	}
+}
+
+func (s *InstallsServiceTestSuite) TestGetOrgPendingApprovalsOmitsContents() {
+	install := s.createTestInstall()
+	workflow := s.deps.Seeder.CreateWorkflow(s.ctx, s.T(), install.ID, app.WorkflowTypeReprovision)
+	step := s.deps.Seeder.CreateWorkflowStep(s.ctx, s.T(), workflow.ID)
+	approval := s.deps.Seeder.CreateWorkflowStepApproval(s.ctx, s.T(), step.ID, app.TerraformPlanApprovalType, "terraform plan output")
+
+	// Contents is json:"-", so the omit can only be asserted against the
+	// query result directly.
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	approvals, err := s.installsService.getOrgPendingApprovals(c, s.testOrg.ID)
+	require.NoError(s.T(), err)
+
+	found := false
+	for _, a := range approvals {
+		if a.ID == approval.ID {
+			found = true
+			assert.Empty(s.T(), a.Contents)
+		}
+	}
+	require.True(s.T(), found, "seeded approval not returned")
 }
 
 func (s *InstallsServiceTestSuite) TestGetOrgPendingApprovalsPagination() {

--- a/services/ctl-api/internal/app/installs/service/get_org_workflows.go
+++ b/services/ctl-api/internal/app/installs/service/get_org_workflows.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
-	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
@@ -104,12 +103,6 @@ func (s *service) getOrgWorkflows(ctx *gin.Context, orgID string, excludePlanOnl
 	query := s.db.WithContext(ctx).
 		Scopes(scopes.WithOffsetPagination).
 		Preload("CreatedBy").
-		Preload("Steps").
-		Preload("Steps.CreatedBy").
-		Preload("Steps.Approval", func(db *gorm.DB) *gorm.DB {
-			return db.Omit("contents")
-		}).
-		Preload("Steps.Approval.Response").
 		Joins("LEFT JOIN installs ON installs.id = install_workflows.owner_id AND install_workflows.owner_type = 'installs'").
 		Where("(install_workflows.owner_type != 'installs' OR installs.deleted_at = 0)").
 		Where("install_workflows.org_id = ?", orgID).

--- a/services/ctl-api/internal/app/installs/service/get_org_workflows.go
+++ b/services/ctl-api/internal/app/installs/service/get_org_workflows.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
@@ -105,7 +106,9 @@ func (s *service) getOrgWorkflows(ctx *gin.Context, orgID string, excludePlanOnl
 		Preload("CreatedBy").
 		Preload("Steps").
 		Preload("Steps.CreatedBy").
-		Preload("Steps.Approval").
+		Preload("Steps.Approval", func(db *gorm.DB) *gorm.DB {
+			return db.Omit("contents")
+		}).
 		Preload("Steps.Approval.Response").
 		Joins("LEFT JOIN installs ON installs.id = install_workflows.owner_id AND install_workflows.owner_type = 'installs'").
 		Where("(install_workflows.owner_type != 'installs' OR installs.deleted_at = 0)").

--- a/services/ctl-api/internal/app/installs/service/get_workflow.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow.go
@@ -90,16 +90,13 @@ func (s *service) getWorkflow(ctx *gin.Context, orgID, workflowID string) (*app.
 				Order("group_idx, group_retry_idx, idx, created_at asc")
 		}).
 		Preload("Steps.CreatedBy").
-		Preload("Steps.Approval").
+		Preload("Steps.Approval", func(db *gorm.DB) *gorm.DB {
+			return db.Omit("contents")
+		}).
 		Preload("Steps.Approval.Response").
 		Preload("StepGroups", func(db *gorm.DB) *gorm.DB {
 			return db.Order("group_idx asc")
 		}).
-		Preload("StepGroups.Steps", func(db *gorm.DB) *gorm.DB {
-			return db.Order("group_retry_idx, idx, created_at asc")
-		}).
-		Preload("StepGroups.Steps.Approval").
-		Preload("StepGroups.Steps.Approval.Response").
 		Where("id = ? AND org_id = ?", workflowID, orgID).
 		First(&installWorkflow)
 	if res.Error != nil {

--- a/services/ctl-api/internal/app/installs/service/get_workflow_step_approval.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow_step_approval.go
@@ -102,6 +102,8 @@ func (s *service) GetInstallWorkflowStepApproval(ctx *gin.Context) {
 
 func (s *service) getWorkflowStepApproval(ctx *gin.Context, OrgID, approvalID string) (*app.WorkflowStepApproval, error) {
 	var approval app.WorkflowStepApproval
+	// No Omit("contents") here: GetWorkflowStepApprovalContents reads
+	// approval.Contents through this getter.
 	res := s.db.WithContext(ctx).
 		Where("id = ? AND org_id = ?", approvalID, OrgID).
 		Preload("InstallWorkflowStep").

--- a/services/ctl-api/internal/app/installs/service/get_workflow_step_group.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow_step_group.go
@@ -54,7 +54,9 @@ func (s *service) getWorkflowStepGroup(ctx *gin.Context, orgID, workflowID, step
 		Preload("Steps", func(db *gorm.DB) *gorm.DB {
 			return db.Order("group_retry_idx, idx, created_at asc")
 		}).
-		Preload("Steps.Approval").
+		Preload("Steps.Approval", func(db *gorm.DB) *gorm.DB {
+			return db.Omit("contents")
+		}).
 		Preload("Steps.Approval.Response").
 		First(&group)
 	if res.Error != nil {

--- a/services/ctl-api/internal/app/installs/service/get_workflow_step_groups.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow_step_groups.go
@@ -56,7 +56,9 @@ func (s *service) getWorkflowStepGroups(ctx *gin.Context, orgID, workflowID stri
 		Preload("Steps", func(db *gorm.DB) *gorm.DB {
 			return db.Order("group_retry_idx, idx, created_at asc")
 		}).
-		Preload("Steps.Approval").
+		Preload("Steps.Approval", func(db *gorm.DB) *gorm.DB {
+			return db.Omit("contents")
+		}).
 		Preload("Steps.Approval.Response").
 		Order("group_idx asc").
 		Find(&groups)

--- a/services/ctl-api/internal/app/installs/service/get_workflow_test.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow_test.go
@@ -4,11 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/tests/testseed"
 )
 
 func (s *InstallsServiceTestSuite) TestGetWorkflowSuccess() {
@@ -30,4 +33,34 @@ func (s *InstallsServiceTestSuite) TestGetWorkflowSuccess() {
 func (s *InstallsServiceTestSuite) TestGetWorkflowNotFound() {
 	rr := s.makeRequest(http.MethodGet, "/v1/workflows/iwf_nonexistent_00000000", nil)
 	require.Equal(s.T(), http.StatusNotFound, rr.Code)
+}
+
+func (s *InstallsServiceTestSuite) TestGetWorkflowOmitsGroupStepsAndApprovalContents() {
+	install := s.createTestInstall()
+	workflow := s.deps.Seeder.CreateWorkflow(s.ctx, s.T(), install.ID, app.WorkflowTypeReprovision)
+	group := s.deps.Seeder.CreateWorkflowStepGroup(s.ctx, s.T(), workflow.ID)
+	step := s.deps.Seeder.CreateWorkflowStep(s.ctx, s.T(), workflow.ID, testseed.WithStepGroup(group.ID))
+	s.deps.Seeder.CreateWorkflowStepApproval(s.ctx, s.T(), step.ID, app.TerraformPlanApprovalType, "terraform plan output")
+
+	path := fmt.Sprintf("/v1/workflows/%s", workflow.ID)
+	rr := s.makeRequest(http.MethodGet, path, nil)
+	require.Equal(s.T(), http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var wf app.Workflow
+	require.NoError(s.T(), json.Unmarshal(rr.Body.Bytes(), &wf))
+	require.Len(s.T(), wf.Steps, 1)
+	require.NotNil(s.T(), wf.Steps[0].Approval)
+	require.Len(s.T(), wf.StepGroups, 1)
+	assert.Equal(s.T(), group.ID, wf.StepGroups[0].ID)
+	assert.Empty(s.T(), wf.StepGroups[0].Steps)
+
+	// Contents is json:"-", so the omit can only be asserted against the
+	// query result directly.
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	loaded, err := s.installsService.getWorkflow(c, s.testOrg.ID, workflow.ID)
+	require.NoError(s.T(), err)
+	require.Len(s.T(), loaded.Steps, 1)
+	require.NotNil(s.T(), loaded.Steps[0].Approval)
+	assert.Empty(s.T(), loaded.Steps[0].Approval.Contents)
+	assert.Empty(s.T(), loaded.StepGroups[0].Steps)
 }

--- a/services/ctl-api/internal/app/installs/service/get_workflows.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflows.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db"
@@ -107,7 +108,9 @@ func (s *service) getWorkflows(ctx *gin.Context, installID string, excludePlanOn
 		Preload("CreatedBy").
 		Preload("Steps").
 		Preload("Steps.CreatedBy").
-		Preload("Steps.Approval").
+		Preload("Steps.Approval", func(db *gorm.DB) *gorm.DB {
+			return db.Omit("contents")
+		}).
 		Preload("Steps.Approval.Response").
 		Where("owner_id = ?", installID).
 		Order("created_at desc")

--- a/services/ctl-api/internal/app/installs/service/get_workflows.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflows.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
-	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db"
@@ -106,12 +105,6 @@ func (s *service) getWorkflows(ctx *gin.Context, installID string, excludePlanOn
 	query := s.db.WithContext(ctx).
 		Scopes(scopes.WithOffsetPagination).
 		Preload("CreatedBy").
-		Preload("Steps").
-		Preload("Steps.CreatedBy").
-		Preload("Steps.Approval", func(db *gorm.DB) *gorm.DB {
-			return db.Omit("contents")
-		}).
-		Preload("Steps.Approval.Response").
 		Where("owner_id = ?", installID).
 		Order("created_at desc")
 

--- a/services/ctl-api/internal/app/installs/service/suite_test.go
+++ b/services/ctl-api/internal/app/installs/service/suite_test.go
@@ -145,7 +145,7 @@ func (s *InstallsServiceTestSuite) expectQueueCreation() {
 		gomock.Any(), // options
 		gomock.Any(), // workflow
 		gomock.Any(), // args
-	).Return(&mockWorkflowRun{}, nil)
+	).Return(&mockWorkflowRun{}, nil).AnyTimes()
 }
 
 func (s *InstallsServiceTestSuite) setupTestData() {
@@ -212,7 +212,7 @@ func (s *InstallsServiceTestSuite) createTestInstallViaAPI() testInstallWithWork
 	}
 
 	rr := s.makeRequest(http.MethodPost, "/v1/installs", body)
-	require.Equal(s.T(), http.StatusCreated, rr.Code)
+	require.Equal(s.T(), http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
 
 	var install app.Install
 	require.NoError(s.T(), json.Unmarshal(rr.Body.Bytes(), &install))

--- a/services/ctl-api/internal/app/installs/service/suite_test.go
+++ b/services/ctl-api/internal/app/installs/service/suite_test.go
@@ -27,6 +27,7 @@ import (
 	temporal "github.com/nuonco/nuon/pkg/temporal/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	flowclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/client"
 	"github.com/nuonco/nuon/services/ctl-api/tests"
 	"github.com/nuonco/nuon/services/ctl-api/tests/testseed"
 )
@@ -97,7 +98,9 @@ func (s *InstallsServiceTestSuite) SetupSuite() {
 			},
 			CustomValidator: true,
 		}),
-		// Service under test
+		// Service under test. flowclient is provided here rather than in
+		// testfx — see the note in tests/testfx.go about import cycles.
+		fx.Provide(flowclient.New),
 		fx.Provide(New),
 		fx.Populate(&s.deps, &s.installsService),
 	)

--- a/services/ctl-api/internal/pkg/config/syncer/syncer_test.go
+++ b/services/ctl-api/internal/pkg/config/syncer/syncer_test.go
@@ -51,13 +51,7 @@ func TestSyncerSuite(t *testing.T) {
 func (s *SyncerTestSuite) SetupSuite() {
 	s.BaseDBTestSuite.SetupSuite()
 
-	// Build FX options using shared test options plus testseed
-	options := append(
-		tests.CtlApiFXOptions(s.T()),
-		// Add testseed provider
-		// fx.Provide(testseed.New), // TODO: Uncomment when fx.In is available
-		// fx.Populate(&s.service),
-	)
+	options := tests.CtlApiFXOptions(s.T())
 
 	s.app = fxtest.New(s.T(), options...)
 	s.app.RequireStart()

--- a/services/ctl-api/tests/testfx.go
+++ b/services/ctl-api/tests/testfx.go
@@ -34,7 +34,6 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/querycollector"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/psql"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
-	flowclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/client"
 	ghpkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/github"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/loops"
@@ -155,6 +154,10 @@ func CtlApiFXOptionsWithMocks(opts TestOpts) []fx.Option {
 
 		// Queue client (uses mock temporal client). The enqueuer gets a no-op
 		// lifecycle so its background workers and sweep workflow never start.
+		// NOTE: flowclient is intentionally NOT provided here — it imports
+		// executeflow, whose import tree reaches back into packages (e.g.
+		// config/syncer) whose tests import this package, creating an import
+		// cycle. Suites that need it (installs service) provide it locally.
 		fx.Provide(func(p testEnqueuerParams) *enqueuer.Enqueuer {
 			return enqueuer.New(enqueuer.Params{
 				DB:      p.DB,
@@ -166,9 +169,6 @@ func CtlApiFXOptionsWithMocks(opts TestOpts) []fx.Option {
 			})
 		}),
 		fx.Provide(queueclient.New),
-
-		// Flow client (uses mock temporal client)
-		fx.Provide(flowclient.New),
 
 		// Queue emitter client (uses mock temporal client)
 		fx.Provide(emitterclient.New),

--- a/services/ctl-api/tests/testfx.go
+++ b/services/ctl-api/tests/testfx.go
@@ -7,8 +7,10 @@ import (
 	"github.com/golang/mock/gomock"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxevent"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 
+	pkgmetrics "github.com/nuonco/nuon/pkg/metrics"
 	temporalclient "github.com/nuonco/nuon/pkg/temporal/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	accountshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/accounts/helpers"
@@ -17,6 +19,7 @@ import (
 	componentshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
 	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	orgshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/helpers"
+	runbookshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/runbooks/helpers"
 	runnershelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
 	vcshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/vcs/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
@@ -28,13 +31,17 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/ch"
 	dblog "github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/log"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/querycollector"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/psql"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
+	flowclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/client"
 	ghpkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/github"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/loops"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/metrics"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+	emitterclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/emitter/client"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/enqueuer"
 	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/temporal/dataconverter"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/temporal/dataconverter/blob"
@@ -46,6 +53,20 @@ import (
 )
 
 func NopFxLogger() fxevent.Logger { return fxevent.NopLogger }
+
+type noopLifecycle struct{}
+
+func (noopLifecycle) Append(fx.Hook) {}
+
+type testEnqueuerParams struct {
+	fx.In
+
+	DB      *gorm.DB `name:"psql"`
+	Cfg     *internal.Config
+	TClient temporalclient.Client
+	L       *zap.Logger
+	MW      pkgmetrics.Writer
+}
 
 // TestMocks holds optional mock/fake clients that tests can supply to CtlApiFXOptionsWithMocks.
 // Tests create their own mock instances and pass them in; FX registers them as the interface types.
@@ -118,6 +139,12 @@ func CtlApiFXOptionsWithMocks(opts TestOpts) []fx.Option {
 		fx.Provide(dataconverter.New),
 
 		// Databases
+		fx.Provide(func(cfg *internal.Config) *querycollector.Collector {
+			if cfg.DebugEnableQueryCollector {
+				return querycollector.NewCollector(5000)
+			}
+			return nil
+		}),
 		fx.Provide(psql.AsPSQL(psql.New)),
 		fx.Provide(ch.AsCH(ch.New)),
 
@@ -126,8 +153,25 @@ func CtlApiFXOptionsWithMocks(opts TestOpts) []fx.Option {
 		fx.Provide(analytics.New),
 		fx.Provide(account.New),
 
-		// Queue client (uses mock temporal client)
+		// Queue client (uses mock temporal client). The enqueuer gets a no-op
+		// lifecycle so its background workers and sweep workflow never start.
+		fx.Provide(func(p testEnqueuerParams) *enqueuer.Enqueuer {
+			return enqueuer.New(enqueuer.Params{
+				DB:      p.DB,
+				Cfg:     p.Cfg,
+				TClient: p.TClient,
+				L:       p.L,
+				MW:      p.MW,
+				LC:      noopLifecycle{},
+			})
+		}),
 		fx.Provide(queueclient.New),
+
+		// Flow client (uses mock temporal client)
+		fx.Provide(flowclient.New),
+
+		// Queue emitter client (uses mock temporal client)
+		fx.Provide(emitterclient.New),
 
 		// Helpers (order matters due to dependencies)
 		fx.Provide(accountshelpers.New),
@@ -136,6 +180,7 @@ func CtlApiFXOptionsWithMocks(opts TestOpts) []fx.Option {
 		fx.Provide(componentshelpers.New),
 		fx.Provide(appshelpers.New),
 		fx.Provide(runnershelpers.New),
+		fx.Provide(runbookshelpers.New),
 		fx.Provide(installshelpers.New),
 		fx.Provide(orgshelpers.New),
 

--- a/services/ctl-api/tests/testseed/app_config.go
+++ b/services/ctl-api/tests/testseed/app_config.go
@@ -20,6 +20,7 @@ func BuildAppConfig(appID string) *app.AppConfig {
 		AppID:       appID,
 		CreatedByID: acct.ID,
 		Status:      app.AppConfigStatusActive,
+		StatusV2:    app.NewCompositeStatus(context.Background(), app.Status(app.AppConfigStatusActive)),
 		CLIVersion:  "development",
 	}
 }
@@ -31,6 +32,7 @@ func (s *Seeder) CreateBareAppConfig(ctx context.Context, t *testing.T, appID st
 	cfg := &app.AppConfig{
 		AppID:      appID,
 		Status:     app.AppConfigStatusActive,
+		StatusV2:   app.NewCompositeStatus(ctx, app.Status(app.AppConfigStatusActive)),
 		CLIVersion: "development",
 	}
 	res := s.db.WithContext(ctx).Create(cfg)
@@ -340,10 +342,13 @@ func (s *Seeder) CreateAppConfig(ctx context.Context, t *testing.T, appID string
 		helmComp.ID, tfComp.ID, dockerComp.ID,
 		k8sComp.ID, extImageComp.ID, jobComp.ID,
 	}
+	activeStatusV2 := app.NewCompositeStatus(ctx, app.Status(app.AppConfigStatusActive))
 	cfg.Status = app.AppConfigStatusActive
+	cfg.StatusV2 = activeStatusV2
 	cfg.ComponentIDs = componentIDs
 	require.NoError(t, s.db.WithContext(ctx).Model(cfg).Updates(map[string]any{
 		"status":        app.AppConfigStatusActive,
+		"status_v2":     activeStatusV2,
 		"component_ids": componentIDs,
 	}).Error)
 

--- a/services/ctl-api/tests/testseed/workflow.go
+++ b/services/ctl-api/tests/testseed/workflow.go
@@ -12,10 +12,11 @@ import (
 // CreateWorkflow persists a Workflow owned by the given install.
 func (s *Seeder) CreateWorkflow(ctx context.Context, t *testing.T, installID string, workflowType app.WorkflowType) *app.Workflow {
 	wf := &app.Workflow{
-		OwnerID:   installID,
-		OwnerType: "installs",
-		Type:      workflowType,
-		Status:    app.NewCompositeStatus(ctx, app.StatusPending),
+		OwnerID:        installID,
+		OwnerType:      "installs",
+		Type:           workflowType,
+		Status:         app.NewCompositeStatus(ctx, app.StatusPending),
+		ApprovalOption: app.InstallApprovalOptionPrompt,
 	}
 	res := s.db.WithContext(ctx).Create(wf)
 	require.NoError(t, res.Error)
@@ -41,6 +42,10 @@ func WithStepSignal(signal *app.Signal) WorkflowStepOption {
 	return func(s *app.WorkflowStep) { s.Signal = signal }
 }
 
+func WithStepGroup(groupID string) WorkflowStepOption {
+	return func(s *app.WorkflowStep) { s.WorkflowStepGroupID = groupID }
+}
+
 // CreateWorkflowStep persists a WorkflowStep for the given workflow.
 func (s *Seeder) CreateWorkflowStep(ctx context.Context, t *testing.T, workflowID string, opts ...WorkflowStepOption) *app.WorkflowStep {
 	step := &app.WorkflowStep{
@@ -53,9 +58,27 @@ func (s *Seeder) CreateWorkflowStep(ctx context.Context, t *testing.T, workflowI
 	for _, opt := range opts {
 		opt(step)
 	}
-	res := s.db.WithContext(ctx).Create(step)
+	tx := s.db.WithContext(ctx)
+	if step.WorkflowStepGroupID == "" {
+		// The column has an FK to workflow_step_groups; an empty string
+		// violates it, so ungrouped steps must insert NULL.
+		tx = tx.Omit("workflow_step_group_id")
+	}
+	res := tx.Create(step)
 	require.NoError(t, res.Error)
 	return step
+}
+
+// CreateWorkflowStepGroup persists a WorkflowStepGroup for the given workflow.
+func (s *Seeder) CreateWorkflowStepGroup(ctx context.Context, t *testing.T, workflowID string) *app.WorkflowStepGroup {
+	group := &app.WorkflowStepGroup{
+		WorkflowID: workflowID,
+		Name:       "test-group",
+		Status:     app.NewCompositeStatus(ctx, app.StatusPending),
+	}
+	res := s.db.WithContext(ctx).Create(group)
+	require.NoError(t, res.Error)
+	return group
 }
 
 // CreateWorkflowStepApproval persists a WorkflowStepApproval for the given step.

--- a/services/dashboard-ui/client/components/workflows/ActiveWorkflowCard.tsx
+++ b/services/dashboard-ui/client/components/workflows/ActiveWorkflowCard.tsx
@@ -7,10 +7,11 @@ import { LabeledValue } from '@/components/common/LabeledValue'
 import { Link } from '@/components/common/Link'
 import { Text } from '@/components/common/Text'
 import { useOrg } from '@/hooks/use-org'
+import { useWorkflowApprovals } from '@/hooks/use-workflow-approvals'
 import type { TInstall, TWorkflow } from '@/types'
 import { cn } from '@/utils/classnames'
 import { toSentenceCase, snakeToWords } from '@/utils/string-utils'
-import { getPendingApprovalCount } from '@/utils/workflow-utils'
+import { getWorkflowPendingApprovals } from '@/utils/workflow-utils'
 import { CancelWorkflowButton } from './CancelWorkflow'
 
 export const ActiveWorkflowCard = ({
@@ -29,16 +30,15 @@ export const ActiveWorkflowCard = ({
   compact?: boolean
 }) => {
   const { org } = useOrg()
+  const { approvals } = useWorkflowApprovals()
   const installId = workflow.owner_id
   const installName = workflow.metadata?.owner_name
-  const pendingApprovals = getPendingApprovalCount(workflow)
-  const pendingApprovalStep = workflow?.steps?.find(
-    (s) =>
-      s?.execution_type === 'approval' &&
-      s?.status?.status === 'approval-awaiting' &&
-      !!s?.approval &&
-      !s?.approval?.response
+  const pendingWorkflowApprovals = getWorkflowPendingApprovals(
+    approvals,
+    workflow?.id
   )
+  const pendingApprovals = pendingWorkflowApprovals.length
+  const pendingApprovalStep = pendingWorkflowApprovals.at(0)?.workflow_step
   const showDriftDetected =
     workflow.plan_only &&
     !!install?.drifted_objects?.find(
@@ -64,7 +64,7 @@ export const ActiveWorkflowCard = ({
         </Text>
       </Link>
       {pendingApprovals > 0 &&
-        (pendingApprovalStep ? (
+        (pendingApprovalStep?.id ? (
           <Link
             href={`/${org.id}/installs/${installId}/workflows/${workflow.id}?panel=${pendingApprovalStep.id}`}
             className="shrink-0 hover:opacity-80 transition-opacity !text-inherit"

--- a/services/dashboard-ui/client/components/workflows/ActiveWorkflows/ActiveWorkflows.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/ActiveWorkflows/ActiveWorkflows.stories.tsx
@@ -2,13 +2,9 @@ export default {
   title: 'Workflows/ActiveWorkflows',
 }
 
+import type { ReactNode } from 'react'
+import { WorkflowApprovalsContext } from '@/providers/workflow-approvals-provider'
 import { ActiveWorkflows } from './ActiveWorkflows'
-
-const pendingStep = {
-  execution_type: 'approval',
-  status: { status: 'approval-awaiting' },
-  approval: { response: null },
-}
 
 function mockWorkflow(
   id: string,
@@ -16,7 +12,6 @@ function mockWorkflow(
   name: string,
   installName: string,
   minutesAgo = 0,
-  opts?: { pendingApproval?: boolean },
 ) {
   return {
     id,
@@ -27,9 +22,28 @@ function mockWorkflow(
     metadata: { owner_name: installName },
     created_at: new Date(Date.now() - minutesAgo * 60000).toISOString(),
     updated_at: new Date().toISOString(),
-    steps: opts?.pendingApproval ? [pendingStep] : [],
   }
 }
+
+const approvalsFor = (...workflowIds: string[]) =>
+  workflowIds.map((id) => ({
+    id: `approval-${id}`,
+    workflow_step: { id: `step-${id}`, install_workflow_id: id },
+  })) as any
+
+const ApprovalsProvider = ({
+  approvals = [],
+  children,
+}: {
+  approvals?: any[]
+  children: ReactNode
+}) => (
+  <WorkflowApprovalsContext.Provider
+    value={{ approvals, isLoading: false, refresh: () => {} }}
+  >
+    {children}
+  </WorkflowApprovalsContext.Provider>
+)
 
 const one = [
   mockWorkflow('wf-1', 'deploy_components', 'Deploy components', 'My Install'),
@@ -42,65 +56,77 @@ const two = [
 
 const four = [
   mockWorkflow('wf-1', 'deploy_components', 'Deploy components', 'My Install'),
-  mockWorkflow('wf-2', 'provision_sandbox', 'Provision sandbox', 'Staging', 5, { pendingApproval: true }),
+  mockWorkflow('wf-2', 'provision_sandbox', 'Provision sandbox', 'Staging', 5),
   mockWorkflow('wf-3', 'action_workflow_run', 'Run migrations', 'Production', 10),
-  mockWorkflow('wf-4', 'reprovision_sandbox', 'Reprovision sandbox', 'Dev', 2, { pendingApproval: true }),
+  mockWorkflow('wf-4', 'reprovision_sandbox', 'Reprovision sandbox', 'Dev', 2),
 ] as any
 
 const six = [
   mockWorkflow('wf-1', 'deploy_components', 'Deploy components', 'My Install'),
-  mockWorkflow('wf-2', 'provision_sandbox', 'Provision sandbox', 'Staging', 5, { pendingApproval: true }),
+  mockWorkflow('wf-2', 'provision_sandbox', 'Provision sandbox', 'Staging', 5),
   mockWorkflow('wf-3', 'action_workflow_run', 'Run migrations', 'Production', 10),
   mockWorkflow('wf-4', 'reprovision_sandbox', 'Reprovision sandbox', 'Dev', 2),
-  mockWorkflow('wf-5', 'deploy_components', 'Deploy components', 'Customer A', 8, { pendingApproval: true }),
+  mockWorkflow('wf-5', 'deploy_components', 'Deploy components', 'Customer A', 8),
   mockWorkflow('wf-6', 'drift_run', 'Drift run', 'Customer B', 15),
 ] as any
 
 const many = [
   mockWorkflow('wf-1', 'deploy_components', 'Deploy components', 'My Install'),
-  mockWorkflow('wf-2', 'provision_sandbox', 'Provision sandbox', 'Staging', 5, { pendingApproval: true }),
+  mockWorkflow('wf-2', 'provision_sandbox', 'Provision sandbox', 'Staging', 5),
   mockWorkflow('wf-3', 'action_workflow_run', 'Run migrations', 'Production', 10),
-  mockWorkflow('wf-4', 'reprovision_sandbox', 'Reprovision sandbox', 'Dev', 2, { pendingApproval: true }),
+  mockWorkflow('wf-4', 'reprovision_sandbox', 'Reprovision sandbox', 'Dev', 2),
   mockWorkflow('wf-5', 'deploy_components', 'Deploy components', 'Customer A', 8),
-  mockWorkflow('wf-6', 'drift_run', 'Drift run', 'Customer B', 15, { pendingApproval: true }),
+  mockWorkflow('wf-6', 'drift_run', 'Drift run', 'Customer B', 15),
   mockWorkflow('wf-7', 'deploy_components', 'Deploy all', 'Customer C', 1),
-  mockWorkflow('wf-8', 'provision_sandbox', 'Provision sandbox', 'Customer D', 3, { pendingApproval: true }),
+  mockWorkflow('wf-8', 'provision_sandbox', 'Provision sandbox', 'Customer D', 3),
   mockWorkflow('wf-9', 'action_workflow_run', 'Sync secrets', 'Customer E', 12),
   mockWorkflow('wf-10', 'deploy_components', 'Deploy components', 'Customer F', 20),
 ] as any
 
 export const Single = () => (
-  <div className="p-4">
-    <ActiveWorkflows workflows={one} />
-  </div>
+  <ApprovalsProvider>
+    <div className="p-4">
+      <ActiveWorkflows workflows={one} />
+    </div>
+  </ApprovalsProvider>
 )
 
 export const Two = () => (
-  <div className="p-4">
-    <ActiveWorkflows workflows={two} />
-  </div>
+  <ApprovalsProvider>
+    <div className="p-4">
+      <ActiveWorkflows workflows={two} />
+    </div>
+  </ApprovalsProvider>
 )
 
 export const Four = () => (
-  <div className="p-4">
-    <ActiveWorkflows workflows={four} />
-  </div>
+  <ApprovalsProvider approvals={approvalsFor('wf-2', 'wf-4')}>
+    <div className="p-4">
+      <ActiveWorkflows workflows={four} />
+    </div>
+  </ApprovalsProvider>
 )
 
 export const Six = () => (
-  <div className="p-4">
-    <ActiveWorkflows workflows={six} />
-  </div>
+  <ApprovalsProvider approvals={approvalsFor('wf-2', 'wf-5')}>
+    <div className="p-4">
+      <ActiveWorkflows workflows={six} />
+    </div>
+  </ApprovalsProvider>
 )
 
 export const Ten = () => (
-  <div className="p-4">
-    <ActiveWorkflows workflows={many} />
-  </div>
+  <ApprovalsProvider approvals={approvalsFor('wf-2', 'wf-4', 'wf-6', 'wf-8')}>
+    <div className="p-4">
+      <ActiveWorkflows workflows={many} />
+    </div>
+  </ApprovalsProvider>
 )
 
 export const Empty = () => (
-  <div className="p-4">
-    <ActiveWorkflows workflows={[]} />
-  </div>
+  <ApprovalsProvider>
+    <div className="p-4">
+      <ActiveWorkflows workflows={[]} />
+    </div>
+  </ApprovalsProvider>
 )

--- a/services/dashboard-ui/client/components/workflows/WorkflowTimeline/WorkflowTimeline.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/WorkflowTimeline/WorkflowTimeline.stories.tsx
@@ -2,8 +2,18 @@ export default {
   title: 'Workflows/WorkflowTimeline',
 }
 
+import type { ReactNode } from 'react'
+import { WorkflowApprovalsContext } from '@/providers/workflow-approvals-provider'
 import { WorkflowTimeline, WorkflowTimelineSkeleton } from './WorkflowTimeline'
 import type { TWorkflow } from '@/types'
+
+const ApprovalsProvider = ({ children }: { children: ReactNode }) => (
+  <WorkflowApprovalsContext.Provider
+    value={{ approvals: [], isLoading: false, refresh: () => {} }}
+  >
+    {children}
+  </WorkflowApprovalsContext.Provider>
+)
 
 const mockWorkflow: TWorkflow = {
   id: 'wf-123',
@@ -30,21 +40,25 @@ const completedWorkflow: TWorkflow = {
 } as TWorkflow
 
 export const Default = () => (
-  <WorkflowTimeline
-    workflows={[mockWorkflow, completedWorkflow]}
-    pagination={{ hasNext: false, offset: 0, limit: 10 }}
-    orgId="org-123"
-    installId="inst-456"
-  />
+  <ApprovalsProvider>
+    <WorkflowTimeline
+      workflows={[mockWorkflow, completedWorkflow]}
+      pagination={{ hasNext: false, offset: 0, limit: 10 }}
+      orgId="org-123"
+      installId="inst-456"
+    />
+  </ApprovalsProvider>
 )
 
 export const Empty = () => (
-  <WorkflowTimeline
-    workflows={[]}
-    pagination={{ hasNext: false, offset: 0, limit: 10 }}
-    orgId="org-123"
-    installId="inst-456"
-  />
+  <ApprovalsProvider>
+    <WorkflowTimeline
+      workflows={[]}
+      pagination={{ hasNext: false, offset: 0, limit: 10 }}
+      orgId="org-123"
+      installId="inst-456"
+    />
+  </ApprovalsProvider>
 )
 
 export const Loading = () => <WorkflowTimelineSkeleton />

--- a/services/dashboard-ui/client/components/workflows/WorkflowTimeline/WorkflowTimeline.tsx
+++ b/services/dashboard-ui/client/components/workflows/WorkflowTimeline/WorkflowTimeline.tsx
@@ -12,8 +12,9 @@ import { TimelineSkeleton } from '@/components/common/TimelineSkeleton'
 import type { TInstall, TWorkflow } from '@/types'
 import {
   getWorkflowBadge,
-  getPendingApprovalCount,
+  getWorkflowPendingApprovals,
 } from '@/utils/workflow-utils'
+import { useWorkflowApprovals } from '@/hooks/use-workflow-approvals'
 import { CancelWorkflowButton } from '../CancelWorkflow'
 
 export interface IWorkflowTimeline {
@@ -33,6 +34,8 @@ export const WorkflowTimeline = ({
   install,
   isLoading,
 }: IWorkflowTimeline) => {
+  const { approvals } = useWorkflowApprovals()
+
   if (isLoading) return <WorkflowTimelineSkeleton />
 
   return workflows?.length ? (
@@ -55,7 +58,7 @@ export const WorkflowTimeline = ({
             ) : null}
             {workflow?.approval_option === 'prompt' &&
             workflow?.status?.status !== 'approval-awaiting' &&
-            getPendingApprovalCount(workflow) ? (
+            getWorkflowPendingApprovals(approvals, workflow?.id).length ? (
               <Badge size="sm" theme="warn">
                 Pending approval
               </Badge>

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -6065,12 +6065,6 @@ export interface components {
       take_ownership?: boolean;
       values?: components["schemas"]["plantypes.HelmValue"][];
       values_files?: string[];
-      /**
-       * @description ValuesOverride is the install-level Helm values override (raw YAML). It is
-       * merged as the highest-precedence layer at deploy time, winning over both
-       * ValuesFiles and Values. Empty means no override (exact no-op).
-       */
-      values_override?: string;
     };
     "plantypes.HelmSandboxMode": {
       plan_contents?: string;

--- a/services/dashboard-ui/client/utils/workflow-utils.ts
+++ b/services/dashboard-ui/client/utils/workflow-utils.ts
@@ -1,6 +1,6 @@
 import type { TBadgeTheme } from '@/components/common/Badge'
 import type { TBannerTheme } from '@/components/common/Banner'
-import type { TWorkflow, TWorkflowStep } from '@/types'
+import type { TWorkflow, TWorkflowStep, TWorkflowStepApproval } from '@/types'
 
 export type TBadgeCfg = {
   children?: string
@@ -320,14 +320,14 @@ export function getPolicyViolationCounts(
   }
 }
 
-export function getPendingApprovalCount(workflow: TWorkflow): number {
+export function getWorkflowPendingApprovals(
+  approvals: TWorkflowStepApproval[] | undefined,
+  workflowId: string | undefined
+): TWorkflowStepApproval[] {
+  if (!workflowId) return []
   return (
-    workflow?.steps?.filter(
-      (s) =>
-        s?.execution_type === 'approval' &&
-        s?.status?.status === 'approval-awaiting' &&
-        s?.approval &&
-        !s?.approval?.response
-    )?.length || 0
+    approvals?.filter(
+      (a) => a?.workflow_step?.install_workflow_id === workflowId
+    ) ?? []
   )
 }


### PR DESCRIPTION
- get_workflow.go — dropped the StepGroups.Steps.* preloads (steps no longer loaded/serialized twice; step_groups is metadata only) and added Omit("contents") to Steps.Approval
- get_workflows.go, get_org_workflows.go — Omit("contents") on Steps.Approval
- get_workflow_step_groups.go, get_workflow_step_group.go — Omit("contents") on Steps.Approval
- get_org_pending_approvals.go — Omit("contents") on the pending-approvals view query
- get_workflow_step_approval.go — left loading contents (the contents-download endpoint reads through it); comment added
- New tests: TestGetWorkflowOmitsGroupStepsAndApprovalContents, TestGetOrgPendingApprovalsOmitsContents

Contract impact: step_groups[].steps disappears from GET /v1/workflows/{id} (no consumers found); everything else is byte-identical since contents was never serialized.
