### PR TITLE
fix: shorten workflow step index name to fit 63 char limit

### DIFF
--- a/services/ctl-api/internal/app/workflow_step.go
+++ b/services/ctl-api/internal/app/workflow_step.go
@@ -171,6 +171,14 @@ func (i *WorkflowStep) Indexes(db *gorm.DB) []migrations.Index {
 				"created_at",
 			},
 		},
+		{
+			Name: indexes.Name(db, &WorkflowStep{}, "stp_tgt_id_type_deleted_at"),
+			Columns: []string{
+				"step_target_id",
+				"step_target_type",
+				"deleted_at",
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
- Adds a new composite index on `install_workflow_steps(step_target_id, step_target_type, deleted_at)`
- Uses a shortened suffix `stp_tgt_id_type_deleted_at` so the full generated name `idx_install_workflow_steps_stp_tgt_id_type_deleted_at` (53 chars) stays within PostgreSQL's 63-character identifier limit