### PR TITLE
feat: create mcp infrastructure

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,3 @@
 {
-  "mcpServers": {
-    "nuon": {
-      "command": "nuon",
-      "args": ["mcp"]
-    }
-  }
+  "mcpServers": {}
 }

--- a/bins/cli/cmd/mcp.go
+++ b/bins/cli/cmd/mcp.go
@@ -34,5 +34,7 @@ Example Claude Code config (.mcp.json):
 	}
 	mcpCmd.Flags().BoolVar(&allowWrites, "allow-writes", false, "expose mutating tools (create_install, deploy_component)")
 
+	mcpCmd.AddCommand(c.mcpSetupCmd())
+
 	return mcpCmd
 }

--- a/bins/cli/cmd/mcp_setup.go
+++ b/bins/cli/cmd/mcp_setup.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+func (c *cli) mcpSetupCmd() *cobra.Command {
+	var (
+		platform string
+		mcpURL   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Configure an MCP client to connect to the Nuon control plane",
+		Long: `Write MCP client configuration for your platform so your AI agent can
+interact with the Nuon control plane over HTTP.
+
+Reads the API token and org ID from your current nuon auth context (~/.nuon).
+Run "nuon auth login" first if you haven't authenticated.
+
+Supported platforms:
+  claude-code    Claude Code (~/.claude.json)
+  cursor         Cursor (.cursor/mcp.json in current directory)`,
+		PersistentPreRunE: c.persistentPreRunE,
+		Annotations:       outputsAnnotation(OutputTable),
+		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
+			if c.cfg.APIToken == "" {
+				return fmt.Errorf("no API token found — run \"nuon auth login\" first")
+			}
+			if c.cfg.OrgID == "" {
+				return fmt.Errorf("no org selected — run \"nuon orgs select\" first")
+			}
+
+			if mcpURL == "" {
+				mcpURL = defaultMCPURL(c.cfg.APIURL)
+			}
+
+			switch platform {
+			case "claude-code", "cursor":
+				return setupProjectMCP(mcpURL, c.cfg.APIToken, c.cfg.OrgID, platform)
+			default:
+				return fmt.Errorf("unsupported platform %q — supported: claude-code, cursor", platform)
+			}
+		}),
+	}
+
+	cmd.Flags().StringVar(&platform, "platform", "", "MCP client platform (claude-code, cursor)")
+	cmd.Flags().StringVar(&mcpURL, "url", "", "MCP server URL (defaults based on environment)")
+	_ = cmd.MarkFlagRequired("platform")
+
+	return cmd
+}
+
+func defaultMCPURL(apiURL string) string {
+	switch apiURL {
+	case "https://api.nuon.co":
+		return "https://ctl.nuon.co/mcp"
+	default:
+		return "http://localhost:8088/mcp"
+	}
+}
+
+type mcpClientConfig struct {
+	MCPServers map[string]mcpServerEntry `json:"mcpServers"`
+}
+
+type mcpServerEntry struct {
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers"`
+}
+
+func nuonMCPEntry(mcpURL, apiToken, orgID string) mcpServerEntry {
+	return mcpServerEntry{
+		URL: mcpURL,
+		Headers: map[string]string{
+			"Authorization": "Bearer " + apiToken,
+			"X-Nuon-Org-ID": orgID,
+		},
+	}
+}
+
+func setupProjectMCP(mcpURL, apiToken, orgID, platform string) error {
+	var configPath string
+	switch platform {
+	case "claude-code":
+		configPath = ".mcp.json"
+	case "cursor":
+		configPath = filepath.Join(".cursor", "mcp.json")
+		if err := os.MkdirAll(".cursor", 0755); err != nil {
+			return fmt.Errorf("unable to create .cursor directory: %w", err)
+		}
+	}
+
+	cfg := mcpClientConfig{MCPServers: map[string]mcpServerEntry{}}
+
+	if data, err := os.ReadFile(configPath); err == nil {
+		_ = json.Unmarshal(data, &cfg)
+	}
+	if cfg.MCPServers == nil {
+		cfg.MCPServers = map[string]mcpServerEntry{}
+	}
+
+	cfg.MCPServers["nuon-api"] = nuonMCPEntry(mcpURL, apiToken, orgID)
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("unable to marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		return fmt.Errorf("unable to write %s: %w", configPath, err)
+	}
+
+	fmt.Printf("Configured %s MCP at %s\n", platform, configPath)
+	fmt.Printf("  URL: %s\n", mcpURL)
+	fmt.Printf("  Org: %s\n", orgID)
+	return nil
+}

--- a/services/ctl-api/cmd/api_mcp.go
+++ b/services/ctl-api/cmd/api_mcp.go
@@ -5,32 +5,29 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/nuonco/nuon/pkg/profiles"
-
 	"github.com/nuonco/nuon/services/ctl-api/internal/fxmodules"
 )
 
