### PR TITLE
fix(ctl-api): compute workflow queue position from live signal status

### DIFF
--- a/services/ctl-api/internal/app/installs/service/get_workflow_queue_position.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow_queue_position.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
@@ -78,48 +79,79 @@ func (s *service) GetWorkflowQueuePosition(ctx *gin.Context) {
 		}
 	}
 
-	// Find signals ahead in the same queue (created before this one, not yet completed).
+	// A signal still occupies the queue until its own status reaches a terminal
+	// state. Workflow status is not a reliable proxy — a signal can be parked
+	// (StatusPending, e.g. signal type not yet registered) or not-yet-enqueued
+	// while its workflow is still non-terminal, and vice versa.
+	terminalStatuses := []string{
+		string(app.StatusSuccess),
+		string(app.StatusError),
+		string(app.StatusCancelled),
+	}
+	workflowOwnerTypes := []string{"install_workflows", "install_action_workflows"}
+
+	inQueue := func(db *gorm.DB) *gorm.DB {
+		return db.
+			Where("queue_id = ?", qs.QueueID).
+			Where("owner_type IN ?", workflowOwnerTypes).
+			Where("status->>'status' NOT IN ?", terminalStatuses)
+	}
+
+	// Total workflows still waiting in this queue (includes this one).
+	var queueDepth int64
+	inQueue(s.db.WithContext(ctx).Model(&app.QueueSignal{})).Count(&queueDepth)
+
+	// Workflows ahead of this one — those enqueued before it that are still in the queue.
+	var aheadCount int64
+	inQueue(s.db.WithContext(ctx).Model(&app.QueueSignal{})).
+		Where("created_at < ? AND id != ?", qs.CreatedAt, qs.ID).
+		Count(&aheadCount)
+
+	// Fetch the signals immediately ahead for display, front to back.
 	var signalsAhead []app.QueueSignal
-	s.db.WithContext(ctx).
-		Where("queue_id = ? AND created_at < ? AND id != ?", qs.QueueID, qs.CreatedAt, qs.ID).
+	inQueue(s.db.WithContext(ctx)).
+		Where("created_at < ? AND id != ?", qs.CreatedAt, qs.ID).
 		Order("created_at ASC").
 		Limit(20).
 		Find(&signalsAhead)
 
-	// Look up the workflows for the signals ahead.
-	items := make([]WorkflowQueueItem, 0, len(signalsAhead))
+	// Batch-load the workflows for the signals ahead to enrich the display items.
+	ownerIDs := make([]string, 0, len(signalsAhead))
 	for _, sig := range signalsAhead {
-		var wf app.Workflow
-		wfRes := s.db.WithContext(ctx).
-			Where("id = ? AND org_id = ?", sig.OwnerID, org.ID).
-			First(&wf)
-		if wfRes.Error != nil {
-			continue
-		}
-
-		// Only include non-terminal workflows.
-		if wf.Status.Status == app.StatusSuccess || wf.Status.Status == app.StatusError ||
-			wf.Status.Status == app.StatusCancelled {
-			continue
-		}
-
-		items = append(items, WorkflowQueueItem{
-			WorkflowID:   wf.ID,
-			WorkflowType: wf.Type,
-			Status:       wf.Status.Status,
-			CreatedAt:    wf.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-		})
+		ownerIDs = append(ownerIDs, sig.OwnerID)
 	}
 
