### PR TITLE
chore: resilience against large workflows

### DIFF
--- a/services/ctl-api/internal/app/components/signals/delete/signal.go
+++ b/services/ctl-api/internal/app/components/signals/delete/signal.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
@@ -12,21 +13,25 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/poll"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
-)
-
-const (
-	defaultPollTimeout time.Duration = time.Second * 10
 )
 
 type Signal struct {
 	ComponentID string `json:"component_id" validate:"required"`
+
+	v *validator.Validate
 }
 
 var _ signal.Signal = (*Signal)(nil)
+var _ signal.SignalWithParams = (*Signal)(nil)
 
 func (s *Signal) Type() signal.SignalType {
 	return SignalType
+}
+
+func (s *Signal) WithParams(p *signal.Params) {
+	s.v = p.V
 }
 
 func (s *Signal) Validate(ctx workflow.Context) error {
@@ -42,7 +47,6 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return err
 	}
 
-	// update status
 	s.updateStatus(ctx, s.ComponentID, app.ComponentStatusDeprovisioning, "deleting component")
 	if err := activities.AwaitDelete(ctx, activities.DeleteRequest{
 		ComponentID: s.ComponentID,
@@ -54,48 +58,43 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	return nil
 }
 
-// pollComponentBeingUnused polls until the component is no longer used by any installs or app configs
 func (s *Signal) pollComponentBeingUnused(ctx workflow.Context, compID string) error {
 	deadline := workflow.Now(ctx).Add(time.Minute * 60)
 
-	inFlight := true
-	for inFlight {
-		appCfg, err := activities.AwaitGetComponentAppConfigByComponentID(ctx, compID)
-		if err != nil {
-			s.updateStatus(ctx, compID, app.ComponentStatusError, "delete: unable to get component app config")
-			return fmt.Errorf("unable to get component app config: %w", err)
-		}
+	return poll.Poll(ctx, s.v, poll.PollOpts{
+		MaxTS:           deadline,
+		InitialInterval: 10 * time.Second,
+		MaxInterval:     5 * time.Minute,
+		BackoffFactor:   2,
+		Fn: func(ctx workflow.Context) error {
+			appCfg, err := activities.AwaitGetComponentAppConfigByComponentID(ctx, compID)
+			if err != nil {
+				s.updateStatus(ctx, compID, app.ComponentStatusError, "delete: unable to get component app config")
+				return errors.Wrap(poll.NonRetryableError, "unable to get component app config")
+			}
 
-		inFlight = false
-		if slices.Contains(appCfg.ComponentIDs, compID) {
-			inFlight = true
-		}
+			if slices.Contains(appCfg.ComponentIDs, compID) {
+				return errors.New("component still in latest app config")
+			}
 
-		depsInstalls, err := activities.AwaitGetComponentInstalls(ctx, activities.GetComponentInstallsRequest{
-			ComponentID: compID,
-			AppID:       appCfg.AppID,
-		})
-		if err != nil {
-			s.updateStatus(ctx, compID, app.ComponentStatusError, "delete: unable to get component dependent installs")
-			return fmt.Errorf("unable to get component dependent installs: %w", err)
-		}
+			depsInstalls, err := activities.AwaitGetComponentInstalls(ctx, activities.GetComponentInstallsRequest{
+				ComponentID: compID,
+				AppID:       appCfg.AppID,
+			})
+			if err != nil {
+				s.updateStatus(ctx, compID, app.ComponentStatusError, "delete: unable to get component dependent installs")
+				return errors.Wrap(poll.NonRetryableError, "unable to get component dependent installs")
+			}
 
-		if len(depsInstalls) > 0 {
-			inFlight = true
-		}
+			if len(depsInstalls) > 0 {
+				return errors.New("component still used by installs")
+			}
 
-		if workflow.Now(ctx).After(deadline) {
-			s.updateStatus(ctx, compID, app.ComponentStatusError, "delete: timed out waiting for dependent installs to remove the component")
-			return fmt.Errorf("timeout waiting for dependent installs to remove the component")
-		}
-
-		workflow.Sleep(ctx, defaultPollTimeout)
-	}
-
-	return nil
+			return nil
+		},
+	})
 }
 
-// updateStatus is a helper method to update component status
 func (s *Signal) updateStatus(ctx workflow.Context, compID string, status app.ComponentStatus, statusDescription string) {
 	l := workflow.GetLogger(ctx)
 	err := activities.AwaitUpdateStatus(ctx, activities.UpdateStatusRequest{

--- a/services/ctl-api/internal/pkg/queue/can_listener.go
+++ b/services/ctl-api/internal/pkg/queue/can_listener.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	canDefaultHintPeriod = 3 * time.Minute // fallback when config is unset
-	canStartJitter       = 60              // seconds of initial jitter
-	canDefaultHistoryMax = 10000           // fallback when config is unset
+	canDefaultHintPeriod        = 3 * time.Minute // fallback when config is unset
+	canStartJitter              = 60              // seconds of initial jitter
+	canDefaultHistoryMax        = 10000           // fallback when config is unset
+	canDefaultTerminateOverhead = 5000            // terminate threshold = historyMax + this
 )
 
 const CheckCANUpdateName string = "check-can"

--- a/services/ctl-api/internal/pkg/queue/handler/run.go
+++ b/services/ctl-api/internal/pkg/queue/handler/run.go
@@ -1,10 +1,12 @@
 package handler
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/pkg/generics"
 	tmetrics "github.com/nuonco/nuon/pkg/temporal/metrics"
@@ -17,6 +19,8 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/workflowmanager"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
+
+const handlerTerminateThreshold = 10000
 
 func (h *handler) run(ctx workflow.Context) (bool, error) {
 	l, err := log.WorkflowLogger(ctx)
@@ -61,12 +65,25 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 	// Handler signals have explicit callbacks for completion, so the alive
 	// checker only needs to detect deletion/expiry. A longer interval reduces
 	// local activity overhead for long-running signals.
-	mgrOpts = append(mgrOpts, workflowmanager.WithCheckInterval(5*time.Minute))
+	mgrOpts = append(mgrOpts, workflowmanager.WithCheckInterval(1*time.Hour))
 
 	// don't continue-as-new mid-phase: it orphans the in-flight update and the
 	// successor run fails the signal while the work is still alive.
 	mgrOpts = append(mgrOpts, workflowmanager.WithDeferRestart(func() bool {
 		return h.validating || h.executing
+	}))
+
+	mgrOpts = append(mgrOpts, workflowmanager.WithTerminateThreshold(handlerTerminateThreshold))
+	mgrOpts = append(mgrOpts, workflowmanager.WithOnTerminated(func(gCtx workflow.Context, historyLen int) {
+		desc := fmt.Sprintf("handler terminated: workflow history (%d) exceeded safety threshold (%d)", historyLen, handlerTerminateThreshold)
+		l.Error(desc,
+			zap.String("queue_signal_id", h.queueSignalID),
+			zap.Int("history_length", historyLen))
+		_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(gCtx, statusactivities.UpdateQueueSignalStatusV2Request{
+			QueueSignalID:     h.queueSignalID,
+			Status:            app.StatusError,
+			StatusDescription: desc,
+		})
 	}))
 
 	// Create a temporal metrics writer for workflow size reporting.
@@ -104,9 +121,17 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 
 	// execute the handler and handle a restart or stop
 	if err := workflow.Await(ctx, func() bool {
-		return generics.AnyTrue(mgr.Stopped, mgr.Restarted, h.finished)
+		return generics.AnyTrue(mgr.Stopped, mgr.Restarted, mgr.Terminated, h.finished)
 	}); err != nil {
 		return false, err
+	}
+
+	// Terminated = emergency exit. Write error status, send callbacks, exit
+	// immediately with no drain wait.
+	if mgr.Terminated {
+		h.setFinished(app.StatusError, "handler terminated due to excessive workflow history")
+		h.sendCompletionCallbacks(ctx)
+		return true, nil
 	}
 
 	// drain in-flight phase updates first: ending the run mid-handler drops its deferred completion callback and wedges the dispatcher. bounded so a stuck handler can't leak the workflow

--- a/services/ctl-api/internal/pkg/queue/handler/run.go
+++ b/services/ctl-api/internal/pkg/queue/handler/run.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/pkg/metrics"
 	tmetrics "github.com/nuonco/nuon/pkg/temporal/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/callback"
@@ -84,14 +86,25 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 			Status:            app.StatusError,
 			StatusDescription: desc,
 		})
+
+		tags := metrics.ToTags(map[string]string{
+			"workflow_type": "Handler",
+			"signal_type":   string(h.sig.Type()),
+		})
+		h.mw.Incr("workflow.terminated", tags)
+		h.mw.Event(&statsd.Event{
+			Title:     "Handler workflow terminated due to excessive history",
+			Text:      fmt.Sprintf("Handler %s (signal: %s) terminated at %d events (threshold: %d)", h.queueSignalID, h.sig.Type(), historyLen, handlerTerminateThreshold),
+			AlertType: statsd.Error,
+			Tags:      tags,
+		})
 	}))
 
