### PR TITLE
feat: admin migration blog storage backfill

### DIFF
--- a/pkg/types/workflows/blobbackfill/blobbackfill.go
+++ b/pkg/types/workflows/blobbackfill/blobbackfill.go
@@ -1,0 +1,45 @@
+package blobbackfill
+
+const (
+	WorkflowName    = "BackfillBlobs"
+	DayWorkflowName = "BackfillBlobsDay"
+	WorkflowID      = "general-blob-backfill"
+
+	ProgressQueryType = "progress"
+)
+
+// RangeRequest is the parent orchestrator input. Callers populate only Tables;
+// the parent fills in the rest and carries it across continue-as-new.
+type RangeRequest struct {
+	Tables      []string         `json:"tables"`
+	Initialized bool             `json:"initialized"`
+	Pending     []DayBucket      `json:"pending"`
+	Processed   map[string]int64 `json:"processed"`
+	DaysTotal   int              `json:"days_total"`
+	DaysDone    int              `json:"days_done"`
+}
+
+// DayBucket is one unit of work: one table on one UTC calendar day.
+type DayBucket struct {
+	Table string `json:"table"`
+	Day   string `json:"day"`
+}
+
+type DayRequest struct {
+	Table string `json:"table"`
+	Day   string `json:"day"`
+}
+
+type DayResult struct {
+	Processed int64 `json:"processed"`
+}
+
+// Progress is the live snapshot returned by the parent's progress query.
+type Progress struct {
+	CurrentTable string           `json:"current_table"`
+	CurrentDay   string           `json:"current_day"`
+	DaysTotal    int              `json:"days_total"`
+	DaysDone     int              `json:"days_done"`
+	Processed    map[string]int64 `json:"processed"`
+	Done         bool             `json:"done"`
+}

--- a/pkg/types/workflows/blobverify/blobverify.go
+++ b/pkg/types/workflows/blobverify/blobverify.go
@@ -1,0 +1,56 @@
+package blobverify
+
+const (
+	WorkflowName    = "VerifyBlobs"
+	DayWorkflowName = "VerifyBlobsDay"
+	WorkflowID      = "general-blob-verify"
+
+	ProgressQueryType = "progress"
+)
+
+// RangeRequest is the parent orchestrator input. Callers populate only Tables;
+// the parent fills in the rest and carries it across continue-as-new.
+type RangeRequest struct {
+	Tables      []string                 `json:"tables"`
+	Initialized bool                     `json:"initialized"`
+	Pending     []DayBucket              `json:"pending"`
+	Tallies     map[string]TableProgress `json:"tallies"`
+	DaysTotal   int                      `json:"days_total"`
+	DaysDone    int                      `json:"days_done"`
+}
+
+// DayBucket is one unit of work: one table on one UTC calendar day.
+type DayBucket struct {
+	Table string `json:"table"`
+	Day   string `json:"day"`
+}
+
+type DayRequest struct {
+	Table string `json:"table"`
+	Day   string `json:"day"`
+}
+
+type DayResult struct {
+	Checked       int64    `json:"checked"`
+	Mismatched    int64    `json:"mismatched"`
+	NotSet        int64    `json:"not_set"`
+	MismatchedIDs []string `json:"mismatched_ids,omitempty"`
+}
+
+type TableProgress struct {
+	Checked    int64 `json:"checked"`
+	Mismatched int64 `json:"mismatched"`
+	NotSet     int64 `json:"not_set"`
+	// MismatchedIDs samples mismatched row ids, capped to keep history bounded.
+	MismatchedIDs []string `json:"mismatched_ids,omitempty"`
+}
+
+// Progress is the live snapshot returned by the parent's progress query.
+type Progress struct {
+	CurrentTable string                   `json:"current_table"`
+	CurrentDay   string                   `json:"current_day"`
+	DaysTotal    int                      `json:"days_total"`
+	DaysDone     int                      `json:"days_done"`
+	Tables       map[string]TableProgress `json:"tables"`
+	Done         bool                     `json:"done"`
+}

