### PR TITLE
fix(ctl-api): bump Azure VNet API version to 2023-11-01 to stop subnet pruning on reprovision

### DIFF
--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_vnet.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_vnet.go
@@ -9,6 +9,19 @@ import (
 // defaultAzureVNetTemplateURL is the default VNet ARM template URL.
 const defaultAzureVNetTemplateURL = "https://raw.githubusercontent.com/nuonco/sandboxes/main/azure-aks/vnet-template.json"
 
+// azureVNetAPIVersion is correctness-critical and must stay >= 2023-09-01.
+//
+// We declare subnets as standalone Microsoft.Network/virtualNetworks/subnets
+// child resources and omit properties.subnets on the VNet itself. Prior to API
+// version 2023-09-01, a VNet PUT that omits subnets PRUNES every subnet not
+// listed inline. On reprovision that prune tries to delete in-use subnets
+// (live NICs from the runner VMSS / AKS) and fails with
+// InUseSubnetCannotBeDeleted. From 2023-09-01 onward, omitting subnets on a
+// VNet PUT preserves the existing subnets, so the reprovision is non-destructive
+// while still never touching foreign/out-of-band subnets (e.g. AGIC ingress).
+// See https://techcommunity.microsoft.com/blog/azurenetworkingblog/azure-virtual-network-now-supports-updates-without-subnet-property/4067952
+const azureVNetAPIVersion = "2023-11-01"
+
 // vnetHoistAllowlist lists VNet template parameters that are intentionally
 // customer-configurable. Only these are surfaced in the parent template.
 var vnetHoistAllowlist = map[string]bool{
@@ -206,7 +219,7 @@ func (t *Templates) getDefaultVNetTemplate() map[string]any {
 		// that ARM does not delete externally-created subnets on re-deploy.
 		map[string]any{
 			"type":       "Microsoft.Network/virtualNetworks",
-			"apiVersion": "2023-04-01",
+			"apiVersion": azureVNetAPIVersion,
 			"name":       "[format('{0}-vnet', parameters('nuonInstallID'))]",
 			"location":   "[parameters('location')]",
 			"tags":       "[parameters('commonTags')]",

--- a/services/ctl-api/internal/pkg/stacks/arm/template_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/template_test.go
@@ -55,6 +55,56 @@ func TestGetAzureTemplate_WithSecrets(t *testing.T) {
 	assertNoNestedBrackets(t, tmplBytes)
 }
 
+// TestDefaultVNet_NonPruningSubnetSemantics guards the fix for
+// InUseSubnetCannotBeDeleted on reprovision: subnets are declared as standalone
+// child resources and omitted from the VNet's own properties, which only
+// preserves existing subnets on a VNet PUT when the API version is >= 2023-09-01.
+func TestDefaultVNet_NonPruningSubnetSemantics(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+
+	deployment := tmpl.getDefaultVNetDeployment(minimalTemplateInput())
+
+	props, ok := deployment["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("vnetDeployment missing properties")
+	}
+	innerTmpl, ok := props["template"].(map[string]any)
+	if !ok {
+		t.Fatalf("vnetDeployment missing inner template")
+	}
+	resources, ok := innerTmpl["resources"].([]any)
+	if !ok {
+		t.Fatalf("inner template missing resources")
+	}
+
+	var foundVNet bool
+	for _, r := range resources {
+		res, ok := r.(map[string]any)
+		if !ok || res["type"] != "Microsoft.Network/virtualNetworks" {
+			continue
+		}
+		foundVNet = true
+
+		if got := res["apiVersion"]; got != azureVNetAPIVersion {
+			t.Errorf("VNet apiVersion = %v, want %s", got, azureVNetAPIVersion)
+		}
+		if azureVNetAPIVersion < "2023-09-01" {
+			t.Errorf("azureVNetAPIVersion %s is < 2023-09-01; omitting subnets on a VNet PUT would prune in-use subnets", azureVNetAPIVersion)
+		}
+
+		vnetProps, ok := res["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("VNet missing properties")
+		}
+		if _, hasSubnets := vnetProps["subnets"]; hasSubnets {
+			t.Error("VNet properties must NOT declare inline subnets; they are standalone child resources to avoid pruning foreign/out-of-band subnets")
+		}
+	}
+	if !foundVNet {
+		t.Fatal("no Microsoft.Network/virtualNetworks resource found in default VNet deployment")
+	}
+}
+
 func assertNoNestedBrackets(t *testing.T, tmplBytes []byte) {
 	t.Helper()
 


### PR DESCRIPTION
## Problem

Azure installs fail to **reprovision** with:

```
InUseSubnetCannotBeDeleted: Subnet <id>-private-runner-subnet is in use by
.../virtualMachineScaleSets/<id>-vmss/... and cannot be deleted.
```

The default Azure VNet ARM deployment declares subnets as standalone `Microsoft.Network/virtualNetworks/subnets` child resources and **omits** `properties.subnets` on the VNet itself — deliberately, so out-of-band subnets (e.g. an AGIC ingress subnet) are never pruned.

The bug is the **VNet API version**. With the VNet pinned to `2023-04-01`, a VNet PUT that omits `subnets` **prunes every subnet not listed inline**. On first deploy there are no NICs so it's harmless; on reprovision the runner VMSS / AKS already occupy those subnets, so the prune tries to delete an in-use subnet and the whole deployment stack fails.

## Fix

Azure changed VNet PUT semantics in **`2023-09-01`+**: omitting `subnets` now **preserves** existing subnets ([MS Azure Networking blog](https://techcommunity.microsoft.com/blog/azurenetworkingblog/azure-virtual-network-now-supports-updates-without-subnet-property/4067952)). This bumps the VNet resource to `2023-11-01`.

- The customer command stays **unchanged** (`--action-on-unmanage deleteAll`).
- The VNet + subnets stay **stack-managed**.
- Foreign / out-of-band subnets are still **never** touched (they aren't in the template).

