### PR TITLE
feat: install stack docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -167,7 +167,10 @@
 							"guides/install-configs",
 							"guides/component-overrides",
 							"guides/runner-kill-switch",
-							"guides/custom-domains"
+							"guides/custom-domains",
+							"guides/provision-stacks-with-cloudformation",
+							"guides/provision-stacks-with-terraform",
+							"guides/provision-stacks-with-spacelift"
 						]
 					},
 					{
@@ -202,7 +205,6 @@
 							"guides/programmable-readmes",
 							"guides/custom-nested-stacks",
 							"guides/customizing-terraform-stack-templates",
-							"guides/provisioning-install-stacks-with-spacelift",
 							"guides/cli-extensions",
 							"guides/external-image-policies",
 							"guides/terraform-cli"

--- a/docs/guides/provision-stacks-with-cloudformation.mdx
+++ b/docs/guides/provision-stacks-with-cloudformation.mdx
@@ -1,0 +1,72 @@
+---
+title: "Provision Stacks with CloudFormation"
+description: "Provision the Nuon AWS install stack with CloudFormation — launch the generated template from the AWS console or the AWS CLI."
+icon: "aws"
+boost: 10
+keywords: ["cloudformation", "install-stacks", "install stack", "aws", "create-stack", "template", "quick create", "aws cli"]
+---
+
+The install stack provisions the runner in your customer's AWS account. AWS installs can use a **CloudFormation**
+stack, and this guide walks through launching the generated template. When an install uses a CloudFormation stack, the
+**await install stack** step in the dashboard surfaces a one-click launch link, the template URL, and ready-to-run AWS
+CLI commands.
+
+<Note>CloudFormation is AWS-only. For AWS you can also use a [Terraform stack](/guides/provision-stacks-with-terraform); GCP and Azure use Terraform.</Note>
+
+## Prerequisites
+
+- **AWS access** — access to the target AWS account with permission to create CloudFormation stacks and the IAM
+  resources the template defines. The stack is created with the `CAPABILITY_NAMED_IAM` capability.
+- **AWS CLI (optional)** — to launch from the command line, install and configure the
+  [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) with credentials for the
+  target account.
+
+## Launch from the AWS console
+
+<Steps>
+  <Step title="Open the quick-launch link">
+    On the await install stack step, click **Quick launch in AWS console**. This opens CloudFormation's quick-create
+    flow with the template URL and stack name prefilled. If you don't see the link, open the AWS console in your target
+    region and create a stack from the template URL shown on the step.
+  </Step>
+  <Step title="Create the stack">
+    Review the stack, acknowledge that it creates named IAM resources, and create it. CloudFormation provisions the
+    runner in your account.
+  </Step>
+  <Step title="Monitor progress">
+    Use **Open in AWS console** on the step (or the CloudFormation console) to watch the stack's events until it
+    reaches `CREATE_COMPLETE`. Once it's up, the install continues.
+  </Step>
+</Steps>
+
+## Launch with the AWS CLI
+
+The dashboard generates the exact commands with your stack name, template URL, and region filled in. Copy them from
+the await install stack step — the general form is:
+
+<Steps>
+  <Step title="Create the stack">
+    ```bash
+    aws cloudformation create-stack \
+      --stack-name <stack-name> \
+      --template-url <template-url> \
+      --capabilities CAPABILITY_NAMED_IAM \
+      --region <region>
+    ```
+  </Step>
+  <Step title="Update an existing stack">
+    To apply a new template version to a stack you already created:
+
+    ```bash
+    aws cloudformation update-stack \
+      --stack-name <stack-name> \
+      --template-url <template-url> \
+      --capabilities CAPABILITY_NAMED_IAM \
+      --region <region>
+    ```
+  </Step>
+  <Step title="Verify">
+    Open the CloudFormation console (the **Open in AWS console** button on the step links straight to the stack's
+    events) and wait for `CREATE_COMPLETE` / `UPDATE_COMPLETE`.
+  </Step>
+</Steps>

--- a/docs/guides/provision-stacks-with-spacelift.mdx
+++ b/docs/guides/provision-stacks-with-spacelift.mdx
@@ -1,16 +1,16 @@
 ---
-title: "Provisioning Install Stacks with Spacelift"
+title: "Provision Stacks with Spacelift"
 description: "Provision the Nuon Terraform install stack through Spacelift instead of running Terraform locally — via a blueprint or the Spacelift Terraform provider."
 icon: "layer-group"
 boost: 10
-keywords: ["spacelift", "install-stacks", "terraform", "blueprint", "install stack", "aws", "gcp", "azure", "raw git", "spacelift blueprint", "spacelift terraform provider"]
+keywords: ["spacelift", "install-stacks", "terraform", "blueprint", "install stack", "aws", "gcp", "raw git", "spacelift blueprint", "spacelift terraform provider"]
 ---
 
 <Note>Spacelift support for install stacks is gated behind a feature flag. [Reach out to Nuon](https://nuon.co/demo-request) to enable it for your org.</Note>
 
 The Terraform install stack provisions the runner in your customer's cloud account. It can be provisioned with the
-Terraform CLI, but customers can also manage it as a [Spacelift](https://spacelift.io/) stack. This works for every
-Terraform install stack — AWS, GCP, and Azure.
+Terraform CLI, but customers can also manage it as a [Spacelift](https://spacelift.io/) stack. This works with any
+Terraform install stack — AWS and GCP.
 
 There are two ways to install a Spacelift stack. Which one your customer uses depends on whether they want to use the
 Spacelift web UI or the
@@ -24,24 +24,18 @@ Both paths run the same [`nuonco/install-stacks`](https://github.com/nuonco/inst
 
 ## Prerequisites
 
-<Steps>
-  <Step title="Enable the feature flag">
-    Spacelift support is gated behind a feature flag. [Reach out to Nuon](https://nuon.co/demo-request) to enable it —
-    the **Spacelift** tab then appears on the await install stack step.
-  </Step>
-  <Step title="Create a Spacelift account">
-    You need a [Spacelift](https://spacelift.io/) account with permission to create blueprints and stacks.
-  </Step>
-  <Step title="Configure a cloud integration">
-    Set up Spacelift's [cloud integration](https://docs.spacelift.io/integrations/cloud-providers) for your target
-    cloud — [AWS](https://docs.spacelift.io/integrations/cloud-providers/aws),
-    [GCP](https://docs.spacelift.io/integrations/cloud-providers/gcp), or
-    [Azure](https://docs.spacelift.io/integrations/cloud-providers/azure). Its identity must have access to provision
-    resources in the target account.
-  </Step>
-</Steps>
+- **Enable the feature flag** — Spacelift support is gated behind a feature flag.
+  [Reach out to Nuon](https://nuon.co/demo-request) to enable it — the **Spacelift** tab then appears on the await
+  install stack step.
+- **Create a Spacelift account** — you need a [Spacelift](https://spacelift.io/) account with permission to create
+  blueprints and stacks.
+- **Configure a cloud integration** — set up Spacelift's
+  [cloud integration](https://docs.spacelift.io/integrations/cloud-providers) for your target cloud —
+  [AWS](https://docs.spacelift.io/integrations/cloud-providers/aws) or
+  [GCP](https://docs.spacelift.io/integrations/cloud-providers/gcp). Its identity must have access to provision
+  resources in the target account.
 
-## Blueprint path
+## Use a blueprint
 
 <Steps>
   <Step title="Create the blueprint">
@@ -68,7 +62,7 @@ Both paths run the same [`nuonco/install-stacks`](https://github.com/nuonco/inst
   </Step>
 </Steps>
 
-## Terraform path
+## Use terraform
 
 This path applies a generated `spacelift.tf` alongside its `inputs.auto.tfvars` and `secrets.auto.tfvars` sibling
 files. The config reads the tfvars via `filebase64`, so you can edit the inputs and replace the secrets with real
@@ -106,8 +100,3 @@ values before applying.
     approval.
   </Step>
 </Steps>
-
-## See also
-
-- [Customizing Terraform Stack Templates](/guides/customizing-terraform-stack-templates) — fork the `install-stacks`
-  repo to customize the stack.

--- a/docs/guides/provision-stacks-with-terraform.mdx
+++ b/docs/guides/provision-stacks-with-terraform.mdx
@@ -1,0 +1,69 @@
+---
+title: "Provision Stacks with Terraform"
+description: "Provision the Nuon Terraform install stack locally with the Terraform CLI — clone the module, configure remote state, and apply your generated tfvars."
+icon: "terminal"
+boost: 10
+keywords: ["terraform", "install-stacks", "install stack", "terraform apply", "inputs.auto.tfvars", "secrets.auto.tfvars", "aws", "gcp", "backend", "remote state"]
+---
+
+The Terraform install stack provisions the runner in your customer's cloud account. When an install uses a Terraform
+stack, the **await install stack** step in the dashboard generates two tfvars files — `inputs.auto.tfvars` and
+`secrets.auto.tfvars` — and this guide walks through applying them with the Terraform CLI. This works for every
+Terraform install stack — AWS and GCP.
+
+The stack is the public [`nuonco/install-stacks`](https://github.com/nuonco/install-stacks) module, with a directory
+per cloud (`aws/`, `gcp/`).
+
+## Prerequisites
+
+- **Install Terraform** — install [Terraform](https://developer.hashicorp.com/terraform/install). The required version
+  is shown on the await install stack step in the dashboard.
+- **Authenticate to your cloud** — configure credentials for the target cloud so Terraform can provision resources —
+  for example the AWS CLI / a configured profile or `gcloud` application-default credentials. The identity must have
+  permission to create the stack's resources in the target account.
+
+## Provision the stack
+
+<Steps>
+  <Step title="Clone the install stack module">
+    Clone the repo and enter the directory for your cloud (`aws` or `gcp`):
+
+    ```bash
+    git clone https://github.com/nuonco/install-stacks.git
+    cd install-stacks/<cloud>
+    ```
+  </Step>
+  <Step title="Configure remote state (recommended)">
+    Store Terraform state in a remote backend so it survives and can be shared. Create a `backend.tf` in the cloud
+    directory pointing at a bucket or container you control — for example, GCS:
+
+    ```hcl
+    terraform {
+      backend "gcs" {
+        bucket = "<your-state-bucket>"
+        prefix = "nuon/<install-id>"
+      }
+    }
+    ```
+
+    Use the equivalent backend for your cloud (`s3` for AWS). See the
+    [Terraform backend docs](https://developer.hashicorp.com/terraform/language/settings/backends/configuration).
+  </Step>
+  <Step title="Save the install configuration">
+    From the dashboard's await install stack step, copy or download the two generated files into the cloud directory:
+
+    - **`inputs.auto.tfvars`** — install identity, runner settings, operation roles, and install inputs.
+    - **`secrets.auto.tfvars`** — secrets and auto-generated secret declarations.
+
+    Both use the `.auto.tfvars` suffix, so Terraform loads them automatically — no `-var-file` flag needed.
+  </Step>
+  <Step title="Apply with Terraform">
+    Initialize and apply:
+
+    ```bash
+    terraform init && terraform apply
+    ```
+
+    This provisions the runner in your customer's cloud account. Once it's up, the install continues.
+  </Step>
+</Steps>


### PR DESCRIPTION
## Summary

We were lacking docs covering how to use the different methods for provisioning an install stack: Terraform, Cloudformation, and Spacelift. This PR adds a guide for each method.