### PR TITLE
feat: add gormlint static analyzer

### DIFF
--- a/bins/gormlint/README.md
+++ b/bins/gormlint/README.md
@@ -1,0 +1,163 @@
+# gormlint
+
+Static analyzer for GORM queries. Catches silent correctness bugs, performance footguns, and convention violations at compile time using `golang.org/x/tools/go/analysis`.
+
+## Analyzers
+
+### `wheregormignored` — Correctness
+
+Detects struct fields tagged `gorm:"-"` used in `Where()` clauses. GORM silently ignores these fields, so the query runs without the intended filter.
+
+```go
+// BAD: ComputedField has gorm:"-", this Where condition is silently dropped
+db.Where(Install{ComputedField: "value"}).First(&install)
+
+// GOOD: use a field that GORM maps to a column
+db.Where(Install{OrgID: orgID}).First(&install)
+```
+
+### `wherezerovalue` — Correctness
+
+Detects literal zero-value fields in `Where()` struct clauses. GORM silently ignores zero values (`0`, `""`, `false`), turning the condition into a no-op.
+
+```go
+// BAD: Age=0 is silently dropped, this loads ALL users
+db.Where(User{Age: 0}).Find(&users)
+
+// GOOD: use a pointer type or map-based Where
+db.Where(map[string]interface{}{"age": 0}).Find(&users)
+```
+
+### `rawsqlwhere` — Convention
+
+Detects raw SQL strings in `Where()` clauses. The codebase convention is struct-based Where for type safety and refactor safety.
+
+```go
+// BAD: raw SQL string — typos and renames break silently
+db.Where("org_id = ?", orgID).First(&install)
+
+// GOOD: struct-based Where — compiler catches field name issues
+db.Where(Install{OrgID: orgID}).First(&install)
+```
+
+### `hardcodedtablename` — Convention
+
+Detects raw SQL strings in `Joins()`, `Order()`, `Select()`, `Group()`, and `Having()`. Hardcoded table/view names bypass the view plugin's automatic routing and break when view versions change.
+
+```go
+// BAD: hardcoded view name breaks when view version changes (v1 → v2)
+db.Joins("JOIN install_states_view_v1 ON ...").Find(&installs)
+
+// GOOD: use views.TableOrViewName() for dynamic view routing
+db.Joins("JOIN " + views.TableOrViewName(db, &app.InstallState{}, " ON ...")).Find(&installs)
+```
+
+### `unboundedpreload` — Performance
+
+Detects `Preload()` calls without a scoping function containing `Limit()`. Without a limit, GORM loads ALL related records — with 10k related rows per parent, this kills performance.
+
+```go
+// BAD: loads every Order for every User
+db.Preload("Orders").Find(&users)
+
+// BAD: scoping function with Order but no Limit
+db.Preload("Orders", func(db *gorm.DB) *gorm.DB {
+    return db.Order("created_at DESC")
+}).Find(&users)
+
+// GOOD: scoping function with Limit
+db.Preload("Orders", func(db *gorm.DB) *gorm.DB {
+    return db.Order("created_at DESC").Limit(10)
+}).Find(&users)
+```
+
+### `unboundedquery` — Performance
+
+Detects `Find()` and `Scan()` calls without `Limit()` anywhere in the query chain. Without a limit, queries can return unbounded result sets.
+
+```go
+// BAD: returns every matching row
+db.Where(User{OrgID: orgID}).Find(&users)
+
+// GOOD: bounded result set
+db.Where(User{OrgID: orgID}).Limit(100).Find(&users)
+
+// GOOD: First/Last/Take implicitly limit to 1 row
+db.Where(User{OrgID: orgID}).First(&user)
+```
+
+### `missingcontext` — Reliability
+
+Detects GORM query chains starting from a struct field (like `s.db`) that lack `.WithContext(ctx)`. Without context, queries have no request tracing, timeout propagation, or cancellation support.
+
+```go
+// BAD: no context — query can't be cancelled, no tracing
+s.db.Where(User{Name: "alice"}).First(&user)
+
+// GOOD: context propagated for tracing and cancellation
+s.db.WithContext(ctx).Where(User{Name: "alice"}).First(&user)
+```
+
+GORM hooks (`BeforeCreate`, `AfterQuery`, etc.) are excluded — their `tx *gorm.DB` parameter already carries context from the parent query.
+
+## Usage
+
+```bash
+# Run all analyzers on ctl-api
+go run ./bins/gormlint ./services/ctl-api/...
+
+# Run a single analyzer
+go run ./bins/gormlint -wheregormignored ./services/ctl-api/...
+
+# JSON output (for CI or tooling)
+go run ./bins/gormlint -json ./services/ctl-api/...
+
+# Build and run
+go build -o gormlint ./bins/gormlint
+./gormlint ./services/ctl-api/...
+
+# Show context lines around findings
+./gormlint -c 3 ./services/ctl-api/...
+```
+
+## Sample Output
+
+```
+services/ctl-api/internal/app/accounts/helpers/update_user_journey_step.go:17:11: unbounded Preload without scoping function; add a func(db *gorm.DB) *gorm.DB with Limit() to prevent loading all related records
+services/ctl-api/internal/app/auth/service/device_code.go:132:12: GORM query chain missing WithContext(); add .WithContext(ctx) for request tracing and cancellation support
+services/ctl-api/internal/app/auth/service/device_code.go:142:8: GORM query chain missing WithContext(); add .WithContext(ctx) for request tracing and cancellation support
+services/ctl-api/internal/app/slack/service/subscribe_modal.go:1506:9: raw SQL string in Joins(); use views.TableOrViewName() or association joins instead of raw SQL join strings
+services/ctl-api/internal/app/accounts/service/get_auth_me.go:68:9: Find() without Limit() in query chain; consider adding Limit() to prevent loading all matching records
+```
+
+## Findings Summary (ctl-api)
+
+As of the initial run on `services/ctl-api/internal/`:
+
+| Analyzer | Findings | Notes |
+|----------|----------|-------|
+| `wheregormignored` | 0 | No current violations (the motivating bug was fixed) |
+| `wherezerovalue` | 0 | No current violations |
+| `rawsqlwhere` | 0 | Where-specific (see `hardcodedtablename` for other SQL strings) |
+| `hardcodedtablename` | 73 | Select: 30, Order: 21, Joins: 12, Group: 10 |
+| `unboundedquery` | 47 | Find: 23, Scan: 24 |
+| `unboundedpreload` | 22 | 20 missing scoping func, 2 scoping without Limit |
+| `missingcontext` | 12 | Concentrated in `auth/service/` |
+
+## Testing
+
+```bash
+go test ./bins/gormlint/analyzers/...
+```
+
+Each analyzer has its own test suite using `analysistest.Run` with `// want` comment directives in test fixtures under `testdata/src/example/`.
+
+## Architecture
+
+Built on `golang.org/x/tools/go/analysis` using `multichecker.Main()`, which provides:
+
+- Per-analyzer enable/disable flags
+- `-json` output for CI integration
+- `-fix` for auto-fixable issues (future)
+- Package pattern arguments (`./...` glob support)
+- Parallel analysis across packages

