### PR TITLE
fix: app provisioning on gcp

### DIFF
--- a/services/ctl-api/internal/app/apps/signals/provision/signal.go
+++ b/services/ctl-api/internal/app/apps/signals/provision/signal.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/apps/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/apps/worker/ecrrepository"
@@ -18,9 +19,18 @@ const SignalType signal.SignalType = "app-provision"
 
 type Signal struct {
 	AppID string `json:"app_id"`
+
+	cfg *internal.Config
 }
 
-var _ signal.Signal = (*Signal)(nil)
+var (
+	_ signal.Signal           = (*Signal)(nil)
+	_ signal.SignalWithParams = (*Signal)(nil)
+)
+
+func (s *Signal) WithParams(params *signal.Params) {
+	s.cfg = params.Cfg
+}
 
 func (s *Signal) Type() signal.SignalType {
 	return SignalType
@@ -100,9 +110,31 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		StatusDescription: "provisioning app resources",
 	})
 
-	// Provision ECR repository (only for default org type)
 	var repoResp *ecrrepository.ProvisionECRRepositoryResponse
-	if currentApp.Org.OrgType == app.OrgTypeDefault {
+	switch {
+	case currentApp.Org.OrgType != app.OrgTypeDefault:
+		repoResp = generics.GetFakeObj[*ecrrepository.ProvisionECRRepositoryResponse]()
+		l.Info("skipping provision app repository",
+			zap.String("app_id", currentApp.ID),
+			zap.String("app_name", currentApp.Name),
+			zap.Any("org_type", currentApp.Org.OrgType),
+			zap.String("org_id", currentApp.Org.ID),
+			zap.String("org_name", currentApp.Org.Name))
+	case s.cfg.IsGCP():
+		repoResp = ecrrepository.BuildGARResponse(
+			s.cfg.ManagementGARRepositoryURL,
+			currentApp.OrgID,
+			s.AppID,
+			s.cfg.AppRegion,
+		)
+	case s.cfg.IsAzure():
+		repoResp = ecrrepository.BuildACRResponse(
+			s.cfg.ManagementACRRegistryURL,
+			currentApp.OrgID,
+			s.AppID,
+			s.cfg.AppRegion,
+		)
+	default:
 		repoResp, err = ecrrepository.AwaitProvisionECRRepository(ctx, &ecrrepository.ProvisionECRRepositoryRequest{
 			OrgID: currentApp.OrgID,
 			AppID: s.AppID,
@@ -110,15 +142,6 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "unable to provision ECR repository")
 		}
-	} else {
-		// For non-default orgs, use fake response
-		repoResp = generics.GetFakeObj[*ecrrepository.ProvisionECRRepositoryResponse]()
-		l.Info("skipping provision ecr",
-			zap.String("app_id", currentApp.ID),
-			zap.String("app_name", currentApp.Name),
-			zap.Any("org_type", currentApp.Org.OrgType),
-			zap.String("org_id", currentApp.Org.ID),
-			zap.String("org_name", currentApp.Org.Name))
 	}
 
 	// Create app repository record

--- a/services/ctl-api/internal/app/apps/worker/ecrrepository/synthetic.go
+++ b/services/ctl-api/internal/app/apps/worker/ecrrepository/synthetic.go
@@ -1,0 +1,25 @@
+package ecrrepository
+
+import "fmt"
+
+// BuildGARResponse synthesizes a ProvisionECRRepositoryResponse for a GCP-hosted
+// control plane. GCP Artifact Registry Docker repositories accept arbitrary path
+// hierarchies, so apps share the management repository with org/app as a path
+// prefix rather than getting their own GCP-side repo.
+func BuildGARResponse(repositoryURL, orgID, appID, region string) *ProvisionECRRepositoryResponse {
+	return &ProvisionECRRepositoryResponse{
+		RepositoryName: fmt.Sprintf("%s/%s", orgID, appID),
+		RepositoryURI:  fmt.Sprintf("%s/%s/%s", repositoryURL, orgID, appID),
+		Region:         region,
+	}
+}
+
+// BuildACRResponse synthesizes a ProvisionECRRepositoryResponse for an
+// Azure-hosted control plane. ACR uses the same shared-registry pattern as GAR.
+func BuildACRResponse(registryURL, orgID, appID, region string) *ProvisionECRRepositoryResponse {
+	return &ProvisionECRRepositoryResponse{
+		RepositoryName: fmt.Sprintf("%s/%s", orgID, appID),
+		RepositoryURI:  fmt.Sprintf("%s/%s/%s", registryURL, orgID, appID),
+		Region:         region,
+	}
+}

--- a/services/ctl-api/internal/app/apps/worker/workflows.go
+++ b/services/ctl-api/internal/app/apps/worker/workflows.go
@@ -15,17 +15,6 @@ import (
 	workerplan "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/worker/plan"
 )
 
-// acrRepositoryResponse builds a ProvisionECRRepositoryResponse for Azure ACR.
-// ACR uses a shared management registry with org/app path prefixes.
-func (w *Workflows) acrRepositoryResponse(orgID, appID string) *ecrrepository.ProvisionECRRepositoryResponse {
-	acrURL := w.cfg.ManagementACRRegistryURL
-	return &ecrrepository.ProvisionECRRepositoryResponse{
-		RepositoryName: fmt.Sprintf("%s/%s", orgID, appID),
-		RepositoryURI:  fmt.Sprintf("%s/%s/%s", acrURL, orgID, appID),
-		Region:         w.cfg.AppRegion,
-	}
-}
-
 type Workflows struct {
 	cfg       *internal.Config
 	v         *validator.Validate

--- a/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
@@ -326,16 +326,29 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		checksum = armResult.Checksum
 	}
 
-	// AWS and Azure converge here, after template generation is complete.
-	// We upload both types of stacks to S3.
-	// Even though Azure cannot use the AWS Quickcreate flow, the Azure CLI can still pull a bicep template file via HTTP.
-
-	// upload and publish the stack
-	if err := activities.AwaitUploadAWSCloudFormationStackVersionTemplate(ctx, &activities.UploadAWSCloudFormationStackVersionTemplateRequest{
-		BucketKey: stackVersion.AWSBucketKey,
-		Template:  tmplByts,
-	}); err != nil {
-		return errors.Wrap(err, "unable to upload cloudformation stack")
+	switch s.cfg.CloudProvider {
+	case string(app.CloudPlatformGCP):
+		gcsResp, err := activities.AwaitUploadGCSInstallStackTemplate(ctx, &activities.UploadGCSInstallStackTemplateRequest{
+			Bucket:   s.cfg.GCSInstallTemplateBucket,
+			Key:      stackVersion.AWSBucketKey,
+			Template: tmplByts,
+		})
+		if err != nil {
+			return errors.Wrap(err, "unable to upload stack template to GCS")
+		}
+		if err := activities.AwaitUpdateInstallStackVersionTemplateURL(ctx, &activities.UpdateInstallStackVersionTemplateURLRequest{
+			ID:          stackVersion.ID,
+			TemplateURL: gcsResp.URL,
+		}); err != nil {
+			return errors.Wrap(err, "unable to update template URL")
+		}
+	default:
+		if err := activities.AwaitUploadAWSCloudFormationStackVersionTemplate(ctx, &activities.UploadAWSCloudFormationStackVersionTemplateRequest{
+			BucketKey: stackVersion.AWSBucketKey,
+			Template:  tmplByts,
+		}); err != nil {
+			return errors.Wrap(err, "unable to upload cloudformation stack")
+		}
 	}
 
 	if err := activities.AwaitSaveInstallStackVersionTemplate(ctx, &activities.SaveInstallStackVersionTemplateRequest{

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -468,5 +468,23 @@ func NewConfig() (*Config, error) {
 		return nil, fmt.Errorf("unable to validate config: %w", err)
 	}
 
+	switch {
+	case cfg.IsGCP():
+		if cfg.ManagementGARRepositoryURL == "" {
+			return nil, fmt.Errorf("management_gar_repository_url is required when cloud_provider=gcp")
+		}
+	case cfg.IsAzure():
+		if cfg.ManagementACRRegistryURL == "" {
+			return nil, fmt.Errorf("management_acr_registry_url is required when cloud_provider=azure")
+		}
+	default:
+		if cfg.ManagementIAMRoleARN == "" {
+			return nil, fmt.Errorf("management_iam_role_arn is required when cloud_provider=aws")
+		}
+		if cfg.ManagementECRRegistryID == "" {
+			return nil, fmt.Errorf("management_ecr_registry_id is required when cloud_provider=aws")
+		}
+	}
+
 	return &cfg, nil
 }


### PR DESCRIPTION
## Summary

Creating apps is failing in Nuon BYOC on GCP. The root cause is that it's trying to select an IAM role, even though it's on GCP. It's not switching on the platform. This PR:

- Adds a GAR repo response to provide the correct URL
- Adds a cloud platform switch to the app provision signal
- Validates the repo URL at config load time, to fail early instead of when you try to create an app the first time

Creating install stacks was also failing. Another case of not pivoting on the platform and still trying to use the AWS path. This PR includes a fix for this as well.