### PR TITLE
feat: (ctl-api) surface composite error when a component build has failed

### DIFF
--- a/services/ctl-api/internal/app/installs/deployerrors/component_build_unavailable_error.go
+++ b/services/ctl-api/internal/app/installs/deployerrors/component_build_unavailable_error.go
@@ -1,0 +1,105 @@
+package deployerrors
+
+import (
+	"fmt"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+// ComponentBuildUnavailableErrorType is the discriminator for a deploy that
+// cannot proceed because the component it targets has no deployable build.
+const ComponentBuildUnavailableErrorType compositeerrors.Type = "deploy.component_build_unavailable"
+
+// ComponentBuildUnavailableReason describes why the build could not be deployed.
+type ComponentBuildUnavailableReason string
+
+const (
+	// ComponentBuildUnavailableReasonFailed means the latest build for the
+	// component is in a terminal failure state (error / policy_failed).
+	ComponentBuildUnavailableReasonFailed ComponentBuildUnavailableReason = "failed"
+
+	// ComponentBuildUnavailableReasonMissing means no build exists for the
+	// component yet. (Not produced yet — reserved for a follow-up that surfaces
+	// missing builds at the workflow-step level.)
+	ComponentBuildUnavailableReasonMissing ComponentBuildUnavailableReason = "missing"
+)
+
+// ComponentBuildUnavailableError is the typed payload for a deploy that cannot
+// run because its component build is unavailable. It implements
+// compositeerrors.CompositeError so it can be frozen onto the owning deploy row
+// and rendered in the dashboard, guiding the user to (re)build the component.
+type ComponentBuildUnavailableError struct {
+	Reason ComponentBuildUnavailableReason `json:"reason"`
+
+	ComponentID   string `json:"component_id,omitempty"`
+	ComponentName string `json:"component_name,omitempty"`
+
+	BuildID                string `json:"build_id,omitempty"`
+	BuildStatus            string `json:"build_status,omitempty"`
+	BuildStatusDescription string `json:"build_status_description,omitempty"`
+}
+
+var _ compositeerrors.CompositeError = (*ComponentBuildUnavailableError)(nil)
+
+func (e *ComponentBuildUnavailableError) Error() string {
+	name := e.ComponentName
+	if name == "" {
+		name = "component"
+	}
+	if e.Reason == ComponentBuildUnavailableReasonMissing {
+		return fmt.Sprintf("No build available for %s", name)
+	}
+	return fmt.Sprintf("Build for %s failed", name)
+}
+
+func (e *ComponentBuildUnavailableError) Type() compositeerrors.Type {
+	return ComponentBuildUnavailableErrorType
+}
+
+func (e *ComponentBuildUnavailableError) Severity() compositeerrors.Severity {
+	return compositeerrors.SeverityError
+}
+
+func (e *ComponentBuildUnavailableError) Sections() []compositeerrors.Section {
+	name := e.ComponentName
+	if name == "" {
+		name = "this component"
+	}
+
+	var why string
+	if e.Reason == ComponentBuildUnavailableReasonMissing {
+		why = fmt.Sprintf("This deploy needs an active build for %s, but no build exists yet. Deploys can only run against a successfully built artifact.", name)
+	} else {
+		why = fmt.Sprintf("This deploy needs an active build for %s, but its most recent build did not complete successfully. Deploys can only run against a successfully built artifact.", name)
+	}
+	sections := []compositeerrors.Section{
+		{
+			Heading: "Why",
+			Body:    why,
+		},
+	}
+
+	if e.BuildStatus != "" || e.BuildStatusDescription != "" {
+		var body string
+		if e.BuildID != "" {
+			body += fmt.Sprintf("Build: `%s`\n\n", e.BuildID)
+		}
+		if e.BuildStatus != "" {
+			body += fmt.Sprintf("Status: `%s`\n\n", e.BuildStatus)
+		}
+		if e.BuildStatusDescription != "" {
+			body += "```\n" + e.BuildStatusDescription + "\n```"
+		}
+		sections = append(sections, compositeerrors.Section{
+			Heading: "Build status",
+			Body:    body,
+		})
+	}
+
+	sections = append(sections, compositeerrors.Section{
+		Heading: "How to fix",
+		Body:    fmt.Sprintf("Build %s, wait for the build to become active, then retry this deploy.", name),
+	})
+
+	return sections
+}

--- a/services/ctl-api/internal/app/installs/deployerrors/component_build_unavailable_error_test.go
+++ b/services/ctl-api/internal/app/installs/deployerrors/component_build_unavailable_error_test.go
@@ -1,0 +1,65 @@
+package deployerrors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+func TestComponentBuildUnavailableError_Failed(t *testing.T) {
+	e := &ComponentBuildUnavailableError{
+		Reason:                 ComponentBuildUnavailableReasonFailed,
+		ComponentID:            "cmp123",
+		ComponentName:          "api",
+		BuildID:                "bld456",
+		BuildStatus:            "error",
+		BuildStatusDescription: "build step failed",
+	}
+
+	if got, want := e.Type(), ComponentBuildUnavailableErrorType; got != want {
+		t.Errorf("Type() = %q, want %q", got, want)
+	}
+	if e.Severity() != compositeerrors.SeverityError {
+		t.Errorf("Severity() = %q, want error", e.Severity())
+	}
+	if got := e.Error(); !strings.Contains(got, "api") || !strings.Contains(got, "failed") {
+		t.Errorf("Error() = %q, want it to mention the component and failure", got)
+	}
+
+	sections := e.Sections()
+	if len(sections) < 2 {
+		t.Fatalf("expected at least why + how-to-fix sections, got %d", len(sections))
+	}
+
+	var joined string
+	for _, s := range sections {
+		joined += s.Heading + "\n" + s.Body + "\n"
+	}
+	for _, want := range []string{"error", "build step failed", "bld456"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("sections missing %q; got:\n%s", want, joined)
+		}
+	}
+	if !strings.Contains(joined, "How to fix") {
+		t.Errorf("sections missing a how-to-fix heading; got:\n%s", joined)
+	}
+}
+
+func TestComponentBuildUnavailableError_Missing(t *testing.T) {
+	e := &ComponentBuildUnavailableError{
+		Reason:        ComponentBuildUnavailableReasonMissing,
+		ComponentName: "worker",
+	}
+	if got := e.Error(); !strings.Contains(got, "worker") {
+		t.Errorf("Error() = %q, want it to mention the component", got)
+	}
+
+	data := compositeerrors.New(e)
+	if data.Type != ComponentBuildUnavailableErrorType {
+		t.Errorf("New().Type = %q, want %q", data.Type, ComponentBuildUnavailableErrorType)
+	}
+	if data.Message == "" {
+		t.Error("New().Message should not be empty")
+	}
+}

