### PR TITLE
feat: (ctl-api) honor skip_auto_retry composite-error hint in step orchestrator

### DIFF
--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
+	activities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow/activities"
 )
 
 // handleStepError marks the step as errored and checks for auto-retry.
@@ -21,6 +22,26 @@ func (s *Signal) handleStepError(ctx workflow.Context, l *zap.Logger, step *app.
 	ar, isAutoRetry := sig.(signal.SignalWithAutoRetry)
 	if !isAutoRetry || !ar.AutoRetry() {
 		return s.markStepFailed(ctx, step, stepErr, nil)
+	}
+
+	// Consult the composite-error hint recorded for this step's target. The
+	// runner-result chokepoint parses a failed execution into a typed composite
+	// error and mirrors its hints onto the target row before this step wakes.
+	// A skip_auto_retry hint (e.g. a missing IAM permission that won't resolve
+	// by retrying) forces the await-retry branch so we park for manual retry
+	// instead of burning auto-retries. Only deploy/sandbox targets carry a
+	// composite_error column, so we skip the lookup for every other target.
+	skipAutoRetry := false
+	if targetHasCompositeError(step.StepTargetType) {
+		if hintsResp, herr := activities.AwaitGetStepErrorHints(ctx, activities.GetStepErrorHintsRequest{
+			StepID: step.ID,
+		}); herr != nil {
+			l.Warn("unable to get step error hints",
+				zap.String("step_id", step.ID),
+				zap.Error(herr))
+		} else if hintsResp != nil {
+			skipAutoRetry = hintsResp.Hints.SkipAutoRetry()
+		}
 	}
 
 	// Determine max retries from the signal, falling back to default.
@@ -83,10 +104,13 @@ func (s *Signal) handleStepError(ctx workflow.Context, l *zap.Logger, step *app.
 		})
 	}
 
