### PR TITLE
fix: (ctl-api) regenerate inputs partial on stack outputs update

### DIFF
--- a/services/ctl-api/internal/pkg/state/partials.go
+++ b/services/ctl-api/internal/pkg/state/partials.go
@@ -68,7 +68,7 @@ var HintToPartials = map[HintType][]PartialName{
 	HintSandboxReprovisioned: {PartialSandbox, PartialDomain},
 	HintActionRan:            {PartialActions},
 	HintStackRunCompleted:    {PartialStack},
-	HintStackOutputsUpdated:  {PartialStack},
+	HintStackOutputsUpdated:  {PartialStack, PartialInputs},
 	HintInputsUpdated:        {PartialInputs},
 	HintSecretsUpdated:       {PartialSecrets},
 	HintRunnerUpdated:        {PartialRunner},


### PR DESCRIPTION
When an install stack run completes, the `stackrun` and `updateinstallstackoutputs` signals write the stack's `install_inputs` into the `InstallInputs` record, then call `HintOrGenerate(HintStackOutputsUpdated)` to regenerate state. That hint only targeted `PartialStack`, so under state-gen-v2 the inputs partial was never re-rendered. Components consuming inputs from stack kept the default placeholders from the initial state generation, deployed with invalid config, and failed to start.

The legacy full-regeneration path always re-rendered the inputs partial, so this only regressed once state-gen-v2 was enabled.

Add `PartialInputs` to `HintStackOutputsUpdated` so stack-derived inputs are rendered into install state before component deploys.