--- a/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
@@ -13,6 +13,7 @@ import (
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/pkg/types/state"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/deployerrors"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/workflowstepapprovalrequest"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/plan"
@@ -214,11 +215,22 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	} else {
 		buildID := s.BuildID
 		if buildID == "" {
-			componentBuild, err := activities.AwaitGetComponentLatestBuildByComponentID(ctx, s.ComponentID)
+			// Prefer the latest active (deployable) build. Only fall back to
+			// the latest build of any status when no active build exists, so a
+			// newer errored build can't mask an older deployable one.
+			activeBuild, err := activities.AwaitGetLatestActiveComponentBuildByComponentID(ctx, s.ComponentID)
 			if err != nil {
-				return fmt.Errorf("unable to get component build: %w", err)
+				return fmt.Errorf("unable to get latest active component build: %w", err)
 			}
-			buildID = componentBuild.ID
+			if activeBuild != nil {
+				buildID = activeBuild.ID
+			} else {
+				componentBuild, err := activities.AwaitGetComponentLatestBuildByComponentID(ctx, s.ComponentID)
+				if err != nil {
+					return fmt.Errorf("unable to get component build: %w", err)
+				}
+				buildID = componentBuild.ID
+			}
 		}
 
 		installDeploy, err = activities.AwaitCreateInstallDeploy(ctx, activities.CreateInstallDeployRequest{
@@ -243,18 +255,22 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		}
 	}()
 
-	err = s.pollForDeployableBuild(ctx, installDeploy.ID, installDeploy.ComponentBuildID)
-	if err != nil {
-		s.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusNoop, "build is not deployable")
-		return errors.Wrap(err, "failed to poll for build")
-	}
-
+	// Point the workflow step at this deploy up front so the dashboard can
+	// surface a composite error recorded below even when the build never
+	// becomes deployable.
 	if err := activities.AwaitUpdateInstallWorkflowStepTarget(ctx, activities.UpdateInstallWorkflowStepTargetRequest{
 		StepID:         s.WorkflowStepID,
 		StepTargetID:   installDeploy.ID,
 		StepTargetType: "install_deploys",
 	}); err != nil {
 		return errors.Wrap(err, "unable to update install workflow")
+	}
+
+	err = s.pollForDeployableBuild(ctx, installDeploy.ID, installDeploy.ComponentBuildID)
+	if err != nil {
+		s.recordBuildFailureCompositeError(ctx, installDeploy.ID, installDeploy.ComponentBuildID)
+		s.updateDeployStatusWithoutStatusSync(ctx, installDeploy.ID, app.InstallDeployStatusNoop, "build is not deployable")
+		return errors.Wrap(err, "failed to poll for build")
 	}
 
 	defer func() {
@@ -302,6 +318,35 @@ func (s *Signal) isBuildDeployable(bld *app.ComponentBuild) bool {
 	return bld.Status == app.ComponentBuildStatusActive
 }
 
+// isTerminalBuildFailure reports whether a build is in a state it cannot
+// recover from, so the deploy should fail fast rather than keep polling.
+func isTerminalBuildFailure(status app.ComponentBuildStatus) bool {
+	return status == app.ComponentBuildStatusError ||
+		status == app.ComponentBuildStatusPolicyFailed
+}
+
+// recordBuildFailureCompositeError freezes a ComponentBuildUnavailableError onto
+// the deploy when the build is in a terminal failure state, so the dashboard can
+// guide the user to rebuild the component. It is best-effort and never returns
+// an error: a build that is merely un-deployable for another reason (e.g. a
+// polling timeout while still building) is left with its plain status.
+func (s *Signal) recordBuildFailureCompositeError(ctx workflow.Context, deployID, componentBuildID string) {
+	bld, err := activities.AwaitGetComponentBuildByComponentBuildID(ctx, componentBuildID)
+	if err != nil || bld == nil || !isTerminalBuildFailure(bld.Status) {
+		return
+	}
+
+	_ = activities.AwaitRecordDeployBuildUnavailableCompositeError(ctx, activities.RecordDeployBuildUnavailableCompositeErrorRequest{
+		DeployID:               deployID,
+		Reason:                 deployerrors.ComponentBuildUnavailableReasonFailed,
+		ComponentID:            s.ComponentID,
+		ComponentName:          bld.ComponentName,
+		BuildID:                bld.ID,
+		BuildStatus:            string(bld.Status),
+		BuildStatusDescription: bld.StatusDescription,
+	})
+}
+
 func (s *Signal) pollForDeployableBuild(ctx workflow.Context, installDeployId, componentBuildID string) error {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
@@ -341,9 +386,9 @@ func (s *Signal) pollForDeployableBuild(ctx workflow.Context, installDeployId, c
 			return nil
 		}
 
-		if bld.Status == app.ComponentBuildStatusError {
-			l.Error("component build is in an error state")
-			return fmt.Errorf("component build is in an error state")
+		if isTerminalBuildFailure(bld.Status) {
+			l.Error("component build is in a terminal failure state", zap.String("status", string(bld.Status)))
+			return fmt.Errorf("component build is in a %s state", bld.Status)
 		}
 
 		workflow.Sleep(ctx, sleepTimer)

--- a/services/ctl-api/internal/app/installs/worker/activities/record_deploy_build_unavailable_composite_error.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/record_deploy_build_unavailable_composite_error.go
@@ -1,0 +1,70 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/deployerrors"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+type RecordDeployBuildUnavailableCompositeErrorRequest struct {
+	DeployID string `validate:"required"`
+
+	Reason deployerrors.ComponentBuildUnavailableReason `validate:"required"`
+
+	ComponentID   string
+	ComponentName string
+
+	BuildID                string
+	BuildStatus            string
+	BuildStatusDescription string
+}
+
+// RecordDeployBuildUnavailableCompositeError freezes a structured
+// ComponentBuildUnavailableError onto the InstallDeploy when a deploy cannot
+// proceed because its component build is unavailable (currently: the latest
+// build is in a terminal failure state). This lets the dashboard guide the
+// user to rebuild the component instead of surfacing a raw status string.
+//
+// It is best-effort: it does not block the deploy failure path.
+//
+// @temporal-gen-v2 activity
+// @max-retries 1
+func (a *Activities) RecordDeployBuildUnavailableCompositeError(ctx context.Context, req RecordDeployBuildUnavailableCompositeErrorRequest) error {
+	l := temporalzap.GetActivityLogger(ctx)
+	l = l.With(
+		zap.String("deploy_id", req.DeployID),
+		zap.String("component_id", req.ComponentID),
+		zap.String("build_id", req.BuildID),
+	)
+
+	ce := &deployerrors.ComponentBuildUnavailableError{
+		Reason:                 req.Reason,
+		ComponentID:            req.ComponentID,
+		ComponentName:          req.ComponentName,
+		BuildID:                req.BuildID,
+		BuildStatus:            req.BuildStatus,
+		BuildStatusDescription: req.BuildStatusDescription,
+	}
+
+	data := compositeerrors.New(ce)
+	res := a.db.WithContext(ctx).
+		Model(&app.InstallDeploy{ID: req.DeployID}).
+		Select("composite_error").
+		Updates(app.InstallDeploy{CompositeError: data})
+	if res.Error != nil {
+		return fmt.Errorf("unable to record deploy build-unavailable composite error: %w", res.Error)
+	}
+	if res.RowsAffected < 1 {
+		return fmt.Errorf("no deploy found for id %s: %w", req.DeployID, gorm.ErrRecordNotFound)
+	}
+
+	l.Info("recorded build-unavailable composite error on deploy", zap.String("reason", string(req.Reason)))
+	return nil
+}


### PR DESCRIPTION
When a component deploy targets a build in a terminal failure state (error / policy_failed), freeze a typed `ComponentBuildUnavailableError` onto the `InstallDeploy` so the dashboard guides the user to rebuild the component, instead of showing a raw status string or hanging on polling.

- Add `ComponentBuildUnavailableError` composite error type (reason "failed"; "missing" reserved for a follow-up)
- Add `RecordDeployBuildUnavailableCompositeError` activity to record it onto `InstallDeploy.composite_error` (best-effort)
- `componentdeploysyncandplan` signal:
  - record the composite error when build polling fails on a terminal build state
  - treat `policy_failed` as terminal so the deploy fails fast instead of polling for up to an hour
  - prefer the latest active build over latest-any when resolving an empty BuildID, so a newer errored build can't mask an older deployable one
  - set the workflow step's deploy target before polling so the error is visible in the dashboard even when the build never becomes deployable

No frontend changes: the existing `CompositeError` renderer surfaces it on the deploy page. Follow-up will cover truly-missing builds via a WorkflowStep-level composite error.

<img width="1352" height="840" alt="Screenshot 2026-06-16 at 10 43 52 PM" src="https://github.com/user-attachments/assets/fff8ccb7-dc1e-4195-af44-33750dbbf285" />
