### PR TITLE
fix: improve pending approvals query

### DIFF
--- a/services/ctl-api/internal/app/installs/service/get_org_pending_approvals.go
+++ b/services/ctl-api/internal/app/installs/service/get_org_pending_approvals.go
@@ -44,15 +44,32 @@ func (s *service) GetOrgPendingApprovals(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, approvals)
 }
 
+// Do not use a view here: the pushed-down org_id makes the planner scan the
+// org's full approval history (~2s cold). ANY(ARRAY(...)) fences the active-step
+// set so it materializes first and approvals are probed by step id, which keeps
+// the plan fast regardless of the planner's choice.
 func (s *service) getOrgPendingApprovals(ctx *gin.Context, orgID string) ([]app.WorkflowStepApproval, error) {
-	viewName := "install_workflow_step_approvals_pending_v1"
 	var approvals []app.WorkflowStepApproval
 	res := s.db.WithContext(ctx).
 		Omit("contents").
-		Scopes(scopes.WithOverrideTable(viewName), scopes.WithOffsetPagination).
-		Joins("LEFT JOIN installs ON installs.id = "+viewName+".owner_id AND "+viewName+".owner_type = 'installs'").
-		Where("("+viewName+".owner_type != 'installs' OR installs.deleted_at = 0)").
-		Where(viewName+".org_id = ?", orgID).
+		Scopes(scopes.WithOffsetPagination).
+		Joins("LEFT JOIN installs ON installs.id = install_workflow_step_approvals.owner_id AND install_workflow_step_approvals.owner_type = 'installs'").
+		Where("install_workflow_step_approvals.owner_type != 'installs' OR installs.deleted_at = 0").
+		Where("install_workflow_step_approvals.deleted_at = 0").
+		Where(`install_workflow_step_approvals.install_workflow_step_id = ANY(ARRAY(
+			SELECT s.id
+			FROM install_workflow_steps s
+			JOIN install_workflows w ON w.id = s.install_workflow_id
+			JOIN installs iw ON iw.id = w.owner_id AND iw.deleted_at = 0
+			WHERE w.org_id = ?
+			  AND w.finished_at IS NULL
+			  AND w.deleted_at = 0
+			  AND w.approval_option = 'prompt'
+			  AND (w.status->>'status') NOT IN ('cancelled', 'error')
+			  AND s.deleted_at = 0
+			  AND (s.status->>'status') NOT IN ('auto-skipped', 'cancelled', 'error')
+		))`, orgID).
+		Where("NOT EXISTS (SELECT 1 FROM install_workflow_step_approval_responses r WHERE r.install_workflow_step_approval_id = install_workflow_step_approvals.id AND r.deleted_at = 0)").
 		Preload("InstallWorkflowStep").
 		Preload("Response").
 		Find(&approvals)

--- a/services/ctl-api/internal/app/workflow.go
+++ b/services/ctl-api/internal/app/workflow.go
@@ -310,6 +310,13 @@ func (i *Workflow) Indexes(db *gorm.DB) []migrations.Index {
 				"created_at DESC",
 			},
 		},
+		{
+			Name: "idx_install_workflows_active_prompt",
+			Columns: []string{
+				"org_id",
+			},
+			Option: "WHERE finished_at IS NULL AND deleted_at = 0 AND approval_option = 'prompt'",
+		},
 	}
 }
 

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -5932,7 +5932,7 @@ export interface components {
        * @description Data is the typed, per-error-type payload: WHAT the error is. Closed
        * schema per Type. Read to render sections and by any future view.
        */
-      data?: number[];
+      data?: Record<string, never>;
       /**
        * @description Hints is the open annotation/directive bag: HOW to handle or present the
        * error. Canonical keys (Hint*) are honored by specific consumers.


### PR DESCRIPTION
The endpoint intermittently hit ~2.2s (Datadog slow-query alerts). Slow when the cache was cold.

Cause

It queried the pending_v1 view, which made Postgres scan the org's entire approval history (~2,500 rows for one org) to find the handful that are actually pending ~9,000 buffers to return a few rows. Cold, that's the 2.2s.

Fix

Rewrite the query to drive from the org's active workflows (few) instead of all its approvals, backed by a new partial index. Uses ANY(ARRAY(...)) so the fast plan is deterministic. No data-model changes; the view is left in place, unused.

Results

- 2,205ms → 3.6ms warm / ~300ms cold worst-case
- Verified identical results to the old view: a set-diff across every org in prod returned zero rows.