### PR TITLE
fix(api): unique install registry image refs per component

### DIFF
--- a/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository.go
@@ -119,8 +119,9 @@ func (p *Planner) getInstallRegistryRepositoryConfig(
 			)
 			return nil, errors.Wrap(err, "unable to render gar repository url")
 		}
-		// GAR requires an image name within the repo: HOST/PROJECT/REPO/IMAGE
-		cfg.Repository = repositoryStr + "/app"
+		// GAR requires an image name within the repo: HOST/PROJECT/REPO/IMAGE.
+		// Per-component paths so resolved-version tags can't collide across components.
+		cfg.Repository = repositoryStr + "/" + imageNameSegment(installDeploy.ComponentName)
 		loginServer, err := render.RenderV2("{{.nuon.sandbox.outputs.gar.registry_url}}", stateData)
 		if err != nil {
 			l.Error("error rendering registy url",
@@ -135,6 +136,29 @@ func (p *Planner) getInstallRegistryRepositoryConfig(
 	}
 
 	return cfg, nil
+}
+
+// imageNameSegment reduces a component name to a valid docker image path
+// segment / tag prefix: lowercase, invalid runs collapsed to a single "-",
+// no leading or trailing separators.
+func imageNameSegment(componentName string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(componentName) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '_':
+			b.WriteRune(r)
+			lastDash = false
+		case !lastDash:
+			b.WriteRune('-')
+			lastDash = true
+		}
+	}
+	segment := strings.Trim(b.String(), "._-")
+	if segment == "" {
+		return "app"
+	}
+	return segment
 }
 
 func (b *Planner) getOrgRegistryRepositoryConfig(ctx workflow.Context, installID, deployID string) (*configs.OCIRegistryRepository, error) {

--- a/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository_test.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository_test.go
@@ -1,0 +1,26 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImageNameSegment(t *testing.T) {
+	cases := map[string]string{
+		"img_altinity_clickhouse_operator": "img_altinity_clickhouse_operator",
+		"My Component":                     "my-component",
+		"foo   bar":                        "foo-bar",
+		"foo--bar":                         "foo-bar",
+		"-leading-and-trailing-":           "leading-and-trailing",
+		"trailing---":                      "trailing",
+		"...dots...":                       "dots",
+		"CTL API (v2)":                     "ctl-api-v2",
+		"":                                 "app",
+		"---":                              "app",
+	}
+
+	for in, want := range cases {
+		assert.Equal(t, want, imageNameSegment(in), "input %q", in)
+	}
+}

--- a/services/ctl-api/internal/app/installs/worker/plan/workflow_plan_sync_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/workflow_plan_sync_plan.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
+	"github.com/nuonco/nuon/pkg/plugins/configs"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 )
 
@@ -75,6 +76,11 @@ func (p *Planner) createSyncPlan(ctx workflow.Context, req *CreateSyncPlanReques
 		dstTag = compBuild.ResolvedTag
 		if dstTag == "" {
 			dstTag = compBuild.ID
+		} else if dstCfg.RegistryType == configs.OCIRegistryTypeECR {
+			// ECR keeps one shared repo (repos must be pre-created), so
+			// prefix the tag to keep resolved versions from colliding
+			// across components.
+			dstTag = imageNameSegment(deploy.ComponentName) + "-" + dstTag
 		}
 	}
 


### PR DESCRIPTION
All components of an install sync into one shared registry location, and since #1487 pushes are tagged by resolved version — so two images at the same upstream version overwrite each other's tag. On byoc-nuon-gcp, `clickhouse-operator:0.24.5` and `metrics-exporter:0.24.5` collided and the operator deployment pulled the metrics-exporter binary; AWS hits the same on its next image re-sync.

- GAR: per-component image paths (`<repo>/<component>`) — paths are created implicitly on push.
- ECR: repos must be pre-created, so prefix the tag with the component name instead (`clickhouse-operator-0.24.5`).

Same-image re-deploys stay idempotent; deploy plans pull by digest and the runner outputs echo the plan, so pushed and rendered refs stay consistent.