### PR TITLE
feat: support draining runner processes on shutdown

### DIFF
--- a/bins/runner/cmd/cli.go
+++ b/bins/runner/cmd/cli.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nuonco/nuon/bins/runner/internal"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/api"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/auth"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/drain"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/errs"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/heartbeater"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/log"
@@ -39,6 +40,7 @@ func (c *cli) commonProviders() []fx.Option {
 		fx.Provide(heartbeater.New),
 		fx.Provide(process.New),
 		fx.Provide(process.NewShutdownPoller),
+		fx.Provide(drain.New),
 		fx.Provide(metrics.New),
 	}
 }

--- a/bins/runner/internal/pkg/drain/drain.go
+++ b/bins/runner/internal/pkg/drain/drain.go
@@ -1,0 +1,67 @@
+package drain
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type Drainer struct {
+	drainOnce sync.Once
+	drainCh   chan struct{}
+
+	mu      sync.Mutex
+	doneChs []<-chan struct{}
+}
+
+func New() *Drainer {
+	return &Drainer{
+		drainCh: make(chan struct{}),
+	}
+}
+
+func (d *Drainer) Register(ch <-chan struct{}) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.doneChs = append(d.doneChs, ch)
+}
+
+func (d *Drainer) Drain() {
+	d.drainOnce.Do(func() {
+		close(d.drainCh)
+	})
+}
+
+func (d *Drainer) DrainCh() <-chan struct{} {
+	return d.drainCh
+}
+
+func (d *Drainer) IsDraining() bool {
+	select {
+	case <-d.drainCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *Drainer) Wait(timeout time.Duration) error {
+	d.mu.Lock()
+	chs := make([]<-chan struct{}, len(d.doneChs))
+	copy(chs, d.doneChs)
+	d.mu.Unlock()
+
+	if len(chs) == 0 {
+		return nil
+	}
+
+	deadline := time.After(timeout)
+	for _, ch := range chs {
+		select {
+		case <-ch:
+		case <-deadline:
+			return fmt.Errorf("drain timed out after %s", timeout)
+		}
+	}
+	return nil
+}

--- a/bins/runner/internal/pkg/drain/drain_test.go
+++ b/bins/runner/internal/pkg/drain/drain_test.go
@@ -1,0 +1,105 @@
+package drain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDrainer_DrainClosesChannel(t *testing.T) {
+	d := New()
+
+	select {
+	case <-d.DrainCh():
+		t.Fatal("drain channel should not be closed before Drain()")
+	default:
+	}
+
+	if d.IsDraining() {
+		t.Fatal("should not be draining before Drain()")
+	}
+
+	d.Drain()
+
+	select {
+	case <-d.DrainCh():
+	default:
+		t.Fatal("drain channel should be closed after Drain()")
+	}
+
+	if !d.IsDraining() {
+		t.Fatal("should be draining after Drain()")
+	}
+}
+
+func TestDrainer_DrainIsIdempotent(t *testing.T) {
+	d := New()
+	d.Drain()
+	d.Drain()
+
+	if !d.IsDraining() {
+		t.Fatal("should still be draining after double Drain()")
+	}
+}
+
+func TestDrainer_WaitNoDoneChannels(t *testing.T) {
+	d := New()
+	d.Drain()
+
+	if err := d.Wait(time.Second); err != nil {
+		t.Fatalf("Wait with no registered channels should return nil: %v", err)
+	}
+}
+
+func TestDrainer_WaitAllDone(t *testing.T) {
+	d := New()
+
+	ch1 := make(chan struct{})
+	ch2 := make(chan struct{})
+	d.Register(ch1)
+	d.Register(ch2)
+
+	d.Drain()
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		close(ch1)
+		time.Sleep(10 * time.Millisecond)
+		close(ch2)
+	}()
+
+	if err := d.Wait(time.Second); err != nil {
+		t.Fatalf("Wait should succeed when all channels close: %v", err)
+	}
+}
+
+func TestDrainer_WaitTimeout(t *testing.T) {
+	d := New()
+
+	ch := make(chan struct{})
+	d.Register(ch)
+
+	d.Drain()
+
+	err := d.Wait(50 * time.Millisecond)
+	if err == nil {
+		t.Fatal("Wait should return error on timeout")
+	}
+}
+
+func TestDrainer_WaitPartialDone(t *testing.T) {
+	d := New()
+
+	ch1 := make(chan struct{})
+	ch2 := make(chan struct{})
+	d.Register(ch1)
+	d.Register(ch2)
+
+	d.Drain()
+
+	close(ch1)
+
+	err := d.Wait(50 * time.Millisecond)
+	if err == nil {
+		t.Fatal("Wait should timeout when only some channels close")
+	}
+}

--- a/bins/runner/internal/pkg/jobloop/base_params.go
+++ b/bins/runner/internal/pkg/jobloop/base_params.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/bins/runner/internal"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/drain"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/errs"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/process"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/settings"
@@ -27,4 +28,5 @@ type BaseParams struct {
 	L *zap.Logger `name:"system"`
 
 	ProcessRegistrar *process.Registrar
+	Drainer          *drain.Drainer
 }

--- a/bins/runner/internal/pkg/jobloop/jobloop.go
+++ b/bins/runner/internal/pkg/jobloop/jobloop.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/nuonco/nuon/bins/runner/internal"
 	"github.com/nuonco/nuon/bins/runner/internal/jobs"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/drain"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/errs"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/process"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/settings"
