### PR TITLE
fix: true runner API URL white-labeling

### DIFF
--- a/bins/cli/cmd/installs.go
+++ b/bins/cli/cmd/installs.go
@@ -115,6 +115,9 @@ provided labels must match (AND semantics):
 		Short: "Create an install",
 		Long: `Create a new install of your app.
 
+--region is required for AWS apps. For GCP and Azure apps the region is
+determined automatically from the stack output after provisioning.
+
 Use --label (repeatable, format key=value) to attach labels at creation time:
 
   nuon installs create -a my-app -n my-install -r us-west-2 \
@@ -131,10 +134,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 	if !c.cfg.Preview {
 		createCmd.MarkFlagRequired("name")
 	}
-	createCmd.Flags().StringVarP(&region, "region", "r", "", "The region to provision this install in")
-	if !c.cfg.Preview {
-		createCmd.MarkFlagRequired("region")
-	}
+	createCmd.Flags().StringVarP(&region, "region", "r", "", "The region to provision this install in (required for AWS installs)")
 	createCmd.Flags().StringSliceVar(&inputs, "inputs", []string{}, "The app input values for the install")
 	createCmd.Flags().StringSliceVar(&labelArgs, "label", []string{}, "Labels to set on the install (repeatable, format: key=value). Example: --label env=prod --label team=platform")
 	createCmd.Flags().BoolVar(&noSelect, "no-select", false, "Do not automatically set the created install as the current install")

--- a/bins/cli/internal/services/installs/create.go
+++ b/bins/cli/internal/services/installs/create.go
@@ -53,15 +53,13 @@ func (s *Service) Create(ctx context.Context, appID, name, region string, inputs
 		return ui.PrintError(fmt.Errorf("label removal (key-) is not allowed at install creation; use `nuon installs label` after the install exists"))
 	}
 
+	req, err := s.buildCreateInstallRequest(ctx, appID, name, region, inputsMap, labelsMap)
+	if err != nil {
+		return ui.PrintError(err)
+	}
+
 	if asJSON {
-		install, err := s.api.CreateInstall(ctx, appID, &models.ServiceCreateInstallRequest{
-			Name: &name,
-			AwsAccount: &models.ServiceCreateInstallRequestAwsAccount{
-				Region: region,
-			},
-			Inputs: inputsMap,
-			Labels: labelsMap,
-		})
+		install, err := s.api.CreateInstall(ctx, appID, req)
 		if err != nil {
 			return ui.PrintJSONError(err)
 		}
@@ -92,14 +90,7 @@ func (s *Service) Create(ctx context.Context, appID, name, region string, inputs
 
 	}
 
-	install, err := s.api.CreateInstall(ctx, appID, &models.ServiceCreateInstallRequest{
-		Name: &name,
-		AwsAccount: &models.ServiceCreateInstallRequestAwsAccount{
-			Region: region,
-		},
-		Inputs: inputsMap,
-		Labels: labelsMap,
-	})
+	install, err := s.api.CreateInstall(ctx, appID, req)
 	if err != nil {
 		return ui.PrintError(fmt.Errorf("error creating install: %w", err))
 	}
@@ -115,4 +106,29 @@ func (s *Service) Create(ctx context.Context, appID, name, region string, inputs
 	browser.OpenURL(url)
 
 	return nil
+}
+
+func (s *Service) buildCreateInstallRequest(ctx context.Context, appID, name, region string, inputs, labelsMap map[string]string) (*models.ServiceCreateInstallRequest, error) {
+	req := &models.ServiceCreateInstallRequest{
+		Name:   &name,
+		Inputs: inputs,
+		Labels: labelsMap,
+	}
+
+	runnerCfg, err := s.api.GetAppRunnerLatestConfig(ctx, appID)
+	if err != nil || runnerCfg == nil {
+		req.AwsAccount = &models.ServiceCreateInstallRequestAwsAccount{Region: region}
+		return req, nil
+	}
+
+	switch runnerCfg.CloudPlatform {
+	case models.AppCloudPlatformGcp:
+		req.GcpAccount = &models.ServiceCreateInstallRequestGcpAccount{Region: region}
+	case models.AppCloudPlatformAzure:
+		req.AzureAccount = &models.ServiceCreateInstallRequestAzureAccount{Location: region}
+	default:
+		req.AwsAccount = &models.ServiceCreateInstallRequestAwsAccount{Region: region}
+	}
+
+	return req, nil
 }

--- a/bins/cli/internal/services/installs/create.go
+++ b/bins/cli/internal/services/installs/create.go
@@ -111,7 +111,7 @@ func (s *Service) Create(ctx context.Context, appID, name, region string, inputs
 func (s *Service) buildCreateInstallRequest(ctx context.Context, appID, name, region string, inputs, labelsMap map[string]string) (*models.ServiceCreateInstallRequest, error) {
 	req := &models.ServiceCreateInstallRequest{
 		Name:   &name,
-		Inputs: inputs,
+		Inputs: s.inputsWithDefaults(ctx, appID, inputs),
 		Labels: labelsMap,
 	}
 
@@ -134,4 +134,25 @@ func (s *Service) buildCreateInstallRequest(ctx context.Context, appID, name, re
 	}
 
 	return req, nil
+}
+
+// inputsWithDefaults merges app input defaults with any explicitly provided values.
+// Explicit values win; defaults fill in anything not provided.
+func (s *Service) inputsWithDefaults(ctx context.Context, appID string, provided map[string]string) map[string]string {
+	inputCfg, err := s.api.GetAppInputLatestConfig(ctx, appID)
+	if err != nil || inputCfg == nil {
+		return provided
+	}
+
+	merged := make(map[string]string)
+	for _, input := range inputCfg.Inputs {
+		if input == nil || input.Name == "" || input.Default == "" {
+			continue
+		}
+		merged[input.Name] = input.Default
+	}
+	for k, v := range provided {
+		merged[k] = v
+	}
+	return merged
 }

--- a/bins/cli/internal/services/installs/create.go
+++ b/bins/cli/internal/services/installs/create.go
@@ -123,9 +123,9 @@ func (s *Service) buildCreateInstallRequest(ctx context.Context, appID, name, re
 
 	switch runnerCfg.CloudPlatform {
 	case models.AppCloudPlatformGcp:
-		req.GcpAccount = &models.ServiceCreateInstallRequestGcpAccount{Region: region}
+		req.GcpAccount = &models.ServiceCreateInstallRequestGcpAccount{}
 	case models.AppCloudPlatformAzure:
-		req.AzureAccount = &models.ServiceCreateInstallRequestAzureAccount{Location: region}
+		req.AzureAccount = &models.ServiceCreateInstallRequestAzureAccount{}
 	default:
 		req.AwsAccount = &models.ServiceCreateInstallRequestAwsAccount{Region: region}
 	}

--- a/bins/cli/internal/services/installs/create.go
+++ b/bins/cli/internal/services/installs/create.go
@@ -127,6 +127,9 @@ func (s *Service) buildCreateInstallRequest(ctx context.Context, appID, name, re
 	case models.AppCloudPlatformAzure:
 		req.AzureAccount = &models.ServiceCreateInstallRequestAzureAccount{}
 	default:
+		if region == "" {
+			return nil, fmt.Errorf("--region is required for AWS installs")
+		}
 		req.AwsAccount = &models.ServiceCreateInstallRequestAwsAccount{Region: region}
 	}
 

--- a/docs/config-ref/runner.mdx
+++ b/docs/config-ref/runner.mdx
@@ -17,6 +17,7 @@ title: 'Runner'
 | **`init_script_url`**<br/>string | initialization script URL URL to a script that runs during runner initialization. Supports HTTP(S), git, file, and relative paths (./). Examples: https://example.com/script.sh, ./scripts/init.sh, g... | **Optional** | `"https://raw.githubusercontent.com/nuonco/runner/refs/heads/main/scripts/aws/init-mng-v2.sh"` |
 | **`instance_type`**<br/>string | machine/instance type for the install runner Cloud machine/instance type used for the install runner host. Cloud-specific value mapped per runner_type (e.g. an EC2 instance type for aws). Defaults ... | **Optional** | `"t3a.medium"`, `"t3.large"` |
 | **`runner_api_url`**<br/>string | custom runner API endpoint Overrides the Nuon runner API URL for all installs created from this app config. Use this to white-label the runner API behind your own domain, which proxies requests to ... | **Optional** | `"https://runner-api.example.com"` |
+| **`public_api_url`**<br/>string | - | **Optional** | - |
 | **`env_var`**<br/>[array](#env_var) | deprecated: use env_vars map instead Deprecated: Array of name/value pairs for environment variables. Use the env_vars map instead | **Optional** | - |
 
 ### `env_var`

--- a/pkg/config/app_runner.go
+++ b/pkg/config/app_runner.go
@@ -26,6 +26,9 @@ type AppRunnerConfig struct {
 	// RunnerAPIURL overrides the Nuon runner API endpoint for installs using this config.
 	RunnerAPIURL string `mapstructure:"runner_api_url,omitempty" toml:"runner_api_url,omitempty"`
 
+	// PublicAPIURL overrides the Nuon public API endpoint used for phone-home callbacks.
+	PublicAPIURL string `mapstructure:"public_api_url,omitempty" toml:"public_api_url,omitempty"`
+
 	// Deprecated
 	EnvVars []EnvironmentVariable `mapstructure:"env_var,omitempty" toml:"env_var"`
 }

--- a/pkg/config/sync/apisyncer/runner_sync.go
+++ b/pkg/config/sync/apisyncer/runner_sync.go
@@ -15,6 +15,7 @@ func (s *syncer) syncAppRunner(ctx context.Context, resource string) error {
 		InitScriptURL: s.cfg.Runner.InitScriptURL,
 		InstanceType:  s.cfg.Runner.InstanceType,
 		RunnerAPIURL:  s.cfg.Runner.RunnerAPIURL,
+		PublicAPIURL:  s.cfg.Runner.PublicAPIURL,
 		Type:          models.NewAppAppRunnerType(models.AppAppRunnerType(s.cfg.Runner.RunnerType)),
 	})
 	if err != nil {

--- a/sdks/nuon-go/models/app_app_runner_config.go
+++ b/sdks/nuon-go/models/app_app_runner_config.go
@@ -55,6 +55,9 @@ type AppAppRunnerConfig struct {
 	// org id
 	OrgID string `json:"org_id,omitempty"`
 
+	// PublicAPIURL overrides the Nuon public API endpoint used for phone-home callbacks.
+	PublicAPIURL string `json:"public_api_url,omitempty"`
+
 	// RunnerAPIURL overrides the Nuon runner API endpoint for installs using this config.
 	RunnerAPIURL string `json:"runner_api_url,omitempty"`
 

--- a/sdks/nuon-go/models/service_create_app_runner_config_request.go
+++ b/sdks/nuon-go/models/service_create_app_runner_config_request.go
@@ -35,6 +35,9 @@ type ServiceCreateAppRunnerConfigRequest struct {
 	// instance type
 	InstanceType string `json:"instance_type,omitempty"`
 
+	// public api url
+	PublicAPIURL string `json:"public_api_url,omitempty"`
+
 	// runner api url
 	RunnerAPIURL string `json:"runner_api_url,omitempty"`
 

--- a/sdks/nuon-runner-go/models/app_app_runner_config.go
+++ b/sdks/nuon-runner-go/models/app_app_runner_config.go
@@ -55,6 +55,9 @@ type AppAppRunnerConfig struct {
 	// org id
 	OrgID string `json:"org_id,omitempty"`
 
+	// PublicAPIURL overrides the Nuon public API endpoint used for phone-home callbacks.
+	PublicAPIURL string `json:"public_api_url,omitempty"`
+
 	// RunnerAPIURL overrides the Nuon runner API endpoint for installs using this config.
 	RunnerAPIURL string `json:"runner_api_url,omitempty"`
 

--- a/services/ctl-api/internal/app/app_runner_config.go
+++ b/services/ctl-api/internal/app/app_runner_config.go
@@ -87,6 +87,9 @@ type AppRunnerConfig struct {
 
 	// RunnerAPIURL overrides the Nuon runner API endpoint for installs using this config.
 	RunnerAPIURL string `json:"runner_api_url,omitzero" gorm:"default null" temporaljson:"runner_api_url,omitzero,omitempty"`
+
+	// PublicAPIURL overrides the Nuon public API endpoint used for phone-home callbacks.
+	PublicAPIURL string `json:"public_api_url,omitzero" gorm:"default null" temporaljson:"public_api_url,omitzero,omitempty"`
 }
 
 func (a *AppRunnerConfig) Indexes(db *gorm.DB) []migrations.Index {

--- a/services/ctl-api/internal/app/apps/service/create_app_runner_config.go
+++ b/services/ctl-api/internal/app/apps/service/create_app_runner_config.go
@@ -21,6 +21,7 @@ type CreateAppRunnerConfigRequest struct {
 	InitScriptURL string                            `json:"init_script_url"`
 	InstanceType  string                            `json:"instance_type"`
 	RunnerAPIURL  string                            `json:"runner_api_url"`
+	PublicAPIURL  string                            `json:"public_api_url"`
 
 	AppConfigID string `json:"app_config_id"`
 }
@@ -81,6 +82,7 @@ func (s *service) createAppRunnerConfig(ctx context.Context, appID string, req *
 		InitScriptURL: req.InitScriptURL,
 		InstanceType:  req.InstanceType,
 		RunnerAPIURL:  req.RunnerAPIURL,
+		PublicAPIURL:  req.PublicAPIURL,
 		Type:          req.Type,
 	}
 	res := s.db.WithContext(ctx).

--- a/services/ctl-api/internal/app/installs/helpers/create_install.go
+++ b/services/ctl-api/internal/app/installs/helpers/create_install.go
@@ -114,25 +114,36 @@ func (s *Helpers) CreateInstall(ctx context.Context, appID string, req *CreateIn
 		install.Labels = labels.Labels(req.Labels)
 	}
 
-	if req.AWSAccount == nil && req.AzureAccount == nil && req.GCPAccount == nil {
-		switch parentApp.AppRunnerConfigs[0].Type {
-		case app.AppRunnerTypeGCP, app.AppRunnerTypeGCPGKE:
+	runnerType := parentApp.AppRunnerConfigs[0].Type
+	switch runnerType {
+	case app.AppRunnerTypeGCP, app.AppRunnerTypeGCPGKE:
+		if req.GCPAccount == nil {
 			req.GCPAccount = &struct {
 				ProjectID string `json:"project_id"`
 				Region    string `json:"region"`
 			}{}
-		case app.AppRunnerTypeAzure, app.AppRunnerTypeAzureAKS, app.AppRunnerTypeAzureACS:
+		}
+		req.AWSAccount = nil
+		req.AzureAccount = nil
+	case app.AppRunnerTypeAzure, app.AppRunnerTypeAzureAKS, app.AppRunnerTypeAzureACS:
+		if req.AzureAccount == nil {
 			req.AzureAccount = &struct {
 				Location string `json:"location"`
 			}{}
-		case app.AppRunnerTypeAWS, app.AppRunnerTypeAWSEKS, app.AppRunnerTypeAWSECS:
+		}
+		req.AWSAccount = nil
+		req.GCPAccount = nil
+	case app.AppRunnerTypeAWS, app.AppRunnerTypeAWSEKS, app.AppRunnerTypeAWSECS:
+		if req.AWSAccount == nil {
 			return nil, stderr.ErrUser{
 				Err:         fmt.Errorf("aws_account.region is required for AWS installs"),
 				Description: "aws_account.region is required for AWS installs",
 			}
-		default:
+		}
+	default:
+		if req.AWSAccount == nil && req.AzureAccount == nil && req.GCPAccount == nil {
 			return nil, stderr.ErrUser{
-				Err:         fmt.Errorf("unable to determine cloud platform from runner type %q", parentApp.AppRunnerConfigs[0].Type),
+				Err:         fmt.Errorf("unable to determine cloud platform from runner type %q", runnerType),
 				Description: "unable to determine cloud platform from app runner config",
 			}
 		}

--- a/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
@@ -164,6 +164,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		StackName:      cfg.StackConfig.Name,
 		Region:         region,
 		Platform:       string(cfg.RunnerConfig.Type),
+		PublicAPIURL:   cfg.RunnerConfig.PublicAPIURL,
 	})
 	if err != nil {
 		return errors.Wrap(err, "unable to create cloudformation stack version")

--- a/services/ctl-api/internal/app/installs/worker/activities/create_install_stack_version.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/create_install_stack_version.go
@@ -18,6 +18,16 @@ type CreateInstallStackVersionRequest struct {
 	Region         string `json:"region"`
 	StackName      string `json:"stack_name"`
 	Platform       string `json:"platform"`
+	PublicAPIURL   string `json:"public_api_url"`
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // @temporal-gen-v2 activity
@@ -33,7 +43,7 @@ func (a *Activities) CreateInstallStackVersion(ctx context.Context, req *CreateI
 		PhoneHomeID:    phoneHomeID,
 		PhoneHomeURL: fmt.Sprintf(
 			"%s/v1/installs/%s/phone-home/%s",
-			a.cfg.PublicAPIURL,
+			firstNonEmpty(req.PublicAPIURL, a.cfg.PublicAPIURL),
 			req.InstallID,
 			phoneHomeID,
 		),

--- a/services/ctl-api/internal/app/installs/worker/activities/update_gcp_account_region.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/update_gcp_account_region.go
@@ -3,8 +3,6 @@ package activities
 import (
 	"context"
 
-	"gorm.io/gorm"
-
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 )
@@ -32,7 +30,14 @@ func (a *Activities) UpdateGCPAccountRegion(ctx context.Context, req *UpdateGCPA
 		return generics.TemporalGormError(res.Error)
 	}
 	if res.RowsAffected < 1 {
-		return generics.TemporalGormError(gorm.ErrRecordNotFound)
+		account := app.GCPAccount{
+			InstallID: req.InstallID,
+			Region:    req.Region,
+			ProjectID: req.ProjectID,
+		}
+		if err := a.db.WithContext(ctx).Create(&account).Error; err != nil {
+			return generics.TemporalGormError(err)
+		}
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
+++ b/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
@@ -127,6 +127,7 @@ func (w *Workflows) GenerateInstallStackVersion(ctx workflow.Context, sreq Gener
 		StackName:      cfg.StackConfig.Name,
 		Region:         region,
 		Platform:       string(cfg.RunnerConfig.Type),
+		PublicAPIURL:   cfg.RunnerConfig.PublicAPIURL,
 	})
 	if err != nil {
 		return errors.Wrap(err, "unable to create cloudformation stack version")

--- a/services/ctl-api/internal/app/runner-auth/service/runner_auth_gcp.go
+++ b/services/ctl-api/internal/app/runner-auth/service/runner_auth_gcp.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -92,8 +93,12 @@ func (s *service) RunnerAuthGCP(ctx *gin.Context) {
 
 	reqCtx := ctx.Request.Context()
 
-	// Step 1: Verify identity token (JWT) — proves project, SA, instance ID
-	payload, err := idtoken.Validate(reqCtx, req.IdentityToken, s.cfg.RunnerAPIURL)
+	// Step 1: Verify identity token (JWT) — proves project, SA, instance ID.
+	// Resolve the expected audience: if the token carries a custom (white-label)
+	// audience that is registered as a runner group URL, use that; otherwise
+	// fall back to the global runner API URL.
+	audience := s.resolveGCPTokenAudience(reqCtx, req.IdentityToken)
+	payload, err := idtoken.Validate(reqCtx, req.IdentityToken, audience)
 	if err != nil {
 		s.l.Warn("runner auth gcp: identity token validation failed", zap.Error(err))
 		ctx.Error(stderr.ErrAuthentication{
@@ -368,6 +373,38 @@ func extractRunnerIDFromMetadata(instance *gcpInstanceResponse) string {
 		}
 	}
 	return ""
+}
+
+// resolveGCPTokenAudience extracts the audience from the (unverified) JWT payload
+// and checks if it is a registered custom runner URL. If so, that URL is returned
+// as the expected audience so white-labeled deployments can authenticate without
+// exposing Nuon's URL. Falls back to cfg.RunnerAPIURL for standard deployments.
+func (s *service) resolveGCPTokenAudience(ctx context.Context, token string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return s.cfg.RunnerAPIURL
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return s.cfg.RunnerAPIURL
+	}
+	var claims struct {
+		Audience string `json:"aud"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Audience == "" {
+		return s.cfg.RunnerAPIURL
+	}
+	if claims.Audience == s.cfg.RunnerAPIURL {
+		return s.cfg.RunnerAPIURL
+	}
+	var count int64
+	s.db.WithContext(ctx).Model(&app.RunnerGroupSettings{}).
+		Where("runner_api_url = ?", claims.Audience).
+		Count(&count)
+	if count > 0 {
+		return claims.Audience
+	}
+	return s.cfg.RunnerAPIURL
 }
 
 func (s *service) validateRunnerGCPIdentity(ctx context.Context, install *app.Install, claims *gcpClaims) error {

--- a/services/ctl-api/internal/pkg/config/syncer/runner/sync.go
+++ b/services/ctl-api/internal/pkg/config/syncer/runner/sync.go
@@ -31,6 +31,7 @@ func Sync(ctx context.Context, db *gorm.DB, cfg *config.AppConfig, appID, appCon
 		InitScriptURL: cfg.Runner.InitScriptURL,
 		InstanceType:  cfg.Runner.InstanceType,
 		RunnerAPIURL:  cfg.Runner.RunnerAPIURL,
+		PublicAPIURL:  cfg.Runner.PublicAPIURL,
 		Type:          app.AppRunnerType(cfg.Runner.RunnerType),
 	}
 

--- a/services/ctl-api/internal/pkg/stacks/arm/arm.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/arm.go
@@ -28,6 +28,13 @@ func NewTemplates(params Params) *Templates {
 	}
 }
 
