### PR TITLE
fix: harden GCP Spacelift install-stack generation

### DIFF
--- a/docs/guides/provision-stacks-with-spacelift.mdx
+++ b/docs/guides/provision-stacks-with-spacelift.mdx
@@ -9,8 +9,8 @@ keywords: ["spacelift", "install-stacks", "terraform", "blueprint", "install sta
 <Note>Spacelift support for install stacks is gated behind a feature flag. [Reach out to Nuon](https://nuon.co/demo-request) to enable it for your org.</Note>
 
 The Terraform install stack provisions the runner in your customer's cloud account. It can be provisioned with the
-Terraform CLI, but customers can also manage it as a [Spacelift](https://spacelift.io/) stack. This works with any
-Terraform install stack — AWS and GCP.
+Terraform CLI, but customers can also manage it as a [Spacelift](https://spacelift.io/) stack. Spacelift provisioning
+currently generates configs for **GCP** install stacks; AWS support is planned.
 
 There are two ways to install a Spacelift stack. Which one your customer uses depends on whether they want to use the
 Spacelift web UI or the
@@ -70,33 +70,48 @@ values before applying.
 
 <Steps>
   <Step title="Save these files together">
-    Download `spacelift.tf`, `inputs.auto.tfvars`, and `secrets.auto.tfvars` from the dashboard and put all three in
-    one directory. Edit `inputs.auto.tfvars` as needed and replace `secrets.auto.tfvars` with your real secret values.
-    Keep them somewhere private — the secrets file is plaintext at rest.
+    Click **Download all** on the dashboard to get `spacelift.tf`, `inputs.auto.tfvars`, and `secrets.auto.tfvars` as
+    a single zip, and unpack all three into one directory (or download them individually and put them in one
+    directory yourself). Edit `inputs.auto.tfvars` as needed — any field left blank is marked with a `# required`
+    comment so you can find it — and replace `secrets.auto.tfvars` with your real secret values. Keep them somewhere
+    private — the secrets file is plaintext at rest.
   </Step>
   <Step title="Authenticate the provider to Spacelift">
     The [`spacelift-io/spacelift`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs) provider
     needs Spacelift API credentials. Create an
-    [API key](https://docs.spacelift.io/integrations/api#api-key-management) and export it as
+    [API key](https://docs.spacelift.io/integrations/api#spacelift-api-key) and export it as
     `SPACELIFT_API_KEY_ENDPOINT`, `SPACELIFT_API_KEY_ID`, and `SPACELIFT_API_KEY_SECRET` before applying. See the
     [provider authentication](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs#authentication)
     docs.
-  </Step>
-  <Step title="Apply with Terraform">
-    Run:
+
+    If you'd rather not export these into your shell (e.g. you have a different Spacelift account's credentials
+    already exported), prefix the commands in the next step instead:
 
     ```bash
-    terraform init && terraform apply
+    SPACELIFT_API_KEY_ENDPOINT=... SPACELIFT_API_KEY_ID=... SPACELIFT_API_KEY_SECRET=... \
+      terraform init && terraform apply
+    ```
+  </Step>
+  <Step title="Apply with Terraform">
+    `spacelift.tf` declares a required `space_id` variable — the Spacelift space to create the stack in. Find a
+    space's ID in the Spacelift dashboard under **Spaces**, then run:
+
+    ```bash
+    terraform init
+    terraform apply -var="space_id=<your-space-id>"
     ```
 
     This creates the install stack and mounts your tfvars via
     [`spacelift_stack`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/stack) and
     [`spacelift_mounted_file`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/mounted_file).
+    It also attaches Spacelift's native GCP cloud integration to the stack via
+    [`spacelift_gcp_service_account`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/gcp_service_account),
+    so there's no manual **Settings → Integrations** step.
   </Step>
-  <Step title="Attach cloud credentials, then run the install stack">
-    Open the created install stack's **Settings → Integrations** and attach your
-    [cloud integration](https://docs.spacelift.io/integrations/cloud-providers). A newly created stack doesn't run on
-    its own, so trigger its first run — it's set to auto-deploy, so it plans and applies your runner without further
-    approval.
+  <Step title="Grant the service account access, then run the install stack">
+    `terraform apply` prints a `gcp_service_account_email` output — grant that service account an IAM role (e.g.
+    `roles/owner`, or a narrower set matching the permissions your install needs) on your target GCP project. A newly
+    created stack doesn't run on its own, so trigger its first run — it's set to auto-deploy, so it plans and applies
+    your runner without further approval.
   </Step>
 </Steps>

--- a/docs/guides/provision-stacks-with-spacelift.mdx
+++ b/docs/guides/provision-stacks-with-spacelift.mdx
@@ -72,9 +72,9 @@ values before applying.
   <Step title="Save these files together">
     Click **Download all** on the dashboard to get `spacelift.tf`, `inputs.auto.tfvars`, and `secrets.auto.tfvars` as
     a single zip, and unpack all three into one directory (or download them individually and put them in one
-    directory yourself). Edit `inputs.auto.tfvars` as needed — any field left blank is marked with a `# required`
-    comment so you can find it — and replace `secrets.auto.tfvars` with your real secret values. Keep them somewhere
-    private — the secrets file is plaintext at rest.
+    directory yourself). Edit `inputs.auto.tfvars` as needed (any field left blank is marked with a `# required`
+    comment so you can find it), and replace `secrets.auto.tfvars` with your real secret values. Keep them somewhere
+    private, the secrets file is plaintext at rest.
   </Step>
   <Step title="Authenticate the provider to Spacelift">
     The [`spacelift-io/spacelift`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs) provider
@@ -93,7 +93,7 @@ values before applying.
     ```
   </Step>
   <Step title="Apply with Terraform">
-    `spacelift.tf` declares a required `space_id` variable — the Spacelift space to create the stack in. Find a
+    `spacelift.tf` declares a required `space_id` variable, the Spacelift space to create the stack in. Find a
     space's ID in the Spacelift dashboard under **Spaces**, then run:
 
     ```bash
@@ -109,7 +109,7 @@ values before applying.
     so there's no manual **Settings → Integrations** step.
   </Step>
   <Step title="Grant the service account access, then run the install stack">
-    `terraform apply` prints a `gcp_service_account_email` output — grant that service account an IAM role (e.g.
+    `terraform apply` prints a `gcp_service_account_email` output. Grant that service account an IAM role (e.g.
     `roles/owner`, or a narrower set matching the permissions your install needs) on your target GCP project. A newly
     created stack doesn't run on its own, so trigger its first run — it's set to auto-deploy, so it plans and applies
     your runner without further approval.

--- a/docs/guides/provision-stacks-with-spacelift.mdx
+++ b/docs/guides/provision-stacks-with-spacelift.mdx
@@ -65,53 +65,60 @@ Both paths run the same [`nuonco/install-stacks`](https://github.com/nuonco/inst
 ## Use terraform
 
 This path applies a generated `spacelift.tf` alongside its `inputs.auto.tfvars` and `secrets.auto.tfvars` sibling
-files. The config reads the tfvars via `filebase64`, so you can edit the inputs and replace the secrets with real
-values before applying.
+files. All three are meant to be edited before applying, so every value you need to fill in is edited into a file
+up front, and the `terraform apply` command itself never changes between steps.
 
 <Steps>
-  <Step title="Save these files together">
+  <Step title="Save and configure the files">
     Click **Download all** on the dashboard to get `spacelift.tf`, `inputs.auto.tfvars`, and `secrets.auto.tfvars` as
-    a single zip, and unpack all three into one directory (or download them individually and put them in one
-    directory yourself). Edit `inputs.auto.tfvars` as needed (any field left blank is marked with a `# required`
-    comment so you can find it), and replace `secrets.auto.tfvars` with your real secret values. Keep them somewhere
-    private, the secrets file is plaintext at rest.
+    a single zip (or download them individually), and unpack all three into one directory.
+
+    Before applying, edit:
+
+    - **`spacelift.tf`**: set the `space_id` variable's `default` to the Spacelift space this stack should live in
+      (find the ID under **Spaces** in the Spacelift dashboard). Already manage your own GCP integration for this
+      stack? Set `attach_gcp_service_account`'s default to `false` instead of using the one this config creates for
+      you.
+    - **`inputs.auto.tfvars`**: fill in any install-specific values, such as `gcp_project_id` and `gcp_region`.
+    - **`secrets.auto.tfvars`**: replace the placeholder values with your real secrets.
+
+    Keep these files somewhere private once edited, the secrets file is plaintext at rest.
   </Step>
   <Step title="Authenticate the provider to Spacelift">
     The [`spacelift-io/spacelift`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs) provider
-    needs Spacelift API credentials. Create an
-    [API key](https://docs.spacelift.io/integrations/api#spacelift-api-key) and export it as
-    `SPACELIFT_API_KEY_ENDPOINT`, `SPACELIFT_API_KEY_ID`, and `SPACELIFT_API_KEY_SECRET` before applying. See the
-    [provider authentication](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs#authentication)
-    docs.
+    needs Spacelift API credentials:
 
-    If you'd rather not export these into your shell (e.g. you have a different Spacelift account's credentials
-    already exported), prefix the commands in the next step instead:
+    - Create an [API key](https://docs.spacelift.io/integrations/api#spacelift-api-key).
+    - Export it as `SPACELIFT_API_KEY_ENDPOINT`, `SPACELIFT_API_KEY_ID`, and `SPACELIFT_API_KEY_SECRET` before
+      applying, or prefix the apply command in the next step if you'd rather not export into your shell:
 
     ```bash
     SPACELIFT_API_KEY_ENDPOINT=... SPACELIFT_API_KEY_ID=... SPACELIFT_API_KEY_SECRET=... \
       terraform init && terraform apply
     ```
+
+    See the [provider authentication](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs#authentication)
+    docs for details.
   </Step>
   <Step title="Apply with Terraform">
-    `spacelift.tf` declares a required `space_id` variable, the Spacelift space to create the stack in. Find a
-    space's ID in the Spacelift dashboard under **Spaces**, then run:
-
     ```bash
-    terraform init
-    terraform apply -var="space_id=<your-space-id>"
+    terraform init && terraform apply
     ```
 
-    This creates the install stack and mounts your tfvars via
-    [`spacelift_stack`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/stack) and
-    [`spacelift_mounted_file`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/mounted_file).
-    It also attaches Spacelift's native GCP cloud integration to the stack via
-    [`spacelift_gcp_service_account`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/gcp_service_account),
+    This creates the install stack via
+    [`spacelift_stack`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/stack),
+    mounts your tfvars via
+    [`spacelift_mounted_file`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/mounted_file),
+    and, unless you disabled it in step 1, attaches Spacelift's native GCP integration via
+    [`spacelift_gcp_service_account`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/gcp_service_account)
     so there's no manual **Settings → Integrations** step.
   </Step>
-  <Step title="Grant the service account access, then run the install stack">
-    `terraform apply` prints a `gcp_service_account_email` output. Grant that service account an IAM role (e.g.
-    `roles/owner`, or a narrower set matching the permissions your install needs) on your target GCP project. A newly
-    created stack doesn't run on its own, so trigger its first run — it's set to auto-deploy, so it plans and applies
-    your runner without further approval.
+  <Step title="Grant access, then run the install stack">
+    - If you attached the GCP integration (the default): grant the printed `gcp_service_account_email` output an IAM
+      role on your target GCP project.
+    - If you attached your own integration instead: confirm its identity already has that access.
+
+    A newly created stack doesn't run on its own, so trigger its first run. It's set to auto-deploy, so it plans and
+    applies your runner without further approval.
   </Step>
 </Steps>

--- a/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
@@ -167,8 +167,8 @@ func TestRenderGCPAccountInjection(t *testing.T) {
 		require.NoError(t, err)
 
 		tfvars := extractTfvars(t, out)
-		assert.NotContains(t, tfvars, "gcp_project_id")
-		assert.NotContains(t, tfvars, "gcp_region")
+		assert.Contains(t, tfvars, `gcp_project_id           = "" # required: set your target GCP project ID`)
+		assert.Contains(t, tfvars, `gcp_region               = "" # required: set your target GCP region`)
 	})
 
 	t.Run("with nil GCPAccount", func(t *testing.T) {
@@ -178,8 +178,8 @@ func TestRenderGCPAccountInjection(t *testing.T) {
 		require.NoError(t, err)
 
 		tfvars := extractTfvars(t, out)
-		assert.NotContains(t, tfvars, "gcp_project_id")
-		assert.NotContains(t, tfvars, "gcp_region")
+		assert.Contains(t, tfvars, `gcp_project_id           = "" # required: set your target GCP project ID`)
+		assert.Contains(t, tfvars, `gcp_region               = "" # required: set your target GCP region`)
 	})
 }
 
@@ -407,6 +407,9 @@ func TestRenderSpaceliftArtifacts(t *testing.T) {
 	assert.Contains(t, adminTF, `write_only    = true`, "secrets mounted file should be secret")
 	assert.Contains(t, adminTF, `filebase64("${path.module}/inputs.auto.tfvars")`)
 	assert.Contains(t, adminTF, `filebase64("${path.module}/secrets.auto.tfvars")`)
+	assert.Contains(t, adminTF, `variable "space_id"`, "admin stack should require an explicit space_id")
+	assert.Contains(t, adminTF, `space_id          = var.space_id`)
+	assert.Contains(t, adminTF, `resource "spacelift_gcp_service_account" "nuon"`, "admin stack should auto-attach the GCP cloud integration")
 
 	assert.Contains(t, blueprint, "project_root: gcp")
 	assert.Contains(t, blueprint, "provider: RAW_GIT")

--- a/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
@@ -167,8 +167,8 @@ func TestRenderGCPAccountInjection(t *testing.T) {
 		require.NoError(t, err)
 
 		tfvars := extractTfvars(t, out)
-		assert.Contains(t, tfvars, `gcp_project_id           = "" # required: set your target GCP project ID`)
-		assert.Contains(t, tfvars, `gcp_region               = "" # required: set your target GCP region`)
+		assert.NotContains(t, tfvars, "gcp_project_id")
+		assert.NotContains(t, tfvars, "gcp_region")
 	})
 
 	t.Run("with nil GCPAccount", func(t *testing.T) {
@@ -178,8 +178,8 @@ func TestRenderGCPAccountInjection(t *testing.T) {
 		require.NoError(t, err)
 
 		tfvars := extractTfvars(t, out)
-		assert.Contains(t, tfvars, `gcp_project_id           = "" # required: set your target GCP project ID`)
-		assert.Contains(t, tfvars, `gcp_region               = "" # required: set your target GCP region`)
+		assert.NotContains(t, tfvars, "gcp_project_id")
+		assert.NotContains(t, tfvars, "gcp_region")
 	})
 }
 
@@ -409,7 +409,9 @@ func TestRenderSpaceliftArtifacts(t *testing.T) {
 	assert.Contains(t, adminTF, `filebase64("${path.module}/secrets.auto.tfvars")`)
 	assert.Contains(t, adminTF, `variable "space_id"`, "admin stack should require an explicit space_id")
 	assert.Contains(t, adminTF, `space_id          = var.space_id`)
-	assert.Contains(t, adminTF, `resource "spacelift_gcp_service_account" "nuon"`, "admin stack should auto-attach the GCP cloud integration")
+	assert.Contains(t, adminTF, `variable "attach_gcp_service_account"`, "GCP integration attach should be toggleable for customers with their own integration")
+	assert.Contains(t, adminTF, `resource "spacelift_gcp_service_account" "nuon"`, "admin stack should auto-attach the GCP cloud integration by default")
+	assert.Contains(t, adminTF, `count        = var.attach_gcp_service_account ? 1 : 0`)
 
 	assert.Contains(t, blueprint, "project_root: gcp")
 	assert.Contains(t, blueprint, "provider: RAW_GIT")

--- a/services/ctl-api/internal/pkg/stacks/gcp/spacelift_tmpl.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/spacelift_tmpl.go
@@ -35,11 +35,7 @@ resource "spacelift_stack" "nuon" {
   }
 }
 
-# Attaches Spacelift's native GCP Workload Identity Federation integration to
-# this stack, so runs get a GOOGLE_OAUTH_ACCESS_TOKEN automatically instead of
-# requiring a manual Settings -> Integrations attachment in the dashboard.
-# You still need to grant service_account_email (see output after apply) an
-# IAM role on your target GCP project.
+# Attaches Spacelift's native GCP integration; grant the printed service account an IAM role on your GCP project.
 resource "spacelift_gcp_service_account" "nuon" {
   stack_id     = spacelift_stack.nuon.id
   token_scopes = ["https://www.googleapis.com/auth/cloud-platform"]

--- a/services/ctl-api/internal/pkg/stacks/gcp/spacelift_tmpl.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/spacelift_tmpl.go
@@ -14,9 +14,15 @@ const spaceliftAdminTfTmpl = `terraform {
   }
 }
 
+variable "space_id" {
+  description = "ID of the Spacelift space to create this stack in. Find it in the Spacelift dashboard under Spaces (the URL slug, e.g. \"legacy\" or a generated ID), or query the spacelift_spaces data source."
+  type        = string
+}
+
 resource "spacelift_stack" "nuon" {
   name              = "nuon-{{.InstallID}}"
   description       = "Nuon runner install stack for {{.InstallID}}"
+  space_id          = var.space_id
   repository        = "install-stacks"
   branch            = "main"
   project_root      = "gcp"
@@ -27,6 +33,16 @@ resource "spacelift_stack" "nuon" {
     namespace = "nuonco"
     url       = "https://github.com/nuonco/install-stacks.git"
   }
+}
+
+# Attaches Spacelift's native GCP Workload Identity Federation integration to
+# this stack, so runs get a GOOGLE_OAUTH_ACCESS_TOKEN automatically instead of
+# requiring a manual Settings -> Integrations attachment in the dashboard.
+# You still need to grant service_account_email (see output after apply) an
+# IAM role on your target GCP project.
+resource "spacelift_gcp_service_account" "nuon" {
+  stack_id     = spacelift_stack.nuon.id
+  token_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 }
 
 resource "spacelift_mounted_file" "inputs" {
@@ -41,6 +57,11 @@ resource "spacelift_mounted_file" "secrets" {
   relative_path = "source/gcp/secrets.auto.tfvars"
   write_only    = true
   content       = filebase64("${path.module}/secrets.auto.tfvars")
+}
+
+output "gcp_service_account_email" {
+  description = "Grant this service account an IAM role on your target GCP project before triggering the stack's first run."
+  value       = spacelift_gcp_service_account.nuon.service_account_email
 }
 `
 

--- a/services/ctl-api/internal/pkg/stacks/gcp/spacelift_tmpl.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/spacelift_tmpl.go
@@ -15,8 +15,20 @@ const spaceliftAdminTfTmpl = `terraform {
 }
 
 variable "space_id" {
-  description = "ID of the Spacelift space to create this stack in. Find it in the Spacelift dashboard under Spaces (the URL slug, e.g. \"legacy\" or a generated ID), or query the spacelift_spaces data source."
+  description = "ID of the Spacelift space to create this stack in. Find it under Spaces in the Spacelift dashboard."
   type        = string
+  default     = ""
+
+  validation {
+    condition     = var.space_id != ""
+    error_message = "Set space_id to the ID of the Spacelift space this stack should live in."
+  }
+}
+
+variable "attach_gcp_service_account" {
+  description = "Attach Spacelift's native GCP integration (a dedicated per-stack service account). Set to false if you already manage your own GCP integration for this stack."
+  type        = bool
+  default     = true
 }
 
 resource "spacelift_stack" "nuon" {
@@ -35,8 +47,8 @@ resource "spacelift_stack" "nuon" {
   }
 }
 
-# Attaches Spacelift's native GCP integration; grant the printed service account an IAM role on your GCP project.
 resource "spacelift_gcp_service_account" "nuon" {
+  count        = var.attach_gcp_service_account ? 1 : 0
   stack_id     = spacelift_stack.nuon.id
   token_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 }
@@ -57,7 +69,7 @@ resource "spacelift_mounted_file" "secrets" {
 
 output "gcp_service_account_email" {
   description = "Grant this service account an IAM role on your target GCP project before triggering the stack's first run."
-  value       = spacelift_gcp_service_account.nuon.service_account_email
+  value       = var.attach_gcp_service_account ? spacelift_gcp_service_account.nuon[0].service_account_email : null
 }
 `
 

--- a/services/ctl-api/internal/pkg/stacks/gcp/tmpl.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/tmpl.go
@@ -3,8 +3,12 @@ package gcp
 const inputsTmpl = `nuon_install_id          = "{{.Install.ID}}"
 nuon_org_id              = "{{.Runner.OrgID}}"
 nuon_app_id              = "{{.Install.AppID}}"
-gcp_project_id           = "{{.GCPProjectID}}"{{if not .GCPProjectID}} # required: set your target GCP project ID{{end}}
-gcp_region               = "{{.GCPRegion}}"{{if not .GCPRegion}} # required: set your target GCP region{{end}}
+{{- if .GCPProjectID}}
+gcp_project_id           = "{{.GCPProjectID}}"
+{{- end}}
+{{- if .GCPRegion}}
+gcp_region               = "{{.GCPRegion}}"
+{{- end}}
 runner_api_url           = "{{.Settings.RunnerAPIURL}}"
 {{- if .APIToken}}
 runner_api_token         = "{{.APIToken}}"

--- a/services/ctl-api/internal/pkg/stacks/gcp/tmpl.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/tmpl.go
@@ -3,12 +3,8 @@ package gcp
 const inputsTmpl = `nuon_install_id          = "{{.Install.ID}}"
 nuon_org_id              = "{{.Runner.OrgID}}"
 nuon_app_id              = "{{.Install.AppID}}"
-{{- if .GCPProjectID}}
-gcp_project_id           = "{{.GCPProjectID}}"
-{{- end}}
-{{- if .GCPRegion}}
-gcp_region               = "{{.GCPRegion}}"
-{{- end}}
+gcp_project_id           = "{{.GCPProjectID}}"{{if not .GCPProjectID}} # required: set your target GCP project ID{{end}}
+gcp_region               = "{{.GCPRegion}}"{{if not .GCPRegion}} # required: set your target GCP region{{end}}
 runner_api_url           = "{{.Settings.RunnerAPIURL}}"
 {{- if .APIToken}}
 runner_api_token         = "{{.APIToken}}"

--- a/services/dashboard-ui/bun.lock
+++ b/services/dashboard-ui/bun.lock
@@ -22,6 +22,7 @@
         "@uiw/react-codemirror": "4.25.9",
         "@xyflow/react": "12.8.2",
         "cronstrue": "2.59.0",
+        "fflate": "0.8.3",
         "html-to-image": "1.11.13",
         "js-confetti": "0.13.1",
         "luxon": "3.7.1",
@@ -784,6 +785,8 @@
     "fault": ["fault@1.0.4", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
@@ -335,6 +335,15 @@ const TerraformSubTab = ({
             Download all (.zip)
           </Button>
         </span>
+        <Text variant="subtext" theme="neutral">
+          Unpack all three into one directory, then edit before applying: set{' '}
+          <code>space_id</code> in <code>spacelift.tf</code> to the Spacelift
+          space this stack should live in (already have your own GCP
+          integration for this stack? set <code>attach_gcp_service_account</code>{' '}
+          to <code>false</code> instead), fill in <code>inputs.auto.tfvars</code>,
+          and replace the placeholders in <code>secrets.auto.tfvars</code> with
+          your real secrets.
+        </Text>
         <Card>
           <span className="flex justify-between items-center">
             <Text>

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { strToU8, zipSync } from 'fflate'
 import { Button } from '@/components/common/Button'
 import { Card } from '@/components/common/Card'
 import { ClickToCopyButton } from '@/components/common/ClickToCopy'
@@ -96,6 +97,7 @@ export const AwaitGCPDetails = ({
                 blueprintYaml={envelope.spaceliftBlueprintYaml}
                 inputsTfvars={envelope.inputs}
                 secretsTfvars={envelope.secrets}
+                installId={installId}
               />
             ),
           }}
@@ -242,6 +244,7 @@ interface ISpaceliftTab {
   blueprintYaml: string
   inputsTfvars: string
   secretsTfvars: string
+  installId?: string
 }
 
 const SpaceliftTab = ({
@@ -249,6 +252,7 @@ const SpaceliftTab = ({
   blueprintYaml,
   inputsTfvars,
   secretsTfvars,
+  installId,
 }: ISpaceliftTab) => {
   return (
     <div className="flex flex-col gap-4 pt-4">
@@ -283,6 +287,7 @@ const SpaceliftTab = ({
               adminTf={adminTf}
               inputsTfvars={inputsTfvars}
               secretsTfvars={secretsTfvars}
+              installId={installId}
             />
           ),
         }}
@@ -295,19 +300,41 @@ interface ITerraformSubTab {
   adminTf: string
   inputsTfvars: string
   secretsTfvars: string
+  installId?: string
 }
 
 const TerraformSubTab = ({
   adminTf,
   inputsTfvars,
   secretsTfvars,
+  installId,
 }: ITerraformSubTab) => {
   return (
     <div className="flex flex-col gap-4 pt-4">
       <div className="flex flex-col gap-4">
-        <Text variant="base" weight="strong">
-          1. Add these files to your Spacelift terraform project
-        </Text>
+        <span className="flex justify-between items-center">
+          <Text variant="base" weight="strong">
+            1. Add these files to your Spacelift terraform project
+          </Text>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => {
+              const zipped = zipSync({
+                'spacelift.tf': strToU8(adminTf),
+                'inputs.auto.tfvars': strToU8(inputsTfvars),
+                'secrets.auto.tfvars': strToU8(secretsTfvars),
+              })
+              createFileDownload(
+                new Blob([zipped], { type: 'application/zip' }),
+                `nuon-spacelift-${installId ?? 'stack'}.zip`,
+                'application/zip'
+              )
+            }}
+          >
+            Download all (.zip)
+          </Button>
+        </span>
         <Card>
           <span className="flex justify-between items-center">
             <Text>

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
@@ -403,6 +403,64 @@ const TerraformSubTab = ({
           <Code variant="preformated">{secretsTfvars}</Code>
         </Card>
       </div>
+
+      <Divider />
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          2. Authenticate the provider to Spacelift
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          Create a{' '}
+          <Link
+            href="https://docs.spacelift.io/integrations/api#spacelift-api-key"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Spacelift API key
+          </Link>{' '}
+          and export it as <code>SPACELIFT_API_KEY_ENDPOINT</code>,{' '}
+          <code>SPACELIFT_API_KEY_ID</code>, and{' '}
+          <code>SPACELIFT_API_KEY_SECRET</code> before applying.
+        </Text>
+      </div>
+
+      <Divider />
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          3. Apply with Terraform
+        </Text>
+        <Card>
+          <span className="flex justify-between items-center">
+            <Text>Run in the directory with all three files</Text>
+            <ClickToCopyButton textToCopy="terraform init && terraform apply" />
+          </span>
+          <Code variant="preformated">terraform init && terraform apply</Code>
+        </Card>
+        <Text variant="subtext" theme="neutral">
+          This creates the install stack, mounts your tfvars, and (unless you
+          set <code>attach_gcp_service_account</code> to <code>false</code>)
+          attaches Spacelift&apos;s native GCP integration, no manual{' '}
+          <strong>Settings → Integrations</strong> step needed.
+        </Text>
+      </div>
+
+      <Divider />
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          4. Grant access, then run the install stack
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          If you attached the GCP integration (the default), grant the
+          printed <code>gcp_service_account_email</code> output an IAM role on
+          your target GCP project. If you attached your own integration
+          instead, confirm its identity already has that access. Then trigger
+          the stack&apos;s first run, it&apos;s set to auto-deploy, so it
+          plans and applies your runner without further approval.
+        </Text>
+      </div>
     </div>
   )
 }

--- a/services/dashboard-ui/package.json
+++ b/services/dashboard-ui/package.json
@@ -40,6 +40,7 @@
     "@uiw/react-codemirror": "4.25.9",
     "@xyflow/react": "12.8.2",
     "cronstrue": "2.59.0",
+    "fflate": "0.8.3",
     "html-to-image": "1.11.13",
     "js-confetti": "0.13.1",
     "luxon": "3.7.1",


### PR DESCRIPTION
GCP BYOC installs via the new Spacelift path had no space_id (silently defaulting to a space the customer's API key often can't create in) and no cloud integration attached (runs failed with "could not find default credentials" until you manually attached one in the dashboard). Now spacelift.tf ships a space_id variable and an attach_gcp_service_account toggle (on by default, off if you already manage your own GCP integration for that stack) that you edit directly into the file alongside the other tfvars, so the apply command never changes between steps. Also fixed the broken API-key doc link, reformatted the terraform-path docs with bullets and matching in-app copy, and added a "Download all" zip button for the three generated files.