-func (c *cli) registerAPI() error {
-	runApiCmd := &cobra.Command{
-		Use:   "api",
-		Short: "run all APIs (public, internal, runner, auth, admin-dashboard, slack, mcp)",
-		Run:   c.runAPI,
+func (c *cli) registerMCPAPI() error {
+	cmd := &cobra.Command{
+		Use:   "api-mcp",
+		Short: "run only the MCP server (streamable HTTP)",
+		Run:   c.runMCPAPI,
 	}
-	rootCmd.AddCommand(runApiCmd)
+	rootCmd.AddCommand(cmd)
 	return nil
 }
 
-func (c *cli) runAPI(cmd *cobra.Command, _ []string) {
+func (c *cli) runMCPAPI(cmd *cobra.Command, _ []string) {
 	providers := make([]fx.Option, 0)
 	providers = append(providers, c.providers()...)
 
 	profilerOptions := profiles.LoadOptionsFromEnv()
 	providers = append(providers, profiles.Module(profilerOptions))
 
-	// Add API-specific modules - all APIs (includes auth service) + MCP
 	providers = append(providers,
 		fxmodules.MiddlewaresModule,
 		fxmodules.AllServicesModule,
-		fxmodules.AllAPIsModule,
 		fxmodules.MCPAPIModule,
 	)
 

--- a/services/ctl-api/cmd/root.go
+++ b/services/ctl-api/cmd/root.go
@@ -17,6 +17,7 @@ func Execute() {
 	c.registerAuthAPI()
 	c.registerAdminDashboardAPI()
 	c.registerSlackAPI()
+	c.registerMCPAPI()
 	c.registerWorker()
 	c.registerStartup()
 

--- a/services/ctl-api/internal/app/apps/service/mcp_get_app.go
+++ b/services/ctl-api/internal/app/apps/service/mcp_get_app.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+)
+
+type mcpGetAppInput struct {
+	App string `json:"app" jsonschema:"app name or ID"`
+}
+
+func (s *service) mcpGetApp(ctx context.Context, _ *mcp.CallToolRequest, in mcpGetAppInput) (*mcp.CallToolResult, any, error) {
+	result, err := s.getApp(ctx, in.App)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return apiPkg.MCPJSONResult(result)
+}

--- a/services/ctl-api/internal/app/apps/service/mcp_list_apps.go
+++ b/services/ctl-api/internal/app/apps/service/mcp_list_apps.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+type mcpListAppsInput struct{}
+
+func (s *service) mcpListApps(ctx context.Context, _ *mcp.CallToolRequest, _ mcpListAppsInput) (*mcp.CallToolResult, any, error) {
+	orgID := keys.OrgIDFromContext(ctx)
+
+	var apps []*app.App
+	org := &app.Org{ID: orgID}
+
+	err := s.db.WithContext(ctx).
+		Preload("Components").
+		Order("apps.name ASC").
+		Model(org).Association("Apps").Find(&apps)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to list apps: %w", err)
+	}
+
+	return apiPkg.MCPJSONResult(apps)
+}

--- a/services/ctl-api/internal/app/apps/service/mcp_register.go
+++ b/services/ctl-api/internal/app/apps/service/mcp_register.go
@@ -1,0 +1,15 @@
+package service
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+func (s *service) RegisterMCPTools(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_apps",
+		Description: "List all apps in the current org with their components. Returns app name, ID, description, and associated components.",
+	}, s.mcpListApps)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_app",
+		Description: "Get an app by name or ID. Returns full app details including components, sandbox configs, and org info. Accepts either the app name or ID.",
+	}, s.mcpGetApp)
+}

--- a/services/ctl-api/internal/app/components/service/mcp_get_component.go
+++ b/services/ctl-api/internal/app/components/service/mcp_get_component.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+type mcpGetComponentInput struct {
+	Component string `json:"component" jsonschema:"component name or ID"`
+}
+
+func (s *service) mcpGetComponent(ctx context.Context, _ *mcp.CallToolRequest, in mcpGetComponentInput) (*mcp.CallToolResult, any, error) {
+	orgID := keys.OrgIDFromContext(ctx)
+
+	component, err := s.findComponent(ctx, orgID, in.Component)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return apiPkg.MCPJSONResult(component)
+}

--- a/services/ctl-api/internal/app/components/service/mcp_list_components.go
+++ b/services/ctl-api/internal/app/components/service/mcp_list_components.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+type mcpListComponentsInput struct {
+	AppID string `json:"app_id,omitempty" jsonschema:"filter components by app ID"`
+}
+
+func (s *service) mcpListComponents(ctx context.Context, _ *mcp.CallToolRequest, in mcpListComponentsInput) (*mcp.CallToolResult, any, error) {
+	orgID := keys.OrgIDFromContext(ctx)
+
+	var components []app.Component
+	tx := s.db.WithContext(ctx).
+		Where(app.Component{OrgID: orgID}).
+		Order("name ASC")
+
+	if in.AppID != "" {
+		tx = tx.Where(app.Component{AppID: in.AppID})
+	}
+
+	if res := tx.Find(&components); res.Error != nil {
+		return nil, nil, fmt.Errorf("unable to list components: %w", res.Error)
+	}
+
+	return apiPkg.MCPJSONResult(components)
+}

