### PR TITLE
fix: jitter cron emitters before the burst, not after

### DIFF
--- a/services/ctl-api/internal/app/runners/helpers/create_process_queues.go
+++ b/services/ctl-api/internal/app/runners/helpers/create_process_queues.go
@@ -44,7 +44,7 @@ func (h *Helpers) CreateProcessQueues(ctx context.Context, runnerID string, proc
 		Description:     "Periodic process health check",
 		Mode:            app.QueueEmitterModeCron,
 		CronSchedule:    healthCheckSchedule,
-		JitterWindow:    time.Second * 30,
+		JitterWindow:    time.Second * 60,
 		SignalType:      "process_healthcheck",
 		SignalExpiresIn: healthCheckExpiry,
 		SignalTemplate: queuesignal.NewRaw("process_healthcheck", map[string]any{

--- a/services/ctl-api/internal/pkg/queue/emitter/cron_ticker.go
+++ b/services/ctl-api/internal/pkg/queue/emitter/cron_ticker.go
@@ -26,8 +26,9 @@ func jitterOffset(emitterID string, window time.Duration) time.Duration {
 }
 
 type CronTickerWorkflowRequest struct {
-	QueueID   string `validate:"required"`
-	EmitterID string `validate:"required"`
+	QueueID      string `validate:"required"`
+	EmitterID    string `validate:"required"`
+	JitterWindow time.Duration
 }
 
 // @temporal-gen-v2 workflow
@@ -43,6 +44,14 @@ func (w *Workflows) CronTicker(ctx workflow.Context, req CronTickerWorkflowReque
 		zap.String("emitter-id", req.EmitterID),
 		zap.String("queue-id", req.QueueID),
 	)
+
+	// Jitter before touching any activities so scheduling load spreads across
+	// the window instead of bursting for every emitter on the same cron tick.
+	if offset := jitterOffset(req.EmitterID, req.JitterWindow); offset > 0 {
+		if err := workflow.Sleep(ctx, offset); err != nil {
+			return err
+		}
+	}
 
 	// Fetch emitter to check status and get signal template
 	emitter, err := activities.AwaitGetEmitter(ctx, &activities.GetEmitterRequest{
@@ -76,12 +85,6 @@ func (w *Workflows) CronTicker(ctx workflow.Context, req CronTickerWorkflowReque
 		l.Info("emitter signals disabled globally, skipping emit",
 			zap.String("queue-id", req.QueueID))
 		return nil
-	}
-
-	if offset := jitterOffset(emitter.ID, emitter.JitterWindow); offset > 0 {
-		if err := workflow.Sleep(ctx, offset); err != nil {
-			return err
-		}
 	}
 
 	// Emit the signal

--- a/services/ctl-api/internal/pkg/queue/emitter/run_cron.go
+++ b/services/ctl-api/internal/pkg/queue/emitter/run_cron.go
@@ -76,8 +76,9 @@ func (e *emitterWorkflow) ensureCronTickerRunning(ctx workflow.Context, l *zap.L
 	})
 
 	req := CronTickerWorkflowRequest{
-		QueueID:   emitter.QueueID,
-		EmitterID: e.emitterID,
+		QueueID:      emitter.QueueID,
+		EmitterID:    e.emitterID,
+		JitterWindow: emitter.JitterWindow,
 	}
 
 	workflow.ExecuteChildWorkflow(childCtx, "CronTicker", req)


### PR DESCRIPTION
CronTicker emitters jitter today happens right before emitSignal, but the workflow start + GetEmitter activity call still fire in lockstep for every emitter on the same cron tick regardless of jitter_window. Moves the jitter to the top of CronTicker (now passed in via the request instead of re-fetched) so it covers the whole tick, and bumps the per-runner-process health check jitter from 30s to 60s since that's the largest single cron_schedule bucket (761 emitters on */5 * * * *) driving the periodic schedule-to-start spikes we've been chasing.