--- a/services/ctl-api/internal/app/general/service/admin_backfill_blobs.go
+++ b/services/ctl-api/internal/app/general/service/admin_backfill_blobs.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	enumsv1 "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	tclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/nuonco/nuon/pkg/types/workflows/blobbackfill"
+	"github.com/nuonco/nuon/pkg/workflows"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+)
+
+const blobBackfillNamespace = "general"
+
+// AdminBackfillBlobsRequest optionally narrows the backfill to a subset of
+// dual-write tables. When empty, every supported table is processed.
+type AdminBackfillBlobsRequest struct {
+	Tables []string `json:"tables"`
+}
+
+// @ID						AdminBackfillBlobs
+// @Summary				backfill dual-write blobs to S3
+// @Description			Starts an orchestrator workflow that enumerates the day-buckets of existing dual-write rows and mirrors each day's rows into S3 blob storage, throttled to the configured per-second S3 write rate. Re-running drains any remaining backlog; an already-running backfill is reused rather than duplicated.
+// @Description
+// @Description			Supported tables: install_states, install_workflow_step_approvals, runner_job_plans, runner_job_execution_outputs, terraform_workspace_states. Leave `tables` empty (or omit the body) to process all of them.
+// @Tags					general/admin
+// @Accept					json
+// @Produce				json
+// @Param					request	body	AdminBackfillBlobsRequest	false	"optional table subset; empty processes all supported tables"
+// @Success				201	{string}	ok
+// @Router					/v1/general/backfill-blobs [post]
+func (s *service) AdminBackfillBlobs(ctx *gin.Context) {
+	var req AdminBackfillBlobsRequest
+	if ctx.Request.ContentLength > 0 {
+		if err := ctx.ShouldBindJSON(&req); err != nil {
+			ctx.Error(fmt.Errorf("unable to parse request: %w", err))
+			return
+		}
+	}
+
+	if err := s.startBlobBackfill(ctx, req.Tables); err != nil {
+		ctx.Error(fmt.Errorf("unable to start blob backfill: %w", err))
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, map[string]string{
+		"status": "ok",
+	})
+}
+
+func (s *service) startBlobBackfill(ctx context.Context, tables []string) error {
+	opts := tclient.StartWorkflowOptions{
+		ID:                       blobbackfill.WorkflowID,
+		TaskQueue:                workflows.APITaskQueue,
+		WorkflowIDReusePolicy:    enumsv1.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+		WorkflowIDConflictPolicy: enumsv1.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 1,
+		},
+		Memo: map[string]interface{}{
+			"started-by": "ctl-api",
+		},
+	}
+
+	if _, err := s.temporalClient.ExecuteWorkflowInNamespace(ctx, blobBackfillNamespace, opts, blobbackfill.WorkflowName, blobbackfill.RangeRequest{
+		Tables: tables,
+	}); err != nil {
+		return fmt.Errorf("unable to execute blob backfill workflow: %w", err)
+	}
+
+	return nil
+}
+
+type BackfillBlobsStatusResponse struct {
+	Running        bool                   `json:"running"`
+	Status         string                 `json:"status"`
+	RunID          string                 `json:"run_id,omitempty"`
+	StartedAt      *time.Time             `json:"started_at,omitempty"`
+	ClosedAt       *time.Time             `json:"closed_at,omitempty"`
+	ElapsedSeconds float64                `json:"elapsed_seconds,omitempty"`
+	Elapsed        string                 `json:"elapsed,omitempty"`
+	Progress       *blobbackfill.Progress `json:"progress,omitempty"`
+}
+
+// @ID						GetBackfillBlobsStatus
+// @Summary				get dual-write blob backfill progress
+// @Description			Reports whether the blob backfill workflow is still running and, when available, a live snapshot of how many rows per table have been mirrored to S3 so far.
+// @Tags					general/admin
+// @Accept					json
+// @Produce				json
+// @Success				200	{object}	BackfillBlobsStatusResponse
+// @Router					/v1/general/backfill-blobs [get]
+func (s *service) GetBackfillBlobsStatus(ctx *gin.Context) {
+	resp, err := s.getBlobBackfillStatus(ctx)
+	if err != nil {
+		var notFoundErr *serviceerror.NotFound
+		if errors.As(err, &notFoundErr) {
+			ctx.Error(stderr.ErrNotFound{Err: fmt.Errorf("blob backfill workflow has not been started")})
+			return
+		}
+		ctx.Error(fmt.Errorf("unable to get blob backfill status: %w", err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, resp)
+}
+
+func (s *service) getBlobBackfillStatus(ctx context.Context) (*BackfillBlobsStatusResponse, error) {
+	exec, err := s.temporalClient.DescribeWorkflowExecutionInNamespace(ctx, blobBackfillNamespace, blobbackfill.WorkflowID, "")
+	if err != nil {
+		return nil, fmt.Errorf("unable to describe blob backfill workflow: %w", err)
+	}
+
+	info := exec.GetWorkflowExecutionInfo()
+	status := info.GetStatus()
+	resp := &BackfillBlobsStatusResponse{
+		Status:  status.String(),
+		Running: status == enumsv1.WORKFLOW_EXECUTION_STATUS_RUNNING,
+		RunID:   info.GetExecution().GetRunId(),
+	}
+
+	if startTS := info.GetStartTime(); startTS != nil {
+		startedAt := startTS.AsTime()
+		resp.StartedAt = &startedAt
+
+		end := time.Now()
+		if closeTS := info.GetCloseTime(); closeTS != nil {
+			closedAt := closeTS.AsTime()
+			resp.ClosedAt = &closedAt
+			end = closedAt
+		}
+
+		elapsed := end.Sub(startedAt)
+		resp.ElapsedSeconds = elapsed.Seconds()
+		resp.Elapsed = elapsed.Round(time.Second).String()
+	}
+
+	encoded, err := s.temporalClient.QueryWorkflowInNamespace(ctx, blobBackfillNamespace, blobbackfill.WorkflowID, "", blobbackfill.ProgressQueryType)
+	if err != nil {
+		// progress query is best-effort: a completed run on a closed workflow may not answer queries.
+		return resp, nil
+	}
+
+	var progress blobbackfill.Progress
+	if err := encoded.Get(&progress); err != nil {
+		return nil, fmt.Errorf("unable to decode blob backfill progress: %w", err)
+	}
+	resp.Progress = &progress
+
+	return resp, nil
+}

--- a/services/ctl-api/internal/app/general/service/admin_verify_blobs.go
+++ b/services/ctl-api/internal/app/general/service/admin_verify_blobs.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	enumsv1 "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	tclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/nuonco/nuon/pkg/types/workflows/blobverify"
+	"github.com/nuonco/nuon/pkg/workflows"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+)
+
+const blobVerifyNamespace = "general"
+
+// AdminVerifyBlobsRequest optionally narrows the verification to a subset of
+// dual-write tables. When empty, every supported table is processed.
+type AdminVerifyBlobsRequest struct {
+	Tables []string `json:"tables"`
+}
+
+// @ID						AdminVerifyBlobs
+// @Summary				verify dual-write blobs against S3
+// @Description			Starts an orchestrator workflow that enumerates the day-buckets of mirrored dual-write rows and verifies each day's rows against S3 blob storage: it confirms each blob's S3 object still matches its recorded checksum and that the blob content matches the canonical origin column. Re-running walks the full set again; an already-running verification is reused rather than duplicated.
+// @Description
+// @Description			Supported tables: install_states, install_workflow_step_approvals, runner_job_plans, runner_job_execution_outputs, terraform_workspace_states. Leave `tables` empty (or omit the body) to process all of them.
+// @Tags					general/admin
+// @Accept					json
+// @Produce				json
+// @Param					request	body	AdminVerifyBlobsRequest	false	"optional table subset; empty processes all supported tables"
+// @Success				201	{string}	ok
+// @Router					/v1/general/verify-blobs [post]
+func (s *service) AdminVerifyBlobs(ctx *gin.Context) {
+	var req AdminVerifyBlobsRequest
+	if ctx.Request.ContentLength > 0 {
+		if err := ctx.ShouldBindJSON(&req); err != nil {
+			ctx.Error(fmt.Errorf("unable to parse request: %w", err))
+			return
+		}
+	}
+
+	if err := s.startBlobVerify(ctx, req.Tables); err != nil {
+		ctx.Error(fmt.Errorf("unable to start blob verify: %w", err))
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, map[string]string{
+		"status": "ok",
+	})
+}
+
+func (s *service) startBlobVerify(ctx context.Context, tables []string) error {
+	opts := tclient.StartWorkflowOptions{
+		ID:                       blobverify.WorkflowID,
+		TaskQueue:                workflows.APITaskQueue,
+		WorkflowIDReusePolicy:    enumsv1.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+		WorkflowIDConflictPolicy: enumsv1.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 1,
+		},
+		Memo: map[string]interface{}{
+			"started-by": "ctl-api",
+		},
+	}
+
+	if _, err := s.temporalClient.ExecuteWorkflowInNamespace(ctx, blobVerifyNamespace, opts, blobverify.WorkflowName, blobverify.RangeRequest{
+		Tables: tables,
+	}); err != nil {
+		return fmt.Errorf("unable to execute blob verify workflow: %w", err)
+	}
+
+	return nil
+}
+
+type VerifyBlobsStatusResponse struct {
+	Running        bool                 `json:"running"`
+	Status         string               `json:"status"`
+	RunID          string               `json:"run_id,omitempty"`
+	StartedAt      *time.Time           `json:"started_at,omitempty"`
+	ClosedAt       *time.Time           `json:"closed_at,omitempty"`
+	ElapsedSeconds float64              `json:"elapsed_seconds,omitempty"`
+	Elapsed        string               `json:"elapsed,omitempty"`
+	Progress       *blobverify.Progress `json:"progress,omitempty"`
+}
+
+// @ID						GetVerifyBlobsStatus
+// @Summary				get dual-write blob verify progress
+// @Description			Reports whether the blob verify workflow is still running and, when available, a live snapshot of how many rows per table have been checked and how many mismatched their checksum or origin column.
+// @Tags					general/admin
+// @Accept					json
+// @Produce				json
+// @Success				200	{object}	VerifyBlobsStatusResponse
+// @Router					/v1/general/verify-blobs [get]
+func (s *service) GetVerifyBlobsStatus(ctx *gin.Context) {
+	resp, err := s.getBlobVerifyStatus(ctx)
+	if err != nil {
+		var notFoundErr *serviceerror.NotFound
+		if errors.As(err, &notFoundErr) {
+			ctx.Error(stderr.ErrNotFound{Err: fmt.Errorf("blob verify workflow has not been started")})
+			return
+		}
+		ctx.Error(fmt.Errorf("unable to get blob verify status: %w", err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, resp)
+}
+
+func (s *service) getBlobVerifyStatus(ctx context.Context) (*VerifyBlobsStatusResponse, error) {
+	exec, err := s.temporalClient.DescribeWorkflowExecutionInNamespace(ctx, blobVerifyNamespace, blobverify.WorkflowID, "")
+	if err != nil {
+		return nil, fmt.Errorf("unable to describe blob verify workflow: %w", err)
+	}
+
+	info := exec.GetWorkflowExecutionInfo()
+	status := info.GetStatus()
+	resp := &VerifyBlobsStatusResponse{
+		Status:  status.String(),
+		Running: status == enumsv1.WORKFLOW_EXECUTION_STATUS_RUNNING,
+		RunID:   info.GetExecution().GetRunId(),
+	}
+
+	if startTS := info.GetStartTime(); startTS != nil {
+		startedAt := startTS.AsTime()
+		resp.StartedAt = &startedAt
+
+		end := time.Now()
+		if closeTS := info.GetCloseTime(); closeTS != nil {
+			closedAt := closeTS.AsTime()
+			resp.ClosedAt = &closedAt
+			end = closedAt
+		}
+
+		elapsed := end.Sub(startedAt)
+		resp.ElapsedSeconds = elapsed.Seconds()
+		resp.Elapsed = elapsed.Round(time.Second).String()
+	}
+
+	encoded, err := s.temporalClient.QueryWorkflowInNamespace(ctx, blobVerifyNamespace, blobverify.WorkflowID, "", blobverify.ProgressQueryType)
+	if err != nil {
+		// progress query is best-effort: a completed run on a closed workflow may not answer queries.
+		return resp, nil
+	}
+
+	var progress blobverify.Progress
+	if err := encoded.Get(&progress); err != nil {
+		return nil, fmt.Errorf("unable to decode blob verify progress: %w", err)
+	}
+	resp.Progress = &progress
+
+	return resp, nil
+}

--- a/services/ctl-api/internal/app/general/service/service.go
+++ b/services/ctl-api/internal/app/general/service/service.go
@@ -78,6 +78,10 @@ func (s *service) RegisterInternalRoutes(api *gin.Engine) error {
 		general.POST("/promotion", s.AdminPromotion)
 		general.POST("/slack-auto-link", s.AdminSlackAutoLink)
 		general.GET("/waitlist", s.AdminGetWaitlist)
+		general.POST("/backfill-blobs", s.AdminBackfillBlobs)
+		general.GET("/backfill-blobs", s.GetBackfillBlobsStatus)
+		general.POST("/verify-blobs", s.AdminVerifyBlobs)
+		general.GET("/verify-blobs", s.GetVerifyBlobsStatus)
 
 		// temporal codec
 		general.POST("/temporal-codec/decode", s.TemporalCodecDecode)

--- a/services/ctl-api/internal/app/general/worker/activities/activities.go
+++ b/services/ctl-api/internal/app/general/worker/activities/activities.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	appshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/slack/autolink"
 	slackclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/slack/client"
 )
@@ -26,6 +27,7 @@ type Activities struct {
 	tClient        temporalclient.Client
 	slackClient    *slackclient.Client
 	autoLinkHelper *autolink.Helper
+	blobSvc        blobstore.Service
 }
 
 type Params struct {
@@ -39,6 +41,7 @@ type Params struct {
 	TemporalClient temporalclient.Client
 	SlackClient    *slackclient.Client
 	AutoLinkHelper *autolink.Helper
+	BlobSvc        blobstore.Service
 }
 
 func New(params Params) (*Activities, error) {
@@ -57,5 +60,6 @@ func New(params Params) (*Activities, error) {
 		tClient:        params.TemporalClient,
 		slackClient:    params.SlackClient,
 		autoLinkHelper: params.AutoLinkHelper,
+		blobSvc:        params.BlobSvc,
 	}, nil
 }

--- a/services/ctl-api/internal/app/general/worker/activities/backfill_blobs.go
+++ b/services/ctl-api/internal/app/general/worker/activities/backfill_blobs.go
@@ -1,0 +1,229 @@
+package activities
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"golang.org/x/time/rate"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
+)
+
+const (
+	defaultBlobBackfillRatePerSecond = 100
+	blobBackfillContentType          = "application/octet-stream"
+)
+
+// blobBackfillTargets whitelists the tables/columns the backfill is allowed to
+// touch. Table and column names are interpolated into SQL, so they must never
+// come from request input — only from this map.
+var blobBackfillTargets = map[string]blobBackfillTarget{
+	"install_states":                  {originColumn: "state", blobColumn: "state_blob", jsonSemantic: true},
+	"install_workflow_step_approvals": {originColumn: "contents", blobColumn: "contents_blob"},
+	"runner_job_plans":                {originColumn: "composite_plan", blobColumn: "composite_plan_blob", jsonSemantic: true},
+	"runner_job_execution_outputs":    {originColumn: "outputs", blobColumn: "outputs_blob", jsonSemantic: true},
+	"terraform_workspace_states":      {originColumn: "contents", blobColumn: "contents_blob", binary: true},
+}
+
+type blobBackfillTarget struct {
+	originColumn string
+	blobColumn   string
+	// jsonSemantic compares the blob against its origin column as parsed JSON
+	// rather than byte-for-byte. Required for jsonb origin columns, whose
+	// Postgres serialization differs from the Go-marshaled bytes uploaded to S3.
+	jsonSemantic bool
+	// binary marks a bytea origin column: it is read raw rather than cast to
+	// text (a ::text cast would yield Postgres hex escapes, not the bytes), and
+	// compared byte-for-byte.
+	binary bool
+}
+
+// contentExpr selects the origin column's bytes: raw for bytea, ::text otherwise.
+func (t blobBackfillTarget) contentExpr() string {
+	if t.binary {
+		return t.originColumn
+	}
+	return t.originColumn + "::text"
+}
+
+type BackfillBlobsRequest struct {
+	Table     string `json:"table"`
+	BatchSize int    `json:"batch_size"`
+	// Day scopes the batch to a single UTC calendar day ("2006-01-02"); empty means the whole table.
+	Day string `json:"day"`
+}
+
+type BackfillBlobsResponse struct {
+	Processed int64 `json:"processed"`
+}
+
+type ListBlobDaysRequest struct {
+	Table string `json:"table"`
+}
+
+type ListBlobDaysResponse struct {
+	Days []string `json:"days"`
+}
+
+const (
+	// dayLayout is the Go layout; pgDayFormat is the equivalent Postgres to_char
+	// template — they are NOT interchangeable (different pattern languages).
+	dayLayout   = "2006-01-02"
+	pgDayFormat = "YYYY-MM-DD"
+)
+
+type blobBackfillRow struct {
+	ID        string `gorm:"column:id"`
+	OrgID     string `gorm:"column:org_id"`
+	CreatedBy string `gorm:"column:created_by_id"`
+	Content   []byte `gorm:"column:content"`
+}
+
+// BackfillBlobs mirrors a batch of rows with content but a null blob column into
+// S3 and records the blob metadata. Self-draining (backfilled rows drop out of
+// the predicate) and paced by an in-activity rate limiter.
+//
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 15m
+func (a *Activities) BackfillBlobs(ctx context.Context, req BackfillBlobsRequest) (*BackfillBlobsResponse, error) {
+	target, ok := blobBackfillTargets[req.Table]
+	if !ok {
+		return nil, fmt.Errorf("unsupported blob backfill table: %q", req.Table)
+	}
+	if req.BatchSize <= 0 {
+		req.BatchSize = 1000
+	}
+
+	ratePerSecond := a.cfg.BlobBackfillRatePerSecond
+	if ratePerSecond <= 0 {
+		ratePerSecond = defaultBlobBackfillRatePerSecond
+	}
+	limiter := rate.NewLimiter(rate.Limit(ratePerSecond), ratePerSecond)
+
+	q := a.db.WithContext(ctx).
+		Table(req.Table).
+		Select(fmt.Sprintf("id, org_id, created_by_id, %s AS content", target.contentExpr())).
+		Where(fmt.Sprintf("%s IS NULL", target.blobColumn)).
+		Where(fmt.Sprintf("%s IS NOT NULL", target.originColumn)).
+		Where("deleted_at = 0")
+	q, err := whereDay(q, req.Day)
+	if err != nil {
+		return nil, err
+	}
+
+	var rows []blobBackfillRow
+	res := q.Order("created_at").
+		Limit(req.BatchSize).
+		Scan(&rows)
+	if res.Error != nil {
+		return nil, fmt.Errorf("unable to select rows to backfill from %s: %w", req.Table, res.Error)
+	}
+
+	var processed int64
+	for _, row := range rows {
+		if err := limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("blob backfill rate limiter interrupted: %w", err)
+		}
+
+		if err := a.backfillBlobRow(ctx, req.Table, target.blobColumn, row); err != nil {
+			return nil, err
+		}
+		processed++
+	}
+
+	a.mw.Count("general.blob_backfill.processed", processed, []string{"table:" + req.Table})
+	return &BackfillBlobsResponse{Processed: processed}, nil
+}
+
+func (a *Activities) backfillBlobRow(ctx context.Context, table, blobColumn string, row blobBackfillRow) error {
+	if row.OrgID == "" {
+		return fmt.Errorf("row %s in %s has no org_id; cannot build blob key", row.ID, table)
+	}
+
+	blobID := domains.NewBlobID()
+	s3Key := fmt.Sprintf("blobs/%s/%s", row.OrgID, blobID)
+
+	checksum, err := a.blobSvc.UploadStream(ctx, s3Key, bytes.NewReader(row.Content))
+	if err != nil {
+		return fmt.Errorf("unable to upload blob for %s row %s: %w", table, row.ID, err)
+	}
+
+	metadata := blobstore.BlobMetadata{
+		BlobID:      blobID,
+		S3Key:       s3Key,
+		Size:        int64(len(row.Content)),
+		ContentType: blobBackfillContentType,
+		Checksum:    checksum,
+		CreatedBy:   row.CreatedBy,
+		CreatedAt:   time.Now().Format(time.RFC3339),
+	}
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("unable to marshal blob metadata for %s row %s: %w", table, row.ID, err)
+	}
+
+	res := a.db.WithContext(ctx).
+		Table(table).
+		Where("id = ?", row.ID).
+		Update(blobColumn, string(metadataJSON))
+	if res.Error != nil {
+		return fmt.Errorf("unable to record blob metadata on %s row %s: %w", table, row.ID, res.Error)
+	}
+
+	return nil
+}
+
+// ListBackfillDays returns the UTC days with un-mirrored rows (origin set, blob null).
+//
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 5m
+func (a *Activities) ListBackfillDays(ctx context.Context, req ListBlobDaysRequest) (*ListBlobDaysResponse, error) {
+	target, ok := blobBackfillTargets[req.Table]
+	if !ok {
+		return nil, fmt.Errorf("unsupported blob backfill table: %q", req.Table)
+	}
+
+	days, err := a.listBlobDays(ctx, req.Table, fmt.Sprintf("%s IS NULL", target.blobColumn), target.originColumn)
+	if err != nil {
+		return nil, err
+	}
+	return &ListBlobDaysResponse{Days: days}, nil
+}
+
+// listBlobDays returns the distinct UTC days with a non-null origin column,
+// optionally narrowed by blobPredicate. table/predicate/column come only from the
+// whitelist map — never request input — since they are interpolated into SQL.
+func (a *Activities) listBlobDays(ctx context.Context, table, blobPredicate, originColumn string) ([]string, error) {
+	q := a.db.WithContext(ctx).
+		Table(table).
+		Distinct(fmt.Sprintf("to_char(created_at AT TIME ZONE 'UTC', '%s') AS day", pgDayFormat)).
+		Where(fmt.Sprintf("%s IS NOT NULL", originColumn)).
+		Where("deleted_at = 0")
+	if blobPredicate != "" {
+		q = q.Where(blobPredicate)
+	}
+
+	var days []string
+	if res := q.Order("day").Pluck("day", &days); res.Error != nil {
+		return nil, fmt.Errorf("unable to list blob days for %s: %w", table, res.Error)
+	}
+	return days, nil
+}
+
+// whereDay scopes a query to rows created within a single UTC calendar day. An
+// empty day is a no-op.
+func whereDay(q *gorm.DB, day string) (*gorm.DB, error) {
+	if day == "" {
+		return q, nil
+	}
+	start, err := time.ParseInLocation(dayLayout, day, time.UTC)
+	if err != nil {
+		return nil, fmt.Errorf("invalid day %q: %w", day, err)
+	}
+	return q.Where("created_at >= ? AND created_at < ?", start, start.Add(24*time.Hour)), nil
+}