--- a/services/ctl-api/internal/app/components/service/mcp_register.go
+++ b/services/ctl-api/internal/app/components/service/mcp_register.go
@@ -1,0 +1,15 @@
+package service
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+func (s *service) RegisterMCPTools(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_components",
+		Description: "List all components in the org. Optionally filter by app_id. Returns component name, ID, type, and app association.",
+	}, s.mcpListComponents)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_component",
+		Description: "Get a component by name or ID. Returns full component details including configs, dependencies, and app info. Accepts either the component name or ID.",
+	}, s.mcpGetComponent)
+}

--- a/services/ctl-api/internal/app/installs/service/mcp_approve_step.go
+++ b/services/ctl-api/internal/app/installs/service/mcp_approve_step.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+	flowclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/client"
+)
+
+type mcpApproveStepInput struct {
+	ApprovalID string `json:"approval_id" jsonschema:"the approval ID to approve"`
+}
+
+func (s *service) mcpApproveStep(ctx context.Context, _ *mcp.CallToolRequest, in mcpApproveStepInput) (*mcp.CallToolResult, any, error) {
+	orgID := keys.OrgIDFromContext(ctx)
+
+	var approval app.WorkflowStepApproval
+	err := s.db.WithContext(ctx).
+		Where("id = ? AND org_id = ?", in.ApprovalID, orgID).
+		Preload("InstallWorkflowStep").
+		Preload("Response").
+		First(&approval).Error
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to find approval %q: %w", in.ApprovalID, err)
+	}
+
+	if approval.Response != nil {
+		return nil, nil, fmt.Errorf("approval already has a response")
+	}
+
+	response := app.WorkflowStepApprovalResponse{
+		InstallWorkflowStepApprovalID: approval.ID,
+		Type:                          app.WorkflowStepApprovalResponseTypeApprove,
+	}
+	if err := s.db.WithContext(ctx).Create(&response).Error; err != nil {
+		return nil, nil, fmt.Errorf("unable to create approval response: %w", err)
+	}
+
+	stepID := approval.InstallWorkflowStepID
+	var step app.WorkflowStep
+	if err := s.db.WithContext(ctx).First(&step, "id = ?", stepID).Error; err != nil {
+		return nil, nil, fmt.Errorf("unable to find step: %w", err)
+	}
+
+	if err := s.flowsClient.ApprovePlan(ctx, &flowclient.ApprovePlanRequest{
+		InstallWorkflowID:  step.OwnerID,
+		StepID:             stepID,
+		ApprovalResponseID: response.ID,
+		ResponseType:       app.WorkflowStepApprovalResponseTypeApprove,
+	}); err != nil {
+		s.l.Warn("failed to dispatch approval", zap.Error(err))
+	}
+
+	return apiPkg.MCPJSONResult(map[string]string{
+		"status":      "approved",
+		"approval_id": approval.ID,
+		"response_id": response.ID,
+	})
+}

--- a/services/ctl-api/internal/app/installs/service/mcp_get_install.go
+++ b/services/ctl-api/internal/app/installs/service/mcp_get_install.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+)
+
+type mcpGetInstallInput struct {
+	Install string `json:"install" jsonschema:"install name or ID"`
+}
+
+func (s *service) mcpGetInstall(ctx context.Context, _ *mcp.CallToolRequest, in mcpGetInstallInput) (*mcp.CallToolResult, any, error) {
+	install, err := s.getInstall(ctx, in.Install)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return apiPkg.MCPJSONResult(install)
+}

--- a/services/ctl-api/internal/app/installs/service/mcp_get_pending_approvals.go
+++ b/services/ctl-api/internal/app/installs/service/mcp_get_pending_approvals.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+type mcpGetPendingApprovalsInput struct{}
+
+func (s *service) mcpGetPendingApprovals(ctx context.Context, _ *mcp.CallToolRequest, _ mcpGetPendingApprovalsInput) (*mcp.CallToolResult, any, error) {
+	orgID := keys.OrgIDFromContext(ctx)
+
+	var approvals []app.WorkflowStepApproval
+	err := s.db.WithContext(ctx).
+		Preload("InstallWorkflowStep").
+		Where(app.WorkflowStepApproval{OrgID: orgID}).
+		Where("id NOT IN (SELECT install_workflow_step_approval_id FROM install_workflow_step_approval_responses WHERE deleted_at = 0)").
+		Order("created_at DESC").
+		Find(&approvals).Error
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to list pending approvals: %w", err)
+	}
+
+	return apiPkg.MCPJSONResult(approvals)
+}