--- a/bins/gormlint/analyzers/hardcodedtablename/analyzer.go
+++ b/bins/gormlint/analyzers/hardcodedtablename/analyzer.go
@@ -1,0 +1,73 @@
+package hardcodedtablename
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "hardcodedtablename",
+	Doc:      "reports raw SQL strings in GORM Joins, Order, Select, Group, and Having calls",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+var flaggedMethods = map[string]string{
+	"Joins":  "use views.TableOrViewName() or association joins instead of raw SQL join strings",
+	"Order":  "use a constant or views.TableOrViewName() for column references",
+	"Select": "use a constant or explicit column list for column references",
+	"Group":  "use a constant or views.TableOrViewName() for column references",
+	"Having": "use a constant or views.TableOrViewName() for column references",
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
+		call := n.(*ast.CallExpr)
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
+
+		suggestion, ok := flaggedMethods[sel.Sel.Name]
+		if !ok {
+			return
+		}
+
+		if len(call.Args) == 0 {
+			return
+		}
+
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return
+		}
+
+		val := strings.Trim(lit.Value, "`\"")
+
+		if sel.Sel.Name == "Joins" && !looksLikeSQL(val) {
+			return
+		}
+
+		pass.Reportf(lit.Pos(), "raw SQL string in %s(); %s", sel.Sel.Name, suggestion)
+	})
+
+	return nil, nil
+}
+
+func looksLikeSQL(s string) bool {
+	upper := strings.ToUpper(s)
+	for _, kw := range []string{"JOIN", " ON ", "SELECT", "FROM", "WHERE"} {
+		if strings.Contains(upper, kw) {
+			return true
+		}
+	}
+	return false
+}

--- a/bins/gormlint/analyzers/hardcodedtablename/analyzer_test.go
+++ b/bins/gormlint/analyzers/hardcodedtablename/analyzer_test.go
@@ -1,0 +1,14 @@
+package hardcodedtablename_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/hardcodedtablename"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, hardcodedtablename.Analyzer, "example")
+}

--- a/bins/gormlint/analyzers/hardcodedtablename/testdata/src/example/example.go
+++ b/bins/gormlint/analyzers/hardcodedtablename/testdata/src/example/example.go
@@ -1,0 +1,32 @@
+package example
+
+import "gorm.io/gorm"
+
+type User struct {
+	ID   string
+	Name string
+}
+
+func badJoinsRawSQL(db *gorm.DB) {
+	db.Joins("JOIN orders ON orders.user_id = users.id").Find(&User{}) // want `raw SQL string in Joins\(\)`
+}
+
+func badOrderRawSQL(db *gorm.DB) {
+	db.Order("created_at DESC").Find(&User{}) // want `raw SQL string in Order\(\)`
+}
+
+func badSelectRawSQL(db *gorm.DB) {
+	db.Select("id, name").Find(&User{}) // want `raw SQL string in Select\(\)`
+}
+
+func badGroupRawSQL(db *gorm.DB) {
+	db.Group("org_id").Find(&User{}) // want `raw SQL string in Group\(\)`
+}
+
+func badHavingRawSQL(db *gorm.DB) {
+	db.Having("count(*) > ?", 5).Find(&User{}) // want `raw SQL string in Having\(\)`
+}
+
+func goodJoinsAssociation(db *gorm.DB) {
+	db.Joins("Orders").Find(&User{})
+}

