### PR TITLE
fix: remove unwanted preloads and activites from hot path

### DIFF
--- a/services/ctl-api/internal/app/installs/signals/actionworkflowrun/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/actionworkflowrun/signal.go
@@ -138,22 +138,17 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return errors.Wrap(err, "unable to get install action workflow")
 	}
 
-	install, err := activities.AwaitGetByInstallID(ctx, installActionWorkflow.InstallID)
+	slimInstall, err := activities.AwaitGetSlimInstallByInstallID(ctx, installActionWorkflow.InstallID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get install")
 	}
 
-	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	found, err := activities.AwaitActionWorkflowInAppConfig(ctx, activities.ActionWorkflowInAppConfigRequest{
+		AppConfigID:      slimInstall.AppConfigID,
+		ActionWorkflowID: installActionWorkflow.ActionWorkflowID,
+	})
 	if err != nil {
-		return errors.Wrap(err, "unable to get app config")
-	}
-
-	found := false
-	for _, workflowCfg := range appCfg.ActionWorkflowConfigs {
-		if workflowCfg.ActionWorkflowID == installActionWorkflow.ActionWorkflowID {
-			found = true
-			break
-		}
+		return errors.Wrap(err, "unable to check action workflow in app config")
 	}
 
 	if !found {
@@ -193,7 +188,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		}
 	}
 
-	if err := s.executeActionWorkflowRun(ctx, install, actionWorkflowRun.ID); err != nil {
+	if err := s.executeActionWorkflowRun(ctx, slimInstall, actionWorkflowRun.ID); err != nil {
 		return errors.Wrap(err, "unable to execute action workflow run")
 	}
 

--- a/services/ctl-api/internal/app/installs/signals/actionworkflowrun/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/actionworkflowrun/signal.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
@@ -188,7 +189,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		}
 	}
 
-	if err := s.executeActionWorkflowRun(ctx, slimInstall, actionWorkflowRun.ID); err != nil {
+	if err := s.executeActionWorkflowRun(ctx, slimInstall.ID, slimInstall.Metadata, actionWorkflowRun.ID); err != nil {
 		return errors.Wrap(err, "unable to execute action workflow run")
 	}
 
@@ -228,11 +229,10 @@ func (s *Signal) executeAdhocRun(ctx workflow.Context) error {
 		return errors.Wrap(err, "unable to get install for adhoc run")
 	}
 
-	return s.executeActionWorkflowRun(ctx, install, run.ID)
+	return s.executeActionWorkflowRun(ctx, install.ID, install.Metadata, run.ID)
 }
 
