### PR TITLE
fix: Some fixes to stuck/orphaned resident handler workflows in installs

### DIFF
--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
@@ -739,8 +739,26 @@ func (s *Signal) parkResident(ctx workflow.Context) (bool, error) {
 			return false, err
 		}
 		if !woke {
-			// Idle out: return cleanly so the queue signal completes and history
-			// stays finite; the host re-warms lazily on the next dispatch.
+			// The idle timer fired. Before closing, make sure no append-step or
+			// retry-step update handler is still running and that no step became
+			// pending. Those handlers persist their step rows before they set
+			// their wake flags, so closing on the timer alone could drop a step
+			// that is still being written. If an update is in flight or a step
+			// is pending, loop back to re-scan and run it.
+			if s.updatesInFlight > 0 {
+				continue
+			}
+			if pos, ok := s.firstPendingGroupPosition(ctx); ok {
+				s.resumeStartIdx = pos
+				return true, nil
+			}
+			// firstPendingGroupPosition yields on activities; re-check the wake
+			// flags in case an update handler started during that window.
+			if s.updatesInFlight > 0 || s.resumeRequested || s.appendRequested {
+				continue
+			}
+			// Nothing pending: return cleanly so the queue signal completes and
+			// history stays bounded. The host re-warms on the next dispatch.
 			return false, nil
 		}
 		// Woke — loop back to re-scan for a pending group.

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
@@ -61,6 +61,14 @@ type Signal struct {
 	// parked resident workflow and run a freshly-added step.
 	appendRequested bool
 
+	// updatesInFlight counts append-step and retry-step update handlers that
+	// are currently executing. Those handlers persist their step rows before
+	// they set appendRequested/resumeRequested, so a resident host that idles
+	// out on its timer alone could close while a step is still being written
+	// and orphan it until the next dispatch re-warms the host. parkResident
+	// will not idle out while this counter is non-zero.
+	updatesInFlight int
+
 	// Cancel state — set by cancel update handlers.
 	cancelRequested bool
 

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/update_append_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/update_append_step.go
@@ -50,6 +50,9 @@ type AppendStepResponse struct {
 // group position runs only the appended step; isWorkflowComplete() then sees all
 // steps terminal again and the loop re-parks.
 func (s *Signal) appendStepHandler(ctx workflow.Context, req AppendStepRequest) (*AppendStepResponse, error) {
+	s.updatesInFlight++
+	defer func() { s.updatesInFlight-- }()
+
 	if !s.Resident {
 		return nil, fmt.Errorf("append-step is only valid on a resident workflow")
 	}

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/update_retry_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/update_retry_step.go
@@ -29,6 +29,9 @@ type RetryStepResponse struct {
 //
 // Flow: API → flow (here) → group → step → directive → group clones
 func (s *Signal) retryStepHandler(ctx workflow.Context, req RetryStepRequest) (*RetryStepResponse, error) {
+	s.updatesInFlight++
+	defer func() { s.updatesInFlight-- }()
+
 	step, err := workflowactivities.AwaitPkgWorkflowsFlowGetFlowsStepByFlowStepID(ctx, req.StepID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get step %s: %w", req.StepID, err)

--- a/services/ctl-api/internal/pkg/queue/handler/validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/validate.go
@@ -23,9 +23,14 @@ type ValidateResponse struct{}
 func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *ValidateResponse, retErr error) {
 	l, _ := log.WorkflowLogger(ctx)
 	h.validating = true
-	defer func() {
-		h.validating = false
 
+	// Apply the terminal status only after the completion callback has been
+	// sent. Setting h.finished earlier lets run() complete the workflow and
+	// abandon the in-flight callback activity, which drops the callback the
+	// dispatcher is waiting on and wedges the queue.
+	var finStatus app.Status
+	var finDesc string
+	defer func() {
 		status := "success"
 		desc := ""
 		if retErr != nil {
@@ -33,17 +38,21 @@ func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *
 			desc = retErr.Error()
 		}
 		callback.Send(ctx, l, cb, callback.Result{Status: status, StatusDescription: desc})
+		if finStatus != "" {
+			h.setFinished(finStatus, finDesc)
+		}
+		h.validating = false
 	}()
 
 	if err := workflow.Await(ctx, func() bool {
 		return h.ready
 	}); err != nil {
-		h.setFinished(app.StatusError, err.Error())
+		finStatus, finDesc = app.StatusError, err.Error()
 		return nil, errors.Wrap(err, "unable to await for ready")
 	}
 
 	if h.sig == nil {
-		h.setFinished(app.StatusError, "signal was empty can not proceed")
+		finStatus, finDesc = app.StatusError, "signal was empty can not proceed"
 		return nil, errors.New("signal was empty can not proceed")
 	}
 
@@ -72,7 +81,7 @@ func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *
 				"validate_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
 			},
 		})
-		h.setFinished(app.StatusError, blockedErr.Error())
+		finStatus, finDesc = app.StatusError, blockedErr.Error()
 		return nil, blockedErr
 	}
 
@@ -95,7 +104,7 @@ func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *
 					"validate_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
 				},
 			})
-			h.setFinished(app.StatusError, panicErr.Error())
+			finStatus, finDesc = app.StatusError, panicErr.Error()
 			return nil, panicErr
 		}
 
@@ -109,7 +118,7 @@ func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *
 				"validate_finished_at": workflow.Now(ctx).UTC().Format(time.RFC3339),
 			},
 		})
-		h.setFinished(app.StatusError, humanDesc)
+		finStatus, finDesc = app.StatusError, humanDesc
 		return nil, temporal.NewNonRetryableApplicationError(
 			"signal failure",
 			humanDesc,


### PR DESCRIPTION
Two independent handler-lifecycle correctness bugs that leave workflows stuck
or drop work in the `installs` namespace. Both sit on top of the merged 1h
alive-check interval revert (#1796).

### 1. Resident host idles out mid-update (flow/executeflow)
Append-step/retry-step update handlers persist their step rows *before* setting
their wake flags. A resident host hitting its 15m idle timeout in that window
could close mid-update and orphan the appended/retried work until the next
dispatch re-warmed the host.

Fix: track in-flight updates with an `updatesInFlight` counter; `parkResident`
refuses to idle out while any update is running, and does a final pending-group
re-scan + wake-flag re-check before closing to cover the activity-yield race.
(Single-threaded workflow execution → counter needs no synchronization.)

### 2. Validate drops its completion callback (queue/handler)
The validate error paths called `setFinished(...)` before the deferred
`callback.Send`, so `run()` could complete the workflow while the callback
activity was still in flight — dropping the callback the dispatcher awaits and
wedging the queue.

Fix: stash the terminal status and apply it via `setFinished` only after
`callback.Send` runs. Mirrors the earlier execute-path fix (#1787).