### PR TITLE
docs: fix component overrides guide 404 (invalid MDX)

### DIFF
--- a/docs/guides/component-overrides.mdx
+++ b/docs/guides/component-overrides.mdx
@@ -99,5 +99,3 @@ affected component.
 
 To revert a component to its app-config values, remove its `[components.<name>]` block (or the individual field) from the
 install config and sync again. The next sync clears the override and redeploys the component with the app defaults.
-</content>
-</invoke>


### PR DESCRIPTION
`/guides/component-overrides` returns a 404 in the docs site even though the page exists and is wired into `docs.json`. 