-func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, install *app.Install, actionWorkflowRunID string) error {
-	installID := install.ID
+func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, installID string, metadata pgtype.Hstore, actionWorkflowRunID string) error {
 	l := workflow.GetLogger(ctx)
 
 	run, err := activities.AwaitGetInstallActionWorkflowRunByRunID(ctx, actionWorkflowRunID)
@@ -352,7 +352,7 @@ func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, install *app.Ins
 			return errors.Wrap(err, "unable to check state-gen-v2 feature")
 		}
 		if err := stategen.HintOrGenerate(ctx, stategen.Request{
-			StateGenV2:      statemanager.UseStateGenV2(orgEnabled, install.Metadata),
+			StateGenV2:      statemanager.UseStateGenV2(orgEnabled, metadata),
 			InstallID:       installID,
 			Targets:         statemanager.TargetsForHint(statemanager.HintActionRan, s.InstallActionWorkflowID),
 			ForceAll:        true,

--- a/services/ctl-api/internal/app/installs/worker/activities/action_workflow_in_app_config.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/action_workflow_in_app_config.go
@@ -1,0 +1,32 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+type ActionWorkflowInAppConfigRequest struct {
+	AppConfigID      string `validate:"required"`
+	ActionWorkflowID string `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) ActionWorkflowInAppConfig(ctx context.Context, req ActionWorkflowInAppConfigRequest) (bool, error) {
+	var count int64
+
+	res := a.db.WithContext(ctx).
+		Model(&app.ActionWorkflowConfig{}).
+		Where(app.ActionWorkflowConfig{
+			AppConfigID:      req.AppConfigID,
+			ActionWorkflowID: req.ActionWorkflowID,
+		}).
+		Count(&count)
+	if res.Error != nil {
+		return false, errors.Wrap(res.Error, "unable to check action workflow in app config")
+	}
+
+	return count > 0, nil
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/get.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/get.go
@@ -2,7 +2,9 @@ package activities
 
 import (
 	"context"
+	"database/sql"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -65,10 +67,21 @@ func (a *Activities) getInstall(ctx context.Context, installID string) (*app.Ins
 	return a.get(ctx, installID)
 }
 
+// SlimInstallResponse is a trimmed projection of app.Install for hot paths that
+// only need core columns, avoiding confusion with a fully-preloaded install.
+type SlimInstallResponse struct {
+	ID          string
+	OrgID       string
+	AppID       string
+	AppConfigID string
+	SandboxMode sql.NullBool
+	Metadata    pgtype.Hstore
+}
+
 // @temporal-gen-v2 activity
 // @as-wrapper
 // @by-field installID
-func (a *Activities) getSlimInstall(ctx context.Context, installID string) (*app.Install, error) {
+func (a *Activities) getSlimInstall(ctx context.Context, installID string) (*SlimInstallResponse, error) {
 	install := app.Install{}
 	res := a.db.WithContext(ctx).
 		First(&install, "id = ?", installID)
@@ -76,5 +89,12 @@ func (a *Activities) getSlimInstall(ctx context.Context, installID string) (*app
 		return nil, dbgenerics.TemporalGormError(res.Error, "unable to get install: %w")
 	}
 
-	return &install, nil
+	return &SlimInstallResponse{
+		ID:          install.ID,
+		OrgID:       install.OrgID,
+		AppID:       install.AppID,
+		AppConfigID: install.AppConfigID,
+		SandboxMode: install.SandboxMode,
+		Metadata:    install.Metadata,
+	}, nil
 }

--- a/services/ctl-api/internal/app/installs/worker/activities/get.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/get.go
@@ -64,3 +64,17 @@ func (a *Activities) get(ctx context.Context, installID string) (*app.Install, e
 func (a *Activities) getInstall(ctx context.Context, installID string) (*app.Install, error) {
 	return a.get(ctx, installID)
 }
+
+// @temporal-gen-v2 activity
+// @as-wrapper
+// @by-field installID
+func (a *Activities) getSlimInstall(ctx context.Context, installID string) (*app.Install, error) {
+	install := app.Install{}
+	res := a.db.WithContext(ctx).
+		First(&install, "id = ?", installID)
+	if res.Error != nil {
+		return nil, dbgenerics.TemporalGormError(res.Error, "unable to get install: %w")
+	}
+
+	return &install, nil
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/get.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/get.go
@@ -82,6 +82,8 @@ type SlimInstallResponse struct {
 // @as-wrapper
 // @by-field installID
 func (a *Activities) getSlimInstall(ctx context.Context, installID string) (*SlimInstallResponse, error) {
+	// full install object is quite costly from query and from logistics in temporal pov, this trim down version only
+	// returns the metadat which is needed in application flow rather than entire app config
 	install := app.Install{}
 	res := a.db.WithContext(ctx).
 		First(&install, "id = ?", installID)

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
@@ -32,12 +32,12 @@ func (p *Planner) createActionWorkflowRunPlan(ctx workflow.Context, runID string
 		return nil, nil, errors.Wrap(err, "unable to get run")
 	}
 
-	install, err := activities.AwaitGetByInstallID(ctx, run.InstallID)
+	slimInstall, err := activities.AwaitGetSlimInstallByInstallID(ctx, run.InstallID)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to get install")
 	}
 
-	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, slimInstall.AppConfigID)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to get app config")
 	}
@@ -132,7 +132,7 @@ func (p *Planner) createActionWorkflowRunPlan(ctx workflow.Context, runID string
 		plan.Steps = append(plan.Steps, stepPlan)
 	}
 
-	if install.SandboxMode.Bool {
+	if slimInstall.SandboxMode.Bool {
 		targetRefs := helpers.GetActionReferences(appCfg, run.ActionWorkflowConfig.ActionWorkflow.Name)
 
 		plan.SandboxMode = &plantypes.SandboxMode{


### PR DESCRIPTION
Get install and get full app config with full preloads are two of the heaviest and fattest queries we have, we query them even though we dont need full information about those entities, this pr trims it down where possible and skips on data passsing betwen activities and workflows to reduce overall temporal encoder do less work