### PR TITLE
feat: change default for s3 backfill rate

### DIFF
--- a/services/ctl-api/internal/app/general/worker/activities/backfill_blobs.go
+++ b/services/ctl-api/internal/app/general/worker/activities/backfill_blobs.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultBlobBackfillRatePerSecond = 100
+	defaultBlobBackfillRatePerSecond = 500
 	blobBackfillContentType          = "application/octet-stream"
 )
 

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -409,7 +409,7 @@ type Config struct {
 	// When enabled, the daily cron hard-deletes process_healthcheck queue signals older than 7 days.
 	QueueSignalCleanupEnabled bool `config:"queue_signal_cleanup_enabled"`
 
-	// BlobBackfillRatePerSecond caps how many S3 PUTs/sec the blob backfill activity issues. Defaults to 100 when unset.
+	// BlobBackfillRatePerSecond caps how many S3 PUTs/sec the blob backfill activity issues. Defaults to 500 when unset.
 	BlobBackfillRatePerSecond int `config:"blob_backfill_rate_per_second"`
 
 	// Slack auto-link reconciler. TeamID + OrgLabelKey must both be set;


### PR DESCRIPTION
change default from 100 to 500. this will improve speed when processing records already backfilled.