### PR TITLE
fix: handle helm tear downs where there is no previous release

### DIFF
--- a/bins/runner/internal/jobs/deploy/helm/operation_diff.go
+++ b/bins/runner/internal/jobs/deploy/helm/operation_diff.go
@@ -171,7 +171,12 @@ func (h *handler) installDiff(ctx context.Context, l *zap.Logger, actionCfg *act
 }
 
 func (h *handler) uninstallDiff(ctx context.Context, l *zap.Logger, actionCfg *action.Configuration, kubeCfg *rest.Config, prevRel *release.Release) (string, *[]diff.ResourceDiff, string, error) {
-	// not functional atm (panics)
+	if prevRel == nil {
+		l.Info("no existing helm release found, nothing to uninstall")
+		empty := make([]diff.ResourceDiff, 0)
+		return "no changes", &empty, "", nil
+	}
+
 	l.Info("loading chart options")
 	chart, err := helm.GetChartByPath(h.state.chartPath)
 	if err != nil {


### PR DESCRIPTION
## Summary

While tearing down the karpenter_nodepools component in the Nuon BYOC on AWS, I found that the job will panic if it does not find a previous helm release. It looks like the chart is rendering an empty manifest in my test install. That looks like a config issue, but regardless the job should not panic.