+func (t *Templates) runnerAPIURL(inp *stacks.TemplateInput) string {
+	if inp.Settings != nil && inp.Settings.RunnerAPIURL != "" {
+		return inp.Settings.RunnerAPIURL
+	}
+	return t.cfg.RunnerAPIURL
+}
+
 func (t *Templates) Template(inp *stacks.TemplateInput) ([]byte, string, error) {
 	tmpl, err := t.getAzureTemplate(inp)
 	if err != nil {

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_runner.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_runner.go
@@ -29,7 +29,7 @@ func (t *Templates) getRunnerLinkedDeployment(inp *stacks.TemplateInput) (map[st
 		"nuonAppID":           inp.Install.AppID,
 		"location":            "[parameters('location')]",
 		"runnerId":            inp.Runner.ID,
-		"runnerApiUrl":        t.cfg.RunnerAPIURL,
+		"runnerApiUrl":        t.runnerAPIURL(inp),
 		"runnerInitScriptUrl": inp.RunnerInitScriptURL,
 		"runnerSubnetId":      "[reference('vnetDeployment').outputs.runnerSubnetId.value]",
 		"customData":          t.buildRunnerCustomData(inp),
@@ -328,5 +328,5 @@ EOF
 # Reload systemd and start the mng service
 systemctl daemon-reload
 systemctl enable --now nuon-runner-mng
-`, inp.Runner.ID, t.cfg.RunnerAPIURL, inp.Settings.ContainerImageURL, inp.Settings.ContainerImageTag, inp.Install.AzureAccount.Location)
+`, inp.Runner.ID, t.runnerAPIURL(inp), inp.Settings.ContainerImageURL, inp.Settings.ContainerImageTag, inp.Install.AzureAccount.Location)
 }

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
@@ -38,7 +38,7 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 		},
 		{
 			Key:   "nuon_runner_api_url",
-			Value: inp.Settings.RunnerAPIURL,
+			Value: a.runnerAPIURL(inp),
 		},
 	}
 
