### PR TITLE
chore(ctl-api): admin endpoint to get identity providers

### DIFF
--- a/services/ctl-api/docs/admin/descriptions/admin_get_identity_providers.md
+++ b/services/ctl-api/docs/admin/descriptions/admin_get_identity_providers.md
@@ -1,0 +1,2 @@
+List all identity providers, returning a slim representation (id, provider type, client id, and enabled status) used to
+determine whether a specific identity provider exists or is enabled.

--- a/services/ctl-api/internal/app/identity-providers/service/admin_get_identity_providers.go
+++ b/services/ctl-api/internal/app/identity-providers/service/admin_get_identity_providers.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// AdminIdentityProviderSummary is a slim representation of an identity provider
+// exposing only the fields needed to determine whether a provider exists or is enabled.
+type AdminIdentityProviderSummary struct {
+	ID           string           `json:"id"`
+	ProviderType app.ProviderType `json:"provider_type"`
+	ClientID     string           `json:"client_id"`
+	Enabled      bool             `json:"enabled"`
+}
+
+// @ID						AdminGetIdentityProviders
+// @Summary				List identity providers
+// @Description.markdown	admin_get_identity_providers.md
+// @Tags					auth/admin
+// @Security				AdminEmail
+// @Accept					json
+// @Produce				json
+// @Failure				500	{object}	stderr.ErrResponse
+// @Success				200	{array}	AdminIdentityProviderSummary
+// @Router					/v1/auth/identity-providers [GET]
+func (s *service) AdminGetIdentityProviders(ctx *gin.Context) {
+	var ips []app.IdentityProvider
+	if err := s.db.WithContext(ctx).Find(&ips).Error; err != nil {
+		s.l.Error("failed to list identity providers", zap.Error(err))
+		ctx.Error(fmt.Errorf("failed to list identity providers: %w", err))
+		return
+	}
+
+	summaries := make([]AdminIdentityProviderSummary, 0, len(ips))
+	for i := range ips {
+		clientID, err := ips[i].GetClientID()
+		if err != nil {
+			s.l.Warn("failed to parse client_id for identity provider",
+				zap.String("id", ips[i].ID),
+				zap.Error(err))
+		}
+
+		summaries = append(summaries, AdminIdentityProviderSummary{
+			ID:           ips[i].ID,
+			ProviderType: ips[i].ProviderType,
+			ClientID:     clientID,
+			Enabled:      ips[i].Enabled,
+		})
+	}
+
+	ctx.JSON(http.StatusOK, summaries)
+}

--- a/services/ctl-api/internal/app/identity-providers/service/service.go
+++ b/services/ctl-api/internal/app/identity-providers/service/service.go
@@ -50,6 +50,7 @@ func (s *service) RegisterInternalRoutes(api *gin.Engine) error {
 	auth := api.Group("/v1/auth")
 	{
 		auth.POST("/identity-providers", s.AdminCreateIdentityProvider)
+		auth.GET("/identity-providers", s.AdminGetIdentityProviders)
 		auth.PATCH("/identity-providers/:identity_provider_id", s.AdminPatchIdentityProvider)
 	}
 	return nil

--- a/services/ctl-api/internal/app/identity_provider.go
+++ b/services/ctl-api/internal/app/identity_provider.go
@@ -96,6 +96,19 @@ func (ip *IdentityProvider) ValidateConfig() error {
 	}
 }
 
+// GetClientID returns the client_id from the provider config, regardless of type.
+func (ip *IdentityProvider) GetClientID() (string, error) {
+	if len(ip.Config) == 0 {
+		return "", nil
+	}
+
+	var cfg providers.BaseConfig
+	if err := json.Unmarshal(ip.Config, &cfg); err != nil {
+		return "", err
+	}
+	return cfg.ClientID, nil
+}
+
 // GetOpenIDConfig unmarshals the Config as OpenIDConfig.
 func (ip *IdentityProvider) GetOpenIDConfig() (*providers.OpenIDConfig, error) {
 	var cfg providers.OpenIDConfig


### PR DESCRIPTION
## Description

list endpoint with a subset of the fields. the goal is to be able to
enable and disable specific identity providers.

Example Response

```json
[
  {
    "id": "idpxxaho0o6b4cs9it480v52wh",
    "provider_type": "oidc",
    "client_id": "string",
    "enabled": true
  }
]
```