### PR TITLE
refactor(api): send correct app url for org invite emails

### DIFF
--- a/services/ctl-api/internal/app/orgs/service/create_invite.go
+++ b/services/ctl-api/internal/app/orgs/service/create_invite.go
@@ -96,7 +96,7 @@ func (s *service) CreateOrgInvite(ctx *gin.Context) {
 	if err := s.enqueueOrgSignal(ctx, queueID, &orginvitecreated.Signal{
 		OrgID:    org.ID,
 		InviteID: invite.ID,
-		LoginURL: fmt.Sprintf("%s/api/auth/login", s.cfg.AppURL),
+		LoginURL: s.cfg.AppURL,
 	}, org.ID); err != nil {
 		ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 		return

--- a/services/ctl-api/internal/app/orgs/service/resend_invite.go
+++ b/services/ctl-api/internal/app/orgs/service/resend_invite.go
@@ -67,7 +67,7 @@ func (s *service) ResendOrgInvite(ctx *gin.Context) {
 	if err := s.enqueueOrgSignal(ctx, queueID, &orginvitecreated.Signal{
 		OrgID:    org.ID,
 		InviteID: invite.ID,
-		LoginURL: fmt.Sprintf("%s/api/auth/login", s.cfg.AppURL),
+		LoginURL: s.cfg.AppURL,
 	}, org.ID); err != nil {
 		ctx.Error(fmt.Errorf("enqueue signal: %w", err))
 		return


### PR DESCRIPTION
Sends `AppURL` to transactional email for org invite emails 