@@ -47,7 +47,7 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 		"RunnerEgressGroupId": cloudformation.Ref("RunnerSecurityGroup"),
 		"InstallId":           inp.Install.ID,
 		"RunnerId":            inp.Runner.ID,
-		"RunnerApiUrl":        inp.Settings.RunnerAPIURL,
+		"RunnerApiUrl":        a.runnerAPIURL(inp),
 		"InstanceType":        cloudformation.Ref("RunnerInstanceType"),
 		"RootVolumeSize":      cloudformation.Ref("RunnerRootVolumeSize"),
 		"RunnerInitScriptUrl": inp.RunnerInitScriptURL, // NOTE(fd): this is user- (provided/configurable)
@@ -74,6 +74,13 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 		}),
 		Tags: t.apply(stackTags, "runner"),
 	}, nil
+}
+
+func (a *Templates) runnerAPIURL(inp *stacks.TemplateInput) string {
+	if inp.Settings != nil && inp.Settings.RunnerAPIURL != "" {
+		return inp.Settings.RunnerAPIURL
+	}
+	return a.cfg.RunnerAPIURL
 }
 
 // getRunnerParameters returns the user-overridable top-level parameters for

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
@@ -38,7 +38,7 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 		},
 		{
 			Key:   "nuon_runner_api_url",
-			Value: a.cfg.RunnerAPIURL,
+			Value: inp.Settings.RunnerAPIURL,
 		},
 	}
 
