### PR TITLE
refactor(ui): correct timestamps and links for workflows

### DIFF
--- a/services/ctl-api/internal/app/installs/service/get_org_workflows.go
+++ b/services/ctl-api/internal/app/installs/service/get_org_workflows.go
@@ -103,6 +103,7 @@ func (s *service) getOrgWorkflows(ctx *gin.Context, orgID string, excludePlanOnl
 	query := s.db.WithContext(ctx).
 		Scopes(scopes.WithOffsetPagination).
 		Preload("CreatedBy").
+		Preload("AppBranchRuns.AppBranch").
 		Joins("LEFT JOIN installs ON installs.id = install_workflows.owner_id AND install_workflows.owner_type = 'installs'").
 		Where("(install_workflows.owner_type != 'installs' OR installs.deleted_at = 0)").
 		Where("install_workflows.org_id = ?", orgID).

--- a/services/dashboard-ui/client/components/workflows/ActiveWorkflowCard.tsx
+++ b/services/dashboard-ui/client/components/workflows/ActiveWorkflowCard.tsx
@@ -11,7 +11,10 @@ import { useWorkflowApprovals } from '@/hooks/use-workflow-approvals'
 import type { TInstall, TWorkflow } from '@/types'
 import { cn } from '@/utils/classnames'
 import { toSentenceCase, snakeToWords } from '@/utils/string-utils'
-import { getWorkflowPendingApprovals } from '@/utils/workflow-utils'
+import {
+  getWorkflowHref,
+  getWorkflowPendingApprovals,
+} from '@/utils/workflow-utils'
 import { CancelWorkflowButton } from './CancelWorkflow'
 
 export const ActiveWorkflowCard = ({
@@ -31,8 +34,9 @@ export const ActiveWorkflowCard = ({
 }) => {
   const { org } = useOrg()
   const { approvals } = useWorkflowApprovals()
-  const installId = workflow.owner_id
-  const installName = workflow.metadata?.owner_name
+  const workflowHref = getWorkflowHref(org.id, workflow)
+  const isAppBranchWorkflow = workflow?.owner_type === 'app_branches'
+  const ownerName = workflow.metadata?.owner_name
   const pendingWorkflowApprovals = getWorkflowPendingApprovals(
     approvals,
     workflow?.id
@@ -50,14 +54,11 @@ export const ActiveWorkflowCard = ({
 
   const titleAndBadges = (
     <>
-      <Link
-        href={`/${org.id}/installs/${installId}/workflows/${workflow.id}`}
-        className="min-w-0"
-      >
+      <Link href={workflowHref} className="min-w-0">
         <Text variant="base" weight="strong" className="truncate">
-          {installName && !install && (
+          {ownerName && !install && (
             <span className="text-cool-grey-500 dark:text-white/50 mr-1.5">
-              {installName} /
+              {ownerName} /
             </span>
           )}
           {workflow.name}
@@ -66,7 +67,11 @@ export const ActiveWorkflowCard = ({
       {pendingApprovals > 0 &&
         (pendingApprovalStep?.id ? (
           <Link
-            href={`/${org.id}/installs/${installId}/workflows/${workflow.id}?panel=${pendingApprovalStep.id}`}
+            href={
+              isAppBranchWorkflow
+                ? workflowHref
+                : `${workflowHref}?panel=${pendingApprovalStep.id}`
+            }
             className="shrink-0 hover:opacity-80 transition-opacity !text-inherit"
           >
             <Badge size="sm" theme="warn">

--- a/services/dashboard-ui/client/components/workflows/WorkflowTimeline/WorkflowTimeline.tsx
+++ b/services/dashboard-ui/client/components/workflows/WorkflowTimeline/WorkflowTimeline.tsx
@@ -137,6 +137,7 @@ export const WorkflowTimeline = ({
                   className="gap-1"
                   variant="subtext"
                   theme="neutral"
+                  title="Created"
                 >
                   <Icon variant="CalendarBlankIcon" />{' '}
                   <Time time={workflow?.created_at} variant="subtext" />
@@ -146,10 +147,15 @@ export const WorkflowTimeline = ({
                   className="gap-1"
                   variant="subtext"
                   theme="neutral"
+                  title={workflow?.finished ? 'Finished' : 'Last updated'}
                 >
                   <Icon variant="ClockClockwiseIcon" />{' '}
                   <Time
-                    time={workflow?.updated_at}
+                    time={
+                      workflow?.finished && workflow?.finished_at
+                        ? workflow.finished_at
+                        : workflow?.updated_at
+                    }
                     variant="subtext"
                     format="relative"
                   />
@@ -160,6 +166,7 @@ export const WorkflowTimeline = ({
                     className="gap-1"
                     variant="subtext"
                     theme="neutral"
+                    title="Duration"
                   >
                     <Icon variant="TimerIcon" />{' '}
                     <Duration

--- a/services/dashboard-ui/client/utils/workflow-utils.ts
+++ b/services/dashboard-ui/client/utils/workflow-utils.ts
@@ -34,6 +34,18 @@ export function getWorkflowBadge(workflow: TWorkflow): TBadgeCfg {
   return status && WORKFLOW_BADGE_MAP[status] ? WORKFLOW_BADGE_MAP[status] : {}
 }
 
+export function getWorkflowHref(orgId: string, workflow: TWorkflow): string {
+  if (workflow?.owner_type === 'app_branches') {
+    const run = workflow?.app_branch_runs?.[0]
+    const appId = run?.app_branch?.app_id
+    const branchId = run?.app_branch?.id ?? workflow?.owner_id
+    if (appId && branchId && workflow?.id) {
+      return `/${orgId}/apps/${appId}/branches/${branchId}/runs/${workflow.id}`
+    }
+  }
+  return `/${orgId}/installs/${workflow?.owner_id}/workflows/${workflow?.id}`
+}
+
 // The retry "lineage" badge — how this attempt relates to its retries. Distinct
 // from the outcome badge (below) so a retry row can show both.
 function getStepLineageBadge(step: TWorkflowStep): TBadgeCfg | undefined {


### PR DESCRIPTION
- Use finished_at with updated_at fallback for workflow timestamps
- Fix active workflow links for app branch runs