### PR TITLE
feat: experimental spacelift support

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -289,6 +289,7 @@
 				"icon": "clock-rotate-left",
 				"pages": [
 					"updates/updates",
+					"updates/037-split-install-stack-tfvars",
 					"updates/036-toggleable-components",
 					"updates/035-runbooks-and-readmes",
 					"updates/034-aws-terraform-install-stack",

--- a/docs/get-started/app-aws-ec2.mdx
+++ b/docs/get-started/app-aws-ec2.mdx
@@ -360,7 +360,7 @@ accept the defaults for all other inputs.
 
 Click the Create Install button at the bottom of the page to start the workflow.
 The provision workflow generates two [install stack](/concepts/stacks) formats — a CloudFormation
-Quick-Create / CLI snippet, and a Terraform `install.tfvars` for the
+Quick-Create / CLI snippet, and Terraform `inputs.auto.tfvars` and `secrets.auto.tfvars` files for the
 [`install-stacks/aws`](https://github.com/nuonco/install-stacks) module — so the
 customer can apply whichever fits their tooling.
 
@@ -392,12 +392,12 @@ Scroll to the bottom, accept the IAM acknowledgement, and click **Create Stack**
 
 #### Option B: Terraform
 
-Download the generated `install.tfvars` from the dashboard, set up a `backend.tf`
-(snippet provided in the dashboard), and run:
+Download the generated `inputs.auto.tfvars` and `secrets.auto.tfvars` files from the
+dashboard, set up a `backend.tf` (snippet provided in the dashboard), and run:
 
 ```sh
 terraform init
-terraform apply -var-file=install.tfvars
+terraform apply
 ```
 
 against the [`install-stacks/aws`](https://github.com/nuonco/install-stacks) module.

--- a/docs/get-started/app-aws-k8s.mdx
+++ b/docs/get-started/app-aws-k8s.mdx
@@ -347,8 +347,8 @@ allowing the customer to enter their own values.
 
 After entering the inputs, click the Create Install button at the bottom of the
 page to start the Workflow. The provision workflow generates two install stack
-formats — a CloudFormation Quick-Create / CLI snippet, and a Terraform
-`install.tfvars` for the [`install-stacks/aws`](https://github.com/nuonco/install-stacks)
+formats — a CloudFormation Quick-Create / CLI snippet, and Terraform
+`inputs.auto.tfvars` and `secrets.auto.tfvars` files for the [`install-stacks/aws`](https://github.com/nuonco/install-stacks)
 module — so the customer can apply whichever fits their tooling.
 
 ![Create Install](/images/get-started/create-your-first-app/tutorial-4.jpeg)
@@ -377,12 +377,12 @@ Stack**.
 
 #### Option B: Terraform
 
-Download the generated `install.tfvars` from the dashboard, set up a `backend.tf`
-(snippet provided in the dashboard), and run:
+Download the generated `inputs.auto.tfvars` and `secrets.auto.tfvars` files from the
+dashboard, set up a `backend.tf` (snippet provided in the dashboard), and run:
 
 ```sh
 terraform init
-terraform apply -var-file=install.tfvars
+terraform apply
 ```
 
 against the [`install-stacks/aws`](https://github.com/nuonco/install-stacks) module.

--- a/docs/get-started/app-aws-lambda.mdx
+++ b/docs/get-started/app-aws-lambda.mdx
@@ -285,7 +285,7 @@ this tutorial.
 
 Click the Create Install button at the bottom of the page to start the Workflow.
 The provision workflow generates two install stack formats — a CloudFormation
-Quick-Create / CLI snippet, and a Terraform `install.tfvars` for the
+Quick-Create / CLI snippet, and Terraform `inputs.auto.tfvars` and `secrets.auto.tfvars` files for the
 [`install-stacks/aws`](https://github.com/nuonco/install-stacks) module — so the
 customer can apply whichever fits their tooling.
 
@@ -317,12 +317,12 @@ Stack**.
 
 #### Option B: Terraform
 
-Download the generated `install.tfvars` from the dashboard, set up a `backend.tf`
-(snippet provided in the dashboard), and run:
+Download the generated `inputs.auto.tfvars` and `secrets.auto.tfvars` files from the
+dashboard, set up a `backend.tf` (snippet provided in the dashboard), and run:
 
 ```sh
 terraform init
-terraform apply -var-file=install.tfvars
+terraform apply
 ```
 
 against the [`install-stacks/aws`](https://github.com/nuonco/install-stacks) module.

--- a/docs/guides/byoc/gcp.mdx
+++ b/docs/guides/byoc/gcp.mdx
@@ -101,9 +101,9 @@ bring your own at any time.
 ## Provision the Install Stack
 
 BYOC Nuon on GCP is provisioned with terraform using the the
-[`nuonco/install-stacks`](https://github.com/nuonco/install-stacks) module. Nuon will share an `install.tfvars` file
-with the values specific to your install which you will augment with configuration and input values you control. Once
-the vars file is populated and the module is in your CI pipeline, you will apply the
+[`nuonco/install-stacks`](https://github.com/nuonco/install-stacks) module. Nuon will share `inputs.auto.tfvars` and
+`secrets.auto.tfvars` files with the values specific to your install which you will augment with configuration and input
+values you control. Once the vars files are populated and the module is in your CI pipeline, you will apply the
 [`nuonco/install-stacks`](https://github.com/nuonco/install-stacks) module to provision the following resources for BYOC
 Nuon:
 
@@ -138,7 +138,11 @@ terraform {
 
 ### 3. Populate and save the install configuration
 
-Save the install config Nuon shared with you as `install.tfvars`. The values fall into two categories.
+Save the install config Nuon shared with you as two files: `inputs.auto.tfvars` and `secrets.auto.tfvars`. Both use
+the `.auto.tfvars` suffix so Terraform loads them automatically at apply time. All variables below live in
+`inputs.auto.tfvars` **except** `secrets` and `auto_generate_secrets`, which go in `secrets.auto.tfvars`.
+
+The values fall into two categories.
 
 **Provided by Nuon** — these come from your install record and Nuon will share them with you:
 
@@ -229,11 +233,12 @@ base64 -i your-github-app-key.pem
 
 ### 4. Apply the install stack
 
-After the `install.tfvars` file is populated, you can apply the stack.
+After the `inputs.auto.tfvars` and `secrets.auto.tfvars` files are populated, you can apply the stack. Both files are
+loaded automatically, so no `-var-file` flag is needed.
 
 ```bash
 terraform init
-terraform apply -var-file=install.tfvars
+terraform apply
 ```
 
 All of the core-infra will be created with your `gcloud` permissions. After this, the Nuon Runner will be deployed in

--- a/docs/platform-support/aws.mdx
+++ b/docs/platform-support/aws.mdx
@@ -59,7 +59,7 @@ helm_driver = "configmap"
 When you create a new install, Nuon generates the install stack your customer uses to provision the runner and base infrastructure in their AWS account. Two stack formats are produced for every AWS install, and your customer can use whichever fits their tooling:
 
 - **CloudFormation** — a generated Cloudformation template, installable via a Quick-Create URL or the AWS CLI.
-- **Terraform** — a generated `install.tfvars` for the [`install-stacks/aws`](https://github.com/nuonco/install-stacks) Terraform module, applied with the standard `terraform` CLI.
+- **Terraform** — generated `inputs.auto.tfvars` and `secrets.auto.tfvars` files for the [`install-stacks/aws`](https://github.com/nuonco/install-stacks) Terraform module, applied with the standard `terraform` CLI.
 
 Both formats describe the same set of resources (IAM operation roles, secrets, and trust to the Nuon control plane), so installs end up in the same state regardless of which one your customer runs.
 
@@ -84,9 +84,9 @@ Either:
 
 From the Terraform tab in the dashboard:
 
-1. Download the generated `install.tfvars`.
+1. Download the generated `inputs.auto.tfvars` and `secrets.auto.tfvars` files.
 2. Create a `backend.tf` to store Terraform state (an S3 snippet is provided in the dashboard).
-3. Run `terraform init && terraform apply -var-file=install.tfvars` against the [`install-stacks/aws`](https://github.com/nuonco/install-stacks) module.
+3. Run `terraform init && terraform apply` against the [`install-stacks/aws`](https://github.com/nuonco/install-stacks) module. Both `.auto.tfvars` files are loaded automatically.
 
 Custom resources from CloudFormation nested stacks are not translated automatically. If you extend the install stack with custom Cloudformation resources, fork [`install-stacks`](https://github.com/nuonco/install-stacks) and make the equivalent Terraform changes there.
 
@@ -96,5 +96,5 @@ If you make changes to the install stack, the install must be reprovisioned.
 
 1. From the install's Overview page, click "Reprovision install" in the "Manage" drop-down. This triggers a reprovision workflow.
 1. A new CloudFormation template and Terraform tfvars are generated.
-1. Send the updated Quick-Create URL / CLI command, or the new `install.tfvars`, to your customer.
-1. Customers using Terraform re-run `terraform apply -var-file=install.tfvars` against the same backend.
+1. Send the updated Quick-Create URL / CLI command, or the new `inputs.auto.tfvars` and `secrets.auto.tfvars` files, to your customer.
+1. Customers using Terraform re-run `terraform apply` against the same backend.

--- a/docs/platform-support/gcp.mdx
+++ b/docs/platform-support/gcp.mdx
@@ -48,7 +48,7 @@ When you create a new install, Nuon will generate a Terraform install stack your
 
 Navigate to the Installs tab in the Nuon dashboard, and click on the "Create Install" button, and select the app you want to install.
 
-This will kick off a provision workflow. The stack will be generated and a pre-configured `install.tfvars` will be provided for it. The tfvars file already has the install ID, runner ID, API token, and IAM permissions interpolated, and can be shared with your customer.
+This will kick off a provision workflow. The stack will be generated and pre-configured `inputs.auto.tfvars` and `secrets.auto.tfvars` files will be provided for it. The tfvars files already have the install ID, runner ID, API token, and IAM permissions interpolated, and can be shared with your customer.
 
 ### Install the Stack
 
@@ -74,13 +74,15 @@ The dashboard provides four steps the customer can follow:
    }
    ```
 
-3. **Save the install configuration** — copy the `install.tfvars` content shown in the dashboard and save it next to the module.
+3. **Save the install configuration** — copy or download the `inputs.auto.tfvars` and `secrets.auto.tfvars` content shown in the dashboard and save both files next to the module.
 
 4. **Apply with Terraform**
 
    ```bash
-   terraform init && terraform apply -var-file=install.tfvars
+   terraform init && terraform apply
    ```
+
+   Both `.auto.tfvars` files are loaded automatically, so no `-var-file` flag is needed.
 
 The customer is prompted for `gcp_project_id` and `gcp_region` at apply time unless those are pre-populated in the install config (`gcp_account.project_id` / `gcp_account.region`), in which case they're injected into the tfvars and applied automatically.
 
@@ -103,5 +105,5 @@ To try it:
 If you make changes to the install stack template, the install must be reprovisioned to update the stack.
 
 1. From the install's Overview page, click on "Reprovision install" in the "Manage" drop-down menu. This will trigger a reprovision workflow.
-1. A new Terraform stack version and `install.tfvars` will be generated.
-1. Send the updated `install.tfvars` to your customer to re-apply with `terraform apply -var-file=install.tfvars`.
+1. A new Terraform stack version and updated `inputs.auto.tfvars` and `secrets.auto.tfvars` files will be generated.
+1. Send the updated files to your customer to re-apply with `terraform apply`.

--- a/docs/updates/037-split-install-stack-tfvars.mdx
+++ b/docs/updates/037-split-install-stack-tfvars.mdx
@@ -1,0 +1,26 @@
+---
+title: 037 - Split install stack tfvars
+description: Install stack Terraform config is now split into inputs.auto.tfvars and secrets.auto.tfvars.
+---
+
+_July 3, 2026_
+
+## Split install stack tfvars
+
+The Terraform install stack config is now generated as two separate, auto-loaded files instead of a single
+`install.tfvars`:
+
+- **`inputs.auto.tfvars`** — install identity, runner settings, IAM operation roles, and `install_inputs`.
+- **`secrets.auto.tfvars`** — `secrets` and `auto_generate_secrets`.
+
+Both use the `.auto.tfvars` suffix, so Terraform loads them automatically. The apply command drops the `-var-file`
+flag:
+
+```bash
+terraform init && terraform apply
+```
+
+The provision workflow's "await install stack" step in the dashboard now shows each file in its own block, each with
+its own copy and download buttons, so you can hand the non-secret config and the secrets to different owners.
+
+This applies to both the [AWS](/platform-support/aws) and [GCP](/platform-support/gcp) Terraform install stacks.

--- a/docs/updates/updates.mdx
+++ b/docs/updates/updates.mdx
@@ -7,6 +7,9 @@ boost: 0.4
 <Note>Nuon issues new Releases frequently, so we recommend you visit the Changelog regularly.</Note>
 
 <CardGroup cols={2}>
+  <Card title="037 - Split install stack tfvars" icon="cloud" href="/updates/037-split-install-stack-tfvars">
+    Install stack Terraform config is now split into inputs.auto.tfvars and secrets.auto.tfvars, applied with a plain terraform apply.
+  </Card>
   <Card title="036 - Toggleable Components" icon="toggle-on" href="/updates/036-toggleable-components">
     Turn components on and off per install, plus Kubernetes contexts and YAML/HCL inputs.
   </Card>

--- a/services/ctl-api/internal/app/installs/service/generate_terraform_installer_config.go
+++ b/services/ctl-api/internal/app/installs/service/generate_terraform_installer_config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -49,10 +50,13 @@ func (s *service) genTerraformInstallerConfig(ctx context.Context, installID str
 	// For installs whose stack-generation workflow has already produced a
 	// tfvars file (GCP installs, and AWS installs which now always render a
 	// Terraform tfvars envelope alongside the CloudFormation template), the
-	// tfvars are stored on the latest InstallStackVersion as a JSON envelope:
-	// {"tfvars": "<hcl body>"}. AWS installs put the envelope in
-	// TerraformContents (so the CFN template can stay in Contents); GCP keeps
-	// it in Contents. Try TerraformContents first, then fall back to Contents.
+	// tfvars are stored on the latest InstallStackVersion as a JSON envelope
+	// with the inputs and secrets split into separate bodies:
+	// {"inputs_tfvars": "<hcl>", "secrets_tfvars": "<hcl>"}. AWS installs put
+	// the envelope in TerraformContents (so the CFN template can stay in
+	// Contents); GCP keeps it in Contents. Try TerraformContents first, then
+	// fall back to Contents. This single-file endpoint concatenates both bodies
+	// — the dashboard offers them as separate downloads.
 	var version app.InstallStackVersion
 	if res := s.db.WithContext(ctx).
 		Where(app.InstallStackVersion{InstallID: install.ID}).
@@ -63,10 +67,14 @@ func (s *service) genTerraformInstallerConfig(ctx context.Context, installID str
 				continue
 			}
 			var envelope struct {
-				TFVars string `json:"tfvars"`
+				InputsTFVars  string `json:"inputs_tfvars"`
+				SecretsTFVars string `json:"secrets_tfvars"`
 			}
-			if err := json.Unmarshal(body, &envelope); err == nil && envelope.TFVars != "" {
-				return envelope.TFVars, nil
+			if err := json.Unmarshal(body, &envelope); err == nil &&
+				(envelope.InputsTFVars != "" || envelope.SecretsTFVars != "") {
+				return strings.TrimSpace(
+					envelope.InputsTFVars+"\n"+envelope.SecretsTFVars,
+				) + "\n", nil
 			}
 		}
 	}

--- a/services/ctl-api/internal/app/org.go
+++ b/services/ctl-api/internal/app/org.go
@@ -82,6 +82,11 @@ const (
 	// dashboard notebooks UI.
 	OrgFeatureNotebooks  OrgFeature = "notebooks"
 	OrgFeatureVersionsUI OrgFeature = "enable-versions-ui"
+	// OrgFeatureSpaceliftInstallStacks surfaces the Spacelift options
+	// (blueprint and administrative stack) on the install stack "await"
+	// step in the dashboard, letting customers provision the Terraform
+	// install stack through Spacelift instead of running Terraform locally.
+	OrgFeatureSpaceliftInstallStacks OrgFeature = "spacelift-install-stacks"
 )
 
 type Org struct {
@@ -203,6 +208,7 @@ func (o *Org) BeforeCreate(tx *gorm.DB) error {
 		OrgFeaturePulumiSandbox:           false,
 		OrgFeaturePulumiUpdatePlans:       false,
 		OrgFeatureNotebooks:               false,
+		OrgFeatureSpaceliftInstallStacks:  false,
 
 		// Enabled by default
 		OrgFeatureParallelRunnerJobs: true,
@@ -254,6 +260,7 @@ func GetFeatures() []OrgFeature {
 		OrgFeatureRunnerJobLongPoll,
 		OrgFeatureNotebooks,
 		OrgFeatureVersionsUI,
+		OrgFeatureSpaceliftInstallStacks,
 	}
 }
 
@@ -289,6 +296,7 @@ func GetFeatureDescriptions() map[OrgFeature]string {
 		OrgFeatureRunnerJobLongPoll:       "Switch the runner from a 5s idle-poll loop to a long-poll endpoint (`/v1/runners/:id/jobs/tail`) so job pickup is sub-second. Surfaced via runner settings; runners pick it up on the next process restart.",
 		OrgFeatureNotebooks:               "Enable install-scoped Notebooks — a Jupyter-style surface where each cell runs a command on the install's runner via a long-lived, warm per-notebook Temporal workflow, skipping the cold install-workflow step tree for near-real-time adhoc execution.",
 		OrgFeatureVersionsUI:              "Enable the install app config versions tab in the dashboard, showing the history of config updates and component diffs for each install.",
+		OrgFeatureSpaceliftInstallStacks:  "Surface the Spacelift options (blueprint and administrative stack) on the install stack await step, so customers can provision the Terraform install stack through Spacelift instead of running Terraform locally.",
 	}
 }
 

--- a/services/ctl-api/internal/pkg/stacks/aws/render.go
+++ b/services/ctl-api/internal/pkg/stacks/aws/render.go
@@ -69,9 +69,13 @@ type AWSTemplateInput struct {
 // not translated. Vendors who extend their CFN stack with custom resources are
 // expected to fork install-stacks and make equivalent Terraform changes there.
 func Render(inputs *stacks.TemplateInput, supportIAMRoleARN string) ([]byte, string, error) {
-	t, err := template.New("aws-stack").Parse(tmpl)
+	inputsT, err := template.New("aws-stack-inputs").Parse(inputsTmpl)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "unable to parse aws template")
+		return nil, "", errors.Wrap(err, "unable to parse aws inputs template")
+	}
+	secretsT, err := template.New("aws-stack-secrets").Parse(secretsTmpl)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "unable to parse aws secrets template")
 	}
 
 	prov, maint, deprov, provMPAs, maintMPAs, deprovMPAs := extractAWSStandardPermissions(inputs.AppCfg)
@@ -144,12 +148,19 @@ func Render(inputs *stacks.TemplateInput, supportIAMRoleARN string) ([]byte, str
 		Secrets:                         secrets,
 	}
 
-	var buf bytes.Buffer
-	if err := t.Execute(&buf, awsInputs); err != nil {
-		return nil, "", errors.Wrap(err, "unable to execute aws template")
+	var inputsBuf bytes.Buffer
+	if err := inputsT.Execute(&inputsBuf, awsInputs); err != nil {
+		return nil, "", errors.Wrap(err, "unable to execute aws inputs template")
+	}
+	var secretsBuf bytes.Buffer
+	if err := secretsT.Execute(&secretsBuf, awsInputs); err != nil {
+		return nil, "", errors.Wrap(err, "unable to execute aws secrets template")
 	}
 
-	envelope := map[string]string{"tfvars": buf.String()}
+	envelope := map[string]string{
+		"inputs_tfvars":  inputsBuf.String(),
+		"secrets_tfvars": secretsBuf.String(),
+	}
 	res, err := json.Marshal(envelope)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "unable to marshal aws tfvars envelope")

--- a/services/ctl-api/internal/pkg/stacks/aws/render_test.go
+++ b/services/ctl-api/internal/pkg/stacks/aws/render_test.go
@@ -38,12 +38,22 @@ func testInput() *stacks.TemplateInput {
 	}
 }
 
-// extractTfvars unwraps the JSON envelope into the raw HCL tfvars string.
+// extractTfvars unwraps the JSON envelope into the raw HCL inputs tfvars string
+// (standard vars, permissions, roles, install_inputs).
 func extractTfvars(t *testing.T, out []byte) string {
 	t.Helper()
 	var envelope map[string]string
 	require.NoError(t, json.Unmarshal(out, &envelope))
-	return envelope["tfvars"]
+	return envelope["inputs_tfvars"]
+}
+
+// extractSecretsTfvars unwraps the JSON envelope into the raw HCL secrets tfvars
+// string (auto_generate_secrets, secrets).
+func extractSecretsTfvars(t *testing.T, out []byte) string {
+	t.Helper()
+	var envelope map[string]string
+	require.NoError(t, json.Unmarshal(out, &envelope))
+	return envelope["secrets_tfvars"]
 }
 
 // findVarValue finds the right-hand side of `<key> = ...` in the HCL tfvars.
@@ -81,8 +91,33 @@ func TestRenderValidJSON(t *testing.T) {
 
 	var parsed map[string]any
 	require.NoError(t, json.Unmarshal(out, &parsed), "rendered envelope must be valid JSON")
-	_, ok := parsed["tfvars"].(string)
-	assert.True(t, ok, "envelope must contain a tfvars string")
+	_, ok := parsed["inputs_tfvars"].(string)
+	assert.True(t, ok, "envelope must contain an inputs_tfvars string")
+	_, ok = parsed["secrets_tfvars"].(string)
+	assert.True(t, ok, "envelope must contain a secrets_tfvars string")
+}
+
+func TestRenderSecretsSplitFromInputs(t *testing.T) {
+	inp := testInput()
+	inp.AppCfg.SecretsConfig.Secrets = []app.AppSecretConfig{
+		{Name: "db_password", AutoGenerate: true},
+		{Name: "api_key", Description: "external api key", Required: true, Default: "abc"},
+	}
+
+	out, _, err := Render(inp, "")
+	require.NoError(t, err)
+
+	inputs := extractTfvars(t, out)
+	secrets := extractSecretsTfvars(t, out)
+
+	assert.Contains(t, inputs, "install_inputs")
+	assert.NotContains(t, inputs, "secrets =")
+	assert.NotContains(t, inputs, "auto_generate_secrets")
+
+	assert.Contains(t, secrets, `auto_generate_secrets = ["db_password", ]`)
+	assert.Contains(t, secrets, `"api_key"`)
+	assert.Contains(t, secrets, "external api key")
+	assert.NotContains(t, secrets, "install_inputs")
 }
 
 func TestRenderStandardVars(t *testing.T) {

--- a/services/ctl-api/internal/pkg/stacks/aws/tmpl.go
+++ b/services/ctl-api/internal/pkg/stacks/aws/tmpl.go
@@ -1,6 +1,6 @@
 package aws
 
-const tmpl = `nuon_install_id          = "{{.Install.ID}}"
+const inputsTmpl = `nuon_install_id          = "{{.Install.ID}}"
 nuon_org_id              = "{{.Runner.OrgID}}"
 nuon_app_id              = "{{.Install.AppID}}"
 {{- if .Install.AWSAccount}}
@@ -46,7 +46,9 @@ install_inputs = {
   "{{.}}" = ""
 {{- end}}
 }
-auto_generate_secrets = [{{range .AutoGenerateSecrets}}"{{.}}", {{end}}]
+`
+
+const secretsTmpl = `auto_generate_secrets = [{{range .AutoGenerateSecrets}}"{{.}}", {{end}}]
 secrets = {
 {{- range .Secrets}}
   "{{.Name}}" = {

--- a/services/ctl-api/internal/pkg/stacks/gcp/render.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/render.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -26,11 +27,30 @@ type GCPSecretTemplateInput struct {
 	Description string
 	Required    bool
 	Default     string
+	// Value is what the secret's `value` renders to in tfvars. For the normal
+	// tfvars it's the secret's Default; for the Spacelift blueprint it's a
+	// `${{ inputs.secret_<name> }}` CEL reference.
+	Value string
+}
+
+// GCPInstallInputTemplateInput holds a customer install input for the template.
+// Value is empty in the normal tfvars and a `${{ inputs.input_<name> }}` CEL
+// reference in the Spacelift blueprint.
+type GCPInstallInputTemplateInput struct {
+	Name  string
+	Value string
 }
 
 // GCPTemplateInput extends TemplateInput with pre-marshaled GCP IAM permission lists.
 type GCPTemplateInput struct {
 	*stacks.TemplateInput
+
+	// GCPProjectID / GCPRegion render as literals in the normal tfvars and as
+	// `${{ inputs.gcp_project_id }}` / `${{ inputs.gcp_region }}` CEL references
+	// in the Spacelift blueprint. Empty omits the line.
+	GCPProjectID string
+	GCPRegion    string
+
 	ProvisionPermissions   string
 	MaintenancePermissions string
 	DeprovisionPermissions string
@@ -41,7 +61,7 @@ type GCPTemplateInput struct {
 
 	BreakGlassRoles []GCPRoleTemplateInput
 	CustomRoles     []GCPRoleTemplateInput
-	InstallInputs   []string
+	InstallInputs   []GCPInstallInputTemplateInput
 
 	AutoGenerateSecrets []string
 	Secrets             []GCPSecretTemplateInput
@@ -61,11 +81,11 @@ func Render(inputs *stacks.TemplateInput) ([]byte, string, error) {
 	breakGlassRoles := extractGCPRolesFromList(inputs.AppCfg.BreakGlassConfig.Roles)
 	customRoles := extractGCPRolesFromList(inputs.AppCfg.PermissionsConfig.CustomRoles)
 
-	var installInputs []string
+	var installInputs []GCPInstallInputTemplateInput
 	if inputs.AppCfg != nil {
 		for _, input := range inputs.AppCfg.InputConfig.AppInputs {
 			if input.Source == app.AppInputSourceCustomer {
-				installInputs = append(installInputs, input.Name)
+				installInputs = append(installInputs, GCPInstallInputTemplateInput{Name: input.Name})
 			}
 		}
 	}
@@ -82,13 +102,22 @@ func Render(inputs *stacks.TemplateInput) ([]byte, string, error) {
 					Description: s.Description,
 					Required:    s.Required,
 					Default:     s.Default,
+					Value:       s.Default,
 				})
 			}
 		}
 	}
 
+	var gcpProjectID, gcpRegion string
+	if inputs.Install.GCPAccount != nil {
+		gcpProjectID = inputs.Install.GCPAccount.ProjectID
+		gcpRegion = inputs.Install.GCPAccount.Region
+	}
+
 	gcpInputs := &GCPTemplateInput{
 		TemplateInput:             inputs,
+		GCPProjectID:              gcpProjectID,
+		GCPRegion:                 gcpRegion,
 		ProvisionPermissions:      prov,
 		MaintenancePermissions:    maint,
 		DeprovisionPermissions:    deprov,
@@ -111,11 +140,47 @@ func Render(inputs *stacks.TemplateInput) ([]byte, string, error) {
 		return nil, "", errors.Wrap(err, "unable to execute gcp secrets template")
 	}
 
-	adminTF, err := renderSpaceliftAdminTF(inputsBuf.String(), secretsBuf.String(), inputs.Install.ID)
+	adminTF, err := renderSpaceliftAdminTF(inputs.Install.ID)
 	if err != nil {
 		return nil, "", err
 	}
-	blueprintYAML, err := renderSpaceliftBlueprint(inputsBuf.String(), secretsBuf.String(), inputs.Install.ID)
+
+	// The blueprint surfaces customer install inputs and secrets as blueprint
+	// inputs, so render a variant of the tfvars where those values are
+	// `${{ inputs.<id> }}` CEL references instead of literals.
+	blueprintTfvarsInput := *gcpInputs
+	blueprintTfvarsInput.GCPProjectID = "${{ inputs.gcp_project_id }}"
+	blueprintTfvarsInput.GCPRegion = "${{ inputs.gcp_region }}"
+	blueprintTfvarsInput.InstallInputs = make([]GCPInstallInputTemplateInput, len(installInputs))
+	for i, in := range installInputs {
+		blueprintTfvarsInput.InstallInputs[i] = GCPInstallInputTemplateInput{
+			Name:  in.Name,
+			Value: fmt.Sprintf("${{ inputs.%s }}", blueprintInstallInputID(in.Name)),
+		}
+	}
+	blueprintTfvarsInput.Secrets = make([]GCPSecretTemplateInput, len(secrets))
+	for i, s := range secrets {
+		blueprintTfvarsInput.Secrets[i] = s
+		blueprintTfvarsInput.Secrets[i].Value = fmt.Sprintf("${{ inputs.%s }}", blueprintSecretID(s.Name))
+	}
+
+	var blueprintInputsBuf, blueprintSecretsBuf bytes.Buffer
+	if err = inputsT.Execute(&blueprintInputsBuf, &blueprintTfvarsInput); err != nil {
+		return nil, "", errors.Wrap(err, "unable to execute gcp blueprint inputs template")
+	}
+	if err = secretsT.Execute(&blueprintSecretsBuf, &blueprintTfvarsInput); err != nil {
+		return nil, "", errors.Wrap(err, "unable to execute gcp blueprint secrets template")
+	}
+
+	blueprintYAML, err := renderSpaceliftBlueprint(spaceliftBlueprintData{
+		InstallID:     inputs.Install.ID,
+		InputsTfvars:  blueprintInputsBuf.String(),
+		SecretsTfvars: blueprintSecretsBuf.String(),
+		GCPProjectID:  gcpProjectID,
+		GCPRegion:     gcpRegion,
+		InstallInputs: installInputs,
+		Secrets:       secrets,
+	})
 	if err != nil {
 		return nil, "", err
 	}

--- a/services/ctl-api/internal/pkg/stacks/gcp/render.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/render.go
@@ -111,11 +111,22 @@ func Render(inputs *stacks.TemplateInput) ([]byte, string, error) {
 		return nil, "", errors.Wrap(err, "unable to execute gcp secrets template")
 	}
 
+	adminTF, err := renderSpaceliftAdminTF(inputsBuf.String(), secretsBuf.String(), inputs.Install.ID)
+	if err != nil {
+		return nil, "", err
+	}
+	blueprintYAML, err := renderSpaceliftBlueprint(inputsBuf.String(), secretsBuf.String(), inputs.Install.ID)
+	if err != nil {
+		return nil, "", err
+	}
+
 	// Wrap tfvars in a JSON envelope so it can be stored in the jsonb column.
 	// The raw tfvars text is HCL, not valid JSON.
 	envelope := map[string]string{
-		"inputs_tfvars":  inputsBuf.String(),
-		"secrets_tfvars": secretsBuf.String(),
+		"inputs_tfvars":            inputsBuf.String(),
+		"secrets_tfvars":           secretsBuf.String(),
+		"spacelift_admin_tf":       adminTF,
+		"spacelift_blueprint_yaml": blueprintYAML,
 	}
 	res, err := json.Marshal(envelope)
 	if err != nil {

--- a/services/ctl-api/internal/pkg/stacks/gcp/render.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/render.go
@@ -48,9 +48,13 @@ type GCPTemplateInput struct {
 }
 
 func Render(inputs *stacks.TemplateInput) ([]byte, string, error) {
-	t, err := template.New("gcp-stack").Parse(tmpl)
+	inputsT, err := template.New("gcp-stack-inputs").Parse(inputsTmpl)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "unable to parse gcp template")
+		return nil, "", errors.Wrap(err, "unable to parse gcp inputs template")
+	}
+	secretsT, err := template.New("gcp-stack-secrets").Parse(secretsTmpl)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "unable to parse gcp secrets template")
 	}
 
 	prov, maint, deprov, provPredefined, maintPredefined, deprovPredefined := extractGCPStandardPermissions(inputs.AppCfg)
@@ -98,15 +102,21 @@ func Render(inputs *stacks.TemplateInput) ([]byte, string, error) {
 		Secrets:                   secrets,
 	}
 
-	var buf bytes.Buffer
-	err = t.Execute(&buf, gcpInputs)
-	if err != nil {
-		return nil, "", errors.Wrap(err, "unable to execute gcp template")
+	var inputsBuf bytes.Buffer
+	if err = inputsT.Execute(&inputsBuf, gcpInputs); err != nil {
+		return nil, "", errors.Wrap(err, "unable to execute gcp inputs template")
+	}
+	var secretsBuf bytes.Buffer
+	if err = secretsT.Execute(&secretsBuf, gcpInputs); err != nil {
+		return nil, "", errors.Wrap(err, "unable to execute gcp secrets template")
 	}
 
 	// Wrap tfvars in a JSON envelope so it can be stored in the jsonb column.
 	// The raw tfvars text is HCL, not valid JSON.
-	envelope := map[string]string{"tfvars": buf.String()}
+	envelope := map[string]string{
+		"inputs_tfvars":  inputsBuf.String(),
+		"secrets_tfvars": secretsBuf.String(),
+	}
 	res, err := json.Marshal(envelope)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "unable to marshal gcp tfvars envelope")

--- a/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
@@ -369,6 +369,11 @@ func extractEnvelopeKey(t *testing.T, out []byte, key string) string {
 
 func TestRenderSpaceliftArtifacts(t *testing.T) {
 	inp := testInput()
+	inp.AppCfg.InputConfig = app.AppInputConfig{
+		AppInputs: []app.AppInput{
+			{Name: "cluster_name", Source: app.AppInputSourceCustomer},
+		},
+	}
 	inp.AppCfg.SecretsConfig = app.AppSecretsConfig{
 		Secrets: []app.AppSecretConfig{
 			{Name: "stripe_key", Description: "Your Stripe API key", Required: true},
@@ -377,9 +382,6 @@ func TestRenderSpaceliftArtifacts(t *testing.T) {
 
 	out, _, err := Render(inp)
 	require.NoError(t, err)
-
-	inputsTfvars := extractTfvars(t, out)
-	secretsTfvars := extractSecretsTfvars(t, out)
 
 	adminTF := extractEnvelopeKey(t, out, "spacelift_admin_tf")
 	blueprint := extractEnvelopeKey(t, out, "spacelift_blueprint_yaml")
@@ -392,26 +394,47 @@ func TestRenderSpaceliftArtifacts(t *testing.T) {
 		assert.Contains(t, artifact, "install-stacks")
 	}
 
+	// The admin stack reads the tfvars from sibling files so the customer can
+	// edit inputs and replace secrets before applying.
 	assert.Contains(t, adminTF, "spacelift_stack")
-	assert.Contains(t, adminTF, `project_root      = "gcp"`)
+	assert.Contains(t, adminTF, `project_root`)
+	assert.Contains(t, adminTF, `"gcp"`)
+	assert.Contains(t, adminTF, "raw_git {")
+	assert.Contains(t, adminTF, `url       = "https://github.com/nuonco/install-stacks.git"`)
 	assert.Contains(t, adminTF, `relative_path = "source/gcp/inputs.auto.tfvars"`)
 	assert.Contains(t, adminTF, `relative_path = "source/gcp/secrets.auto.tfvars"`)
 	assert.Contains(t, adminTF, `write_only    = false`, "inputs mounted file should be plain")
 	assert.Contains(t, adminTF, `write_only    = true`, "secrets mounted file should be secret")
+	assert.Contains(t, adminTF, `filebase64("${path.module}/inputs.auto.tfvars")`)
+	assert.Contains(t, adminTF, `filebase64("${path.module}/secrets.auto.tfvars")`)
 
 	assert.Contains(t, blueprint, "project_root: gcp")
+	assert.Contains(t, blueprint, "provider: RAW_GIT")
+	assert.Contains(t, blueprint, "repository_url: https://github.com/nuonco/install-stacks.git")
 	assert.Contains(t, blueprint, "vendor:")
+	assert.NotContains(t, blueprint, "trigger_run", "blueprint must not auto-trigger: GCP creds aren't attachable via blueprint, so the first run would fail auth")
 
-	inputsB64 := base64.StdEncoding.EncodeToString([]byte(inputsTfvars))
-	secretsB64 := base64.StdEncoding.EncodeToString([]byte(secretsTfvars))
-	assert.Contains(t, adminTF, inputsB64, "admin tf should mount the rendered inputs tfvars")
-	assert.Contains(t, adminTF, secretsB64, "admin tf should mount the rendered secrets tfvars")
-	assert.Contains(t, blueprint, inputsB64, "blueprint should mount the rendered inputs tfvars")
-	assert.Contains(t, blueprint, secretsB64, "blueprint should mount the rendered secrets tfvars")
+	// GCP project/region, customer install inputs, and secrets are exposed as
+	// blueprint inputs and interpolated into the (plaintext) mounted tfvars via CEL.
+	assert.Contains(t, blueprint, "inputs:")
+	assert.Contains(t, blueprint, "id: gcp_project_id")
+	assert.Contains(t, blueprint, `default: "my-gcp-project"`)
+	assert.Contains(t, blueprint, "id: gcp_region")
+	assert.Contains(t, blueprint, `default: "us-central1"`)
+	assert.Contains(t, blueprint, "id: input_cluster_name")
+	assert.Contains(t, blueprint, "type: short_text")
+	assert.Contains(t, blueprint, "id: secret_stripe_key")
+	assert.Contains(t, blueprint, "type: secret")
+	assert.Contains(t, blueprint, "description: Your Stripe API key")
 
-	decoded, err := base64.StdEncoding.DecodeString(inputsB64)
-	require.NoError(t, err)
-	assert.Equal(t, inputsTfvars, string(decoded))
+	assert.Contains(t, blueprint, `gcp_project_id           = "${{ inputs.gcp_project_id }}"`)
+	assert.Contains(t, blueprint, `gcp_region               = "${{ inputs.gcp_region }}"`)
+	assert.Contains(t, blueprint, `"cluster_name" = "${{ inputs.input_cluster_name }}"`)
+	assert.Contains(t, blueprint, `value       = "${{ inputs.secret_stripe_key }}"`)
+
+	// Content is plaintext (not base64) so CEL interpolation works.
+	assert.Contains(t, blueprint, "nuon_install_id")
+	assert.NotContains(t, blueprint, base64.StdEncoding.EncodeToString([]byte("nuon_install_id")))
 }
 
 func TestRenderPredefinedRoleValues(t *testing.T) {

--- a/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
@@ -96,13 +96,25 @@ func testInputWithCustomRoles() *stacks.TemplateInput {
 	return inp
 }
 
-// extractTfvars parses the JSON envelope and returns the tfvars string.
+// extractTfvars parses the JSON envelope and returns the inputs tfvars string
+// (standard vars, permissions, roles, install_inputs).
 func extractTfvars(t *testing.T, out []byte) string {
 	t.Helper()
 	var envelope map[string]string
 	require.NoError(t, json.Unmarshal(out, &envelope))
-	tfvars, ok := envelope["tfvars"]
-	require.True(t, ok, "envelope must contain 'tfvars' key")
+	tfvars, ok := envelope["inputs_tfvars"]
+	require.True(t, ok, "envelope must contain 'inputs_tfvars' key")
+	return tfvars
+}
+
+// extractSecretsTfvars parses the JSON envelope and returns the secrets tfvars
+// string (auto_generate_secrets, secrets).
+func extractSecretsTfvars(t *testing.T, out []byte) string {
+	t.Helper()
+	var envelope map[string]string
+	require.NoError(t, json.Unmarshal(out, &envelope))
+	tfvars, ok := envelope["secrets_tfvars"]
+	require.True(t, ok, "envelope must contain 'secrets_tfvars' key")
 	return tfvars
 }
 
@@ -317,7 +329,7 @@ func TestRenderSecrets(t *testing.T) {
 		out, _, err := Render(inp)
 		require.NoError(t, err)
 
-		tfvars := extractTfvars(t, out)
+		tfvars := extractSecretsTfvars(t, out)
 
 		// auto-gen should be in the list
 		assert.Contains(t, tfvars, `auto_generate_secrets = ["db_password", ]`)
@@ -338,7 +350,7 @@ func TestRenderSecrets(t *testing.T) {
 		out, _, err := Render(testInput())
 		require.NoError(t, err)
 
-		tfvars := extractTfvars(t, out)
+		tfvars := extractSecretsTfvars(t, out)
 
 		assert.Contains(t, tfvars, "auto_generate_secrets = []")
 		assert.Contains(t, tfvars, "secrets = {\n}")

--- a/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -355,6 +356,62 @@ func TestRenderSecrets(t *testing.T) {
 		assert.Contains(t, tfvars, "auto_generate_secrets = []")
 		assert.Contains(t, tfvars, "secrets = {\n}")
 	})
+}
+
+func extractEnvelopeKey(t *testing.T, out []byte, key string) string {
+	t.Helper()
+	var envelope map[string]string
+	require.NoError(t, json.Unmarshal(out, &envelope))
+	val, ok := envelope[key]
+	require.True(t, ok, "envelope must contain %q key", key)
+	return val
+}
+
+func TestRenderSpaceliftArtifacts(t *testing.T) {
+	inp := testInput()
+	inp.AppCfg.SecretsConfig = app.AppSecretsConfig{
+		Secrets: []app.AppSecretConfig{
+			{Name: "stripe_key", Description: "Your Stripe API key", Required: true},
+		},
+	}
+
+	out, _, err := Render(inp)
+	require.NoError(t, err)
+
+	inputsTfvars := extractTfvars(t, out)
+	secretsTfvars := extractSecretsTfvars(t, out)
+
+	adminTF := extractEnvelopeKey(t, out, "spacelift_admin_tf")
+	blueprint := extractEnvelopeKey(t, out, "spacelift_blueprint_yaml")
+
+	require.NotEmpty(t, adminTF)
+	require.NotEmpty(t, blueprint)
+
+	for _, artifact := range []string{adminTF, blueprint} {
+		assert.Contains(t, artifact, inp.Install.ID)
+		assert.Contains(t, artifact, "install-stacks")
+	}
+
+	assert.Contains(t, adminTF, "spacelift_stack")
+	assert.Contains(t, adminTF, `project_root      = "gcp"`)
+	assert.Contains(t, adminTF, `relative_path = "source/gcp/inputs.auto.tfvars"`)
+	assert.Contains(t, adminTF, `relative_path = "source/gcp/secrets.auto.tfvars"`)
+	assert.Contains(t, adminTF, `write_only    = false`, "inputs mounted file should be plain")
+	assert.Contains(t, adminTF, `write_only    = true`, "secrets mounted file should be secret")
+
+	assert.Contains(t, blueprint, "project_root: gcp")
+	assert.Contains(t, blueprint, "vendor:")
+
+	inputsB64 := base64.StdEncoding.EncodeToString([]byte(inputsTfvars))
+	secretsB64 := base64.StdEncoding.EncodeToString([]byte(secretsTfvars))
+	assert.Contains(t, adminTF, inputsB64, "admin tf should mount the rendered inputs tfvars")
+	assert.Contains(t, adminTF, secretsB64, "admin tf should mount the rendered secrets tfvars")
+	assert.Contains(t, blueprint, inputsB64, "blueprint should mount the rendered inputs tfvars")
+	assert.Contains(t, blueprint, secretsB64, "blueprint should mount the rendered secrets tfvars")
+
+	decoded, err := base64.StdEncoding.DecodeString(inputsB64)
+	require.NoError(t, err)
+	assert.Equal(t, inputsTfvars, string(decoded))
 }
 
 func TestRenderPredefinedRoleValues(t *testing.T) {

--- a/services/ctl-api/internal/pkg/stacks/gcp/spacelift.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/spacelift.go
@@ -2,51 +2,120 @@ package gcp
 
 import (
 	"bytes"
-	"encoding/base64"
+	"strings"
 	"text/template"
 
 	"github.com/pkg/errors"
 )
 
 // defaultSpaceliftTerraformVersion is the Terraform version pinned on generated
-// Spacelift stacks/blueprints. Kept in lockstep with the install-stacks//gcp
-// module's versions.tf constraint.
-const defaultSpaceliftTerraformVersion = "1.9.0"
+// Spacelift stacks/blueprints. Satisfies the install-stacks//gcp module's
+// versions.tf constraint (>= 1.5) and stays within the versions Spacelift's
+// TERRAFORM_FOSS workflow tool exposes.
+const defaultSpaceliftTerraformVersion = "1.5.7"
 
-type spaceliftTemplateInput struct {
+// blueprintInstallInputID / blueprintSecretID map a Nuon install-input or
+// secret name to the blueprint input id it's exposed as. The prefixes keep the
+// two namespaces from colliding when an input and a secret share a name.
+func blueprintInstallInputID(name string) string { return "input_" + name }
+func blueprintSecretID(name string) string       { return "secret_" + name }
+
+type spaceliftAdminTemplateInput struct {
 	InstallID        string
 	TerraformVersion string
-	InputsB64        string
-	SecretsB64       string
 }
 
-func newSpaceliftTemplateInput(inputsTfvars, secretsTfvars, installID string) spaceliftTemplateInput {
-	return spaceliftTemplateInput{
+func renderSpaceliftAdminTF(installID string) (string, error) {
+	t, err := template.New("gcp-spacelift-admin-tf").Parse(spaceliftAdminTfTmpl)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to parse gcp spacelift admin template")
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, spaceliftAdminTemplateInput{
 		InstallID:        installID,
 		TerraformVersion: defaultSpaceliftTerraformVersion,
-		InputsB64:        base64.StdEncoding.EncodeToString([]byte(inputsTfvars)),
-		SecretsB64:       base64.StdEncoding.EncodeToString([]byte(secretsTfvars)),
+	}); err != nil {
+		return "", errors.Wrap(err, "unable to execute gcp spacelift admin template")
 	}
-}
-
-func renderSpaceliftAdminTF(inputsTfvars, secretsTfvars, installID string) (string, error) {
-	return renderSpaceliftTemplate("gcp-spacelift-admin-tf", spaceliftAdminTfTmpl, inputsTfvars, secretsTfvars, installID)
-}
-
-func renderSpaceliftBlueprint(inputsTfvars, secretsTfvars, installID string) (string, error) {
-	return renderSpaceliftTemplate("gcp-spacelift-blueprint", spaceliftBlueprintTmpl, inputsTfvars, secretsTfvars, installID)
-}
-
-func renderSpaceliftTemplate(name, tmpl, inputsTfvars, secretsTfvars, installID string) (string, error) {
-	t, err := template.New(name).Parse(tmpl)
-	if err != nil {
-		return "", errors.Wrapf(err, "unable to parse %s template", name)
-	}
-
-	var buf bytes.Buffer
-	if err := t.Execute(&buf, newSpaceliftTemplateInput(inputsTfvars, secretsTfvars, installID)); err != nil {
-		return "", errors.Wrapf(err, "unable to execute %s template", name)
-	}
-
 	return buf.String(), nil
+}
+
+// spaceliftBlueprintData is the caller-facing input for the blueprint renderer.
+type spaceliftBlueprintData struct {
+	InstallID     string
+	InputsTfvars  string
+	SecretsTfvars string
+	GCPProjectID  string
+	GCPRegion     string
+	InstallInputs []GCPInstallInputTemplateInput
+	Secrets       []GCPSecretTemplateInput
+}
+
+type blueprintInput struct {
+	ID          string
+	Name        string
+	Type        string
+	Description string
+	Default     string
+}
+
+type spaceliftBlueprintTemplateInput struct {
+	InstallID        string
+	TerraformVersion string
+	Inputs           []blueprintInput
+	InputsTfvars     string
+	SecretsTfvars    string
+}
+
+func renderSpaceliftBlueprint(data spaceliftBlueprintData) (string, error) {
+	inputs := []blueprintInput{
+		{ID: "gcp_project_id", Name: "GCP project ID", Type: "short_text", Default: data.GCPProjectID},
+		{ID: "gcp_region", Name: "GCP region", Type: "short_text", Default: data.GCPRegion},
+	}
+	for _, in := range data.InstallInputs {
+		inputs = append(inputs, blueprintInput{
+			ID:   blueprintInstallInputID(in.Name),
+			Name: in.Name,
+			Type: "short_text",
+		})
+	}
+	for _, s := range data.Secrets {
+		inputs = append(inputs, blueprintInput{
+			ID:          blueprintSecretID(s.Name),
+			Name:        s.Name,
+			Type:        "secret",
+			Description: s.Description,
+		})
+	}
+
+	t, err := template.New("gcp-spacelift-blueprint").Parse(spaceliftBlueprintTmpl)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to parse gcp spacelift blueprint template")
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, spaceliftBlueprintTemplateInput{
+		InstallID:        data.InstallID,
+		TerraformVersion: defaultSpaceliftTerraformVersion,
+		Inputs:           inputs,
+		InputsTfvars:     indentLines(data.InputsTfvars, 10),
+		SecretsTfvars:    indentLines(data.SecretsTfvars, 10),
+	}); err != nil {
+		return "", errors.Wrap(err, "unable to execute gcp spacelift blueprint template")
+	}
+	return strings.TrimLeft(buf.String(), "\n"), nil
+}
+
+// indentLines prefixes every non-empty line of s with n spaces, for embedding
+// tfvars as a YAML block scalar. The trailing newline is dropped so the block
+// doesn't emit a trailing whitespace-only line.
+func indentLines(s string, n int) string {
+	pad := strings.Repeat(" ", n)
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+		lines[i] = pad + line
+	}
+	return strings.Join(lines, "\n")
 }

--- a/services/ctl-api/internal/pkg/stacks/gcp/spacelift.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/spacelift.go
@@ -1,0 +1,52 @@
+package gcp
+
+import (
+	"bytes"
+	"encoding/base64"
+	"text/template"
+
+	"github.com/pkg/errors"
+)
+
+// defaultSpaceliftTerraformVersion is the Terraform version pinned on generated
+// Spacelift stacks/blueprints. Kept in lockstep with the install-stacks//gcp
+// module's versions.tf constraint.
+const defaultSpaceliftTerraformVersion = "1.9.0"
+
+type spaceliftTemplateInput struct {
+	InstallID        string
+	TerraformVersion string
+	InputsB64        string
+	SecretsB64       string
+}
+
+func newSpaceliftTemplateInput(inputsTfvars, secretsTfvars, installID string) spaceliftTemplateInput {
+	return spaceliftTemplateInput{
+		InstallID:        installID,
+		TerraformVersion: defaultSpaceliftTerraformVersion,
+		InputsB64:        base64.StdEncoding.EncodeToString([]byte(inputsTfvars)),
+		SecretsB64:       base64.StdEncoding.EncodeToString([]byte(secretsTfvars)),
+	}
+}
+
+func renderSpaceliftAdminTF(inputsTfvars, secretsTfvars, installID string) (string, error) {
+	return renderSpaceliftTemplate("gcp-spacelift-admin-tf", spaceliftAdminTfTmpl, inputsTfvars, secretsTfvars, installID)
+}
+
+func renderSpaceliftBlueprint(inputsTfvars, secretsTfvars, installID string) (string, error) {
+	return renderSpaceliftTemplate("gcp-spacelift-blueprint", spaceliftBlueprintTmpl, inputsTfvars, secretsTfvars, installID)
+}
+
+func renderSpaceliftTemplate(name, tmpl, inputsTfvars, secretsTfvars, installID string) (string, error) {
+	t, err := template.New(name).Parse(tmpl)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to parse %s template", name)
+	}
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, newSpaceliftTemplateInput(inputsTfvars, secretsTfvars, installID)); err != nil {
+		return "", errors.Wrapf(err, "unable to execute %s template", name)
+	}
+
+	return buf.String(), nil
+}

--- a/services/ctl-api/internal/pkg/stacks/gcp/spacelift_tmpl.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/spacelift_tmpl.go
@@ -2,9 +2,10 @@ package gcp
 
 // spaceliftAdminTfTmpl renders an administrative-stack Terraform config that uses
 // the spacelift-io/spacelift provider to create a stack running the public
-// install-stacks//gcp module. The generated inputs/secrets tfvars are mounted
-// into the stack workspace as base64-encoded files so no values need to live in
-// VCS. The secrets file is write-only so its contents aren't exposed after apply.
+// install-stacks//gcp module. The inputs/secrets tfvars are read from sibling
+// files (delivered alongside this config) rather than embedded, so the customer
+// can edit inputs.auto.tfvars and replace secrets.auto.tfvars before applying.
+// The secrets file is write-only so its contents aren't exposed after apply.
 const spaceliftAdminTfTmpl = `terraform {
   required_providers {
     spacelift = {
@@ -21,36 +22,58 @@ resource "spacelift_stack" "nuon" {
   project_root      = "gcp"
   terraform_version = "{{.TerraformVersion}}"
   autodeploy        = true
+
+  raw_git {
+    namespace = "nuonco"
+    url       = "https://github.com/nuonco/install-stacks.git"
+  }
 }
 
 resource "spacelift_mounted_file" "inputs" {
   stack_id      = spacelift_stack.nuon.id
   relative_path = "source/gcp/inputs.auto.tfvars"
   write_only    = false
-  content       = "{{.InputsB64}}"
+  content       = filebase64("${path.module}/inputs.auto.tfvars")
 }
 
 resource "spacelift_mounted_file" "secrets" {
   stack_id      = spacelift_stack.nuon.id
   relative_path = "source/gcp/secrets.auto.tfvars"
   write_only    = true
-  content       = "{{.SecretsB64}}"
+  content       = filebase64("${path.module}/secrets.auto.tfvars")
 }
 `
 
 // spaceliftBlueprintTmpl renders a Spacelift blueprint that provisions a stack
-// running the public install-stacks//gcp module, mounting the generated
-// inputs/secrets tfvars as base64-encoded files.
-const spaceliftBlueprintTmpl = `inputs: []
+// running the public install-stacks//gcp module. Customer install inputs and
+// secrets are exposed as blueprint inputs and interpolated into the mounted
+// tfvars via CEL (`${{ inputs.<id> }}`); the mounted-file content is plaintext,
+// which is what blueprints expect (unlike the provider's spacelift_mounted_file).
+const spaceliftBlueprintTmpl = `{{- if .Inputs}}
+inputs:
+{{- range .Inputs}}
+  - id: {{.ID}}
+    name: {{.Name}}
+    type: {{.Type}}
+{{- if .Description}}
+    description: {{.Description}}
+{{- end}}
+{{- if .Default}}
+    default: "{{.Default}}"
+{{- end}}
+{{- end}}
+{{- else}}
+inputs: []
+{{- end}}
 stack:
   name: nuon-{{.InstallID}}
   description: Nuon runner install stack for {{.InstallID}}
   space: root
   vcs:
     branch: main
-    repository: install-stacks
+    provider: RAW_GIT
+    repository_url: https://github.com/nuonco/install-stacks.git
     project_root: gcp
-    provider: GITHUB
   vendor:
     terraform:
       manage_state: true
@@ -58,9 +81,11 @@ stack:
   environment:
     mounted_files:
       - path: source/gcp/inputs.auto.tfvars
-        write_only: false
-        content: {{.InputsB64}}
+        secret: false
+        content: |
+{{.InputsTfvars}}
       - path: source/gcp/secrets.auto.tfvars
-        write_only: true
-        content: {{.SecretsB64}}
+        secret: true
+        content: |
+{{.SecretsTfvars}}
 `

--- a/services/ctl-api/internal/pkg/stacks/gcp/spacelift_tmpl.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/spacelift_tmpl.go
@@ -1,0 +1,66 @@
+package gcp
+
+// spaceliftAdminTfTmpl renders an administrative-stack Terraform config that uses
+// the spacelift-io/spacelift provider to create a stack running the public
+// install-stacks//gcp module. The generated inputs/secrets tfvars are mounted
+// into the stack workspace as base64-encoded files so no values need to live in
+// VCS. The secrets file is write-only so its contents aren't exposed after apply.
+const spaceliftAdminTfTmpl = `terraform {
+  required_providers {
+    spacelift = {
+      source = "spacelift-io/spacelift"
+    }
+  }
+}
+
+resource "spacelift_stack" "nuon" {
+  name              = "nuon-{{.InstallID}}"
+  description       = "Nuon runner install stack for {{.InstallID}}"
+  repository        = "install-stacks"
+  branch            = "main"
+  project_root      = "gcp"
+  terraform_version = "{{.TerraformVersion}}"
+  autodeploy        = true
+}
+
+resource "spacelift_mounted_file" "inputs" {
+  stack_id      = spacelift_stack.nuon.id
+  relative_path = "source/gcp/inputs.auto.tfvars"
+  write_only    = false
+  content       = "{{.InputsB64}}"
+}
+
+resource "spacelift_mounted_file" "secrets" {
+  stack_id      = spacelift_stack.nuon.id
+  relative_path = "source/gcp/secrets.auto.tfvars"
+  write_only    = true
+  content       = "{{.SecretsB64}}"
+}
+`
+
+// spaceliftBlueprintTmpl renders a Spacelift blueprint that provisions a stack
+// running the public install-stacks//gcp module, mounting the generated
+// inputs/secrets tfvars as base64-encoded files.
+const spaceliftBlueprintTmpl = `inputs: []
+stack:
+  name: nuon-{{.InstallID}}
+  description: Nuon runner install stack for {{.InstallID}}
+  space: root
+  vcs:
+    branch: main
+    repository: install-stacks
+    project_root: gcp
+    provider: GITHUB
+  vendor:
+    terraform:
+      manage_state: true
+      version: "{{.TerraformVersion}}"
+  environment:
+    mounted_files:
+      - path: source/gcp/inputs.auto.tfvars
+        write_only: false
+        content: {{.InputsB64}}
+      - path: source/gcp/secrets.auto.tfvars
+        write_only: true
+        content: {{.SecretsB64}}
+`

--- a/services/ctl-api/internal/pkg/stacks/gcp/tmpl.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/tmpl.go
@@ -3,13 +3,11 @@ package gcp
 const inputsTmpl = `nuon_install_id          = "{{.Install.ID}}"
 nuon_org_id              = "{{.Runner.OrgID}}"
 nuon_app_id              = "{{.Install.AppID}}"
-{{- if .Install.GCPAccount}}
-{{- if .Install.GCPAccount.ProjectID}}
-gcp_project_id           = "{{.Install.GCPAccount.ProjectID}}"
+{{- if .GCPProjectID}}
+gcp_project_id           = "{{.GCPProjectID}}"
 {{- end}}
-{{- if .Install.GCPAccount.Region}}
-gcp_region               = "{{.Install.GCPAccount.Region}}"
-{{- end}}
+{{- if .GCPRegion}}
+gcp_region               = "{{.GCPRegion}}"
 {{- end}}
 runner_api_url           = "{{.Settings.RunnerAPIURL}}"
 {{- if .APIToken}}
@@ -47,7 +45,7 @@ custom_roles = {
 }
 install_inputs = {
 {{- range .InstallInputs}}
-  "{{.}}" = ""
+  "{{.Name}}" = "{{.Value}}"
 {{- end}}
 }
 `
@@ -58,7 +56,7 @@ secrets = {
   "{{.Name}}" = {
     description = "{{.Description}}"
     required    = {{.Required}}
-    value       = "{{.Default}}"
+    value       = "{{.Value}}"
   }
 {{- end}}
 }

--- a/services/ctl-api/internal/pkg/stacks/gcp/tmpl.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/tmpl.go
@@ -1,6 +1,6 @@
 package gcp
 
-const tmpl = `nuon_install_id          = "{{.Install.ID}}"
+const inputsTmpl = `nuon_install_id          = "{{.Install.ID}}"
 nuon_org_id              = "{{.Runner.OrgID}}"
 nuon_app_id              = "{{.Install.AppID}}"
 {{- if .Install.GCPAccount}}
@@ -50,7 +50,9 @@ install_inputs = {
   "{{.}}" = ""
 {{- end}}
 }
-auto_generate_secrets = [{{range .AutoGenerateSecrets}}"{{.}}", {{end}}]
+`
+
+const secretsTmpl = `auto_generate_secrets = [{{range .AutoGenerateSecrets}}"{{.}}", {{end}}]
 secrets = {
 {{- range .Secrets}}
   "{{.Name}}" = {

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAWSDetails/AwaitAWSDetails.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAWSDetails/AwaitAWSDetails.stories.tsx
@@ -14,21 +14,36 @@ const mockStack = {
   ],
 } as any
 
-const mockTfvars = `nuon_install_id        = "inl4xabsyaqxp0cb2oy5l8urvf"
+const mockInputsTfvars = `nuon_install_id        = "inl4xabsyaqxp0cb2oy5l8urvf"
 nuon_org_id            = "orgnwi4odoca7y0z9wddc1767e"
 nuon_app_id            = "appk2o58477kw8jbounuxpkaqr"
 aws_region             = "us-east-1"
 runner_api_url         = "https://api.nuon.co/runner"
 runner_id              = "run4dbg9i5fzwdlq7zk1llbout"
-runner_init_script_url = "https://raw.githubusercontent.com/nuonco/runner/refs/heads/main/scripts/aws/init.sh"
 phone_home_url         = "https://api.nuon.co/v1/installs/inl4xabsyaqxp0cb2oy5l8urvf/phone-home/aws3no0qz8sxsbqa13dgs2pfb3"
+install_inputs = {
+  "cluster_name" = ""
+}
+`
+
+const mockSecretsTfvars = `auto_generate_secrets = ["db_password", ]
+secrets = {
+  "stripe_key" = {
+    description = "Your Stripe API key"
+    required    = true
+    value       = ""
+  }
+}
 `
 
 const mockStackWithBoth = {
   versions: [
     {
       ...mockStack.versions[0],
-      terraform_contents: JSON.stringify({ tfvars: mockTfvars }),
+      terraform_contents: JSON.stringify({
+        inputs_tfvars: mockInputsTfvars,
+        secrets_tfvars: mockSecretsTfvars,
+      }),
       terraform_checksum: 'sha256-abc',
     },
   ],

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAWSDetails/AwaitAWSDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAWSDetails/AwaitAWSDetails.tsx
@@ -8,6 +8,7 @@ import { Link } from '@/components/common/Link'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Tabs } from '@/components/common/Tabs'
 import { Text } from '@/components/common/Text'
+import { createFileDownload } from '@/utils/file-download'
 import type { IStackDetails } from '../types'
 
 interface IAwaitAWSDetails extends IStackDetails {
@@ -17,10 +18,15 @@ interface IAwaitAWSDetails extends IStackDetails {
 }
 
 // The tfvars envelope ctl-api stores in `terraform_contents` is a JSON
-// document of shape `{"tfvars": "<hcl body>"}`. Mirrors the GCP parser at
-// AwaitGCPDetails.tsx.
-function parseTfvars(contents: unknown): string {
-  if (!contents) return ''
+// document of shape `{"inputs_tfvars": "<hcl>", "secrets_tfvars": "<hcl>"}`.
+// Mirrors the GCP parser at AwaitGCPDetails.tsx.
+interface TfvarsEnvelope {
+  inputs: string
+  secrets: string
+}
+
+function parseTfvars(contents: unknown): TfvarsEnvelope {
+  if (!contents) return { inputs: '', secrets: '' }
 
   let raw: unknown = contents
   if (typeof raw === 'string') {
@@ -30,16 +36,20 @@ function parseTfvars(contents: unknown): string {
       try {
         raw = JSON.parse(atob(raw as string))
       } catch {
-        return ''
+        return { inputs: '', secrets: '' }
       }
     }
   }
 
-  if (typeof raw === 'object' && raw !== null && 'tfvars' in raw) {
-    return String((raw as Record<string, unknown>).tfvars ?? '')
+  if (typeof raw === 'object' && raw !== null) {
+    const rec = raw as Record<string, unknown>
+    return {
+      inputs: String(rec.inputs_tfvars ?? ''),
+      secrets: String(rec.secrets_tfvars ?? ''),
+    }
   }
 
-  return ''
+  return { inputs: '', secrets: '' }
 }
 
 export const AwaitAWSDetails = ({
@@ -58,11 +68,11 @@ export const AwaitAWSDetails = ({
       })
     | undefined
 
-  const tfvarsContent = useMemo(
+  const tfvars = useMemo(
     () => parseTfvars(versionExt?.terraform_contents),
     [versionExt?.terraform_contents]
   )
-  const hasTerraform = tfvarsContent.length > 0
+  const hasTerraform = tfvars.inputs.length > 0 || tfvars.secrets.length > 0
 
   return (
     <div className="flex flex-col gap-4">
@@ -83,7 +93,8 @@ export const AwaitAWSDetails = ({
             ),
             terraform: (
               <TerraformTab
-                tfvarsContent={tfvarsContent}
+                inputsTfvars={tfvars.inputs}
+                secretsTfvars={tfvars.secrets}
                 installId={installId}
               />
             ),
@@ -251,11 +262,16 @@ const CloudFormationTab = ({
 }
 
 interface ITerraformTab {
-  tfvarsContent: string
+  inputsTfvars: string
+  secretsTfvars: string
   installId?: string
 }
 
-const TerraformTab = ({ tfvarsContent, installId }: ITerraformTab) => {
+const TerraformTab = ({
+  inputsTfvars,
+  secretsTfvars,
+  installId,
+}: ITerraformTab) => {
   const cloneCmd = `git clone https://github.com/nuonco/install-stacks.git
 cd install-stacks/aws`
 
@@ -267,7 +283,7 @@ cd install-stacks/aws`
   }
 }`
 
-  const applyCmd = `terraform init && terraform apply -var-file=install.tfvars`
+  const applyCmd = `terraform init && terraform apply`
 
   return (
     <div className="flex flex-col gap-4 pt-4">
@@ -312,11 +328,42 @@ cd install-stacks/aws`
         <Card>
           <span className="flex justify-between items-center">
             <Text>
-              Save this as <code>install.tfvars</code>
+              Save this as <code>inputs.auto.tfvars</code>
             </Text>
-            <ClickToCopyButton textToCopy={tfvarsContent} />
+            <span className="flex gap-2 items-center">
+              <ClickToCopyButton textToCopy={inputsTfvars} />
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() =>
+                  createFileDownload(inputsTfvars, 'inputs.auto.tfvars')
+                }
+              >
+                Download
+              </Button>
+            </span>
           </span>
-          <Code variant="preformated">{tfvarsContent}</Code>
+          <Code variant="preformated">{inputsTfvars}</Code>
+        </Card>
+        <Card>
+          <span className="flex justify-between items-center">
+            <Text>
+              Save this as <code>secrets.auto.tfvars</code>
+            </Text>
+            <span className="flex gap-2 items-center">
+              <ClickToCopyButton textToCopy={secretsTfvars} />
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() =>
+                  createFileDownload(secretsTfvars, 'secrets.auto.tfvars')
+                }
+              >
+                Download
+              </Button>
+            </span>
+          </span>
+          <Code variant="preformated">{secretsTfvars}</Code>
         </Card>
       </div>
 

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.stories.tsx
@@ -25,45 +25,79 @@ resource "spacelift_stack" "nuon" {
   repository        = "install-stacks"
   branch            = "main"
   project_root      = "gcp"
-  terraform_version = "1.9.0"
+  terraform_version = "1.5.7"
   autodeploy        = true
+
+  raw_git {
+    namespace = "nuonco"
+    url       = "https://github.com/nuonco/install-stacks.git"
+  }
 }
 
 resource "spacelift_mounted_file" "inputs" {
   stack_id      = spacelift_stack.nuon.id
   relative_path = "source/gcp/inputs.auto.tfvars"
   write_only    = false
-  content       = "bnVvbl9pbnN0YWxsX2lkID0gImluc3RhbGwtMSIK"
+  content       = filebase64("\${path.module}/inputs.auto.tfvars")
 }
 
 resource "spacelift_mounted_file" "secrets" {
   stack_id      = spacelift_stack.nuon.id
   relative_path = "source/gcp/secrets.auto.tfvars"
   write_only    = true
-  content       = "YXV0b19nZW5lcmF0ZV9zZWNyZXRzID0gW10K"
+  content       = filebase64("\${path.module}/secrets.auto.tfvars")
 }
 `,
-        spacelift_blueprint_yaml: `inputs: []
+        spacelift_blueprint_yaml: `inputs:
+  - id: gcp_project_id
+    name: GCP project ID
+    type: short_text
+    default: "my-gcp-project"
+  - id: gcp_region
+    name: GCP region
+    type: short_text
+    default: "us-central1"
+  - id: input_cluster_name
+    name: cluster_name
+    type: short_text
+  - id: secret_stripe_key
+    name: stripe_key
+    type: secret
+    description: Your Stripe API key
 stack:
   name: nuon-install-1
   space: root
   vcs:
     branch: main
-    repository: install-stacks
+    provider: RAW_GIT
+    repository_url: https://github.com/nuonco/install-stacks.git
     project_root: gcp
-    provider: GITHUB
   vendor:
     terraform:
       manage_state: true
-      version: "1.9.0"
+      version: "1.5.7"
   environment:
     mounted_files:
       - path: source/gcp/inputs.auto.tfvars
-        write_only: false
-        content: bnVvbl9pbnN0YWxsX2lkID0gImluc3RhbGwtMSIK
+        secret: false
+        content: |
+          nuon_install_id = "install-1"
+          gcp_project_id = "\${{ inputs.gcp_project_id }}"
+          gcp_region = "\${{ inputs.gcp_region }}"
+          install_inputs = {
+            "cluster_name" = "\${{ inputs.input_cluster_name }}"
+          }
       - path: source/gcp/secrets.auto.tfvars
-        write_only: true
-        content: YXV0b19nZW5lcmF0ZV9zZWNyZXRzID0gW10K
+        secret: true
+        content: |
+          auto_generate_secrets = []
+          secrets = {
+            "stripe_key" = {
+              description = "Your Stripe API key"
+              required    = true
+              value       = "\${{ inputs.secret_stripe_key }}"
+            }
+          }
 `,
       }),
     },

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.stories.tsx
@@ -12,6 +12,59 @@ const mockStack = {
           'nuon_install_id = "install-1"\ninstall_inputs = {\n  "cluster_name" = ""\n}\n',
         secrets_tfvars:
           'auto_generate_secrets = ["db_password", ]\nsecrets = {\n  "stripe_key" = {\n    description = "Your Stripe API key"\n    required    = true\n    value       = ""\n  }\n}\n',
+        spacelift_admin_tf: `terraform {
+  required_providers {
+    spacelift = {
+      source = "spacelift-io/spacelift"
+    }
+  }
+}
+
+resource "spacelift_stack" "nuon" {
+  name              = "nuon-install-1"
+  repository        = "install-stacks"
+  branch            = "main"
+  project_root      = "gcp"
+  terraform_version = "1.9.0"
+  autodeploy        = true
+}
+
+resource "spacelift_mounted_file" "inputs" {
+  stack_id      = spacelift_stack.nuon.id
+  relative_path = "source/gcp/inputs.auto.tfvars"
+  write_only    = false
+  content       = "bnVvbl9pbnN0YWxsX2lkID0gImluc3RhbGwtMSIK"
+}
+
+resource "spacelift_mounted_file" "secrets" {
+  stack_id      = spacelift_stack.nuon.id
+  relative_path = "source/gcp/secrets.auto.tfvars"
+  write_only    = true
+  content       = "YXV0b19nZW5lcmF0ZV9zZWNyZXRzID0gW10K"
+}
+`,
+        spacelift_blueprint_yaml: `inputs: []
+stack:
+  name: nuon-install-1
+  space: root
+  vcs:
+    branch: main
+    repository: install-stacks
+    project_root: gcp
+    provider: GITHUB
+  vendor:
+    terraform:
+      manage_state: true
+      version: "1.9.0"
+  environment:
+    mounted_files:
+      - path: source/gcp/inputs.auto.tfvars
+        write_only: false
+        content: bnVvbl9pbnN0YWxsX2lkID0gImluc3RhbGwtMSIK
+      - path: source/gcp/secrets.auto.tfvars
+        write_only: true
+        content: YXV0b19nZW5lcmF0ZV9zZWNyZXRzID0gW10K
+`,
       }),
     },
   ],

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.stories.tsx
@@ -111,6 +111,17 @@ const mockStep = {
 
 export const Default = () => (
   <div className="max-w-2xl p-4">
+    <AwaitGCPDetails
+      stack={mockStack}
+      step={mockStep}
+      installId="install-1"
+      spaceliftEnabled
+    />
+  </div>
+)
+
+export const SpaceliftDisabled = () => (
+  <div className="max-w-2xl p-4">
     <AwaitGCPDetails stack={mockStack} step={mockStep} installId="install-1" />
   </div>
 )

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.stories.tsx
@@ -7,7 +7,12 @@ import { AwaitGCPDetails, AwaitGCPDetailsSkeleton } from './AwaitGCPDetails'
 const mockStack = {
   versions: [
     {
-      contents: JSON.stringify({ tfvars: 'install_id = "install-1"' }),
+      contents: JSON.stringify({
+        inputs_tfvars:
+          'nuon_install_id = "install-1"\ninstall_inputs = {\n  "cluster_name" = ""\n}\n',
+        secrets_tfvars:
+          'auto_generate_secrets = ["db_password", ]\nsecrets = {\n  "stripe_key" = {\n    description = "Your Stripe API key"\n    required    = true\n    value       = ""\n  }\n}\n',
+      }),
     },
   ],
 } as any

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
@@ -4,6 +4,7 @@ import { Card } from '@/components/common/Card'
 import { ClickToCopyButton } from '@/components/common/ClickToCopy'
 import { Code } from '@/components/common/Code'
 import { Divider } from '@/components/common/Divider'
+import { Link } from '@/components/common/Link'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Tabs } from '@/components/common/Tabs'
 import { Text } from '@/components/common/Text'
@@ -87,6 +88,8 @@ export const AwaitGCPDetails = ({ stack, installId }: IAwaitGCPDetails) => {
               <SpaceliftTab
                 adminTf={envelope.spaceliftAdminTf}
                 blueprintYaml={envelope.spaceliftBlueprintYaml}
+                inputsTfvars={envelope.inputs}
+                secretsTfvars={envelope.secrets}
               />
             ),
           }}
@@ -231,9 +234,16 @@ cd install-stacks/gcp`
 interface ISpaceliftTab {
   adminTf: string
   blueprintYaml: string
+  inputsTfvars: string
+  secretsTfvars: string
 }
 
-const SpaceliftTab = ({ adminTf, blueprintYaml }: ISpaceliftTab) => {
+const SpaceliftTab = ({
+  adminTf,
+  blueprintYaml,
+  inputsTfvars,
+  secretsTfvars,
+}: ISpaceliftTab) => {
   return (
     <div className="flex flex-col gap-4 pt-4">
       <Text variant="subtext" theme="neutral">
@@ -242,15 +252,58 @@ const SpaceliftTab = ({ adminTf, blueprintYaml }: ISpaceliftTab) => {
         generated tfvars — pick whichever fits how you manage Spacelift.
       </Text>
 
+      <Tabs
+        initActiveTab="blueprint"
+        tabs={{
+          blueprint: <BlueprintSubTab blueprintYaml={blueprintYaml} />,
+          'administrative stack': (
+            <AdminStackSubTab
+              adminTf={adminTf}
+              inputsTfvars={inputsTfvars}
+              secretsTfvars={secretsTfvars}
+            />
+          ),
+        }}
+      />
+    </div>
+  )
+}
+
+interface IAdminStackSubTab {
+  adminTf: string
+  inputsTfvars: string
+  secretsTfvars: string
+}
+
+const AdminStackSubTab = ({
+  adminTf,
+  inputsTfvars,
+  secretsTfvars,
+}: IAdminStackSubTab) => {
+  return (
+    <div className="flex flex-col gap-4 pt-4">
+      <Text variant="subtext" theme="neutral">
+        The stack that runs this <code>spacelift.tf</code> is the administrative
+        (parent) stack — its run uses the Spacelift Terraform provider to create
+        the install stack and mount your tfvars.
+      </Text>
+
       <div className="flex flex-col gap-4">
         <Text variant="base" weight="strong">
-          Option A — administrative stack
+          1. Save these files together in a repo
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          Commit all three to one directory of a Git repo connected to
+          Spacelift. The <code>spacelift.tf</code> reads the tfvars from its
+          sibling files, so you can edit <code>inputs.auto.tfvars</code> and
+          replace <code>secrets.auto.tfvars</code> with your real secret values
+          before applying. Use a private repo — the secrets file is plaintext at
+          rest here.
         </Text>
         <Card>
           <span className="flex justify-between items-center">
             <Text>
-              Apply this from an existing admin stack as{' '}
-              <code>spacelift.tf</code>
+              Save this as <code>spacelift.tf</code>
             </Text>
             <span className="flex gap-2 items-center">
               <ClickToCopyButton textToCopy={adminTf} />
@@ -265,19 +318,153 @@ const SpaceliftTab = ({ adminTf, blueprintYaml }: ISpaceliftTab) => {
           </span>
           <Code variant="preformated">{adminTf}</Code>
         </Card>
-      </div>
-
-      <Divider dividerWord="or" />
-
-      <div className="flex flex-col gap-4">
-        <Text variant="base" weight="strong">
-          Option B — blueprint
-        </Text>
         <Card>
           <span className="flex justify-between items-center">
             <Text>
-              Import and publish this blueprint, then create a stack from it
+              Save this as <code>inputs.auto.tfvars</code>
             </Text>
+            <span className="flex gap-2 items-center">
+              <ClickToCopyButton textToCopy={inputsTfvars} />
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() =>
+                  createFileDownload(inputsTfvars, 'inputs.auto.tfvars')
+                }
+              >
+                Download
+              </Button>
+            </span>
+          </span>
+          <Code variant="preformated">{inputsTfvars}</Code>
+        </Card>
+        <Card>
+          <span className="flex justify-between items-center">
+            <Text>
+              Save this as <code>secrets.auto.tfvars</code>
+            </Text>
+            <span className="flex gap-2 items-center">
+              <ClickToCopyButton textToCopy={secretsTfvars} />
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() =>
+                  createFileDownload(secretsTfvars, 'secrets.auto.tfvars')
+                }
+              >
+                Download
+              </Button>
+            </span>
+          </span>
+          <Code variant="preformated">{secretsTfvars}</Code>
+        </Card>
+      </div>
+
+      <Divider />
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          2. Create the parent stack
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          In Spacelift, create a Terraform stack pointed at your repo. Set the{' '}
+          <strong>project root</strong> to the directory holding the three
+          files, pick your branch, and choose a Terraform version at or above
+          the one pinned in <code>spacelift.tf</code>. See{' '}
+          <Link
+            href="https://docs.spacelift.io/concepts/stack/creating-a-stack"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Creating a stack
+          </Link>
+          .
+        </Text>
+      </div>
+
+      <Divider />
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          3. Grant it permission to manage Spacelift
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          The provider authenticates automatically — Spacelift injects{' '}
+          <code>SPACELIFT_API_TOKEN</code> into runs of stacks that have a role
+          attached. Open the stack&apos;s <strong>Settings → Roles</strong>,
+          click <strong>Manage roles</strong>, and add the{' '}
+          <strong>Space Admin</strong> role for its space. This replaces the
+          deprecated Administrative flag. See{' '}
+          <Link
+            href="https://docs.spacelift.io/concepts/authorization/assigning-roles-stacks"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Assigning roles to stacks
+          </Link>{' '}
+          and the{' '}
+          <Link
+            href="https://docs.spacelift.io/vendors/terraform/terraform-provider"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Terraform provider
+          </Link>{' '}
+          docs.
+        </Text>
+      </div>
+
+      <Divider />
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          4. Run it
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          Trigger a run on the parent stack. On apply it creates the install
+          stack and mounts your tfvars. A newly created stack doesn&apos;t run
+          on its own, so trigger the install stack&apos;s first run — it&apos;s
+          set to auto-deploy, so it plans and applies your runner without
+          further approval.
+        </Text>
+      </div>
+    </div>
+  )
+}
+
+interface IBlueprintSubTab {
+  blueprintYaml: string
+}
+
+const BlueprintSubTab = ({ blueprintYaml }: IBlueprintSubTab) => {
+  return (
+    <div className="flex flex-col gap-4 pt-4">
+      <Text variant="subtext" theme="neutral">
+        A blueprint is a template Spacelift uses to create a stack. This one
+        embeds your tfvars, so publishing it and creating a stack provisions the
+        install with no extra configuration. See{' '}
+        <Link
+          href="https://docs.spacelift.io/concepts/blueprint/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Blueprints
+        </Link>
+        .
+      </Text>
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          1. Create the blueprint
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          In Spacelift, go to <strong>Blueprints → Create blueprint</strong> and
+          paste this YAML as the template body. It starts as a draft you can
+          edit freely.
+        </Text>
+        <Card>
+          <span className="flex justify-between items-center">
+            <Text>Blueprint template body</Text>
             <span className="flex gap-2 items-center">
               <ClickToCopyButton textToCopy={blueprintYaml} />
               <Button
@@ -293,6 +480,57 @@ const SpaceliftTab = ({ adminTf, blueprintYaml }: ISpaceliftTab) => {
           </span>
           <Code variant="preformated">{blueprintYaml}</Code>
         </Card>
+      </div>
+
+      <Divider />
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          2. Publish it
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          Click <strong>Publish</strong> to move the blueprint from draft to
+          published. The template clones the public{' '}
+          <code>install-stacks</code> repository over raw Git, so no VCS
+          integration setup is required. Publishing is one-way — to change a
+          published blueprint you clone it, edit, and publish again.
+        </Text>
+      </div>
+
+      <Divider />
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          3. Create a stack and fill in the inputs
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          On the published blueprint, click <strong>Create stack</strong> and
+          fill in the GCP project, region, and any install inputs and secrets.
+          This creates the stack but doesn&apos;t run it yet.
+        </Text>
+      </div>
+
+      <Divider />
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          4. Attach GCP credentials, then trigger the run
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          Open the new stack&apos;s{' '}
+          <strong>Settings → Integrations</strong> and attach your{' '}
+          <Link
+            href="https://docs.spacelift.io/integrations/cloud-providers/gcp"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GCP integration
+          </Link>{' '}
+          (its service account must already have IAM access on the target
+          project). Then trigger the stack&apos;s first run — it provisions the
+          runner. The run isn&apos;t triggered automatically because GCP
+          credentials can&apos;t be attached from the blueprint itself.
+        </Text>
       </div>
     </div>
   )

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
@@ -55,17 +55,23 @@ function parseEnvelope(contents: unknown): StackEnvelope {
 
 interface IAwaitGCPDetails extends IStackDetails {
   installId?: string
+  spaceliftEnabled?: boolean
 }
 
-export const AwaitGCPDetails = ({ stack, installId }: IAwaitGCPDetails) => {
+export const AwaitGCPDetails = ({
+  stack,
+  installId,
+  spaceliftEnabled,
+}: IAwaitGCPDetails) => {
   const version = stack?.versions?.at(0)
   const envelope = useMemo(
     () => parseEnvelope(version?.contents),
     [version?.contents]
   )
   const hasSpacelift =
-    envelope.spaceliftAdminTf.length > 0 ||
-    envelope.spaceliftBlueprintYaml.length > 0
+    !!spaceliftEnabled &&
+    (envelope.spaceliftAdminTf.length > 0 ||
+      envelope.spaceliftBlueprintYaml.length > 0)
 
   return (
     <div className="flex flex-col gap-4">

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
@@ -5,17 +5,26 @@ import { ClickToCopyButton } from '@/components/common/ClickToCopy'
 import { Code } from '@/components/common/Code'
 import { Divider } from '@/components/common/Divider'
 import { Skeleton } from '@/components/common/Skeleton'
+import { Tabs } from '@/components/common/Tabs'
 import { Text } from '@/components/common/Text'
 import { createFileDownload } from '@/utils/file-download'
 import type { IStackDetails } from '../types'
 
-interface TfvarsEnvelope {
+interface StackEnvelope {
   inputs: string
   secrets: string
+  spaceliftAdminTf: string
+  spaceliftBlueprintYaml: string
 }
 
-function parseTfvars(contents: unknown): TfvarsEnvelope {
-  if (!contents) return { inputs: '', secrets: '' }
+function parseEnvelope(contents: unknown): StackEnvelope {
+  const empty: StackEnvelope = {
+    inputs: '',
+    secrets: '',
+    spaceliftAdminTf: '',
+    spaceliftBlueprintYaml: '',
+  }
+  if (!contents) return empty
 
   let raw = contents
   if (typeof raw === 'string') {
@@ -25,7 +34,7 @@ function parseTfvars(contents: unknown): TfvarsEnvelope {
       try {
         raw = JSON.parse(atob(raw as string))
       } catch {
-        return { inputs: '', secrets: '' }
+        return empty
       }
     }
   }
@@ -35,10 +44,12 @@ function parseTfvars(contents: unknown): TfvarsEnvelope {
     return {
       inputs: String(rec.inputs_tfvars ?? ''),
       secrets: String(rec.secrets_tfvars ?? ''),
+      spaceliftAdminTf: String(rec.spacelift_admin_tf ?? ''),
+      spaceliftBlueprintYaml: String(rec.spacelift_blueprint_yaml ?? ''),
     }
   }
 
-  return { inputs: '', secrets: '' }
+  return empty
 }
 
 interface IAwaitGCPDetails extends IStackDetails {
@@ -47,11 +58,61 @@ interface IAwaitGCPDetails extends IStackDetails {
 
 export const AwaitGCPDetails = ({ stack, installId }: IAwaitGCPDetails) => {
   const version = stack?.versions?.at(0)
-  const tfvars = useMemo(
-    () => parseTfvars(version?.contents),
+  const envelope = useMemo(
+    () => parseEnvelope(version?.contents),
     [version?.contents]
   )
+  const hasSpacelift =
+    envelope.spaceliftAdminTf.length > 0 ||
+    envelope.spaceliftBlueprintYaml.length > 0
 
+  return (
+    <div className="flex flex-col gap-4">
+      <Text variant="base" weight="strong">
+        Setup your install stack
+      </Text>
+
+      {hasSpacelift ? (
+        <Tabs
+          initActiveTab="terraform"
+          tabs={{
+            terraform: (
+              <TerraformTab
+                inputsTfvars={envelope.inputs}
+                secretsTfvars={envelope.secrets}
+                installId={installId}
+              />
+            ),
+            spacelift: (
+              <SpaceliftTab
+                adminTf={envelope.spaceliftAdminTf}
+                blueprintYaml={envelope.spaceliftBlueprintYaml}
+              />
+            ),
+          }}
+        />
+      ) : (
+        <TerraformTab
+          inputsTfvars={envelope.inputs}
+          secretsTfvars={envelope.secrets}
+          installId={installId}
+        />
+      )}
+    </div>
+  )
+}
+
+interface ITerraformTab {
+  inputsTfvars: string
+  secretsTfvars: string
+  installId?: string
+}
+
+const TerraformTab = ({
+  inputsTfvars,
+  secretsTfvars,
+  installId,
+}: ITerraformTab) => {
   const cloneCmd = `git clone https://github.com/nuonco/install-stacks.git
 cd install-stacks/gcp`
 
@@ -65,7 +126,7 @@ cd install-stacks/gcp`
   const applyCmd = `terraform init && terraform apply`
 
   return (
-    <>
+    <div className="flex flex-col gap-4 pt-4">
       <div className="flex flex-col gap-4">
         <Text variant="base" weight="strong">
           1. Clone the install stack module
@@ -112,19 +173,19 @@ cd install-stacks/gcp`
               Save this as <code>inputs.auto.tfvars</code>
             </Text>
             <span className="flex gap-2 items-center">
-              <ClickToCopyButton textToCopy={tfvars.inputs} />
+              <ClickToCopyButton textToCopy={inputsTfvars} />
               <Button
                 size="sm"
                 variant="secondary"
                 onClick={() =>
-                  createFileDownload(tfvars.inputs, 'inputs.auto.tfvars')
+                  createFileDownload(inputsTfvars, 'inputs.auto.tfvars')
                 }
               >
                 Download
               </Button>
             </span>
           </span>
-          <Code variant="preformated">{tfvars.inputs}</Code>
+          <Code variant="preformated">{inputsTfvars}</Code>
         </Card>
         <Card>
           <span className="flex justify-between items-center">
@@ -132,19 +193,19 @@ cd install-stacks/gcp`
               Save this as <code>secrets.auto.tfvars</code>
             </Text>
             <span className="flex gap-2 items-center">
-              <ClickToCopyButton textToCopy={tfvars.secrets} />
+              <ClickToCopyButton textToCopy={secretsTfvars} />
               <Button
                 size="sm"
                 variant="secondary"
                 onClick={() =>
-                  createFileDownload(tfvars.secrets, 'secrets.auto.tfvars')
+                  createFileDownload(secretsTfvars, 'secrets.auto.tfvars')
                 }
               >
                 Download
               </Button>
             </span>
           </span>
-          <Code variant="preformated">{tfvars.secrets}</Code>
+          <Code variant="preformated">{secretsTfvars}</Code>
         </Card>
       </div>
 
@@ -163,7 +224,77 @@ cd install-stacks/gcp`
           <Code variant="preformated">{applyCmd}</Code>
         </Card>
       </div>
-    </>
+    </div>
+  )
+}
+
+interface ISpaceliftTab {
+  adminTf: string
+  blueprintYaml: string
+}
+
+const SpaceliftTab = ({ adminTf, blueprintYaml }: ISpaceliftTab) => {
+  return (
+    <div className="flex flex-col gap-4 pt-4">
+      <Text variant="subtext" theme="neutral">
+        Run the install stack in Spacelift instead of applying Terraform
+        yourself. Both options run the same install-stacks module and mount your
+        generated tfvars — pick whichever fits how you manage Spacelift.
+      </Text>
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          Option A — administrative stack
+        </Text>
+        <Card>
+          <span className="flex justify-between items-center">
+            <Text>
+              Apply this from an existing admin stack as{' '}
+              <code>spacelift.tf</code>
+            </Text>
+            <span className="flex gap-2 items-center">
+              <ClickToCopyButton textToCopy={adminTf} />
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => createFileDownload(adminTf, 'spacelift.tf')}
+              >
+                Download
+              </Button>
+            </span>
+          </span>
+          <Code variant="preformated">{adminTf}</Code>
+        </Card>
+      </div>
+
+      <Divider dividerWord="or" />
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          Option B — blueprint
+        </Text>
+        <Card>
+          <span className="flex justify-between items-center">
+            <Text>
+              Import and publish this blueprint, then create a stack from it
+            </Text>
+            <span className="flex gap-2 items-center">
+              <ClickToCopyButton textToCopy={blueprintYaml} />
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() =>
+                  createFileDownload(blueprintYaml, 'blueprint.yaml')
+                }
+              >
+                Download
+              </Button>
+            </span>
+          </span>
+          <Code variant="preformated">{blueprintYaml}</Code>
+        </Card>
+      </div>
+    </div>
   )
 }
 

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
@@ -1,14 +1,21 @@
 import { useMemo } from 'react'
+import { Button } from '@/components/common/Button'
 import { Card } from '@/components/common/Card'
 import { ClickToCopyButton } from '@/components/common/ClickToCopy'
 import { Code } from '@/components/common/Code'
 import { Divider } from '@/components/common/Divider'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Text } from '@/components/common/Text'
+import { createFileDownload } from '@/utils/file-download'
 import type { IStackDetails } from '../types'
 
-function parseTfvars(contents: unknown): string {
-  if (!contents) return ''
+interface TfvarsEnvelope {
+  inputs: string
+  secrets: string
+}
+
+function parseTfvars(contents: unknown): TfvarsEnvelope {
+  if (!contents) return { inputs: '', secrets: '' }
 
   let raw = contents
   if (typeof raw === 'string') {
@@ -18,16 +25,20 @@ function parseTfvars(contents: unknown): string {
       try {
         raw = JSON.parse(atob(raw as string))
       } catch {
-        return ''
+        return { inputs: '', secrets: '' }
       }
     }
   }
 
-  if (typeof raw === 'object' && raw !== null && 'tfvars' in raw) {
-    return String((raw as Record<string, unknown>).tfvars ?? '')
+  if (typeof raw === 'object' && raw !== null) {
+    const rec = raw as Record<string, unknown>
+    return {
+      inputs: String(rec.inputs_tfvars ?? ''),
+      secrets: String(rec.secrets_tfvars ?? ''),
+    }
   }
 
-  return ''
+  return { inputs: '', secrets: '' }
 }
 
 interface IAwaitGCPDetails extends IStackDetails {
@@ -36,7 +47,7 @@ interface IAwaitGCPDetails extends IStackDetails {
 
 export const AwaitGCPDetails = ({ stack, installId }: IAwaitGCPDetails) => {
   const version = stack?.versions?.at(0)
-  const tfvarsContent = useMemo(
+  const tfvars = useMemo(
     () => parseTfvars(version?.contents),
     [version?.contents]
   )
@@ -51,7 +62,7 @@ cd install-stacks/gcp`
   }
 }`
 
-  const applyCmd = `terraform init && terraform apply -var-file=install.tfvars`
+  const applyCmd = `terraform init && terraform apply`
 
   return (
     <>
@@ -98,11 +109,42 @@ cd install-stacks/gcp`
         <Card>
           <span className="flex justify-between items-center">
             <Text>
-              Save this as <code>install.tfvars</code>
+              Save this as <code>inputs.auto.tfvars</code>
             </Text>
-            <ClickToCopyButton textToCopy={tfvarsContent} />
+            <span className="flex gap-2 items-center">
+              <ClickToCopyButton textToCopy={tfvars.inputs} />
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() =>
+                  createFileDownload(tfvars.inputs, 'inputs.auto.tfvars')
+                }
+              >
+                Download
+              </Button>
+            </span>
           </span>
-          <Code variant="preformated">{tfvarsContent}</Code>
+          <Code variant="preformated">{tfvars.inputs}</Code>
+        </Card>
+        <Card>
+          <span className="flex justify-between items-center">
+            <Text>
+              Save this as <code>secrets.auto.tfvars</code>
+            </Text>
+            <span className="flex gap-2 items-center">
+              <ClickToCopyButton textToCopy={tfvars.secrets} />
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() =>
+                  createFileDownload(tfvars.secrets, 'secrets.auto.tfvars')
+                }
+              >
+                Download
+              </Button>
+            </span>
+          </span>
+          <Code variant="preformated">{tfvars.secrets}</Code>
         </Card>
       </div>
 

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetailsContainer.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetailsContainer.tsx
@@ -2,7 +2,22 @@ import { useInstall } from '@/hooks/use-install'
 import { AwaitGCPDetails } from './AwaitGCPDetails'
 import type { IStackDetails } from '../types'
 
-export const AwaitGCPDetailsContainer = ({ stack, step }: IStackDetails) => {
+interface IAwaitGCPDetailsContainer extends IStackDetails {
+  spaceliftEnabled?: boolean
+}
+
+export const AwaitGCPDetailsContainer = ({
+  stack,
+  step,
+  spaceliftEnabled,
+}: IAwaitGCPDetailsContainer) => {
   const { install } = useInstall()
-  return <AwaitGCPDetails stack={stack} step={step} installId={install?.id} />
+  return (
+    <AwaitGCPDetails
+      stack={stack}
+      step={step}
+      installId={install?.id}
+      spaceliftEnabled={spaceliftEnabled}
+    />
+  )
 }

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitStackDetails/AwaitStackDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitStackDetails/AwaitStackDetails.tsx
@@ -23,9 +23,15 @@ import type { IStackDetails } from '../types'
 
 interface IAwaitStackDetails extends IStackDetails {
   runnerType?: string
+  spaceliftEnabled?: boolean
 }
 
-export const AwaitStackDetails = ({ stack, runnerType, ...props }: IAwaitStackDetails) => {
+export const AwaitStackDetails = ({
+  stack,
+  runnerType,
+  spaceliftEnabled,
+  ...props
+}: IAwaitStackDetails) => {
   const outputValues = useMemo(
     () => objectToKeyValueArray(stack?.install_stack_outputs?.data_contents),
     [stack?.install_stack_outputs]
@@ -67,7 +73,11 @@ export const AwaitStackDetails = ({ stack, runnerType, ...props }: IAwaitStackDe
       {runnerType?.startsWith('aws') ? (
         <AwaitAWSDetails stack={stack} {...props} />
       ) : runnerType === 'gcp' ? (
-        <AwaitGCPDetails stack={stack} {...props} />
+        <AwaitGCPDetails
+          stack={stack}
+          spaceliftEnabled={spaceliftEnabled}
+          {...props}
+        />
       ) : (
         <AwaitAzureDetails stack={stack} {...props} />
       )}

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitStackDetails/AwaitStackDetailsContainer.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitStackDetails/AwaitStackDetailsContainer.tsx
@@ -1,12 +1,15 @@
 import { useInstall } from '@/hooks/use-install'
+import { useOrg } from '@/hooks/use-org'
 import { AwaitStackDetails, AwaitStackDetailsSkeleton } from './AwaitStackDetails'
 import type { IStackDetails } from '../types'
 
 export const AwaitStackDetailsContainer = (props: IStackDetails) => {
   const { install } = useInstall()
+  const { org } = useOrg()
   return (
     <AwaitStackDetails
       runnerType={install?.app_runner_config?.app_runner_type}
+      spaceliftEnabled={!!org?.features?.['spacelift-install-stacks']}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary

Driven by a potential customer interest in using Spacelift to manage install stacks, this PR adds support for provisioning an install stack using two new methods, along with some quality-of-life updates to the Terraform method.

The Spacelift method is behind a feature toggle.

### Spacelift Blueprints

Configure and provision an install stack using the Spacelift UI. The customer can install the blueprint, create a stack, and configure it using Spacelift stack inputs and secrets.

<img width="3024" height="1964" alt="Screenshot 2026-07-05 at 13 42 37" src="https://github.com/user-attachments/assets/b48615e2-28d2-458a-b446-cf80f72e0fb8" />

### Spacelift Administrative Stacks

Configure and provision an install using the Spacelift Terraform provider. The customer can copy the generated terraform config into their VCS, and add the variables and secrets into Spacelift (or whatever secret store their using.)

<img width="3024" height="1964" alt="Screenshot 2026-07-05 at 13 42 44" src="https://github.com/user-attachments/assets/15cb2d50-c0f8-4c8a-aa80-4bfb6084c4f5" />

### Terraform

This PR also splits up the generated `install.tfvars` file to break out secrets, and renames the files so they will be picked up by the terraform CLI automatically.