-	// Count total queue depth from non-terminal signals.
-	var totalDepth int64
-	s.db.WithContext(ctx).Model(&app.QueueSignal{}).
-		Where("queue_id = ?", qs.QueueID).
-		Count(&totalDepth)
+	workflowsByID := make(map[string]app.Workflow, len(ownerIDs))
+	if len(ownerIDs) > 0 {
+		var wfs []app.Workflow
+		s.db.WithContext(ctx).
+			Where("id IN ? AND org_id = ?", ownerIDs, org.ID).
+			Find(&wfs)
+		for _, wf := range wfs {
+			workflowsByID[wf.ID] = wf
+		}
+	}
+
+	items := make([]WorkflowQueueItem, 0, len(signalsAhead))
+	for _, sig := range signalsAhead {
+		item := WorkflowQueueItem{
+			WorkflowID: sig.OwnerID,
+			Status:     sig.Status.Status,
+			CreatedAt:  sig.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		}
+		// Action workflows live in a different table and won't resolve here; they
+		// still count toward position but display without an enriched type.
+		if wf, ok := workflowsByID[sig.OwnerID]; ok {
+			item.WorkflowType = wf.Type
+			item.Status = wf.Status.Status
+			item.CreatedAt = wf.CreatedAt.Format("2006-01-02T15:04:05Z07:00")
+		}
+		items = append(items, item)
+	}
 
 	ctx.JSON(http.StatusOK, WorkflowQueuePositionResponse{
-		Position:     len(items) + 1, // 1-based: this workflow is after the items ahead
-		QueueDepth:   int(totalDepth),
+		Position:     int(aheadCount) + 1, // 1-based: this workflow is after the ones ahead
+		QueueDepth:   int(queueDepth),
 		SignalsAhead: items,
 	})
 }

