### PR TITLE
chore(api): hyphenate underscores in install registry image names

### DIFF
--- a/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository.go
@@ -138,15 +138,15 @@ func (p *Planner) getInstallRegistryRepositoryConfig(
 	return cfg, nil
 }
 
-// imageNameSegment reduces a component name to a valid docker image path
-// segment / tag prefix: lowercase, invalid runs collapsed to a single "-",
-// no leading or trailing separators.
+// imageNameSegment reduces a component name to a docker image path segment /
+// tag prefix: lowercase, every run of non-alphanumerics (including "_")
+// collapsed to a single "-", no leading or trailing separator.
 func imageNameSegment(componentName string) string {
 	var b strings.Builder
 	lastDash := false
 	for _, r := range strings.ToLower(componentName) {
 		switch {
-		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '_':
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
 			b.WriteRune(r)
 			lastDash = false
 		case !lastDash:
@@ -154,7 +154,7 @@ func imageNameSegment(componentName string) string {
 			lastDash = true
 		}
 	}
-	segment := strings.Trim(b.String(), "._-")
+	segment := strings.Trim(b.String(), "-")
 	if segment == "" {
 		return "app"
 	}

--- a/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository.go
@@ -92,7 +92,9 @@ func (p *Planner) getInstallRegistryRepositoryConfig(
 			)
 			return nil, errors.Wrap(err, "unable to render acr repository name")
 		}
-		cfg.Repository = repositoryStr
+		// Per-component paths so resolved-version tags can't collide across
+		// components. ACR creates nested repositories implicitly on push.
+		cfg.Repository = repositoryStr + "/" + imageNameSegment(installDeploy.ComponentName)
 		loginServer, err := render.RenderV2("{{.nuon.sandbox.outputs.acr.login_server}}", stateData)
 		if err != nil {
 			l.Error("error rendering registy url",

--- a/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository_test.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository_test.go
@@ -8,16 +8,17 @@ import (
 
 func TestImageNameSegment(t *testing.T) {
 	cases := map[string]string{
-		"img_altinity_clickhouse_operator": "img_altinity_clickhouse_operator",
+		"img_nuon_ctl_api":                 "img-nuon-ctl-api",
+		"img_altinity_clickhouse_operator": "img-altinity-clickhouse-operator",
 		"My Component":                     "my-component",
 		"foo   bar":                        "foo-bar",
 		"foo--bar":                         "foo-bar",
 		"-leading-and-trailing-":           "leading-and-trailing",
-		"trailing---":                      "trailing",
+		"trailing___":                      "trailing",
 		"...dots...":                       "dots",
 		"CTL API (v2)":                     "ctl-api-v2",
 		"":                                 "app",
-		"---":                              "app",
+		"___":                              "app",
 	}
 
 	for in, want := range cases {


### PR DESCRIPTION
Follow-up to #1676. `imageNameSegment` kept underscores, so component names like `img_nuon_ctl_api` produced `img_nuon_ctl_api-0.19.1009` tags and `/app/img_nuon_ctl_api` paths. Collapse `_` (and any non-alphanumeric run) to a single `-` so names are consistently hyphenated.