### PR TITLE
fix(ctl-api): pin latest terraform version to bypass GitHub API 403

### DIFF
--- a/services/ctl-api/internal/pkg/terraform/client.go
+++ b/services/ctl-api/internal/pkg/terraform/client.go
@@ -30,18 +30,12 @@ func New() Client {
 	return &client
 }
 
+// PinnedLatestVersion is a temporary hard-coded stand-in for the latest Terraform release.
+const PinnedLatestVersion = "1.15.7"
+
 func (client *TerraformClient) GetLatestVersion() (string, error) {
-	if version, ok := client.cache.Get("version"); ok {
-		return version, nil
-	}
-
-	version, err := client.FetchVersion()
-	if err != nil {
-		return "", err
-	}
-
-	client.cache.Set("version", version)
-	return version, nil
+	// Temporarily bypass the GitHub API call to avoid 403s
+	return PinnedLatestVersion, nil
 }
 
 type GitHubRelease struct {

--- a/services/ctl-api/internal/pkg/terraform/client_test.go
+++ b/services/ctl-api/internal/pkg/terraform/client_test.go
@@ -18,60 +18,61 @@ func newTestTerraformClient(url string) *TerraformClient {
 	}
 }
 
-func TestGetLatestVersion_Success(t *testing.T) {
+func TestGetLatestVersion_ReturnsPinned(t *testing.T) {
+	// GetLatestVersion is temporarily hard-coded to avoid the GitHub API's
+	// 403 rate-limiting; it must not make any HTTP call.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(GitHubRelease{TagName: "v1.9.0"})
+		t.Fatal("GetLatestVersion should not make an HTTP call while pinned")
 	}))
 	defer server.Close()
 
 	version, err := newTestTerraformClient(server.URL).GetLatestVersion()
 	require.NoError(t, err)
+	assert.Equal(t, PinnedLatestVersion, version)
+}
+
+// The tests below cover FetchVersion, which is dormant while GetLatestVersion
+// is pinned but retained so the GitHub-API path is ready to be restored.
+
+func TestFetchVersion_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(GitHubRelease{TagName: "v1.9.0"})
+	}))
+	defer server.Close()
+
+	version, err := newTestTerraformClient(server.URL).FetchVersion()
+	require.NoError(t, err)
 	assert.Equal(t, "1.9.0", version)
 }
 
-func TestGetLatestVersion_StripsvPrefix(t *testing.T) {
+func TestFetchVersion_StripsvPrefix(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(GitHubRelease{TagName: "v2.0.0"})
 	}))
 	defer server.Close()
 
-	version, err := newTestTerraformClient(server.URL).GetLatestVersion()
+	version, err := newTestTerraformClient(server.URL).FetchVersion()
 	require.NoError(t, err)
 	assert.Equal(t, "2.0.0", version)
 }
 
-func TestGetLatestVersion_CachesResult(t *testing.T) {
-	calls := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
-		json.NewEncoder(w).Encode(GitHubRelease{TagName: "v1.9.0"})
-	}))
-	defer server.Close()
-
-	client := newTestTerraformClient(server.URL)
-	client.GetLatestVersion()
-	client.GetLatestVersion()
-
-	assert.Equal(t, 1, calls, "expected 1 HTTP call due to caching")
-}
-
-func TestGetLatestVersion_NonOKStatus(t *testing.T) {
+func TestFetchVersion_NonOKStatus(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server.Close()
 
-	_, err := newTestTerraformClient(server.URL).GetLatestVersion()
+	_, err := newTestTerraformClient(server.URL).FetchVersion()
 	require.Error(t, err)
 }
 
-func TestGetLatestVersion_InvalidJSON(t *testing.T) {
+func TestFetchVersion_InvalidJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("not json"))
 	}))
 	defer server.Close()
 
-	_, err := newTestTerraformClient(server.URL).GetLatestVersion()
+	_, err := newTestTerraformClient(server.URL).FetchVersion()
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
## Summary

Temporarily pinning the terraform provider version, to get around github 403 errors.