### PR TITLE
fix: upsert gcp account in UpdateGCPAccountRegion if row missing

### DIFF
--- a/services/ctl-api/internal/app/installs/worker/activities/update_gcp_account_region.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/update_gcp_account_region.go
@@ -3,8 +3,6 @@ package activities
 import (
 	"context"
 
-	"gorm.io/gorm"
-
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 )
@@ -32,7 +30,14 @@ func (a *Activities) UpdateGCPAccountRegion(ctx context.Context, req *UpdateGCPA
 		return generics.TemporalGormError(res.Error)
 	}
 	if res.RowsAffected < 1 {
-		return generics.TemporalGormError(gorm.ErrRecordNotFound)
+		account := app.GCPAccount{
+			InstallID: req.InstallID,
+			Region:    req.Region,
+			ProjectID: req.ProjectID,
+		}
+		if err := a.db.WithContext(ctx).Create(&account).Error; err != nil {
+			return generics.TemporalGormError(err)
+		}
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/runner-auth/service/runner_auth_gcp.go
+++ b/services/ctl-api/internal/app/runner-auth/service/runner_auth_gcp.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -92,8 +93,12 @@ func (s *service) RunnerAuthGCP(ctx *gin.Context) {
 
 	reqCtx := ctx.Request.Context()
 
-	// Step 1: Verify identity token (JWT) — proves project, SA, instance ID
-	payload, err := idtoken.Validate(reqCtx, req.IdentityToken, s.cfg.RunnerAPIURL)
+	// Step 1: Verify identity token (JWT) — proves project, SA, instance ID.
+	// Resolve the expected audience: if the token carries a custom (white-label)
+	// audience that is registered as a runner group URL, use that; otherwise
+	// fall back to the global runner API URL.
+	audience := s.resolveGCPTokenAudience(reqCtx, req.IdentityToken)
+	payload, err := idtoken.Validate(reqCtx, req.IdentityToken, audience)
 	if err != nil {
 		s.l.Warn("runner auth gcp: identity token validation failed", zap.Error(err))
 		ctx.Error(stderr.ErrAuthentication{
@@ -368,6 +373,38 @@ func extractRunnerIDFromMetadata(instance *gcpInstanceResponse) string {
 		}
 	}
 	return ""
+}
+
+// resolveGCPTokenAudience extracts the audience from the (unverified) JWT payload
+// and checks if it is a registered custom runner URL. If so, that URL is returned
+// as the expected audience so white-labeled deployments can authenticate without
+// exposing Nuon's URL. Falls back to cfg.RunnerAPIURL for standard deployments.
+func (s *service) resolveGCPTokenAudience(ctx context.Context, token string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return s.cfg.RunnerAPIURL
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return s.cfg.RunnerAPIURL
+	}
+	var claims struct {
+		Audience string `json:"aud"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Audience == "" {
+		return s.cfg.RunnerAPIURL
+	}
+	if claims.Audience == s.cfg.RunnerAPIURL {
+		return s.cfg.RunnerAPIURL
+	}
+	var count int64
+	s.db.WithContext(ctx).Model(&app.RunnerGroupSettings{}).
+		Where("runner_api_url = ?", claims.Audience).
+		Count(&count)
+	if count > 0 {
+		return claims.Audience
+	}
+	return s.cfg.RunnerAPIURL
 }
 
 func (s *service) validateRunnerGCPIdentity(ctx context.Context, install *app.Install, claims *gcpClaims) error {

--- a/services/ctl-api/internal/pkg/stacks/arm/arm.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/arm.go
@@ -28,6 +28,13 @@ func NewTemplates(params Params) *Templates {
 	}
 }
 
+func (t *Templates) runnerAPIURL(inp *stacks.TemplateInput) string {
+	if inp.Settings != nil && inp.Settings.RunnerAPIURL != "" {
+		return inp.Settings.RunnerAPIURL
+	}
+	return t.cfg.RunnerAPIURL
+}
+
 func (t *Templates) Template(inp *stacks.TemplateInput) ([]byte, string, error) {
 	tmpl, err := t.getAzureTemplate(inp)
 	if err != nil {

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_runner.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_runner.go
@@ -29,7 +29,7 @@ func (t *Templates) getRunnerLinkedDeployment(inp *stacks.TemplateInput) (map[st
 		"nuonAppID":           inp.Install.AppID,
 		"location":            "[parameters('location')]",
 		"runnerId":            inp.Runner.ID,
-		"runnerApiUrl":        t.cfg.RunnerAPIURL,
+		"runnerApiUrl":        t.runnerAPIURL(inp),
 		"runnerInitScriptUrl": inp.RunnerInitScriptURL,
 		"runnerSubnetId":      "[reference('vnetDeployment').outputs.runnerSubnetId.value]",
 		"customData":          t.buildRunnerCustomData(inp),
@@ -328,5 +328,5 @@ EOF
 # Reload systemd and start the mng service
 systemctl daemon-reload
 systemctl enable --now nuon-runner-mng
-`, inp.Runner.ID, t.cfg.RunnerAPIURL, inp.Settings.ContainerImageURL, inp.Settings.ContainerImageTag, inp.Install.AzureAccount.Location)
+`, inp.Runner.ID, t.runnerAPIURL(inp), inp.Settings.ContainerImageURL, inp.Settings.ContainerImageTag, inp.Install.AzureAccount.Location)
 }

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
@@ -38,7 +38,7 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 		},
 		{
 			Key:   "nuon_runner_api_url",
-			Value: inp.Settings.RunnerAPIURL,
+			Value: a.runnerAPIURL(inp),
 		},
 	}
 
@@ -47,7 +47,7 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 		"RunnerEgressGroupId": cloudformation.Ref("RunnerSecurityGroup"),
 		"InstallId":           inp.Install.ID,
 		"RunnerId":            inp.Runner.ID,
-		"RunnerApiUrl":        inp.Settings.RunnerAPIURL,
+		"RunnerApiUrl":        a.runnerAPIURL(inp),
 		"InstanceType":        cloudformation.Ref("RunnerInstanceType"),
 		"RootVolumeSize":      cloudformation.Ref("RunnerRootVolumeSize"),
 		"RunnerInitScriptUrl": inp.RunnerInitScriptURL, // NOTE(fd): this is user- (provided/configurable)
@@ -74,6 +74,13 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 		}),
 		Tags: t.apply(stackTags, "runner"),
 	}, nil
+}
+
+func (a *Templates) runnerAPIURL(inp *stacks.TemplateInput) string {
+	if inp.Settings != nil && inp.Settings.RunnerAPIURL != "" {
+		return inp.Settings.RunnerAPIURL
+	}
+	return a.cfg.RunnerAPIURL
 }
 
 // getRunnerParameters returns the user-overridable top-level parameters for

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
@@ -38,7 +38,7 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 		},
 		{
 			Key:   "nuon_runner_api_url",
-			Value: a.cfg.RunnerAPIURL,
+			Value: inp.Settings.RunnerAPIURL,
 		},
 	}
 
@@ -47,7 +47,7 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 		"RunnerEgressGroupId": cloudformation.Ref("RunnerSecurityGroup"),
 		"InstallId":           inp.Install.ID,
 		"RunnerId":            inp.Runner.ID,
-		"RunnerApiUrl":        a.cfg.RunnerAPIURL,
+		"RunnerApiUrl":        inp.Settings.RunnerAPIURL,
 		"InstanceType":        cloudformation.Ref("RunnerInstanceType"),
 		"RootVolumeSize":      cloudformation.Ref("RunnerRootVolumeSize"),
 		"RunnerInitScriptUrl": inp.RunnerInitScriptURL, // NOTE(fd): this is user- (provided/configurable)


### PR DESCRIPTION
creates the gcp_accounts row on first phone-home when install was created without a pre-existing GCP account