### PR TITLE
feat: replica read on count metrics

### DIFF
--- a/services/ctl-api/internal/app/general/worker/activities/get_queue_signal_enqueue_metrics.go
+++ b/services/ctl-api/internal/app/general/worker/activities/get_queue_signal_enqueue_metrics.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
 )
 
 type UnenqueuedByType struct {
@@ -29,8 +31,12 @@ func (a *Activities) GetQueueSignalEnqueueMetrics(ctx context.Context, req GetQu
 func (a *Activities) getQueueSignalEnqueueMetrics(ctx context.Context, db *gorm.DB) (*QueueSignalEnqueueMetrics, error) {
 	var m QueueSignalEnqueueMetrics
 
-	// Count total queue signals in non-terminal queued state
+	// Count total queue signals in non-terminal queued state. Force this read
+	// onto the replica pool: it's a background metrics cron, so replica lag is
+	// irrelevant, and ForceReplica bypasses the table ACL (raw SQL has no
+	// resolvable table for the allow-list to match).
 	if res := db.WithContext(ctx).
+		Scopes(scopes.ForceReplica).
 		Raw(`SELECT count(*) FROM queue_signals WHERE deleted_at = 0`).
 		Scan(&m.TotalQueued); res.Error != nil {
 		return nil, fmt.Errorf("unable to count total queue signals: %w", res.Error)

--- a/services/ctl-api/internal/app/installs/service/service.go
+++ b/services/ctl-api/internal/app/installs/service/service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	componenthelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
-	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/replica"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
 	flowclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/client"
@@ -83,7 +82,7 @@ func (s *service) RegisterPublicRoutes(ge *gin.Engine) error {
 	// individual installs
 	installs := ge.Group("/v1/installs/:install_id")
 	{
-		installs.GET("", replica.OptIn(), s.GetInstall)
+		installs.GET("", s.GetInstall)
 		installs.PATCH("", s.UpdateInstall)
 		installs.DELETE("", s.DeleteInstall)
 		installs.POST("/labels", s.AddInstallLabels)

--- a/services/ctl-api/internal/app/installs/worker/activities/get.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/get.go
@@ -13,7 +13,6 @@ import (
 // @temporal-gen-v2 activity
 // @as-wrapper
 // @by-field installID
-// @replica-read
 func (a *Activities) get(ctx context.Context, installID string) (*app.Install, error) {
 	return a.getInstall(ctx, installID)
 }

--- a/services/ctl-api/internal/app/orgs/service/get_orgs.go
+++ b/services/ctl-api/internal/app/orgs/service/get_orgs.go
@@ -51,7 +51,7 @@ func (s *service) GetCurrentUserOrgs(ctx *gin.Context) {
 func (s *service) getOrgs(ctx *gin.Context, orgIDs []string, q string) ([]app.Org, error) {
 	var orgs []app.Org
 	tx := s.db.WithContext(ctx).
-		Scopes(scopes.WithOffsetPagination, scopes.WithReplica).
+		Scopes(scopes.WithOffsetPagination).
 		Joins("JOIN accounts ON accounts.id = orgs.created_by_id").
 		Where("orgs.id IN ?", orgIDs).
 		Order(fmt.Sprintf("CASE WHEN accounts.account_type = '%s' THEN 1 ELSE 0 END, orgs.id", app.AccountTypeCanary))

--- a/services/ctl-api/internal/pkg/db/routing/callback.go
+++ b/services/ctl-api/internal/pkg/db/routing/callback.go
@@ -24,6 +24,12 @@ func (p *Plugin) Initialize(db *gorm.DB) error {
 	if err := db.Callback().Raw().Before("*").Register("routing:decide", p.decide); err != nil {
 		return err
 	}
+	// Row covers db.Raw(...).Scan(...) and db.Row()/Rows(), which run through
+	// gorm's Row processor rather than Query/Raw. Without this, raw read
+	// queries never get a routing decision and always fall back to primary.
+	if err := db.Callback().Row().Before("*").Register("routing:decide", p.decide); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
setup count for replica read usage for the replica pool plugin.
register metrics count for queue signals for replica read.
remove test setups for replica reading. will re add things at a later time.