### PR TITLE
fix: right-size handler CAN terminate threshold

### DIFF
--- a/services/ctl-api/internal/pkg/queue/handler/run.go
+++ b/services/ctl-api/internal/pkg/queue/handler/run.go
@@ -22,7 +22,13 @@ import (
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
-const handlerTerminateThreshold = 20000
+const (
+	handlerCANHistoryMax = 10000
+	// overhead keeps terminateThreshold above historyMax so CAN always fires before the hard kill (matches queue.canDefaultTerminateOverhead).
+	handlerCANTerminateOverhead = 5000
+
+	handlerTerminateThreshold = handlerCANHistoryMax + handlerCANTerminateOverhead
+)
 
 func (h *handler) run(ctx workflow.Context) (bool, error) {
 	l, err := log.WorkflowLogger(ctx)
@@ -74,6 +80,7 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 		return h.validating || h.executing
 	}))
 
+	mgrOpts = append(mgrOpts, workflowmanager.WithHistoryMax(handlerCANHistoryMax))
 	mgrOpts = append(mgrOpts, workflowmanager.WithTerminateThreshold(handlerTerminateThreshold))
 	mgrOpts = append(mgrOpts, workflowmanager.WithOnTerminated(func(gCtx workflow.Context, historyLen int) {
 		desc := fmt.Sprintf("handler terminated: workflow history (%d) exceeded safety threshold (%d)", historyLen, handlerTerminateThreshold)


### PR DESCRIPTION
#1758 fixed handler workflows getting orphaned mid-phase by bumping the terminate threshold 10k to 20k, but that was picked ad hoc instead of following the historyMax + overhead pattern queue/run.go already uses for the same problem. Doubling the ceiling doubled worst-case replay cost, which is most of why temporal_workflow_task_replay_latency has been climbing again since Jul 1. This derives the threshold as historyMax + 5000, same overhead already proven safe on the sibling queue workflow, keeping the orphan fix while cutting the ceiling back to 15k.