--- a/services/ctl-api/internal/app/installs/service/mcp_get_workflow.go
+++ b/services/ctl-api/internal/app/installs/service/mcp_get_workflow.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+type mcpGetWorkflowInput struct {
+	WorkflowID string `json:"workflow_id" jsonschema:"workflow ID"`
+}
+
+type mcpWorkflowSummary struct {
+	ID                string                   `json:"id"`
+	Type              string                   `json:"type"`
+	Status            string                   `json:"status"`
+	StatusDescription string                   `json:"status_description"`
+	OwnerID           string                   `json:"owner_id"`
+	OwnerName         string                   `json:"owner_name,omitempty"`
+	CreatedAt         string                   `json:"created_at"`
+	CompletedSteps    int                      `json:"completed_steps"`
+	TotalSteps        int                      `json:"total_steps"`
+	PendingApproval   *mcpPendingApprovalInfo  `json:"pending_approval,omitempty"`
+	Steps             []mcpWorkflowStepSummary `json:"steps"`
+}
+
+type mcpPendingApprovalInfo struct {
+	ApprovalID string `json:"approval_id"`
+	StepName   string `json:"step_name"`
+	Type       string `json:"type"`
+}
+
+type mcpWorkflowStepSummary struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+func (s *service) mcpGetWorkflow(ctx context.Context, _ *mcp.CallToolRequest, in mcpGetWorkflowInput) (*mcp.CallToolResult, any, error) {
+	orgID := keys.OrgIDFromContext(ctx)
+
+	var workflow app.Workflow
+	err := s.db.WithContext(ctx).
+		Preload("CreatedBy").
+		Preload("Steps", func(db *gorm.DB) *gorm.DB {
+			return db.Order("group_idx, group_retry_idx, idx, created_at asc")
+		}).
+		Preload("Steps.Approval", func(db *gorm.DB) *gorm.DB {
+			return db.Omit("contents")
+		}).
+		Preload("Steps.Approval.Response").
+		Preload("StepGroups", func(db *gorm.DB) *gorm.DB {
+			return db.Order("group_idx asc")
+		}).
+		Where("id = ? AND org_id = ?", in.WorkflowID, orgID).
+		First(&workflow).Error
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to find workflow %q: %w", in.WorkflowID, err)
+	}
+
+	summary := mcpWorkflowSummary{
+		ID:                workflow.ID,
+		Type:              string(workflow.Type),
+		Status:            string(workflow.Status.Status),
+		StatusDescription: workflow.Status.StatusHumanDescription,
+		OwnerID:           workflow.OwnerID,
+		OwnerName:         workflow.OwnerName,
+		CreatedAt:         workflow.CreatedAt.String(),
+	}
+
+	for _, step := range workflow.Steps {
+		summary.TotalSteps++
+		stepStatus := string(step.Status.Status)
+		if stepStatus == string(app.StatusSuccess) {
+			summary.CompletedSteps++
+		}
+
+		summary.Steps = append(summary.Steps, mcpWorkflowStepSummary{
+			ID:     step.ID,
+			Name:   step.Name,
+			Status: stepStatus,
+		})
+
+		if step.Approval != nil && step.Approval.Response == nil {
+			summary.PendingApproval = &mcpPendingApprovalInfo{
+				ApprovalID: step.Approval.ID,
+				StepName:   step.Name,
+				Type:       string(step.Approval.Type),
+			}
+		}
+	}
+
+	return apiPkg.MCPJSONResult(summary)
+}

--- a/services/ctl-api/internal/app/installs/service/mcp_list_install_components.go
+++ b/services/ctl-api/internal/app/installs/service/mcp_list_install_components.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
+)
+
+type mcpListInstallComponentsInput struct {
+	Install string `json:"install" jsonschema:"install name or ID"`
+}
+
+func (s *service) mcpListInstallComponents(ctx context.Context, _ *mcp.CallToolRequest, in mcpListInstallComponentsInput) (*mcp.CallToolResult, any, error) {
+	orgID := keys.OrgIDFromContext(ctx)
+
+	var install app.Install
+	err := s.db.WithContext(ctx).
+		Where(app.Install{OrgID: orgID}).
+		Where("id = ? OR name = ?", in.Install, in.Install).
+		First(&install).Error
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to find install %q: %w", in.Install, err)
+	}
+
+	var components []app.InstallComponent
+	err = s.db.WithContext(ctx).
+		Preload("Component").
+		Preload("InstallDeploys", func(db *gorm.DB) *gorm.DB {
+			return db.
+				Scopes(scopes.WithOverrideTable(views.CustomViewName(s.db, &app.InstallDeploy{}, "latest_view_v1"))).
+				Order("install_deploys_latest_view_v1.created_at DESC")
+		}).
+		Where(app.InstallComponent{InstallID: install.ID}).
+		Find(&components).Error
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to list install components: %w", err)
+	}
+
+	return apiPkg.MCPJSONResult(components)
+}

