### PR TITLE
chore: improve build cancellation + inactive components

### DIFF
--- a/services/ctl-api/docs/public/descriptions/cancel_component_build.md
+++ b/services/ctl-api/docs/public/descriptions/cancel_component_build.md
@@ -1,0 +1,1 @@
+Cancel a component build by cancelling its queue signal. If the build has an in-flight runner job, it will also be cancelled.

--- a/services/ctl-api/internal/app/components/helpers/helpers.go
+++ b/services/ctl-api/internal/app/components/helpers/helpers.go
@@ -35,3 +35,7 @@ func New(params Params) *Helpers {
 		queueClient: params.QueueClient,
 	}
 }
+
+func (h *Helpers) QueueClient() *queueclient.Client {
+	return h.queueClient
+}

--- a/services/ctl-api/internal/app/components/service/cancel_component_build.go
+++ b/services/ctl-api/internal/app/components/service/cancel_component_build.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+)
+
+// @ID						CancelAppComponentBuild
+// @Summary				cancel component build
+// @Description.markdown	cancel_component_build.md
+// @Param					app_id			path	string	true	"app ID"
+// @Param					component_id	path	string	true	"component ID"
+// @Param					build_id		path	string	true	"build ID"
+// @Tags					components
+// @Accept					json
+// @Produce				json
+// @Security				APIKey
+// @Security				OrgID
+// @Failure				400	{object}	stderr.ErrResponse
+// @Failure				401	{object}	stderr.ErrResponse
+// @Failure				403	{object}	stderr.ErrResponse
+// @Failure				404	{object}	stderr.ErrResponse
+// @Failure				500	{object}	stderr.ErrResponse
+// @Success				202	{object}	app.ComponentBuild
+// @Router					/v1/apps/{app_id}/components/{component_id}/builds/{build_id}/cancel [POST]
+func (s *service) CancelAppComponentBuild(ctx *gin.Context) {
+	orgID, err := cctx.OrgIDFromContext(ctx)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	bldID := ctx.Param("build_id")
+
+	var bld app.ComponentBuild
+	if err := s.db.WithContext(ctx).
+		Preload("QueueSignal").
+		First(&bld, "id = ? AND org_id = ?", bldID, orgID).Error; err != nil {
+		ctx.Error(fmt.Errorf("unable to get build: %w", err))
+		return
+	}
+
+	if bld.QueueSignal == nil {
+		ctx.Error(fmt.Errorf("build has no queue signal"))
+		return
+	}
+
+	if _, err := s.queueClient.CancelSignal(ctx, bld.QueueSignal.ID); err != nil {
+		ctx.Error(fmt.Errorf("unable to cancel build signal: %w", err))
+		return
+	}
+
+	ctx.JSON(http.StatusAccepted, bld)
+}

--- a/services/ctl-api/internal/app/components/service/service.go
+++ b/services/ctl-api/internal/app/components/service/service.go
@@ -91,6 +91,7 @@ func (s *service) RegisterPublicRoutes(api *gin.Engine) error {
 				builds.POST("", s.CreateAppComponentBuild)
 				builds.GET("/latest", s.GetAppComponentLatestBuild)
 				builds.GET("/:build_id", s.GetAppComponentBuild)
+				builds.POST("/:build_id/cancel", s.CancelAppComponentBuild)
 				builds.GET("", s.GetAppComponentBuilds)
 			}
 

--- a/services/ctl-api/internal/app/components/signals/build/signal.go
+++ b/services/ctl-api/internal/app/components/signals/build/signal.go
@@ -11,6 +11,7 @@ import (
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/pkg/plugins/configs"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	createdsignal "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/created"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/plan"
 	orgprovision "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/provision"
@@ -22,6 +23,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
+	jobactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
@@ -29,9 +31,14 @@ type Signal struct {
 	ComponentID string `json:"component_id" validate:"required"`
 	BuildID     string `json:"build_id" validate:"required"`
 	SandboxMode bool   `json:"sandbox_mode"`
+
+	runnerJobID string
 }
 
-var _ signal.Signal = (*Signal)(nil)
+var (
+	_ signal.Signal           = (*Signal)(nil)
+	_ signal.SignalWithCancel = (*Signal)(nil)
+)
 
 func (s *Signal) Type() signal.SignalType {
 	return SignalType
@@ -82,6 +89,13 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusError, "org provision not ready")
 		return fmt.Errorf("org provision not ready: %w", err)
 	}
+	if comp.Status != app.ComponentStatusActive {
+		createdSignal := &createdsignal.Signal{ComponentID: s.ComponentID}
+		if err := createdSignal.Execute(ctx); err != nil {
+			s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusError, "unable to activate component")
+			return fmt.Errorf("unable to activate component: %w", err)
+		}
+	}
 
 	build, err := activities.AwaitGetComponentBuildByID(ctx, s.BuildID)
 	if err != nil {
@@ -96,11 +110,6 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 			"created_by":     build.CreatedBy.Email,
 		})
 		return err