--- a/services/ctl-api/internal/app/general/worker/activities/verify_blobs.go
+++ b/services/ctl-api/internal/app/general/worker/activities/verify_blobs.go
@@ -1,0 +1,190 @@
+package activities
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+
+	"golang.org/x/time/rate"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
+)
+
+const maxVerifyMismatchSamples = 100
+
+type VerifyBlobsRequest struct {
+	Table     string `json:"table"`
+	BatchSize int    `json:"batch_size"`
+	// Day scopes the batch to a single UTC calendar day ("2006-01-02"); empty means the whole table.
+	Day string `json:"day"`
+	// Cursor is the last id from the previous batch; rows are walked in ascending id order.
+	Cursor string `json:"cursor"`
+}
+
+type BlobMismatch struct {
+	ID     string `json:"id"`
+	Reason string `json:"reason"`
+}
+
+type VerifyBlobsResponse struct {
+	Checked    int64          `json:"checked"`
+	Mismatched int64          `json:"mismatched"`
+	NotSet     int64          `json:"not_set"`
+	Mismatches []BlobMismatch `json:"mismatches,omitempty"`
+	NextCursor string         `json:"next_cursor"`
+}
+
+type blobVerifyRow struct {
+	ID       string `gorm:"column:id"`
+	BlobMeta string `gorm:"column:blob_meta"`
+	Content  []byte `gorm:"column:content"`
+}
+
+// VerifyBlobs reads a batch of rows as-is and tallies each: null blob -> not_set;
+// otherwise download from S3 and confirm checksum + content against the origin
+// column (byte-for-byte, or JSON-semantic for jsonb) -> mismatched on a diff.
+//
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 15m
+func (a *Activities) VerifyBlobs(ctx context.Context, req VerifyBlobsRequest) (*VerifyBlobsResponse, error) {
+	target, ok := blobBackfillTargets[req.Table]
+	if !ok {
+		return nil, fmt.Errorf("unsupported blob verify table: %q", req.Table)
+	}
+	if req.BatchSize <= 0 {
+		req.BatchSize = 1000
+	}
+
+	ratePerSecond := a.cfg.BlobBackfillRatePerSecond
+	if ratePerSecond <= 0 {
+		ratePerSecond = defaultBlobBackfillRatePerSecond
+	}
+	limiter := rate.NewLimiter(rate.Limit(ratePerSecond), ratePerSecond)
+
+	q := a.db.WithContext(ctx).
+		Table(req.Table).
+		Select(fmt.Sprintf("id, %s::text AS blob_meta, %s AS content", target.blobColumn, target.contentExpr())).
+		Where(fmt.Sprintf("%s IS NOT NULL", target.originColumn)).
+		Where("deleted_at = 0")
+	q, err := whereDay(q, req.Day)
+	if err != nil {
+		return nil, err
+	}
+	if req.Cursor != "" {
+		q = q.Where("id > ?", req.Cursor)
+	}
+
+	var rows []blobVerifyRow
+	if res := q.Order("id").Limit(req.BatchSize).Scan(&rows); res.Error != nil {
+		return nil, fmt.Errorf("unable to select rows to verify from %s: %w", req.Table, res.Error)
+	}
+
+	resp := &VerifyBlobsResponse{}
+
+	for _, row := range rows {
+		resp.Checked++
+		resp.NextCursor = row.ID
+
+		if row.BlobMeta == "" {
+			resp.NotSet++
+			continue
+		}
+
+		if err := limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("blob verify rate limiter interrupted: %w", err)
+		}
+
+		reason, err := a.verifyBlobRow(ctx, target.jsonSemantic, row)
+		if err != nil {
+			return nil, err
+		}
+		if reason != "" {
+			resp.Mismatched++
+			if len(resp.Mismatches) < maxVerifyMismatchSamples {
+				resp.Mismatches = append(resp.Mismatches, BlobMismatch{ID: row.ID, Reason: reason})
+			}
+		}
+	}
+
+	a.mw.Count("general.blob_verify.checked", resp.Checked, []string{"table:" + req.Table})
+	a.mw.Count("general.blob_verify.mismatched", resp.Mismatched, []string{"table:" + req.Table})
+	a.mw.Count("general.blob_verify.not_set", resp.NotSet, []string{"table:" + req.Table})
+	return resp, nil
+}
+
+// verifyBlobRow returns an empty reason when the row's blob matches both its
+// recorded checksum and its origin column; otherwise it returns a description of
+// the first mismatch found.
+func (a *Activities) verifyBlobRow(ctx context.Context, jsonSemantic bool, row blobVerifyRow) (string, error) {
+	var metadata blobstore.BlobMetadata
+	if err := json.Unmarshal([]byte(row.BlobMeta), &metadata); err != nil {
+		return fmt.Sprintf("unable to parse blob metadata: %v", err), nil
+	}
+	if metadata.S3Key == "" {
+		return "blob metadata has no s3_key", nil
+	}
+
+	reader, err := a.blobSvc.DownloadStream(ctx, metadata.S3Key)
+	if err != nil {
+		return fmt.Sprintf("unable to download blob from s3 key %q: %v", metadata.S3Key, err), nil
+	}
+	defer reader.Close()
+
+	hash := sha256.New()
+	content, err := io.ReadAll(io.TeeReader(reader, hash))
+	if err != nil {
+		return "", fmt.Errorf("unable to read blob from s3 key %q: %w", metadata.S3Key, err)
+	}
+
+	if got := fmt.Sprintf("sha256:%x", hash.Sum(nil)); metadata.Checksum != "" && got != metadata.Checksum {
+		return fmt.Sprintf("s3 object checksum %s does not match recorded %s", got, metadata.Checksum), nil
+	}
+
+	if jsonSemantic {
+		equal, err := jsonEqual(string(content), string(row.Content))
+		if err != nil {
+			return fmt.Sprintf("unable to compare blob json to origin column: %v", err), nil
+		}
+		if !equal {
+			return "blob json content does not match origin column", nil
+		}
+		return "", nil
+	}
+
+	if !bytes.Equal(content, row.Content) {
+		return "blob content does not match origin column", nil
+	}
+	return "", nil
+}
+
+// ListVerifyDays returns the UTC days with rows (origin set), regardless of blob state.
+//
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 5m
+func (a *Activities) ListVerifyDays(ctx context.Context, req ListBlobDaysRequest) (*ListBlobDaysResponse, error) {
+	target, ok := blobBackfillTargets[req.Table]
+	if !ok {
+		return nil, fmt.Errorf("unsupported blob verify table: %q", req.Table)
+	}
+
+	days, err := a.listBlobDays(ctx, req.Table, "", target.originColumn)
+	if err != nil {
+		return nil, err
+	}
+	return &ListBlobDaysResponse{Days: days}, nil
+}
+
+func jsonEqual(a, b string) (bool, error) {
+	var av, bv any
+	if err := json.Unmarshal([]byte(a), &av); err != nil {
+		return false, fmt.Errorf("blob: %w", err)
+	}
+	if err := json.Unmarshal([]byte(b), &bv); err != nil {
+		return false, fmt.Errorf("origin: %w", err)
+	}
+	return reflect.DeepEqual(av, bv), nil
+}