--- a/services/ctl-api/internal/app/installs/service/mcp_list_installs.go
+++ b/services/ctl-api/internal/app/installs/service/mcp_list_installs.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+type mcpListInstallsInput struct {
+	AppID string `json:"app_id,omitempty" jsonschema:"filter installs by app ID"`
+}
+
+func (s *service) mcpListInstalls(ctx context.Context, _ *mcp.CallToolRequest, in mcpListInstallsInput) (*mcp.CallToolResult, any, error) {
+	orgID := keys.OrgIDFromContext(ctx)
+
+	var installs []app.Install
+	tx := s.db.WithContext(ctx).
+		Preload("App").
+		Where(app.Install{OrgID: orgID}).
+		Order("name ASC")
+
+	if in.AppID != "" {
+		tx = tx.Where(app.Install{AppID: in.AppID})
+	}
+
+	if res := tx.Find(&installs); res.Error != nil {
+		return nil, nil, fmt.Errorf("unable to list installs: %w", res.Error)
+	}
+
+	return apiPkg.MCPJSONResult(installs)
+}

--- a/services/ctl-api/internal/app/installs/service/mcp_list_workflows.go
+++ b/services/ctl-api/internal/app/installs/service/mcp_list_workflows.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+type mcpListWorkflowsInput struct {
+	InstallID string `json:"install_id" jsonschema:"install ID to list workflows for"`
+}
+
+func (s *service) mcpListWorkflows(ctx context.Context, _ *mcp.CallToolRequest, in mcpListWorkflowsInput) (*mcp.CallToolResult, any, error) {
+	orgID := keys.OrgIDFromContext(ctx)
+
+	var workflows []app.Workflow
+	err := s.db.WithContext(ctx).
+		Where(app.Workflow{OrgID: orgID, OwnerID: in.InstallID}).
+		Order("created_at DESC").
+		Limit(20).
+		Find(&workflows).Error
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to list workflows: %w", err)
+	}
+
+	return apiPkg.MCPJSONResult(workflows)
+}

--- a/services/ctl-api/internal/app/installs/service/mcp_register.go
+++ b/services/ctl-api/internal/app/installs/service/mcp_register.go
@@ -1,0 +1,49 @@
+package service
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+func (s *service) RegisterMCPTools(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_installs",
+		Description: "List all installs in the current org. Optionally filter by app_id to see installs for a specific app. Returns install name, ID, app, status, and cloud platform.",
+	}, s.mcpListInstalls)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_install",
+		Description: "Get a single install by name or ID. Returns full install details including app info, cloud account, sandbox config, and component status. Accepts either the install name or ID.",
+	}, s.mcpGetInstall)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_install_components",
+		Description: "List all components deployed on an install with their current deploy status and latest deploy info. Use this to see what's deployed and whether deploys are healthy.",
+	}, s.mcpListInstallComponents)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_workflows",
+		Description: "List the 20 most recent workflows for an install. Returns workflow type, status, and timestamps. Use get_workflow for full step details on a specific workflow.",
+	}, s.mcpListWorkflows)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_workflow",
+		Description: "Get a workflow by ID with a summary of all steps and their statuses. If a step is awaiting approval, the pending_approval field will contain the approval_id needed to approve or reject it. Use this to follow a workflow's progress and find pending approvals.",
+	}, s.mcpGetWorkflow)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_pending_approvals",
+		Description: "List all pending workflow step approvals across the entire org. Returns approvals that have not yet received a response. Use approve_step or reject_step to respond to them.",
+	}, s.mcpGetPendingApprovals)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "approve_step",
+		Description: "WRITE OPERATION: Approve a pending workflow step approval. This unblocks the workflow and allows it to proceed to the next step. " +
+			"The approval is irreversible — once approved, the workflow will continue executing (e.g., terraform apply, helm install). " +
+			"Always review the plan contents via get_workflow before approving. Requires the approval_id from get_workflow or get_pending_approvals.",
+	}, s.mcpApproveStep)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "reject_step",
+		Description: "WRITE OPERATION: Reject a pending workflow step approval. This stops the workflow from proceeding. " +
+			"The rejection is irreversible for this workflow run — a new workflow must be triggered to retry. " +
+			"Provide a reason to help the team understand why the approval was denied.",
+	}, s.mcpRejectStep)
+}

