### PR TITLE
fix(api): cancel orphaned workflows via DB when queue signal is gone

### DIFF
--- a/services/ctl-api/internal/app/installs/service/cancel_workflow.go
+++ b/services/ctl-api/internal/app/installs/service/cancel_workflow.go
@@ -2,12 +2,13 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"go.uber.org/zap"
+	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -112,9 +113,17 @@ func (s *service) cancelSingleWorkflow(ctx *gin.Context, orgID, workflowID strin
 	if _, err := s.flowsClient.CancelWorkflow(ctx, &flowclient.CancelWorkflowRequest{
 		InstallWorkflowID: wf.ID,
 	}); err != nil {
-		s.l.Warn("failed to cancel workflow via queues",
-			zap.String("workflow_id", wf.ID),
-			zap.Error(err))
+		// Orphaned workflows (e.g. weeks-old rows stuck in-progress) no longer
+		// have a live execute-flow queue signal — it was soft-deleted once the
+		// handler finished. There is nothing to signal, so flip the row
+		// directly in the DB rather than leaving it stuck in-progress forever.
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			if dbErr := s.cancelWorkflow(ctx, wf.ID); dbErr != nil {
+				return fmt.Errorf("unable to cancel orphaned workflow: %w", dbErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("unable to cancel workflow via queues: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Cancelling a workflow from the org dashboard silently does nothing

### Problem

Cancelling an active workflow from the **org dashboard** ("Active workflows" cards) shows a confirmation modal and a success toast, but the workflow never actually cancels. Cancelling the same workflow from its **detail page** appears to work. The issue could not be reproduced locally.

### Root cause

The dashboard and detail page both hit the same endpoint (`POST /v1/workflows/{id}/cancel` → `cancelSingleWorkflow`), so the request was identical. The real problem was in the backend cancel path for in-progress workflows:

```go
if _, err := s.flowsClient.CancelWorkflow(ctx, ...); err != nil {
    s.l.Warn("failed to cancel workflow via queues", ...) // error swallowed
}
return nil // → always 202 Accepted
```

`flowsClient.CancelWorkflow` looks up the workflow's `execute-workflow` queue signal via `findQueueSignalByOwner`, which queries **without `.Unscoped()`** — so it only sees non-soft-deleted rows. `QueueSignal` is soft-deleted once its execute-flow handler finishes.

The dashboard's "Active workflows" list shows everything with `finished_at IS NULL` and a non-terminal status. **Weeks-old workflows stuck in `in-progress`** accumulate there even though their queue signal was soft-deleted long ago. Cancelling one:

1. `findQueueSignalByOwner` → `record not found`
2. error swallowed, logged as a warning
3. handler returns `202`
4. frontend treats `202` as success → "{name} was cancelled" toast
5. nothing actually changes

Confirmed in Datadog (`service:ctl-api`, `cancel_workflow.go:115`):

```
unable to find execute-flow queue signal: queue signal not found
for owner <wf_id> type execute-workflow: record not found
```

It didn't reproduce locally because local workflows finish in seconds (`finished_at` gets set) — you never build up weeks-old orphaned `in-progress` rows with a deleted signal.

### Fix

In `cancelSingleWorkflow`, stop swallowing the error and handle the orphan case:

- **Queue signal not found** (`errors.Is(err, gorm.ErrRecordNotFound)`) → fall back to the existing DB cancel (`s.cancelWorkflow`), flipping the stuck row to `cancelled`. This makes orphaned weeks-old workflows cancellable from the dashboard.
- **Any other failure** → return the error so the API responds 5xx and the UI shows a real error toast instead of false success.

The dashboard's multi-select "Cancel workflows" routes through the same helper, so it's fixed too.

### Testing

- `go build ./services/ctl-api/internal/app/installs/service/` passes.
- Existing cancel integration tests (`pending` → DB-cancel path, nonexistent → 404) are unaffected — the change only touches the post-queue-failure branch for in-progress workflows.
