### PR TITLE
fix: shorten workflow step target index name to fit Postgres 63-char limit

### DIFF
--- a/services/ctl-api/internal/app/workflow_step.go
+++ b/services/ctl-api/internal/app/workflow_step.go
@@ -172,7 +172,7 @@ func (i *WorkflowStep) Indexes(db *gorm.DB) []migrations.Index {
 			},
 		},
 		{
-			Name: indexes.Name(db, &WorkflowStep{}, "step_target_id_step_target_type_deleted_at"),
+			Name: indexes.Name(db, &WorkflowStep{}, "target_id_target_type_deleted_at"),
 			Columns: []string{
 				"step_target_id",
 				"step_target_type",


### PR DESCRIPTION
## What

Shorten the `WorkflowStep` target index name so it fits within Postgres's 63-char identifier limit.

## Why

The index added in #1701 generated the identifier:

```
idx_install_workflow_steps_step_target_id_step_target_type_deleted_at  (69 chars)
```

`indexes.Name()` panics when a generated index name exceeds 63 chars, so **ctl-api crashed on startup during index migration**:

```
panic: index idx_install_workflow_steps_step_target_id_step_target_type_deleted_at
       for table install_workflow_steps is too long
```

## Change

Rename the index suffix `step_target_id_step_target_type_deleted_at` → `target_id_target_type_deleted_at`, yielding `idx_install_workflow_steps_target_id_target_type_deleted_at` (58 chars). The indexed columns (`step_target_id`, `step_target_type`, `deleted_at`) are unchanged.