--- a/services/ctl-api/internal/app/installs/service/mcp_reject_step.go
+++ b/services/ctl-api/internal/app/installs/service/mcp_reject_step.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+	flowclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/client"
+)
+
+type mcpRejectStepInput struct {
+	ApprovalID string `json:"approval_id" jsonschema:"the approval ID to reject"`
+	Reason     string `json:"reason,omitempty" jsonschema:"reason for rejection"`
+}
+
+func (s *service) mcpRejectStep(ctx context.Context, _ *mcp.CallToolRequest, in mcpRejectStepInput) (*mcp.CallToolResult, any, error) {
+	orgID := keys.OrgIDFromContext(ctx)
+
+	var approval app.WorkflowStepApproval
+	err := s.db.WithContext(ctx).
+		Where("id = ? AND org_id = ?", in.ApprovalID, orgID).
+		Preload("InstallWorkflowStep").
+		Preload("Response").
+		First(&approval).Error
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to find approval %q: %w", in.ApprovalID, err)
+	}
+
+	if approval.Response != nil {
+		return nil, nil, fmt.Errorf("approval already has a response")
+	}
+
+	response := app.WorkflowStepApprovalResponse{
+		InstallWorkflowStepApprovalID: approval.ID,
+		Type:                          app.WorkflowStepApprovalResponseTypeDeny,
+		Note:                          in.Reason,
+	}
+	if err := s.db.WithContext(ctx).Create(&response).Error; err != nil {
+		return nil, nil, fmt.Errorf("unable to create approval response: %w", err)
+	}
+
+	stepID := approval.InstallWorkflowStepID
+	var step app.WorkflowStep
+	if err := s.db.WithContext(ctx).First(&step, "id = ?", stepID).Error; err != nil {
+		return nil, nil, fmt.Errorf("unable to find step: %w", err)
+	}
+
+	if err := s.flowsClient.ApprovePlan(ctx, &flowclient.ApprovePlanRequest{
+		InstallWorkflowID:  step.OwnerID,
+		StepID:             stepID,
+		ApprovalResponseID: response.ID,
+		ResponseType:       app.WorkflowStepApprovalResponseTypeDeny,
+	}); err != nil {
+		s.l.Warn("failed to dispatch rejection", zap.Error(err))
+	}
+
+	return apiPkg.MCPJSONResult(map[string]string{
+		"status":      "rejected",
+		"approval_id": approval.ID,
+		"response_id": response.ID,
+	})
+}

--- a/services/ctl-api/internal/app/mcp/server/auth.go
+++ b/services/ctl-api/internal/app/mcp/server/auth.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+type authResult struct {
+	OrgID     string
+	AccountID string
+}
+
+func (s *Server) authenticate(r *http.Request) (*authResult, error) {
+	token := extractBearerToken(r)
+	if token == "" {
+		s.l.Warn("MCP auth: missing authorization header")
+		return nil, fmt.Errorf("missing authorization header")
+	}
+
+	orgID := r.Header.Get("X-Nuon-Org-ID")
+	if orgID == "" {
+		s.l.Warn("MCP auth: missing X-Nuon-Org-ID header")
+		return nil, fmt.Errorf("missing X-Nuon-Org-ID header")
+	}
+
+	var userToken app.Token
+	res := s.db.
+		WithContext(r.Context()).
+		Where(&app.Token{Token: token}).
+		First(&userToken)
+	if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+		s.l.Warn("MCP auth: token not found in database")
+		return nil, fmt.Errorf("invalid token")
+	}
+	if res.Error != nil {
+		s.l.Warn("MCP auth: token lookup error", zap.Error(res.Error))
+		return nil, fmt.Errorf("unable to look up token: %w", res.Error)
+	}
+
+	if time.Now().After(userToken.ExpiresAt) {
+		s.l.Warn("MCP auth: token is expired")
+		return nil, fmt.Errorf("token is expired")
+	}
+
+	var acct app.Account
+	res = s.db.WithContext(r.Context()).
+		Preload("Roles").
+		Preload("Roles.Org").
+		Preload("Roles.Policies").
+		First(&acct, "id = ?", userToken.AccountID)
+	if res.Error != nil {
+		s.l.Warn("MCP auth: unable to fetch account", zap.Error(res.Error))
+		return nil, fmt.Errorf("unable to fetch account: %w", res.Error)
+	}
+
+	hasAccess := false
+	for _, oid := range acct.OrgIDs {
+		if oid == orgID {
+			hasAccess = true
+			break
+		}
+	}
+	if !hasAccess {
+		s.l.Warn("MCP auth: account does not have access to org", zap.String("org_id", orgID), zap.Strings("account_org_ids", acct.OrgIDs))
+		return nil, fmt.Errorf("account does not have access to org %s", orgID)
+	}
+
+	s.l.Info("MCP auth: success", zap.String("account_id", acct.ID), zap.String("org_id", orgID))
+	return &authResult{
+		OrgID:     orgID,
+		AccountID: acct.ID,
+	}, nil
+}
+
+func extractBearerToken(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return ""
+	}
+	parts := strings.SplitN(auth, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "bearer") {
+		return ""
+	}
+	return parts[1]
+}