-	}
-
-	if comp.Status != app.ComponentStatusActive {
-		s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusError, "component is not active")
-		return notify(fmt.Errorf("component is not active"))
 	}
 
 	if err := s.execBuild(ctx, s.ComponentID, s.BuildID, currentApp, s.SandboxMode); err != nil {
@@ -142,6 +151,7 @@ func (s *Signal) execBuild(ctx workflow.Context, compID, buildID string, current
 		s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to create job")
 		return fmt.Errorf("unable to create job: %w", err)
 	}
+	s.runnerJobID = runnerJob.ID
 
 	cloudProvider, _ := activities.AwaitGetCloudProvider(ctx, &activities.GetCloudProviderRequest{})
 	runPlan, err := plan.AwaitCreateComponentBuildPlan(ctx, &plan.CreateComponentBuildPlanRequest{
@@ -235,6 +245,16 @@ func (s *Signal) updateBuildStatus(ctx workflow.Context, bldID string, status ap
 			zap.Error(err))
 		return
 	}
+}
+
+func (s *Signal) Cancel(ctx workflow.Context) error {
+	cancelCtx, cancel := workflow.NewDisconnectedContext(ctx)
+	defer cancel()
+	s.updateBuildStatus(cancelCtx, s.BuildID, app.ComponentBuildStatus(app.StatusCancelled), "build cancelled")
+	if s.runnerJobID != "" {
+		jobactivities.AwaitPkgWorkflowsJobCancelJobByID(cancelCtx, s.runnerJobID)
+	}
+	return nil
 }
 
 func (s *Signal) sendNotification(ctx workflow.Context, typ notifications.Type, appID string, vars map[string]string) {

--- a/services/ctl-api/internal/pkg/config/syncer/components/sync.go
+++ b/services/ctl-api/internal/pkg/config/syncer/components/sync.go
@@ -11,7 +11,9 @@ import (
 	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	componenthelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
+	createdsignal "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/created"
 	vcshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/vcs/helpers"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
 
 // EnsureComponent creates a component if it doesn't exist, using the shared helpers
@@ -29,7 +31,7 @@ func EnsureComponent(ctx context.Context, db *gorm.DB, helpers *componenthelpers
 		}
 	}
 
-	_, err = helpers.CreateComponent(ctx, &componenthelpers.CreateComponentParams{
+	newComp, err := helpers.CreateComponent(ctx, &componenthelpers.CreateComponentParams{
 		AppID:            appID,
 		Name:             comp.Name,
 		VarName:          comp.VarName,
@@ -40,6 +42,28 @@ func EnsureComponent(ctx context.Context, db *gorm.DB, helpers *componenthelpers
 	if err != nil {
 		return sync.SyncInternalErr{
 			Description: fmt.Sprintf("unable to create component %s", comp.Name),
+			Err:         err,
+		}
+	}
+
+	q, err := helpers.QueueClient().GetQueueByOwner(ctx, newComp.ID, "components")
+	if err != nil {
+		return sync.SyncInternalErr{
+			Description: fmt.Sprintf("unable to get queue for component %s", comp.Name),
+			Err:         err,
+		}
+	}
+
+	if _, err := helpers.QueueClient().EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+		QueueID:   q.ID,
+		OwnerID:   newComp.ID,
+		OwnerType: "components",
+		Signal: &createdsignal.Signal{
+			ComponentID: newComp.ID,
+		},
+	}); err != nil {
+		return sync.SyncInternalErr{
+			Description: fmt.Sprintf("unable to enqueue created signal for component %s", comp.Name),
 			Err:         err,
 		}
 	}

--- a/services/dashboard-ui/client/components/builds/BuildHeader/BuildHeader.tsx
+++ b/services/dashboard-ui/client/components/builds/BuildHeader/BuildHeader.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
 import { BackLink } from '@/components/common/BackLink'
 import { Badge } from '@/components/common/Badge'
+import { Button } from '@/components/common/Button'
 import { ClickToCopy } from '@/components/common/ClickToCopy'
 import { Duration } from '@/components/common/Duration'
 import { Icon } from '@/components/common/Icon'
@@ -9,13 +12,16 @@ import { LabeledValue } from '@/components/common/LabeledValue'
 import { LabeledStatus } from '@/components/common/LabeledStatus'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
+import { Toast } from '@/components/surfaces/Toast'
 import { ComponentType } from '@/components/components/ComponentType'
 import { ComponentConfigContextTooltip } from '@/components/components/ComponentConfigContextTooltip'
 import { CommitDetails } from '@/components/common/CommitDetails'
 import { RunnerJobPlanButton } from '@/components/runners/RunnerJobPlan'
-import { CancelRunnerJobButton } from '@/components/runners/CancelRunnerJob'
 import { AdminDashboardLink } from '@/components/admin/AdminDashboardLink'
-import type { TApp, TBuild, TComponent } from '@/types'
+import { useOrg } from '@/hooks/use-org'
+import { useToast } from '@/hooks/use-toast'
+import { cancelComponentBuild } from '@/lib'
+import type { TApp, TAPIError, TBuild, TComponent } from '@/types'
 import { isImageBuild } from '@/utils/image-ref'
 import { toSentenceCase } from '@/utils/string-utils'
 
@@ -26,6 +32,44 @@ interface IBuildHeader {
 }
 
 export const BuildHeader = ({ component, build, app }: IBuildHeader) => {
+  const { org } = useOrg()
+  const { addToast } = useToast()
+  const [hasBeenCanceled, setHasBeenCanceled] = useState(false)
+
+  const { mutate: cancelBuild, isPending: isCanceling } = useMutation<
+    unknown,
+    TAPIError
+  >({
+    mutationFn: () =>
+      cancelComponentBuild({
+        orgId: org.id,
+        appId: app.id,
+        componentId: component.id,
+        buildId: build.id,
+      }),
+    onSuccess: () => {
+      setHasBeenCanceled(true)
+      addToast(
+        <Toast heading="Build cancelled." theme="success">
+          <Text>Successfully cancelled the build.</Text>
+        </Toast>,
+      )
+    },
+    onError: (err: { error?: string }) => {
+      addToast(
+        <Toast heading="Cancel build failed." theme="error">
+          <Text>{err?.error || 'Unknown error occurred.'}</Text>
+        </Toast>,
+      )
+    },
+  })
+
+  const isCancelable =
+    build?.queue_signal &&
+    build?.status_v2?.status !== 'active' &&
+    build?.status_v2?.status !== 'error' &&
+    build?.status_v2?.status !== 'cancelled'
+
   return (
     <header className="p-6 border-b flex flex-col gap-4">
       <div className="flex items-center justify-between">
@@ -103,17 +147,27 @@ export const BuildHeader = ({ component, build, app }: IBuildHeader) => {
             </Text>
           </div>
           <div className="flex items-center gap-4">
-            {build?.runner_job &&
-            build?.status_v2?.status !== 'active' &&
-            build?.status_v2?.status !== 'error' ? (
-              <CancelRunnerJobButton
-                jobType="build"
-                runnerJob={build?.runner_job}
-              />
+            {isCancelable ? (
+              <Button
+                variant="danger"
+                disabled={isCanceling || hasBeenCanceled}
+                onClick={() => cancelBuild()}
+              >
+                {isCanceling ? (
+                  <span className="flex items-center gap-2">
+                    <Icon variant="Loading" className="animate-spin" />
+                    Canceling
+                  </span>
+                ) : hasBeenCanceled ? (
+                  'Canceled'
+                ) : (
+                  'Cancel build'
+                )}
+              </Button>
             ) : null}
             {build?.queue_signal ? (
               <AdminDashboardLink
-                path={`/queue-signals?search=${build.id}`}
+                path={`/queues/${build.queue_signal.queue_id}/signals/${build.queue_signal.id}`}
                 label="View signal"
               />
             ) : null}

--- a/services/dashboard-ui/client/lib/ctl-api/apps/components/builds/cancel-component-build.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/components/builds/cancel-component-build.ts
@@ -1,0 +1,20 @@
+import { api } from '@/lib/api'
+import type { TBuild } from '@/types'
+
+export async function cancelComponentBuild({
+  orgId,
+  appId,
+  componentId,
+  buildId,
+}: {
+  orgId: string
+  appId: string
+  componentId: string
+  buildId: string
+}) {
+  return api<TBuild>({
+    method: 'POST',
+    orgId,
+    path: `apps/${appId}/components/${componentId}/builds/${buildId}/cancel`,
+  })
+}

--- a/services/dashboard-ui/client/lib/ctl-api/apps/components/builds/index.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/components/builds/index.ts
@@ -1,2 +1,3 @@
+export * from './cancel-component-build'
 export * from './get-component-build'
 export * from './get-component-builds'


### PR DESCRIPTION
This improves some failure modes around component builds:

1. if a component was not successfully marked as created, when a build is attempted it would fail. Now, this changes it 
   to automatically re-run the "created" signal to mark it as active.
2. previously, only builds that were actively at the runner-job step would be cancellable. Now, they cancel via the 
   signal which ensures the status is correctly set and allows us to essentially, cancel queued builds.
3. fixed an issue where the admin link on a build page did not work.
