### PR TITLE
feat(ui): show the drift scan cron when set for sandbox

### DIFF
--- a/services/dashboard-ui/client/components/apps/config/AppSandbox.stories.tsx
+++ b/services/dashboard-ui/client/components/apps/config/AppSandbox.stories.tsx
@@ -9,6 +9,7 @@ export const Default = () => (
     appConfig={{
       sandbox: {
         terraform_version: '1.5.7',
+        drift_schedule: '0 2 * * *',
         public_git_vcs_config: {
           repo: 'https://github.com/my-org/sandbox-config',
           branch: 'main',

--- a/services/dashboard-ui/client/components/apps/config/AppSandbox.tsx
+++ b/services/dashboard-ui/client/components/apps/config/AppSandbox.tsx
@@ -1,3 +1,4 @@
+import { Cron } from '@/components/common/Cron'
 import { GitRepo } from '@/components/common/GitRepo'
 import { KeyValueList } from '@/components/common/KeyValueList'
 import { LabeledValue } from '@/components/common/LabeledValue'
@@ -41,6 +42,11 @@ export const AppSandbox = ({ appConfig }: IAppSandbox) => {
               {sandboxConfig.terraform_version}
             </LabeledValue>
           )
+        )}
+        {sandboxConfig?.drift_schedule && (
+          <LabeledValue label="Drift schedule">
+            <Cron cron={sandboxConfig.drift_schedule} variant="subtext" />
+          </LabeledValue>
         )}
       </div>
       {sandboxVariables?.length ? (

--- a/services/dashboard-ui/client/components/sandbox/SandboxConfigCard/SandboxConfigCard.tsx
+++ b/services/dashboard-ui/client/components/sandbox/SandboxConfigCard/SandboxConfigCard.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/common/Button'
 import { Card, type ICard } from '@/components/common/Card'
+import { Cron } from '@/components/common/Cron'
 import { GitRepo } from '@/components/common/GitRepo'
 import { KeyValueList } from '@/components/common/KeyValueList'
 import { LabeledValue } from '@/components/common/LabeledValue'
@@ -90,6 +91,11 @@ export const SandboxConfigCard = ({
                 {config.terraform_version}
               </LabeledValue>
             )
+          )}
+          {config.drift_schedule && (
+            <LabeledValue label="Drift schedule">
+              <Cron cron={config.drift_schedule} variant="subtext" />
+            </LabeledValue>
           )}
         </div>
 


### PR DESCRIPTION
When enabled show the drift scan cron schedule in the sandbox configs