### PR TITLE
fix: don't require --region in preview install create TUI

### DIFF
--- a/bins/cli/internal/services/installs/create.go
+++ b/bins/cli/internal/services/installs/create.go
@@ -38,6 +38,33 @@ func (s *Service) Create(ctx context.Context, appID, name, region string, inputs
 		}
 	}
 
+	// the preview TUI collects its own inputs, and pre-fills name/region from
+	// flags when passed, so it doesn't need (and shouldn't be blocked by) the
+	// flag-based request validation below
+	if s.cfg.Preview && !asJSON {
+		installID, _ := creator.InstallCreatorApp(
+			ctx,
+			s.cfg,
+			s.api,
+			appID,
+			name,
+			region,
+		)
+		if installID == "" {
+			ui.PrintLn("no install created")
+			return nil
+		}
+		ui.PrintLn(fmt.Sprintf("fetching workflow for new install: %s", installID))
+		// get the first workflow for this install and open it
+		workflows, _, err := s.api.GetWorkflows(ctx, installID, &models.GetPaginatedQuery{Limit: 1, Offset: 0})
+		if err != nil {
+			return ui.PrintError(errors.Wrap(err, "failed to get initial workflow for this new install"))
+		}
+		wf := workflows[0]
+		workflow.WorkflowApp(ctx, s.cfg, s.api, installID, wf.ID, false)
+		return nil
+	}
+
 	// we collect these and pass them down so we can pre-fill specific fields
 	inputsMap := make(map[string]string)
 	for _, kv := range inputs {
@@ -65,29 +92,6 @@ func (s *Service) Create(ctx context.Context, appID, name, region string, inputs
 		}
 		ui.PrintJSON(install)
 		return nil
-	}
-
-	if s.cfg.Preview {
-		installID, _ := creator.InstallCreatorApp(
-			ctx,
-			s.cfg,
-			s.api,
-			appID,
-		)
-		if installID == "" {
-			ui.PrintLn("no install created")
-			return nil
-		}
-		ui.PrintLn(fmt.Sprintf("fetching workflow for new install: %s", installID))
-		// get the first workflow for this install and open it
-		workflows, _, err := s.api.GetWorkflows(ctx, installID, &models.GetPaginatedQuery{Limit: 1, Offset: 0})
-		if err != nil {
-			return ui.PrintError(errors.Wrap(err, "failed to get initial workflow for this new install"))
-		}
-		wf := workflows[0]
-		workflow.WorkflowApp(ctx, s.cfg, s.api, installID, wf.ID, false)
-		return nil
-
 	}
 
 	install, err := s.api.CreateInstall(ctx, appID, req)

--- a/bins/cli/internal/ui/v3/install/creator/data.go
+++ b/bins/cli/internal/ui/v3/install/creator/data.go
@@ -9,7 +9,22 @@ import (
 	"github.com/nuonco/nuon/sdks/nuon-go/models"
 )
 
-var awsRegions = []string{"us-east-1", "us-east-2", "us-west-1", "us-west-2"}
+var awsRegions = []string{
+	"us-east-1", "us-east-2", "us-west-1", "us-west-2",
+	"af-south-1",
+	"ap-east-1", "ap-south-1", "ap-south-2",
+	"ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-southeast-4",
+	"ap-northeast-1", "ap-northeast-2", "ap-northeast-3",
+	"ca-central-1", "ca-west-1",
+	"eu-central-1", "eu-central-2",
+	"eu-west-1", "eu-west-2", "eu-west-3",
+	"eu-south-1", "eu-south-2",
+	"eu-north-1",
+	"il-central-1",
+	"me-south-1", "me-central-1",
+	"sa-east-1",
+	"us-gov-east-1", "us-gov-west-1",
+}
 
 type inputMapping struct {
 	name             string
@@ -35,11 +50,45 @@ func fetchConfigCmd(m model) tea.Cmd {
 			return configFetchedMsg{err: err}
 		}
 
+		cloudPlatform := models.AppCloudPlatformAws
+		if runnerCfg, err := m.api.GetAppRunnerLatestConfig(m.ctx, m.appID); err == nil && runnerCfg != nil && runnerCfg.CloudPlatform != "" {
+			cloudPlatform = runnerCfg.CloudPlatform
+		}
+
 		return configFetchedMsg{
-			inputConfig: inputConfig,
-			app:         app,
+			inputConfig:   inputConfig,
+			app:           app,
+			cloudPlatform: cloudPlatform,
 		}
 	}