--- a/services/ctl-api/internal/app/mcp/server/server.go
+++ b/services/ctl-api/internal/app/mcp/server/server.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+type Params struct {
+	fx.In
+
+	LC         fx.Lifecycle
+	Shutdowner fx.Shutdowner
+	DB         *gorm.DB `name:"psql"`
+	L          *zap.Logger
+	Cfg        *internal.Config
+	Services   []api.Service `group:"services"`
+}
+
+type Server struct {
+	db         *gorm.DB
+	l          *zap.Logger
+	cfg        *internal.Config
+	services   []api.Service
+	httpServer *http.Server
+
+	mu       sync.RWMutex
+	sessions map[string]*authResult
+}
+
+func New(params Params) *Server {
+	s := &Server{
+		db:       params.DB,
+		l:        params.L.Named("mcp"),
+		cfg:      params.Cfg,
+		services: params.Services,
+		sessions: make(map[string]*authResult),
+	}
+
+	mcpHandler := mcp.NewStreamableHTTPHandler(
+		s.getServerForRequest,
+		&mcp.StreamableHTTPOptions{
+			SessionTimeout: 30 * time.Minute,
+			Logger:         slog.Default(),
+		},
+	)
+
+	s.httpServer = &http.Server{
+		Addr:    net.JoinHostPort("0.0.0.0", params.Cfg.MCPHTTPPort),
+		Handler: s.authContextMiddleware(mcpHandler),
+	}
+
+	params.LC.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			s.l.Info("starting MCP server", zap.String("addr", s.httpServer.Addr))
+			go func() {
+				if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+					s.l.Error("MCP server error", zap.Error(err))
+					_ = params.Shutdowner.Shutdown()
+				}
+			}()
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			s.l.Info("stopping MCP server")
+			return s.httpServer.Shutdown(ctx)
+		},
+	})
+
+	return s
+}
+
+func (s *Server) getServerForRequest(r *http.Request) *mcp.Server {
+	auth, err := s.authenticate(r)
+	if err != nil {
+		s.l.Warn("MCP auth failed", zap.Error(err))
+		return nil
+	}
+
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "nuon-ctl",
+		Version: "1.0.0",
+	}, &mcp.ServerOptions{
+		Instructions: fmt.Sprintf("Nuon control plane MCP server. Authenticated as account %s in org %s.", auth.AccountID, auth.OrgID),
+	})
+
+	for _, svc := range s.services {
+		if mcpSvc, ok := svc.(api.MCPService); ok {
+			mcpSvc.RegisterMCPTools(server)
+		}
+	}
+
+	sessionID := r.Header.Get("Mcp-Session-Id")
+	if sessionID != "" {
+		s.mu.Lock()
+		s.sessions[sessionID] = auth
+		s.mu.Unlock()
+	}
+
+	return server
+}
+
+func (s *Server) authContextMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sessionID := r.Header.Get("Mcp-Session-Id")
+		if sessionID != "" {
+			s.mu.RLock()
+			auth, ok := s.sessions[sessionID]
+			s.mu.RUnlock()
+			if ok {
+				ctx := withMCPAuth(r.Context(), auth.OrgID, auth.AccountID)
+				r = r.WithContext(ctx)
+			}
+		}
+
+		if keys.OrgIDFromContext(r.Context()) == "" {
+			auth, err := s.authenticate(r)
+			if err == nil {
+				ctx := withMCPAuth(r.Context(), auth.OrgID, auth.AccountID)
+				r = r.WithContext(ctx)
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func withMCPAuth(ctx context.Context, orgID, accountID string) context.Context {
+	ctx = context.WithValue(ctx, keys.OrgIDCtxKey, orgID)
+	ctx = context.WithValue(ctx, keys.AccountIDCtxKey, accountID)
+	return ctx
+}

--- a/services/ctl-api/internal/app/orgs/service/mcp_register.go
+++ b/services/ctl-api/internal/app/orgs/service/mcp_register.go
@@ -1,0 +1,10 @@
+package service
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+func (s *service) RegisterMCPTools(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "whoami",
+		Description: "Get the current authenticated account and organization. Returns account ID, email, and org ID/name. Use this first to confirm your auth context.",
+	}, s.mcpWhoami)
+}

--- a/services/ctl-api/internal/app/orgs/service/mcp_whoami.go
+++ b/services/ctl-api/internal/app/orgs/service/mcp_whoami.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+type mcpWhoamiInput struct{}
+
+func (s *service) mcpWhoami(ctx context.Context, _ *mcp.CallToolRequest, _ mcpWhoamiInput) (*mcp.CallToolResult, any, error) {
+	orgID := keys.OrgIDFromContext(ctx)
+	accountID := keys.CreatedByIDFromContext(ctx)
+
+	var acct app.Account
+	if res := s.db.WithContext(ctx).First(&acct, "id = ?", accountID); res.Error != nil {
+		return nil, nil, fmt.Errorf("unable to fetch account: %w", res.Error)
+	}
+
+	org, err := s.getOrg(ctx, orgID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return apiPkg.MCPJSONResult(map[string]any{
+		"account": map[string]string{"id": acct.ID, "email": acct.Email},
+		"org":     map[string]string{"id": org.ID, "name": org.Name},
+	})
+}

--- a/services/ctl-api/internal/app/runbooks/service/mcp_get_runbook.go
+++ b/services/ctl-api/internal/app/runbooks/service/mcp_get_runbook.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+type mcpGetRunbookInput struct {
+	RunbookID string `json:"runbook_id" jsonschema:"runbook ID"`
+}
+
+func (s *service) mcpGetRunbook(ctx context.Context, _ *mcp.CallToolRequest, in mcpGetRunbookInput) (*mcp.CallToolResult, any, error) {
+	orgID := keys.OrgIDFromContext(ctx)
+
+	var runbook app.Runbook
+	err := s.db.WithContext(ctx).
+		Preload("RunbookConfig").
+		Where(app.Runbook{OrgID: orgID}).
+		Where("id = ?", in.RunbookID).
+		First(&runbook).Error
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to find runbook %q: %w", in.RunbookID, err)
+	}
+
+	return apiPkg.MCPJSONResult(runbook)
+}

