### PR TITLE
fix(onboarding): refinements and quickstart & first app fixes

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -27,6 +27,10 @@ You can also enable autocomplete for you shell. Run `nuon completion` to see wha
 source <(nuon completion <your-shell>)
 ```
 
+<Note>
+The Nuon CLI changes frequently. To ensure you have the latest version, run `brew upgrade nuonco/tap/nuon` regularly. If you encounter any CLI command errors, please check you are using the latest version.
+</Note>
+
 ### Install Script
 
 If you are not using Homebrew, you can use our install script to automatically download and install the correct binary
@@ -74,8 +78,6 @@ chmod +x nuon
 ```
 
 ### Updates
-
-<Note>The Nuon CLI changes frequently, so we recommend you update it regularly.</Note>
 
 You can update the CLI using Homebrew:
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,428 +1,428 @@
 {
-  "$schema": "https://mintlify.com/docs.json",
-  "theme": "aspen",
-  "name": "Nuon documentation",
-  "description": "Nuon is the BYOC (bring-your-own-cloud) deployment platform for software vendors. Deploy applications — Terraform, Helm, Kubernetes manifests, container images — into customer AWS, Azure, or GCP accounts with no cross-account IAM. Includes runners, operation roles for least-privilege IAM, drift detection, approval workflows, and policies for compliance.",
-  "seo": {
-    "indexing": "all",
-    "metatags": {
-      "og:site_name": "Nuon Documentation",
-      "og:type": "website",
-      "twitter:card": "summary_large_image",
-      "twitter:site": "@nuonco"
-    }
-  },
-  "contextual": {
-    "options": ["copy", "view", "cursor", "chatgpt", "claude"]
-  },
-  "colors": {
-    "primary": "#256A7F",
-    "light": "#4CC9F0",
-    "dark": "#256A7F"
-  },
-  "background": {
-    "color": {
-      "light": "#FAFAFA"
-    }
-  },
-  "favicon": "/favicon.svg",
-  "custom": {
-    "css": "/style.css"
-  },
-  "fonts": {
-    "family": "Inter"
-  },
-  "navigation": {
-    "tabs": [
-      {
-        "tab": "Quickstart",
-        "icon": "rocket",
-        "pages": [
-          "get-started/quickstart",
-          "get-started/introduction",
-          "get-started/create-your-first-app",
-          {
-            "group": "Deployment Options",
-            "root": "guides/deployment-options",
-            "boost": 5,
-            "expanded": true,
-            "pages": [
-              "guides/nuon-cloud",
-              {
-                "group": "Install Nuon BYOC",
-                "root": "guides/byoc",
-                "expanded": false,
-                "pages": [
-                  "guides/byoc/requirements",
-                  "guides/byoc/aws",
-                  "guides/byoc/azure",
-                  "guides/byoc/gcp"
-                ]
-              },
-              {
-                "group": "Self-Hosted Nuon",
-                "root": "guides/self-hosted",
-                "expanded": false,
-                "pages": [
-                  "guides/self-hosted/supported-platforms"
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "How it Works",
-        "icon": "lightbulb",
-        "groups": [
-          {
-            "group": "Overview",
-            "boost": 3,
-            "pages": ["concepts/overview", "concepts/glossary"]
-          },
-          {
-            "group": "Connect Your App",
-            "boost": 3,
-            "pages": [
-              "concepts/apps",
-              {
-                "group": "Components",
-                "root": "concepts/components",
-                "icon": "object-group",
-                "boost": 3,
-                "pages": [
-                  "concepts/components/auto-retries"
-                ]
-              },
-              "concepts/sandboxes",
-              "concepts/app-inputs",
-              "concepts/app-secrets",
-              "concepts/app-variables",
-              "concepts/runners"
-            ]
-          },
-          {
-            "group": "Customer installs",
-            "boost": 3,
-            "pages": [
-              "guides/app-install-life-cycle",
-              {
-                "group": "Stacks",
-                "root": "concepts/stacks",
-                "icon": "layer-group",
-                "expanded": true,
-                "pages": [
-                  "concepts/stacks/stand-alone-vpc",
-                  "concepts/stacks/customer-vpc",
-                  "concepts/stacks/customer-cluster"
-                ]
-              },
-              "concepts/cli"
-            ]
-          },
-          {
-            "group": "Continuous Delivery",
-            "boost": 3,
-            "pages": ["get-started/day-2-operations", "concepts/workflows", "concepts/actions", "concepts/policies", "concepts/operation-roles"]
-          }
-        ]
-      },
-      {
-        "tab": "How-tos",
-        "icon": "screwdriver-wrench",
-        "groups": [
-          {
-            "group": "Connect Your App",
-            "boost": 3,
-            "pages": [
-              "guides/app-init",
-              "guides/managing-apps",
-              "guides/managing-components",
-              "guides/component-dependencies",
-              "guides/configuring-inputs-and-secrets",
-              "guides/configuring-sandboxes",
-              "guides/using-variables",
-              "guides/vcs",
-              {
-                "group": "Components",
-                "pages": [
-                  "guides/docker-build-components",
-                  "guides/container-image-components",
-                  "guides/image-update-policies",
-                  "guides/helm-chart-components",
-                  "guides/kubernetes-manifest-components",
-                  "guides/terraform-components"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Install with a Customer",
-            "boost": 3,
-            "pages": [
-              "guides/vendor-customers",
-              "guides/install-configs",
-              "guides/runner-kill-switch",
-              "guides/custom-domains"
-            ]
-          },
-          {
-            "group": "Day 2 Operations",
-            "boost": 3,
-            "pages": [
-              "guides/actions",
-              "guides/adhoc-actions",
-              "guides/configuring-policies",
-              "guides/operation-roles",
-              "guides/runner-management-mode",
-              "guides/team-management"
-            ]
-          },
-          {
-            "group": "Integrations",
-            "boost": 2,
-            "pages": [
-              "guides/control-plane-integration",
-              "guides/github-actions",
-              "guides/webhooks",
-              "guides/slack",
-              "guides/ai-and-apps"
-            ]
-          },
-          {
-            "group": "Advanced",
-            "boost": 2,
-            "pages": [
-              "guides/using-readmes",
-              "guides/programmable-readmes",
-              "guides/runbooks",
-              "guides/custom-nested-stacks",
-              "guides/customizing-terraform-stack-templates",
-              "guides/cli-extensions",
-              "guides/external-image-policies",
-              "guides/terraform-cli"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Reference",
-        "icon": "book",
-        "pages": [
-          {
-            "group": "Cloud Reference",
-            "boost": 1,
-            "pages": [
-              "platform-support/introduction",
-              "platform-support/aws",
-              "platform-support/azure",
-              "platform-support/gcp"
-            ]
-          },
-          {
-            "group": "Interface Reference",
-            "pages": [
-              {
-                "group": "CLI",
-                "root": "cli",
-                "pages": [
-                  "cli-commands"
-                ]
-              },
-              "tui",
-              "nuon-api",
-              "sdks"
-            ]
-          },
-          {
-            "group": "Config Reference",
-            "root": "config-ref/index",
-            "boost": 0.25,
-            "expanded": true,
-            "pages": [
-              "configuration-files",
-              {
-                "group": "Component Types",
-                "pages": [
-                  "config-ref/container-image",
-                  "config-ref/docker-build",
-                  "config-ref/helm",
-                  "config-ref/kubernetes-manifest",
-                  "config-ref/terraform"
-                ]
-              },
-              {
-                "group": "Configuration Types",
-                "pages": [
-                  "config-ref/action",
-                  "config-ref/break-glass",
-                  "config-ref/inputs",
-                  "config-ref/install",
-                  "config-ref/installer",
-                  "config-ref/metadata",
-                  "config-ref/permissions",
-                  "config-ref/policies",
-                  "config-ref/runner",
-                  "config-ref/sandbox",
-                  "config-ref/secrets",
-                  "config-ref/stack"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Architecture Reference",
-            "boost": 1.5,
-            "pages": [
-              "architecture/platform",
-              "architecture/app-deployment",
-              "architecture/runner-auth",
-              "security"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Changelog",
-        "icon": "clock-rotate-left",
-        "pages": [
-          "updates/updates",
-          "updates/035-runbooks-and-readmes",
-          "updates/034-aws-terraform-install-stack",
-          "updates/033-Workflow-Policy-and-improved-cloud-support",
-          "updates/032-extensions-and-roles",
-          "updates/031-operation-roles",
-          "updates/030-policies",
-          "updates/029-auth-inputs-better-nested-templates",
-          "updates/028-open-source",
-          "updates/027-install-config-toggle",
-          "updates/026-helm-repository-support",
-          "updates/025-temporal-stability",
-          "updates/024-install-inputs-ui-redesign",
-          "updates/023-drift-workflow-improvements",
-          "updates/022-nuon-cli-github-actions",
-          "updates/021-drift-detection",
-          "updates/020-break-glass-actions",
-          "updates/019-self-service",
-          "updates/018-management-mode",
-          "updates/017-noop-approvals-stability-updates",
-          "updates/016-enhanced-install-config-files-and-improved-plans",
-          "updates/015-azure-support",
-          "updates/014-install-config-files",
-          "updates/013-kubernetes-manifest-component",
-          "updates/012-approval-diffs-plan-only",
-          "updates/011-approval-updates",
-          "updates/010-approvals",
-          "updates/009-action-triggers-secrets-configs",
-          "updates/008-vcs-stacks-fixes",
-          "updates/007-secret-formats",
-          "updates/006-secrets-workflows",
-          "updates/005-developer-experience",
-          "updates/004-secrets",
-          "updates/003-install-deletes-cancel-improvements",
-          "updates/002-inputs-dependencies",
-          "updates/001-install-workflows-actions"
-        ]
-      },
-      {
-        "tab": "Knowledge Base",
-        "icon": "book-open",
-        "href": "https://support.nuon.co"
-      }
-    ],
-    "global": {
-      "anchors": []
-    }
-  },
-  "logo": {
-    "light": "/logo/light.svg",
-    "dark": "/logo/dark.svg",
-    "href": "/get-started/introduction"
-  },
-  "navbar": {
-    "links": [
-      {
-        "label": "GitHub",
-        "href": "https://github.com/nuonco/nuon",
-        "icon": "github",
-        "iconType": "brands"
-      },
-      {
-        "label": "Slack",
-        "href": "https://nuon-byoc.slack.com/join/shared_invite/zt-1q323vw9z-C8ztRP~HfWjZx6AXi50VRA#/shared-invite/email",
-        "icon": "slack",
-        "iconType": "brands"
-      }
-    ],
-    "primary": {
-      "type": "button",
-      "label": "Sign up",
-      "href": "https://app.nuon.co/"
-    }
-  },
-  "api": {
-    "openapi": "https://api.nuon.co/oapi/v3"
-  },
-  "footer": {
-    "socials": {
-      "website": "https://www.nuon.co",
-      "x": "https://twitter.com/nuoninc",
-      "linkedin": "https://www.linkedin.com/company/nuonco/"
-    }
-  },
-  "integrations": {
-    "plausible": {
-      "domain": "docs.nuon.co"
-    }
-  },
-  "redirects": [
-    {
-      "source": "/",
-      "destination": "/get-started/introduction"
-    },
-    {
-      "source": "/api-ref",
-      "destination": "/nuon-api"
-    },
-    {
-      "source": "/api-ref/getting-started",
-      "destination": "/nuon-api"
-    },
-    {
-      "source": "/changelog",
-      "destination": "/updates/updates"
-    },
-    {
-      "source": "/faq",
-      "destination": "/support/support"
-    },
-    {
-      "source": "/runner-architecture",
-      "destination": "/architecture/platform"
-    },
-    {
-      "source": "/architecture/byoc",
-      "destination": "/architecture/app-deployment"
-    },
-    {
-      "source": "/concepts/installs",
-      "destination": "/guides/app-install-life-cycle"
-    },
-    {
-      "source": "/deployment-options",
-      "destination": "/guides/deployment-options"
-    },
-    {
-      "source": "/guides/self-hosting",
-      "destination": "/guides/self-hosted"
-    },
-    {
-      "source": "/guides/programmatic-install-config",
-      "destination": "/guides/install-configs"
-    },
-    {
-      "source": "/guides/notifications",
-      "destination": "/guides/slack"
-    }
-  ]
+	"$schema": "https://mintlify.com/docs.json",
+	"theme": "aspen",
+	"name": "Nuon documentation",
+	"description": "Nuon is the BYOC (bring-your-own-cloud) deployment platform for software vendors. Deploy applications — Terraform, Helm, Kubernetes manifests, container images — into customer AWS, Azure, or GCP accounts with no cross-account IAM. Includes runners, operation roles for least-privilege IAM, drift detection, approval workflows, and policies for compliance.",
+	"seo": {
+		"indexing": "all",
+		"metatags": {
+			"og:site_name": "Nuon Documentation",
+			"og:type": "website",
+			"twitter:card": "summary_large_image",
+			"twitter:site": "@nuonco"
+		}
+	},
+	"contextual": {
+		"options": ["copy", "view", "cursor", "chatgpt", "claude"]
+	},
+	"colors": {
+		"primary": "#256A7F",
+		"light": "#4CC9F0",
+		"dark": "#256A7F"
+	},
+	"background": {
+		"color": {
+			"light": "#FAFAFA"
+		}
+	},
+	"favicon": "/favicon.svg",
+	"custom": {
+		"css": "/style.css"
+	},
+	"fonts": {
+		"family": "Inter"
+	},
+	"navigation": {
+		"tabs": [
+			{
+				"tab": "Quickstart",
+				"icon": "rocket",
+				"pages": [
+					"get-started/quickstart",
+					"get-started/create-your-first-app",
+					"get-started/introduction",
+					{
+						"group": "Deployment Options",
+						"root": "guides/deployment-options",
+						"boost": 5,
+						"expanded": true,
+						"pages": [
+							"guides/nuon-cloud",
+							{
+								"group": "Install Nuon BYOC",
+								"root": "guides/byoc",
+								"expanded": false,
+								"pages": [
+									"guides/byoc/requirements",
+									"guides/byoc/aws",
+									"guides/byoc/azure",
+									"guides/byoc/gcp"
+								]
+							},
+							{
+								"group": "Self-Hosted Nuon",
+								"root": "guides/self-hosted",
+								"expanded": false,
+								"pages": ["guides/self-hosted/supported-platforms"]
+							}
+						]
+					}
+				]
+			},
+			{
+				"tab": "How it Works",
+				"icon": "lightbulb",
+				"groups": [
+					{
+						"group": "Overview",
+						"boost": 3,
+						"pages": ["concepts/overview", "concepts/glossary"]
+					},
+					{
+						"group": "Connect Your App",
+						"boost": 3,
+						"pages": [
+							"concepts/apps",
+							{
+								"group": "Components",
+								"root": "concepts/components",
+								"icon": "object-group",
+								"boost": 3,
+								"pages": ["concepts/components/auto-retries"]
+							},
+							"concepts/sandboxes",
+							"concepts/app-inputs",
+							"concepts/app-secrets",
+							"concepts/app-variables",
+							"concepts/runners"
+						]
+					},
+					{
+						"group": "Customer installs",
+						"boost": 3,
+						"pages": [
+							"guides/app-install-life-cycle",
+							{
+								"group": "Stacks",
+								"root": "concepts/stacks",
+								"icon": "layer-group",
+								"expanded": true,
+								"pages": [
+									"concepts/stacks/stand-alone-vpc",
+									"concepts/stacks/customer-vpc",
+									"concepts/stacks/customer-cluster"
+								]
+							},
+							"concepts/cli"
+						]
+					},
+					{
+						"group": "Continuous Delivery",
+						"boost": 3,
+						"pages": [
+							"get-started/day-2-operations",
+							"concepts/workflows",
+							"concepts/actions",
+							"concepts/policies",
+							"concepts/operation-roles"
+						]
+					}
+				]
+			},
+			{
+				"tab": "How-tos",
+				"icon": "screwdriver-wrench",
+				"groups": [
+					{
+						"group": "Connect Your App",
+						"boost": 3,
+						"pages": [
+							"guides/app-init",
+							"guides/managing-apps",
+							"guides/managing-components",
+							"guides/component-dependencies",
+							"guides/configuring-inputs-and-secrets",
+							"guides/configuring-sandboxes",
+							"guides/using-variables",
+							"guides/vcs",
+							{
+								"group": "Components",
+								"pages": [
+									"guides/docker-build-components",
+									"guides/container-image-components",
+									"guides/image-update-policies",
+									"guides/helm-chart-components",
+									"guides/kubernetes-manifest-components",
+									"guides/terraform-components"
+								]
+							}
+						]
+					},
+					{
+						"group": "Install with a Customer",
+						"boost": 3,
+						"pages": [
+							"guides/vendor-customers",
+							"guides/install-configs",
+							"guides/runner-kill-switch",
+							"guides/custom-domains"
+						]
+					},
+					{
+						"group": "Day 2 Operations",
+						"boost": 3,
+						"pages": [
+							"guides/actions",
+							"guides/adhoc-actions",
+							"guides/configuring-policies",
+							"guides/operation-roles",
+							"guides/runner-management-mode",
+							"guides/team-management"
+						]
+					},
+					{
+						"group": "Integrations",
+						"boost": 2,
+						"pages": [
+							"guides/control-plane-integration",
+							"guides/github-actions",
+							"guides/webhooks",
+							"guides/slack",
+							"guides/ai-and-apps"
+						]
+					},
+					{
+						"group": "Advanced",
+						"boost": 2,
+						"pages": [
+							"guides/using-readmes",
+							"guides/programmable-readmes",
+							"guides/runbooks",
+							"guides/custom-nested-stacks",
+							"guides/customizing-terraform-stack-templates",
+							"guides/cli-extensions",
+							"guides/external-image-policies",
+							"guides/terraform-cli"
+						]
+					}
+				]
+			},
+			{
+				"tab": "Reference",
+				"icon": "book",
+				"pages": [
+					{
+						"group": "Cloud Reference",
+						"boost": 1,
+						"pages": [
+							"platform-support/introduction",
+							"platform-support/aws",
+							"platform-support/azure",
+							"platform-support/gcp"
+						]
+					},
+					{
+						"group": "Interface Reference",
+						"pages": [
+							{
+								"group": "CLI",
+								"root": "cli",
+								"pages": ["cli-commands"]
+							},
+							"tui",
+							"nuon-api",
+							"sdks"
+						]
+					},
+					{
+						"group": "Config Reference",
+						"root": "config-ref/index",
+						"boost": 0.25,
+						"expanded": true,
+						"pages": [
+							"configuration-files",
+							{
+								"group": "Component Types",
+								"pages": [
+									"config-ref/container-image",
+									"config-ref/docker-build",
+									"config-ref/helm",
+									"config-ref/kubernetes-manifest",
+									"config-ref/terraform"
+								]
+							},
+							{
+								"group": "Configuration Types",
+								"pages": [
+									"config-ref/action",
+									"config-ref/break-glass",
+									"config-ref/inputs",
+									"config-ref/install",
+									"config-ref/installer",
+									"config-ref/metadata",
+									"config-ref/permissions",
+									"config-ref/policies",
+									"config-ref/runner",
+									"config-ref/sandbox",
+									"config-ref/secrets",
+									"config-ref/stack"
+								]
+							}
+						]
+					},
+					{
+						"group": "Architecture Reference",
+						"boost": 1.5,
+						"pages": [
+							"architecture/platform",
+							"architecture/app-deployment",
+							"architecture/runner-auth",
+							"security"
+						]
+					}
+				]
+			},
+			{
+				"tab": "Changelog",
+				"icon": "clock-rotate-left",
+				"pages": [
+					"updates/updates",
+					"updates/035-runbooks-and-readmes",
+					"updates/034-aws-terraform-install-stack",
+					"updates/033-Workflow-Policy-and-improved-cloud-support",
+					"updates/032-extensions-and-roles",
+					"updates/031-operation-roles",
+					"updates/030-policies",
+					"updates/029-auth-inputs-better-nested-templates",
+					"updates/028-open-source",
+					"updates/027-install-config-toggle",
+					"updates/026-helm-repository-support",
+					"updates/025-temporal-stability",
+					"updates/024-install-inputs-ui-redesign",
+					"updates/023-drift-workflow-improvements",
+					"updates/022-nuon-cli-github-actions",
+					"updates/021-drift-detection",
+					"updates/020-break-glass-actions",
+					"updates/019-self-service",
+					"updates/018-management-mode",
+					"updates/017-noop-approvals-stability-updates",
+					"updates/016-enhanced-install-config-files-and-improved-plans",
+					"updates/015-azure-support",
+					"updates/014-install-config-files",
+					"updates/013-kubernetes-manifest-component",
+					"updates/012-approval-diffs-plan-only",
+					"updates/011-approval-updates",
+					"updates/010-approvals",
+					"updates/009-action-triggers-secrets-configs",
+					"updates/008-vcs-stacks-fixes",
+					"updates/007-secret-formats",
+					"updates/006-secrets-workflows",
+					"updates/005-developer-experience",
+					"updates/004-secrets",
+					"updates/003-install-deletes-cancel-improvements",
+					"updates/002-inputs-dependencies",
+					"updates/001-install-workflows-actions"
+				]
+			},
+			{
+				"tab": "Knowledge Base",
+				"icon": "book-open",
+				"href": "https://support.nuon.co"
+			}
+		],
+		"global": {
+			"anchors": []
+		}
+	},
+	"logo": {
+		"light": "/logo/light.svg",
+		"dark": "/logo/dark.svg",
+		"href": "/get-started/introduction"
+	},
+	"navbar": {
+		"links": [
+			{
+				"label": "GitHub",
+				"href": "https://github.com/nuonco/nuon",
+				"icon": "github",
+				"iconType": "brands"
+			},
+			{
+				"label": "Slack",
+				"href": "https://nuon-byoc.slack.com/join/shared_invite/zt-1q323vw9z-C8ztRP~HfWjZx6AXi50VRA#/shared-invite/email",
+				"icon": "slack",
+				"iconType": "brands"
+			}
+		],
+		"primary": {
+			"type": "button",
+			"label": "Sign up",
+			"href": "https://app.nuon.co/"
+		}
+	},
+	"api": {
+		"openapi": "https://api.nuon.co/oapi/v3"
+	},
+	"footer": {
+		"socials": {
+			"website": "https://www.nuon.co",
+			"x": "https://twitter.com/nuoninc",
+			"linkedin": "https://www.linkedin.com/company/nuonco/"
+		}
+	},
+	"integrations": {
+		"plausible": {
+			"domain": "docs.nuon.co"
+		}
+	},
+	"redirects": [
+		{
+			"source": "/",
+			"destination": "/get-started/introduction"
+		},
+		{
+			"source": "/api-ref",
+			"destination": "/nuon-api"
+		},
+		{
+			"source": "/api-ref/getting-started",
+			"destination": "/nuon-api"
+		},
+		{
+			"source": "/changelog",
+			"destination": "/updates/updates"
+		},
+		{
+			"source": "/faq",
+			"destination": "/support/support"
+		},
+		{
+			"source": "/runner-architecture",
+			"destination": "/architecture/platform"
+		},
+		{
+			"source": "/architecture/byoc",
+			"destination": "/architecture/app-deployment"
+		},
+		{
+			"source": "/concepts/installs",
+			"destination": "/guides/app-install-life-cycle"
+		},
+		{
+			"source": "/deployment-options",
+			"destination": "/guides/deployment-options"
+		},
+		{
+			"source": "/guides/self-hosting",
+			"destination": "/guides/self-hosted"
+		},
+		{
+			"source": "/guides/programmatic-install-config",
+			"destination": "/guides/install-configs"
+		},
+		{
+			"source": "/guides/notifications",
+			"destination": "/guides/slack"
+		}
+	]
 }

--- a/docs/get-started/create-your-first-app.mdx
+++ b/docs/get-started/create-your-first-app.mdx
@@ -1,29 +1,29 @@
 ---
 title: "Create Your First App"
-description: "Deploy an example app to learn Nuon, then package a version of your own product into a test cloud account."
+description: "Use an example app to learn Nuon or package your app with Nuon."
 keywords: ["first app", "example app", "package an app", "wrap existing Terraform", "wrap existing Helm chart", "deploy to test account", "deploy your own app", "first install"]
 ---
 
-Your first app can take one of two forms, and both deploy into a **test cloud account**:
+Your first app can take one of two forms, and both deploy into your cloud account:
 
-- **An example app** — the fastest way to see Nuon work end to end. Deploy one of our pre-built [example app configs](https://github.com/nuonco/example-app-configs) without writing any config yourself.
-- **Your own app** — a real version of your product, packaged from your existing Terraform, Helm, Kubernetes, and Docker assets.
-
-If you're new to Nuon, start with an example app.
+- **An example app (recommended)** — the fastest way to see Nuon work end to end. Use one of our pre-built [example apps](https://github.com/nuonco/example-app-configs).
+- **Your own app** — your app packaged in Nuon's configuration format and referencing your existing Terraform, Helm, Kubernetes, and Docker assets.
 
 <Tip>
-Want the bigger picture first? The [App & Install Life Cycle](/guides/app-install-life-cycle) guide walks through packaging, installing, and operating an app.
+New to Nuon? Read the [App & Install Life Cycle](/guides/app-install-life-cycle) guide to understand how apps are packaged, installed and managed with Nuon.
 </Tip>
 
-## Deploy an Example App
+## Use an Example App
 
-Each guide below deploys a working example into a test AWS account:
+Each guide below deploys a working example into your AWS account:
 
 - [eks-simple](/get-started/app-aws-k8s): An AWS EKS (Kubernetes) Traefik `whoami` application (~35 min)
-- [cde](/get-started/app-aws-ec2): An AWS EC2 VM you connect to with `ssh` and VS Code Web (~31 min)
+- [cde](/get-started/app-aws-ec2): An AWS EC2 VM you connect to with `ssh` and VS Code Web (~26 min)
 - [aws-lambda](/get-started/app-aws-lambda): A Lambda function with DynamoDB and API Gateway (~26 min)
 
 Estimated times above include creating the initial VPC, Subnets, Nat Gateway, ASG, EC2 VM, and a healthy Nuon runner (~11 min). For the fastest duration, approve all workflow steps when the app install begins.
+
+cde and aws-lambda are less resource and cost intensive than eks-simple which provisions a Kubernetes cluster with 3 nodes.
 
 For these and other examples, clone the [example-app-configs repository](https://github.com/nuonco/example-app-configs) and run:
 
@@ -36,13 +36,15 @@ nuon apps sync
 nuon installs create --name <install-name> --region <region>
 ```
 
-## Deploy Your Own App
+## Use Your Own App
 
-When you're ready to deploy a real version of your own product, package your existing Terraform, Helm, Kubernetes, and Docker assets into a Nuon app — then install it into a **test cloud account** before going anywhere near production. The CLI commands are the same as the example above.
+When you're ready to try your app with Nuon, package your existing Terraform, Helm, Kubernetes manifest, and container image assets into a Nuon app — then install it into your AWS, Azure or GCP.
 
-See [how apps are configured](/concepts/apps#how-do-you-configure-an-app) to structure your app, including connecting a private GitHub repository.
+See [how apps are configured](/concepts/apps#how-do-you-configure-an-app) to structure your app, including connecting a GitHub repository.
+
+Use agents like Claude Code to build your app by learning from Nuon's example apps. See our [AI and Apps Building docs](/guides/ai-and-apps) for more info.
 
 ## Prerequisites
 
-- [Sign up for the self-service free trial](https://app.nuon.co). You'll get a login and an org in Nuon's cloud.
-- A **test cloud account** to install into. The example apps above use AWS — [set up an AWS account](https://docs.aws.amazon.com/SetUp/latest/UserGuide/setup-overview.html) if you don't have one. Nuon also supports Azure and GCP.
+- [Sign up for the free trial](https://app.nuon.co). You'll get a login and an org in Nuon Cloud.
+- The example apps above need an AWS account to install into. [Set up an AWS account](https://docs.aws.amazon.com/SetUp/latest/UserGuide/setup-overview.html) if you don't have one. Nuon also has apps for Azure and GCP [in our example apps repo](https://github.com/nuonco/example-app-configs).

--- a/docs/get-started/introduction.mdx
+++ b/docs/get-started/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: Home
+title: Docs Home
 description: "Continuous delivery into your customer's cloud."
 mode: "frame"
 boost: 5

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -1,34 +1,34 @@
 ---
 title: 'Quickstart'
-description: "Deploy your first app with Nuon in a few minutes by shipping an example app into a test cloud account."
+description: "Deploy your first app with Nuon in a few minutes by shipping an example Kubernetes app into an AWS account."
 boost: 5
 keywords: ["getting started", "first deployment", "example app", "try Nuon", "deploy example app", "test account", "install guide", "nuon apps sync", "nuon installs create", "nuon auth login"]
 ---
 
 <Note>
 You'll need two things before you start:
-- A Nuon account — [sign up for the free trial](https://app.nuon.co/).
-- A **test cloud account** (AWS, Azure, or GCP) to deploy into. A throwaway or sandbox account is ideal for your first install.
+- A Nuon Cloud account — [sign up for the free trial](https://app.nuon.co/).
+- An AWS account to deploy the app into.
 </Note>
 
-The fastest way to see Nuon work is to deploy one of our example apps into a test cloud account. Copy and paste the flow below, or follow the walkthrough underneath for detail on each step.
+Copy and paste the flow below, or follow the walkthrough underneath for detail on each step of the Quickstart.
 
 ```sh
 # 1. Install the CLI
 brew install nuonco/tap/nuon
 
-# 2. Log in
+# 2. Authenticate with Nuon Cloud
 nuon auth login
 
-# 3. Grab the example apps and pick one (Kubernetes on AWS shown here)
+# 3. Clone Nuon's example apps repo 
 git clone https://github.com/nuonco/example-app-configs
-cd example-app-configs/eks-simple
 
-# 4. Define the app from its TOML config
+# 4. Create the app and sync it with Nuon Cloud. (Kubernetes on AWS shown here)
+cd example-app-configs/eks-simple
 nuon apps create --name eks-simple
 nuon apps sync
 
-# 5. Deploy it into your test cloud account
+# 5. Install the app in your AWS account
 nuon installs create --name <install-name> --region <region>
 ```
 
@@ -40,53 +40,54 @@ brew install nuonco/tap/nuon
 
 If you are not using Homebrew, refer to our [CLI](/cli) documentation for other installation options.
 
-<Note>
-The Nuon CLI changes frequently. To ensure you have the latest version, run `brew upgrade nuonco/tap/nuon` regularly. If you encounter any CLI command errors, please check you are using the latest version.
-</Note>
-
-## Authenticate
+## Authenticate to Nuon Cloud
 
 ```sh
 nuon auth login
 ```
 
-Follow the prompts in the browser and log in with a Google account.
+Follow the prompt in the browser and log in with a Google account.
 
-## Deploy an Example App
+## Clone the Example Apps Repo
 
-The quickest path is to deploy one of our [example apps](https://github.com/nuonco/example-app-configs) into a test cloud account. Clone the repo and pick one — `eks-simple` (Kubernetes on AWS) is a good starting point:
+Nuon maintains a [example apps](https://github.com/nuonco/example-app-configs) repo to demonstrate how to package various apps on AWS, Azure and GCP with various architectures like Kubernetes, VM and serverless.
 
 ```sh
 git clone https://github.com/nuonco/example-app-configs
-cd example-app-configs/eks-simple
+```
 
+## Create and Sync the Example App
+
+For the Quickstart, we're using an AWS EKS (Kubernetes) app called eks-simple with a whoami Helm component, an ACM certificate, and an Application Load Balancer to access the whoami service. View the app configuration in the [example apps repo](https://github.com/nuonco/example-app-configs/tree/main/eks-simple) or with your IDE and the cloned repo.
+
+Use the Nuon CLI to create the app then sync its contents into Nuon Cloud. The sync triggers the app's components (e.g., images, Helm, Kubernetes manifests, Terraform) to be built into OCI artifacts that are stored in your org's container registry. Nuon will use these artifacts when installing your app.
+
+The app name should match the directory name.
+
+```sh
+cd example-app-configs/eks-simple
 nuon apps create --name eks-simple
 nuon apps sync
 ```
 
-<Note>
-Apps are defined in TOML config files and applied with `nuon apps sync` — not through CLI flags or YAML values. `nuon apps create` registers the app in the control plane; `nuon apps sync` uploads the TOML config from the current directory and builds it. The app name should match the directory name.
-</Note>
+## Install the Example App in AWS
 
-Now create an install to deploy the app into your test cloud account:
+Now create an install to deploy the app into your AWS account:
 
 ```sh
 nuon installs create --name <install-name> --region <region>
 ```
 
 - `--name` (`-n`) names this install.
-- `--region` (`-r`) is the cloud region to provision into, for example `us-west-2`.
+- `--region` (`-r`) is the AWS region to provision into, for example `us-east-1`.
 
-<Note>
-Deployments are started with `nuon installs create` — there is no `nuon installs deploy` command. To redeploy components to an existing install later, use `nuon installs deploy-components`.
-</Note>
 
-For guided, per-cloud walkthroughs (AWS EKS, EC2, and Lambda) with prerequisites and timings, see [Create Your First App](/get-started/create-your-first-app).
+## Guided Walkthroughs
+
+For guided walkthroughs including this eks-simple app and EC2 and serverless apps, see [Create Your First App](/get-started/create-your-first-app).
 
 ## Deploy Your Own App
 
-When you're ready to package your own software, wrap your existing Terraform, Helm, Kubernetes, and Docker assets into a Nuon app — the commands are the same (`nuon apps create`, `nuon apps sync`, then `nuon installs create`).
+When you're ready to package your own software, wrap your existing Terraform, Helm, Kubernetes manifest, and container image assets into a Nuon app — the commands are the same (`nuon apps create`, `nuon apps sync`, then `nuon installs create`).
 
-<Card title="Ready to deploy your own app?" icon="rocket" href="/concepts/apps#how-do-you-configure-an-app">
-  Learn how Nuon apps are configured — including connecting a private GitHub repository — then follow [Create Your First App](/get-started/create-your-first-app) for a full walkthrough.
-</Card>
+Use agents like Claude Code to build your app by learning from Nuon's example apps. See our [AI and Apps Building docs](/guides/ai-and-apps) for more info.

--- a/services/dashboard-ui/client/components/installs/forms/CreateInstallForm/CreateInstallForm.tsx
+++ b/services/dashboard-ui/client/components/installs/forms/CreateInstallForm/CreateInstallForm.tsx
@@ -18,6 +18,8 @@ interface ICreateInstallFormPresentation {
   onSubmit?: (formData: FormData) => Promise<any>
   onSuccess?: (result: any) => void
   onCancel: () => void
+  defaultAutoApprove?: boolean
+  autoApproveDescription?: React.ReactNode
 }
 
 export const CreateInstallForm = forwardRef<
@@ -34,6 +36,8 @@ export const CreateInstallForm = forwardRef<
       clearDraft,
       onSubmit,
       onSuccess,
+      defaultAutoApprove,
+      autoApproveDescription,
     },
     ref
   ) => {
@@ -110,7 +114,7 @@ export const CreateInstallForm = forwardRef<
             <CheckboxInput
               name="auto-approve"
               className="mt-[6px]"
-              defaultChecked={draftValues?.['auto-approve'] === 'on' || false}
+              defaultChecked={draftValues ? draftValues['auto-approve'] === 'true' : Boolean(defaultAutoApprove)}
               labelProps={{
                 className: 'items-start',
                 labelText: (
@@ -119,9 +123,13 @@ export const CreateInstallForm = forwardRef<
                       Auto-approve changes
                     </Text>
                     <Text variant="subtext" theme="neutral">
-                      Automatically approve and apply all future changes without
-                      manual confirmation. You can change this later in the
-                      install settings.
+                      {autoApproveDescription ?? (
+                        <>
+                          Automatically approve and apply all future changes
+                          without manual confirmation. You can change this later
+                          in the install settings.
+                        </>
+                      )}
                     </Text>
                   </div>
                 ),

--- a/services/dashboard-ui/client/components/installs/forms/shared/types.ts
+++ b/services/dashboard-ui/client/components/installs/forms/shared/types.ts
@@ -11,6 +11,8 @@ export interface ICreateInstallForm {
   isLoading?: boolean
   error?: any
   onRegisterClearDraft?: (clearFn: () => void) => void
+  defaultAutoApprove?: boolean
+  autoApproveDescription?: React.ReactNode
 }
 
 export interface IUpdateInstallForm {

--- a/services/dashboard-ui/client/components/onboarding/WizardStepView.tsx
+++ b/services/dashboard-ui/client/components/onboarding/WizardStepView.tsx
@@ -41,7 +41,7 @@ export function WizardStepView() {
             {visibleStep.title}
           </Text>
           {visibleStep.description && (
-            <Text variant="body" theme="neutral" as="p" className="max-w-md !text-pretty">
+            <Text variant="body" theme="neutral" as="div" className="max-w-2xl !text-pretty">
               {visibleStep.description}
             </Text>
           )}

--- a/services/dashboard-ui/client/components/onboarding/steps/CreateAppStep.tsx
+++ b/services/dashboard-ui/client/components/onboarding/steps/CreateAppStep.tsx
@@ -25,6 +25,13 @@ const EXAMPLE_APPS: IExampleApp[] = [
     dir: 'example-app-configs/eks-simple',
   },
   {
+    id: 'cde',
+    name: 'AWS EC2 and Claude Code',
+    description: 'A VM accessible with SSH and VS Code Web',
+    repo: 'https://github.com/nuonco/example-app-configs',
+    dir: 'example-app-configs/cde',
+  },
+  {
     id: 'aws-lambda',
     name: 'AWS Lambda',
     description: 'Serverless function deployed to AWS Lambda',
@@ -33,24 +40,24 @@ const EXAMPLE_APPS: IExampleApp[] = [
   },
   {
     id: 'httpbin',
-    name: 'AWS EC2 / httpbin',
+    name: 'AWS EC2 Simple',
     description: 'HTTP testing service running on EC2',
     repo: 'https://github.com/nuonco/example-app-configs',
     dir: 'example-app-configs/httpbin',
   },
   {
-    id: 'coder',
-    name: 'Coder',
-    description: 'Remote development environments with Coder',
+    id: 'ecs-simple',
+    name: 'AWS ECS Simple',
+    description: 'A simple containerized service deployed to AWS ECS',
     repo: 'https://github.com/nuonco/example-app-configs',
-    dir: 'example-app-configs/coder',
+    dir: 'example-app-configs/ecs-simple',
   },
   {
-    id: 'mattermost',
-    name: 'Mattermost',
-    description: 'Open-source team messaging platform',
+    id: 'coder',
+    name: 'Coder & Grafana on AWS EKS',
+    description: 'Dev environments for Claude Code agents and devs with coder.com',
     repo: 'https://github.com/nuonco/example-app-configs',
-    dir: 'example-app-configs/mattermost',
+    dir: 'example-app-configs/coder',
   },
 ]
 
@@ -120,7 +127,7 @@ export const CreateAppStep = ({ onAdvance, setSharedData, nextStepTitle }: IWiza
             </div>
           </div>
           <div className="flex flex-col gap-3">
-            <Text variant="subtext" theme="neutral">Create your app</Text>
+            <Text variant="subtext" theme="neutral">Create your app (required to proceed)</Text>
             <div className="relative">
               <ClickToCopyButton className="w-fit !absolute right-2 top-3" textToCopy={`nuon apps create -n ${selectedApp.id}`} />
               <CodeBlock language="bash">{`nuon apps create -n ${selectedApp.id}`}</CodeBlock>

--- a/services/dashboard-ui/client/components/onboarding/steps/CreateInstallStep/CreateInstallStep.tsx
+++ b/services/dashboard-ui/client/components/onboarding/steps/CreateInstallStep/CreateInstallStep.tsx
@@ -105,6 +105,8 @@ export const CreateInstallStepContent = ({
         inputConfig={app.input_config}
         onSubmit={(formData: FormData) => onSubmit(formData)}
         onCancel={() => {}}
+        defaultAutoApprove
+        autoApproveDescription="Automatically approve and apply all future changes without manual confirmation. Defaulted to on for a faster trial flow."
       />
 
       <div className="flex justify-end">

--- a/services/dashboard-ui/client/components/onboarding/steps/CreateOrgStep/CreateOrgStep.tsx
+++ b/services/dashboard-ui/client/components/onboarding/steps/CreateOrgStep/CreateOrgStep.tsx
@@ -66,7 +66,7 @@ export const CreateOrgStep = ({
             <Input
               id="org-name"
               name="orgName"
-              placeholder="e.g. swift-harbor-ridge"
+              placeholder="swift-harbor-ridge"
               required
               value={orgName}
               onChange={(e) => onOrgNameChange(e.target.value)}

--- a/services/dashboard-ui/client/components/onboarding/steps/DownloadCliStep.tsx
+++ b/services/dashboard-ui/client/components/onboarding/steps/DownloadCliStep.tsx
@@ -47,7 +47,7 @@ export const DownloadCliStep = ({
 
       <div className="flex flex-col gap-2">
         <Text variant="body" weight="strong">
-          Authenticate
+          Authenticate (required to proceed)
         </Text>
         <div className="relative">
           <ClickToCopyButton

--- a/services/dashboard-ui/client/components/onboarding/steps/SyncAppStep.tsx
+++ b/services/dashboard-ui/client/components/onboarding/steps/SyncAppStep.tsx
@@ -13,6 +13,7 @@ export const SyncAppStep = ({ onAdvance, nextStepTitle }: IWizardStepComponentPr
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-3">
+        <Text variant="body" weight="strong">Sync your app (required to proceed)</Text>
         <div className="relative">
           <ClickToCopyButton className="w-fit !absolute right-2 top-3" textToCopy="nuon apps sync" />
           <CodeBlock language="bash">nuon apps sync</CodeBlock>

--- a/services/dashboard-ui/client/components/onboarding/steps/WelcomeStep/WelcomeStep.tsx
+++ b/services/dashboard-ui/client/components/onboarding/steps/WelcomeStep/WelcomeStep.tsx
@@ -18,7 +18,7 @@ export const WelcomeStep = ({ isPending, nextStepTitle, onSubmit, onAdvance }: I
     <form onSubmit={onSubmit} className="flex flex-col gap-6">
       <div className="flex items-center justify-between">
         <Text variant="body" theme="neutral">
-          Before we get started, tell us a bit about yourself.
+          Tell us a bit about yourself (optional).
         </Text>
         <UserProfile />
       </div>
@@ -26,19 +26,17 @@ export const WelcomeStep = ({ isPending, nextStepTitle, onSubmit, onAdvance }: I
         <Input
           id="jobTitle"
           name="jobTitle"
-          placeholder="e.g. Platform Engineer"
           labelProps={{ labelText: 'Job Title' }}
         />
         <Input
           id="companyName"
           name="companyName"
-          placeholder="e.g. Acme Corp"
           labelProps={{ labelText: 'Company Name' }}
         />
         <Textarea
           id="tellUsMore"
           name="tellUsMore"
-          placeholder="Tell us about your use case..."
+          placeholder="How did you find us? What is your use case, app architecture, cloud providers?"
           labelProps={{ labelText: 'Tell us more' }}
           rows={3}
         />

--- a/services/dashboard-ui/client/providers/onboarding-wizard-provider.tsx
+++ b/services/dashboard-ui/client/providers/onboarding-wizard-provider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useState, useCallback, useEffect } from 'react'
-import type { ComponentType } from 'react'
+import type { ComponentType, ReactNode } from 'react'
 
 export interface IWizardStepComponentProps {
   isComplete: boolean
@@ -14,7 +14,7 @@ export interface IWizardStepDef<TData = unknown> {
   id: string
   title: string
   navLabel?: string
-  description?: string
+  description?: ReactNode
   hideTitle?: boolean
   component: ComponentType<IWizardStepComponentProps>
   data?: TData

--- a/services/dashboard-ui/client/views/Onboarding.tsx
+++ b/services/dashboard-ui/client/views/Onboarding.tsx
@@ -32,14 +32,30 @@ const STEPS = [
     id: 'step-1',
     title: 'Welcome to Nuon',
     navLabel: 'Get Started',
-    description: "Let's setup your account.",
     component: WelcomeStep,
   },
   {
     id: 'step-2',
     title: 'Create your org',
     navLabel: 'Create Org',
-    description: 'Set up your organization.',
+    description: (
+      <div className="flex flex-col gap-2">
+        <p>
+          An org is an isolated place for metadata about your apps, installs, workflows and logs in Nuon Cloud.
+        </p>
+        <p className="text-sm opacity-80">
+          <a
+            href="https://nuon.co/contact-sales"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-600 dark:text-primary-400 underline underline-offset-2"
+          >
+            Contact sales
+          </a>{' '}
+          if you want to run Nuon&apos;s control plane in your AWS, Azure, or GCP.
+        </p>
+      </div>
+    ),
     component: CreateOrgStep,
   },
   {
@@ -60,17 +76,25 @@ const STEPS = [
   },
   {
     id: 'step-5',
-    title: 'Sync your app config',
+    title: 'Sync your app',
     navLabel: 'Sync App',
-    description:
-      'Syncing pushes your app config to Nuon and triggers a build. Run this from inside your cloned app directory.',
+    description: (
+      <div className="flex flex-col gap-2">
+        <p>
+          Syncing pushes your app to Nuon and triggers a build. Run this from inside your cloned app directory.
+        </p>
+        <p className="text-sm opacity-80">
+          A build creates OCI artifacts for the components in your app (e.g., Helm, Terraform, container image, Kubernetes manifest, etc.) and stores them in an isolated container registry in your org.
+        </p>
+      </div>
+    ),
     component: SyncAppStep,
   },
   {
     id: 'step-6',
     title: 'Create an install',
     navLabel: 'Deploy Install',
-    description: 'Create an install to deploy your app to a cloud account.',
+    description: 'Create an install to deploy your app to a cloud account. (Scroll down to find the Create install button.)',
     component: CreateInstallStep,
   },
 ]


### PR DESCRIPTION
## Summary

Dashboard onboarding (v1) copy and behavior refinements, plus quickstart / first-app docs updates.

### Dashboard onboarding
- Reorder the example apps in the Create App step and add `cde`; refresh display names and descriptions
- Tighten copy on Welcome, Create Org (with a Contact sales link to `nuon.co/contact-sales`), Sync App, and Create Install
- Widen the wizard description container and allow ReactNode descriptions so the Create Org step can render the inline link
- Add per-step "required to proceed" labels above the gating commands on Download CLI and Sync App
- Default auto-approve to on in the onboarding install flow and fix the draft-restore comparison (was checking `'on'` against the persisted `'true'`/`'false'`)
- Narrow `autoApproveDescription` on the install form to `string` (was `ReactNode`, but every call site passes a string literal)
- Remove redundant placeholders (`Job Title`, `Company Name`) and drop "config" language from the Sync App step
- Tag the install step description with a "scroll down to find the Create install button" hint

### Docs

**Sidebar order (`docs/docs.json`)**
- Reordered the Get Started group to `Quickstart → Create Your First App → Introduction`. Previously it was `Quickstart → Introduction → Create Your First App`, which buried the natural next step (a guided per-cloud walkthrough) behind the overview page. New order tracks how someone actually proceeds: do the Quickstart, then graduate to the longer first-app guide, with Introduction available as a reference.

**Quickstart (`docs/get-started/quickstart.mdx`)**
- The page had a copy-paste code block with five numbered steps at the top, followed by detailed sections below — but the detailed section headings didn't mirror the numbered steps. Steps 3, 4, and 5 were all lumped under a single "Deploy an Example App" heading, so readers couldn't easily map between the top-of-page recipe and the walkthrough underneath. Rewrote the section headings to track 1:1 with the numbered comments (`Install the CLI`, `Authenticate to Nuon Cloud`, `Clone the Example Apps Repo`, `Create and Sync the Example App`, `Install the Example App in AWS`) so the two halves of the page reinforce each other instead of competing.
- Funneled the page to a single concrete AWS path (was vague multi-cloud "test cloud account" framing). Faster to copy/paste and finish without making a cloud choice up front.
- Added a real explanation of what `nuon apps sync` does — that it builds OCI artifacts and stores them in the org's container registry. This aligns with the new build-definition copy in the dashboard's Sync App step.
- Renamed "Nuon account" → "Nuon Cloud account" to match the product naming used in the dashboard (also changed in this PR).
- Removed the inline "Apps are defined in TOML" Note — it interrupted the flow and the TOML aside is covered better on the Apps concept page.
- Added a closing pointer to AI agents for building your own app from the examples, since that's the natural next step after the example flow.

**First app guide (`docs/get-started/create-your-first-app.mdx`)**
- Dropped the "test cloud account" framing everywhere. Real users frequently don't have a sandbox account, and the phrasing made the flow feel like a side path rather than the real product flow.
- Marked the example-app path as **recommended** for first-time users to remove decision paralysis between "example" and "your own app".
- Updated the `cde` estimated time (~31 → ~26 min) and added a note that `cde` and `aws-lambda` are less resource- and cost-intensive than `eks-simple` (which spins up an EKS cluster with 3 nodes) so people can pick the right starter for their tolerance.
- Added the same AI agents pointer for packaging your own app.

**CLI page (`docs/cli.mdx`)**
- Moved the "Nuon CLI changes frequently, run `brew upgrade` regularly" Note up to sit right after the Homebrew install instructions. It was previously buried under the "Updates" section, where users hitting stale-CLI errors wouldn't see it in time.

**Introduction (`docs/get-started/introduction.mdx`)**
- Sidebar title `Home` → `Docs Home` so it's unambiguous against the site-wide Home / marketing nav.

## Testing

All of the above were tested locally in sandbox mode.