--- a/services/ctl-api/internal/app/general/worker/backfill_blobs_workflow.go
+++ b/services/ctl-api/internal/app/general/worker/backfill_blobs_workflow.go
@@ -1,0 +1,151 @@
+package worker
+
+import (
+	"fmt"
+
+	enumsv1 "go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/pkg/types/workflows/blobbackfill"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/general/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+)
+
+const (
+	blobBackfillBatchSize = 1000
+	// caps batches per child and buckets per parent run so workflow history stays bounded.
+	blobBackfillMaxBatches = 5000
+	blobBucketsPerRun      = 100
+)
+
+var defaultBlobBackfillTables = []string{
+	"install_states",
+	"install_workflow_step_approvals",
+	"runner_job_plans",
+	"runner_job_execution_outputs",
+	"terraform_workspace_states",
+}
+
+// BackfillBlobs enumerates the day-buckets with un-mirrored rows and drains them
+// one (table, day) child at a time, continue-as-newing to keep history bounded.
+// Running sequentially keeps the per-activity S3 rate limiter acting globally.
+func (w *Workflows) BackfillBlobs(ctx workflow.Context, req blobbackfill.RangeRequest) error {
+	l, err := log.WorkflowLogger(ctx)
+	if err != nil {
+		return err
+	}
+
+	if req.Processed == nil {
+		req.Processed = map[string]int64{}
+	}
+
+	progress := blobbackfill.Progress{
+		Processed: req.Processed,
+		DaysTotal: req.DaysTotal,
+		DaysDone:  req.DaysDone,
+	}
+	if err := workflow.SetQueryHandler(ctx, blobbackfill.ProgressQueryType, func() (blobbackfill.Progress, error) {
+		return progress, nil
+	}); err != nil {
+		return errors.Wrap(err, "unable to register blob backfill progress query handler")
+	}
+
+	if !req.Initialized {
+		l.Info("general workflow execution", zap.String("type", "blob-backfill"))
+
+		tables := req.Tables
+		if len(tables) == 0 {
+			tables = defaultBlobBackfillTables
+		}
+
+		for _, table := range tables {
+			if _, ok := req.Processed[table]; !ok {
+				req.Processed[table] = 0
+			}
+
+			resp, err := activities.AwaitListBackfillDays(ctx, activities.ListBlobDaysRequest{Table: table})
+			if err != nil {
+				return errors.Wrapf(err, "unable to list backfill days for %s", table)
+			}
+			for _, day := range resp.Days {
+				req.Pending = append(req.Pending, blobbackfill.DayBucket{Table: table, Day: day})
+			}
+		}
+
+		req.Tables = tables
+		req.Initialized = true
+		req.DaysTotal = len(req.Pending)
+		progress.DaysTotal = req.DaysTotal
+	}
+
+	processedThisRun := 0
+	for len(req.Pending) > 0 && processedThisRun < blobBucketsPerRun {
+		bucket := req.Pending[0]
+		req.Pending = req.Pending[1:]
+
+		progress.CurrentTable = bucket.Table
+		progress.CurrentDay = bucket.Day
+
+		result, err := w.runBackfillDay(ctx, bucket)
+		if err != nil {
+			return errors.Wrapf(err, "unable to backfill %s day %s", bucket.Table, bucket.Day)
+		}
+
+		req.Processed[bucket.Table] += result.Processed
+		req.DaysDone++
+		progress.DaysDone = req.DaysDone
+		processedThisRun++
+	}
+
+	if len(req.Pending) > 0 {
+		l.Info("continuing blob backfill", zap.Int("days_done", req.DaysDone), zap.Int("days_total", req.DaysTotal))
+		return workflow.NewContinueAsNewError(ctx, blobbackfill.WorkflowName, req)
+	}
+
+	progress.CurrentTable = ""
+	progress.CurrentDay = ""
+	progress.Done = true
+	l.Info("backfilled blobs", zap.Int("days", req.DaysDone))
+	return nil
+}
+
+func (w *Workflows) runBackfillDay(ctx workflow.Context, bucket blobbackfill.DayBucket) (blobbackfill.DayResult, error) {
+	childID := fmt.Sprintf("%s-%s-%s", blobbackfill.WorkflowID, bucket.Table, bucket.Day)
+	childCtx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
+		WorkflowID:            childID,
+		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+	})
+
+	var result blobbackfill.DayResult
+	if err := workflow.ExecuteChildWorkflow(childCtx, blobbackfill.DayWorkflowName, blobbackfill.DayRequest{
+		Table: bucket.Table,
+		Day:   bucket.Day,
+	}).Get(childCtx, &result); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// BackfillBlobsDay drains every un-mirrored row created within its day.
+func (w *Workflows) BackfillBlobsDay(ctx workflow.Context, req blobbackfill.DayRequest) (blobbackfill.DayResult, error) {
+	var result blobbackfill.DayResult
+	for i := 0; i < blobBackfillMaxBatches; i++ {
+		resp, err := activities.AwaitBackfillBlobs(ctx, activities.BackfillBlobsRequest{
+			Table:     req.Table,
+			Day:       req.Day,
+			BatchSize: blobBackfillBatchSize,
+		})
+		if err != nil {
+			return result, errors.Wrapf(err, "unable to backfill blobs for %s day %s", req.Table, req.Day)
+		}
+
+		result.Processed += resp.Processed
+		if resp.Processed < blobBackfillBatchSize {
+			break
+		}
+	}
+	return result, nil
+}

