### PR TITLE
fix(ui): narrow autoApproveDescription to string

### DIFF
--- a/services/dashboard-ui/client/components/installs/forms/CreateInstallForm/CreateInstallForm.tsx
+++ b/services/dashboard-ui/client/components/installs/forms/CreateInstallForm/CreateInstallForm.tsx
@@ -19,7 +19,7 @@ interface ICreateInstallFormPresentation {
   onSuccess?: (result: any) => void
   onCancel: () => void
   defaultAutoApprove?: boolean
-  autoApproveDescription?: React.ReactNode
+  autoApproveDescription?: string
 }
 
 export const CreateInstallForm = forwardRef<

--- a/services/dashboard-ui/client/components/installs/forms/shared/types.ts
+++ b/services/dashboard-ui/client/components/installs/forms/shared/types.ts
@@ -12,7 +12,7 @@ export interface ICreateInstallForm {
   error?: any
   onRegisterClearDraft?: (clearFn: () => void) => void
   defaultAutoApprove?: boolean
-  autoApproveDescription?: React.ReactNode
+  autoApproveDescription?: string
 }
 
 export interface IUpdateInstallForm {


### PR DESCRIPTION
## Summary

Follow-up to review feedback on #1679 — narrows `autoApproveDescription` on the install form from `React.ReactNode` to `string`.

The only call site (`CreateInstallStep.tsx`) passes a string literal, so `ReactNode` was wider than needed. The render path uses `{autoApproveDescription ?? (...)}` and is unaffected.

Files touched:
- `services/dashboard-ui/client/components/installs/forms/CreateInstallForm/CreateInstallForm.tsx`
- `services/dashboard-ui/client/components/installs/forms/shared/types.ts`

## Test plan

- [x] Tested locally in sandbox mode (the broader onboarding flow was already verified in #1679; this is a pure type narrowing with no runtime change)