+}
+
+// needsRegion reports whether the install creation form should collect an AWS
+// region. GCP and Azure installs have their region determined automatically
+// from the stack output after provisioning.
+func (m *model) needsRegion() bool {
+	return m.cloudPlatform != models.AppCloudPlatformGcp && m.cloudPlatform != models.AppCloudPlatformAzure
+}
+
+// regionOffset is 1 when the region field is present (shifting focus indexes
+// for the dynamic input fields that follow it), otherwise 0.
+func (m *model) regionOffset() int {
+	if m.needsRegion() {
+		return 1
+	}
+	return 0
+}
+
+// fieldPrefilled reports whether the field at focusIdx was already supplied
+// via a CLI flag (--name / --region), and so doesn't need user input.
+func (m *model) fieldPrefilled(focusIdx int) bool {
+	if focusIdx == 0 {
+		return m.name != ""
+	}
+	if m.needsRegion() && focusIdx == 1 {
+		return m.presetRegion != ""
+	}
+	return false
 }
 
 func (m *model) createFormInputs() {
@@ -52,6 +101,9 @@ func (m *model) createFormInputs() {
 	nameInput.CharLimit = 100
 	nameInput.SetWidth(50)
 	nameInput.Prompt = ""
+	if m.name != "" {
+		nameInput.SetValue(m.name)
+	}
 	m.inputs = append(m.inputs, nameInput)
 	m.inputMappings = append(m.inputMappings, inputMapping{
 		name:        "name",
@@ -61,6 +113,14 @@ func (m *model) createFormInputs() {
 	})
 
 	// 2. Region is handled separately with regionIndex
+	if m.presetRegion != "" {
+		for i, r := range awsRegions {
+			if r == m.presetRegion {
+				m.regionIndex = i
+				break
+			}
+		}
+	}
 
 	// 3. Dynamic inputs from app config, organized by groups
 	if m.inputConfig != nil && m.inputConfig.InputGroups != nil {
@@ -105,25 +165,33 @@ func (m *model) createFormInputs() {
 		}
 	}
 
-	// Focus the first input
+	// Focus the first field that wasn't already pre-filled via --name/--region
+	// flags, stopping at the last field so there's always something focused.
 	if len(m.inputs) > 0 {
-		m.inputs[0].Focus()
 		m.focusIndex = 0
+		totalFields := len(m.inputs) + m.regionOffset()
+		for m.focusIndex < totalFields-1 && m.fieldPrefilled(m.focusIndex) {
+			m.nextInput()
+		}
+		if newInputIdx := m.focusIndexToInputIndex(m.focusIndex); newInputIdx >= 0 {
+			m.inputs[newInputIdx].Focus()
+		}
 	}
 
 	m.updateViewportContent()
 }
 
-// focusIndexToInputIndex converts a focusIndex (which includes region at index 1)
-// to an index in the m.inputs array. Returns -1 if focusIndex points to region field.
+// focusIndexToInputIndex converts a focusIndex (which includes the region
+// field at index 1, when present) to an index in the m.inputs array. Returns
+// -1 if focusIndex points to the region field.
 func (m *model) focusIndexToInputIndex(focusIdx int) int {
-	if focusIdx == 1 {
-		return -1 // region field, not in inputs array
-	}
 	if focusIdx == 0 {
 		return 0 // name field
 	}
-	return focusIdx - 1
+	if m.needsRegion() && focusIdx == 1 {
+		return -1 // region field, not in inputs array
+	}
+	return focusIdx - m.regionOffset()
 }
 
 func (m *model) nextInput() {
@@ -132,7 +200,7 @@ func (m *model) nextInput() {
 	}
 
 	m.focusIndex++
-	totalFields := len(m.inputs) + 1 // +1 for region field
+	totalFields := len(m.inputs) + m.regionOffset()
 	if m.focusIndex >= totalFields {
 		m.focusIndex = 0
 	}
@@ -150,7 +218,7 @@ func (m *model) prevInput() {
 	}
 
 	m.focusIndex--
-	totalFields := len(m.inputs) + 1
+	totalFields := len(m.inputs) + m.regionOffset()
 	if m.focusIndex < 0 {
 		m.focusIndex = totalFields - 1
 	}
@@ -197,15 +265,23 @@ func (m *model) submitForm() tea.Cmd {
 		}
 
 		name := strings.TrimSpace(m.inputs[0].Value())
-		region := awsRegions[m.regionIndex]
 
-		install, err := m.api.CreateInstall(m.ctx, m.appID, &models.ServiceCreateInstallRequest{
-			Name: &name,
-			AwsAccount: &models.ServiceCreateInstallRequestAwsAccount{
-				Region: region,
-			},
+		req := &models.ServiceCreateInstallRequest{
+			Name:   &name,
 			Inputs: inputsMap,
-		})
+		}
+		switch m.cloudPlatform {
+		case models.AppCloudPlatformGcp:
+			req.GcpAccount = &models.ServiceCreateInstallRequestGcpAccount{}
+		case models.AppCloudPlatformAzure:
+			req.AzureAccount = &models.ServiceCreateInstallRequestAzureAccount{}
+		default:
+			req.AwsAccount = &models.ServiceCreateInstallRequestAwsAccount{
+				Region: awsRegions[m.regionIndex],
+			}
+		}
+
+		install, err := m.api.CreateInstall(m.ctx, m.appID, req)
 
 		if err != nil {
 			return installCreatedMsg{err: err}

--- a/bins/cli/internal/ui/v3/install/creator/main.go
+++ b/bins/cli/internal/ui/v3/install/creator/main.go
@@ -41,14 +41,17 @@ type model struct {
 	api nuon.Client
 
 	// top level information
-	appID string
+	appID        string
+	name         string
+	presetRegion string
 
 	width  int
 	height int
 
 	// data
-	inputConfig *models.AppAppInputConfig
-	app         *models.AppApp
+	inputConfig   *models.AppAppInputConfig
+	app           *models.AppApp
+	cloudPlatform models.AppCloudPlatform
 
 	// form state
 	inputs        []textinput.Model
@@ -80,6 +83,8 @@ func initialModel(
 	cfg *config.Config,
 	api nuon.Client,
 	appID string,
+	name string,
+	region string,
 ) model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
@@ -89,16 +94,18 @@ func initialModel(
 	vp.YPosition = 0
 
 	m := model{
-		ctx:      ctx,
-		cfg:      cfg,
-		api:      api,
-		appID:    appID,
-		viewport: vp,
-		spinner:  s,
-		help:     help.New(),
-		status:   common.StatusBarRequest{Message: "Loading app configuration..."},
-		loading:  true,
-		keys:     keys,
+		ctx:          ctx,
+		cfg:          cfg,
+		api:          api,
+		appID:        appID,
+		name:         name,
+		presetRegion: region,
+		viewport:     vp,
+		spinner:      s,
+		help:         help.New(),
+		status:       common.StatusBarRequest{Message: "Loading app configuration..."},
+		loading:      true,
+		keys:         keys,
 	}
 
 	return m
@@ -130,6 +137,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.inputConfig = msg.inputConfig
 			m.app = msg.app
+			m.cloudPlatform = msg.cloudPlatform
 			m.createFormInputs()
 			m.setLogMessage("Fill in the form and press Enter to create install", "info")
 		}
@@ -208,7 +216,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(cmds...)
 
 		default:
-			if m.focusIndex == 1 {
+			if m.needsRegion() && m.focusIndex == 1 {
 				// Region field
 				if msg.String() == "left" || msg.String() == "h" {
 					m.regionIndex--
@@ -257,12 +265,14 @@ func InstallCreatorApp(
 	cfg *config.Config,
 	api nuon.Client,
 	appID string,
+	name string,
+	region string,
 ) (string, error) {
 	if !cfg.Interactive {
 		return "", errors.New("interactive terminal required for install creation; use nuon installs create --name <name> --region <region> flags")
 	}
 
-	m := initialModel(ctx, cfg, api, appID)
+	m := initialModel(ctx, cfg, api, appID, name, region)
 	p := tea.NewProgram(m)
 
 	finalModel, err := p.Run()

--- a/bins/cli/internal/ui/v3/install/creator/messages.go
+++ b/bins/cli/internal/ui/v3/install/creator/messages.go
@@ -8,9 +8,10 @@ import (
 )
 
 type configFetchedMsg struct {
-	inputConfig *models.AppAppInputConfig
-	app         *models.AppApp
-	err         error
+	inputConfig   *models.AppAppInputConfig
+	app           *models.AppApp
+	cloudPlatform models.AppCloudPlatform
+	err           error
 }
 
 type installCreatedMsg struct {

--- a/bins/cli/internal/ui/v3/install/creator/view.go
+++ b/bins/cli/internal/ui/v3/install/creator/view.go
@@ -148,22 +148,26 @@ func (m *model) updateViewportContent() {
 		fieldLines[0] = lineCount
 	}
 
-	// Region field (focusIndex 1)
-	sections = appendSection(sections, labelStyle.Render("AWS Region"))
-	sections = appendSection(sections, styles.TextError.Render(" *"))
-	sections = appendSection(sections, descStyle.Render("AWS region for the installation (use left/right arrows to change)"))
+	// Region field (focusIndex 1), only shown for AWS installs — GCP and Azure
+	// installs have their region determined automatically after provisioning.
+	regionOffset := m.regionOffset()
+	if m.needsRegion() {
+		sections = appendSection(sections, labelStyle.Render("AWS Region"))
+		sections = appendSection(sections, styles.TextError.Render(" *"))
+		sections = appendSection(sections, descStyle.Render("AWS region for the installation (use left/right arrows to change)"))
 
-	regionDisplay := fmt.Sprintf("  %s  ", awsRegions[m.regionIndex])
-	if m.focusIndex == 1 {
-		regionDisplay = focusedInputStyle.Render(regionDisplay)
-	} else {
-		regionDisplay = blurredInputStyle.Render(regionDisplay)
+		regionDisplay := fmt.Sprintf("  %s  ", awsRegions[m.regionIndex])
+		if m.focusIndex == 1 {
+			regionDisplay = focusedInputStyle.Render(regionDisplay)
+		} else {
+			regionDisplay = blurredInputStyle.Render(regionDisplay)
+		}
+		sections = appendSection(sections, regionDisplay)
+		fieldLines[1] = lineCount
+		sections = appendSection(sections, "\n")
 	}
-	sections = appendSection(sections, regionDisplay)
-	fieldLines[1] = lineCount
-	sections = appendSection(sections, "\n")
 
-	// Dynamic input fields (focusIndex 2+), grouped
+	// Dynamic input fields, grouped
 	ghStyle := groupHeaderStyle(width)
 	giStyle := groupInputsStyle(width)
 	lastGroupID := ""
@@ -196,7 +200,7 @@ func (m *model) updateViewportContent() {
 		}
 
 		fieldContent := m.inputs[i].View()
-		if m.focusIndex == i+1 {
+		if m.focusIndex == i+regionOffset {
 			inputSections = append(inputSections, focusedInputStyle.Render(fieldContent))
 		} else {
 			inputSections = append(inputSections, blurredInputStyle.Render(fieldContent))
@@ -208,7 +212,7 @@ func (m *model) updateViewportContent() {
 			),
 		)
 		sections = appendSection(sections, rendered)
-		fieldLines[i+1] = lineCount
+		fieldLines[i+regionOffset] = lineCount
 	}
 
 	m.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Top, sections...))


### PR DESCRIPTION
- Preview install create TUI no longer fails on missing --region before it even launches
- TUI skips the region step for GCP/Azure apps (region is auto-determined), keeps it for AWS
- --name and --region flags pre-fill the TUI form and focus skips past pre-filled fields
- Full AWS region list