### PR TITLE
fix: skip drain await when no handlers in flight

### DIFF
--- a/services/ctl-api/internal/pkg/queue/handler/run.go
+++ b/services/ctl-api/internal/pkg/queue/handler/run.go
@@ -163,11 +163,12 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 		return true, nil
 	}
 
-	// drain in-flight phase updates first: ending the run mid-handler drops its deferred completion callback and wedges the dispatcher. bounded so a stuck handler can't leak the workflow
-	if _, err := workflow.AwaitWithTimeout(ctx, callback.QuickTimeout, func() bool {
-		return workflow.AllHandlersFinished(ctx)
-	}); err != nil {
-		return false, err
+	if !workflow.AllHandlersFinished(ctx) {
+		if _, err := workflow.AwaitWithTimeout(ctx, callback.QuickTimeout, func() bool {
+			return workflow.AllHandlersFinished(ctx)
+		}); err != nil {
+			return false, err
+		}
 	}
 
 	if mgr.Restarted {


### PR DESCRIPTION
AwaitWithTimeout was unconditional — adds a timer event to history on every handler iteration even when nothing is in flight. Guard with AllHandlersFinished check so the timer only fires when there's actually something to drain.