### PR TITLE
fix(ui): only show queue position when workflow is pending

### DIFF
--- a/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowStatusSection/WorkflowStatusSectionContainer.tsx
+++ b/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowStatusSection/WorkflowStatusSectionContainer.tsx
@@ -55,7 +55,7 @@ export const WorkflowStatusSectionContainer = () => {
   return (
     <WorkflowStatusSection
       workflow={workflow}
-      queuePosition={queuePosition}
+      queuePosition={isPending ? queuePosition : undefined}
       installId={install?.id}
       orgId={org?.id}
       onCancelWorkflow={handleCancelWorkflow}


### PR DESCRIPTION
Only show the workflow queue position if the workflow is pending