### PR TITLE
fix: wire runner_api_url through apisyncer and regenerate SDKs

### DIFF
--- a/docs/config-ref/runner.mdx
+++ b/docs/config-ref/runner.mdx
@@ -16,6 +16,7 @@ title: 'Runner'
 | **`helm_driver`**<br/>string | Helm driver configuration Specifies the backend driver for Helm operations (e.g., 'configmap', 'secret') | **Optional** | `"configmap"`, `"secret"` |
 | **`init_script_url`**<br/>string | initialization script URL URL to a script that runs during runner initialization. Supports HTTP(S), git, file, and relative paths (./). Examples: https://example.com/script.sh, ./scripts/init.sh, g... | **Optional** | `"https://raw.githubusercontent.com/nuonco/runner/refs/heads/main/scripts/aws/init-mng-v2.sh"` |
 | **`instance_type`**<br/>string | machine/instance type for the install runner Cloud machine/instance type used for the install runner host. Cloud-specific value mapped per runner_type (e.g. an EC2 instance type for aws). Defaults ... | **Optional** | `"t3a.medium"`, `"t3.large"` |
+| **`runner_api_url`**<br/>string | custom runner API endpoint Overrides the Nuon runner API URL for all installs created from this app config. Use this to white-label the runner API behind your own domain, which proxies requests to ... | **Optional** | `"https://runner-api.example.com"` |
 | **`env_var`**<br/>[array](#env_var) | deprecated: use env_vars map instead Deprecated: Array of name/value pairs for environment variables. Use the env_vars map instead | **Optional** | - |
 
 ### `env_var`

--- a/pkg/config/sync/apisyncer/runner_sync.go
+++ b/pkg/config/sync/apisyncer/runner_sync.go
@@ -14,6 +14,7 @@ func (s *syncer) syncAppRunner(ctx context.Context, resource string) error {
 		HelmDriver:    models.AppAppRunnerConfigHelmDriverType(s.cfg.Runner.HelmDriver),
 		InitScriptURL: s.cfg.Runner.InitScriptURL,
 		InstanceType:  s.cfg.Runner.InstanceType,
+		RunnerAPIURL:  s.cfg.Runner.RunnerAPIURL,
 		Type:          models.NewAppAppRunnerType(models.AppAppRunnerType(s.cfg.Runner.RunnerType)),
 	})
 	if err != nil {

--- a/sdks/nuon-go/models/app_app_runner_config.go
+++ b/sdks/nuon-go/models/app_app_runner_config.go
@@ -55,6 +55,9 @@ type AppAppRunnerConfig struct {
 	// org id
 	OrgID string `json:"org_id,omitempty"`
 
+	// RunnerAPIURL overrides the Nuon runner API endpoint for installs using this config.
+	RunnerAPIURL string `json:"runner_api_url,omitempty"`
+
 	// updated at
 	UpdatedAt string `json:"updated_at,omitempty"`
 }

--- a/sdks/nuon-go/models/service_create_app_config_request.go
+++ b/sdks/nuon-go/models/service_create_app_config_request.go
@@ -31,6 +31,7 @@ type ServiceCreateAppConfigRequest struct {
 	Readme string `json:"readme,omitempty"`
 
 	// SkipNotification suppresses the app-config-synced signal emission.
+	// Used when creating a config as part of app deletion cleanup.
 	SkipNotification bool `json:"skip_notification,omitempty"`
 }
 

--- a/sdks/nuon-go/models/service_create_app_runner_config_request.go
+++ b/sdks/nuon-go/models/service_create_app_runner_config_request.go
@@ -35,6 +35,9 @@ type ServiceCreateAppRunnerConfigRequest struct {
 	// instance type
 	InstanceType string `json:"instance_type,omitempty"`
 
+	// runner api url
+	RunnerAPIURL string `json:"runner_api_url,omitempty"`
+
 	// type
 	// Required: true
 	Type *AppAppRunnerType `json:"type"`

--- a/sdks/nuon-runner-go/models/app_app_runner_config.go
+++ b/sdks/nuon-runner-go/models/app_app_runner_config.go
@@ -55,6 +55,9 @@ type AppAppRunnerConfig struct {
 	// org id
 	OrgID string `json:"org_id,omitempty"`
 
+	// RunnerAPIURL overrides the Nuon runner API endpoint for installs using this config.
+	RunnerAPIURL string `json:"runner_api_url,omitempty"`
+
 	// updated at
 	UpdatedAt string `json:"updated_at,omitempty"`
 }

--- a/sdks/nuon-runner-go/models/service_runner_public_settings.go
+++ b/sdks/nuon-runner-go/models/service_runner_public_settings.go
@@ -26,6 +26,9 @@ type ServiceRunnerPublicSettings struct {
 
 	// binary version
 	BinaryVersion string `json:"binary_version,omitempty"`
+
+	// runner api url
+	RunnerAPIURL string `json:"runner_api_url,omitempty"`
 }
 
 // Validate validates this service runner public settings


### PR DESCRIPTION
apisyncer was not sending runner_api_url; SDK models regenerated to include the field