-	// Check auto-retry budget — user can still manually retry up to maxRetries.
-	if nextRetryIndex > maxAutoRetries {
-		l.Warn("auto retries exhausted",
+	// Park for manual retry when auto-retries are exhausted OR the composite
+	// error hinted that auto-retry won't help. The user can still manually
+	// retry up to maxRetries.
+	if skipAutoRetry || nextRetryIndex > maxAutoRetries {
+		l.Warn("parking step for manual retry",
 			zap.String("step_id", step.ID),
+			zap.Bool("skip_auto_retry", skipAutoRetry),
 			zap.Int("max_auto_retries", maxAutoRetries),
 			zap.Int("max_retries", maxRetries),
 			zap.Int("retry_index", retryIndex))
@@ -97,7 +121,8 @@ func (s *Signal) handleStepError(ctx workflow.Context, l *zap.Logger, step *app.
 			l.Info("step is skippable, continuing workflow after exhausted retries",
 				zap.String("step_id", step.ID))
 			_ = s.markStepFailed(ctx, step, stepErr, map[string]any{
-				"auto_retries_exhausted": true,
+				"auto_retries_exhausted": nextRetryIndex > maxAutoRetries,
+				"skip_auto_retry":        skipAutoRetry,
 				"max_auto_retries":       maxAutoRetries,
 				"max_retries":            maxRetries,
 				"retry_index":            retryIndex,
@@ -112,7 +137,8 @@ func (s *Signal) handleStepError(ctx workflow.Context, l *zap.Logger, step *app.
 		// Mark step as errored and write the await-retry directive.
 		// Execute() blocks here until the user retries or cancels.
 		_ = s.markStepFailed(ctx, step, stepErr, map[string]any{
-			"auto_retries_exhausted": true,
+			"auto_retries_exhausted": nextRetryIndex > maxAutoRetries,
+			"skip_auto_retry":        skipAutoRetry,
 			"max_auto_retries":       maxAutoRetries,
 			"max_retries":            maxRetries,
 			"retry_index":            retryIndex,
@@ -206,4 +232,21 @@ func (s *Signal) markStepFailed(ctx workflow.Context, step *app.WorkflowStep, st
 		return errors.Wrap(err, "unable to mark step as error")
 	}
 	return stepErr
+}
+
+// targetHasCompositeError reports whether a step's target type carries a
+// composite_error column that the runner-result chokepoint mirrors hints onto.
+// Only these targets are worth a GetStepErrorHints lookup.
+//
+// NOTE: Expand this as more target types gain composite_error columns.
+func targetHasCompositeError(targetType string) bool {
+	switch app.WorkflowStepTargetType(targetType) {
+	case app.WorkflowStepTargetTypeInstallDeploy,
+		app.WorkflowStepTargetTypeInstallDeploys,
+		app.WorkflowStepTargetTypeInstallSandboxRun,
+		app.WorkflowStepTargetTypeInstallSandboxRuns:
+		return true
+	default:
+		return false
+	}
 }

--- a/services/ctl-api/internal/pkg/flow/testworker/flow_skip_auto_retry_test.go
+++ b/services/ctl-api/internal/pkg/flow/testworker/flow_skip_auto_retry_test.go
@@ -1,0 +1,82 @@
+package testworker
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/directive"
+	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
+)
+
+// seedDeployWithSkipAutoRetry creates a minimal InstallDeploy row carrying a
+// composite error whose hints request skip_auto_retry, mirroring what the
+// runner-result chokepoint writes for e.g. a missing IAM permission.
+func (e *FlowTestSuite) seedDeployWithSkipAutoRetry(ctx context.Context) *app.InstallDeploy {
+	orgID, err := cctx.OrgIDFromContext(ctx)
+	require.Nil(e.T(), err)
+
+	deploy := app.InstallDeploy{
+		OrgID:              orgID,
+		CreatedByID:        generics.GetFakeObj[string](),
+		ComponentBuildID:   generics.GetFakeObj[string](),
+		InstallComponentID: generics.GetFakeObj[string](),
+		Status:             app.InstallDeployStatus(app.StatusError),
+		StatusDescription:  "permission denied",
+		CompositeError: &compositeerrors.CompositeErrorData{
+			Version:  compositeerrors.SchemaVersion,
+			Type:     "terraform.aws_permission",
+			Severity: compositeerrors.SeverityError,
+			Message:  "AccessDenied: not authorized to perform s3:CreateBucket",
+			Hints: compositeerrors.Hints{
+				compositeerrors.HintSkipAutoRetry: "true",
+			},
+		},
+	}
+	res := e.service.DB.WithContext(ctx).Create(&deploy)
+	require.Nil(e.T(), res.Error)
+	return &deploy
+}
+
+// TestSkipAutoRetryParksStepForManualRetry verifies that when a failed step's
+// target carries a composite error with the skip_auto_retry hint, the step is
+// parked for manual retry on the FIRST failure, the workflow reaches
+// StatusFailedPendingRetry and no auto-retry clones are created, instead of
+// burning through the signal's auto-retry budget.
+func (e *FlowTestSuite) TestSkipAutoRetryParksStepForManualRetry() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+	ownerID, ownerType := newTestOwner()
+
+	deploy := e.seedDeployWithSkipAutoRetry(ctx)
+
+	flw, queueID := e.setupFlowTest(ctx, ownerID, ownerType, []app.WorkflowStep{
+		{Name: "skip-auto-retry-step", Idx: 100, GroupIdx: 1, ExecutionType: app.WorkflowStepExecutionTypeSystem,
+			Retryable:      true,
+			StepTargetType: string(app.WorkflowStepTargetTypeInstallDeploys),
+			StepTargetID:   deploy.ID,
+			QueueSignal:    &signaldb.SignalData{Signal: &AutoRetrySignal{}}},
+	})
+
+	e.enqueueFlow(ctx, queueID, flw, ownerID, ownerType)
+
+	// The signal always fails and normally auto-retries 3 times, but the
+	// skip_auto_retry hint forces an immediate park for manual retry.
+	e.waitForWorkflowStatus(ctx, flw.ID, app.StatusFailedPendingRetry)
+
+	// No auto-retry clones should have been created.
+	steps := e.getStepsByWorkflow(ctx, flw.ID)
+	require.Len(e.T(), steps, 1,
+		"expected exactly 1 step (no auto-retry clones), got %d", len(steps))
+
+	step := steps[0]
+	require.Equal(e.T(), app.StatusError, step.Status.Status)
+	require.Equal(e.T(), string(directive.StepAwaitRetry), step.ResultDirective,
+		"step should be parked with the await-retry directive")
+	require.Equal(e.T(), true, step.Status.Metadata["skip_auto_retry"],
+		"step metadata should record skip_auto_retry")
+}

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/get_step_error_hints.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/get_step_error_hints.go
@@ -1,0 +1,82 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+)
+
+type GetStepErrorHintsRequest struct {
+	StepID string `json:"step_id" validate:"required"`
+}
+
+type GetStepErrorHintsResponse struct {
+	Hints compositeerrors.Hints `json:"hints,omitempty"`
+}
+
+// GetStepErrorHints returns the composite-error hints recorded for a failed
+// step's target. The runner-result chokepoint parses a failed execution into a
+// typed composite error and mirrors it (with its hints) onto the target
+// aggregate row (install_deploys / install_sandbox_runs). This activity reads
+// those hints back so the step orchestrator can act on them (e.g. skip
+// auto-retries for a failure that won't resolve by retrying).
+//
+// It is best-effort: a target with no composite error, or a target type that
+// carries no composite_error column, yields empty hints.
+//
+// @temporal-gen-v2 activity
+// @max-retries 1
+func (a *Activities) GetStepErrorHints(ctx context.Context, req GetStepErrorHintsRequest) (*GetStepErrorHintsResponse, error) {
+	step, err := a.PkgWorkflowsFlowGetFlowsStep(ctx, GetFlowStepRequest{
+		FlowStepID: req.StepID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get step")
+	}
+
+	ce, err := a.stepTargetCompositeError(ctx, step)
+	if err != nil {
+		return nil, err
+	}
+	if ce == nil {
+		return &GetStepErrorHintsResponse{}, nil
+	}
+
+	return &GetStepErrorHintsResponse{Hints: ce.Hints}, nil
+}
+
+// stepTargetCompositeError reads the composite_error column off the step's
+// target aggregate row. Only target types that carry the column are handled;
+// any other target (or an unset target) yields nil.
+func (a *Activities) stepTargetCompositeError(ctx context.Context, step *app.WorkflowStep) (*compositeerrors.CompositeErrorData, error) {
+	if step.StepTargetID == "" {
+		return nil, nil
+	}
+
+	switch app.WorkflowStepTargetType(step.StepTargetType) {
+	case app.WorkflowStepTargetTypeInstallDeploy, app.WorkflowStepTargetTypeInstallDeploys:
+		var deploy app.InstallDeploy
+		if err := a.db.WithContext(ctx).
+			Select("composite_error").
+			First(&deploy, "id = ?", step.StepTargetID).Error; err != nil {
+			// A missing target row is terminal (won't resolve by retrying); a
+			// transient DB error stays retryable.
+			return nil, generics.TemporalGormError(err, "unable to get install deploy")
+		}
+		return deploy.CompositeError, nil
+	case app.WorkflowStepTargetTypeInstallSandboxRun, app.WorkflowStepTargetTypeInstallSandboxRuns:
+		var run app.InstallSandboxRun
+		if err := a.db.WithContext(ctx).
+			Select("composite_error").
+			First(&run, "id = ?", step.StepTargetID).Error; err != nil {
+			return nil, generics.TemporalGormError(err, "unable to get install sandbox run")
+		}
+		return run.CompositeError, nil
+	default:
+		return nil, nil
+	}
+}


### PR DESCRIPTION
When a runner job fails, the result chokepoint parses a typed composite error and mirrors its hints onto the step target row (install_deploys / install_sandbox_runs). `handleStepError` now reads that hint via a new `GetStepErrorHints` activity: a `skip_auto_retry` hint (e.g. a missing IAM permission that won't resolve by retrying) forces the await-retry branch, parking the step for manual retry on the first failure instead of burning the signal's auto-retry budget. Records `skip_auto_retry` in step metadata for the dashboard.

Adds an integration test asserting the workflow parks at `StatusFailedPendingRetry` with no auto-retry clones.