### PR TITLE
feat(ctl-api): enable runner job & log tail long polling by default

### DIFF
--- a/services/ctl-api/internal/app/org.go
+++ b/services/ctl-api/internal/app/org.go
@@ -201,8 +201,6 @@ func (o *Org) BeforeCreate(tx *gorm.DB) error {
 		OrgFeatureRunbooks:                true,
 		OrgFeaturePulumiSandbox:           false,
 		OrgFeaturePulumiUpdatePlans:       false,
-		OrgFeatureLogTailLongPoll:         false,
-		OrgFeatureRunnerJobLongPoll:       false,
 		OrgFeatureNotebooks:               false,
 
 		// Enabled by default
@@ -212,6 +210,8 @@ func (o *Org) BeforeCreate(tx *gorm.DB) error {
 		OrgFeatureOrgRunner:          true,
 		OrgFeatureOrgSettings:        true,
 		OrgFeatureAppBranches:        true,
+		OrgFeatureLogTailLongPoll:    true,
+		OrgFeatureRunnerJobLongPoll:  true,
 	}
 	for _, feature := range GetFeatures() {
 		if _, ok := o.Features[string(feature)]; !ok {


### PR DESCRIPTION
Defaults the `runner-job-long-poll` and `log-tail-long-poll` org feature flags to on for newly created orgs.