### PR TITLE
fix: hide role selector if ther are no roles to select

### DIFF
--- a/services/dashboard-ui/client/components/actions/InstallActionManualRun/InstallActionManualRun.tsx
+++ b/services/dashboard-ui/client/components/actions/InstallActionManualRun/InstallActionManualRun.tsx
@@ -26,6 +26,7 @@ interface IInstallActionManualRunModal extends Omit<IModal, 'onSubmit'> {
   action: TAction
   actionConfigId: string
   isLoading: boolean
+  rolesUnavailable?: boolean
   onSubmit: (vars: Record<string, string>, role: string) => void
   roleSelector: ReactNode
 }
@@ -34,6 +35,7 @@ export const InstallActionManualRunModal = ({
   action,
   actionConfigId,
   isLoading,
+  rolesUnavailable,
   onSubmit,
   roleSelector,
   ...props
@@ -96,7 +98,7 @@ export const InstallActionManualRunModal = ({
             Run action
           </>
         ),
-        disabled: isLoading,
+        disabled: isLoading || rolesUnavailable,
         onClick: handlePrimaryAction,
         variant: 'primary',
       }}

--- a/services/dashboard-ui/client/components/actions/InstallActionManualRun/InstallActionManualRunContainer.tsx
+++ b/services/dashboard-ui/client/components/actions/InstallActionManualRun/InstallActionManualRunContainer.tsx
@@ -34,6 +34,7 @@ export const InstallActionManualRunModalContainer = ({
   const { removeModal } = useSurfaces()
   const { addToast } = useToast()
   const [selectedRole, setSelectedRole] = useState<string>('')
+  const [rolesUnavailable, setRolesUnavailable] = useState(false)
 
   const { isPending: isLoading, mutate } = useMutation({
     mutationFn: (body: Parameters<typeof runAction>[0]['body'] & { role?: string }) =>
@@ -95,6 +96,7 @@ export const InstallActionManualRunModalContainer = ({
       action={action}
       actionConfigId={actionConfigId}
       isLoading={isLoading}
+      rolesUnavailable={rolesUnavailable}
       onSubmit={handleSubmit}
       roleSelector={
         <RoleSelector
@@ -105,6 +107,7 @@ export const InstallActionManualRunModalContainer = ({
           value={selectedRole}
           onChange={setSelectedRole}
           name="role"
+          onAvailabilityChange={(available) => setRolesUnavailable(!available)}
         />
       }
       {...props}

--- a/services/dashboard-ui/client/components/install-components/management/DeployAllComponents/DeployAllComponents.tsx
+++ b/services/dashboard-ui/client/components/install-components/management/DeployAllComponents/DeployAllComponents.tsx
@@ -9,6 +9,7 @@ interface IDeployAllComponentsModal extends Omit<IModal, 'onSubmit'> {
   installName: string
   isPending: boolean
   isKickedOff: boolean
+  rolesUnavailable?: boolean
   error?: { error?: string } | null
   onSubmit: (params: { role: string }) => void
   roleSelector: (props: {
@@ -21,6 +22,7 @@ export const DeployAllComponentsModal = ({
   installName,
   isPending,
   isKickedOff,
+  rolesUnavailable,
   error,
   onSubmit,
   roleSelector,
@@ -50,7 +52,7 @@ export const DeployAllComponentsModal = ({
         ) : (
           'Deploy all components'
         ),
-        disabled: isKickedOff || isPending,
+        disabled: isKickedOff || isPending || rolesUnavailable,
         onClick: () => onSubmit({ role: selectedRole }),
         variant: 'primary',
       }}

--- a/services/dashboard-ui/client/components/install-components/management/DeployAllComponents/DeployAllComponentsContainer.tsx
+++ b/services/dashboard-ui/client/components/install-components/management/DeployAllComponents/DeployAllComponentsContainer.tsx
@@ -28,6 +28,7 @@ export const DeployAllComponentsModalContainer = ({
   const { addToast } = useToast()
   const queryClient = useQueryClient()
   const [isKickedOff, setIsKickedOff] = useState(false)
+  const [rolesUnavailable, setRolesUnavailable] = useState(false)
 
   const { mutate: execute, isPending, error } = useMutation({
     mutationFn: (params: { body: Parameters<typeof deployComponents>[0]['body'] }) =>
@@ -85,6 +86,7 @@ export const DeployAllComponentsModalContainer = ({
       installName={install.name}
       isPending={isPending}
       isKickedOff={isKickedOff}
+      rolesUnavailable={rolesUnavailable}
       error={error as any}
       onSubmit={({ role }) =>
         execute({ body: { plan_only: false, ...(role && { role }) } })
@@ -96,6 +98,7 @@ export const DeployAllComponentsModalContainer = ({
           value={value}
           onChange={onChange}
           name="role"
+          onAvailabilityChange={(available) => setRolesUnavailable(!available)}
         />
       )}
       {...props}

--- a/services/dashboard-ui/client/components/install-components/management/DeployComponent/DeployComponent.tsx
+++ b/services/dashboard-ui/client/components/install-components/management/DeployComponent/DeployComponent.tsx
@@ -13,6 +13,7 @@ interface IDeployComponentModal extends Omit<IModal, 'onSubmit'> {
   currentDeployStatus?: string
   installId: string
   isPending: boolean
+  rolesUnavailable?: boolean
   error?: { error?: string } | null
   onSubmit: (params: {
     buildId: string
@@ -38,6 +39,7 @@ export const DeployComponentModal = ({
   currentDeployStatus,
   installId,
   isPending,
+  rolesUnavailable,
   error,
   onSubmit,
   onClose,
@@ -50,7 +52,7 @@ export const DeployComponentModal = ({
   const [deployDependencies, setDeployDependencies] = useState(false)
   const [selectedRole, setSelectedRole] = useState<string>('')
 
-  const isDeployDisabled = !buildId || isPending
+  const isDeployDisabled = !buildId || isPending || rolesUnavailable
 
   const handleClose = () => {
     setBuildId(undefined)

--- a/services/dashboard-ui/client/components/install-components/management/DeployComponent/DeployComponentContainer.tsx
+++ b/services/dashboard-ui/client/components/install-components/management/DeployComponent/DeployComponentContainer.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '@/hooks/use-auth'
@@ -35,6 +36,7 @@ export const DeployComponentModalContainer = ({
   const { removeModal } = useSurfaces()
   const { addToast } = useToast()
   const queryClient = useQueryClient()
+  const [rolesUnavailable, setRolesUnavailable] = useState(false)
 
   const { mutate: execute, isPending, error } = useMutation({
     mutationFn: (params: { body: Parameters<typeof deployComponent>[0]['body'] }) =>
@@ -96,6 +98,7 @@ export const DeployComponentModalContainer = ({
       currentDeployStatus={currentDeployStatus}
       installId={install.id}
       isPending={isPending}
+      rolesUnavailable={rolesUnavailable}
       error={error as any}
       onSubmit={({ buildId, deployDependents, deployDependencies, role }) => {
         execute({
@@ -129,6 +132,7 @@ export const DeployComponentModalContainer = ({
           value={value}
           onChange={onChange}
           name="role"
+          onAvailabilityChange={(available) => setRolesUnavailable(!available)}
         />
       )}
       {...props}

--- a/services/dashboard-ui/client/components/install-components/management/TeardownComponent/TeardownComponent.tsx
+++ b/services/dashboard-ui/client/components/install-components/management/TeardownComponent/TeardownComponent.tsx
@@ -10,6 +10,7 @@ import type { TComponent } from '@/types'
 interface ITeardownComponentModal extends Omit<IModal, 'onSubmit'> {
   component: TComponent
   isPending: boolean
+  rolesUnavailable?: boolean
   error?: { error?: string } | null
   onSubmit: (params: { role: string }) => void
   onClose: () => void
@@ -22,6 +23,7 @@ interface ITeardownComponentModal extends Omit<IModal, 'onSubmit'> {
 export const TeardownComponentModal = ({
   component,
   isPending,
+  rolesUnavailable,
   error,
   onSubmit,
   onClose,
@@ -32,7 +34,7 @@ export const TeardownComponentModal = ({
   const [selectedRole, setSelectedRole] = useState<string>('')
 
   const isConfirmValid = confirmName === component.name
-  const canTeardown = isConfirmValid && !isPending
+  const canTeardown = isConfirmValid && !isPending && !rolesUnavailable
 
   const handleClose = () => {
     setConfirmName('')

--- a/services/dashboard-ui/client/components/install-components/management/TeardownComponent/TeardownComponentContainer.tsx
+++ b/services/dashboard-ui/client/components/install-components/management/TeardownComponent/TeardownComponentContainer.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '@/hooks/use-auth'
@@ -29,6 +30,7 @@ export const TeardownComponentModalContainer = ({
   const { removeModal } = useSurfaces()
   const { addToast } = useToast()
   const queryClient = useQueryClient()
+  const [rolesUnavailable, setRolesUnavailable] = useState(false)
 
   const { mutate: execute, isPending, error } = useMutation({
     mutationFn: (params: { body: Parameters<typeof teardownComponent>[0]['body'] }) =>
@@ -88,6 +90,7 @@ export const TeardownComponentModalContainer = ({
     <TeardownComponentModal
       component={component}
       isPending={isPending}
+      rolesUnavailable={rolesUnavailable}
       error={error as any}
       onSubmit={({ role }) => {
         execute({
@@ -110,6 +113,7 @@ export const TeardownComponentModalContainer = ({
           value={value}
           onChange={onChange}
           name="role"
+          onAvailabilityChange={(available) => setRolesUnavailable(!available)}
         />
       )}
       {...props}

--- a/services/dashboard-ui/client/components/installs/management/Reprovision/ReprovisionContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/Reprovision/ReprovisionContainer.tsx
@@ -72,6 +72,7 @@ export const ReprovisionModalContainer = ({ ...props }: IReprovision & Omit<IMod
           value={selectedRole}
           onChange={setSelectedRole}
           name="role"
+          hideWhenEmpty
         />
       }
       {...props}

--- a/services/dashboard-ui/client/components/installs/management/RunAdhocAction/RunAdhocAction.tsx
+++ b/services/dashboard-ui/client/components/installs/management/RunAdhocAction/RunAdhocAction.tsx
@@ -13,6 +13,7 @@ interface IRunAdhocActionModal extends Omit<IModal, 'onSubmit'> {
   installId: string
   initialValues?: TRunAdhocActionBody
   isPending: boolean
+  rolesUnavailable?: boolean
   error: any
   onSubmit: (body: TRunAdhocActionBody) => void
   onDraftResume: (onResume: () => void, onStartFresh: () => void, onClose: () => void, draftTimestamp: string) => void
@@ -24,6 +25,7 @@ export const RunAdhocActionModal = ({
   installId,
   initialValues,
   isPending,
+  rolesUnavailable,
   error,
   onSubmit,
   onDraftResume,
@@ -164,7 +166,7 @@ export const RunAdhocActionModal = ({
           'Run action'
         ),
         onClick: () => formRef.current?.requestSubmit(),
-        disabled: isPending,
+        disabled: isPending || rolesUnavailable,
         variant: 'primary',
       }}
       size="lg"

--- a/services/dashboard-ui/client/components/installs/management/RunAdhocAction/RunAdhocActionContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/RunAdhocAction/RunAdhocActionContainer.tsx
@@ -32,6 +32,7 @@ export const RunAdhocActionModalContainer = ({
   const [selectedRole, setSelectedRole] = useState<string>(
     initialValues?.role || ''
   )
+  const [rolesUnavailable, setRolesUnavailable] = useState(false)
 
   const {
     mutate,
@@ -102,6 +103,7 @@ export const RunAdhocActionModalContainer = ({
       installId={install.id}
       initialValues={initialValues}
       isPending={isLoading}
+      rolesUnavailable={rolesUnavailable}
       error={error}
       onSubmit={(body) => mutate(body)}
       onDraftResume={handleDraftResume}
@@ -112,6 +114,7 @@ export const RunAdhocActionModalContainer = ({
           principalType="action"
           value={selectedRole}
           onChange={setSelectedRole}
+          onAvailabilityChange={(available) => setRolesUnavailable(!available)}
         />
       }
       {...props}

--- a/services/dashboard-ui/client/components/roles/RoleSelector/RoleSelector.tsx
+++ b/services/dashboard-ui/client/components/roles/RoleSelector/RoleSelector.tsx
@@ -1,3 +1,5 @@
+import { Banner } from '@/components/common/Banner'
+import { Text } from '@/components/common/Text'
 import { Select, type SelectOption } from '@/components/common/form/Select'
 
 const ROLE_TYPE_CONFIG = {
@@ -22,6 +24,7 @@ interface IRoleSelector {
   onChange?: (value: string) => void
   name?: string
   disabled?: boolean
+  hideWhenEmpty?: boolean
 }
 
 export const RoleSelector = ({
@@ -32,9 +35,19 @@ export const RoleSelector = ({
   onChange,
   name,
   disabled,
+  hideWhenEmpty,
 }: IRoleSelector) => {
   if (!isLoading && !isError && roles.length === 0) {
-    return null
+    if (hideWhenEmpty) {
+      return null
+    }
+    return (
+      <Banner theme="warn">
+        <Text variant="body">
+          No execution roles are available for this operation. Add or enable a role in your install stack to continue.
+        </Text>
+      </Banner>
+    )
   }
 
   const defaultRole = roles.find((r) => r.default)

--- a/services/dashboard-ui/client/components/roles/RoleSelector/RoleSelector.tsx
+++ b/services/dashboard-ui/client/components/roles/RoleSelector/RoleSelector.tsx
@@ -33,6 +33,10 @@ export const RoleSelector = ({
   name,
   disabled,
 }: IRoleSelector) => {
+  if (!isLoading && !isError && roles.length === 0) {
+    return null
+  }
+
   const defaultRole = roles.find((r) => r.default)
 
   const roleOption = (role: TAvailableRole, value: string): SelectOption => ({
@@ -53,16 +57,14 @@ export const RoleSelector = ({
     ? 'Loading available roles…'
     : isError
       ? 'Failed to load available roles'
-      : roles.length === 0
-        ? 'No roles available from install stack outputs'
-        : 'If unset, the default role is used.'
+      : 'If unset, the default role is used.'
 
   return (
     <Select
       name={name}
       value={value ?? ''}
       onChange={(e) => onChange?.(e.target.value)}
-      disabled={disabled || isLoading || isError || roles.length === 0}
+      disabled={disabled || isLoading || isError}
       options={options}
       placeholder={defaultRole ? defaultRole.name : 'Use default role'}
       labelProps={{ labelText: 'Execution role (optional)' }}

--- a/services/dashboard-ui/client/components/roles/RoleSelector/RoleSelectorContainer.tsx
+++ b/services/dashboard-ui/client/components/roles/RoleSelector/RoleSelectorContainer.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useOrg } from '@/hooks/use-org'
 import { getAvailableRoles } from '@/lib'
@@ -13,6 +14,8 @@ interface IRoleSelectorContainer {
   onChange?: (value: string) => void
   name?: string
   disabled?: boolean
+  hideWhenEmpty?: boolean
+  onAvailabilityChange?: (available: boolean) => void
 }
 
 export const RoleSelectorContainer = ({
@@ -24,6 +27,8 @@ export const RoleSelectorContainer = ({
   onChange,
   name,
   disabled,
+  hideWhenEmpty,
+  onAvailabilityChange,
 }: IRoleSelectorContainer) => {
   const { org } = useOrg()
 
@@ -36,6 +41,11 @@ export const RoleSelectorContainer = ({
 
   const roles = data?.roles ?? []
 
+  useEffect(() => {
+    if (!onAvailabilityChange) return
+    onAvailabilityChange(isLoading || isError || roles.length > 0)
+  }, [isLoading, isError, roles.length, onAvailabilityChange])
+
   return (
     <RoleSelector
       roles={roles as any}
@@ -45,6 +55,7 @@ export const RoleSelectorContainer = ({
       onChange={onChange}
       name={name}
       disabled={disabled}
+      hideWhenEmpty={hideWhenEmpty}
     />
   )
 }

--- a/services/dashboard-ui/client/components/sandbox/management/ReprovisionSandbox/ReprovisionSandbox.tsx
+++ b/services/dashboard-ui/client/components/sandbox/management/ReprovisionSandbox/ReprovisionSandbox.tsx
@@ -24,6 +24,7 @@ export const ReprovisionSandboxModal = ({
 }: IReprovisionSandboxModal) => {
   const [selectedRole, setSelectedRole] = useState<string>('')
   const [skipComponents, setSkipComponents] = useState(false)
+  const [rolesUnavailable, setRolesUnavailable] = useState(false)
 
   return (
     <Modal
@@ -40,7 +41,7 @@ export const ReprovisionSandboxModal = ({
             Reprovision sandbox
           </span>
         ),
-        disabled: isPending,
+        disabled: isPending || rolesUnavailable,
         onClick: () => onSubmit({ selectedRole, skipComponents }),
         variant: 'primary' as const,
       }}
@@ -65,6 +66,7 @@ export const ReprovisionSandboxModal = ({
           value={selectedRole}
           onChange={setSelectedRole}
           name="role"
+          onAvailabilityChange={(available) => setRolesUnavailable(!available)}
         />
 
         <div className="flex items-start">


### PR DESCRIPTION
If no roles are available for a particular install, currently we currently show empty select list, instead show a warning saying roles are not available and skip allowing triggering an operation which requires a role. 