### PR TITLE
fix(ctl-api): pivot app reprovision repo on cloud platform

### DIFF
--- a/services/ctl-api/internal/app/apps/signals/reprovision/signal.go
+++ b/services/ctl-api/internal/app/apps/signals/reprovision/signal.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/apps/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/apps/worker/ecrrepository"
@@ -17,9 +19,18 @@ const SignalType signal.SignalType = "app-reprovision"
 
 type Signal struct {
 	AppID string `json:"app_id"`
+
+	cfg *internal.Config
 }
 
-var _ signal.Signal = (*Signal)(nil)
+var (
+	_ signal.Signal           = (*Signal)(nil)
+	_ signal.SignalWithParams = (*Signal)(nil)
+)
+
+func (s *Signal) WithParams(params *signal.Params) {
+	s.cfg = params.Cfg
+}
 
 func (s *Signal) Type() signal.SignalType {
 	return SignalType
@@ -99,9 +110,31 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		StatusDescription: "reprovisioning app resources",
 	})
 
-	// Provision ECR repository (only for default org type)
 	var repoResp *ecrrepository.ProvisionECRRepositoryResponse
-	if currentApp.Org.OrgType == app.OrgTypeDefault {
+	switch {
+	case currentApp.Org.OrgType != app.OrgTypeDefault:
+		repoResp = generics.GetFakeObj[*ecrrepository.ProvisionECRRepositoryResponse]()
+		l.Info("skipping reprovision app repository",
+			zap.String("app_id", currentApp.ID),
+			zap.String("app_name", currentApp.Name),
+			zap.Any("org_type", currentApp.Org.OrgType),
+			zap.String("org_id", currentApp.Org.ID),
+			zap.String("org_name", currentApp.Org.Name))
+	case s.cfg.IsGCP():
+		repoResp = ecrrepository.BuildGARResponse(
+			s.cfg.ManagementGARRepositoryURL,
+			currentApp.OrgID,
+			s.AppID,
+			s.cfg.AppRegion,
+		)
+	case s.cfg.IsAzure():
+		repoResp = ecrrepository.BuildACRResponse(
+			s.cfg.ManagementACRRegistryURL,
+			currentApp.OrgID,
+			s.AppID,
+			s.cfg.AppRegion,
+		)
+	default:
 		repoResp, err = ecrrepository.AwaitProvisionECRRepository(ctx, &ecrrepository.ProvisionECRRepositoryRequest{
 			OrgID: currentApp.OrgID,
 			AppID: s.AppID,
@@ -109,13 +142,6 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "unable to provision ECR repository")
 		}
-	} else {
-		l.Info("skipping reprovision ecr",
-			zap.String("app_id", currentApp.ID),
-			zap.String("app_name", currentApp.Name),
-			zap.Any("org_type", currentApp.Org.OrgType),
-			zap.String("org_id", currentApp.Org.ID),
-			zap.String("org_name", currentApp.Org.Name))
 	}
 
 	// Create app repository record


### PR DESCRIPTION
App reprovision still used the AWS ECR path for default orgs and failed on GCP/Azure control planes. #1694 fixed the provision signal but not reprovision (the GCP/Azure switch lived in the legacy `worker/reprovision.go` removed in #1532 and was never restored here).

This mirrors the provision signal: GAR on GCP, ACR on Azure, ECR on AWS, fake response for non-default orgs.