### PR TITLE
fix(runner): keep bare repo/tag in oci sync outputs

### DIFF
--- a/bins/runner/internal/jobs/sync/oci/outputs.go
+++ b/bins/runner/internal/jobs/sync/oci/outputs.go
@@ -9,21 +9,19 @@ import (
 )
 
 func (h *handler) Outputs(ctx context.Context) (map[string]interface{}, error) {
-	// When the runner has resolved a manifest digest, the `repository`,
-	// `tag`, and `ref` outputs are rewritten so user templates render
-	// digest-pinned references by default:
+	// `repository` and `tag` are a long-standing public output contract:
+	// app configs compose them as `{{.repository}}:{{.tag}}` (helm values,
+	// terraform vars). They must stay the bare repository and resolved tag —
+	// rewriting repository to the digest-pinned form breaks every such
+	// template, and clearing the tag does NOT fail loudly: charts default an
+	// empty tag to .Chart.AppVersion, yielding invalid `repo@sha256:...:tag`
+	// refs that only surface as pull failures at deploy time.
 	//
-	//   - repository  → "<full_repo>@sha256:<digest>" (existing
-	//                   `image: {{.repository}}` templates pin automatically)
-	//   - tag         → "" (a legacy
-	//                   `image: {{.repository}}:{{.tag}}` template surfaces
-	//                   as an invalid trailing-colon ref instead of
-	//                   silently deploying a mutable tag)
-	//   - ref         → same digest-pinned form, exposed as a stable alias
-	//   - display_tag → the resolved tag for human display
+	// Digest pinning is exposed additively instead:
 	//
-	// Without a digest (non-image artifacts) the legacy `repository = bare
-	// repo`, `tag = DstTag` shape is preserved.
+	//   - ref         → "<full_repo>@sha256:<digest>" for templates that
+	//                   opt in to digest-pinned pulls ("" without a digest)
+	//   - display_tag → the resolved tag, stable alias of `tag`
 	digest := ""
 	if h.state.descriptor != nil {
 		digest = h.state.descriptor.Digest.String()
@@ -41,23 +39,14 @@ func (h *handler) Outputs(ctx context.Context) (map[string]interface{}, error) {
 		fullRepo = fmt.Sprintf("%s/%s", loginServer, fullRepo)
 	}
 
-	var (
-		repositoryOut string
-		tagOut        string
-		refOut        string
-	)
+	refOut := ""
 	if digest != "" && fullRepo != "" {
 		refOut = fmt.Sprintf("%s@%s", fullRepo, digest)
-		repositoryOut = refOut
-		tagOut = ""
-	} else {
-		repositoryOut = h.state.plan.Dst.Repository
-		tagOut = h.state.plan.DstTag
 	}
 
 	obj := map[string]interface{}{
-		"repository":  repositoryOut,
-		"tag":         tagOut,
+		"repository":  h.state.plan.Dst.Repository,
+		"tag":         h.state.plan.DstTag,
 		"ref":         refOut,
 		"display_tag": h.state.plan.DstTag,
 	}

--- a/pkg/types/state/oci_artifact_outputs.go
+++ b/pkg/types/state/oci_artifact_outputs.go
@@ -1,23 +1,18 @@
 package state
 
 type OCIArtifactOutputs struct {
-	// Repository is the canonical pull reference for the synced artifact.
-	// When the runner has resolved a manifest digest, Repository is
-	// rewritten to the digest-pinned form (`<full_repo>@sha256:<digest>`)
-	// so user templates of the form `image: "{{.outputs.image.repository}}"`
-	// are automatically digest-pinned without any user opt-in.
-	//
-	// Without a resolved digest the original bare-repository form is
-	// preserved.
+	// Repository is the bare repository of the synced artifact (no tag, no
+	// digest). Long-standing public output contract: user templates compose
+	// it as `image: "{{.repository}}:{{.tag}}"`, so it must never carry a
+	// digest suffix — use Ref for a digest-pinned pull reference.
 	Repository string `mapstructure:"repository"`
-	// Tag is the resolved image tag. Intentionally cleared to `""` whenever
-	// Repository has been rewritten to a digest-pinned form, so legacy
-	// `image: "{{.repository}}:{{.tag}}"` templates surface as obviously
-	// invalid trailing-colon refs (rather than silently deploying a mutable
-	// tag). Use DisplayTag for the human-friendly tag.
+	// Tag is the resolved image tag, composed with Repository by user
+	// templates. Never cleared: charts default an empty tag to their
+	// appVersion, which silently produces invalid refs when combined with
+	// any non-bare repository.
 	Tag string `mapstructure:"tag"`
-	// Ref is the canonical digest-pinned pull reference, kept as a stable
-	// alias of Repository for clarity:
+	// Ref is the canonical digest-pinned pull reference for templates that
+	// opt in to digest-pinned pulls:
 	//
 	//   <login_server>/<repository>@sha256:<digest>
 	//


### PR DESCRIPTION
#1487 rewrites `outputs.image.repository` to `repo@sha256:<digest>` and clears `tag` when the sync resolves a digest. Charts default an empty tag to `appVersion`, so `{{.repository}}:{{.tag}}` templates render invalid refs like `.../app@sha256:6b60...:0.24.5` (broke byoc-nuon-gcp; AWS breaks on its next image sync).

Restore `repository`/`tag` to bare repo + resolved tag. Digest pinning stays available via `ref` and `display_tag`. Build dedup reads `digest`, unaffected.