### PR TITLE
fix: missing closing tag in byoc gcp doc update

### DIFF
--- a/docs/guides/byoc/gcp.mdx
+++ b/docs/guides/byoc/gcp.mdx
@@ -225,6 +225,7 @@ To encode your PEM key:
 ```bash
 base64 -i your-github-app-key.pem
 ```
+</Note>
 
 ### 4. Apply the install stack
 


### PR DESCRIPTION
## Summary

A missing closing tag in our docs got through our PR checks.