### PR TITLE
fix: missing index for workflow steps

### DIFF
--- a/services/ctl-api/internal/app/workflow_step.go
+++ b/services/ctl-api/internal/app/workflow_step.go
@@ -171,6 +171,14 @@ func (i *WorkflowStep) Indexes(db *gorm.DB) []migrations.Index {
 				"created_at",
 			},
 		},
+		{
+			Name: indexes.Name(db, &WorkflowStep{}, "step_target_id_step_target_type_deleted_at"),
+			Columns: []string{
+				"step_target_id",
+				"step_target_type",
+				"deleted_at",
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
```
SELECT * FROM "install_workflow_steps" WHERE ("install_workflow_steps"."step_target_id" = $1 AND "install_workflow_steps"."step_target_type" = $2) AND "install_workflow_steps"."deleted_at" = $3 ORDER BY "install_workflow_steps"."id" LIMIT $4
```

cpu intensive query missing an index