@@ -47,7 +47,7 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 		"RunnerEgressGroupId": cloudformation.Ref("RunnerSecurityGroup"),
 		"InstallId":           inp.Install.ID,
 		"RunnerId":            inp.Runner.ID,
-		"RunnerApiUrl":        a.cfg.RunnerAPIURL,
+		"RunnerApiUrl":        inp.Settings.RunnerAPIURL,
 		"InstanceType":        cloudformation.Ref("RunnerInstanceType"),
 		"RootVolumeSize":      cloudformation.Ref("RunnerRootVolumeSize"),
 		"RunnerInitScriptUrl": inp.RunnerInitScriptURL, // NOTE(fd): this is user- (provided/configurable)


### PR DESCRIPTION
Adds white-label support for the Nuon runner API — customers can route all runner traffic through their own domain.

- new `runner_api_url` + `public_api_url` fields in app runner config; set both to your proxy domain in runner.toml
- GCP auth now accepts tokens with a registered custom audience URL (not just the global config URL)
- AWS CloudFormation tag uses the runner group's custom URL instead of the hardcoded global one
- GCP account row is now upserted on phone-home instead of erroring when it doesn't exist yet
- CLI `--region` is optional for GCP/Azure installs (region comes from stack output)
- input defaults are pre-populated at install creation time to avoid a parallel update-inputs race with provisioning