### PR TITLE
fix(ctl-api): default operation role by parent workflow type

### DIFF
--- a/services/ctl-api/internal/app/installs/service/get_available_roles.go
+++ b/services/ctl-api/internal/app/installs/service/get_available_roles.go
@@ -176,7 +176,7 @@ func (s *service) getDefaultRoleName(
 		if operationType == app.OperationTeardown {
 			installDeploy.Type = app.InstallDeployTypeTeardown
 		}
-		roleSelection, _, err := operationroles.GetRoleForDeploy(s.l, appCfg, installDeploy, latestConfig, installStack, installState)
+		roleSelection, _, err := operationroles.GetRoleForDeploy(s.l, appCfg, installDeploy, latestConfig, installStack, installState, "")
 		if err != nil {
 			return "", err
 		}
@@ -219,7 +219,7 @@ func (s *service) getDefaultRoleName(
 		run := &app.InstallActionWorkflowRun{
 			ActionWorkflowConfig: *actionWorkflowCfg,
 		}
-		roleSelection, _, err := operationroles.GetRoleForAction(s.l, appCfg, run, installStack, installState)
+		roleSelection, _, err := operationroles.GetRoleForAction(s.l, appCfg, run, installStack, installState, "")
 		if err != nil {
 			return "", err
 		}

--- a/services/ctl-api/internal/app/installs/service/get_available_roles.go
+++ b/services/ctl-api/internal/app/installs/service/get_available_roles.go
@@ -176,7 +176,7 @@ func (s *service) getDefaultRoleName(
 		if operationType == app.OperationTeardown {
 			installDeploy.Type = app.InstallDeployTypeTeardown
 		}
-		roleSelection, _, err := operationroles.GetRoleForDeploy(s.l, appCfg, installDeploy, latestConfig, installStack, installState, "")
+		roleSelection, _, err := operationroles.GetRoleForDeploy(s.l, appCfg, installDeploy, latestConfig, installStack, installState, nil)
 		if err != nil {
 			return "", err
 		}
@@ -219,7 +219,7 @@ func (s *service) getDefaultRoleName(
 		run := &app.InstallActionWorkflowRun{
 			ActionWorkflowConfig: *actionWorkflowCfg,
 		}
-		roleSelection, _, err := operationroles.GetRoleForAction(s.l, appCfg, run, installStack, installState, "")
+		roleSelection, _, err := operationroles.GetRoleForAction(s.l, appCfg, run, installStack, installState, nil)
 		if err != nil {
 			return "", err
 		}

--- a/services/ctl-api/internal/app/installs/worker/activities/workflow_default_role.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/workflow_default_role.go
@@ -1,0 +1,10 @@
+package activities
+
+import "context"
+
+type WorkflowDefaultRoleEnabledRequest struct{}
+
+// @temporal-gen-v2 activity
+func (a *Activities) WorkflowDefaultRoleEnabled(ctx context.Context, req WorkflowDefaultRoleEnabledRequest) (bool, error) {
+	return a.cfg.WorkflowDefaultRoleEnabled, nil
+}

--- a/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+	operationroles "github.com/nuonco/nuon/services/ctl-api/internal/pkg/operation-roles"
 )
 
 func (p *Planner) getInstallRegistryRepositoryConfig(
@@ -30,6 +31,7 @@ func (p *Planner) getInstallRegistryRepositoryConfig(
 	appCfg *app.AppConfig,
 	stack *app.InstallStack,
 	installState *state.State,
+	roleSelection *operationroles.RoleSelection,
 ) (*configs.OCIRegistryRepository, error) {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
@@ -42,7 +44,7 @@ func (p *Planner) getInstallRegistryRepositoryConfig(
 	}
 
 	sessionName := fmt.Sprintf("oci-sync-%s-%s", installDeploy.InstallID, installDeploy.ID)
-	cloudAuth, err := p.getAuthForDeploy(ctx, installDeploy, compBuild, appCfg, stack, installState, sessionName)
+	cloudAuth, err := p.getAuthForDeploy(ctx, roleSelection, stack, sessionName)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get auth for install registry")
 	}

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
@@ -80,7 +80,7 @@ func (p *Planner) createActionWorkflowRunPlan(ctx workflow.Context, runID string
 		attrs["action.id"] = run.ID
 	}
 
-	cloudAuth, roleSelection, err := p.getAuthForActionWorkflowRun(ctx, stack.InstallStackOutputs, run, appCfg, &install.Org, stack, state)
+	cloudAuth, roleSelection, err := p.getAuthForActionWorkflowRun(ctx, stack.InstallStackOutputs, run, appCfg, stack, state)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to get auth for action workflow run")
 	}
@@ -155,12 +155,11 @@ func (p *Planner) getRoleForAction(
 	ctx workflow.Context,
 	l *zap.Logger,
 	appCfg *app.AppConfig,
-	org *app.Org,
 	run *app.InstallActionWorkflowRun,
 	stack *app.InstallStack,
 	installState *state.State,
 ) (*operationroles.RoleSelection, app.OperationType, error) {
-	defaultRole := p.defaultRoleForInstallWorkflow(ctx, l, appCfg, org, generics.FromPtrStr(run.InstallWorkflowID))
+	defaultRole := p.defaultRoleForInstallWorkflow(ctx, l, appCfg, generics.FromPtrStr(run.InstallWorkflowID))
 	return operationroles.GetRoleForAction(l, appCfg, run, stack, installState, defaultRole)
 }
 
@@ -169,7 +168,6 @@ func (p *Planner) getAuthForActionWorkflowRun(
 	outputs app.InstallStackOutputs,
 	run *app.InstallActionWorkflowRun,
 	appCfg *app.AppConfig,
-	org *app.Org,
 	stack *app.InstallStack,
 	installState *state.State,
 ) (*CloudAuth, *operationroles.RoleSelection, error) {
@@ -178,7 +176,7 @@ func (p *Planner) getAuthForActionWorkflowRun(
 		return nil, nil, err
 	}
 
-	roleSelection, operation, err := p.getRoleForAction(ctx, l, appCfg, org, run, stack, installState)
+	roleSelection, operation, err := p.getRoleForAction(ctx, l, appCfg, run, stack, installState)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
@@ -80,7 +80,7 @@ func (p *Planner) createActionWorkflowRunPlan(ctx workflow.Context, runID string
 		attrs["action.id"] = run.ID
 	}
 
-	cloudAuth, roleSelection, err := p.getAuthForActionWorkflowRun(ctx, stack.InstallStackOutputs, run, appCfg, stack, state)
+	cloudAuth, roleSelection, err := p.getAuthForActionWorkflowRun(ctx, stack.InstallStackOutputs, run, appCfg, &install.Org, stack, state)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to get auth for action workflow run")
 	}
@@ -155,11 +155,12 @@ func (p *Planner) getRoleForAction(
 	ctx workflow.Context,
 	l *zap.Logger,
 	appCfg *app.AppConfig,
+	org *app.Org,
 	run *app.InstallActionWorkflowRun,
 	stack *app.InstallStack,
 	installState *state.State,
 ) (*operationroles.RoleSelection, app.OperationType, error) {
-	defaultRole := p.defaultRoleForInstallWorkflow(ctx, l, appCfg, generics.FromPtrStr(run.InstallWorkflowID))
+	defaultRole := p.defaultRoleForInstallWorkflow(ctx, l, appCfg, org, generics.FromPtrStr(run.InstallWorkflowID))
 	return operationroles.GetRoleForAction(l, appCfg, run, stack, installState, defaultRole)
 }
 
@@ -168,6 +169,7 @@ func (p *Planner) getAuthForActionWorkflowRun(
 	outputs app.InstallStackOutputs,
 	run *app.InstallActionWorkflowRun,
 	appCfg *app.AppConfig,
+	org *app.Org,
 	stack *app.InstallStack,
 	installState *state.State,
 ) (*CloudAuth, *operationroles.RoleSelection, error) {
@@ -176,7 +178,7 @@ func (p *Planner) getAuthForActionWorkflowRun(
 		return nil, nil, err
 	}
 
-	roleSelection, operation, err := p.getRoleForAction(ctx, l, appCfg, run, stack, installState)
+	roleSelection, operation, err := p.getRoleForAction(ctx, l, appCfg, org, run, stack, installState)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
@@ -152,13 +152,15 @@ func hstoreToMap(hstore pgtype.Hstore) map[string]string {
 }
 
 func (p *Planner) getRoleForAction(
+	ctx workflow.Context,
 	l *zap.Logger,
 	appCfg *app.AppConfig,
 	run *app.InstallActionWorkflowRun,
 	stack *app.InstallStack,
 	installState *state.State,
 ) (*operationroles.RoleSelection, app.OperationType, error) {
-	return operationroles.GetRoleForAction(l, appCfg, run, stack, installState)
+	defaultRole := p.defaultRoleForInstallWorkflow(ctx, l, appCfg, generics.FromPtrStr(run.InstallWorkflowID))
+	return operationroles.GetRoleForAction(l, appCfg, run, stack, installState, defaultRole)
 }
 
 func (p *Planner) getAuthForActionWorkflowRun(
@@ -174,7 +176,7 @@ func (p *Planner) getAuthForActionWorkflowRun(
 		return nil, nil, err
 	}
 
-	roleSelection, operation, err := p.getRoleForAction(l, appCfg, run, stack, installState)
+	roleSelection, operation, err := p.getRoleForAction(ctx, l, appCfg, run, stack, installState)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
@@ -159,8 +159,8 @@ func (p *Planner) getRoleForAction(
 	stack *app.InstallStack,
 	installState *state.State,
 ) (*operationroles.RoleSelection, app.OperationType, error) {
-	defaultRole := p.defaultRoleForInstallWorkflow(ctx, l, appCfg, generics.FromPtrStr(run.InstallWorkflowID))
-	return operationroles.GetRoleForAction(l, appCfg, run, stack, installState, defaultRole)
+	flw := p.installWorkflowForRoleDefault(ctx, l, generics.FromPtrStr(run.InstallWorkflowID))
+	return operationroles.GetRoleForAction(l, appCfg, run, stack, installState, flw)
 }
 
 func (p *Planner) getAuthForActionWorkflowRun(

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run_test.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run_test.go
@@ -429,7 +429,7 @@ func TestGetRoleForAction(t *testing.T) {
 				run,
 				stack,
 				installState,
-				"",
+				nil,
 			)
 
 			require.NoError(t, err, "getRoleForAction should not return error for test: %s", tt.description)

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run_test.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestGetRoleForAction(t *testing.T) {
-	p := &Planner{}
 	l := zap.NewNop()
 
 	tests := []struct {
@@ -424,12 +423,13 @@ func TestGetRoleForAction(t *testing.T) {
 				Name: "test-install",
 			}
 
-			roleSelection, operation, err := p.getRoleForAction(
+			roleSelection, operation, err := operationroles.GetRoleForAction(
 				l,
 				appConfig,
 				run,
 				stack,
 				installState,
+				"",
 			)
 
 			require.NoError(t, err, "getRoleForAction should not return error for test: %s", tt.description)

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
@@ -64,7 +64,7 @@ func (p *Planner) createDeployPlan(ctx workflow.Context, req *CreateDeployPlanRe
 	// we get same information.
 	// unless, we change response models like appcfg, installdeploy, build, stack etc somewhere in middle, which should
 	// not happen ideally.
-	roleSelection, _, err := p.getRoleForDeploy(ctx, l, appCfg, &install.Org, installDeploy, build, stack, installState)
+	roleSelection, _, err := p.getRoleForDeploy(ctx, l, appCfg, installDeploy, build, stack, installState)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to get role for deploy")
 	}
@@ -178,13 +178,12 @@ func (p *Planner) getRoleForDeploy(
 	ctx workflow.Context,
 	l *zap.Logger,
 	appCfg *app.AppConfig,
-	org *app.Org,
 	installDeploy *app.InstallDeploy,
 	compBuild *app.ComponentBuild,
 	stack *app.InstallStack,
 	installState *state.State,
 ) (*operationroles.RoleSelection, app.OperationType, error) {
-	defaultRole := p.defaultRoleForInstallWorkflow(ctx, l, appCfg, org, generics.FromPtrStr(installDeploy.InstallWorkflowID))
+	defaultRole := p.defaultRoleForInstallWorkflow(ctx, l, appCfg, generics.FromPtrStr(installDeploy.InstallWorkflowID))
 	return operationroles.GetRoleForDeploy(l, appCfg, installDeploy, &compBuild.ComponentConfigConnection, stack, installState, defaultRole)
 }
 
@@ -196,14 +195,21 @@ func (p *Planner) defaultRoleForInstallWorkflow(
 	ctx workflow.Context,
 	l *zap.Logger,
 	appCfg *app.AppConfig,
-	org *app.Org,
 	installWorkflowID string,
 ) string {
 	fallback := appCfg.PermissionsConfig.MaintenanceRole.Name
 
-	// Gate on the already-loaded org features so orgs that have not opted in
-	// pay no extra activity cost and keep the legacy maintenance-role default.
-	if org == nil || !org.HasFeature(app.OrgFeatureWorkflowDefaultRole) {
+	// Gate on the global server-side config flag (set via the
+	// WORKFLOW_DEFAULT_ROLE_ENABLED env var). When disabled, every workflow keeps
+	// the legacy maintenance-role default.
+	enabled, err := activities.AwaitWorkflowDefaultRoleEnabled(ctx, activities.WorkflowDefaultRoleEnabledRequest{})
+	if err != nil {
+		l.Warn("unable to check workflow-default-role config; using maintenance role",
+			zap.Error(err),
+		)
+		return fallback
+	}
+	if !enabled {
 		return fallback
 	}
 

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
@@ -183,39 +183,35 @@ func (p *Planner) getRoleForDeploy(
 	stack *app.InstallStack,
 	installState *state.State,
 ) (*operationroles.RoleSelection, app.OperationType, error) {
-	defaultRole := p.defaultRoleForInstallWorkflow(ctx, l, appCfg, generics.FromPtrStr(installDeploy.InstallWorkflowID))
-	return operationroles.GetRoleForDeploy(l, appCfg, installDeploy, &compBuild.ComponentConfigConnection, stack, installState, defaultRole)
+	flw := p.installWorkflowForRoleDefault(ctx, l, generics.FromPtrStr(installDeploy.InstallWorkflowID))
+	return operationroles.GetRoleForDeploy(l, appCfg, installDeploy, &compBuild.ComponentConfigConnection, stack, installState, flw)
 }
 
-// defaultRoleForInstallWorkflow resolves the lowest-precedence default role for
-// a step based on its parent install workflow type. It falls back to the
-// maintenance role when the workflow can't be resolved so planning never fails
-// on role defaulting.
-func (p *Planner) defaultRoleForInstallWorkflow(
+// installWorkflowForRoleDefault returns the parent install workflow used to
+// derive a step's lowest-precedence default role, or nil when workflow-type
+// defaulting should not apply. It returns nil when the global config flag is
+// off (WORKFLOW_DEFAULT_ROLE_ENABLED) or the workflow can't be resolved, so the
+// operation-roles package falls back to the maintenance role and planning never
+// fails on role defaulting.
+func (p *Planner) installWorkflowForRoleDefault(
 	ctx workflow.Context,
 	l *zap.Logger,
-	appCfg *app.AppConfig,
 	installWorkflowID string,
-) string {
-	fallback := appCfg.PermissionsConfig.MaintenanceRole.Name
-
-	// Gate on the global server-side config flag (set via the
-	// WORKFLOW_DEFAULT_ROLE_ENABLED env var). When disabled, every workflow keeps
-	// the legacy maintenance-role default.
+) *app.Workflow {
 	enabled, err := activities.AwaitWorkflowDefaultRoleEnabled(ctx, activities.WorkflowDefaultRoleEnabledRequest{})
 	if err != nil {
 		l.Warn("unable to check workflow-default-role config; using maintenance role",
 			zap.Error(err),
 		)
-		return fallback
+		return nil
 	}
 	if !enabled {
-		return fallback
+		return nil
 	}
 
 	if installWorkflowID == "" {
 		l.Warn("install workflow ID missing for role default; using maintenance role")
-		return fallback
+		return nil
 	}
 
 	flw, err := activities.AwaitGetInstallWorkflowByID(ctx, installWorkflowID)
@@ -224,10 +220,10 @@ func (p *Planner) defaultRoleForInstallWorkflow(
 			zap.String("install_workflow_id", installWorkflowID),
 			zap.Error(err),
 		)
-		return fallback
+		return nil
 	}
 
-	return operationroles.DefaultRoleForWorkflowType(appCfg, flw.Type)
+	return flw
 }
 
 // getAuthForDeploy builds cloud auth from an already-resolved role selection.

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
@@ -64,7 +64,7 @@ func (p *Planner) createDeployPlan(ctx workflow.Context, req *CreateDeployPlanRe
 	// we get same information.
 	// unless, we change response models like appcfg, installdeploy, build, stack etc somewhere in middle, which should
 	// not happen ideally.
-	roleSelection, _, err := p.getRoleForDeploy(ctx, l, appCfg, installDeploy, build, stack, installState)
+	roleSelection, _, err := p.getRoleForDeploy(ctx, l, appCfg, &install.Org, installDeploy, build, stack, installState)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to get role for deploy")
 	}
@@ -178,12 +178,13 @@ func (p *Planner) getRoleForDeploy(
 	ctx workflow.Context,
 	l *zap.Logger,
 	appCfg *app.AppConfig,
+	org *app.Org,
 	installDeploy *app.InstallDeploy,
 	compBuild *app.ComponentBuild,
 	stack *app.InstallStack,
 	installState *state.State,
 ) (*operationroles.RoleSelection, app.OperationType, error) {
-	defaultRole := p.defaultRoleForInstallWorkflow(ctx, l, appCfg, generics.FromPtrStr(installDeploy.InstallWorkflowID))
+	defaultRole := p.defaultRoleForInstallWorkflow(ctx, l, appCfg, org, generics.FromPtrStr(installDeploy.InstallWorkflowID))
 	return operationroles.GetRoleForDeploy(l, appCfg, installDeploy, &compBuild.ComponentConfigConnection, stack, installState, defaultRole)
 }
 
@@ -195,18 +196,14 @@ func (p *Planner) defaultRoleForInstallWorkflow(
 	ctx workflow.Context,
 	l *zap.Logger,
 	appCfg *app.AppConfig,
+	org *app.Org,
 	installWorkflowID string,
 ) string {
 	fallback := appCfg.PermissionsConfig.MaintenanceRole.Name
 
-	enabled, err := activities.AwaitHasFeatureByFeature(ctx, string(app.OrgFeatureWorkflowDefaultRole))
-	if err != nil {
-		l.Warn("unable to check workflow-default-role feature; using maintenance role",
-			zap.Error(err),
-		)
-		return fallback
-	}
-	if !enabled {
+	// Gate on the already-loaded org features so orgs that have not opted in
+	// pay no extra activity cost and keep the legacy maintenance-role default.
+	if org == nil || !org.HasFeature(app.OrgFeatureWorkflowDefaultRole) {
 		return fallback
 	}
 

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
@@ -69,7 +69,7 @@ func (p *Planner) createDeployPlan(ctx workflow.Context, req *CreateDeployPlanRe
 		return nil, nil, errors.Wrap(err, "unable to get role for deploy")
 	}
 
-	ociConfig, err := p.getInstallRegistryRepositoryConfig(ctx, installDeploy, build, appCfg, stack, installState)
+	ociConfig, err := p.getInstallRegistryRepositoryConfig(ctx, installDeploy, build, appCfg, stack, installState, roleSelection)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to get install registry repository config")
 	}
@@ -109,7 +109,7 @@ func (p *Planner) createDeployPlan(ctx workflow.Context, req *CreateDeployPlanRe
 		plan.NoopDeployPlan = p.createNoopDeployPlan()
 	case app.ComponentTypeTerraformModule:
 		l.Info("generating terraform plan")
-		tfPlan, err := p.createTerraformDeployPlan(ctx, req, appCfg, stack, installState, installDeploy)
+		tfPlan, err := p.createTerraformDeployPlan(ctx, req, appCfg, stack, installState, installDeploy, roleSelection)
 		if err != nil {
 			l.Info("error generating terraform plan", zap.Error(err))
 			return nil, nil, errors.Wrap(err, "unable to create terraform deploy plan")
@@ -117,7 +117,7 @@ func (p *Planner) createDeployPlan(ctx workflow.Context, req *CreateDeployPlanRe
 		plan.TerraformDeployPlan = tfPlan
 	case app.ComponentTypeHelmChart:
 		l.Info("generating helm plan")
-		helmPlan, err := p.createHelmDeployPlan(ctx, req, appCfg, stack, installState, installDeploy)
+		helmPlan, err := p.createHelmDeployPlan(ctx, req, appCfg, stack, installState, installDeploy, roleSelection)
 		if err != nil {
 			l.Error("error generating helm plan", zap.Error(err))
 			return nil, nil, errors.Wrap(err, "unable to helm deploy plan")
@@ -125,7 +125,7 @@ func (p *Planner) createDeployPlan(ctx workflow.Context, req *CreateDeployPlanRe
 		plan.HelmDeployPlan = helmPlan
 	case app.ComponentTypeKubernetesManifest:
 		l.Info("generating kubernetes manifest plan")
-		kubernetesManifestPlan, err := p.createKubernetesManifestDeployPlan(ctx, req, appCfg, stack, installState, installDeploy)
+		kubernetesManifestPlan, err := p.createKubernetesManifestDeployPlan(ctx, req, appCfg, stack, installState, installDeploy, roleSelection)
 		if err != nil {
 			l.Error("error generating kubernetes manifest plan", zap.Error(err))
 			return nil, nil, errors.Wrap(err, "unable to kubernets manifest deploy plan")
@@ -133,7 +133,7 @@ func (p *Planner) createDeployPlan(ctx workflow.Context, req *CreateDeployPlanRe
 		plan.KubernetesManifestDeployPlan = kubernetesManifestPlan
 	case app.ComponentTypePulumi:
 		l.Info("generating pulumi plan")
-		pulumiPlan, err := p.createPulumiDeployPlan(ctx, req, appCfg, stack, installState, installDeploy)
+		pulumiPlan, err := p.createPulumiDeployPlan(ctx, req, appCfg, stack, installState, installDeploy, roleSelection)
 		if err != nil {
 			l.Error("error generating pulumi plan", zap.Error(err))
 			return nil, nil, errors.Wrap(err, "unable to create pulumi deploy plan")
@@ -227,13 +227,14 @@ func (p *Planner) defaultRoleForInstallWorkflow(
 	return operationroles.DefaultRoleForWorkflowType(appCfg, flw.Type)
 }
 
+// getAuthForDeploy builds cloud auth from an already-resolved role selection.
+// The role is selected once per deploy/sync plan and threaded through so the
+// auth embedded in the runner plan can never diverge from the recorded role
+// selection, and the role-default activities only run once per plan.
 func (p *Planner) getAuthForDeploy(
 	ctx workflow.Context,
-	installDeploy *app.InstallDeploy,
-	compBuild *app.ComponentBuild,
-	appCfg *app.AppConfig,
+	roleSelection *operationroles.RoleSelection,
 	stack *app.InstallStack,
-	installState *state.State,
 	sessionName string,
 ) (*CloudAuth, error) {
 	l, err := log.WorkflowLogger(ctx)
@@ -241,25 +242,11 @@ func (p *Planner) getAuthForDeploy(
 		return nil, err
 	}
 
-	roleSelection, operation, err := p.getRoleForDeploy(
-		ctx,
-		l,
-		appCfg,
-		installDeploy,
-		compBuild,
-		stack,
-		installState,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	l.Info("selected role for component deploy plan",
+	l.Info("using selected role for component deploy auth",
 		zap.String("role_name", roleSelection.RoleName),
 		zap.String("role_arn", roleSelection.RoleARN),
 		zap.String("source", string(roleSelection.Source)),
-		zap.String("operation", string(operation)),
-		zap.String("deploy_type", string(installDeploy.Type)),
+		zap.String("session_name", sessionName),
 	)
 
 	return getCloudAuth(roleSelection, &stack.InstallStackOutputs, sessionName)

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/pkg/config/refs"
+	"github.com/nuonco/nuon/pkg/generics"
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/pkg/types/state"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -63,7 +64,7 @@ func (p *Planner) createDeployPlan(ctx workflow.Context, req *CreateDeployPlanRe
 	// we get same information.
 	// unless, we change response models like appcfg, installdeploy, build, stack etc somewhere in middle, which should
 	// not happen ideally.
-	roleSelection, _, err := p.getRoleForDeploy(l, appCfg, installDeploy, build, stack, installState)
+	roleSelection, _, err := p.getRoleForDeploy(ctx, l, appCfg, installDeploy, build, stack, installState)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to get role for deploy")
 	}
@@ -174,6 +175,7 @@ func (p *Planner) createDeployPlan(ctx workflow.Context, req *CreateDeployPlanRe
 }
 
 func (p *Planner) getRoleForDeploy(
+	ctx workflow.Context,
 	l *zap.Logger,
 	appCfg *app.AppConfig,
 	installDeploy *app.InstallDeploy,
@@ -181,7 +183,37 @@ func (p *Planner) getRoleForDeploy(
 	stack *app.InstallStack,
 	installState *state.State,
 ) (*operationroles.RoleSelection, app.OperationType, error) {
-	return operationroles.GetRoleForDeploy(l, appCfg, installDeploy, &compBuild.ComponentConfigConnection, stack, installState)
+	defaultRole := p.defaultRoleForInstallWorkflow(ctx, l, appCfg, generics.FromPtrStr(installDeploy.InstallWorkflowID))
+	return operationroles.GetRoleForDeploy(l, appCfg, installDeploy, &compBuild.ComponentConfigConnection, stack, installState, defaultRole)
+}
+
+// defaultRoleForInstallWorkflow resolves the lowest-precedence default role for
+// a step based on its parent install workflow type. It falls back to the
+// maintenance role when the workflow can't be resolved so planning never fails
+// on role defaulting.
+func (p *Planner) defaultRoleForInstallWorkflow(
+	ctx workflow.Context,
+	l *zap.Logger,
+	appCfg *app.AppConfig,
+	installWorkflowID string,
+) string {
+	fallback := appCfg.PermissionsConfig.MaintenanceRole.Name
+
+	if installWorkflowID == "" {
+		l.Warn("install workflow ID missing for role default; using maintenance role")
+		return fallback
+	}
+
+	flw, err := activities.AwaitGetInstallWorkflowByID(ctx, installWorkflowID)
+	if err != nil {
+		l.Warn("unable to get install workflow for role default; using maintenance role",
+			zap.String("install_workflow_id", installWorkflowID),
+			zap.Error(err),
+		)
+		return fallback
+	}
+
+	return operationroles.DefaultRoleForWorkflowType(appCfg, flw.Type)
 }
 
 func (p *Planner) getAuthForDeploy(
@@ -199,6 +231,7 @@ func (p *Planner) getAuthForDeploy(
 	}
 
 	roleSelection, operation, err := p.getRoleForDeploy(
+		ctx,
 		l,
 		appCfg,
 		installDeploy,

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
@@ -199,6 +199,17 @@ func (p *Planner) defaultRoleForInstallWorkflow(
 ) string {
 	fallback := appCfg.PermissionsConfig.MaintenanceRole.Name
 
+	enabled, err := activities.AwaitHasFeatureByFeature(ctx, string(app.OrgFeatureWorkflowDefaultRole))
+	if err != nil {
+		l.Warn("unable to check workflow-default-role feature; using maintenance role",
+			zap.Error(err),
+		)
+		return fallback
+	}
+	if !enabled {
+		return fallback
+	}
+
 	if installWorkflowID == "" {
 		l.Warn("install workflow ID missing for role default; using maintenance role")
 		return fallback

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan_test.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan_test.go
@@ -431,7 +431,7 @@ func TestGetRoleForDeploy(t *testing.T) {
 				&compBuild.ComponentConfigConnection,
 				stack,
 				installState,
-				"",
+				nil,
 			)
 
 			require.NoError(t, err, "getRoleForDeploy should not return error for test: %s", tt.description)

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan_test.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestGetRoleForDeploy(t *testing.T) {
-	p := &Planner{}
-
 	tests := []struct {
 		name               string
 		installDeployType  app.InstallDeployType
@@ -426,13 +424,14 @@ func TestGetRoleForDeploy(t *testing.T) {
 				Name: "test-install",
 			}
 
-			roleSelection, operation, err := p.getRoleForDeploy(
+			roleSelection, operation, err := operationroles.GetRoleForDeploy(
 				zap.NewNop(),
 				appConfig,
 				installDeploy,
-				compBuild,
+				&compBuild.ComponentConfigConnection,
 				stack,
 				installState,
+				"",
 			)
 
 			require.NoError(t, err, "getRoleForDeploy should not return error for test: %s", tt.description)

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_pulumi.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_pulumi.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+	operationroles "github.com/nuonco/nuon/services/ctl-api/internal/pkg/operation-roles"
 )
 
 func (p *Planner) createPulumiDeployPlan(
@@ -23,6 +24,7 @@ func (p *Planner) createPulumiDeployPlan(
 	stack *app.InstallStack,
 	state *state.State,
 	installDeploy *app.InstallDeploy,
+	roleSelection *operationroles.RoleSelection,
 ) (*plantypes.PulumiDeployPlan, error) {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
@@ -81,11 +83,8 @@ func (p *Planner) createPulumiDeployPlan(
 
 	cloudAuth, err := p.getAuthForDeploy(
 		ctx,
-		installDeploy,
-		compBuild,
-		appCfg,
+		roleSelection,
 		stack,
-		state,
 		fmt.Sprintf("component-deploy-%s", installDeploy.ID),
 	)
 	if err != nil {

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_terraform_module.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_terraform_module.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+	operationroles "github.com/nuonco/nuon/services/ctl-api/internal/pkg/operation-roles"
 )
 
 //go:embed fake_terraform_state.json
@@ -38,6 +39,7 @@ func (p *Planner) createTerraformDeployPlan(
 	stack *app.InstallStack,
 	state *state.State,
 	installDeploy *app.InstallDeploy,
+	roleSelection *operationroles.RoleSelection,
 ) (*plantypes.TerraformDeployPlan, error) {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
@@ -112,11 +114,8 @@ func (p *Planner) createTerraformDeployPlan(
 
 	cloudAuth, err := p.getAuthForDeploy(
 		ctx,
-		installDeploy,
-		compBuild,
-		appCfg,
+		roleSelection,
 		stack,
-		state,
 		fmt.Sprintf("component-deploy-%s", installDeploy.ID),
 	)
 	if err != nil {

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_helm_deploy.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_helm_deploy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+	operationroles "github.com/nuonco/nuon/services/ctl-api/internal/pkg/operation-roles"
 )
 
 //go:embed fake_helm_plan.json
@@ -33,6 +34,7 @@ func (p *Planner) createHelmDeployPlan(
 	stack *app.InstallStack,
 	state *state.State,
 	installDeploy *app.InstallDeploy,
+	roleSelection *operationroles.RoleSelection,
 ) (*plantypes.HelmDeployPlan, error) {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
@@ -119,11 +121,8 @@ func (p *Planner) createHelmDeployPlan(
 
 	cloudAuth, err := p.getAuthForDeploy(
 		ctx,
-		installDeploy,
-		compBuild,
-		appCfg,
+		roleSelection,
 		stack,
-		state,
 		fmt.Sprintf("component-deploy-%s", installDeploy.ID),
 	)
 	if err != nil {

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_kubernetes_manifest_deploy.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_kubernetes_manifest_deploy.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+	operationroles "github.com/nuonco/nuon/services/ctl-api/internal/pkg/operation-roles"
 )
 
 func (p *Planner) createKubernetesManifestDeployPlan(
@@ -28,6 +29,7 @@ func (p *Planner) createKubernetesManifestDeployPlan(
 	stack *app.InstallStack,
 	state *statepkg.State,
 	installDeploy *app.InstallDeploy,
+	roleSelection *operationroles.RoleSelection,
 ) (*plantypes.KubernetesManifestDeployPlan, error) {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
@@ -90,11 +92,8 @@ func (p *Planner) createKubernetesManifestDeployPlan(
 
 	cloudAuth, err := p.getAuthForDeploy(
 		ctx,
-		installDeploy,
-		compBuild,
-		appCfg,
+		roleSelection,
 		stack,
-		state,
 		fmt.Sprintf("component-deploy-%s", installDeploy.ID),
 	)
 	if err != nil {

--- a/services/ctl-api/internal/app/installs/worker/plan/workflow_plan_sync_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/workflow_plan_sync_plan.go
@@ -8,6 +8,7 @@ import (
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/pkg/plugins/configs"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 )
 
 func (p *Planner) createSyncPlan(ctx workflow.Context, req *CreateSyncPlanRequest) (*plantypes.SyncOCIPlan, error) {
@@ -48,7 +49,17 @@ func (p *Planner) createSyncPlan(ctx workflow.Context, req *CreateSyncPlanReques
 		return nil, errors.Wrap(err, "unable to get install state")
 	}
 
-	dstCfg, err := p.getInstallRegistryRepositoryConfig(ctx, deploy, compBuild, appCfg, stack, installState)
+	l, err := log.WorkflowLogger(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get logger")
+	}
+
+	roleSelection, _, err := p.getRoleForDeploy(ctx, l, appCfg, deploy, compBuild, stack, installState)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get role for deploy")
+	}
+
+	dstCfg, err := p.getInstallRegistryRepositoryConfig(ctx, deploy, compBuild, appCfg, stack, installState, roleSelection)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get install registry repository")
 	}

--- a/services/ctl-api/internal/app/installs/worker/plan/workflow_plan_sync_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/workflow_plan_sync_plan.go
@@ -54,7 +54,7 @@ func (p *Planner) createSyncPlan(ctx workflow.Context, req *CreateSyncPlanReques
 		return nil, errors.Wrap(err, "unable to get logger")
 	}
 
-	roleSelection, _, err := p.getRoleForDeploy(ctx, l, appCfg, &install.Org, deploy, compBuild, stack, installState)
+	roleSelection, _, err := p.getRoleForDeploy(ctx, l, appCfg, deploy, compBuild, stack, installState)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get role for deploy")
 	}

--- a/services/ctl-api/internal/app/installs/worker/plan/workflow_plan_sync_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/workflow_plan_sync_plan.go
@@ -54,7 +54,7 @@ func (p *Planner) createSyncPlan(ctx workflow.Context, req *CreateSyncPlanReques
 		return nil, errors.Wrap(err, "unable to get logger")
 	}
 
-	roleSelection, _, err := p.getRoleForDeploy(ctx, l, appCfg, deploy, compBuild, stack, installState)
+	roleSelection, _, err := p.getRoleForDeploy(ctx, l, appCfg, &install.Org, deploy, compBuild, stack, installState)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get role for deploy")
 	}

--- a/services/ctl-api/internal/app/org.go
+++ b/services/ctl-api/internal/app/org.go
@@ -81,6 +81,14 @@ const (
 	// workflow. Gates all `/v1/installs/:id/notebooks` endpoints and the
 	// dashboard notebooks UI.
 	OrgFeatureNotebooks OrgFeature = "notebooks"
+	// OrgFeatureWorkflowDefaultRole drives the lowest-precedence default
+	// operation role from the parent install workflow type: provision/
+	// reprovision workflows default to the provision role, deprovision
+	// workflows to the deprovision role, and everything else to the
+	// maintenance role. When disabled, component deploys and action runs
+	// always default to the maintenance role (legacy behavior). Runtime,
+	// break-glass, entity, and matrix overrides always take precedence.
+	OrgFeatureWorkflowDefaultRole OrgFeature = "workflow-default-role"
 )
 
 type Org struct {
@@ -204,6 +212,7 @@ func (o *Org) BeforeCreate(tx *gorm.DB) error {
 		OrgFeatureLogTailLongPoll:         false,
 		OrgFeatureRunnerJobLongPoll:       false,
 		OrgFeatureNotebooks:               false,
+		OrgFeatureWorkflowDefaultRole:     false,
 
 		// Enabled by default
 		OrgFeatureParallelRunnerJobs: true,
@@ -252,6 +261,7 @@ func GetFeatures() []OrgFeature {
 		OrgFeatureLogTailLongPoll,
 		OrgFeatureRunnerJobLongPoll,
 		OrgFeatureNotebooks,
+		OrgFeatureWorkflowDefaultRole,
 	}
 }
 
@@ -286,6 +296,7 @@ func GetFeatureDescriptions() map[OrgFeature]string {
 		OrgFeatureLogTailLongPoll:         "Enable the long-poll log-tail endpoint (`/v1/log-streams/:id/logs/tail`) — the dashboard BFF probes it for near-real-time log streaming and falls back to legacy 1s polling when off",
 		OrgFeatureRunnerJobLongPoll:       "Switch the runner from a 5s idle-poll loop to a long-poll endpoint (`/v1/runners/:id/jobs/tail`) so job pickup is sub-second. Surfaced via runner settings; runners pick it up on the next process restart.",
 		OrgFeatureNotebooks:               "Enable install-scoped Notebooks — a Jupyter-style surface where each cell runs a command on the install's runner via a long-lived, warm per-notebook Temporal workflow, skipping the cold install-workflow step tree for near-real-time adhoc execution.",
+		OrgFeatureWorkflowDefaultRole:     "Default the operation role from the parent install workflow type: provision/reprovision workflows use the provision role and deprovision workflows use the deprovision role for all steps (including component deploys and action runs); everything else uses the maintenance role. When off, deploys and action runs always default to the maintenance role. Per-component runtime/break-glass/entity/matrix overrides still take precedence.",
 	}
 }
 

--- a/services/ctl-api/internal/app/org.go
+++ b/services/ctl-api/internal/app/org.go
@@ -236,6 +236,13 @@ func (o *Org) BeforeCreate(tx *gorm.DB) error {
 	return nil
 }
 
+// HasFeature reports whether the given feature flag is enabled for the org.
+// It reads the already-loaded Features map (normalized in AfterQuery), so it
+// performs no database or activity calls.
+func (o *Org) HasFeature(feature OrgFeature) bool {
+	return o.Features[string(feature)]
+}
+
 // active feature flags for an orgs
 func GetFeatures() []OrgFeature {
 	return []OrgFeature{

--- a/services/ctl-api/internal/app/org.go
+++ b/services/ctl-api/internal/app/org.go
@@ -81,14 +81,6 @@ const (
 	// workflow. Gates all `/v1/installs/:id/notebooks` endpoints and the
 	// dashboard notebooks UI.
 	OrgFeatureNotebooks OrgFeature = "notebooks"
-	// OrgFeatureWorkflowDefaultRole drives the lowest-precedence default
-	// operation role from the parent install workflow type: provision/
-	// reprovision workflows default to the provision role, deprovision
-	// workflows to the deprovision role, and everything else to the
-	// maintenance role. When disabled, component deploys and action runs
-	// always default to the maintenance role (legacy behavior). Runtime,
-	// break-glass, entity, and matrix overrides always take precedence.
-	OrgFeatureWorkflowDefaultRole OrgFeature = "workflow-default-role"
 )
 
 type Org struct {
@@ -212,7 +204,6 @@ func (o *Org) BeforeCreate(tx *gorm.DB) error {
 		OrgFeatureLogTailLongPoll:         false,
 		OrgFeatureRunnerJobLongPoll:       false,
 		OrgFeatureNotebooks:               false,
-		OrgFeatureWorkflowDefaultRole:     false,
 
 		// Enabled by default
 		OrgFeatureParallelRunnerJobs: true,
@@ -234,13 +225,6 @@ func (o *Org) BeforeCreate(tx *gorm.DB) error {
 
 	o.CreatedByID = createdByIDFromContext(tx.Statement.Context)
 	return nil
-}
-
-// HasFeature reports whether the given feature flag is enabled for the org.
-// It reads the already-loaded Features map (normalized in AfterQuery), so it
-// performs no database or activity calls.
-func (o *Org) HasFeature(feature OrgFeature) bool {
-	return o.Features[string(feature)]
 }
 
 // active feature flags for an orgs
@@ -268,7 +252,6 @@ func GetFeatures() []OrgFeature {
 		OrgFeatureLogTailLongPoll,
 		OrgFeatureRunnerJobLongPoll,
 		OrgFeatureNotebooks,
-		OrgFeatureWorkflowDefaultRole,
 	}
 }
 
@@ -303,7 +286,6 @@ func GetFeatureDescriptions() map[OrgFeature]string {
 		OrgFeatureLogTailLongPoll:         "Enable the long-poll log-tail endpoint (`/v1/log-streams/:id/logs/tail`) — the dashboard BFF probes it for near-real-time log streaming and falls back to legacy 1s polling when off",
 		OrgFeatureRunnerJobLongPoll:       "Switch the runner from a 5s idle-poll loop to a long-poll endpoint (`/v1/runners/:id/jobs/tail`) so job pickup is sub-second. Surfaced via runner settings; runners pick it up on the next process restart.",
 		OrgFeatureNotebooks:               "Enable install-scoped Notebooks — a Jupyter-style surface where each cell runs a command on the install's runner via a long-lived, warm per-notebook Temporal workflow, skipping the cold install-workflow step tree for near-real-time adhoc execution.",
-		OrgFeatureWorkflowDefaultRole:     "Default the operation role from the parent install workflow type: provision/reprovision workflows use the provision role and deprovision workflows use the deprovision role for all steps (including component deploys and action runs); everything else uses the maintenance role. When off, deploys and action runs always default to the maintenance role. Per-component runtime/break-glass/entity/matrix overrides still take precedence.",
 	}
 }
 

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -148,6 +148,13 @@ func init() {
 
 	// Flow check thresholds
 	config.RegisterDefault("stale_plan_threshold", "72h") // override with STALE_PLAN_THRESHOLD env var
+
+	// When true, the lowest-precedence operation role is defaulted from the parent
+	// install workflow type (provision/reprovision -> provision role, deprovision ->
+	// deprovision role; everything else -> maintenance role). When false, deploys and
+	// action runs default to the maintenance role. Global rollout switch for all orgs;
+	// override with WORKFLOW_DEFAULT_ROLE_ENABLED env var.
+	config.RegisterDefault("workflow_default_role_enabled", false)
 }
 
 type Config struct {
@@ -432,6 +439,10 @@ type Config struct {
 
 	// Flow check thresholds
 	StalePlanThreshold string `config:"stale_plan_threshold"`
+
+	// WorkflowDefaultRoleEnabled is a global switch (all orgs) that defaults the
+	// lowest-precedence operation role from the parent install workflow type.
+	WorkflowDefaultRoleEnabled bool `config:"workflow_default_role_enabled"`
 }
 
 func (c *Config) IsAWS() bool {

--- a/services/ctl-api/internal/pkg/operation-roles/builders.go
+++ b/services/ctl-api/internal/pkg/operation-roles/builders.go
@@ -18,16 +18,14 @@ func GetRoleForDeploy(
 	compCfgConn *app.ComponentConfigConnection,
 	stack *app.InstallStack,
 	installState *state.State,
-	defaultRole string,
+	flw *app.Workflow,
 ) (*RoleSelection, app.OperationType, error) {
 	operation := app.OperationDeploy
 	if installDeploy.Type == app.InstallDeployTypeTeardown {
 		operation = app.OperationTeardown
 	}
 
-	if defaultRole == "" {
-		defaultRole = appCfg.PermissionsConfig.MaintenanceRole.Name
-	}
+	defaultRole := defaultRoleForWorkflow(appCfg, flw)
 
 	selectionCtx := &SelectionContext{
 		Operation:     operation,
@@ -147,13 +145,11 @@ func GetRoleForAction(
 	run *app.InstallActionWorkflowRun,
 	stack *app.InstallStack,
 	installState *state.State,
-	defaultRole string,
+	flw *app.Workflow,
 ) (*RoleSelection, app.OperationType, error) {
 	operation := app.OperationTrigger
 
-	if defaultRole == "" {
-		defaultRole = appCfg.PermissionsConfig.MaintenanceRole.Name
-	}
+	defaultRole := defaultRoleForWorkflow(appCfg, flw)
 
 	var entityRoles map[app.OperationType]string
 	if run.ActionWorkflowConfig.Role != "" {

--- a/services/ctl-api/internal/pkg/operation-roles/builders.go
+++ b/services/ctl-api/internal/pkg/operation-roles/builders.go
@@ -18,10 +18,15 @@ func GetRoleForDeploy(
 	compCfgConn *app.ComponentConfigConnection,
 	stack *app.InstallStack,
 	installState *state.State,
+	defaultRole string,
 ) (*RoleSelection, app.OperationType, error) {
 	operation := app.OperationDeploy
 	if installDeploy.Type == app.InstallDeployTypeTeardown {
 		operation = app.OperationTeardown
+	}
+
+	if defaultRole == "" {
+		defaultRole = appCfg.PermissionsConfig.MaintenanceRole.Name
 	}
 
 	selectionCtx := &SelectionContext{
@@ -33,7 +38,7 @@ func GetRoleForDeploy(
 			compCfgConn.OperationRoles,
 		),
 		MatrixRules:  appCfg.OperationRoleConfig.Rules,
-		DefaultRole:  appCfg.PermissionsConfig.MaintenanceRole.Name,
+		DefaultRole:  defaultRole,
 		AppConfig:    appCfg,
 		StackOutputs: &stack.InstallStackOutputs,
 		InstallState: installState,
@@ -142,8 +147,13 @@ func GetRoleForAction(
 	run *app.InstallActionWorkflowRun,
 	stack *app.InstallStack,
 	installState *state.State,
+	defaultRole string,
 ) (*RoleSelection, app.OperationType, error) {
 	operation := app.OperationTrigger
+
+	if defaultRole == "" {
+		defaultRole = appCfg.PermissionsConfig.MaintenanceRole.Name
+	}
 
 	var entityRoles map[app.OperationType]string
 	if run.ActionWorkflowConfig.Role != "" {
@@ -164,7 +174,7 @@ func GetRoleForAction(
 		RuntimeRole:    run.Role,
 		EntityRoles:    entityRoles,
 		MatrixRules:    appCfg.OperationRoleConfig.Rules,
-		DefaultRole:    appCfg.PermissionsConfig.MaintenanceRole.Name,
+		DefaultRole:    defaultRole,
 		AppConfig:      appCfg,
 		StackOutputs:   &stack.InstallStackOutputs,
 		BreakGlassRole: breakGlassRole,

--- a/services/ctl-api/internal/pkg/operation-roles/default_role.go
+++ b/services/ctl-api/internal/pkg/operation-roles/default_role.go
@@ -25,3 +25,14 @@ func DefaultRoleForWorkflowType(appCfg *app.AppConfig, workflowType app.Workflow
 		return appCfg.PermissionsConfig.MaintenanceRole.Name
 	}
 }
+
+// defaultRoleForWorkflow returns the lowest-precedence default role for a step.
+// A nil workflow means workflow-type defaulting does not apply (the config flag
+// is off, or the parent workflow could not be resolved), so it falls back to the
+// maintenance role.
+func defaultRoleForWorkflow(appCfg *app.AppConfig, flw *app.Workflow) string {
+	if flw == nil {
+		return appCfg.PermissionsConfig.MaintenanceRole.Name
+	}
+	return DefaultRoleForWorkflowType(appCfg, flw.Type)
+}

--- a/services/ctl-api/internal/pkg/operation-roles/default_role.go
+++ b/services/ctl-api/internal/pkg/operation-roles/default_role.go
@@ -1,0 +1,27 @@
+package operationroles
+
+import "github.com/nuonco/nuon/services/ctl-api/internal/app"
+
+// DefaultRoleForWorkflowType returns the default role name to use for a step
+// based on the type of the parent install workflow it runs within.
+//
+// Provisioning workflows run every step as the provision role, deprovisioning
+// workflows run every step as the deprovision role, and everything else (manual
+// deploys, input updates, action runs, drift, etc.) uses the maintenance role.
+//
+// This is only the lowest-precedence default: runtime, break-glass, entity and
+// matrix role selections still take precedence over it.
+func DefaultRoleForWorkflowType(appCfg *app.AppConfig, workflowType app.WorkflowType) string {
+	switch workflowType {
+	case app.WorkflowTypeProvision,
+		app.WorkflowTypeReprovision,
+		app.WorkflowTypeReprovisionSandbox,
+		app.WorkflowTypeDriftRunReprovisionSandbox:
+		return appCfg.PermissionsConfig.ProvisionRole.Name
+	case app.WorkflowTypeDeprovision,
+		app.WorkflowTypeDeprovisionSandbox:
+		return appCfg.PermissionsConfig.DeprovisionRole.Name
+	default:
+		return appCfg.PermissionsConfig.MaintenanceRole.Name
+	}
+}

--- a/services/ctl-api/internal/pkg/operation-roles/default_role_test.go
+++ b/services/ctl-api/internal/pkg/operation-roles/default_role_test.go
@@ -1,0 +1,47 @@
+package operationroles
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+func TestDefaultRoleForWorkflowType(t *testing.T) {
+	appCfg := &app.AppConfig{
+		PermissionsConfig: app.AppPermissionsConfig{
+			ProvisionRole:   app.AppAWSIAMRoleConfig{Name: "provision"},
+			DeprovisionRole: app.AppAWSIAMRoleConfig{Name: "deprovision"},
+			MaintenanceRole: app.AppAWSIAMRoleConfig{Name: "maintenance"},
+		},
+	}
+
+	tests := []struct {
+		workflowType app.WorkflowType
+		expected     string
+	}{
+		{app.WorkflowTypeProvision, "provision"},
+		{app.WorkflowTypeReprovision, "provision"},
+		{app.WorkflowTypeReprovisionSandbox, "provision"},
+		{app.WorkflowTypeDriftRunReprovisionSandbox, "provision"},
+		{app.WorkflowTypeDeprovision, "deprovision"},
+		{app.WorkflowTypeDeprovisionSandbox, "deprovision"},
+		{app.WorkflowTypeManualDeploy, "maintenance"},
+		{app.WorkflowTypeInputUpdate, "maintenance"},
+		{app.WorkflowTypeDeployComponents, "maintenance"},
+		{app.WorkflowTypeTeardownComponent, "maintenance"},
+		{app.WorkflowTypeTeardownComponents, "maintenance"},
+		{app.WorkflowTypeActionWorkflowRun, "maintenance"},
+		{app.WorkflowTypeSyncSecrets, "maintenance"},
+		{app.WorkflowTypeDriftRun, "maintenance"},
+		{app.WorkflowTypeRunbookRun, "maintenance"},
+		{"", "maintenance"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.workflowType), func(t *testing.T) {
+			assert.Equal(t, tt.expected, DefaultRoleForWorkflowType(appCfg, tt.workflowType))
+		})
+	}
+}

--- a/services/ctl-api/internal/pkg/operation-roles/default_role_test.go
+++ b/services/ctl-api/internal/pkg/operation-roles/default_role_test.go
@@ -45,3 +45,30 @@ func TestDefaultRoleForWorkflowType(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultRoleForWorkflow(t *testing.T) {
+	appCfg := &app.AppConfig{
+		PermissionsConfig: app.AppPermissionsConfig{
+			ProvisionRole:   app.AppAWSIAMRoleConfig{Name: "provision"},
+			DeprovisionRole: app.AppAWSIAMRoleConfig{Name: "deprovision"},
+			MaintenanceRole: app.AppAWSIAMRoleConfig{Name: "maintenance"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		flw      *app.Workflow
+		expected string
+	}{
+		{"nil workflow falls back to maintenance", nil, "maintenance"},
+		{"provision workflow uses provision role", &app.Workflow{Type: app.WorkflowTypeProvision}, "provision"},
+		{"deprovision workflow uses deprovision role", &app.Workflow{Type: app.WorkflowTypeDeprovision}, "deprovision"},
+		{"manual deploy uses maintenance role", &app.Workflow{Type: app.WorkflowTypeManualDeploy}, "maintenance"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, defaultRoleForWorkflow(appCfg, tt.flw))
+		})
+	}
+}


### PR DESCRIPTION
This PR updates how we pick default role for each step, and instead of picking `maintenance` role by default, we use workflow type to determine this. It only changes the lowest-precedence default, so runtime/break-glass/entity/matrix overrides still win.

- parent workflow type -> default role
  - provision / reprovision / *_reprovision_sandbox -> provision role
  - deprovision / deprovision_sandbox -> deprovision role
  - everything else (deploy, input update, action, drift, sync secrets, runbook, ...) -> maintenance role
    

Provision/deprovision workflows now run all deploy and action steps as the provision/deprovision role by default; everything else stays on the maintenance role. Runtime/break-glass/entity/matrix overrides still win.

These changes are disabled by default, and can be enabled by setting config `workflow_default_role_enabled` to `true` (or by setting the env variable `WORKFLOW_DEFAULT_ROLE_ENABLED`)