### PR TITLE
feat(dashboard-ui): show install components as per-component cards with toggles

### DIFF
--- a/services/dashboard-ui/client/components/installs/forms/shared/ComponentOverridesSection.stories.tsx
+++ b/services/dashboard-ui/client/components/installs/forms/shared/ComponentOverridesSection.stories.tsx
@@ -1,0 +1,118 @@
+export default {
+  title: 'Installs/Forms/ComponentOverridesSection',
+}
+
+import { ComponentOverridesSection } from './ComponentOverridesSection'
+import type { TAppInputConfig } from '@/types'
+
+type TGroup = NonNullable<TAppInputConfig['input_groups']>[number]
+
+// hex-encoded component names (Go hex.EncodeToString of the component name)
+const HEX = {
+  certificate: '6365727469666963617465',
+  api_gateway: '6170695f67617465776179',
+  whoami: '77686f616d69',
+}
+
+const group: TGroup = {
+  id: 'group-overrides',
+  name: 'nuon_component_overrides',
+  display_name: 'Component overrides',
+  index: 3,
+  app_inputs: [
+    {
+      id: 'i1',
+      name: `nuon_component_override_v1_tf_vars_${HEX.certificate}`,
+      display_name: 'certificate tf vars',
+      type: 'hcl',
+      required: false,
+      default: 'domain = "app.example.com"\n',
+      index: 0,
+      source: 'vendor',
+    },
+    {
+      id: 'i2',
+      name: `nuon_component_override_v1_enabled_${HEX.certificate}`,
+      display_name: 'certificate enabled',
+      type: 'bool',
+      required: false,
+      default: 'true',
+      index: 1,
+      source: 'vendor',
+    },
+    {
+      id: 'i3',
+      name: `nuon_component_override_v1_tf_vars_${HEX.api_gateway}`,
+      display_name: 'api_gateway tf vars',
+      type: 'hcl',
+      required: false,
+      default: 'stage = "prod"\n',
+      index: 2,
+      source: 'vendor',
+    },
+    {
+      id: 'i4',
+      name: `nuon_component_override_v1_enabled_${HEX.api_gateway}`,
+      display_name: 'api_gateway enabled',
+      type: 'bool',
+      required: false,
+      default: 'true',
+      index: 3,
+      source: 'vendor',
+    },
+    {
+      id: 'i5',
+      name: `nuon_component_override_v1_helm_values_${HEX.whoami}`,
+      display_name: 'whoami helm values',
+      type: 'yaml',
+      required: false,
+      default: 'replicaCount: 2\n',
+      index: 4,
+      source: 'vendor',
+    },
+  ],
+} as TGroup
+
+export const Default = () => (
+  <form className="max-w-2xl p-6 flex flex-col gap-6">
+    <ComponentOverridesSection group={group} />
+  </form>
+)
+
+// api_gateway starts disabled via a draft value; its config editor greys out.
+export const WithDisabledComponent = () => (
+  <form className="max-w-2xl p-6 flex flex-col gap-6">
+    <ComponentOverridesSection
+      group={group}
+      draftValues={{
+        [`inputs:nuon_component_override_v1_enabled_${HEX.api_gateway}`]: 'false',
+      }}
+    />
+  </form>
+)
+
+// A component with only an enabled toggle and no config override.
+const toggleOnlyGroup: TGroup = {
+  id: 'group-overrides-toggle-only',
+  name: 'nuon_component_overrides',
+  display_name: 'Component overrides',
+  index: 0,
+  app_inputs: [
+    {
+      id: 't1',
+      name: `nuon_component_override_v1_enabled_${HEX.whoami}`,
+      display_name: 'whoami enabled',
+      type: 'bool',
+      required: false,
+      default: 'false',
+      index: 0,
+      source: 'vendor',
+    },
+  ],
+} as TGroup
+
+export const ToggleOnly = () => (
+  <form className="max-w-2xl p-6 flex flex-col gap-6">
+    <ComponentOverridesSection group={toggleOnlyGroup} />
+  </form>
+)