-	// Create a temporal metrics writer for workflow size reporting.
-	if h.mw != nil && h.v != nil {
-		if tmw, err := tmetrics.New(h.v, tmetrics.WithMetricsWriter(h.mw)); err == nil {
-			mgrOpts = append(mgrOpts, workflowmanager.WithMetricsWriter(tmw))
-		}
+	tmw, err := tmetrics.New(h.v, tmetrics.WithMetricsWriter(h.mw))
+	if err != nil {
+		return false, errors.Wrap(err, "unable to create temporal metrics writer")
 	}
+	mgrOpts = append(mgrOpts, workflowmanager.WithMetricsWriter(tmw))
 
 	mgrOpts = append(mgrOpts, workflowmanager.WithAliveChecker(func(gCtx workflow.Context) (bool, error) {
 		qs, err := activities.LocalAwaitGetQueueSignalByQueueSignalID(gCtx, h.queueSignalID)

--- a/services/ctl-api/internal/pkg/queue/run.go
+++ b/services/ctl-api/internal/pkg/queue/run.go
@@ -83,8 +83,10 @@ func (q *queue) run(ctx workflow.Context) (bool, error) {
 	if q.cfg != nil && q.cfg.QueueContinueAsNewHintPeriod > 0 {
 		hintPeriod = q.cfg.QueueContinueAsNewHintPeriod
 	}
+	terminateThreshold := historyMax + canDefaultTerminateOverhead
 	mgr := workflowmanager.New(
 		workflowmanager.WithHistoryMax(historyMax),
+		workflowmanager.WithTerminateThreshold(terminateThreshold),
 		workflowmanager.WithCheckInterval(hintPeriod),
 		workflowmanager.WithMetricsWriter(q.mw),
 		workflowmanager.WithAliveChecker(func(gCtx workflow.Context) (bool, error) {
@@ -96,6 +98,13 @@ func (q *queue) run(ctx workflow.Context) (bool, error) {
 				return true, nil // transient error, keep going
 			}
 			return true, nil
+		}),
+		workflowmanager.WithOnTerminated(func(gCtx workflow.Context, historyLen int) {
+			l.Error("queue terminated: workflow history exceeded safety threshold",
+				zap.String("queue_id", q.queueID),
+				zap.Int("history_length", historyLen),
+				zap.Int("terminate_threshold", terminateThreshold))
+			q.setStatus(gCtx, l, QueueStatusStopped)
 		}),
 		workflowmanager.WithCANHintChecker(workflowmanager.CANHintCheckerFunc{
 			CheckFn: func(gCtx workflow.Context) (bool, error) {
@@ -115,8 +124,11 @@ func (q *queue) run(ctx workflow.Context) (bool, error) {
 	// Bridge manager state to queue fields.
 	workflow.Go(ctx, func(gCtx workflow.Context) {
 		_ = workflow.Await(gCtx, func() bool {
-			return mgr.Stopped || mgr.Restarted
+			return mgr.Stopped || mgr.Restarted || mgr.Terminated
 		})
+		if mgr.Terminated {
+			q.stopped = true
+		}
 		if mgr.Stopped {
 			q.stopped = true
 		}

--- a/services/ctl-api/internal/pkg/queue/run.go
+++ b/services/ctl-api/internal/pkg/queue/run.go
@@ -1,8 +1,10 @@
 package queue
 
 import (
+	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
@@ -105,6 +107,15 @@ func (q *queue) run(ctx workflow.Context) (bool, error) {
 				zap.Int("history_length", historyLen),
 				zap.Int("terminate_threshold", terminateThreshold))
 			q.setStatus(gCtx, l, QueueStatusStopped)
+
+			tags := []string{"workflow_type:Queue"}
+			q.mw.Incr(gCtx, "workflow.terminated", tags...)
+			q.mw.Event(gCtx, &statsd.Event{
+				Title:     "Queue workflow terminated due to excessive history",
+				Text:      fmt.Sprintf("Queue %s terminated at %d events (threshold: %d)", q.queueID, historyLen, terminateThreshold),
+				AlertType: statsd.Error,
+				Tags:      tags,
+			})
 		}),
 		workflowmanager.WithCANHintChecker(workflowmanager.CANHintCheckerFunc{
 			CheckFn: func(gCtx workflow.Context) (bool, error) {

--- a/services/ctl-api/internal/pkg/queue/workflowmanager/manager.go
+++ b/services/ctl-api/internal/pkg/queue/workflowmanager/manager.go
@@ -31,18 +31,26 @@ type Manager struct {
 	// (history too large, hint requested, or error recovery).
 	Restarted bool
 
+	// Terminated is set to true when the workflow history exceeds the
+	// terminate threshold. Unlike Restarted, this fires immediately
+	// with no deferral — the workflow must exit without draining.
+	Terminated bool
+
 	opts options
 }
 
 type options struct {
-	historyMax    int
-	checkInterval time.Duration
-	aliveChecker  func(ctx workflow.Context) (bool, error)
-	canHint       CANHintChecker
-	expiryChecker func(ctx workflow.Context) (*time.Time, error)
-	mw            tmetrics.Writer
-	onStopped     func(ctx workflow.Context)
-	deferRestart  func() bool
+	historyMax         int
+	terminateThreshold int
+	checkInterval      time.Duration
+	maxDeferrals       int
+	aliveChecker       func(ctx workflow.Context) (bool, error)
+	canHint            CANHintChecker
+	expiryChecker      func(ctx workflow.Context) (*time.Time, error)
+	mw                 tmetrics.Writer
+	onStopped          func(ctx workflow.Context)
+	onTerminated       func(ctx workflow.Context, historyLen int)
+	deferRestart       func() bool
 }
 
 // Option configures a Manager.
@@ -52,6 +60,14 @@ type Option func(*options)
 // continue-as-new. Defaults to 10000.
 func WithHistoryMax(n int) Option {
 	return func(o *options) { o.historyMax = n }
+}
+
+// WithTerminateThreshold sets a hard ceiling on workflow history length.
+// When exceeded, the manager sets Terminated=true immediately — no deferral,
+// no draining. Callers should treat this as an emergency exit. A value of 0
+// (the default) disables the terminate threshold.
+func WithTerminateThreshold(n int) Option {
+	return func(o *options) { o.terminateThreshold = n }
 }
 
 // WithCheckInterval sets how often the background goroutine runs checks.
@@ -90,11 +106,30 @@ func WithOnStopped(fn func(ctx workflow.Context)) Option {
 	return func(o *options) { o.onStopped = fn }
 }
 
+// WithOnTerminated provides a callback invoked when the manager sets
+// Terminated=true. Use this to write error status or send notifications
+// before the workflow exits. Keep it fast — the workflow is in an
+// emergency-exit path.
+func WithOnTerminated(fn func(ctx workflow.Context, historyLen int)) Option {
+	return func(o *options) { o.onTerminated = fn }
+}
+
 // WithDeferRestart holds off continue-as-new while fn returns true. Stop
 // decisions are still honored. Continue-as-new abandons in-flight updates, so
 // restarting mid-phase would orphan it and be misread as a crash.
+//
+// Use WithMaxDeferrals to bound how many consecutive checks can be deferred
+// before forcing a restart anyway.
 func WithDeferRestart(fn func() bool) Option {
 	return func(o *options) { o.deferRestart = fn }
+}
+
+// WithMaxDeferrals limits the number of consecutive CAN checks that can be
+// deferred by WithDeferRestart. After n consecutive deferrals the manager
+// forces a restart regardless of the deferral function. A value of 0 (the
+// default) means unlimited deferrals.
+func WithMaxDeferrals(n int) Option {
+	return func(o *options) { o.maxDeferrals = n }
 }
 
 // New creates a Manager with the given options.
@@ -138,8 +173,10 @@ func (m *Manager) RunCANCheck(ctx workflow.Context) (bool, *CANResponse) {
 func (m *Manager) run(ctx workflow.Context) {
 	l, _ := log.WorkflowLogger(ctx)
 
+	var consecutiveDeferrals int
+
 	for {
-		if m.Stopped || m.Restarted {
+		if m.Stopped || m.Restarted || m.Terminated {
 			return
 		}
 
@@ -154,21 +191,52 @@ func (m *Manager) run(ctx workflow.Context) {
 			return
 		}
 
-		if m.Stopped || m.Restarted {
+		if m.Stopped || m.Restarted || m.Terminated {
 			return
+		}
+
+		// Check 0: terminate threshold — hard ceiling, no deferral.
+		if m.opts.terminateThreshold > 0 {
+			info := workflow.GetInfo(ctx)
+			historyLen := info.GetCurrentHistoryLength()
+			if historyLen >= m.opts.terminateThreshold {
+				if l != nil {
+					l.Error("workflow history exceeded terminate threshold, forcing immediate termination",
+						zap.Int("history_length", historyLen),
+						zap.Int("terminate_threshold", m.opts.terminateThreshold))
+				}
+				m.Terminated = true
+				if m.opts.onTerminated != nil {
+					m.opts.onTerminated(ctx, historyLen)
+				}
+				return
+			}
 		}
 
 		// Check 1: continue-as-new (history size + hint).
 		restarting, _ := m.checkCAN(ctx, l)
 		if restarting {
 			if m.restartDeferred() {
+				consecutiveDeferrals++
+				forceRestart := m.opts.maxDeferrals > 0 && consecutiveDeferrals >= m.opts.maxDeferrals
+				if forceRestart {
+					if l != nil {
+						l.Warn("continue-as-new forced after max consecutive deferrals",
+							zap.Int("consecutive_deferrals", consecutiveDeferrals))
+					}
+					m.Restarted = true
+					return
+				}
 				if l != nil {
-					l.Info("continue-as-new needed but deferred until in-flight phase completes")
+					l.Info("continue-as-new needed but deferred until in-flight phase completes",
+						zap.Int("consecutive_deferrals", consecutiveDeferrals))
 				}
 			} else {
 				m.Restarted = true
 				return
 			}
+		} else {
+			consecutiveDeferrals = 0
 		}
 
 		// Check 2: alive check.

--- a/services/ctl-api/internal/pkg/queue/workflowmanager/manager.go
+++ b/services/ctl-api/internal/pkg/queue/workflowmanager/manager.go
@@ -43,7 +43,6 @@ type options struct {
 	historyMax         int
 	terminateThreshold int
 	checkInterval      time.Duration
-	maxDeferrals       int
 	aliveChecker       func(ctx workflow.Context) (bool, error)
 	canHint            CANHintChecker
 	expiryChecker      func(ctx workflow.Context) (*time.Time, error)
@@ -117,19 +116,8 @@ func WithOnTerminated(fn func(ctx workflow.Context, historyLen int)) Option {
 // WithDeferRestart holds off continue-as-new while fn returns true. Stop
 // decisions are still honored. Continue-as-new abandons in-flight updates, so
 // restarting mid-phase would orphan it and be misread as a crash.
-//
-// Use WithMaxDeferrals to bound how many consecutive checks can be deferred
-// before forcing a restart anyway.
 func WithDeferRestart(fn func() bool) Option {
 	return func(o *options) { o.deferRestart = fn }
-}
-
-// WithMaxDeferrals limits the number of consecutive CAN checks that can be
-// deferred by WithDeferRestart. After n consecutive deferrals the manager
-// forces a restart regardless of the deferral function. A value of 0 (the
-// default) means unlimited deferrals.
-func WithMaxDeferrals(n int) Option {
-	return func(o *options) { o.maxDeferrals = n }
 }
 
 // New creates a Manager with the given options.
@@ -173,8 +161,6 @@ func (m *Manager) RunCANCheck(ctx workflow.Context) (bool, *CANResponse) {
 func (m *Manager) run(ctx workflow.Context) {
 	l, _ := log.WorkflowLogger(ctx)
 
-	var consecutiveDeferrals int
-
 	for {
 		if m.Stopped || m.Restarted || m.Terminated {
 			return
@@ -217,26 +203,13 @@ func (m *Manager) run(ctx workflow.Context) {
 		restarting, _ := m.checkCAN(ctx, l)
 		if restarting {
 			if m.restartDeferred() {
-				consecutiveDeferrals++
-				forceRestart := m.opts.maxDeferrals > 0 && consecutiveDeferrals >= m.opts.maxDeferrals
-				if forceRestart {
-					if l != nil {
-						l.Warn("continue-as-new forced after max consecutive deferrals",
-							zap.Int("consecutive_deferrals", consecutiveDeferrals))
-					}
-					m.Restarted = true
-					return
-				}
 				if l != nil {
-					l.Info("continue-as-new needed but deferred until in-flight phase completes",
-						zap.Int("consecutive_deferrals", consecutiveDeferrals))
+					l.Info("continue-as-new needed but deferred until in-flight phase completes")
 				}
 			} else {
 				m.Restarted = true
 				return
 			}
-		} else {
-			consecutiveDeferrals = 0
 		}
 
 		// Check 2: alive check.

--- a/services/ctl-api/internal/pkg/temporal/dataconverter/blob/decode.go
+++ b/services/ctl-api/internal/pkg/temporal/dataconverter/blob/decode.go
@@ -92,6 +92,11 @@ func (d *dataConverter) decodePayload(payload *commonpb.Payload) (*commonpb.Payl
 	}
 
 	size = float64(len(data))
+
+	if err := d.cache.Put(blobID, data); err != nil {
+		d.l.Warn("error writing decoded blob to cache", zap.Error(err), zap.String("blob_id", blobID))
+	}
+
 	return d.restorePayload(payload, data, metadataPrefix), nil
 }
 


### PR DESCRIPTION
This introduces some changes to make large workflows harder to accumulate. Some workflows can cause thrashing in 
workers, due to large states, and app configs being moved around.

1. We add a terminate manager - if a workflow is over a certain size, it will be terminated by the manager.
2. We change the way components delete works, to remove polling and use a smarter polling implementation.
3. Make the CAN loops run less frequently, so for long lived or runaway workflows we do not accumulate as many events.