--- a/services/ctl-api/internal/app/runbooks/service/mcp_list_runbooks.go
+++ b/services/ctl-api/internal/app/runbooks/service/mcp_list_runbooks.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+type mcpListRunbooksInput struct {
+	AppID string `json:"app_id" jsonschema:"app ID to list runbooks for"`
+}
+
+func (s *service) mcpListRunbooks(ctx context.Context, _ *mcp.CallToolRequest, in mcpListRunbooksInput) (*mcp.CallToolResult, any, error) {
+	orgID := keys.OrgIDFromContext(ctx)
+
+	var runbooks []app.Runbook
+	err := s.db.WithContext(ctx).
+		Where(app.Runbook{OrgID: orgID, AppID: in.AppID}).
+		Order("created_at DESC").
+		Find(&runbooks).Error
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to list runbooks: %w", err)
+	}
+
+	return apiPkg.MCPJSONResult(runbooks)
+}

--- a/services/ctl-api/internal/app/runbooks/service/mcp_register.go
+++ b/services/ctl-api/internal/app/runbooks/service/mcp_register.go
@@ -1,0 +1,15 @@
+package service
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+func (s *service) RegisterMCPTools(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_runbooks",
+		Description: "List all runbooks for an app. Runbooks define ordered sequences of deploy and action steps that can be executed on installs.",
+	}, s.mcpListRunbooks)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_runbook",
+		Description: "Get a runbook by ID with its configuration and steps. Returns the runbook definition including the ordered sequence of operations.",
+	}, s.mcpGetRunbook)
+}

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -22,6 +22,7 @@ func init() {
 	config.RegisterDefault("auth_http_port", "8084")
 	config.RegisterDefault("admin_dashboard_http_port", "8087")
 	config.RegisterDefault("slack_http_port", "8089")
+	config.RegisterDefault("mcp_http_port", "8088")
 	// Slack secrets: dev-only insecure defaults so the slack-libs FX module
 	// (statejwt.New) and signing.Middleware construction don't fail boot
 	// when no SLACK_* env is set. Prod overrides via env. Same pattern as
@@ -180,6 +181,7 @@ type Config struct {
 	AdminDashboardHTTPPort string `config:"admin_dashboard_http_port" validate:"required"`
 	AdminDashboardDistDir  string `config:"admin_dashboard_dist_dir"`
 	SlackHTTPPort          string `config:"slack_http_port" validate:"required"`
+	MCPHTTPPort            string `config:"mcp_http_port"`
 
 	WorkerHealthcheckPort    string `config:"worker_healthcheck_port"`
 	WorkerHealthcheckEnabled bool   `config:"worker_healthcheck_enabled"`

--- a/services/ctl-api/internal/fxmodules/mcp.go
+++ b/services/ctl-api/internal/fxmodules/mcp.go
@@ -1,0 +1,11 @@
+package fxmodules
+
+import (
+	"go.uber.org/fx"
+
+	mcpserver "github.com/nuonco/nuon/services/ctl-api/internal/app/mcp/server"
+)
+
+var MCPAPIModule = fx.Module("mcp-api",
+	fx.Invoke(mcpserver.New),
+)

--- a/services/ctl-api/internal/pkg/api/mcp_service.go
+++ b/services/ctl-api/internal/pkg/api/mcp_service.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type MCPService interface {
+	RegisterMCPTools(server *mcp.Server)
+}
+
+func MCPJSONResult(v any) (*mcp.CallToolResult, any, error) {
+	j, err := json.Marshal(v)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(j)}},
+	}, nil, nil
+}


### PR DESCRIPTION
This PR creates the basic MCP infrastructure for Nuon's API based MCP.

The premise here is that we enable tool handlers alongside each part of the application, such as an api handler and this 
allows us to create custom experiences for interacting with the system via MCP.

@im-Amitto, I know you had some work in here. My thinking is that we should consolidate your cli based MCP into this, 
and then have the nuon cli's stdio mcp just proxy to the api, using local credentials. What do you think?
