### PR TITLE
chore: protect against runaway retries on specific activities

### DIFF
--- a/services/ctl-api/internal/interceptors/metrics/activity_interceptor.go
+++ b/services/ctl-api/internal/interceptors/metrics/activity_interceptor.go
@@ -44,6 +44,8 @@ func (a *actInterceptor) ExecuteActivity(
 		"workflow_type": info.WorkflowType.Name,
 	}
 
+	a.mw.Gauge("temporal_activity.retry_count", float64(info.Attempt), metrics.ToTags(tags))
+
 	// Inject a MetricContext so the GORM metrics plugin can emit per-query metrics
 	// from worker activities (same key used by HTTP middleware).
 	metricCtx := &cctx.MetricContext{

--- a/services/ctl-api/internal/pkg/queue/emitter/activities/emit_signal.go
+++ b/services/ctl-api/internal/pkg/queue/emitter/activities/emit_signal.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.temporal.io/sdk/temporal"
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -25,6 +26,7 @@ type EmitSignalResponse struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 10
 func (a *Activities) EmitSignal(ctx context.Context, req *EmitSignalRequest) (*EmitSignalResponse, error) {
 	// Get the emitter to access its signal template
 	var emitter app.QueueEmitter
@@ -35,7 +37,11 @@ func (a *Activities) EmitSignal(ctx context.Context, req *EmitSignalRequest) (*E
 	}
 
 	if emitter.SignalTemplate.Signal == nil {
-		return nil, errors.New("emitter has no signal template configured")
+		return nil, temporal.NewNonRetryableApplicationError(
+			"emitter has no signal template configured",
+			"EMITTER_CONFIG_ERROR",
+			nil,
+		)
 	}
 
 	// Check for existing in-flight signals from this emitter to prevent backup

--- a/services/ctl-api/internal/pkg/queue/handler/activities/send_signal.go
+++ b/services/ctl-api/internal/pkg/queue/handler/activities/send_signal.go
@@ -2,9 +2,12 @@ package activities
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
 	"go.uber.org/zap"
 )
 
@@ -24,6 +27,7 @@ type SendSignalRequest struct {
 
 // @temporal-gen-v2 activity
 // @start-to-close-timeout 30s
+// @max-retries 10
 func (a *Activities) SendSignal(ctx context.Context, req SendSignalRequest) error {
 	l := activity.GetLogger(ctx)
 
@@ -36,12 +40,20 @@ func (a *Activities) SendSignal(ctx context.Context, req SendSignalRequest) erro
 		req.Payload,
 	)
 	if err != nil {
-		// Best-effort: the target workflow may have already terminated.
-		// Log and return the error so callers can decide how to handle it.
 		l.Warn("failed to send completion signal",
 			zap.String("target_workflow", req.Callback.WorkflowID),
 			zap.String("signal_name", req.Callback.SignalName),
 			zap.Error(err))
+
+		var notFoundErr *serviceerror.NotFound
+		if stderrors.As(err, &notFoundErr) {
+			return temporal.NewNonRetryableApplicationError(
+				"target workflow not found",
+				"WORKFLOW_NOT_FOUND",
+				err,
+			)
+		}
+
 		return errors.Wrap(err, "unable to send signal")
 	}
 


### PR DESCRIPTION
This PR protects against zombie activities, that can occupy activity slots. We add a new gauge that shows total retry 
count, and proactively terminate activities after 10 retries for some problematic ones.