--- a/services/ctl-api/internal/app/general/worker/verify_blobs_workflow.go
+++ b/services/ctl-api/internal/app/general/worker/verify_blobs_workflow.go
@@ -1,0 +1,164 @@
+package worker
+
+import (
+	"fmt"
+
+	enumsv1 "go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/pkg/types/workflows/blobverify"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/general/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+)
+
+const (
+	blobVerifyBatchSize  = 1000
+	blobVerifyMaxBatches = 5000
+	// maxMismatchIDSamples caps retained mismatched ids so parent history stays small.
+	maxMismatchIDSamples = 100
+)
+
+// VerifyBlobs enumerates the day-buckets with rows and walks them one
+// (table, day) child at a time, continue-as-newing to keep history bounded.
+// Running sequentially keeps the per-activity S3 rate limiter acting globally.
+func (w *Workflows) VerifyBlobs(ctx workflow.Context, req blobverify.RangeRequest) error {
+	l, err := log.WorkflowLogger(ctx)
+	if err != nil {
+		return err
+	}
+
+	if req.Tallies == nil {
+		req.Tallies = map[string]blobverify.TableProgress{}
+	}
+
+	progress := blobverify.Progress{
+		Tables:    req.Tallies,
+		DaysTotal: req.DaysTotal,
+		DaysDone:  req.DaysDone,
+	}
+	if err := workflow.SetQueryHandler(ctx, blobverify.ProgressQueryType, func() (blobverify.Progress, error) {
+		return progress, nil
+	}); err != nil {
+		return errors.Wrap(err, "unable to register blob verify progress query handler")
+	}
+
+	if !req.Initialized {
+		l.Info("general workflow execution", zap.String("type", "blob-verify"))
+
+		tables := req.Tables
+		if len(tables) == 0 {
+			tables = defaultBlobBackfillTables
+		}
+
+		for _, table := range tables {
+			if _, ok := req.Tallies[table]; !ok {
+				req.Tallies[table] = blobverify.TableProgress{}
+			}
+
+			resp, err := activities.AwaitListVerifyDays(ctx, activities.ListBlobDaysRequest{Table: table})
+			if err != nil {
+				return errors.Wrapf(err, "unable to list verify days for %s", table)
+			}
+			for _, day := range resp.Days {
+				req.Pending = append(req.Pending, blobverify.DayBucket{Table: table, Day: day})
+			}
+		}
+
+		req.Tables = tables
+		req.Initialized = true
+		req.DaysTotal = len(req.Pending)
+		progress.DaysTotal = req.DaysTotal
+	}
+
+	processedThisRun := 0
+	for len(req.Pending) > 0 && processedThisRun < blobBucketsPerRun {
+		bucket := req.Pending[0]
+		req.Pending = req.Pending[1:]
+
+		progress.CurrentTable = bucket.Table
+		progress.CurrentDay = bucket.Day
+
+		result, err := w.runVerifyDay(ctx, bucket)
+		if err != nil {
+			return errors.Wrapf(err, "unable to verify %s day %s", bucket.Table, bucket.Day)
+		}
+
+		tp := req.Tallies[bucket.Table]
+		tp.Checked += result.Checked
+		tp.Mismatched += result.Mismatched
+		tp.NotSet += result.NotSet
+		for _, id := range result.MismatchedIDs {
+			if len(tp.MismatchedIDs) < maxMismatchIDSamples {
+				tp.MismatchedIDs = append(tp.MismatchedIDs, id)
+			}
+		}
+		req.Tallies[bucket.Table] = tp
+
+		req.DaysDone++
+		progress.DaysDone = req.DaysDone
+		processedThisRun++
+	}
+
+	if len(req.Pending) > 0 {
+		l.Info("continuing blob verify", zap.Int("days_done", req.DaysDone), zap.Int("days_total", req.DaysTotal))
+		return workflow.NewContinueAsNewError(ctx, blobverify.WorkflowName, req)
+	}
+
+	progress.CurrentTable = ""
+	progress.CurrentDay = ""
+	progress.Done = true
+	l.Info("verified blobs", zap.Int("days", req.DaysDone))
+	return nil
+}
+
+func (w *Workflows) runVerifyDay(ctx workflow.Context, bucket blobverify.DayBucket) (blobverify.DayResult, error) {
+	childID := fmt.Sprintf("%s-%s-%s", blobverify.WorkflowID, bucket.Table, bucket.Day)
+	childCtx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
+		WorkflowID:            childID,
+		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+	})
+
+	var result blobverify.DayResult
+	if err := workflow.ExecuteChildWorkflow(childCtx, blobverify.DayWorkflowName, blobverify.DayRequest{
+		Table: bucket.Table,
+		Day:   bucket.Day,
+	}).Get(childCtx, &result); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// VerifyBlobsDay verifies every row created within its day, walking by id cursor.
+func (w *Workflows) VerifyBlobsDay(ctx workflow.Context, req blobverify.DayRequest) (blobverify.DayResult, error) {
+	var result blobverify.DayResult
+	cursor := ""
+	for i := 0; i < blobVerifyMaxBatches; i++ {
+		resp, err := activities.AwaitVerifyBlobs(ctx, activities.VerifyBlobsRequest{
+			Table:     req.Table,
+			Day:       req.Day,
+			BatchSize: blobVerifyBatchSize,
+			Cursor:    cursor,
+		})
+		if err != nil {
+			return result, errors.Wrapf(err, "unable to verify blobs for %s day %s", req.Table, req.Day)
+		}
+
+		result.Checked += resp.Checked
+		result.Mismatched += resp.Mismatched
+		result.NotSet += resp.NotSet
+		for _, m := range resp.Mismatches {
+			if len(result.MismatchedIDs) < maxMismatchIDSamples {
+				result.MismatchedIDs = append(result.MismatchedIDs, m.ID)
+			}
+		}
+
+		if resp.Checked < blobVerifyBatchSize {
+			break
+		}
+		cursor = resp.NextCursor
+	}
+	return result, nil
+}