--- a/services/dashboard-ui/client/components/installs/forms/shared/ComponentOverridesSection.tsx
+++ b/services/dashboard-ui/client/components/installs/forms/shared/ComponentOverridesSection.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react'
+import { Badge } from '@/components/common/Badge'
+import { CodeInput } from '@/components/common/form/CodeInput'
+import { Toggle } from '@/components/common/form/Toggle'
+import { Expand } from '@/components/common/Expand'
+import { Text } from '@/components/common/Text'
+import {
+  groupComponentOverrideInputs,
+  type TComponentOverrideCard,
+  type TComponentType,
+} from '@/utils/install-utils'
+import type { TAppInput, TAppInputConfig, TInstall } from '@/types'
+
+const COMPONENT_TYPE_LABELS: Record<TComponentType, string> = {
+  terraform_module: 'Terraform module',
+  helm_chart: 'Helm chart',
+}
+
+const CONFIG_KIND: Record<
+  'tf_vars' | 'helm_values',
+  { label: string; language: 'hcl' | 'yaml'; placeholder: string }
+> = {
+  tf_vars: {
+    label: 'Terraform variables',
+    language: 'hcl',
+    placeholder: 'Enter HCL (.tfvars) configuration...',
+  },
+  helm_values: {
+    label: 'Helm values',
+    language: 'yaml',
+    placeholder: 'Enter YAML configuration...',
+  },
+}
+
+const ComponentOverrideCard = ({
+  card,
+  mergedValues,
+}: {
+  card: TComponentOverrideCard<TAppInput>
+  mergedValues?: Record<string, string>
+}) => {
+  const { enabledInput, configInput, configKind } = card
+  const toggleable = !!enabledInput
+
+  const initialEnabled = enabledInput
+    ? (mergedValues?.[enabledInput.name || ''] ?? enabledInput.default) ===
+      'true'
+    : true
+  const [enabled, setEnabled] = useState(initialEnabled)
+
+  const config = configKind ? CONFIG_KIND[configKind] : undefined
+
+  return (
+    <div className="flex flex-col gap-3 border rounded-md p-4">
+      <div className="flex items-center justify-between gap-4">
+        <span className="flex items-center gap-2">
+          <Text variant="body" weight="strong">
+            {card.component}
+          </Text>
+          {card.componentType && (
+            <Badge size="sm" theme="neutral">
+              {COMPONENT_TYPE_LABELS[card.componentType]}
+            </Badge>
+          )}
+        </span>
+
+        {toggleable ? (
+          <>
+            <input
+              type="hidden"
+              name={`inputs:${enabledInput!.name}`}
+              value={enabled ? 'true' : 'false'}
+            />
+            <Toggle
+              checked={enabled}
+              onChange={setEnabled}
+              label={enabled ? 'Enabled' : 'Disabled'}
+            />
+          </>
+        ) : (
+          <Text variant="subtext" theme="neutral">
+            Always deployed
+          </Text>
+        )}
+      </div>
+
+      {toggleable && !enabled && (
+        <Text variant="subtext" theme="neutral">
+          Disabled — won't be deployed on this install.
+        </Text>
+      )}
+
+      {configInput && config && (
+        <Expand
+          id={`override-${card.component}-config`}
+          heading={
+            <Text variant="subtext" weight="strong">
+              {config.label}{' '}
+              <Text variant="subtext" theme="neutral">
+                (optional)
+              </Text>
+            </Text>
+          }
+          headerClassName="!px-4 bg-code"
+          className="border rounded-md"
+        >
+          <div className="p-4 border-t">
+            <CodeInput
+              language={config.language}
+              name={`inputs:${configInput.name}`}
+              defaultValue={
+                mergedValues?.[configInput.name || ''] ?? configInput.default
+              }
+              placeholder={config.placeholder}
+              minHeight={120}
+              disabled={!enabled}
+            />
+          </div>
+        </Expand>
+      )}
+    </div>
+  )
+}
+
+export const ComponentOverridesSection = ({
+  group,
+  install,
+  draftValues,
+}: {
+  group: NonNullable<TAppInputConfig['input_groups']>[number]
+  install?: TInstall
+  draftValues?: Record<string, string> | null
+}) => {
+  const installInputs = install ? install?.install_inputs?.at(0)?.values : {}
+
+  const hasDraftValues = draftValues && Object.keys(draftValues).length > 0
+  const normalizedDraftValues: Record<string, string> = {}
+  if (hasDraftValues) {
+    Object.entries(draftValues!).forEach(([key, value]) => {
+      if (key.startsWith('inputs:')) {
+        normalizedDraftValues[key.replace('inputs:', '')] = value
+      }
+    })
+  }
+  const mergedValues = hasDraftValues
+    ? { ...installInputs, ...normalizedDraftValues }
+    : installInputs
+
+  const cards = groupComponentOverrideInputs(group?.app_inputs || [])
+  if (cards.length === 0) {
+    return null
+  }
+
+  return (
+    <fieldset className="flex flex-col gap-6 border-t pt-6">
+      <legend className="flex flex-col gap-0 pr-6">
+        <span className="text-lg font-semibold">Components</span>
+        <span className="text-sm font-normal">
+          Choose which components deploy on this install and customize each one.
+        </span>
+      </legend>
+
+      <div className="flex flex-col gap-4">
+        {cards.map((card) => (
+          <ComponentOverrideCard
+            key={card.component}
+            card={card}
+            mergedValues={mergedValues}
+          />
+        ))}
+      </div>
+    </fieldset>
+  )
+}