--- a/services/ctl-api/internal/app/installs/service/get_workflow_queue_position_test.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow_queue_position_test.go
@@ -1,0 +1,110 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
+)
+
+const workflowSignalOwnerType = "install_workflows"
+
+func (s *InstallsServiceTestSuite) createQueue(installID string) *app.Queue {
+	q := &app.Queue{
+		ID:          domains.NewQueueID(),
+		CreatedByID: s.testAcc.ID,
+		OrgID:       &s.testOrg.ID,
+		OwnerID:     installID,
+		OwnerType:   "installs",
+	}
+	require.NoError(s.T(), s.deps.DB.WithContext(s.ctx).Create(q).Error)
+	return q
+}
+
+func (s *InstallsServiceTestSuite) createQueueSignal(queueID, ownerID string, status app.Status, createdAt time.Time) *app.QueueSignal {
+	sig := &app.QueueSignal{
+		CreatedByID: s.testAcc.ID,
+		OrgID:       &s.testOrg.ID,
+		QueueID:     queueID,
+		OwnerID:     ownerID,
+		OwnerType:   workflowSignalOwnerType,
+		Status:      app.NewCompositeStatus(s.ctx, status),
+		CreatedAt:   createdAt,
+		Workflow:    signaldb.WorkflowRef{IDTemplate: "wf-%s"},
+	}
+	require.NoError(s.T(), s.deps.DB.WithContext(s.ctx).Create(sig).Error)
+	return sig
+}
+
+func (s *InstallsServiceTestSuite) getQueuePosition(workflowID string) WorkflowQueuePositionResponse {
+	path := fmt.Sprintf("/v1/workflows/%s/queue-position", workflowID)
+	rr := s.makeRequest(http.MethodGet, path, nil)
+	require.Equal(s.T(), http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	var result WorkflowQueuePositionResponse
+	require.NoError(s.T(), json.Unmarshal(rr.Body.Bytes(), &result))
+	return result
+}
+
+func (s *InstallsServiceTestSuite) TestGetWorkflowQueuePositionWithSignalsAhead() {
+	install := s.createTestInstall()
+	queue := s.createQueue(install.ID)
+	base := time.Now().UTC().Add(-time.Hour)
+
+	wfA := s.deps.Seeder.CreateWorkflow(s.ctx, s.T(), install.ID, app.WorkflowTypeReprovision)
+	wfB := s.deps.Seeder.CreateWorkflow(s.ctx, s.T(), install.ID, app.WorkflowTypeReprovision)
+	wfDone := s.deps.Seeder.CreateWorkflow(s.ctx, s.T(), install.ID, app.WorkflowTypeReprovision)
+	wfTarget := s.deps.Seeder.CreateWorkflow(s.ctx, s.T(), install.ID, app.WorkflowTypeReprovision)
+
+	s.createQueueSignal(queue.ID, wfA.ID, app.StatusQueued, base)
+	// A parked (pending) signal still occupies the queue and must be counted.
+	s.createQueueSignal(queue.ID, wfB.ID, app.StatusPending, base.Add(time.Minute))
+	// A completed signal is no longer in the queue and must be excluded.
+	s.createQueueSignal(queue.ID, wfDone.ID, app.StatusSuccess, base.Add(2*time.Minute))
+	s.createQueueSignal(queue.ID, wfTarget.ID, app.StatusQueued, base.Add(3*time.Minute))
+
+	result := s.getQueuePosition(wfTarget.ID)
+
+	assert.Equal(s.T(), 3, result.Position, "two non-terminal signals ahead + self")
+	assert.Equal(s.T(), 3, result.QueueDepth, "three non-terminal signals in the queue")
+	require.Len(s.T(), result.SignalsAhead, 2, "completed signal excluded")
+	assert.Equal(s.T(), wfA.ID, result.SignalsAhead[0].WorkflowID, "ordered front to back")
+	assert.Equal(s.T(), wfB.ID, result.SignalsAhead[1].WorkflowID)
+	assert.Equal(s.T(), app.WorkflowTypeReprovision, result.SignalsAhead[0].WorkflowType)
+}
+
+func (s *InstallsServiceTestSuite) TestGetWorkflowQueuePositionAtFront() {
+	install := s.createTestInstall()
+	queue := s.createQueue(install.ID)
+	base := time.Now().UTC().Add(-time.Hour)
+
+	wfDone := s.deps.Seeder.CreateWorkflow(s.ctx, s.T(), install.ID, app.WorkflowTypeReprovision)
+	wfTarget := s.deps.Seeder.CreateWorkflow(s.ctx, s.T(), install.ID, app.WorkflowTypeReprovision)
+
+	s.createQueueSignal(queue.ID, wfDone.ID, app.StatusSuccess, base)
+	s.createQueueSignal(queue.ID, wfTarget.ID, app.StatusQueued, base.Add(time.Minute))
+
+	result := s.getQueuePosition(wfTarget.ID)
+
+	assert.Equal(s.T(), 1, result.Position)
+	assert.Equal(s.T(), 1, result.QueueDepth)
+	assert.Empty(s.T(), result.SignalsAhead)
+}
+
+func (s *InstallsServiceTestSuite) TestGetWorkflowQueuePositionNoSignal() {
+	install := s.createTestInstall()
+	workflow := s.deps.Seeder.CreateWorkflow(s.ctx, s.T(), install.ID, app.WorkflowTypeReprovision)
+
+	result := s.getQueuePosition(workflow.ID)
+
+	assert.Equal(s.T(), 0, result.Position)
+	assert.Equal(s.T(), 0, result.QueueDepth)
+	assert.Empty(s.T(), result.SignalsAhead)
+}

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -4433,7 +4433,6 @@ export interface components {
       stale_at?: components["schemas"]["generics.NullTime"];
       /** @description StalePartials lists which state partials are stale and need regeneration on next read. */
       stale_partials?: components["schemas"]["state.PartialName"][];
-      state_blob?: components["schemas"]["blobstore.Blob"];
       triggered_by_id?: string;
       triggered_by_type?: string;
       updated_at?: string;


### PR DESCRIPTION
## Compute workflow queue position from live signal status

### Problem
The "Position X of Y in queue" shown on the workflow detail page was computed from the wrong rows:

- **`queue_depth` ("of Y") never decreased.** It counted *every* signal ever created for the queue, and queue signals are never deleted — so it was effectively a lifetime total that only grew.
- **`signals_ahead` / `position` were usually wrong.** The query grabbed the *oldest 20 signals in the install's entire history* (`created_at ASC LIMIT 20`) instead of the ones immediately ahead, then filtered by *workflow* status. On any install with history those are long-completed, so the ahead-list silently emptied out and position collapsed to 1.

### Fix
Compute everything from the queue's real source of truth — **signal status**:

- Count only **non-terminal** signals (`queued`, `in_progress`, and parked `pending`) for both queue depth and the count of signals ahead.
- Select the signals *immediately* ahead (front-to-back) for display.
- Batch-load workflows for the ahead-list instead of an N+1 per-signal lookup.

Using non-terminal status (rather than strictly `queued`/`in_progress`) correctly counts parked and not-yet-enqueued signals that still occupy the queue.

### Tests
Adds integration tests covering signals ahead (incl. a parked `pending` counted and a completed one excluded), at-front, and no-signal cases.