### PR TITLE
fix(ui): aws-only stack overrides, skip empty input groups

### DIFF
--- a/services/dashboard-ui/client/components/installs/forms/CreateInstallForm/CreateInstallForm.tsx
+++ b/services/dashboard-ui/client/components/installs/forms/CreateInstallForm/CreateInstallForm.tsx
@@ -129,6 +129,8 @@ export const CreateInstallForm = forwardRef<
             />
           </div>
 
+          {/* Nested CloudFormation template overrides only apply to AWS install stacks */}
+          {platform === 'aws' && (
           <Expand
             id="advanced-stack-overrides"
             heading="Advanced"
@@ -175,6 +177,7 @@ export const CreateInstallForm = forwardRef<
               </div>
             </div>
           </Expand>
+          )}
 
           {inputConfig && (
             <InputConfigFields

--- a/services/dashboard-ui/client/utils/app-utils.test.ts
+++ b/services/dashboard-ui/client/utils/app-utils.test.ts
@@ -180,7 +180,7 @@ describe('app-utils', () => {
       ])
     })
 
-    test('should handle groups with no matching inputs', () => {
+    test('should omit groups with no matching inputs', () => {
       const groups: TAppConfig['input']['input_groups'] = [
         {
           id: 'group-1',
@@ -202,15 +202,7 @@ describe('app-utils', () => {
 
       const result = normalizeAppInputGroups(groups, inputs)
 
-      expect(result).toEqual([
-        {
-          id: 'group-1',
-          name: 'Empty Group',
-          description: 'Group with no inputs',
-          index: 1,
-          app_inputs: [],
-        },
-      ])
+      expect(result).toEqual([])
     })
 
     test('should handle empty groups array', () => {
@@ -243,15 +235,7 @@ describe('app-utils', () => {
 
       const result = normalizeAppInputGroups(groups, inputs)
 
-      expect(result).toEqual([
-        {
-          id: 'group-1',
-          name: 'Test Group',
-          description: 'Test description',
-          index: 1,
-          app_inputs: [],
-        },
-      ])
+      expect(result).toEqual([])
     })
 
     test('should handle both empty arrays', () => {
@@ -275,7 +259,15 @@ describe('app-utils', () => {
         } as any,
       ]
 
-      const inputs: TAppConfig['input']['inputs'] = []
+      const inputs: TAppConfig['input']['inputs'] = [
+        {
+          id: 'input-1',
+          name: 'test_input',
+          type: 'string',
+          group_id: 'group-1',
+          required: true,
+        },
+      ]
 
       const result = normalizeAppInputGroups(groups, inputs)
 
@@ -285,8 +277,8 @@ describe('app-utils', () => {
         description: 'Advanced configuration options',
         index: 10,
         custom_field: 'custom_value',
-        app_inputs: [],
       }))
+      expect(result[0].app_inputs).toHaveLength(1)
     })
   })
 })

--- a/services/dashboard-ui/client/utils/app-utils.ts
+++ b/services/dashboard-ui/client/utils/app-utils.ts
@@ -27,8 +27,10 @@ export function normalizeAppInputGroups(
   groups: TAppConfig['input']['input_groups'],
   inputs: TAppConfig['input']['inputs']
 ) {
-  return groups.map((group) => ({
-    ...group,
-    app_inputs: inputs.filter((input) => input.group_id === group.id),
-  }))
+  return groups
+    .map((group) => ({
+      ...group,
+      app_inputs: inputs.filter((input) => input.group_id === group.id),
+    }))
+    .filter((group) => group.app_inputs.length > 0)
 }


### PR DESCRIPTION
- Create-install form: the VPC/runner CloudFormation override fields are AWS-only (`stack.toml`), but rendered for every platform — gate on `platform === 'aws'`.
- `normalizeAppInputGroups`: filter out input groups with no inputs so app overview / current-inputs views don't render empty sections (e.g. the byoc "Auth0 Authentication" group).

Tests + tsc pass.