--- a/services/dashboard-ui/client/components/installs/forms/shared/InputConfigFields.stories.tsx
+++ b/services/dashboard-ui/client/components/installs/forms/shared/InputConfigFields.stories.tsx
@@ -155,10 +155,22 @@ const mockInputConfig: TAppInputConfig = {
     },
     {
       id: 'group-overrides',
+      name: 'nuon_component_overrides',
       display_name: 'Component overrides',
       description: 'Per-component install-level Helm values and Terraform vars',
       index: 3,
       app_inputs: [
+        {
+          id: 'input-enabled-whoami',
+          name: 'nuon_component_override_v1_enabled_77686f616d69',
+          display_name: 'whoami enabled',
+          description: 'Whether whoami is deployed on this install',
+          type: 'bool',
+          required: false,
+          default: 'true',
+          index: 0,
+          source: 'vendor',
+        },
         {
           id: 'input-helm-whoami',
           name: 'nuon_component_override_v1_helm_values_77686f616d69',

--- a/services/dashboard-ui/client/components/installs/forms/shared/InputConfigFields.tsx
+++ b/services/dashboard-ui/client/components/installs/forms/shared/InputConfigFields.tsx
@@ -3,8 +3,10 @@ import { Input } from '@/components/common/form/Input'
 import { CodeInput } from '@/components/common/form/CodeInput'
 import { Text } from '@/components/common/Text'
 import { Expand } from '@/components/common/Expand'
+import { COMPONENT_OVERRIDE_INPUT_GROUP } from '@/utils/install-utils'
 import type { TAppInputConfig, TInstall } from '@/types'
 import type { IInputConfigFields } from './types'
+import { ComponentOverridesSection } from './ComponentOverridesSection'
 
 const CODE_INPUT_TYPES = {
   json: {
@@ -283,16 +285,26 @@ export const InputConfigFields = ({
 
   return (
     <>
-      {/* Render vendor input groups normally */}
-      {vendorGroups.map((group) => (
-        <InputGroupFields
-          key={`vendor-${group.id}`}
-          groupInputs={group}
-          install={install}
-          disabled={false}
-          draftValues={draftValues}
-        />
-      ))}
+      {/* Render vendor input groups normally, except the reserved
+          component-overrides group which renders as per-component cards. */}
+      {vendorGroups.map((group) =>
+        group.name === COMPONENT_OVERRIDE_INPUT_GROUP ? (
+          <ComponentOverridesSection
+            key={`vendor-${group.id}`}
+            group={group}
+            install={install}
+            draftValues={draftValues}
+          />
+        ) : (
+          <InputGroupFields
+            key={`vendor-${group.id}`}
+            groupInputs={group}
+            install={install}
+            disabled={false}
+            draftValues={draftValues}
+          />
+        )
+      )}
 
       {/* Render customer input groups with header */}
       {customerGroups.length > 0 && (

--- a/services/dashboard-ui/client/types/ctl-api.types.ts
+++ b/services/dashboard-ui/client/types/ctl-api.types.ts
@@ -13,6 +13,7 @@ export type TVCSBranch = { name: string }
 export type TApp = components['schemas']['app.App']
 export type TAppConfig = components['schemas']['app.AppConfig']
 export type TAppInputConfig = components['schemas']['app.AppInputConfig']
+export type TAppInput = components['schemas']['app.AppInput']
 export type TAppRunnerConfig = components['schemas']['app.AppRunnerConfig']
 export type TAppSandboxConfig = components['schemas']['app.AppSandboxConfig']
 export type TAppKubernetesContextsConfig =

--- a/services/dashboard-ui/client/utils/install-utils.test.ts
+++ b/services/dashboard-ui/client/utils/install-utils.test.ts
@@ -6,7 +6,15 @@ import {
   getInstallStatusTitle,
   getInputDisplayName,
   getComponentOverrideKind,
+  groupComponentOverrideInputs,
 } from './install-utils'
+
+// hex-encoded component names used by the reserved synthetic input naming scheme
+const HEX = {
+  certificate: '6365727469666963617465',
+  api_gateway: '6170695f67617465776179',
+  whoami: '77686f616d69',
+}
 
 describe('install-utils', () => {
   describe('getComponentOverrideKind', () => {
@@ -300,6 +308,74 @@ describe('install-utils', () => {
       expect(result1).toBe('Runner status is unknown')
       expect(result2).toBe('Sandbox status is unknown')
       expect(result3).toBe('Deployment status is unknown')
+    })
+  })
+
+  describe('groupComponentOverrideInputs', () => {
+    test('merges enabled + tf_vars for the same component into one card', () => {
+      const cards = groupComponentOverrideInputs([
+        { name: `nuon_component_override_v1_tf_vars_${HEX.certificate}`, index: 3 },
+        { name: `nuon_component_override_v1_enabled_${HEX.certificate}`, index: 4 },
+      ])
+
+      expect(cards).toHaveLength(1)
+      expect(cards[0].component).toBe('certificate')
+      expect(cards[0].enabledInput).not.toBeNull()
+      expect(cards[0].configInput).not.toBeNull()
+      expect(cards[0].configKind).toBe('tf_vars')
+      expect(cards[0].componentType).toBe('terraform_module')
+    })
+
+    test('non-toggleable component (config only) has no enabled input', () => {
+      const cards = groupComponentOverrideInputs([
+        { name: `nuon_component_override_v1_tf_vars_${HEX.certificate}`, index: 1 },
+      ])
+
+      expect(cards).toHaveLength(1)
+      expect(cards[0].enabledInput).toBeNull()
+      expect(cards[0].configInput).not.toBeNull()
+      expect(cards[0].componentType).toBe('terraform_module')
+    })
+
+    test('toggle-only component (enabled only) has no config input or type', () => {
+      const cards = groupComponentOverrideInputs([
+        { name: `nuon_component_override_v1_enabled_${HEX.whoami}`, index: 1 },
+      ])
+
+      expect(cards).toHaveLength(1)
+      expect(cards[0].enabledInput).not.toBeNull()
+      expect(cards[0].configInput).toBeNull()
+      expect(cards[0].configKind).toBeNull()
+      expect(cards[0].componentType).toBeUndefined()
+    })
+
+    test('helm_values maps to helm_chart type', () => {
+      const cards = groupComponentOverrideInputs([
+        { name: `nuon_component_override_v1_helm_values_${HEX.whoami}`, index: 1 },
+      ])
+
+      expect(cards[0].configKind).toBe('helm_values')
+      expect(cards[0].componentType).toBe('helm_chart')
+    })
+
+    test('ignores non-override inputs', () => {
+      const cards = groupComponentOverrideInputs([
+        { name: 'domain', index: 0 },
+        { name: `nuon_component_override_v1_enabled_${HEX.certificate}`, index: 1 },
+      ])
+
+      expect(cards).toHaveLength(1)
+      expect(cards[0].component).toBe('certificate')
+    })
+
+    test('orders cards by each component earliest input index', () => {
+      const cards = groupComponentOverrideInputs([
+        { name: `nuon_component_override_v1_enabled_${HEX.api_gateway}`, index: 10 },
+        { name: `nuon_component_override_v1_tf_vars_${HEX.certificate}`, index: 2 },
+        { name: `nuon_component_override_v1_tf_vars_${HEX.api_gateway}`, index: 9 },
+      ])
+
+      expect(cards.map((c) => c.component)).toEqual(['certificate', 'api_gateway'])
     })
   })
 })

--- a/services/dashboard-ui/client/utils/install-utils.ts
+++ b/services/dashboard-ui/client/utils/install-utils.ts
@@ -9,6 +9,10 @@
 // and the component name is hex-encoded to keep the key safe and reversible.
 const COMPONENT_OVERRIDE_INPUT_PREFIX = 'nuon_component_override_v1_'
 
+// Reserved input group that holds all synthetic per-component override inputs.
+// Must match the Go constant config.ComponentOverrideInputGroup.
+export const COMPONENT_OVERRIDE_INPUT_GROUP = 'nuon_component_overrides'
+
 // Override kinds whose value is structured config (rendered in a syntax-
 // highlighted code block). Other kinds (e.g. "enabled") render as plain text.
 // This is the only place that needs updating when a new *code* override kind is
@@ -74,6 +78,61 @@ export function getInputDisplayName(name: string): string {
   const parsed = parseComponentOverrideInput(name)
   if (!parsed) return name
   return `components.${parsed.component}.${parsed.kind}`
+}
+
+export type TComponentType = 'terraform_module' | 'helm_chart'
+
+// A single toggleable/configurable component reconstructed from the flat
+// synthetic override inputs the API exposes. `enabledInput` drives the on/off
+// toggle (present iff the component is toggleable); `configInput` drives the
+// tf_vars/helm_values editor (present iff the component takes structured config).
+export type TComponentOverrideCard<I> = {
+  component: string
+  componentType?: TComponentType
+  enabledInput: I | null
+  configInput: I | null
+  configKind: TComponentOverrideKind | null
+  index: number
+}
+
+// groupComponentOverrideInputs regroups the flat per-component override inputs
+// (which the API/config expose as separate inputs) into one entry per
+// component, keyed off the component name encoded in each input's reserved name.
+// Non-override inputs are ignored. The result is ordered by each component's
+// earliest input index so display order stays stable across syncs.
+export function groupComponentOverrideInputs<
+  I extends { name?: string; index?: number },
+>(inputs: I[]): TComponentOverrideCard<I>[] {
+  const byComponent = new Map<string, TComponentOverrideCard<I>>()
+
+  for (const input of inputs) {
+    const parsed = input.name ? parseComponentOverrideInput(input.name) : null
+    if (!parsed) continue
+
+    let card = byComponent.get(parsed.component)
+    if (!card) {
+      card = {
+        component: parsed.component,
+        enabledInput: null,
+        configInput: null,
+        configKind: null,
+        index: input.index ?? 0,
+      }
+      byComponent.set(parsed.component, card)
+    }
+    card.index = Math.min(card.index, input.index ?? 0)
+
+    if (parsed.kind === 'enabled') {
+      card.enabledInput = input
+    } else if (parsed.kind === 'tf_vars' || parsed.kind === 'helm_values') {
+      card.configInput = input
+      card.configKind = parsed.kind
+      card.componentType =
+        parsed.kind === 'tf_vars' ? 'terraform_module' : 'helm_chart'
+    }
+  }
+
+  return [...byComponent.values()].sort((a, b) => a.index - b.index)
 }
 
 type TTitleMap = Record<string, string>


### PR DESCRIPTION
Redesigns the create/update install form's component-overrides section. Each toggleable/configurable component now renders as **one card** instead of scattered flat inputs:

- Toggleable components get an on/off **switch** (replacing the previously buried checkbox).
- Their `tf_vars` / `helm_values` editors nest inside the card.
- Disabled cards grey out their config.


