### PR TITLE
fix: (dashboard-ui) hide empty composite error banner

### DIFF
--- a/services/dashboard-ui/client/components/common/CompositeError/CompositeError.tsx
+++ b/services/dashboard-ui/client/components/common/CompositeError/CompositeError.tsx
@@ -19,6 +19,18 @@ export const CompositeError = ({ error }: ICompositeError) => {
   const theme = SEVERITY_THEME[error?.severity] ?? 'error'
   const sections = Array.isArray(error?.sections) ? error.sections : []
 
+  const hasContent =
+    Boolean(error?.message?.trim()) ||
+    Boolean(error?.type?.trim()) ||
+    sections.some(
+      (section) =>
+        Boolean(section?.heading?.trim()) || Boolean(section?.body?.trim()),
+    )
+
+  if (!hasContent) {
+    return null
+  }
+
   return (
     <Banner theme={theme}>
       <div className="flex w-full min-w-0 flex-col gap-2">


### PR DESCRIPTION
`CompositeError` in UI now returns `null` when the payload has no meaningful content (blank message/type and no non-empty sections). The API can sometimes emit a truthy-but-empty object, which produced an empty error box on the sandbox run and deploy step detail/logs views. Guarding inside the shared component fixes every call site at once.