### PR TITLE
revert: restore Handler alive-check interval to 1h

### DIFF
--- a/services/ctl-api/internal/pkg/queue/handler/run.go
+++ b/services/ctl-api/internal/pkg/queue/handler/run.go
@@ -70,8 +70,9 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 	// DB query to avoid redundant round-trips.
 	var mgrOpts []workflowmanager.Option
 	// Handler signals have explicit callbacks for completion, so the alive
-	// checker only needs to detect deletion/expiry.
-	mgrOpts = append(mgrOpts, workflowmanager.WithCheckInterval(5*time.Minute))
+	// checker only needs to detect deletion/expiry. A longer interval reduces
+	// local activity overhead for long-running signals.
+	mgrOpts = append(mgrOpts, workflowmanager.WithCheckInterval(1*time.Hour))
 
 	// don't continue-as-new mid-phase: it orphans the in-flight update and the
 	// successor run fails the signal while the work is still alive.


### PR DESCRIPTION
Reverts the interval part of #1758. At current concurrent Handler execution volume, the 5m interval multiplies DB load enough to correlate with the recent WAL/commit contention on the Temporal Postgres instance. Keeping the other two fixes from #1758 (deferred-CAN Await, terminate threshold) as-is.