### PR TITLE
fix: github pem must be base64 encoded for nuon on gcp as well as on aws

### DIFF
--- a/docs/guides/byoc/gcp.mdx
+++ b/docs/guides/byoc/gcp.mdx
@@ -212,10 +212,19 @@ The `secrets` map must be popoulated with the following:
 
 | Secret                    | Value                                                                         |
 | ------------------------- | ----------------------------------------------------------------------------- |
-| `github_app_key`          | Your GitHub App PEM key (paste directly — Terraform preserves newlines).      |
+| `github_app_key`          | Your base64-encoded GitHub App PEM key                                        |
 | `nuon_auth_client_secret` | OIDC Client Secret from your identity provider.                               |
 | `slack_client_secret`     | Client Secret from your Slack app (optional — required only if using Slack).  |
 | `slack_signing_secret`    | Signing Secret from your Slack app (optional — required only if using Slack). |
+
+<Note>
+The GitHub App PEM key must be base64 encoded because AWS CloudFormation doesn't preserve newlines in text fields.
+
+To encode your PEM key:
+
+```bash
+base64 -i your-github-app-key.pem
+```
 
 ### 4. Apply the install stack
 


### PR DESCRIPTION
## Summary

The Nuon BYOC on GCP setup guide directs users to paste their Github app PEM key into the tfvars file. CTL API is expecting it to be base64 encoded, and it will also cause the `terraform apply` on the stack to fail. It needs to be base64 encoded like it in the AWS setup guide.