@@ -44,13 +45,19 @@ type jobLoop struct {
 	settings *settings.Settings
 	cfg      *internal.Config
 
-	ctx        context.Context
-	ctxCancel  func()
+	pollCtx    context.Context
+	pollCancel func()
+	jobCtx     context.Context
+	jobCancel  func()
+
 	l          *zap.Logger
 	mw         metrics.Writer
 	shutdowner fx.Shutdowner
 
 	processRegistrar *process.Registrar
+
+	drainer   *drain.Drainer
+	jobDoneCh chan struct{}
 
 	// coalescers maps execution_id -> per-execution status writer. The
 	// jobLoop type is shared by every concurrent job (parallel-runner-
@@ -64,8 +71,11 @@ type jobLoop struct {
 }
 
 func New(handlers []jobs.JobHandler, jobGroup models.AppRunnerJobGroup, params BaseParams) *jobLoop {
-	ctx := context.Background()
-	ctx, cancelFn := context.WithCancel(ctx)
+	pollCtx, pollCancel := context.WithCancel(context.Background())
+	jobCtx, jobCancel := context.WithCancel(context.Background())
+
+	jobDoneCh := make(chan struct{})
+	params.Drainer.Register(jobDoneCh)
 
 	jl := &jobLoop{
 		apiClient:   params.Client,
@@ -74,15 +84,22 @@ func New(handlers []jobs.JobHandler, jobGroup models.AppRunnerJobGroup, params B
 		jobGroup:    jobGroup,
 		jobHandlers: handlers,
 
-		pool:             pool.New().WithMaxGoroutines(1),
-		ctx:              ctx,
-		ctxCancel:        cancelFn,
-		l:                params.L,
-		settings:         params.Settings,
-		cfg:              params.Cfg,
-		mw:               params.MW,
-		shutdowner:       params.Shutdowner,
+		pool:       pool.New().WithMaxGoroutines(1),
+		pollCtx:    pollCtx,
+		pollCancel: pollCancel,
+		jobCtx:     jobCtx,
+		jobCancel:  jobCancel,
+		l:          params.L,
+		settings:   params.Settings,
+		cfg:        params.Cfg,
+		mw:         params.MW,
+		shutdowner: params.Shutdowner,
+
 		processRegistrar: params.ProcessRegistrar,
+
+		drainer:    params.Drainer,
+		jobDoneCh:  jobDoneCh,
+		coalescers: make(map[string]*statusCoalescer),
 	}
 
 	params.LC.Append(jl.LifecycleHook())

--- a/bins/runner/internal/pkg/jobloop/lifecycle.go
+++ b/bins/runner/internal/pkg/jobloop/lifecycle.go
@@ -12,8 +12,13 @@ func (j *jobLoop) Start() error {
 	return nil
 }
 
+func (j *jobLoop) Drain() {
+	j.pollCancel()
+}
+
 func (j *jobLoop) Stop() error {
-	j.ctxCancel()
+	j.pollCancel()
+	j.jobCancel()
 	j.pool.Wait()
 	j.setStopped()
 	return nil
@@ -21,12 +26,9 @@ func (j *jobLoop) Stop() error {
 
 func (j *jobLoop) LifecycleHook() fx.Hook {
 	return fx.Hook{
-		// start the background loop to update the settings
 		OnStart: func(context.Context) error {
 			return j.Start()
 		},
-
-		// stop the loop and wait for the background goroutine to return
 		OnStop: func(context.Context) error {
 			return j.Stop()
 		},

--- a/bins/runner/internal/pkg/jobloop/worker.go
+++ b/bins/runner/internal/pkg/jobloop/worker.go
@@ -36,6 +36,11 @@ func (j *jobLoop) runWorker() {
 		l.Warn("job loop stopped due to error", zap.Error(err))
 	}
 
+	if j.drainer.IsDraining() {
+		l.Info("worker exited cleanly due to drain")
+		return
+	}
+
 	l.Warn("shutting down runner due to closing job loop")
 	os.Exit(155)
 	if err := j.shutdowner.Shutdown(fx.ExitCode(1)); err != nil {
@@ -44,15 +49,15 @@ func (j *jobLoop) runWorker() {
 }
 
 func (j *jobLoop) worker() error {
-	// useTail flips to false once the org returns 404 from the tail
-	// endpoint so we don't keep re-probing a known-disabled endpoint
-	// every iteration; falls back to the legacy poll for the lifetime
-	// of this process.
 	useTail := j.settings != nil && j.settings.LongPollJobs
 
 	for {
 		select {
-		case <-j.ctx.Done():
+		case <-j.pollCtx.Done():
+			close(j.jobDoneCh)
+			return nil
+		case <-j.drainer.DrainCh():
+			close(j.jobDoneCh)
 			return nil
 		default:
 		}
@@ -66,22 +71,18 @@ func (j *jobLoop) worker() error {
 			}
 			j.l.Error("unable to fetch jobs", zap.Error(err))
 
-			if err := smithytime.SleepWithContext(j.ctx, defaultJobPollBackoff); err != nil {
-				return err
+			if err := smithytime.SleepWithContext(j.pollCtx, defaultJobPollBackoff); err != nil {
+				close(j.jobDoneCh)
+				return nil
 			}
 			continue
 		}
 
 		if len(jobs) < 1 {
-			// On the tail path the server has already held the
-			// request open up to `tailJobPollWait`, so reissue
-			// immediately instead of sleeping `starvedJobPollBackoff`
-			// and reintroducing the 5s pickup latency we just
-			// removed. The legacy GetJobs path keeps the old
-			// backoff to avoid hammering the API.
 			if !useTail {
-				if err := smithytime.SleepWithContext(j.ctx, starvedJobPollBackoff); err != nil {
-					return err
+				if err := smithytime.SleepWithContext(j.pollCtx, starvedJobPollBackoff); err != nil {
+					close(j.jobDoneCh)
+					return nil
 				}
 			}
 			continue
@@ -89,16 +90,14 @@ func (j *jobLoop) worker() error {
 
 		job := jobs[0]
 
-		// execute the job
 		var pc panics.Catcher
 		pc.Try(func() {
-			err = j.executeJob(j.ctx, job)
+			err = j.executeJob(j.jobCtx, job)
 		})
 		if err != nil {
 			j.errRecorder.Record("job failed", err)
 		}
 
-		// if a panic is _recorded_ we do not restart the runner automatically.
 		if rc := pc.Recovered(); rc != nil {
 			j.l.Error("job panic",
 				zap.String("stack-trace", rc.String()),
@@ -107,9 +106,17 @@ func (j *jobLoop) worker() error {
 			)
 		}
 
-		// iterate for the next loop
-		if err := smithytime.SleepWithContext(j.ctx, defaultJobPollBackoff); err != nil {
-			return err
+		select {
+		case <-j.drainer.DrainCh():
+			j.l.Info("drain requested, exiting worker after completing job")
+			close(j.jobDoneCh)
+			return nil
+		default:
+		}
+
+		if err := smithytime.SleepWithContext(j.pollCtx, defaultJobPollBackoff); err != nil {
+			close(j.jobDoneCh)
+			return nil
 		}
 	}
 }
@@ -120,12 +127,12 @@ func (j *jobLoop) worker() error {
 // open. The legacy path keeps the original 5s ceiling.
 func (j *jobLoop) fetchAvailableJobs(useTail bool) ([]*models.AppRunnerJob, error) {
 	if useTail {
-		tctx, cancel := context.WithTimeoutCause(j.ctx, tailJobPollTimeout, errors.Wrapf(context.DeadlineExceeded, "tail poll for jobs in group %s timed out", j.jobGroup))
+		tctx, cancel := context.WithTimeoutCause(j.pollCtx, tailJobPollTimeout, errors.Wrapf(context.DeadlineExceeded, "tail poll for jobs in group %s timed out", j.jobGroup))
 		defer cancel()
 		return j.apiClient.TailJobs(tctx, j.jobGroup, tailJobPollWait)
 	}
 
-	tctx, cancel := context.WithTimeoutCause(j.ctx, 5*time.Second, errors.Wrapf(context.DeadlineExceeded, "polling for jobs in group %s timed out", j.jobGroup))
+	tctx, cancel := context.WithTimeoutCause(j.pollCtx, 5*time.Second, errors.Wrapf(context.DeadlineExceeded, "polling for jobs in group %s timed out", j.jobGroup))
 	defer cancel()
 	var lim *int64
 	return j.apiClient.GetJobs(tctx, j.jobGroup, j.jobStatus, lim)

--- a/bins/runner/internal/pkg/process/shutdown_poller.go
+++ b/bins/runner/internal/pkg/process/shutdown_poller.go
@@ -11,15 +11,18 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/bins/runner/internal"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/drain"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/health"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/settings"
 	pkgshutdown "github.com/nuonco/nuon/bins/runner/internal/pkg/shutdown"
 	nuonrunner "github.com/nuonco/nuon/sdks/nuon-runner-go"
+	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 )
 
 const (
 	shutdownPollInterval = 5 * time.Second
 	forceExitTimeout     = 5 * time.Second
+	drainTimeout         = 30 * time.Minute
 )
 
 type ShutdownPollerParams struct {
@@ -33,6 +36,7 @@ type ShutdownPollerParams struct {
 	Settings   *settings.Settings
 	Shutdowner fx.Shutdowner
 	V          *validator.Validate
+	Drainer    *drain.Drainer
 
 	// only provided in the mng process; nil in the install/run process.
 	Health *health.Server `optional:"true"`
@@ -46,6 +50,7 @@ type ShutdownPoller struct {
 	shutdowner fx.Shutdowner
 	settings   *settings.Settings
 	health     *health.Server
+	drainer    *drain.Drainer
 
 	podShutdown *podShutdown
 
@@ -65,6 +70,7 @@ func NewShutdownPoller(params ShutdownPollerParams) *ShutdownPoller {
 		shutdowner:  params.Shutdowner,
 		settings:    params.Settings,
 		health:      params.Health,
+		drainer:     params.Drainer,
 		podShutdown: newPodShutdown(params.Cfg, params.Settings, params.L),
 		ctx:         ctx,
 		cancelFn:    cancelFn,
@@ -119,16 +125,43 @@ func (sp *ShutdownPoller) check(ctx context.Context) {
 		}
 
 		if shutdown.Status == "requested" {
-			sp.l.Info("shutdown requested, marking as completed and initiating graceful shutdown",
+			sp.l.Info("shutdown requested, entering drain mode",
 				zap.String("process_id", processID),
 				zap.String("shutdown_id", shutdown.ID),
 				zap.String("shutdown_type", string(shutdown.Type)),
 			)
 
+			status := "pending-shutdown"
+			if _, err := sp.apiClient.UpdateProcess(ctx, processID, &models.ServiceUpdateRunnerProcessRequest{
+				Status:            &status,
+				StatusDescription: "draining in-flight jobs before shutdown",
+			}); err != nil {
+				sp.l.Warn("unable to update process status to pending-shutdown", zap.Error(err))
+			}
+
+			sp.drainer.Drain()
+
+			if err := sp.drainer.Wait(drainTimeout); err != nil {
+				sp.l.Warn("drain timeout exceeded, proceeding with shutdown",
+					zap.Error(err),
+					zap.Duration("timeout", drainTimeout),
+				)
+			} else {
+				sp.l.Info("all in-flight jobs completed, proceeding with shutdown")
+			}
+
+			status = "shutting-down"
+			if _, err := sp.apiClient.UpdateProcess(ctx, processID, &models.ServiceUpdateRunnerProcessRequest{
+				Status:            &status,
+				StatusDescription: "all jobs drained, shutting down",
+			}); err != nil {
+				sp.l.Warn("unable to update process status to shutting-down", zap.Error(err))
+			}
+
 			if _, err := sp.apiClient.CompleteShutdown(ctx, processID, shutdown.ID); err != nil {
 				sp.l.Warn("unable to mark shutdown as completed", zap.Error(err))
 			} else {
-				sp.l.Info("shutdown completed successfully, initiating process exit",
+				sp.l.Info("shutdown marked as completed",
 					zap.String("process_id", processID),
 					zap.String("shutdown_id", shutdown.ID),
 				)
@@ -141,15 +174,12 @@ func (sp *ShutdownPoller) check(ctx context.Context) {
 			}
 
 			if sp.registrar.ProcessType() == "mng" {
-				// On Azure, don't power the VM off. An instance refresh in Azure takes 10m+ to complete.
-				// Keep the VM on and let the Azure control plane replace it.
 				if sp.settings.Platform == "azure" {
 					if sp.health != nil {
 						sp.l.Info("mng process shutdown - marking vm as unhealthy; letting azure vmss replace the instance")
 						sp.health.SetUnhealthy()
 						return
 					}
-					// should never happen: the mng process always wires the health server. fall back to poweroff.
 					sp.l.Error("mng process shutdown on azure but health server is nil; falling back to vm poweroff")
 					if err := pkgshutdown.Shutdown(ctx, sp.l, sp.v); err != nil {
 						sp.l.Warn("VM shutdown failed", zap.Error(err))
@@ -162,7 +192,6 @@ func (sp *ShutdownPoller) check(ctx context.Context) {
 				}
 			}
 
-			// Force-kill the process if fx.Shutdown doesn't complete in time.
 			go func() {
 				time.Sleep(forceExitTimeout)
 				sp.l.Warn("graceful shutdown did not complete in time, forcing exit",

--- a/plans/shutdown-protection/index.html
+++ b/plans/shutdown-protection/index.html
@@ -1,0 +1,1185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Runner Process Shutdown Protection — Plan Review</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #161b22;
+    --surface2: #1c2129;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-muted: #8b949e;
+    --accent: #58a6ff;
+    --accent-dim: #1f6feb33;
+    --green: #3fb950;
+    --orange: #d29922;
+    --red: #f85149;
+    --purple: #bc8cff;
+    --code-bg: #0d1117;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    padding: 0;
+  }
+  .layout {
+    display: flex;
+    min-height: 100vh;
+  }
+  .sidebar {
+    width: 260px;
+    background: var(--surface);
+    border-right: 1px solid var(--border);
+    padding: 24px 16px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    overflow-y: auto;
+  }
+  .sidebar h3 {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+  }
+  .sidebar a {
+    display: block;
+    color: var(--text-muted);
+    text-decoration: none;
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-size: 14px;
+    margin-bottom: 2px;
+    transition: all 0.15s;
+  }
+  .sidebar a:hover, .sidebar a.active {
+    color: var(--text);
+    background: var(--accent-dim);
+  }
+  .sidebar .section-label {
+    margin-top: 20px;
+    font-weight: 600;
+    color: var(--text);
+    font-size: 13px;
+    padding: 6px 10px;
+  }
+  .main {
+    margin-left: 260px;
+    flex: 1;
+    max-width: 900px;
+    padding: 48px 48px 120px;
+  }
+  h1 {
+    font-size: 32px;
+    font-weight: 700;
+    margin-bottom: 8px;
+  }
+  .subtitle {
+    color: var(--text-muted);
+    font-size: 16px;
+    margin-bottom: 40px;
+  }
+  h2 {
+    font-size: 24px;
+    font-weight: 600;
+    margin-top: 48px;
+    margin-bottom: 16px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border);
+  }
+  h3 {
+    font-size: 18px;
+    font-weight: 600;
+    margin-top: 32px;
+    margin-bottom: 12px;
+    color: var(--accent);
+  }
+  h4 {
+    font-size: 15px;
+    font-weight: 600;
+    margin-top: 24px;
+    margin-bottom: 8px;
+    color: var(--purple);
+  }
+  p, li {
+    font-size: 15px;
+    color: var(--text);
+    margin-bottom: 10px;
+  }
+  ul, ol {
+    padding-left: 24px;
+    margin-bottom: 16px;
+  }
+  li { margin-bottom: 6px; }
+  code {
+    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    font-size: 13px;
+    background: var(--surface2);
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: var(--accent);
+  }
+  pre {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px 20px;
+    overflow-x: auto;
+    margin: 12px 0 20px;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  pre code {
+    background: none;
+    padding: 0;
+    color: var(--text);
+  }
+  .keyword { color: #ff7b72; }
+  .type { color: #79c0ff; }
+  .string { color: #a5d6ff; }
+  .comment { color: #8b949e; font-style: italic; }
+  .func { color: #d2a8ff; }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 16px 0 24px;
+    font-size: 14px;
+  }
+  th {
+    text-align: left;
+    padding: 10px 14px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    font-weight: 600;
+    color: var(--text-muted);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  td {
+    padding: 10px 14px;
+    border: 1px solid var(--border);
+    vertical-align: top;
+  }
+  td code {
+    font-size: 12px;
+    white-space: nowrap;
+  }
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 600;
+  }
+  .badge-new { background: #23863633; color: var(--green); }
+  .badge-modify { background: #d2992233; color: var(--orange); }
+
+  .callout {
+    border-left: 3px solid var(--accent);
+    background: var(--surface);
+    padding: 14px 18px;
+    border-radius: 0 8px 8px 0;
+    margin: 16px 0;
+  }
+  .callout.warn {
+    border-left-color: var(--orange);
+  }
+
+  /* Diagram */
+  .diagram-container {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 32px;
+    margin: 24px 0;
+    overflow-x: auto;
+  }
+  .diagram-controls {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+  .diagram-controls button {
+    padding: 6px 14px;
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text);
+    cursor: pointer;
+    font-size: 13px;
+    transition: all 0.15s;
+  }
+  .diagram-controls button:hover {
+    background: var(--accent-dim);
+    border-color: var(--accent);
+  }
+  .diagram-controls button.active {
+    background: var(--accent-dim);
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  #sequence-diagram {
+    position: relative;
+    min-height: 500px;
+    font-family: 'SF Mono', monospace;
+    font-size: 13px;
+  }
+  .actor-lane {
+    position: absolute;
+    top: 0;
+    width: 2px;
+    background: var(--border);
+    height: 100%;
+  }
+  .actor-label {
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+    background: var(--accent-dim);
+    border: 1px solid var(--accent);
+    color: var(--accent);
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-weight: 600;
+    white-space: nowrap;
+    font-size: 12px;
+  }
+  .seq-step {
+    position: absolute;
+    transition: all 0.4s ease;
+    opacity: 0;
+  }
+  .seq-step.visible {
+    opacity: 1;
+  }
+  .seq-arrow {
+    height: 2px;
+    background: var(--green);
+    position: absolute;
+  }
+  .seq-arrow::after {
+    content: '';
+    position: absolute;
+    right: -1px;
+    top: -5px;
+    border: 6px solid transparent;
+    border-left-color: var(--green);
+  }
+  .seq-arrow.reverse { background: var(--purple); }
+  .seq-arrow.reverse::after { border-left-color: transparent; border-right-color: var(--purple); left: -1px; right: auto; top: -5px; }
+  .seq-label {
+    position: absolute;
+    white-space: nowrap;
+    font-size: 12px;
+    color: var(--text);
+    background: var(--surface);
+    padding: 2px 8px;
+    border-radius: 4px;
+  }
+  .seq-action {
+    position: absolute;
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--text-muted);
+    white-space: nowrap;
+  }
+  .seq-action.highlight {
+    border-color: var(--green);
+    color: var(--green);
+  }
+
+  /* SVG-based diagram */
+  .seq-svg {
+    width: 100%;
+    min-height: 620px;
+  }
+  .seq-svg text {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  }
+  .seq-svg .lane { stroke: #30363d; stroke-width: 1; stroke-dasharray: 6 4; }
+  .seq-svg .arrow { stroke-width: 2; fill: none; marker-end: url(#arrowGreen); }
+  .seq-svg .arrow-reverse { stroke-width: 2; fill: none; marker-end: url(#arrowPurple); }
+  .seq-svg .actor-box { fill: #1f6feb22; stroke: #58a6ff; stroke-width: 1; rx: 6; }
+  .seq-svg .action-box { fill: #1c2129; stroke: #30363d; stroke-width: 1; rx: 6; }
+  .seq-svg .action-box.hl { stroke: #3fb950; }
+  .seq-svg .action-box.wait { stroke: #d29922; stroke-dasharray: 4 3; }
+  .seq-svg .step-group { opacity: 0; transition: opacity 0.5s ease; }
+  .seq-svg .step-group.visible { opacity: 1; }
+
+  /* Inline commenting */
+  .commentable {
+    position: relative;
+    cursor: pointer;
+    border-radius: 6px;
+    transition: background 0.15s;
+  }
+  .commentable:hover {
+    background: #58a6ff0a;
+  }
+  .commentable:hover::before {
+    content: '+';
+    position: absolute;
+    left: -32px;
+    top: 4px;
+    width: 22px;
+    height: 22px;
+    background: var(--accent);
+    color: var(--bg);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1;
+  }
+  .comment-thread {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    border-radius: 0 8px 8px 0;
+    padding: 14px 18px;
+    margin: 8px 0 16px;
+    display: none;
+  }
+  .comment-thread.open {
+    display: block;
+  }
+  .comment-thread textarea {
+    width: 100%;
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text);
+    padding: 10px 14px;
+    font-family: inherit;
+    font-size: 14px;
+    resize: vertical;
+    min-height: 80px;
+    margin-bottom: 10px;
+  }
+  .comment-thread textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .comment-thread button {
+    padding: 8px 18px;
+    background: var(--accent);
+    color: var(--bg);
+    border: none;
+    border-radius: 6px;
+    font-weight: 600;
+    font-size: 13px;
+    cursor: pointer;
+    margin-right: 8px;
+  }
+  .comment-thread button:hover {
+    opacity: 0.9;
+  }
+  .comment-thread button.cancel {
+    background: transparent;
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+  }
+  .saved-comment {
+    background: var(--surface2);
+    border-radius: 6px;
+    padding: 10px 14px;
+    margin-bottom: 10px;
+    font-size: 14px;
+    color: var(--text);
+    position: relative;
+  }
+  .saved-comment .comment-meta {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-bottom: 4px;
+  }
+  .comment-count {
+    display: inline-block;
+    background: var(--accent);
+    color: var(--bg);
+    font-size: 11px;
+    font-weight: 700;
+    padding: 1px 6px;
+    border-radius: 10px;
+    margin-left: 6px;
+    vertical-align: middle;
+  }
+
+  /* Comment panel */
+  #comment-panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 340px;
+    height: 100vh;
+    background: var(--surface);
+    border-left: 1px solid var(--border);
+    padding: 20px;
+    overflow-y: auto;
+    transform: translateX(100%);
+    transition: transform 0.25s ease;
+    z-index: 100;
+  }
+  #comment-panel.open {
+    transform: translateX(0);
+  }
+  #comment-panel h3 {
+    color: var(--text);
+    margin-bottom: 16px;
+    font-size: 16px;
+  }
+  .panel-comment {
+    background: var(--surface2);
+    border-radius: 8px;
+    padding: 12px 14px;
+    margin-bottom: 12px;
+    border-left: 3px solid var(--accent);
+  }
+  .panel-comment .pc-section {
+    font-size: 11px;
+    color: var(--accent);
+    margin-bottom: 4px;
+    font-weight: 600;
+  }
+  .panel-comment .pc-text {
+    font-size: 14px;
+    color: var(--text);
+  }
+  .panel-comment .pc-time {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-top: 6px;
+  }
+  #toggle-panel {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    z-index: 101;
+    padding: 12px 20px;
+    background: var(--accent);
+    color: var(--bg);
+    border: none;
+    border-radius: 28px;
+    font-weight: 700;
+    font-size: 14px;
+    cursor: pointer;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  #toggle-panel:hover { opacity: 0.9; }
+  #comment-total {
+    background: var(--bg);
+    color: var(--accent);
+    padding: 1px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+  }
+
+  /* Edge case cards */
+  .edge-case-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    margin: 16px 0;
+  }
+  .edge-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px 16px;
+  }
+  .edge-card strong {
+    display: block;
+    font-size: 13px;
+    margin-bottom: 4px;
+    color: var(--orange);
+  }
+  .edge-card p {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin: 0;
+  }
+</style>
+</head>
+<body>
+
+<div class="layout">
+  <nav class="sidebar">
+    <h3>Plan Review</h3>
+    <a href="#context">Context</a>
+    <div class="section-label">Part 1: Runner Drain</div>
+    <a href="#p1-root-cause">Root Cause</a>
+    <a href="#p1-design">Design</a>
+    <a href="#p1-files">File Changes</a>
+    <a href="#p1-sequence">Sequence Diagram</a>
+    <div class="section-label">Part 2: API Hold</div>
+    <a href="#p2-root-cause">Root Cause</a>
+    <a href="#p2-design">Design</a>
+    <a href="#p2-activity">New Activity</a>
+    <a href="#p2-signal-change">Signal Change</a>
+    <div class="section-label">Summary</div>
+    <a href="#edge-cases">Edge Cases</a>
+    <a href="#files-summary">Files Summary</a>
+    <a href="#verification">Verification</a>
+  </nav>
+
+  <main class="main">
+    <h1>Runner Process Shutdown Protection</h1>
+    <p class="subtitle">Plan review document &mdash; click any section to leave inline comments</p>
+
+    <!-- CONTEXT -->
+    <section id="context">
+      <h2>Context</h2>
+      <div class="commentable" data-section="context">
+        <p>When a runner process shutdown is requested (e.g., at 8-hour rotation), two things go wrong:</p>
+        <ol>
+          <li><strong>In-flight jobs get killed</strong> &mdash; the <code>jobLoop</code> context is cancelled, terminating the running job</li>
+          <li><strong>New jobs queued during shutdown get stuck</strong> &mdash; the <code>processjob</code> signal marks jobs "available" for a draining runner that will never pick them up, leading to timeout</li>
+        </ol>
+        <p>Two changes needed:</p>
+        <ol>
+          <li><strong>Runner-side drain:</strong> Stop accepting new jobs, finish the in-flight job, then shut down</li>
+          <li><strong>API-side hold:</strong> The <code>processjob</code> signal should not dispatch a job to a runner with a pending shutdown &mdash; wait until shutdown completes and a new healthy process appears</li>
+        </ol>
+      </div>
+    </section>
+
+    <!-- PART 1 -->
+    <section id="part1">
+      <h2>Part 1: Runner-Side Drain</h2>
+
+      <div id="p1-root-cause" class="commentable" data-section="p1-root-cause">
+        <h3>Root Cause</h3>
+        <p>The <code>jobLoop</code> uses a single <code>ctx</code>/<code>ctxCancel</code> for both polling and job execution. <code>Stop()</code> cancels everything simultaneously. The <code>ShutdownPoller</code> and <code>jobLoop</code> are decoupled FX components &mdash; the only coordination path is <code>fx.Shutdowner.Shutdown()</code> which triggers all <code>OnStop</code> hooks including the job loop's <code>Stop()</code>.</p>
+      </div>
+
+      <div id="p1-design" class="commentable" data-section="p1-design">
+        <h3>Design: Drainer + Two-Context Separation</h3>
+
+        <h4>New: <code>bins/runner/internal/pkg/jobloop/drain.go</code></h4>
+        <p>An FX singleton that the <code>ShutdownPoller</code> signals and all <code>jobLoop</code> instances listen to.</p>
+        <pre><code><span class="keyword">type</span> <span class="type">Drainer</span> <span class="keyword">struct</span> {
+    drainOnce <span class="type">sync.Once</span>
+    drainCh   <span class="keyword">chan struct</span>{}   <span class="comment">// closed when Drain() is called</span>
+    mu        <span class="type">sync.Mutex</span>
+    doneChs   []&lt;-<span class="keyword">chan struct</span>{} <span class="comment">// one per job loop</span>
+}</code></pre>
+        <p>Methods:</p>
+        <ul>
+          <li><code>NewDrainer() *Drainer</code> &mdash; FX constructor</li>
+          <li><code>Register(ch &lt;-chan struct{})</code> &mdash; each job loop registers its done channel</li>
+          <li><code>Drain()</code> &mdash; closes <code>drainCh</code>, signaling all loops to stop</li>
+          <li><code>DrainCh() &lt;-chan struct{}</code> &mdash; for loops to <code>select</code> on</li>
+          <li><code>Wait(timeout) error</code> &mdash; blocks until all done channels close or timeout</li>
+        </ul>
+
+        <h4>Two-Context Split in <code>jobLoop</code></h4>
+        <p>Replace the single <code>ctx</code>/<code>ctxCancel</code> with:</p>
+        <ul>
+          <li><code>pollCtx</code> / <code>pollCancel</code> &mdash; controls the polling loop; cancelled on drain</li>
+          <li><code>jobCtx</code> / <code>jobCancel</code> &mdash; controls in-flight job execution; only cancelled on hard stop</li>
+        </ul>
+      </div>
+
+      <div id="p1-files" class="commentable" data-section="p1-files">
+        <h3>File Changes</h3>
+
+        <h4><code>jobloop.go</code></h4>
+        <ul>
+          <li>Replace <code>ctx</code>/<code>ctxCancel</code> &rarr; <code>pollCtx</code>/<code>pollCancel</code> + <code>jobCtx</code>/<code>jobCancel</code></li>
+          <li>Add <code>drainer *Drainer</code> and <code>jobDoneCh chan struct{}</code></li>
+          <li>Register <code>jobDoneCh</code> with drainer in <code>New()</code></li>
+        </ul>
+
+        <h4><code>base_params.go</code></h4>
+        <ul><li>Add <code>Drainer *Drainer</code> to <code>BaseParams</code></li></ul>
+
+        <h4><code>worker.go</code></h4>
+        <ul>
+          <li>Top-of-loop: <code>j.pollCtx.Done()</code> instead of <code>j.ctx.Done()</code></li>
+          <li>Drain check via <code>j.drainer.DrainCh()</code> &mdash; if draining with no in-flight job, close <code>jobDoneCh</code>, return</li>
+          <li><code>j.executeJob(j.jobCtx, job)</code> &mdash; drain doesn't cancel in-flight jobs</li>
+          <li>After <code>executeJob</code>, re-check drain</li>
+          <li><code>fetchAvailableJobs()</code>: derive timeout from <code>j.pollCtx</code></li>
+          <li><code>runWorker()</code>: gate <code>os.Exit(155)</code> &mdash; skip if draining</li>
+        </ul>
+
+        <h4><code>lifecycle.go</code></h4>
+        <ul>
+          <li>Add <code>Drain()</code>: calls <code>j.pollCancel()</code></li>
+          <li><code>Stop()</code>: cancel both <code>pollCancel()</code> and <code>jobCancel()</code>, then wait</li>
+        </ul>
+
+        <h4><code>shutdown_poller.go</code></h4>
+        <p>New flow when shutdown is <code>"requested"</code>:</p>
+        <ol>
+          <li><code>UpdateProcess()</code> &rarr; status <code>"pending-shutdown"</code></li>
+          <li><code>drainer.Drain()</code> &mdash; all job loops stop accepting new jobs</li>
+          <li><code>drainer.Wait(30m)</code> &mdash; block until in-flight jobs complete</li>
+          <li><code>UpdateProcess()</code> &rarr; status <code>"shutting-down"</code></li>
+          <li><code>CompleteShutdown()</code> (moved to after drain)</li>
+          <li>Existing pod/VM shutdown logic (unchanged)</li>
+          <li>Force-exit + <code>fx.Shutdowner.Shutdown()</code> (5s post-drain)</li>
+        </ol>
+
+        <h4><code>cli.go</code></h4>
+        <ul><li>Add <code>fx.Provide(jobloop.NewDrainer)</code> to <code>commonProviders()</code></li></ul>
+      </div>
+
+      <!-- INTERACTIVE SEQUENCE DIAGRAM -->
+      <div id="p1-sequence">
+        <h3>Sequence Diagram</h3>
+        <div class="diagram-container">
+          <div class="diagram-controls">
+            <button class="active" onclick="setDiagramMode('auto')">Auto-play</button>
+            <button onclick="setDiagramMode('step')">Step through</button>
+            <button onclick="resetDiagram()" style="margin-left:auto">Reset</button>
+          </div>
+          <svg class="seq-svg" viewBox="0 0 820 640" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <marker id="arrowGreen" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+                <path d="M0,0 L10,4 L0,8" fill="#3fb950" />
+              </marker>
+              <marker id="arrowPurple" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+                <path d="M0,0 L10,4 L0,8" fill="#bc8cff" />
+              </marker>
+              <marker id="arrowOrange" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+                <path d="M0,0 L10,4 L0,8" fill="#d29922" />
+              </marker>
+            </defs>
+
+            <!-- Actor labels -->
+            <rect class="actor-box" x="40" y="10" width="130" height="32" />
+            <text x="105" y="31" text-anchor="middle" fill="#58a6ff" font-size="13" font-weight="600">ctl-api</text>
+            <rect class="actor-box" x="280" y="10" width="160" height="32" />
+            <text x="360" y="31" text-anchor="middle" fill="#58a6ff" font-size="13" font-weight="600">ShutdownPoller</text>
+            <rect class="actor-box" x="570" y="10" width="130" height="32" />
+            <text x="635" y="31" text-anchor="middle" fill="#58a6ff" font-size="13" font-weight="600">jobLoop (worker)</text>
+
+            <!-- Lanes -->
+            <line class="lane" x1="105" y1="46" x2="105" y2="620" />
+            <line class="lane" x1="360" y1="46" x2="360" y2="620" />
+            <line class="lane" x1="635" y1="46" x2="635" y2="620" />
+
+            <!-- Step 1: Shutdown requested -->
+            <g class="step-group" data-step="0">
+              <line x1="105" y1="80" x2="350" y2="80" stroke="#3fb950" stroke-width="2" marker-end="url(#arrowGreen)" />
+              <rect x="145" y="66" width="160" height="22" rx="4" fill="#161b22" />
+              <text x="225" y="81" text-anchor="middle" fill="#e6edf3" font-size="11">shutdown "requested"</text>
+            </g>
+
+            <!-- Step 2: Update process pending-shutdown -->
+            <g class="step-group" data-step="1">
+              <line x1="360" y1="115" x2="115" y2="115" stroke="#bc8cff" stroke-width="2" marker-end="url(#arrowPurple)" />
+              <rect class="action-box" x="125" y="102" width="225" height="22" />
+              <text x="237" y="117" text-anchor="middle" fill="#d29922" font-size="11">UpdateProcess("pending-shutdown")</text>
+            </g>
+
+            <!-- Step 3: Drain signal -->
+            <g class="step-group" data-step="2">
+              <line x1="360" y1="155" x2="625" y2="155" stroke="#3fb950" stroke-width="2" marker-end="url(#arrowGreen)" />
+              <rect x="420" y="141" width="140" height="22" rx="4" fill="#161b22" />
+              <text x="490" y="156" text-anchor="middle" fill="#3fb950" font-size="11" font-weight="600">drainer.Drain()</text>
+            </g>
+
+            <!-- Step 4: pollCtx cancelled -->
+            <g class="step-group" data-step="3">
+              <rect class="action-box hl" x="560" y="180" width="150" height="22" />
+              <text x="635" y="195" text-anchor="middle" fill="#3fb950" font-size="11">pollCtx cancelled</text>
+              <rect class="action-box hl" x="560" y="210" width="150" height="22" />
+              <text x="635" y="225" text-anchor="middle" fill="#3fb950" font-size="11">stops polling for jobs</text>
+            </g>
+
+            <!-- Step 5: Wait -->
+            <g class="step-group" data-step="4">
+              <rect class="action-box wait" x="295" y="250" width="135" height="22" />
+              <text x="362" y="265" text-anchor="middle" fill="#d29922" font-size="11">drainer.Wait(30m)</text>
+              <line x1="360" y1="280" x2="360" y2="360" stroke="#d29922" stroke-width="2" stroke-dasharray="4 3" />
+              <rect x="370" y="305" width="100" height="20" rx="4" fill="#161b22" />
+              <text x="420" y="319" text-anchor="middle" fill="#8b949e" font-size="10">waiting...</text>
+            </g>
+
+            <!-- Step 6: Job finishes -->
+            <g class="step-group" data-step="5">
+              <rect class="action-box hl" x="555" y="290" width="160" height="22" />
+              <text x="635" y="305" text-anchor="middle" fill="#e6edf3" font-size="11">in-flight job finishes</text>
+              <line x1="635" y1="335" x2="370" y2="335" stroke="#bc8cff" stroke-width="2" marker-end="url(#arrowPurple)" />
+              <rect x="420" y="322" width="160" height="22" rx="4" fill="#161b22" />
+              <text x="500" y="337" text-anchor="middle" fill="#bc8cff" font-size="11">close(jobDoneCh)</text>
+            </g>
+
+            <!-- Step 7: Shutting down -->
+            <g class="step-group" data-step="6">
+              <line x1="360" y1="385" x2="115" y2="385" stroke="#bc8cff" stroke-width="2" marker-end="url(#arrowPurple)" />
+              <rect class="action-box" x="130" y="372" width="220" height="22" />
+              <text x="240" y="387" text-anchor="middle" fill="#d29922" font-size="11">UpdateProcess("shutting-down")</text>
+            </g>
+
+            <!-- Step 8: Complete shutdown -->
+            <g class="step-group" data-step="7">
+              <line x1="360" y1="420" x2="115" y2="420" stroke="#bc8cff" stroke-width="2" marker-end="url(#arrowPurple)" />
+              <rect class="action-box" x="148" y="407" width="180" height="22" />
+              <text x="238" y="422" text-anchor="middle" fill="#e6edf3" font-size="11">CompleteShutdown()</text>
+            </g>
+
+            <!-- Step 9: fx.Shutdown -->
+            <g class="step-group" data-step="8">
+              <rect class="action-box" x="295" y="455" width="130" height="22" />
+              <text x="360" y="470" text-anchor="middle" fill="#f85149" font-size="11">fx.Shutdown()</text>
+            </g>
+
+            <!-- Step 10: Final status -->
+            <g class="step-group" data-step="9">
+              <line x1="360" y1="500" x2="115" y2="500" stroke="#bc8cff" stroke-width="2" marker-end="url(#arrowPurple)" />
+              <rect class="action-box" x="130" y="487" width="220" height="22" />
+              <text x="240" y="502" text-anchor="middle" fill="#f85149" font-size="11">process.stop() &rarr; "shut-down"</text>
+            </g>
+
+            <!-- Status bar at bottom -->
+            <g class="step-group" data-step="9">
+              <rect x="40" y="545" width="720" height="55" rx="8" fill="#161b22" stroke="#30363d" />
+              <text x="60" y="570" fill="#8b949e" font-size="11">Status transitions:</text>
+              <rect x="60" y="578" width="55" height="16" rx="4" fill="#238636" />
+              <text x="87" y="590" text-anchor="middle" fill="#fff" font-size="9" font-weight="600">active</text>
+              <text x="125" y="590" fill="#8b949e" font-size="12">&rarr;</text>
+              <rect x="140" y="578" width="110" height="16" rx="4" fill="#d29922" />
+              <text x="195" y="590" text-anchor="middle" fill="#000" font-size="9" font-weight="600">pending-shutdown</text>
+              <text x="260" y="590" fill="#8b949e" font-size="12">&rarr;</text>
+              <rect x="275" y="578" width="95" height="16" rx="4" fill="#da3633" />
+              <text x="322" y="590" text-anchor="middle" fill="#fff" font-size="9" font-weight="600">shutting-down</text>
+              <text x="380" y="590" fill="#8b949e" font-size="12">&rarr;</text>
+              <rect x="395" y="578" width="70" height="16" rx="4" fill="#8b949e" />
+              <text x="430" y="590" text-anchor="middle" fill="#000" font-size="9" font-weight="600">shut-down</text>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </section>
+
+    <!-- PART 2 -->
+    <section id="part2">
+      <h2>Part 2: API-Side &mdash; Hold Jobs During Runner Shutdown</h2>
+
+      <div id="p2-root-cause" class="commentable" data-section="p2-root-cause">
+        <h3>Root Cause</h3>
+        <p>In <code>processjob</code> signal's <code>startJobExecution()</code>, the runner health-wait loop (lines 251-313) only checks if the runner status is <code>active</code>. It doesn't check whether the runner's process has a pending shutdown. So it marks the job "available" and the draining runner ignores it, leading to <code>AvailableTimeout</code> expiry.</p>
+      </div>
+
+      <div id="p2-design" class="commentable" data-section="p2-design">
+        <h3>Design: Shutdown-Aware Health Loop</h3>
+        <p>The <code>startJobExecution()</code> health loop already polls runner status. We add a check: <strong>does this runner have an open (requested/in-progress) process shutdown?</strong> If yes, keep waiting &mdash; don't mark the job available yet.</p>
+        <div class="callout">
+          The loop becomes: "wait until runner is <code>active</code> AND no pending shutdown exists."
+        </div>
+      </div>
+
+      <div id="p2-activity" class="commentable" data-section="p2-activity">
+        <h3>New Activity: <code>HasOpenProcessShutdown</code></h3>
+        <p>File: <code>services/ctl-api/.../activities/has_open_process_shutdown.go</code></p>
+        <pre><code><span class="keyword">type</span> <span class="type">HasOpenProcessShutdownRequest</span> <span class="keyword">struct</span> {
+    RunnerID <span class="type">string</span> <span class="string">`validate:"required"`</span>
+}
+
+<span class="keyword">type</span> <span class="type">HasOpenProcessShutdownResponse</span> <span class="keyword">struct</span> {
+    HasOpenShutdown <span class="type">bool</span>
+}
+
+<span class="comment">// @temporal-gen-v2 activity</span>
+<span class="comment">// @by-field RunnerID</span>
+<span class="keyword">func</span> (a *<span class="type">Activities</span>) <span class="func">HasOpenProcessShutdown</span>(
+    ctx <span class="type">context.Context</span>,
+    req <span class="type">HasOpenProcessShutdownRequest</span>,
+) (*<span class="type">HasOpenProcessShutdownResponse</span>, <span class="type">error</span>) {
+    <span class="keyword">var</span> count <span class="type">int64</span>
+    res := a.db.WithContext(ctx).
+        Model(&amp;app.<span class="type">RunnerProcessShutdown</span>{}).
+        Joins(<span class="string">"JOIN runner_processes ON ..."</span>).
+        Where(<span class="string">"composite_status->>'status' IN ?"</span>,
+            []<span class="type">string</span>{<span class="string">"requested"</span>, <span class="string">"in-progress"</span>}).
+        Count(&amp;count)
+    <span class="keyword">return</span> &amp;<span class="type">HasOpenProcessShutdownResponse</span>{
+        HasOpenShutdown: count > 0,
+    }, res.Error
+}</code></pre>
+        <p>Follows the exact pattern from <code>hasOpenProcessShutdown()</code> in <code>report_runner_process_terminating.go</code>, but as a Temporal activity querying by runner ID.</p>
+      </div>
+
+      <div id="p2-signal-change" class="commentable" data-section="p2-signal-change">
+        <h3>Signal Change: <code>processjob/signal.go</code></h3>
+        <p>In <code>startJobExecution()</code>, the runner-health polling loop changes from:</p>
+        <pre><code><span class="keyword">for</span> attempt := 0; ; attempt++ {
+    runnerStatus = <span class="func">AwaitGetRunnerStatusByID</span>(...)
+    <span class="keyword">if</span> runnerStatus == active { <span class="keyword">break</span> }
+    <span class="comment">// ... timeout checks ...</span>
+    workflow.Sleep(ctx, pollPeriod(attempt))
+}</code></pre>
+        <p>To:</p>
+        <pre><code><span class="keyword">for</span> attempt := 0; ; attempt++ {
+    runnerStatus = <span class="func">AwaitGetRunnerStatusByID</span>(...)
+    shutdownResp = <span class="func">AwaitHasOpenProcessShutdown</span>(...)
+
+    <span class="keyword">if</span> runnerStatus == active &amp;&amp; !shutdownResp.HasOpenShutdown {
+        <span class="keyword">break</span>  <span class="comment">// healthy AND no pending shutdown</span>
+    }
+
+    <span class="comment">// ... existing timeout checks ...</span>
+    workflow.Sleep(ctx, pollPeriod(attempt))
+}</code></pre>
+        <p>The job stays in this loop until the old process drains, shuts down, a new process starts and becomes <code>active</code>, and no open shutdown records remain. Then the job is marked "available" and the new process picks it up.</p>
+        <div class="callout warn">
+          <strong>Safety nets preserved:</strong> The existing <code>AvailableTimeout</code> and <code>OverallTimeout</code> still apply. If a new process never comes up, the job eventually times out.
+        </div>
+      </div>
+    </section>
+
+    <!-- EDGE CASES -->
+    <section id="edge-cases">
+      <h2>Edge Cases</h2>
+      <div class="commentable" data-section="edge-cases">
+        <div class="edge-case-grid">
+          <div class="edge-card">
+            <strong>No in-flight job at drain</strong>
+            <p><code>pollCtx</code> cancellation interrupts fetch/sleep. Worker exits immediately, <code>Wait()</code> returns instantly.</p>
+          </div>
+          <div class="edge-card">
+            <strong>Long-poll blocking</strong>
+            <p><code>fetchAvailableJobs</code> derives timeout from <code>pollCtx</code>. Cancellation aborts the HTTP request.</p>
+          </div>
+          <div class="edge-card">
+            <strong>mng process</strong>
+            <p>Gets a <code>Drainer</code> injected &mdash; harmless if no job is running. Management jobs are short-lived.</p>
+          </div>
+          <div class="edge-card">
+            <strong>Drain timeout (30m)</strong>
+            <p>Shutdown proceeds anyway. <code>fx.Shutdown</code> triggers hard stop via <code>jobCancel()</code>.</p>
+          </div>
+          <div class="edge-card">
+            <strong><code>os.Exit(155)</code> in runWorker</strong>
+            <p>Must not fire during drain &mdash; check drainer state before calling exit.</p>
+          </div>
+          <div class="edge-card">
+            <strong>Job queued during shutdown</strong>
+            <p><code>processjob</code> signal holds in health loop until new process is active with no open shutdown.</p>
+          </div>
+          <div class="edge-card">
+            <strong>Runner never restarts</strong>
+            <p><code>OverallTimeout</code> eventually marks the job as timed out.</p>
+          </div>
+          <div class="edge-card">
+            <strong>Multiple shutdowns</strong>
+            <p><code>HasOpenProcessShutdown</code> counts any open shutdown, so stacked requests are handled.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- FILES SUMMARY -->
+    <section id="files-summary">
+      <h2>Files Summary</h2>
+      <div class="commentable" data-section="files-summary">
+        <table>
+          <thead>
+            <tr><th>File</th><th>Change</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>bins/runner/.../jobloop/drain.go</code></td><td><span class="badge badge-new">NEW</span> Drainer coordinator</td></tr>
+            <tr><td><code>bins/runner/.../jobloop/jobloop.go</code></td><td><span class="badge badge-modify">MODIFY</span> Split context, add drainer</td></tr>
+            <tr><td><code>bins/runner/.../jobloop/base_params.go</code></td><td><span class="badge badge-modify">MODIFY</span> Add Drainer to BaseParams</td></tr>
+            <tr><td><code>bins/runner/.../jobloop/worker.go</code></td><td><span class="badge badge-modify">MODIFY</span> pollCtx/jobCtx, drain checks</td></tr>
+            <tr><td><code>bins/runner/.../jobloop/lifecycle.go</code></td><td><span class="badge badge-modify">MODIFY</span> Add Drain(), update Stop()</td></tr>
+            <tr><td><code>bins/runner/.../process/shutdown_poller.go</code></td><td><span class="badge badge-modify">MODIFY</span> Drain-then-shutdown flow</td></tr>
+            <tr><td><code>bins/runner/cmd/cli.go</code></td><td><span class="badge badge-modify">MODIFY</span> Provide Drainer in FX</td></tr>
+            <tr><td><code>services/ctl-api/.../activities/has_open_process_shutdown.go</code></td><td><span class="badge badge-new">NEW</span> Temporal activity</td></tr>
+            <tr><td><code>services/ctl-api/.../signals/processjob/signal.go</code></td><td><span class="badge badge-modify">MODIFY</span> Check shutdown in health loop</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- VERIFICATION -->
+    <section id="verification">
+      <h2>Verification</h2>
+      <div class="commentable" data-section="verification">
+        <ol>
+          <li><strong>Unit test:</strong> <code>drain_test.go</code> &mdash; register done channels, drain, verify wait</li>
+          <li><strong>Build runner:</strong> <code>cd bins/runner && go build ./...</code></li>
+          <li><strong>Runner tests:</strong> <code>cd bins/runner && go test ./...</code></li>
+          <li><strong>Code gen:</strong> <code>go generate ./services/ctl-api/...</code></li>
+          <li><strong>API build:</strong> <code>cd services/ctl-api && go build ./...</code></li>
+          <li><strong>Manual test:</strong> Start runner, submit long job, trigger shutdown &rarr; verify drain completes, job finishes, new process picks up subsequent jobs</li>
+        </ol>
+      </div>
+    </section>
+  </main>
+</div>
+
+<!-- Comment panel -->
+<div id="comment-panel">
+  <h3>All Comments</h3>
+  <div id="panel-comments"></div>
+  <p style="color:var(--text-muted); font-size:13px; margin-top:16px;">Comments are saved as individual files in<br><code style="font-size:11px">plans/shutdown-protection/comments/</code></p>
+</div>
+<button id="toggle-panel" onclick="togglePanel()">
+  Comments <span id="comment-total">0</span>
+</button>
+
+<script>
+// =========================================================
+// Inline commenting system — saves each comment as a file
+// readable by the Claude agent.
+// =========================================================
+
+const STORAGE_KEY = 'shutdown-plan-comments';
+let comments = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+let panelOpen = false;
+
+function togglePanel() {
+  panelOpen = !panelOpen;
+  document.getElementById('comment-panel').classList.toggle('open', panelOpen);
+}
+
+function renderAllComments() {
+  // Render inline threads
+  document.querySelectorAll('.comment-thread').forEach(t => {
+    const section = t.dataset.section;
+    const threadComments = comments.filter(c => c.section === section);
+    const container = t.querySelector('.thread-comments');
+    container.innerHTML = threadComments.map(c => `
+      <div class="saved-comment">
+        <div class="comment-meta">${new Date(c.timestamp).toLocaleString()}</div>
+        ${escapeHtml(c.text)}
+      </div>
+    `).join('');
+  });
+
+  // Render panel
+  const panel = document.getElementById('panel-comments');
+  panel.innerHTML = comments.length === 0
+    ? '<p style="color:var(--text-muted);font-size:14px;">No comments yet. Click any section to add one.</p>'
+    : comments.map(c => `
+      <div class="panel-comment">
+        <div class="pc-section">${c.section}</div>
+        <div class="pc-text">${escapeHtml(c.text)}</div>
+        <div class="pc-time">${new Date(c.timestamp).toLocaleString()}</div>
+      </div>
+    `).join('');
+
+  // Update badge counts
+  document.getElementById('comment-total').textContent = comments.length;
+  document.querySelectorAll('.commentable').forEach(el => {
+    const section = el.dataset.section;
+    const count = comments.filter(c => c.section === section).length;
+    const existing = el.querySelector('.comment-count');
+    if (existing) existing.remove();
+    if (count > 0) {
+      const badge = document.createElement('span');
+      badge.className = 'comment-count';
+      badge.textContent = count;
+      (el.querySelector('h3') || el.querySelector('h4') || el).prepend(badge);
+    }
+  });
+}
+
+function saveComment(section, text) {
+  const comment = {
+    id: 'comment-' + Date.now(),
+    section: section,
+    text: text.trim(),
+    timestamp: new Date().toISOString()
+  };
+  comments.push(comment);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(comments));
+
+  // "Save" to file by creating a downloadable blob and also posting
+  // the comment data into a hidden form that writes to disk via the
+  // save-comments endpoint (see below for the static fallback).
+  saveCommentFile(comment);
+  renderAllComments();
+}
+
+function saveCommentFile(comment) {
+  // POST to local server which writes the file to comments/ directory
+  fetch('/save-comment', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(comment)
+  }).then(r => r.json()).then(data => {
+    console.log('Comment saved to:', data.file);
+  }).catch(err => {
+    console.warn('Could not save comment to server (run serve.sh):', err);
+  });
+}
+
+function exportAllComments() {
+  if (comments.length === 0) { alert('No comments to export.'); return; }
+  comments.forEach(c => {
+    const content = [
+      '---', 'section: ' + c.section, 'timestamp: ' + c.timestamp,
+      'id: ' + c.id, '---', '', c.text, ''
+    ].join('\n');
+    const blob = new Blob([content], { type: 'text/markdown' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = c.id + '.md';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  });
+}
+
+function dumpCommentsToSingleFile() {
+  if (comments.length === 0) { alert('No comments to export.'); return; }
+  const lines = comments.map(c => [
+    '## ' + c.section,
+    '*' + new Date(c.timestamp).toLocaleString() + '*',
+    '', c.text, '', '---', ''
+  ].join('\n'));
+  const blob = new Blob([lines.join('\n')], { type: 'text/markdown' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'all-comments.md';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+// Attach click handlers to commentable sections
+document.querySelectorAll('.commentable').forEach(el => {
+  const section = el.dataset.section;
+
+  // Create thread container
+  const thread = document.createElement('div');
+  thread.className = 'comment-thread';
+  thread.dataset.section = section;
+  thread.innerHTML = `
+    <div class="thread-comments"></div>
+    <textarea placeholder="Leave a comment on this section..."></textarea>
+    <button onclick="submitComment(this, '${section}')">Save Comment</button>
+    <button class="cancel" onclick="this.closest('.comment-thread').classList.remove('open')">Cancel</button>
+  `;
+  el.after(thread);
+
+  el.addEventListener('click', (e) => {
+    if (e.target.tagName === 'A' || e.target.tagName === 'CODE') return;
+    thread.classList.toggle('open');
+    if (thread.classList.contains('open')) {
+      thread.querySelector('textarea').focus();
+    }
+  });
+});
+
+function submitComment(btn, section) {
+  const thread = btn.closest('.comment-thread');
+  const textarea = thread.querySelector('textarea');
+  const text = textarea.value.trim();
+  if (!text) return;
+  saveComment(section, text);
+  textarea.value = '';
+}
+
+// Add export button to panel
+const exportBtn = document.createElement('button');
+exportBtn.textContent = 'Export All Comments';
+exportBtn.style.cssText = 'margin-top:16px;padding:8px 16px;background:var(--surface2);border:1px solid var(--border);border-radius:6px;color:var(--text);cursor:pointer;font-size:13px;width:100%;';
+exportBtn.onclick = dumpCommentsToSingleFile;
+document.getElementById('comment-panel').appendChild(exportBtn);
+
+renderAllComments();
+
+// =========================================================
+// Interactive sequence diagram
+// =========================================================
+
+let diagramMode = 'auto';
+let currentStep = -1;
+const totalSteps = 10;
+let autoTimer = null;
+
+function setDiagramMode(mode) {
+  diagramMode = mode;
+  document.querySelectorAll('.diagram-controls button').forEach(b => b.classList.remove('active'));
+  event.target.classList.add('active');
+  if (mode === 'auto') {
+    resetDiagram();
+    startAutoPlay();
+  } else {
+    stopAutoPlay();
+  }
+}
+
+function resetDiagram() {
+  stopAutoPlay();
+  currentStep = -1;
+  document.querySelectorAll('.step-group').forEach(g => g.classList.remove('visible'));
+  if (diagramMode === 'auto') startAutoPlay();
+}
+
+function showStep(n) {
+  if (n < 0 || n >= totalSteps) return;
+  document.querySelectorAll(`.step-group[data-step="${n}"]`).forEach(g => g.classList.add('visible'));
+  currentStep = n;
+}
+
+function startAutoPlay() {
+  stopAutoPlay();
+  let step = 0;
+  autoTimer = setInterval(() => {
+    showStep(step);
+    step++;
+    if (step >= totalSteps) stopAutoPlay();
+  }, 800);
+}
+
+function stopAutoPlay() {
+  if (autoTimer) { clearInterval(autoTimer); autoTimer = null; }
+}
+
+// Step-through on click
+document.querySelector('.diagram-container').addEventListener('click', (e) => {
+  if (diagramMode !== 'step') return;
+  if (e.target.tagName === 'BUTTON') return;
+  showStep(currentStep + 1);
+});
+
+// Start auto-play on load
+startAutoPlay();
+
+// Sidebar active state
+const observer = new IntersectionObserver(entries => {
+  entries.forEach(e => {
+    if (e.isIntersecting) {
+      document.querySelectorAll('.sidebar a').forEach(a => a.classList.remove('active'));
+      const link = document.querySelector(`.sidebar a[href="#${e.target.id}"]`);
+      if (link) link.classList.add('active');
+    }
+  });
+}, { threshold: 0.3 });
+document.querySelectorAll('section[id], div[id]').forEach(s => observer.observe(s));
+</script>
+
+</body>
+</html>

--- a/plans/shutdown-protection/serve.sh
+++ b/plans/shutdown-protection/serve.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Serve the plan review document and handle comment saving.
+# Usage: ./serve.sh
+# Then open http://localhost:8899 in your browser.
+#
+# Comments you add inline will be saved as individual .md files
+# in the comments/ directory, readable by Claude.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+PORT=8899
+
+echo "Starting plan review server on http://localhost:$PORT"
+echo "Comments will be saved to: $(pwd)/comments/"
+echo ""
+
+python3 -c "
+import http.server
+import json
+import os
+import re
+from urllib.parse import urlparse
+
+COMMENTS_DIR = 'comments'
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_POST(self):
+        if self.path == '/save-comment':
+            length = int(self.headers['Content-Length'])
+            body = json.loads(self.rfile.read(length))
+
+            comment_id = body.get('id', 'comment-unknown')
+            section = body.get('section', 'unknown')
+            text = body.get('text', '')
+            timestamp = body.get('timestamp', '')
+
+            # Sanitize filename
+            safe_id = re.sub(r'[^a-zA-Z0-9_-]', '', comment_id)
+            filepath = os.path.join(COMMENTS_DIR, f'{safe_id}.md')
+
+            content = f'''---
+section: {section}
+timestamp: {timestamp}
+id: {comment_id}
+---
+
+{text}
+'''
+            os.makedirs(COMMENTS_DIR, exist_ok=True)
+            with open(filepath, 'w') as f:
+                f.write(content)
+
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('Access-Control-Allow-Origin', '*')
+            self.end_headers()
+            self.wfile.write(json.dumps({'ok': True, 'file': filepath}).encode())
+            print(f'  Saved comment: {filepath} (section: {section})')
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'POST, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+        self.end_headers()
+
+    def log_message(self, format, *args):
+        if '/save-comment' in str(args):
+            return  # already printed above
+        super().log_message(format, *args)
+
+http.server.HTTPServer(('', $PORT), Handler).serve_forever()
+"

--- a/services/ctl-api/internal/app/admin-dashboard/service/queue_signal_detail.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/queue_signal_detail.go
@@ -397,6 +397,31 @@ func (s *service) getWorkflowInfo(c *gin.Context, namespace, workflowID string) 
 	// Extract enqueued signals from EnqueueSignal activities
 	info.EnqueuedSignals = s.extractEnqueuedSignals(c, activities)
 
+	// Also extract enqueued signals from child workflows (e.g. ExecuteJob enqueues process_job)
+	seen := map[string]bool{}
+	for _, es := range info.EnqueuedSignals {
+		seen[es.QueueSignalID] = true
+	}
+	for _, cw := range childWorkflows {
+		if cw.WorkflowID == "" {
+			continue
+		}
+		cwNS := cw.Namespace
+		if cwNS == "" {
+			cwNS = namespace
+		}
+		childInfo := s.getWorkflowInfo(c, cwNS, cw.WorkflowID)
+		if childInfo == nil {
+			continue
+		}
+		for _, es := range childInfo.EnqueuedSignals {
+			if !seen[es.QueueSignalID] {
+				seen[es.QueueSignalID] = true
+				info.EnqueuedSignals = append(info.EnqueuedSignals, es)
+			}
+		}
+	}
+
 	// Build update executions by associating activities with updates based on event ID ranges
 	if len(updates) > 0 {
 		info.UpdateExecutions, info.OrphanActivities = s.buildUpdateExecutions(updates, activities, info.AwaitedSignals, info.EnqueuedSignals)

--- a/services/ctl-api/internal/app/runners/signals/processjob/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/processjob/signal.go
@@ -236,32 +236,149 @@ func (s *Signal) startJobExecution(ctx workflow.Context, job *app.RunnerJob) (bo
 		return false, false, err
 	}
 
-	availableStart := workflow.Now(ctx)
-	l.Info("marking job as available for runner to pick up")
-	s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusAvailable, "waiting for runner to reserve job")
-
-	start := workflow.Now(ctx)
 	overallTimeout := job.CreatedAt.Add(job.OverallTimeout)
-	availableTimeout := start.Add(job.AvailableTimeout)
 
 	var jobExecutionFound bool
 	var runnerStatus app.RunnerStatus
 
-	if job.Group != app.RunnerJobGroupOperations {
-		// Check the runner's health before sleeping. The common case is that the
-		// runner is already active when the job is enqueued, so checking first
-		// lets us proceed with zero wait instead of always burning a full
-		// pollPeriod on a bare workflow.Sleep before the first status check.
-		for attempt := 0; ; attempt++ {
-			runnerStatus, err = activities.AwaitGetRunnerStatusByID(ctx, job.RunnerID)
-			if err != nil {
-				l.Warn("unable to determine runner status", zap.Error(err))
-				return false, false, err
+	// Outer loop: health-wait → mark available → pickup-wait.
+	// If the pickup-wait times out because the runner is shutting down,
+	// we loop back to health-wait until a new process comes up.
+	for !jobExecutionFound {
+		availableStart := workflow.Now(ctx)
+		availableTimeout := availableStart.Add(job.AvailableTimeout)
+
+		if job.Group != app.RunnerJobGroupOperations {
+			// Wait until the runner is healthy AND has no pending shutdown.
+			for attempt := 0; ; attempt++ {
+				runnerStatus, err = activities.AwaitGetRunnerStatusByID(ctx, job.RunnerID)
+				if err != nil {
+					l.Warn("unable to determine runner status", zap.Error(err))
+					return false, false, err
+				}
+
+				shutdownResp, shutdownErr := activities.AwaitHasOpenProcessShutdown(ctx, activities.HasOpenProcessShutdownRequest{
+					RunnerID: job.RunnerID,
+				})
+				hasOpenShutdown := shutdownErr == nil && shutdownResp.HasOpenShutdown
+
+				if runnerStatus == app.RunnerStatusActive && !hasOpenShutdown {
+					break
+				}
+
+				if hasOpenShutdown {
+					l.Info("runner has pending shutdown, waiting for new process",
+						zap.String("runner_id", job.RunnerID),
+					)
+				}
+				etags["runner_status"] = string(runnerStatus)
+
+				jobStatus, err := activities.AwaitGetJobStatusByID(ctx, job.ID)
+				if err != nil {
+					return false, false, nil
+				}
+				if jobStatus == app.RunnerJobStatusCancelled {
+					l.Error("job was cancelled")
+					tags["status"] = "job_cancelled"
+					return false, false, nil
+				}
+
+				now := workflow.Now(ctx)
+				if now.After(overallTimeout) {
+					l.Error("overall job timeout reached")
+					s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusTimedOut, "overall timeout waiting for runner to be healthy")
+					tags["status"] = "runner_unhealthy"
+
+					s.mw.Event(ctx, &statsd.Event{
+						Title:          "Overall job timeout reached waiting for runner to become healthy",
+						Text:           "Overall end-to-end job execution timeout reached while waiting for job to bewcome healthy",
+						Tags:           metrics.ToTags(etags),
+						SourceTypeName: "nuon-jobsys",
+						Priority:       statsd.Normal,
+						AlertType:      statsd.Error,
+						AggregationKey: "runner-job-timeout-waiting-for-healthy-runner",
+					})
+					return false, false, nil
+				}
+
+				if now.After(availableTimeout) {
+					l.Error("timeout waiting for job to be picked up")
+					s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusTimedOut, "timeout waiting for runner to become healthy")
+					tags["status"] = "runner_unhealthy"
+
+					s.mw.Event(ctx, &statsd.Event{
+						Title:          "Available timeout reached waiting for runner to become healthy",
+						Text:           "Job is ready for execution, but runner did not become healthy within the available timeout",
+						Tags:           metrics.ToTags(etags),
+						SourceTypeName: "nuon-jobsys",
+						Priority:       statsd.Low,
+						AlertType:      statsd.Warning,
+						AggregationKey: "runner-job-timeout-waiting-for-healthy-runner",
+					})
+					return true, false, nil
+				}
+
+				workflow.Sleep(ctx, pollPeriod(attempt))
 			}
-			if runnerStatus == app.RunnerStatusActive {
-				break
+		}
+
+		// Runner is healthy — mark job available and reset the available timeout.
+		availableStart = workflow.Now(ctx)
+		availableTimeout = availableStart.Add(job.AvailableTimeout)
+		l.Info("marking job as available for runner to pick up")
+		s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusAvailable, "waiting for runner to reserve job")
+
+		// Poll until the job is picked up and an execution exists.
+		pickupCh := workflow.GetSignalChannel(ctx, PickupSignalName(job.ID))
+		retryHealthWait := false
+		for attempt := 0; !jobExecutionFound; attempt++ {
+			sleepOrSignal(ctx, pickupCh, pollPeriod(attempt))
+
+			now := workflow.Now(ctx)
+			if now.After(overallTimeout) {
+				l.Error("overall job timeout reached")
+				s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusTimedOut, "overall timeout")
+				tags["status"] = "overall_timeout"
+
+				etags["status"] = "overall_timeout"
+				s.mw.Event(ctx, &statsd.Event{
+					Title:          "Overall job timeout reached without job starting",
+					Text:           "Overall end-to-end job execution timeout reached without ever having been picked up",
+					Tags:           metrics.ToTags(etags),
+					SourceTypeName: "nuon-jobsys",
+					Priority:       statsd.Normal,
+					AlertType:      statsd.Error,
+					AggregationKey: "runner-job-timeout-awaiting-job-pickup",
+				})
+				return false, false, nil
 			}
-			etags["runner_status"] = string(runnerStatus)
+
+			if now.After(availableTimeout) {
+				shutdownResp, shutdownErr := activities.AwaitHasOpenProcessShutdown(ctx, activities.HasOpenProcessShutdownRequest{
+					RunnerID: job.RunnerID,
+				})
+				if shutdownErr == nil && shutdownResp.HasOpenShutdown {
+					l.Info("available timeout reached but runner has pending shutdown, waiting for new process before retrying")
+					retryHealthWait = true
+					break
+				}
+
+				l.Error("timeout waiting for job to be picked up")
+				s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusTimedOut, "timeout waiting for runner to pick up job")
+				tags["status"] = "available_timeout"
+
+				etags["status"] = "available_timeout"
+				s.mw.Event(ctx, &statsd.Event{
+					Title:          "Timeout waiting for runner job to be picked up",
+					Text:           "Job was marked as ready for execution, and runner appears to be in a healthy state, but runner did not pick up the job within the available timeout",
+					Tags:           metrics.ToTags(etags),
+					SourceTypeName: "nuon-jobsys",
+					Priority:       statsd.Normal,
+					AlertType:      statsd.Error,
+					AggregationKey: "runner-job-timeout-awaiting-job-pickup",
+				})
+				return true, false, nil
+			}
 
 			jobStatus, err := activities.AwaitGetJobStatusByID(ctx, job.ID)
 			if err != nil {
@@ -273,109 +390,19 @@ func (s *Signal) startJobExecution(ctx workflow.Context, job *app.RunnerJob) (bo
 				return false, false, nil
 			}
 
-			now := workflow.Now(ctx)
-			if now.After(overallTimeout) {
-				l.Error("overall job timeout reached")
-				s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusTimedOut, "overall timeout waiting for runner to be healthy")
-				tags["status"] = "runner_unhealthy"
-
-				s.mw.Event(ctx, &statsd.Event{
-					Title:          "Overall job timeout reached waiting for runner to become healthy",
-					Text:           "Overall end-to-end job execution timeout reached while waiting for job to bewcome healthy",
-					Tags:           metrics.ToTags(etags),
-					SourceTypeName: "nuon-jobsys",
-					Priority:       statsd.Normal,
-					AlertType:      statsd.Error,
-					AggregationKey: "runner-job-timeout-waiting-for-healthy-runner",
-				})
-				return false, false, nil
-			}
-
-			if now.After(availableTimeout) {
-				l.Error("timeout waiting for job to be picked up")
-				s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusTimedOut, "timeout waiting for runner to become healthy")
-				tags["status"] = "runner_unhealthy"
-
-				s.mw.Event(ctx, &statsd.Event{
-					Title:          "Available timeout reached waiting for runner to become healthy",
-					Text:           "Job is ready for execution, but runner did not become healthy within the available timeout",
-					Tags:           metrics.ToTags(etags),
-					SourceTypeName: "nuon-jobsys",
-					Priority:       statsd.Low,
-					AlertType:      statsd.Warning,
-					AggregationKey: "runner-job-timeout-waiting-for-healthy-runner",
-				})
-				return true, false, nil
-			}
-
-			// Runner not yet healthy — wait out a poll tick before re-checking.
-			workflow.Sleep(ctx, pollPeriod(attempt))
-		}
-	}
-
-	// poll until the job is picked up, and an execution exists. The
-	// CreateRunnerJobExecution handler signals this channel the moment the
-	// runner reserves the job, so we usually wake on the first tick instead
-	// of sleeping out a full pollPeriod.
-	pickupCh := workflow.GetSignalChannel(ctx, PickupSignalName(job.ID))
-	for attempt := 0; !jobExecutionFound; attempt++ {
-		sleepOrSignal(ctx, pickupCh, pollPeriod(attempt))
-
-		now := workflow.Now(ctx)
-		if now.After(overallTimeout) {
-			l.Error("overall job timeout reached")
-			s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusTimedOut, "overall timeout")
-			tags["status"] = "overall_timeout"
-
-			etags["status"] = "overall_timeout"
-			s.mw.Event(ctx, &statsd.Event{
-				Title:          "Overall job timeout reached without job starting",
-				Text:           "Overall end-to-end job execution timeout reached without ever having been picked up",
-				Tags:           metrics.ToTags(etags),
-				SourceTypeName: "nuon-jobsys",
-				Priority:       statsd.Normal,
-				AlertType:      statsd.Error,
-				AggregationKey: "runner-job-timeout-awaiting-job-pickup",
+			jobExecutionResp, err := activities.AwaitGetLatestJobExecution(ctx, activities.GetLatestJobExecutionRequest{
+				JobID:       job.ID,
+				AvailableAt: availableStart,
 			})
-			return false, false, nil
+			if err != nil {
+				return false, false, fmt.Errorf("error fetching latest job execution: %w", err)
+			}
+			jobExecutionFound = jobExecutionResp.Found
 		}
 
-		if now.After(availableTimeout) {
-			l.Error("timeout waiting for job to be picked up")
-			s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusTimedOut, "timeout waiting for runner to pick up job")
-			tags["status"] = "available_timeout"
-
-			etags["status"] = "available_timeout"
-			s.mw.Event(ctx, &statsd.Event{
-				Title:          "Timeout waiting for runner job to be picked up",
-				Text:           "Job was marked as ready for execution, and runner appears to be in a healthy state, but runner did not pick up the job within the available timeout",
-				Tags:           metrics.ToTags(etags),
-				SourceTypeName: "nuon-jobsys",
-				Priority:       statsd.Normal,
-				AlertType:      statsd.Error,
-				AggregationKey: "runner-job-timeout-awaiting-job-pickup",
-			})
-			return true, false, nil
+		if retryHealthWait {
+			continue
 		}
-
-		jobStatus, err := activities.AwaitGetJobStatusByID(ctx, job.ID)
-		if err != nil {
-			return false, false, nil
-		}
-		if jobStatus == app.RunnerJobStatusCancelled {
-			l.Error("job was cancelled")
-			tags["status"] = "job_cancelled"
-			return false, false, nil
-		}
-
-		jobExecutionResp, err := activities.AwaitGetLatestJobExecution(ctx, activities.GetLatestJobExecutionRequest{
-			JobID:       job.ID,
-			AvailableAt: availableStart,
-		})
-		if err != nil {
-			return false, false, fmt.Errorf("error fetching latest job execution: %w", err)
-		}
-		jobExecutionFound = jobExecutionResp.Found
 	}
 
 	l.Info("job picked up by runner and is in progress")

--- a/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal.go
@@ -106,23 +106,23 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 func (s *Signal) checkOrgRunner(ctx workflow.Context, l *zap.Logger, tmw tmetrics.Writer, runner *app.Runner, tags map[string]string) error {
 	_, err := activities.AwaitGetCurrentRunnerProcess(ctx, activities.GetCurrentRunnerProcessRequest{
 		RunnerID:    s.RunnerID,
-		ProcessType: string(app.RunnerProcessTypeOrg),
+		ProcessType: string(app.RunnerProcessTypeBuild),
 	})
 
-	tags["missing_org_process"] = "false"
+	tags["missing_build_process"] = "false"
 	if err != nil {
 		if isNotFound(err) {
-			l.Warn("org runner has no active org process",
+			l.Warn("org runner has no active build process",
 				zap.String("runner_id", s.RunnerID),
 			)
-			tags["missing_org_process"] = "true"
+			tags["missing_build_process"] = "true"
 			tmw.Incr(ctx, "runner.health_check", metrics.ToTags(tags, metrics.ToTag("result", "unhealthy"))...)
 			if runner.Status == app.RunnerStatusActive {
-				s.emitOfflineEvent(ctx, runner, "no active org process")
+				s.emitOfflineEvent(ctx, runner, "no active build process")
 			}
-			return s.updateRunnerStatus(ctx, runner, app.RunnerStatusOffline, "no active org process", nil)
+			return s.updateRunnerStatus(ctx, runner, app.RunnerStatusOffline, "no active build process", nil)
 		}
-		return errors.Wrap(err, "unable to get current org process")
+		return errors.Wrap(err, "unable to get current build process")
 	}
 
 	tmw.Incr(ctx, "runner.health_check", metrics.ToTags(tags, metrics.ToTag("result", "healthy"))...)

--- a/services/ctl-api/internal/app/runners/worker/activities/has_active_runner_process.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/has_active_runner_process.go
@@ -20,7 +20,12 @@ func (a *Activities) HasActiveRunnerProcess(ctx context.Context, req HasActiveRu
 	var count int64
 	res := a.db.WithContext(ctx).
 		Model(&app.RunnerProcess{}).
-		Where("runner_id = ? AND composite_status->>'status' = ?", req.RunnerID, string(app.RunnerProcessStatusActive)).
+		Where("runner_id = ?", req.RunnerID).
+		Where("composite_status->>'status' IN ?", []string{
+			string(app.RunnerProcessStatusActive),
+			string(app.RunnerProcessStatusPendingShutdown),
+			string(app.RunnerProcessStatusShuttingDown),
+		}).
 		Count(&count)
 	if res.Error != nil {
 		return nil, res.Error

--- a/services/ctl-api/internal/app/runners/worker/activities/has_open_process_shutdown.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/has_open_process_shutdown.go
@@ -17,11 +17,29 @@ type HasOpenProcessShutdownResponse struct {
 // @temporal-gen-v2 activity
 // @by-field RunnerID
 func (a *Activities) HasOpenProcessShutdown(ctx context.Context, req HasOpenProcessShutdownRequest) (*HasOpenProcessShutdownResponse, error) {
-	var count int64
+	var processIDs []string
 	res := a.db.WithContext(ctx).
+		Model(&app.RunnerProcess{}).
+		Where(app.RunnerProcess{RunnerID: req.RunnerID}).
+		Where("composite_status->>'status' IN ?", []string{
+			string(app.RunnerProcessStatusActive),
+			string(app.RunnerProcessStatusPendingShutdown),
+			string(app.RunnerProcessStatusShuttingDown),
+		}).
+		Pluck("id", &processIDs)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+
+	if len(processIDs) == 0 {
+		return &HasOpenProcessShutdownResponse{HasOpenShutdown: false}, nil
+	}
+
+	var count int64
+	res = a.db.WithContext(ctx).
 		Model(&app.RunnerProcessShutdown{}).
-		Joins("JOIN runner_processes ON runner_processes.id = runner_process_shutdowns.runner_process_id AND runner_processes.runner_id = ?", req.RunnerID).
-		Where("runner_process_shutdowns.composite_status->>'status' IN ?", []string{
+		Where("runner_process_id IN ?", processIDs).
+		Where("composite_status->>'status' IN ?", []string{
 			string(app.RunnerProcessShutdownStatusRequested),
 			string(app.RunnerProcessShutdownStatusInProgress),
 		}).

--- a/services/ctl-api/internal/app/runners/worker/activities/has_open_process_shutdown.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/has_open_process_shutdown.go
@@ -1,0 +1,34 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+type HasOpenProcessShutdownRequest struct {
+	RunnerID string `validate:"required"`
+}
+
+type HasOpenProcessShutdownResponse struct {
+	HasOpenShutdown bool
+}
+
+// @temporal-gen-v2 activity
+// @by-field RunnerID
+func (a *Activities) HasOpenProcessShutdown(ctx context.Context, req HasOpenProcessShutdownRequest) (*HasOpenProcessShutdownResponse, error) {
+	var count int64
+	res := a.db.WithContext(ctx).
+		Model(&app.RunnerProcessShutdown{}).
+		Joins("JOIN runner_processes ON runner_processes.id = runner_process_shutdowns.runner_process_id AND runner_processes.runner_id = ?", req.RunnerID).
+		Where("runner_process_shutdowns.composite_status->>'status' IN ?", []string{
+			string(app.RunnerProcessShutdownStatusRequested),
+			string(app.RunnerProcessShutdownStatusInProgress),
+		}).
+		Count(&count)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+
+	return &HasOpenProcessShutdownResponse{HasOpenShutdown: count > 0}, nil
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/113_backfill_runner_healthcheck_emitter.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/113_backfill_runner_healthcheck_emitter.go
@@ -1,0 +1,25 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+func (m *Migrations) Migration113BackfillRunnerHealthcheckEmitter(ctx context.Context, db *gorm.DB) error {
+	var runners []app.Runner
+	if res := db.WithContext(ctx).Find(&runners); res.Error != nil {
+		return fmt.Errorf("unable to list runners: %w", res.Error)
+	}
+
+	for _, runner := range runners {
+		if err := m.runnersHelpers.EnsureRunnerSignalsQueue(ctx, runner.ID); err != nil {
+			return fmt.Errorf("unable to ensure runner signals queue for runner %s: %w", runner.ID, err)
+		}
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/all.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/all.go
@@ -124,5 +124,9 @@ func (m *Migrations) All() []migrations.Migration {
 			Name: "112-runner-job-available-notify-trigger",
 			Fn:   m.Migration112RunnerJobAvailableNotifyTrigger,
 		},
+		{
+			Name: "113-backfill-runner-healthcheck-emitter",
+			Fn:   m.Migration113BackfillRunnerHealthcheckEmitter,
+		},
 	}
 }

--- a/services/ctl-api/internal/pkg/db/psql/migrations/migrations.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/migrations.go
@@ -1,6 +1,7 @@
 package migrations
 
 import (
+	runnershelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
 	"go.uber.org/fx"
 )
@@ -8,15 +9,18 @@ import (
 type Params struct {
 	fx.In
 
-	AcctClient *account.Client
+	AcctClient     *account.Client
+	RunnersHelpers *runnershelpers.Helpers
 }
 
 type Migrations struct {
-	acctClient *account.Client
+	acctClient     *account.Client
+	runnersHelpers *runnershelpers.Helpers
 }
 
 func New(params Params) *Migrations {
 	return &Migrations{
-		acctClient: params.AcctClient,
+		acctClient:     params.AcctClient,
+		runnersHelpers: params.RunnersHelpers,
 	}
 }

--- a/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx.go
+++ b/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx.go
@@ -5,6 +5,7 @@ import (
 
 	"go.temporal.io/sdk/workflow"
 
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	qcctx "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/cctx"
 )
@@ -37,6 +38,9 @@ func Apply(ctx context.Context, sc qcctx.SignalContext) context.Context {
 	if sc.TraceID != "" {
 		ctx = cctx.SetTraceIDContext(ctx, sc.TraceID)
 	}
+	if sc.LogStreamID != "" {
+		ctx = cctx.SetLogStreamContext(ctx, &app.LogStream{ID: sc.LogStreamID})
+	}
 	return ctx
 }
 
@@ -53,6 +57,9 @@ func ApplyWorkflow(ctx workflow.Context, sc qcctx.SignalContext) workflow.Contex
 	}
 	if sc.TraceID != "" {
 		ctx = cctx.SetTraceIDWorkflowContext(ctx, sc.TraceID)
+	}
+	if sc.LogStreamID != "" {
+		ctx = cctx.SetLogStreamWorkflowContext(ctx, &app.LogStream{ID: sc.LogStreamID})
 	}
 	return ctx
 }

--- a/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.tsx
+++ b/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.tsx
@@ -332,37 +332,15 @@ export const InstallStatuses = ({
     )
 
   const allStatuses = [
-    install?.drifted_objects?.length ? 'warn' : 'active',
     stackStatus,
     effectiveStatus(install?.runner_status),
     effectiveStatus(install?.sandbox_status),
     effectiveStatus(install?.composite_component_status),
+    install?.drifted_objects?.length ? 'warn' : 'active',
   ]
   const { worstStatus } = getWorstStatusTheme(allStatuses)
 
   const compositeItems = [
-    ...(install?.drifted_objects
-      ? [
-          {
-            id: 'drift',
-            title: 'Drift detection',
-            subtitle: install.drifted_objects.length
-              ? 'Drift detected'
-              : 'No drift',
-            href: install.drifted_objects.length
-              ? `/${install.org_id}/installs/${install.id}/workflows`
-              : undefined,
-            leftContent: (
-              <Status
-                status={install.drifted_objects.length ? 'warn' : 'active'}
-                isWithoutText
-                variant="timeline"
-                iconSize={16}
-              />
-            ),
-          },
-        ]
-      : []),
     ...(stackStatus
       ? [
           {
@@ -431,15 +409,37 @@ export const InstallStatuses = ({
         />
       ),
     },
+    ...(install?.drifted_objects
+      ? [
+          {
+            id: 'drift',
+            title: 'Drift detection',
+            subtitle: install.drifted_objects.length
+              ? 'Drift detected'
+              : 'No drift',
+            href: install.drifted_objects.length
+              ? `/${install.org_id}/installs/${install.id}/workflows`
+              : undefined,
+            leftContent: (
+              <Status
+                status={install.drifted_objects.length ? 'warn' : 'active'}
+                isWithoutText
+                variant="timeline"
+                iconSize={16}
+              />
+            ),
+          },
+        ]
+      : []),
   ]
 
   const expandedContent = (
     <div className={cn('flex items-center flex-wrap gap-2', { 'hidden @5xl:flex': collapsible })}>
-      {install?.drifted_objects ? wrap('Drift detection', driftContent) : null}
       {stackContent ? wrap('Stack', stackContent) : null}
       {wrap('Runner', runnerContent)}
       {wrap('Sandbox', sandboxContent)}
       {wrap('Components', componentsContent)}
+      {install?.drifted_objects ? wrap('Drift detection', driftContent) : null}
     </div>
   )
 


### PR DESCRIPTION
This PR adds support for draining a process when shutting down. As implemented, the runner will reject new jobs, and wait up to 30 minutes for the current job(s) to finish before properly shutting down. This prevents lost state, and ensures that we do not interrupt any job for a shutdown (unless it's over 30 minutes).

While in here, fix an issue with dependencies between runner-healthchecks and processes, and make signal dependencies more clear in the admin dashboard.