--- a/services/ctl-api/internal/app/general/worker/workflows.go
+++ b/services/ctl-api/internal/app/general/worker/workflows.go
@@ -25,6 +25,10 @@ func (w Workflows) All() []any {
 	wkflows := []any{
 		w.Metrics,
 		w.CleanupQueueSignals,
+		w.BackfillBlobs,
+		w.BackfillBlobsDay,
+		w.VerifyBlobs,
+		w.VerifyBlobsDay,
 	}
 	return wkflows
 }
@@ -34,6 +38,10 @@ func (w *Workflows) ListWorkflowFns() []any {
 	return []any{
 		w.Metrics,
 		w.CleanupQueueSignals,
+		w.BackfillBlobs,
+		w.BackfillBlobsDay,
+		w.VerifyBlobs,
+		w.VerifyBlobsDay,
 	}
 }
 

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -409,6 +409,9 @@ type Config struct {
 	// When enabled, the daily cron hard-deletes process_healthcheck queue signals older than 7 days.
 	QueueSignalCleanupEnabled bool `config:"queue_signal_cleanup_enabled"`
 
+	// BlobBackfillRatePerSecond caps how many S3 PUTs/sec the blob backfill activity issues. Defaults to 100 when unset.
+	BlobBackfillRatePerSecond int `config:"blob_backfill_rate_per_second"`
+
 	// Slack auto-link reconciler. TeamID + OrgLabelKey must both be set;
 	// ChannelID is optional and seeds a default org-wide subscription per link.
 	SlackAutoLinkTeamID        string `config:"slack_auto_link_team_id"`


### PR DESCRIPTION
## Admin migration tooling: dual-write blob backfill & verify

Adds admin Temporal workflows (HTTP triggers + live status) to backfill existing dual-write rows into S3 and verify mirrored blobs against their origin columns.

A parent enqueues one child workflow per `(table, day)`. The day list is derived from the data (no fixed range) and runs until nothing remains.

### Endpoints (admin API)

| Method | Route | Purpose |
|--------|-------|---------|
| POST | `/v1/general/backfill-blobs` | Start backfill |
| GET | `/v1/general/backfill-blobs` | Live progress |
| POST | `/v1/general/verify-blobs` | Start verify |
| GET | `/v1/general/verify-blobs` | Live progress |

Optional `{ "tables": [...] }` body; omit or leave empty to process all tables. Re-running reuses an in-flight job instead of duplicating it.

### Supported tables

- `install_states` (jsonb)
- `install_workflow_step_approvals` (text)
- `runner_job_plans` (jsonb)
- `runner_job_execution_outputs` (jsonb)
- `terraform_workspace_states` (bytea, read raw, compared byte-for-byte)

Blob-only columns with no origin to backfill from are excluded.