### PR TITLE
feat: (temporal/blob) content-address blob keys to dedupe S3 and cache

### DIFF
--- a/pkg/filecache/filecache.go
+++ b/pkg/filecache/filecache.go
@@ -155,6 +155,26 @@ func (c *FileCache) Get(id string) ([]byte, bool) {
 	return data, true
 }
 
+// Has reports whether an entry is currently tracked and promotes it to most
+// recently used. It does not read the file from disk, so it is cheaper than Get
+// when only presence matters. A tracked entry implies the data was previously
+// written to durable storage, so callers can safely skip re-uploading.
+// Nil-safe: calling Has on a nil *FileCache returns false.
+func (c *FileCache) Has(id string) bool {
+	if c == nil {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[id]
+	if ok {
+		c.order.MoveToFront(entry.element)
+	}
+	return ok
+}
+
 // Len returns the number of entries currently in the cache.
 // Nil-safe: calling Len on a nil *FileCache returns 0.
 func (c *FileCache) Len() int {

--- a/pkg/filecache/filecache_test.go
+++ b/pkg/filecache/filecache_test.go
@@ -50,6 +50,35 @@ func (s *FileCacheSuite) TestPutAndGet() {
 	assert.Equal(s.T(), data, got)
 }
 
+func (s *FileCacheSuite) TestHas() {
+	err := s.cache.Put("key1", []byte("data"))
+	require.NoError(s.T(), err)
+
+	assert.True(s.T(), s.cache.Has("key1"))
+	assert.False(s.T(), s.cache.Has("nonexistent"))
+}
+
+func (s *FileCacheSuite) TestHasPromotesLRU() {
+	for i := 0; i < 5; i++ {
+		err := s.cache.Put(fmt.Sprintf("key%d", i), []byte("x"))
+		require.NoError(s.T(), err)
+	}
+
+	// Promote key0 via Has, then trigger eviction with a new entry.
+	assert.True(s.T(), s.cache.Has("key0"))
+	err := s.cache.Put("key5", []byte("x"))
+	require.NoError(s.T(), err)
+
+	// key1 (now oldest) is evicted; key0 survives because Has promoted it.
+	assert.False(s.T(), s.cache.Has("key1"))
+	assert.True(s.T(), s.cache.Has("key0"))
+}
+
+func (s *FileCacheSuite) TestHasNilSafety() {
+	var nilCache *FileCache
+	assert.False(s.T(), nilCache.Has("key1"))
+}
+
 func (s *FileCacheSuite) TestGetMiss() {
 	got, ok := s.cache.Get("nonexistent")
 	assert.False(s.T(), ok)

--- a/services/ctl-api/internal/pkg/temporal/dataconverter/blob/blob.go
+++ b/services/ctl-api/internal/pkg/temporal/dataconverter/blob/blob.go
@@ -13,6 +13,10 @@ import (
 
 const encoding = "nuon/blob"
 
+// blobIDPrefix namespaces content-addressed blob IDs (prefix + hex sha256 of the
+// payload data).
+const blobIDPrefix = "tpb"
+
 var _ converter.PayloadCodec = (*dataConverter)(nil)
 
 type dataConverter struct {

--- a/services/ctl-api/internal/pkg/temporal/dataconverter/blob/encode.go
+++ b/services/ctl-api/internal/pkg/temporal/dataconverter/blob/encode.go
@@ -2,7 +2,9 @@ package blob
 
 import (
 	"context"
-	"fmt"
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
 	"strings"
 	"time"
 
@@ -10,7 +12,6 @@ import (
 	"go.temporal.io/sdk/converter"
 	"go.uber.org/zap"
 
-	"github.com/nuonco/nuon/pkg/shortid/domains"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
 
@@ -45,8 +46,9 @@ func (d *dataConverter) encodePayload(payload *commonpb.Payload) (*commonpb.Payl
 
 	startTime := time.Now()
 	status := "success"
+	cache := "no"
 	defer func() {
-		tags := []string{"format:blob", "status:" + status, "cache:no"}
+		tags := []string{"format:blob", "status:" + status, "cache:" + cache}
 		d.mw.Incr("temporal.dataconverter.encode", tags)
 		d.mw.Timing("temporal.dataconverter.encode.latency", time.Since(startTime), tags)
 		if status == "success" {
@@ -54,38 +56,46 @@ func (d *dataConverter) encodePayload(payload *commonpb.Payload) (*commonpb.Payl
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), d.cfg.TemporalBlobS3Timeout)
-	defer cancel()
-
-	// Generate blob ID and S3 key
-	blobID := domains.NewTemporalBlob()
+	// Content-addressed key: identical payloads map to the same blob, so repeated
+	// encodes of the same data (fanned out across activities, or replayed across
+	// cron ticks) dedupe to a single S3 object and a single cache entry.
+	sum := sha256.Sum256(payload.Data)
+	hexSum := hex.EncodeToString(sum[:])
+	blobID := blobIDPrefix + hexSum
+	checksum := "sha256:" + hexSum
 	s3Key := d.cfg.TemporalBlobS3Prefix + blobID
 
-	// Upload to S3
-	reader := strings.NewReader(string(payload.Data))
-	checksum, err := d.blobSvc.UploadStream(ctx, s3Key, reader)
-	if err != nil {
-		status = "error"
-		d.l.Error("error uploading blob to S3", zap.Error(err), zap.String("s3_key", s3Key))
-		// Graceful degradation: return original payload
-		return payload, nil
-	}
+	// A tracked cache entry means this content is already durable in S3 (we either
+	// uploaded it here or fetched it from S3 during a prior decode), so we can skip
+	// the upload and DB write.
+	if d.cache.Has(blobID) {
+		cache = "yes"
+	} else {
+		ctx, cancel := context.WithTimeout(context.Background(), d.cfg.TemporalBlobS3Timeout)
+		defer cancel()
 
-	// Write pointer row to DB
-	dbRecord := app.TemporalBlob{
-		S3Key:    s3Key,
-		Checksum: checksum,
-		Size:     int64(len(payload.Data)),
-	}
-	if res := d.db.WithContext(ctx).Create(&dbRecord); res.Error != nil {
-		d.l.Error("error writing blob record", zap.Error(res.Error), zap.String("s3_key", s3Key))
-		// S3 upload succeeded but DB write failed; payload is in S3 and can be recovered
-		// Still return the encoded payload since the s3_key is in metadata
-	}
+		reader := strings.NewReader(string(payload.Data))
+		if _, err := d.blobSvc.UploadStream(ctx, s3Key, reader); err != nil {
+			status = "error"
+			d.l.Error("error uploading blob to S3", zap.Error(err), zap.String("s3_key", s3Key))
+			// Graceful degradation: return original payload
+			return payload, nil
+		}
 
-	// Write to local file cache
-	if err := d.cache.Put(blobID, payload.Data); err != nil {
-		d.l.Warn("error writing to blob cache", zap.Error(err), zap.String("blob_id", blobID))
+		dbRecord := app.TemporalBlob{
+			S3Key:    s3Key,
+			Checksum: checksum,
+			Size:     int64(len(payload.Data)),
+		}
+		if res := d.db.WithContext(ctx).Create(&dbRecord); res.Error != nil {
+			d.l.Error("error writing blob record", zap.Error(res.Error), zap.String("s3_key", s3Key))
+			// S3 upload succeeded but DB write failed; payload is in S3 and can be recovered
+			// Still return the encoded payload since the s3_key is in metadata
+		}
+
+		if err := d.cache.Put(blobID, payload.Data); err != nil {
+			d.l.Warn("error writing to blob cache", zap.Error(err), zap.String("blob_id", blobID))
+		}
 	}
 
 	// Build encoded payload
@@ -96,7 +106,7 @@ func (d *dataConverter) encodePayload(payload *commonpb.Payload) (*commonpb.Payl
 			"nuon/blob/blob_id":        []byte(blobID),
 			"nuon/blob/s3_key":         []byte(s3Key),
 			"nuon/blob/checksum":       []byte(checksum),
-			"nuon/blob/size":           []byte(fmt.Sprintf("%d", len(payload.Data))),
+			"nuon/blob/size":           []byte(strconv.Itoa(len(payload.Data))),
 		},
 		Data: []byte(blobID),
 	}

--- a/services/ctl-api/internal/pkg/temporal/dataconverter/blob/encode_test.go
+++ b/services/ctl-api/internal/pkg/temporal/dataconverter/blob/encode_test.go
@@ -1,0 +1,133 @@
+package blob
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"testing"
+	"time"
+
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/converter"
+	"go.uber.org/zap"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/pkg/filecache"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+type countingBlobSvc struct {
+	uploads   int
+	lastS3Key string
+}
+
+func (c *countingBlobSvc) Upload(ctx context.Context, s3Key string, data []byte) error { return nil }
+func (c *countingBlobSvc) Download(ctx context.Context, s3Key string) ([]byte, error) {
+	return nil, nil
+}
+func (c *countingBlobSvc) UploadStream(ctx context.Context, s3Key string, reader io.Reader) (string, error) {
+	c.uploads++
+	c.lastS3Key = s3Key
+	_, _ = io.Copy(io.Discard, reader)
+	return "checksum", nil
+}
+func (c *countingBlobSvc) DownloadStream(ctx context.Context, s3Key string) (io.ReadCloser, error) {
+	return nil, nil
+}
+func (c *countingBlobSvc) GetMetadata(ctx context.Context, s3Key string) (int64, string, error) {
+	return 0, "", nil
+}
+
+type noopMetrics struct{}
+
+func (noopMetrics) Incr(string, []string)                  {}
+func (noopMetrics) Decr(string, []string)                  {}
+func (noopMetrics) Timing(string, time.Duration, []string) {}
+func (noopMetrics) Gauge(string, float64, []string)        {}
+func (noopMetrics) Count(string, int64, []string)          {}
+func (noopMetrics) Distribution(string, float64, []string) {}
+func (noopMetrics) Event(*statsd.Event)                    {}
+func (noopMetrics) Flush()                                 {}
+
+func newTestConverter(t *testing.T, blobSvc *countingBlobSvc) *dataConverter {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec("CREATE TABLE temporal_blobs (id text PRIMARY KEY, created_at datetime, updated_at datetime, deleted_at integer, s3_key text NOT NULL, checksum text, size integer)").Error)
+
+	cache, err := filecache.New(filecache.Options{Dir: t.TempDir(), MaxCount: 100, MaxBytes: 10 << 20})
+	require.NoError(t, err)
+
+	return &dataConverter{
+		cfg: &internal.Config{
+			TemporalDataConverterLargePayloadSize: 10,
+			TemporalBlobS3Prefix:                  "prefix/",
+			TemporalBlobS3Timeout:                 5 * time.Second,
+		},
+		l:             zap.NewNop(),
+		db:            db,
+		blobSvc:       blobSvc,
+		mw:            noopMetrics{},
+		cache:         cache,
+		encodeEnabled: true,
+	}
+}
+
+func newPayload(data []byte) *commonpb.Payload {
+	return &commonpb.Payload{
+		Metadata: map[string][]byte{converter.MetadataEncoding: []byte("json/plain")},
+		Data:     data,
+	}
+}
+
+func TestEncodeContentAddressedKey(t *testing.T) {
+	blobSvc := &countingBlobSvc{}
+	d := newTestConverter(t, blobSvc)
+
+	data := []byte("this payload is larger than the threshold")
+	encoded, err := d.encodePayload(newPayload(data))
+	require.NoError(t, err)
+
+	sum := sha256.Sum256(data)
+	wantID := blobIDPrefix + hex.EncodeToString(sum[:])
+
+	assert.Equal(t, wantID, string(encoded.Data))
+	assert.Equal(t, wantID, string(encoded.Metadata["nuon/blob/blob_id"]))
+	assert.Equal(t, "prefix/"+wantID, string(encoded.Metadata["nuon/blob/s3_key"]))
+	assert.Equal(t, []byte(encoding), encoded.Metadata[converter.MetadataEncoding])
+}
+
+func TestEncodeDedupesIdenticalContent(t *testing.T) {
+	blobSvc := &countingBlobSvc{}
+	d := newTestConverter(t, blobSvc)
+
+	data := []byte("this payload is larger than the threshold")
+
+	first, err := d.encodePayload(newPayload(data))
+	require.NoError(t, err)
+	second, err := d.encodePayload(newPayload(data))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, blobSvc.uploads, "identical content must upload only once")
+	assert.Equal(t, string(first.Data), string(second.Data), "identical content must map to the same key")
+}
+
+func TestEncodeDistinctContentUploadsSeparately(t *testing.T) {
+	blobSvc := &countingBlobSvc{}
+	d := newTestConverter(t, blobSvc)
+
+	a, err := d.encodePayload(newPayload([]byte("payload A over the threshold")))
+	require.NoError(t, err)
+	b, err := d.encodePayload(newPayload([]byte("payload B over the threshold")))
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, blobSvc.uploads, "distinct content must upload separately")
+	assert.NotEqual(t, string(a.Data), string(b.Data), "distinct content must map to different keys")
+}


### PR DESCRIPTION
The blob data converter generated a random key per encode, so identical large payloads were uploaded to S3 and cached under a new key every time. On a prod installs worker this meant ~1000 cache files for only ~200 unique contents (~78% duplication), and cron bursts drove 50-100% local cache misses with ~74ms S3 decode latency.

Derive the blob key from `sha256(payload.Data)` so identical content maps to one S3 object and one cache entry, reused across activity fan-out, cron ticks, and (per pod) prior decodes. Skip the S3 upload and DB insert when the local cache already tracks the key, via a new `FileCache.Has()` that checks presence and promotes LRU without a disk read.

Decode is unchanged and reads the key from payload metadata, so existing random-key blobs still decode; no migration needed.

Note: `temporal_blobs` rows can now share an `s3_key` and a referencing history may have no row, so row age must not be treated as blob liveness by any future GC.