### PR TITLE
fix: (ctl-api) read skip_auto_retry hint from runner job execution result

### DIFF
--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/get_step_error_hints.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/get_step_error_hints.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 )
 
 type GetStepErrorHintsRequest struct {
@@ -20,13 +20,13 @@ type GetStepErrorHintsResponse struct {
 
 // GetStepErrorHints returns the composite-error hints recorded for a failed
 // step's target. The runner-result chokepoint parses a failed execution into a
-// typed composite error and mirrors it (with its hints) onto the target
-// aggregate row (install_deploys / install_sandbox_runs). This activity reads
-// those hints back so the step orchestrator can act on them (e.g. skip
-// auto-retries for a failure that won't resolve by retrying).
+// typed composite error and stores it (with its hints) on the execution's
+// result row. This activity reads those hints back so the step orchestrator can
+// act on them (e.g. skip auto-retries for a failure that won't resolve by
+// retrying).
 //
 // It is best-effort: a target with no composite error, or a target type that
-// carries no composite_error column, yields empty hints.
+// carries no runner job, yields empty hints.
 //
 // @temporal-gen-v2 activity
 // @max-retries 1
@@ -49,34 +49,52 @@ func (a *Activities) GetStepErrorHints(ctx context.Context, req GetStepErrorHint
 	return &GetStepErrorHintsResponse{Hints: ce.Hints}, nil
 }
 
-// stepTargetCompositeError reads the composite_error column off the step's
-// target aggregate row. Only target types that carry the column are handled;
-// any other target (or an unset target) yields nil.
+// stepTargetCompositeError reads the composite error off the step target's
+// latest runner job execution result. This is the canonical, per-attempt copy:
+// the runner posts the result before the job is marked terminal, so the row is
+// visible by the time the step wakes and this activity runs. Reading it here
+// rather than the mirrored install_deploys / install_sandbox_runs aggregate
+// column avoids racing the chokepoint's best-effort aggregate write.
+//
+// Only deploy/sandbox-run targets own runner jobs with parsed composite errors;
+// any other target (or an unset target) yields nil. A missing runner
+// job/execution/result means no hint was recorded, so we yield nil rather than
+// failing.
 func (a *Activities) stepTargetCompositeError(ctx context.Context, step *app.WorkflowStep) (*compositeerrors.CompositeErrorData, error) {
 	if step.StepTargetID == "" {
 		return nil, nil
 	}
 
 	switch app.WorkflowStepTargetType(step.StepTargetType) {
-	case app.WorkflowStepTargetTypeInstallDeploy, app.WorkflowStepTargetTypeInstallDeploys:
-		var deploy app.InstallDeploy
-		if err := a.db.WithContext(ctx).
-			Select("composite_error").
-			First(&deploy, "id = ?", step.StepTargetID).Error; err != nil {
-			// A missing target row is terminal (won't resolve by retrying); a
-			// transient DB error stays retryable.
-			return nil, generics.TemporalGormError(err, "unable to get install deploy")
-		}
-		return deploy.CompositeError, nil
-	case app.WorkflowStepTargetTypeInstallSandboxRun, app.WorkflowStepTargetTypeInstallSandboxRuns:
-		var run app.InstallSandboxRun
-		if err := a.db.WithContext(ctx).
-			Select("composite_error").
-			First(&run, "id = ?", step.StepTargetID).Error; err != nil {
-			return nil, generics.TemporalGormError(err, "unable to get install sandbox run")
-		}
-		return run.CompositeError, nil
+	case app.WorkflowStepTargetTypeInstallDeploy, app.WorkflowStepTargetTypeInstallDeploys,
+		app.WorkflowStepTargetTypeInstallSandboxRun, app.WorkflowStepTargetTypeInstallSandboxRuns:
 	default:
 		return nil, nil
 	}
+
+	runnerJob, err := a.getRunnerJob(ctx, &GetRunnerJobRequest{RunnerJobOwnerID: step.StepTargetID})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "unable to get runner job for step target")
+	}
+
+	execution, err := a.getRunnerJobExecution(ctx, GetRunnerJobExecutionRequest{RunnerJobID: runnerJob.ID})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "unable to get runner job execution for step target")
+	}
+
+	result, err := a.getRunnerJobExecutionResult(ctx, GetRunnerJobExecutionResultRequest{RunnerJobExecutionID: execution.ID})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "unable to get runner job execution result for step target")
+	}
+
+	return result.CompositeError, nil
 }


### PR DESCRIPTION
`handleStepError` read the composite-error hint from the mirrored `install_deploys` / `install_sandbox_runs` aggregate column, which is written by a separate best-effort path on the runner-result POST. That write can lag the step's error handling, so the first group attempt could miss a `skip_auto_retry` hint and auto-retry the group anyway.

Read the hint from the step target's latest runner job execution result instead. That row carries the parsed composite error and is posted before the job is marked terminal, so it is visible by the time the step wakes and this activity runs, removing the race.