### PR TITLE
feat: slow update on archive state

### DIFF
--- a/services/ctl-api/internal/app/install_state.go
+++ b/services/ctl-api/internal/app/install_state.go
@@ -71,6 +71,13 @@ func (i *InstallState) Indexes(db *gorm.DB) []migrations.Index {
 				"install_id",
 			},
 		},
+		{
+			Name: indexes.Name(db, &InstallState{}, "install_id_created_at"),
+			Columns: []string{
+				"install_id",
+				"created_at",
+			},
+		},
 	}
 }
 

--- a/services/ctl-api/internal/app/installs/worker/activities/archive_state.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/archive_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
 )
 
 type ArchiveStateRequest struct {
@@ -12,12 +13,13 @@ type ArchiveStateRequest struct {
 
 // @temporal-gen-v2 activity
 func (a *Activities) ArchiveState(ctx context.Context, req *ArchiveStateRequest) error {
-	retainCount := 50 // Number of states to retain
+	retainCount := 2 // Number of states to retain
 
 	err := a.db.WithContext(ctx).
-		Where("install_id = ? AND id NOT IN (?)",
+		Where("install_id = ? AND archived = false AND id NOT IN (?)",
 			req.InstallID,
 			a.db.Model(&app.InstallState{}).
+				Scopes(scopes.WithDisableViews).
 				Select("id").
 				Where("install_id = ?", req.InstallID).
 				Order("created_at DESC").

--- a/services/ctl-api/internal/app/installs/worker/activities/archive_state.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/archive_state.go
@@ -13,7 +13,7 @@ type ArchiveStateRequest struct {
 
 // @temporal-gen-v2 activity
 func (a *Activities) ArchiveState(ctx context.Context, req *ArchiveStateRequest) error {
-	retainCount := 2 // Number of states to retain
+	retainCount := 50 // Number of states to retain
 
 	err := a.db.WithContext(ctx).
 		Where("install_id = ? AND archived = false AND id NOT IN (?)",


### PR DESCRIPTION
fix slow udpates during archiving of old install_states.
 - only update non archived records
 - missing index for the install_state filter
 
also this wont be necessary once we fully switch to s3blobs.