### PR TITLE
feat: dual write s3 blob

### DIFF
--- a/services/ctl-api/internal/app/install_state.go
+++ b/services/ctl-api/internal/app/install_state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/pkg/shortid/domains"
 	"github.com/nuonco/nuon/pkg/types/state"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/indexes"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
@@ -39,8 +40,9 @@ type InstallState struct {
 	Install   Install `json:"-" faker:"-" temporaljson:"install,omitzero,omitempty"`
 	InstallID string  `json:"install_id,omitzero" gorm:"notnull" temporaljson:"install_id,omitzero,omitempty"`
 
-	State   *state.State `json:"contents,omitzero" gorm:"type:jsonb" swaggertype:"string" temporaljson:"-"`
-	Version int          `json:"version,omitzero" gorm:"->;-:migration" temporaljson:"version,omitzero,omitempty"`
+	State     *state.State    `json:"contents,omitzero" gorm:"type:jsonb" swaggertype:"string" temporaljson:"-"`
+	StateBlob *blobstore.Blob `json:"-" temporaljson:"-"`
+	Version   int             `json:"version,omitzero" gorm:"->;-:migration" temporaljson:"version,omitzero,omitempty"`
 
 	TriggeredByID   string `json:"triggered_by_id,omitzero" gorm:"type:text;check:triggered_by_id_checker,char_length(id)=26"`
 	TriggeredByType string `json:"triggered_by_type,omitzero" gorm:"type:text;"`
@@ -107,6 +109,10 @@ func (a *InstallState) BeforeCreate(tx *gorm.DB) error {
 				return fmt.Errorf("org_id is required and could not be determined")
 			}
 		}
+	}
+
+	if err := a.StateBlob.BeforeCreate(tx); err != nil {
+		return err
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/installs/worker/activities/create_step_approval.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/create_step_approval.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
 )
 
 type CreateStepApprovalRequest struct {
@@ -46,6 +49,20 @@ func (a *Activities) CreateStepApproval(ctx context.Context, req *CreateStepAppr
 		OwnerID:               req.OwnerID,
 		Contents:              plan,
 		Type:                  req.Type,
+	}
+
+	if plan != "" {
+		// the blob upload in WorkflowStepApproval's BeforeCreate hook requires org_id on the context
+		if keys.OrgIDFromContext(ctx) == "" {
+			var step app.WorkflowStep
+			if res := a.db.WithContext(ctx).Select("org_id").First(&step, "id = ?", req.StepID); res.Error != nil {
+				return nil, errors.Wrap(res.Error, "unable to look up step org for approval contents")
+			}
+			ctx = cctx.SetOrgIDContext(ctx, step.OrgID)
+		}
+
+		sa.ContentsBlob = &blobstore.Blob{}
+		sa.ContentsBlob.Set(plan)
 	}
 
 	// workflows polymorphic step approvals do not have a runner job ID

--- a/services/ctl-api/internal/app/installs/worker/activities/save_state.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/save_state.go
@@ -2,11 +2,15 @@ package activities
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/pkg/types/state"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
 )
 
 type SaveStateRequest struct {
@@ -20,13 +24,29 @@ type SaveStateRequest struct {
 
 // @temporal-gen-v2 activity
 func (a *Activities) SaveState(ctx context.Context, req *SaveStateRequest) (*app.InstallState, error) {
+	// the blob upload in InstallState's BeforeCreate hook requires org_id on the context
+	if keys.OrgIDFromContext(ctx) == "" {
+		var install app.Install
+		if res := a.db.WithContext(ctx).Select("org_id").First(&install, "id = ?", req.InstallID); res.Error != nil {
+			return nil, errors.Wrap(res.Error, "unable to look up install org for state")
+		}
+		ctx = cctx.SetOrgIDContext(ctx, install.OrgID)
+	}
+
+	stateJSON, err := json.Marshal(req.State)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to marshal install state for blob")
+	}
+
 	obj := &app.InstallState{
 		InstallID:       req.InstallID,
 		TriggeredByID:   req.TriggeredByID,
 		TriggeredByType: req.TriggeredByType,
 		State:           req.State,
 		GeneratedBy:     req.GeneratedBy,
+		StateBlob:       &blobstore.Blob{},
 	}
+	obj.StateBlob.Set(string(stateJSON))
 
 	res := a.db.WithContext(ctx).
 		Create(&obj)

--- a/services/ctl-api/internal/app/workflow_step_approval.go
+++ b/services/ctl-api/internal/app/workflow_step_approval.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/plugin/soft_delete"
 
 	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/indexes"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
@@ -48,7 +49,8 @@ type WorkflowStepApproval struct {
 	OwnerID   string `json:"owner_id,omitzero" gorm:"type:text;check:owner_id_checker,char_length(id)=26;index:idx_runner_jobs_owner_id,priority:1" temporaljson:"owner_id,omitzero,omitempty"`
 	OwnerType string `json:"owner_type,omitzero" gorm:"type:text;" temporaljson:"owner_type,omitzero,omitempty"`
 
-	Contents string `json:"-" temporaljson:"-"`
+	Contents     string          `json:"-" temporaljson:"-"`
+	ContentsBlob *blobstore.Blob `json:"-" temporaljson:"-"`
 
 	Type WorkflowStepApprovalType `json:"type"`
 
@@ -75,6 +77,11 @@ func (c *WorkflowStepApproval) BeforeCreate(tx *gorm.DB) error {
 	if c.OrgID == "" {
 		c.OrgID = orgIDFromContext(tx.Statement.Context)
 	}
+
+	if err := c.ContentsBlob.BeforeCreate(tx); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/services/ctl-api/internal/middlewares/blob/middleware.go
+++ b/services/ctl-api/internal/middlewares/blob/middleware.go
@@ -18,7 +18,9 @@ func (m middleware) Name() string {
 
 func (m middleware) Handler() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		blobstore.WithBlobServiceGin(ctx, m.svc)
+		ctx.Request = ctx.Request.WithContext(
+			blobstore.WithBlobService(ctx.Request.Context(), m.svc),
+		)
 		ctx.Next()
 	}
 }

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -4433,6 +4433,7 @@ export interface components {
       stale_at?: components["schemas"]["generics.NullTime"];
       /** @description StalePartials lists which state partials are stale and need regeneration on next read. */
       stale_partials?: components["schemas"]["state.PartialName"][];
+      state_blob?: components["schemas"]["blobstore.Blob"];
       triggered_by_id?: string;
       triggered_by_type?: string;
       updated_at?: string;


### PR DESCRIPTION
Dual-write install state, plans, and component outputs to S3 blob storage

Now that blob storage (blobstore.Blob) is available, this dual-writes three large fields to S3 alongside their existing Postgres columns. The existing columns stay the source of truth — reads are unchanged — so this just starts populating S3 in parallel ahead of a future read cutover.

What's dual-written:
- Install state -- InstallState.State → StateBlob (SaveState activity)
- Workflow approval content
