### PR TITLE
fix: mark dropped runner jobs failed instead of silently succeeding

### DIFF
--- a/services/ctl-api/internal/app/runner_job.go
+++ b/services/ctl-api/internal/app/runner_job.go
@@ -42,6 +42,23 @@ const (
 	RunnerJobStatusUnknown RunnerJobStatus = "unknown"
 )
 
+// IsTerminal reports whether the status is a final state that the job will not
+// transition out of. A job left in a non-terminal status when its execution
+// loop ends has been dropped and must not be read as success downstream.
+func (s RunnerJobStatus) IsTerminal() bool {
+	switch s {
+	case RunnerJobStatusFinished,
+		RunnerJobStatusFailed,
+		RunnerJobStatusTimedOut,
+		RunnerJobStatusNotAttempted,
+		RunnerJobStatusCancelled,
+		RunnerJobStatusUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
 type RunnerJobGroup string
 
 const (

--- a/services/ctl-api/internal/app/runners/signals/processjob/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/processjob/signal.go
@@ -204,6 +204,19 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		}
 	}
 
+	// All execution attempts are exhausted. If the final attempt ended in a
+	// retryable-but-non-terminal state (e.g. the execution was cancelled by a
+	// runner restart with no retries remaining), no terminal job status was
+	// written. Leaving the job non-terminal makes downstream workflows read it
+	// as success, so mark it failed.
+	finalStatus, err := activities.AwaitGetJobStatusByID(ctx, s.JobID)
+	if err != nil {
+		return err
+	}
+	if !finalStatus.IsTerminal() {
+		s.updateJobStatus(ctx, s.JobID, app.RunnerJobStatusFailed, "job execution attempts exhausted without completing")
+	}
+
 	return nil
 }
 

--- a/services/ctl-api/internal/pkg/workflows/job/exec.go
+++ b/services/ctl-api/internal/pkg/workflows/job/exec.go
@@ -72,12 +72,15 @@ func (w *Workflows) ExecuteJob(ctx workflow.Context, req *ExecuteJobRequest) (ap
 		return app.RunnerJobStatus(""), errors.Wrap(err, "unable to get job")
 	}
 
-	if generics.SliceContains(job.Status, failureStatuses) {
+	// Only an explicit "finished" status counts as success. Any other status —
+	// including non-terminal ones like "in-progress" or "available" left behind
+	// by a dropped execution — must fail the job rather than be read as success.
+	if job.Status != app.RunnerJobStatusFinished {
 		msg := "job did not succeed"
 		if job.StatusDescription != "" {
 			msg = fmt.Sprintf("job did not succeed: %s", job.StatusDescription)
 		}
-		return job.Status, temporal.NewNonRetryableApplicationError(msg, "api", fmt.Errorf("job failed with status %s: %s", job.Status, job.StatusDescription))
+		return job.Status, temporal.NewNonRetryableApplicationError(msg, "api", fmt.Errorf("job did not finish successfully, status %s: %s", job.Status, job.StatusDescription))
 	}
 
 	return job.Status, nil


### PR DESCRIPTION
## What

Prevent a dropped/cancelled runner job execution from surfacing as a successful deploy step.

## Why

When a runner restarts mid-job, the in-flight `runner_job_execution` is cancelled but the parent `runner_jobs` row can be left in a **non-terminal** status (`in-progress` / `available`). Two compounding bugs then turned that dropped work into a false success:

1. **`processjob.Execute()`** :  the cancelled-execution branch writes no job status and is retryable. When the `MaxExecutions` loop exhausts in that state, the function fell through to `return nil`, leaving the job non-terminal.
2. **`ExecuteJob`** :  its success check only rejected an allowlist of *failure* statuses, so a job left at `in-progress`/`available` was treated as success.

Net effect: an interrupted terraform apply rolled up as a successful deploy and the workflow step showed `success`.

## Change

- Add `RunnerJobStatus.IsTerminal()`.
- In `processjob.Execute()`, after the execution loop, mark the job `failed` (`job execution attempts exhausted without completing`) if it isn't already terminal.
- In `ExecuteJob`, require `runner_jobs.status == finished` for success; any other status returns an error. This matches what `pollJob` already enforces.