--- a/bins/gormlint/analyzers/hardcodedtablename/testdata/src/gorm.io/gorm/gorm.go
+++ b/bins/gormlint/analyzers/hardcodedtablename/testdata/src/gorm.io/gorm/gorm.go
@@ -1,0 +1,30 @@
+package gorm
+
+type DB struct{}
+
+func (db *DB) Where(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) First(dest interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Find(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Preload(query string, args ...interface{}) *DB    { return db }
+func (db *DB) Model(value interface{}) *DB                      { return db }
+func (db *DB) Create(value interface{}) *DB                     { return db }
+func (db *DB) Save(value interface{}) *DB                       { return db }
+func (db *DB) Update(column string, value interface{}) *DB      { return db }
+func (db *DB) Updates(values interface{}) *DB                   { return db }
+func (db *DB) Delete(value interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Scan(dest interface{}) *DB                        { return db }
+func (db *DB) Count(count *int64) *DB                           { return db }
+func (db *DB) Limit(limit int) *DB                              { return db }
+func (db *DB) Order(value interface{}) *DB                      { return db }
+func (db *DB) Select(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Joins(query string, args ...interface{}) *DB      { return db }
+func (db *DB) Group(name string) *DB                            { return db }
+func (db *DB) Having(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Last(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Take(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Exec(sql string, values ...interface{}) *DB       { return db }
+func (db *DB) Raw(sql string, values ...interface{}) *DB        { return db }
+func (db *DB) WithContext(ctx interface{}) *DB                  { return db }
+func (db *DB) Pluck(column string, dest interface{}) *DB        { return db }
+
+type Error = error

--- a/bins/gormlint/analyzers/missingcontext/analyzer.go
+++ b/bins/gormlint/analyzers/missingcontext/analyzer.go
@@ -1,0 +1,192 @@
+package missingcontext
+
+import (
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "missingcontext",
+	Doc:      "reports GORM query chains that lack WithContext(), losing request tracing and cancellation",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+var terminalMethods = map[string]bool{
+	"Find":    true,
+	"First":   true,
+	"Last":    true,
+	"Take":    true,
+	"Create":  true,
+	"Save":    true,
+	"Update":  true,
+	"Updates": true,
+	"Delete":  true,
+	"Scan":    true,
+	"Count":   true,
+	"Exec":    true,
+	"Raw":     true,
+	"Pluck":   true,
+}
+
+var gormChainMethods = map[string]bool{
+	"Where":       true,
+	"Preload":     true,
+	"Model":       true,
+	"Joins":       true,
+	"Order":       true,
+	"Select":      true,
+	"Group":       true,
+	"Having":      true,
+	"Limit":       true,
+	"Offset":      true,
+	"Scopes":      true,
+	"Or":          true,
+	"Not":         true,
+	"WithContext": true,
+}
+
+var hookReceiverParams = map[string]bool{
+	"BeforeCreate": true,
+	"AfterCreate":  true,
+	"BeforeUpdate": true,
+	"AfterUpdate":  true,
+	"BeforeDelete": true,
+	"AfterDelete":  true,
+	"BeforeSave":   true,
+	"AfterSave":    true,
+	"AfterQuery":   true,
+	"AfterFind":    true,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
+		call := n.(*ast.CallExpr)
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
+
+		if !terminalMethods[sel.Sel.Name] {
+			return
+		}
+
+		if chainContainsWithContext(sel.X) {
+			return
+		}
+
+		root := chainRoot(sel.X)
+		if root == nil {
+			return
+		}
+
+		if !isGormDBField(pass, root) {
+			return
+		}
+
+		if isInsideGormHook(pass, call) {
+			return
+		}
+
+		pass.Reportf(call.Pos(), "GORM query chain missing WithContext(); add .WithContext(ctx) for request tracing and cancellation support")
+	})
+
+	return nil, nil
+}
+
+func chainContainsWithContext(expr ast.Expr) bool {
+	for {
+		call, ok := expr.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return false
+		}
+		if sel.Sel.Name == "WithContext" {
+			return true
+		}
+		if !gormChainMethods[sel.Sel.Name] && !terminalMethods[sel.Sel.Name] {
+			return false
+		}
+		expr = sel.X
+	}
+}
+
+func chainRoot(expr ast.Expr) ast.Expr {
+	for {
+		call, ok := expr.(*ast.CallExpr)
+		if !ok {
+			return expr
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return expr
+		}
+		if !gormChainMethods[sel.Sel.Name] && !terminalMethods[sel.Sel.Name] {
+			return expr
+		}
+		expr = sel.X
+	}
+}
+
+func isGormDBField(pass *analysis.Pass, expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+
+	if sel.Sel.Name != "db" && sel.Sel.Name != "DB" {
+		return false
+	}
+
+	typ := pass.TypesInfo.TypeOf(expr)
+	if typ == nil {
+		return false
+	}
+
+	return isGormDBType(typ)
+}
+
+func isGormDBType(t types.Type) bool {
+	ptr, ok := t.(*types.Pointer)
+	if ok {
+		t = ptr.Elem()
+	}
+
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+
+	obj := named.Obj()
+	return obj.Name() == "DB" && obj.Pkg() != nil && obj.Pkg().Path() == "gorm.io/gorm"
+}
+
+func isInsideGormHook(pass *analysis.Pass, node ast.Node) bool {
+	for _, f := range pass.Files {
+		for _, decl := range f.Decls {
+			funcDecl, ok := decl.(*ast.FuncDecl)
+			if !ok || funcDecl.Recv == nil {
+				continue
+			}
+
+			if hookReceiverParams[funcDecl.Name.Name] && nodeWithin(node, funcDecl) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func nodeWithin(node ast.Node, funcDecl *ast.FuncDecl) bool {
+	return node.Pos() >= funcDecl.Body.Pos() && node.End() <= funcDecl.Body.End()
+}

--- a/bins/gormlint/analyzers/missingcontext/analyzer_test.go
+++ b/bins/gormlint/analyzers/missingcontext/analyzer_test.go
@@ -1,0 +1,14 @@
+package missingcontext_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/missingcontext"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, missingcontext.Analyzer, "example")
+}

--- a/bins/gormlint/analyzers/missingcontext/testdata/src/example/example.go
+++ b/bins/gormlint/analyzers/missingcontext/testdata/src/example/example.go
@@ -1,0 +1,41 @@
+package example
+
+import "gorm.io/gorm"
+
+type svc struct {
+	db *gorm.DB
+}
+
+type User struct {
+	ID   string
+	Name string
+}
+
+func (s *svc) badNoContext() {
+	var user User
+	s.db.Where(User{Name: "alice"}).First(&user) // want `GORM query chain missing WithContext\(\)`
+	_ = user
+}
+
+func (s *svc) badNoContextFind() {
+	var users []User
+	s.db.Where(User{Name: "alice"}).Find(&users) // want `GORM query chain missing WithContext\(\)`
+	_ = users
+}
+
+func (s *svc) goodWithContext() {
+	var user User
+	s.db.WithContext(nil).Where(User{Name: "alice"}).First(&user)
+	_ = user
+}
+
+func (u *User) AfterQuery(tx *gorm.DB) error {
+	var related User
+	tx.Where(User{Name: "related"}).First(&related)
+	return nil
+}
+
+func goodLocalDB(db *gorm.DB) {
+	var user User
+	db.Where(User{Name: "alice"}).First(&user)
+}

--- a/bins/gormlint/analyzers/missingcontext/testdata/src/gorm.io/gorm/gorm.go
+++ b/bins/gormlint/analyzers/missingcontext/testdata/src/gorm.io/gorm/gorm.go
@@ -1,0 +1,30 @@
+package gorm
+
+type DB struct{}
+
+func (db *DB) Where(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) First(dest interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Find(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Preload(query string, args ...interface{}) *DB    { return db }
+func (db *DB) Model(value interface{}) *DB                      { return db }
+func (db *DB) Create(value interface{}) *DB                     { return db }
+func (db *DB) Save(value interface{}) *DB                       { return db }
+func (db *DB) Update(column string, value interface{}) *DB      { return db }
+func (db *DB) Updates(values interface{}) *DB                   { return db }
+func (db *DB) Delete(value interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Scan(dest interface{}) *DB                        { return db }
+func (db *DB) Count(count *int64) *DB                           { return db }
+func (db *DB) Limit(limit int) *DB                              { return db }
+func (db *DB) Order(value interface{}) *DB                      { return db }
+func (db *DB) Select(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Joins(query string, args ...interface{}) *DB      { return db }
+func (db *DB) Group(name string) *DB                            { return db }
+func (db *DB) Having(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Last(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Take(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Exec(sql string, values ...interface{}) *DB       { return db }
+func (db *DB) Raw(sql string, values ...interface{}) *DB        { return db }
+func (db *DB) WithContext(ctx interface{}) *DB                  { return db }
+func (db *DB) Pluck(column string, dest interface{}) *DB        { return db }
+
+type Error = error

--- a/bins/gormlint/analyzers/rawsqlwhere/analyzer.go
+++ b/bins/gormlint/analyzers/rawsqlwhere/analyzer.go
@@ -1,0 +1,43 @@
+package rawsqlwhere
+
+import (
+	"go/ast"
+	"go/token"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "rawsqlwhere",
+	Doc:      "reports raw SQL string arguments in GORM Where clauses; prefer struct-based Where for type safety",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
+		call := n.(*ast.CallExpr)
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Where" {
+			return
+		}
+
+		if len(call.Args) == 0 {
+			return
+		}
+
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return
+		}
+
+		pass.Reportf(lit.Pos(), "raw SQL string in Where clause; prefer struct-based Where for type safety and refactor safety")
+	})
+
+	return nil, nil
+}

--- a/bins/gormlint/analyzers/rawsqlwhere/analyzer_test.go
+++ b/bins/gormlint/analyzers/rawsqlwhere/analyzer_test.go
@@ -1,0 +1,14 @@
+package rawsqlwhere_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/rawsqlwhere"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, rawsqlwhere.Analyzer, "example")
+}

--- a/bins/gormlint/analyzers/rawsqlwhere/testdata/src/example/example.go
+++ b/bins/gormlint/analyzers/rawsqlwhere/testdata/src/example/example.go
@@ -1,0 +1,25 @@
+package example
+
+import "gorm.io/gorm"
+
+type User struct {
+	ID    string
+	Name  string
+	OrgID string
+}
+
+func badRawSQLWhere(db *gorm.DB) {
+	db.Where("name = ?", "alice").First(&User{}) // want `raw SQL string in Where clause`
+}
+
+func badRawSQLWhereMultiple(db *gorm.DB) {
+	db.Where("name = ? AND org_id = ?", "alice", "org1").First(&User{}) // want `raw SQL string in Where clause`
+}
+
+func goodStructWhere(db *gorm.DB) {
+	db.Where(User{Name: "alice"}).First(&User{})
+}
+
+func goodStructWherePointer(db *gorm.DB) {
+	db.Where(&User{Name: "alice"}).First(&User{})
+}

--- a/bins/gormlint/analyzers/rawsqlwhere/testdata/src/gorm.io/gorm/gorm.go
+++ b/bins/gormlint/analyzers/rawsqlwhere/testdata/src/gorm.io/gorm/gorm.go
@@ -1,0 +1,30 @@
+package gorm
+
+type DB struct{}
+
+func (db *DB) Where(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) First(dest interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Find(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Preload(query string, args ...interface{}) *DB    { return db }
+func (db *DB) Model(value interface{}) *DB                      { return db }
+func (db *DB) Create(value interface{}) *DB                     { return db }
+func (db *DB) Save(value interface{}) *DB                       { return db }
+func (db *DB) Update(column string, value interface{}) *DB      { return db }
+func (db *DB) Updates(values interface{}) *DB                   { return db }
+func (db *DB) Delete(value interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Scan(dest interface{}) *DB                        { return db }
+func (db *DB) Count(count *int64) *DB                           { return db }
+func (db *DB) Limit(limit int) *DB                              { return db }
+func (db *DB) Order(value interface{}) *DB                      { return db }
+func (db *DB) Select(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Joins(query string, args ...interface{}) *DB      { return db }
+func (db *DB) Group(name string) *DB                            { return db }
+func (db *DB) Having(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Last(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Take(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Exec(sql string, values ...interface{}) *DB       { return db }
+func (db *DB) Raw(sql string, values ...interface{}) *DB        { return db }
+func (db *DB) WithContext(ctx interface{}) *DB                  { return db }
+func (db *DB) Pluck(column string, dest interface{}) *DB        { return db }
+
+type Error = error

--- a/bins/gormlint/analyzers/unboundedpreload/analyzer.go
+++ b/bins/gormlint/analyzers/unboundedpreload/analyzer.go
@@ -1,0 +1,79 @@
+package unboundedpreload
+
+import (
+	"go/ast"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "unboundedpreload",
+	Doc:      "reports GORM Preload calls without a scoping function containing Limit",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
+		call := n.(*ast.CallExpr)
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Preload" {
+			return
+		}
+
+		if len(call.Args) == 0 {
+			return
+		}
+
+		hasScopingFunc := false
+		hasLimit := false
+
+		for _, arg := range call.Args[1:] {
+			funcLit, ok := arg.(*ast.FuncLit)
+			if !ok {
+				continue
+			}
+			hasScopingFunc = true
+			hasLimit = containsLimitCall(funcLit.Body)
+		}
+
+		if !hasScopingFunc {
+			pass.Reportf(call.Pos(), "unbounded Preload without scoping function; add a func(db *gorm.DB) *gorm.DB with Limit() to prevent loading all related records")
+			return
+		}
+
+		if !hasLimit {
+			pass.Reportf(call.Pos(), "Preload scoping function has no Limit(); consider adding Limit() to prevent loading all related records")
+		}
+	})
+
+	return nil, nil
+}
+
+func containsLimitCall(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel.Name == "Limit" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/bins/gormlint/analyzers/unboundedpreload/analyzer_test.go
+++ b/bins/gormlint/analyzers/unboundedpreload/analyzer_test.go
@@ -1,0 +1,14 @@
+package unboundedpreload_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/unboundedpreload"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, unboundedpreload.Analyzer, "example")
+}

--- a/bins/gormlint/analyzers/unboundedpreload/testdata/src/example/example.go
+++ b/bins/gormlint/analyzers/unboundedpreload/testdata/src/example/example.go
@@ -1,0 +1,35 @@
+package example
+
+import "gorm.io/gorm"
+
+type User struct {
+	ID     string
+	Orders []Order
+}
+
+type Order struct {
+	ID     string
+	UserID string
+}
+
+func badNoScopingFunc(db *gorm.DB) {
+	db.Preload("Orders").Find(&User{}) // want `unbounded Preload without scoping function`
+}
+
+func badScopingFuncNoLimit(db *gorm.DB) {
+	db.Preload("Orders", func(db *gorm.DB) *gorm.DB { // want `Preload scoping function has no Limit`
+		return db.Order("created_at DESC")
+	}).Find(&User{})
+}
+
+func goodScopingFuncWithLimit(db *gorm.DB) {
+	db.Preload("Orders", func(db *gorm.DB) *gorm.DB {
+		return db.Order("created_at DESC").Limit(10)
+	}).Find(&User{})
+}
+
+func goodScopingFuncWithWhereAndLimit(db *gorm.DB) {
+	db.Preload("Orders", func(db *gorm.DB) *gorm.DB {
+		return db.Where("status = ?", "active").Limit(5)
+	}).Find(&User{})
+}

--- a/bins/gormlint/analyzers/unboundedpreload/testdata/src/gorm.io/gorm/gorm.go
+++ b/bins/gormlint/analyzers/unboundedpreload/testdata/src/gorm.io/gorm/gorm.go
@@ -1,0 +1,30 @@
+package gorm
+
+type DB struct{}
+
+func (db *DB) Where(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) First(dest interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Find(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Preload(query string, args ...interface{}) *DB    { return db }
+func (db *DB) Model(value interface{}) *DB                      { return db }
+func (db *DB) Create(value interface{}) *DB                     { return db }
+func (db *DB) Save(value interface{}) *DB                       { return db }
+func (db *DB) Update(column string, value interface{}) *DB      { return db }
+func (db *DB) Updates(values interface{}) *DB                   { return db }
+func (db *DB) Delete(value interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Scan(dest interface{}) *DB                        { return db }
+func (db *DB) Count(count *int64) *DB                           { return db }
+func (db *DB) Limit(limit int) *DB                              { return db }
+func (db *DB) Order(value interface{}) *DB                      { return db }
+func (db *DB) Select(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Joins(query string, args ...interface{}) *DB      { return db }
+func (db *DB) Group(name string) *DB                            { return db }
+func (db *DB) Having(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Last(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Take(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Exec(sql string, values ...interface{}) *DB       { return db }
+func (db *DB) Raw(sql string, values ...interface{}) *DB        { return db }
+func (db *DB) WithContext(ctx interface{}) *DB                  { return db }
+func (db *DB) Pluck(column string, dest interface{}) *DB        { return db }
+
+type Error = error

--- a/bins/gormlint/analyzers/unboundedquery/analyzer.go
+++ b/bins/gormlint/analyzers/unboundedquery/analyzer.go
@@ -1,0 +1,71 @@
+package unboundedquery
+
+import (
+	"go/ast"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "unboundedquery",
+	Doc:      "reports GORM Find/Scan calls without a Limit in the query chain",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+var terminalMethods = map[string]bool{
+	"Find": true,
+	"Scan": true,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
+		call := n.(*ast.CallExpr)
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
+
+		if !terminalMethods[sel.Sel.Name] {
+			return
+		}
+
+		if sel.Sel.Name == "Find" && len(call.Args) > 1 {
+			return
+		}
+
+		if chainContains(sel.X, "Limit") {
+			return
+		}
+
+		if chainContains(sel.X, "First") || chainContains(sel.X, "Last") || chainContains(sel.X, "Take") {
+			return
+		}
+
+		pass.Reportf(call.Pos(), "%s() without Limit() in query chain; consider adding Limit() to prevent loading all matching records", sel.Sel.Name)
+	})
+
+	return nil, nil
+}
+
+func chainContains(expr ast.Expr, methodName string) bool {
+	for {
+		call, ok := expr.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return false
+		}
+		if sel.Sel.Name == methodName {
+			return true
+		}
+		expr = sel.X
+	}
+}

--- a/bins/gormlint/analyzers/unboundedquery/analyzer_test.go
+++ b/bins/gormlint/analyzers/unboundedquery/analyzer_test.go
@@ -1,0 +1,14 @@
+package unboundedquery_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/unboundedquery"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, unboundedquery.Analyzer, "example")
+}

--- a/bins/gormlint/analyzers/unboundedquery/testdata/src/example/example.go
+++ b/bins/gormlint/analyzers/unboundedquery/testdata/src/example/example.go
@@ -1,0 +1,42 @@
+package example
+
+import "gorm.io/gorm"
+
+type User struct {
+	ID   string
+	Name string
+}
+
+func badFindNoLimit(db *gorm.DB) {
+	var users []User
+	db.Where(User{Name: "alice"}).Find(&users) // want `Find\(\) without Limit\(\) in query chain`
+	_ = users
+}
+
+func badScanNoLimit(db *gorm.DB) {
+	var users []User
+	db.Where(User{Name: "alice"}).Scan(&users) // want `Scan\(\) without Limit\(\) in query chain`
+	_ = users
+}
+
+func badFindWithOrderNoLimit(db *gorm.DB) {
+	var users []User
+	db.Where(User{Name: "alice"}).Order("name").Find(&users) // want `Find\(\) without Limit\(\) in query chain`
+	_ = users
+}
+
+func goodFindWithLimit(db *gorm.DB) {
+	var users []User
+	db.Where(User{Name: "alice"}).Limit(100).Find(&users)
+	_ = users
+}
+
+func goodFindWithInlineCondition(db *gorm.DB) {
+	var user User
+	db.Find(&user, "id = ?", "123")
+}
+
+func goodFirst(db *gorm.DB) {
+	var user User
+	db.Where(User{Name: "alice"}).First(&user)
+}

--- a/bins/gormlint/analyzers/unboundedquery/testdata/src/gorm.io/gorm/gorm.go
+++ b/bins/gormlint/analyzers/unboundedquery/testdata/src/gorm.io/gorm/gorm.go
@@ -1,0 +1,30 @@
+package gorm
+
+type DB struct{}
+
+func (db *DB) Where(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) First(dest interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Find(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Preload(query string, args ...interface{}) *DB    { return db }
+func (db *DB) Model(value interface{}) *DB                      { return db }
+func (db *DB) Create(value interface{}) *DB                     { return db }
+func (db *DB) Save(value interface{}) *DB                       { return db }
+func (db *DB) Update(column string, value interface{}) *DB      { return db }
+func (db *DB) Updates(values interface{}) *DB                   { return db }
+func (db *DB) Delete(value interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Scan(dest interface{}) *DB                        { return db }
+func (db *DB) Count(count *int64) *DB                           { return db }
+func (db *DB) Limit(limit int) *DB                              { return db }
+func (db *DB) Order(value interface{}) *DB                      { return db }
+func (db *DB) Select(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Joins(query string, args ...interface{}) *DB      { return db }
+func (db *DB) Group(name string) *DB                            { return db }
+func (db *DB) Having(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Last(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Take(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Exec(sql string, values ...interface{}) *DB       { return db }
+func (db *DB) Raw(sql string, values ...interface{}) *DB        { return db }
+func (db *DB) WithContext(ctx interface{}) *DB                  { return db }
+func (db *DB) Pluck(column string, dest interface{}) *DB        { return db }
+
+type Error = error

--- a/bins/gormlint/analyzers/wheregormignored/analyzer.go
+++ b/bins/gormlint/analyzers/wheregormignored/analyzer.go
@@ -1,0 +1,104 @@
+package wheregormignored
+
+import (
+	"go/ast"
+	"go/types"
+	"reflect"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "wheregormignored",
+	Doc:      "reports struct fields tagged gorm:\"-\" used in GORM Where clauses",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
+		call := n.(*ast.CallExpr)
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Where" {
+			return
+		}
+
+		if len(call.Args) == 0 {
+			return
+		}
+
+		lit, ok := call.Args[0].(*ast.CompositeLit)
+		if !ok {
+			// Also handle &Struct{} (address-of composite literal)
+			unary, ok := call.Args[0].(*ast.UnaryExpr)
+			if !ok {
+				return
+			}
+			lit, ok = unary.X.(*ast.CompositeLit)
+			if !ok {
+				return
+			}
+		}
+
+		typ := pass.TypesInfo.TypeOf(lit)
+		if typ == nil {
+			return
+		}
+
+		structType := underlyingStruct(typ)
+		if structType == nil {
+			return
+		}
+
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			ident, ok := kv.Key.(*ast.Ident)
+			if !ok {
+				continue
+			}
+
+			fieldIdx := fieldIndex(structType, ident.Name)
+			if fieldIdx < 0 {
+				continue
+			}
+
+			tag := structType.Tag(fieldIdx)
+			if tag == "" {
+				continue
+			}
+
+			gormTag := reflect.StructTag(tag).Get("gorm")
+			if gormTag == "-" {
+				pass.Reportf(kv.Pos(), "field %q has gorm:\"-\" tag and will be silently ignored in this Where clause", ident.Name)
+			}
+		}
+	})
+
+	return nil, nil
+}
+
+func underlyingStruct(t types.Type) *types.Struct {
+	t = t.Underlying()
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem().Underlying()
+	}
+	s, _ := t.(*types.Struct)
+	return s
+}
+
+func fieldIndex(s *types.Struct, name string) int {
+	for i := 0; i < s.NumFields(); i++ {
+		if s.Field(i).Name() == name {
+			return i
+		}
+	}
+	return -1
+}

--- a/bins/gormlint/analyzers/wheregormignored/analyzer_test.go
+++ b/bins/gormlint/analyzers/wheregormignored/analyzer_test.go
@@ -1,0 +1,14 @@
+package wheregormignored_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/wheregormignored"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, wheregormignored.Analyzer, "example")
+}

--- a/bins/gormlint/analyzers/wheregormignored/testdata/src/example/example.go
+++ b/bins/gormlint/analyzers/wheregormignored/testdata/src/example/example.go
@@ -1,0 +1,31 @@
+package example
+
+import "gorm.io/gorm"
+
+type User struct {
+	ID       string
+	Name     string
+	OrgID    string
+	Computed string `gorm:"-"`
+	Links    string `gorm:"-"`
+}
+
+func badWhereGormIgnored(db *gorm.DB) {
+	db.Where(User{Computed: "val"}).First(&User{}) // want `field "Computed" has gorm:"-" tag and will be silently ignored in this Where clause`
+}
+
+func badWhereGormIgnoredPointer(db *gorm.DB) {
+	db.Where(&User{Links: "val"}).First(&User{}) // want `field "Links" has gorm:"-" tag and will be silently ignored in this Where clause`
+}
+
+func badWhereGormIgnoredMixed(db *gorm.DB) {
+	db.Where(User{Name: "good", Computed: "bad"}).First(&User{}) // want `field "Computed" has gorm:"-" tag and will be silently ignored in this Where clause`
+}
+
+func goodWhereNormalFields(db *gorm.DB) {
+	db.Where(User{Name: "val", OrgID: "org123"}).First(&User{})
+}
+
+func goodWhereStringCondition(db *gorm.DB) {
+	db.Where("name = ?", "val").First(&User{})
+}

--- a/bins/gormlint/analyzers/wheregormignored/testdata/src/gorm.io/gorm/gorm.go
+++ b/bins/gormlint/analyzers/wheregormignored/testdata/src/gorm.io/gorm/gorm.go
@@ -1,0 +1,30 @@
+package gorm
+
+type DB struct{}
+
+func (db *DB) Where(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) First(dest interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Find(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Preload(query string, args ...interface{}) *DB    { return db }
+func (db *DB) Model(value interface{}) *DB                      { return db }
+func (db *DB) Create(value interface{}) *DB                     { return db }
+func (db *DB) Save(value interface{}) *DB                       { return db }
+func (db *DB) Update(column string, value interface{}) *DB      { return db }
+func (db *DB) Updates(values interface{}) *DB                   { return db }
+func (db *DB) Delete(value interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Scan(dest interface{}) *DB                        { return db }
+func (db *DB) Count(count *int64) *DB                           { return db }
+func (db *DB) Limit(limit int) *DB                              { return db }
+func (db *DB) Order(value interface{}) *DB                      { return db }
+func (db *DB) Select(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Joins(query string, args ...interface{}) *DB      { return db }
+func (db *DB) Group(name string) *DB                            { return db }
+func (db *DB) Having(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Last(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Take(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Exec(sql string, values ...interface{}) *DB       { return db }
+func (db *DB) Raw(sql string, values ...interface{}) *DB        { return db }
+func (db *DB) WithContext(ctx interface{}) *DB                  { return db }
+func (db *DB) Pluck(column string, dest interface{}) *DB        { return db }
+
+type Error = error

--- a/bins/gormlint/analyzers/wherezerovalue/analyzer.go
+++ b/bins/gormlint/analyzers/wherezerovalue/analyzer.go
@@ -1,0 +1,128 @@
+package wherezerovalue
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"reflect"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "wherezerovalue",
+	Doc:      "reports literal zero-value fields in GORM Where struct clauses that will be silently ignored",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
+		call := n.(*ast.CallExpr)
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Where" {
+			return
+		}
+
+		if len(call.Args) == 0 {
+			return
+		}
+
+		lit := extractCompositeLit(call.Args[0])
+		if lit == nil {
+			return
+		}
+
+		typ := pass.TypesInfo.TypeOf(lit)
+		if typ == nil {
+			return
+		}
+
+		structType := underlyingStruct(typ)
+		if structType == nil {
+			return
+		}
+
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			ident, ok := kv.Key.(*ast.Ident)
+			if !ok {
+				continue
+			}
+
+			fieldIdx := fieldIndex(structType, ident.Name)
+			if fieldIdx < 0 {
+				continue
+			}
+
+			tag := structType.Tag(fieldIdx)
+			if tag != "" {
+				gormTag := reflect.StructTag(tag).Get("gorm")
+				if gormTag == "-" {
+					continue
+				}
+			}
+
+			if isLiteralZero(kv.Value) {
+				pass.Reportf(kv.Pos(), "field %q has zero value and will be silently ignored by GORM in this Where clause; use a pointer type or map-based Where", ident.Name)
+			}
+		}
+	})
+
+	return nil, nil
+}
+
+func isLiteralZero(expr ast.Expr) bool {
+	switch v := expr.(type) {
+	case *ast.BasicLit:
+		switch v.Kind {
+		case token.INT:
+			return v.Value == "0"
+		case token.FLOAT:
+			return v.Value == "0.0" || v.Value == "0."
+		case token.STRING:
+			return v.Value == `""` || v.Value == "``"
+		}
+	case *ast.Ident:
+		return v.Name == "false"
+	}
+	return false
+}
+
+func extractCompositeLit(expr ast.Expr) *ast.CompositeLit {
+	if lit, ok := expr.(*ast.CompositeLit); ok {
+		return lit
+	}
+	if unary, ok := expr.(*ast.UnaryExpr); ok {
+		if lit, ok := unary.X.(*ast.CompositeLit); ok {
+			return lit
+		}
+	}
+	return nil
+}
+
+func underlyingStruct(t types.Type) *types.Struct {
+	t = t.Underlying()
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem().Underlying()
+	}
+	s, _ := t.(*types.Struct)
+	return s
+}
+
+func fieldIndex(s *types.Struct, name string) int {
+	for i := 0; i < s.NumFields(); i++ {
+		if s.Field(i).Name() == name {
+			return i
+		}
+	}
+	return -1
+}

--- a/bins/gormlint/analyzers/wherezerovalue/analyzer_test.go
+++ b/bins/gormlint/analyzers/wherezerovalue/analyzer_test.go
@@ -1,0 +1,14 @@
+package wherezerovalue_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/wherezerovalue"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, wherezerovalue.Analyzer, "example")
+}

--- a/bins/gormlint/analyzers/wherezerovalue/testdata/src/example/example.go
+++ b/bins/gormlint/analyzers/wherezerovalue/testdata/src/example/example.go
@@ -1,0 +1,36 @@
+package example
+
+import "gorm.io/gorm"
+
+type User struct {
+	ID     string
+	Name   string
+	Age    int
+	Active bool
+	Score  float64
+}
+
+func badZeroInt(db *gorm.DB) {
+	db.Where(User{Age: 0}).First(&User{}) // want `field "Age" has zero value and will be silently ignored by GORM in this Where clause`
+}
+
+func badZeroBool(db *gorm.DB) {
+	db.Where(User{Active: false}).First(&User{}) // want `field "Active" has zero value and will be silently ignored by GORM in this Where clause`
+}
+
+func badZeroString(db *gorm.DB) {
+	db.Where(User{Name: ""}).First(&User{}) // want `field "Name" has zero value and will be silently ignored by GORM in this Where clause`
+}
+
+func badZeroFloat(db *gorm.DB) {
+	db.Where(User{Score: 0.0}).First(&User{}) // want `field "Score" has zero value and will be silently ignored by GORM in this Where clause`
+}
+
+func goodNonZeroValues(db *gorm.DB) {
+	db.Where(User{Name: "alice", Age: 25, Active: true}).First(&User{})
+}
+
+func goodVariableValue(db *gorm.DB) {
+	age := 0
+	db.Where(User{Age: age}).First(&User{})
+}

--- a/bins/gormlint/analyzers/wherezerovalue/testdata/src/gorm.io/gorm/gorm.go
+++ b/bins/gormlint/analyzers/wherezerovalue/testdata/src/gorm.io/gorm/gorm.go
@@ -1,0 +1,30 @@
+package gorm
+
+type DB struct{}
+
+func (db *DB) Where(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) First(dest interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Find(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Preload(query string, args ...interface{}) *DB    { return db }
+func (db *DB) Model(value interface{}) *DB                      { return db }
+func (db *DB) Create(value interface{}) *DB                     { return db }
+func (db *DB) Save(value interface{}) *DB                       { return db }
+func (db *DB) Update(column string, value interface{}) *DB      { return db }
+func (db *DB) Updates(values interface{}) *DB                   { return db }
+func (db *DB) Delete(value interface{}, conds ...interface{}) *DB { return db }
+func (db *DB) Scan(dest interface{}) *DB                        { return db }
+func (db *DB) Count(count *int64) *DB                           { return db }
+func (db *DB) Limit(limit int) *DB                              { return db }
+func (db *DB) Order(value interface{}) *DB                      { return db }
+func (db *DB) Select(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Joins(query string, args ...interface{}) *DB      { return db }
+func (db *DB) Group(name string) *DB                            { return db }
+func (db *DB) Having(query interface{}, args ...interface{}) *DB { return db }
+func (db *DB) Last(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Take(dest interface{}, conds ...interface{}) *DB  { return db }
+func (db *DB) Exec(sql string, values ...interface{}) *DB       { return db }
+func (db *DB) Raw(sql string, values ...interface{}) *DB        { return db }
+func (db *DB) WithContext(ctx interface{}) *DB                  { return db }
+func (db *DB) Pluck(column string, dest interface{}) *DB        { return db }
+
+type Error = error

--- a/bins/gormlint/main.go
+++ b/bins/gormlint/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"golang.org/x/tools/go/analysis/multichecker"
+
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/hardcodedtablename"
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/missingcontext"
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/rawsqlwhere"
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/unboundedpreload"
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/unboundedquery"
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/wheregormignored"
+	"github.com/nuonco/nuon/bins/gormlint/analyzers/wherezerovalue"
+)
+
+func main() {
+	multichecker.Main(
+		wheregormignored.Analyzer,
+		wherezerovalue.Analyzer,
+		rawsqlwhere.Analyzer,
+		hardcodedtablename.Analyzer,
+		unboundedpreload.Analyzer,
+		unboundedquery.Analyzer,
+		missingcontext.Analyzer,
+	)
+}


### PR DESCRIPTION
Adds a static analyzer for gorm. It checks for things such as unbounded preloads, missing context calls, and other 
things.

More details coming, and we'll probably move it out of `nuonco/nuon`.
