### PR TITLE
fix: support GCS-backed blob storage on GCP-hosted control plane

### DIFF
--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -79,6 +79,7 @@ func init() {
 
 	config.RegisterDefault("aws_cloudformation_stack_template_bucket_region", "us-east-1")
 	config.RegisterDefault("gcp_stack_template_bucket", "nuon-install-templates-gcp")
+	config.RegisterDefault("blob_storage_provider", "s3")
 	config.RegisterDefault("gcp_stack_template_base_url", "https://storage.googleapis.com/nuon-install-templates-gcp")
 	config.RegisterDefault("org_creation_email_allow_list", "nuon.co")
 	config.RegisterDefault("temporal_dataconverter_large_payload_size", 1024*128)
@@ -427,9 +428,12 @@ type Config struct {
 	// their first org. Empty disables the integration (e.g. BYOC/self-hosted).
 	SFTrialEndpoint string `config:"sf_trial_access_endpoint"`
 
-	// Blob storage configuration
-	BlobStorageBucket string `config:"blob_storage_bucket" validate:"required"`
-	BlobStorageRegion string `config:"blob_storage_region" validate:"required"`
+	// Blob storage configuration. Provider selects the backend: "s3" (default,
+	// AWS-hosted installs) or "gcs" (self-hosted control-plane installs on GCP,
+	// where BlobStorageBucket is a native GCS bucket rather than S3).
+	BlobStorageBucket   string `config:"blob_storage_bucket" validate:"required"`
+	BlobStorageRegion   string `config:"blob_storage_region" validate:"required"`
+	BlobStorageProvider string `config:"blob_storage_provider" validate:"required,oneof=s3 gcs"`
 
 	// Enqueuer worker pool size — how many signals can be enqueued in parallel.
 	EnqueuerMaxWorkers int `config:"enqueuer_max_workers"`

--- a/services/ctl-api/internal/pkg/blobstore/gcs_service.go
+++ b/services/ctl-api/internal/pkg/blobstore/gcs_service.go
@@ -1,0 +1,138 @@
+package blobstore
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"time"
+
+	"cloud.google.com/go/storage"
+
+	"github.com/nuonco/nuon/pkg/metrics"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+// gcsService is the GCS-backed implementation of Service, used when
+// BLOB_STORAGE_PROVIDER=gcs. Auth is via Application Default Credentials —
+// on a GCP-hosted control plane this resolves through GKE Workload Identity,
+// which already carries roles/storage.admin on the blob bucket.
+type gcsService struct {
+	cfg    *internal.Config
+	bucket *storage.BucketHandle
+	mw     metrics.Writer
+
+	// dlInFlight mirrors the S3 service's in-flight download gauge.
+	dlInFlight int64
+}
+
+func newGCSService(ctx context.Context, cfg *internal.Config, mw metrics.Writer) (Service, error) {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gcs client: %w", err)
+	}
+
+	return &gcsService{
+		cfg:    cfg,
+		bucket: client.Bucket(cfg.BlobStorageBucket),
+		mw:     mw,
+	}, nil
+}
+
+func (s *gcsService) Upload(ctx context.Context, key string, data []byte) error {
+	if _, err := s.writeObject(ctx, key, bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("failed to upload blob: %w", err)
+	}
+	return nil
+}
+
+func (s *gcsService) Download(ctx context.Context, key string) ([]byte, error) {
+	r, err := s.bucket.Object(key).NewReader(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get object: %w", err)
+	}
+	defer r.Close()
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read object: %w", err)
+	}
+	return data, nil
+}
+
+func (s *gcsService) UploadStream(ctx context.Context, key string, reader io.Reader) (string, error) {
+	checksum, err := s.writeObject(ctx, key, reader)
+	if err != nil {
+		return "", fmt.Errorf("failed to upload stream: %w", err)
+	}
+	return checksum, nil
+}
+
+// writeObject streams reader into the object at key, returning a sha256:<hex>
+// checksum of the content — same format as the S3 uploader.
+func (s *gcsService) writeObject(ctx context.Context, key string, reader io.Reader) (string, error) {
+	// Cancelling the writer's context aborts the upload on a copy error,
+	// replacing the deprecated Writer.CloseWithError.
+	wctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	w := s.bucket.Object(key).NewWriter(wctx)
+
+	hash := sha256.New()
+	if _, err := io.Copy(w, io.TeeReader(reader, hash)); err != nil {
+		cancel()
+		return "", fmt.Errorf("failed to write object: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return "", fmt.Errorf("failed to close writer: %w", err)
+	}
+
+	return fmt.Sprintf("sha256:%x", hash.Sum(nil)), nil
+}
+
+func (s *gcsService) DownloadStream(ctx context.Context, key string) (io.ReadCloser, error) {
+	inFlight := atomic.AddInt64(&s.dlInFlight, 1)
+	s.mw.Gauge("blobstore.gcs.download.in_flight", float64(inFlight), nil)
+
+	start := time.Now()
+	r, err := s.bucket.Object(key).NewReader(ctx)
+	if err != nil {
+		s.mw.Gauge("blobstore.gcs.download.in_flight", float64(atomic.AddInt64(&s.dlInFlight, -1)), nil)
+		s.mw.Timing("blobstore.gcs.get_object.latency", time.Since(start), []string{"status:error"})
+		s.mw.Incr("blobstore.gcs.get_object", []string{"status:error"})
+		return nil, fmt.Errorf("failed to get object: %w", err)
+	}
+
+	s.mw.Timing("blobstore.gcs.get_object.latency", time.Since(start), []string{"status:success"})
+	s.mw.Incr("blobstore.gcs.get_object", []string{"status:success"})
+
+	return &meteredBody{
+		rc:    r,
+		start: start,
+		onClose: func(nbytes int64, dur time.Duration) {
+			s.mw.Gauge("blobstore.gcs.download.in_flight", float64(atomic.AddInt64(&s.dlInFlight, -1)), nil)
+			s.mw.Timing("blobstore.gcs.download.latency", dur, nil)
+			s.mw.Distribution("blobstore.gcs.download.bytes", float64(nbytes), nil)
+		},
+	}, nil
+}
+
+func (s *gcsService) GetMetadata(ctx context.Context, key string) (int64, string, error) {
+	start := time.Now()
+	attrs, err := s.bucket.Object(key).Attrs(ctx)
+	if err != nil {
+		s.mw.Timing("blobstore.gcs.head_object.latency", time.Since(start), []string{"status:error"})
+		s.mw.Incr("blobstore.gcs.head_object", []string{"status:error"})
+		return 0, "", fmt.Errorf("failed to get metadata: %w", err)
+	}
+	s.mw.Timing("blobstore.gcs.head_object.latency", time.Since(start), []string{"status:success"})
+	s.mw.Incr("blobstore.gcs.head_object", []string{"status:success"})
+
+	contentType := attrs.ContentType
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	return attrs.Size, contentType, nil
+}

--- a/services/ctl-api/internal/pkg/blobstore/service.go
+++ b/services/ctl-api/internal/pkg/blobstore/service.go
@@ -56,6 +56,10 @@ type service struct {
 
 // NewService creates a new blob storage service
 func NewService(cfg *internal.Config, mw metrics.Writer) (Service, error) {
+	if cfg.BlobStorageProvider == "gcs" {
+		return newGCSService(context.Background(), cfg, mw)
+	}
+
 	v := validator.New()
 
 	// Create uploader


### PR DESCRIPTION
Blob storage (runner job plans, build blobs) always used the raw AWS S3 SDK, so every write failed with an endpoint-resolution error on self-hosted GCP installs. Adds a GCS-backed Service, selected via BLOB_STORAGE_PROVIDER=gcs (defaults to s3, no behavior change for AWS installs).