### PR TITLE
fix: resolve component dependencies in server-side app config syncer

### DIFF
--- a/services/ctl-api/internal/pkg/config/syncer/components/docker.go
+++ b/services/ctl-api/internal/pkg/config/syncer/components/docker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/pkg/config/sync"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	componenthelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
 	vcshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/vcs/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/config/syncer/validation"
@@ -20,7 +21,7 @@ import (
 
 // SyncDockerBuildComponent creates or updates a Docker build component configuration.
 // Duplicates logic from services/ctl-api/internal/app/components/service/create_docker_build_component_config.go
-func SyncDockerBuildComponent(ctx context.Context, db *gorm.DB, vcsHelper *vcshelpers.Helpers, comp *config.Component, componentID, appID, appConfigID string) (string, string, error) {
+func SyncDockerBuildComponent(ctx context.Context, db *gorm.DB, vcsHelper *vcshelpers.Helpers, compHelpers *componenthelpers.Helpers, comp *config.Component, componentID, appID, appConfigID string) (string, string, error) {
 	// Validate Docker build component
 	if err := validateDockerBuildComponent(comp); err != nil {
 		return "", "", sync.SyncErr{
@@ -82,9 +83,13 @@ func SyncDockerBuildComponent(ctx context.Context, db *gorm.DB, vcsHelper *vcshe
 	// Resolve component dependencies
 	depIDs := []string{}
 	if len(comp.Dependencies) > 0 {
-		// TODO: Implement GetComponentIDs helper
-		// For now, we'll leave dependencies empty
-		// depIDs, err = helpers.GetComponentIDs(ctx, appID, comp.Dependencies)
+		depIDs, err = compHelpers.GetComponentIDs(ctx, appID, comp.Dependencies)
+		if err != nil {
+			return "", "", sync.SyncInternalErr{
+				Description: fmt.Sprintf("unable to resolve dependencies for component %s", comp.Name),
+				Err:         err,
+			}
+		}
 	}
 
 	// Build env vars map

--- a/services/ctl-api/internal/pkg/config/syncer/components/external_image.go
+++ b/services/ctl-api/internal/pkg/config/syncer/components/external_image.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/pkg/config/sync"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	componenthelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/config/syncer/validation"
 )
@@ -20,7 +21,7 @@ import (
 //
 // Mirrors creation logic from
 // services/ctl-api/internal/app/components/service/create_external_image_config.go.
-func SyncExternalImageComponent(ctx context.Context, db *gorm.DB, comp *config.Component, componentID, appID, appConfigID string) (string, string, error) {
+func SyncExternalImageComponent(ctx context.Context, db *gorm.DB, compHelpers *componenthelpers.Helpers, comp *config.Component, componentID, appID, appConfigID string) (string, string, error) {
 	if err := validateExternalImageComponent(comp); err != nil {
 		return "", "", sync.SyncErr{
 			Resource:    fmt.Sprintf("component-%s", comp.Name),
@@ -33,6 +34,17 @@ func SyncExternalImageComponent(ctx context.Context, db *gorm.DB, comp *config.C
 		return "", "", sync.SyncErr{
 			Resource:    fmt.Sprintf("component-%s", comp.Name),
 			Description: err.Error(),
+		}
+	}
+
+	depIDs := []string{}
+	if len(comp.Dependencies) > 0 {
+		depIDs, err = compHelpers.GetComponentIDs(ctx, appID, comp.Dependencies)
+		if err != nil {
+			return "", "", sync.SyncInternalErr{
+				Description: fmt.Sprintf("unable to resolve dependencies for component %s", comp.Name),
+				Err:         err,
+			}
 		}
 	}
 
@@ -62,7 +74,7 @@ func SyncExternalImageComponent(ctx context.Context, db *gorm.DB, comp *config.C
 		ExternalImageComponentConfig: &cfg,
 		ComponentID:                  componentID,
 		AppConfigID:                  appConfigID,
-		ComponentDependencyIDs:       pq.StringArray{},
+		ComponentDependencyIDs:       pq.StringArray(depIDs),
 		References:                   pq.StringArray(references),
 		Checksum:                     comp.Checksum,
 		BuildTimeout:                 comp.ExternalImage.BuildTimeout,

--- a/services/ctl-api/internal/pkg/config/syncer/components/helm.go
+++ b/services/ctl-api/internal/pkg/config/syncer/components/helm.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/pkg/config/sync"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	componenthelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
 	vcshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/vcs/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/config/syncer/validation"
@@ -20,7 +21,7 @@ import (
 
 // SyncHelmComponent creates or updates a Helm component configuration.
 // Duplicates logic from services/ctl-api/internal/app/components/service/create_helm_component_config.go
-func SyncHelmComponent(ctx context.Context, db *gorm.DB, vcsHelper *vcshelpers.Helpers, comp *config.Component, componentID, appID, appConfigID string) (string, string, error) {
+func SyncHelmComponent(ctx context.Context, db *gorm.DB, vcsHelper *vcshelpers.Helpers, compHelpers *componenthelpers.Helpers, comp *config.Component, componentID, appID, appConfigID string) (string, string, error) {
 	// Validate Helm component
 	if err := validateHelmComponent(comp); err != nil {
 		return "", "", sync.SyncErr{
@@ -82,7 +83,13 @@ func SyncHelmComponent(ctx context.Context, db *gorm.DB, vcsHelper *vcshelpers.H
 	// Resolve component dependencies
 	depIDs := []string{}
 	if len(comp.Dependencies) > 0 {
-		// TODO: Implement GetComponentIDs helper
+		depIDs, err = compHelpers.GetComponentIDs(ctx, appID, comp.Dependencies)
+		if err != nil {
+			return "", "", sync.SyncInternalErr{
+				Description: fmt.Sprintf("unable to resolve dependencies for component %s", comp.Name),
+				Err:         err,
+			}
+		}
 	}
 
 	// Build values map

--- a/services/ctl-api/internal/pkg/config/syncer/components/kubernetes.go
+++ b/services/ctl-api/internal/pkg/config/syncer/components/kubernetes.go
@@ -12,11 +12,12 @@ import (
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/pkg/config/sync"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	componenthelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
 	vcshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/vcs/helpers"
 )
 
 // SyncKubernetesManifestComponent creates or updates a Kubernetes manifest component configuration.
-func SyncKubernetesManifestComponent(ctx context.Context, db *gorm.DB, vcsHelper *vcshelpers.Helpers, comp *config.Component, componentID, appID, appConfigID string) (string, string, error) {
+func SyncKubernetesManifestComponent(ctx context.Context, db *gorm.DB, vcsHelper *vcshelpers.Helpers, compHelpers *componenthelpers.Helpers, comp *config.Component, componentID, appID, appConfigID string) (string, string, error) {
 	if comp.KubernetesManifest == nil {
 		return "", "", sync.SyncErr{
 			Resource:    fmt.Sprintf("component-%s", comp.Name),
@@ -72,6 +73,18 @@ func SyncKubernetesManifestComponent(ctx context.Context, db *gorm.DB, vcsHelper
 		}
 	}
 
+	// Resolve component dependencies
+	depIDs := []string{}
+	if len(comp.Dependencies) > 0 {
+		depIDs, err = compHelpers.GetComponentIDs(ctx, appID, comp.Dependencies)
+		if err != nil {
+			return "", "", sync.SyncInternalErr{
+				Description: fmt.Sprintf("unable to resolve dependencies for component %s", comp.Name),
+				Err:         err,
+			}
+		}
+	}
+
 	// Build kustomize config if present
 	var kustomize *app.KustomizeConfig
 	if comp.KubernetesManifest.Kustomize != nil {
@@ -110,7 +123,7 @@ func SyncKubernetesManifestComponent(ctx context.Context, db *gorm.DB, vcsHelper
 		KubernetesContextName:             comp.KubernetesContext,
 		ComponentID:                       componentID,
 		AppConfigID:                       appConfigID,
-		ComponentDependencyIDs:            pq.StringArray{},
+		ComponentDependencyIDs:            pq.StringArray(depIDs),
 		References:                        pq.StringArray(references),
 		Checksum:                          comp.Checksum,
 		BuildTimeout:                      comp.KubernetesManifest.BuildTimeout,

--- a/services/ctl-api/internal/pkg/config/syncer/components/pulumi.go
+++ b/services/ctl-api/internal/pkg/config/syncer/components/pulumi.go
@@ -12,10 +12,11 @@ import (
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/pkg/config/sync"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	componenthelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
 	vcshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/vcs/helpers"
 )
 
-func SyncPulumiComponent(ctx context.Context, db *gorm.DB, vcsHelper *vcshelpers.Helpers, comp *config.Component, componentID, appID, appConfigID string) (string, string, error) {
+func SyncPulumiComponent(ctx context.Context, db *gorm.DB, vcsHelper *vcshelpers.Helpers, compHelpers *componenthelpers.Helpers, comp *config.Component, componentID, appID, appConfigID string) (string, string, error) {
 	if comp.Pulumi == nil {
 		return "", "", sync.SyncErr{
 			Resource:    fmt.Sprintf("component-%s", comp.Name),
@@ -95,17 +96,29 @@ func SyncPulumiComponent(ctx context.Context, db *gorm.DB, vcsHelper *vcshelpers
 		references = append(references, ref.String())
 	}
 
+	depIDs := []string{}
+	if len(comp.Dependencies) > 0 {
+		depIDs, err = compHelpers.GetComponentIDs(ctx, appID, comp.Dependencies)
+		if err != nil {
+			return "", "", sync.SyncInternalErr{
+				Description: fmt.Sprintf("unable to resolve dependencies for component %s", comp.Name),
+				Err:         err,
+			}
+		}
+	}
+
 	ccc := app.ComponentConfigConnection{
-		PulumiComponentConfig: &pulumiCfg,
-		KubernetesContextName: comp.KubernetesContext,
-		ComponentID:           componentID,
-		AppConfigID:           appConfigID,
-		References:            references,
-		BuildTimeout:          obj.BuildTimeout,
-		DeployTimeout:         obj.DeployTimeout,
-		MaxAutoRetries:        obj.MaxAutoRetries,
-		SkipNoops:             obj.SkipNoops,
-		OperationRoles:        operationRoles,
+		PulumiComponentConfig:  &pulumiCfg,
+		KubernetesContextName:  comp.KubernetesContext,
+		ComponentID:            componentID,
+		AppConfigID:            appConfigID,
+		ComponentDependencyIDs: pq.StringArray(depIDs),
+		References:             references,
+		BuildTimeout:           obj.BuildTimeout,
+		DeployTimeout:          obj.DeployTimeout,
+		MaxAutoRetries:         obj.MaxAutoRetries,
+		SkipNoops:              obj.SkipNoops,
+		OperationRoles:         operationRoles,
 	}
 
 	if obj.AutoApproveOnPoliciesPassing != nil {

--- a/services/ctl-api/internal/pkg/config/syncer/components/sync.go
+++ b/services/ctl-api/internal/pkg/config/syncer/components/sync.go
@@ -106,12 +106,12 @@ func SyncComponent(ctx context.Context, db *gorm.DB, helpers *componenthelpers.H
 
 	switch comp.Type.APIType() {
 	case "docker_build":
-		configID, checksum, err = SyncDockerBuildComponent(ctx, db, vcsHelper, comp, apiComp.ID, appID, appConfigID)
+		configID, checksum, err = SyncDockerBuildComponent(ctx, db, vcsHelper, helpers, comp, apiComp.ID, appID, appConfigID)
 		if err != nil {
 			return err
 		}
 	case "helm_chart":
-		configID, checksum, err = SyncHelmComponent(ctx, db, vcsHelper, comp, apiComp.ID, appID, appConfigID)
+		configID, checksum, err = SyncHelmComponent(ctx, db, vcsHelper, helpers, comp, apiComp.ID, appID, appConfigID)
 		if err != nil {
 			return err
 		}
@@ -121,7 +121,7 @@ func SyncComponent(ctx context.Context, db *gorm.DB, helpers *componenthelpers.H
 			return err
 		}
 	case "external_image":
-		configID, checksum, err = SyncExternalImageComponent(ctx, db, comp, apiComp.ID, appID, appConfigID)
+		configID, checksum, err = SyncExternalImageComponent(ctx, db, helpers, comp, apiComp.ID, appID, appConfigID)
 		if err != nil {
 			return err
 		}
@@ -142,7 +142,7 @@ func SyncComponent(ctx context.Context, db *gorm.DB, helpers *componenthelpers.H
 			}
 		}
 	case "pulumi":
-		configID, checksum, err = SyncPulumiComponent(ctx, db, vcsHelper, comp, apiComp.ID, appID, appConfigID)
+		configID, checksum, err = SyncPulumiComponent(ctx, db, vcsHelper, helpers, comp, apiComp.ID, appID, appConfigID)
 		if err != nil {
 			return err
 		}
@@ -150,7 +150,7 @@ func SyncComponent(ctx context.Context, db *gorm.DB, helpers *componenthelpers.H
 		configID = ""
 		checksum = ""
 	case "kubernetes_manifest":
-		configID, checksum, err = SyncKubernetesManifestComponent(ctx, db, vcsHelper, comp, apiComp.ID, appID, appConfigID)
+		configID, checksum, err = SyncKubernetesManifestComponent(ctx, db, vcsHelper, helpers, comp, apiComp.ID, appID, appConfigID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The server-side DBSyncer (introduced with app branches in #515) never resolved component dependency names to IDs for helm, docker, external_image, kubernetes, and pulumi components, only terraform did.

As a result, `ComponentConfigConnection.ComponentDependencyIDs` was empty for these types, so the component detail page showed no dependencies once an app config routed through the branch path instead of the legacy CLI apisyncer.

Bring all types to parity with terraform by resolving dependencies via `compHelpers.GetComponentIDs` and persisting them on the connection.