### PR TITLE
feat: (ctl-api) terraform tool-layer composite-error parser

### DIFF
--- a/services/ctl-api/internal/app/runners/errparse/dispatch_integration_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/dispatch_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse"
 	awsparse "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/aws"
 	genericparse "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/generic"
+	tfparse "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/terraform"
 )
 
 // This external test package imports both parser packages so their init()
@@ -38,5 +39,28 @@ func TestDefaultRegistry_GenericCatchesUnclassified(t *testing.T) {
 	}
 	if _, ok := ce.(*genericparse.GenericError); !ok {
 		t.Fatalf("expected generic fallback, got %T (type %q)", ce, ce.Type())
+	}
+}
+
+// TestDefaultRegistry_ToolLayerOrdering asserts the three-layer contract on a
+// terraform job: a terraform diagnostic that no provider parser recognises
+// yields the tool-layer parser (not the raw generic dump), while an AWS
+// permission blob on the same job is still won by the provider layer.
+func TestDefaultRegistry_ToolLayerOrdering(t *testing.T) {
+	tfDiag, err := os.ReadFile(filepath.Join("terraform", "testdata", "invalid_reference.txt"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	ce := errparse.Parse(&errparse.ParseContext{Raw: string(tfDiag), Tool: errparse.ToolTerraform})
+	if _, ok := ce.(*tfparse.TerraformError); !ok {
+		t.Fatalf("expected terraform tool-layer parser to win over generic, got %T (type %q)", ce, ce.Type())
+	}
+
+	awsBlob := "Error: creating S3 Bucket (acme): AccessDenied: User: " +
+		"arn:aws:iam::123:role/nuon-runner is not authorized to perform: " +
+		"s3:CreateBucket on resource: arn:aws:s3:::acme"
+	ce = errparse.Parse(&errparse.ParseContext{Raw: awsBlob, Tool: errparse.ToolTerraform})
+	if _, ok := ce.(*awsparse.AWSPermissionError); !ok {
+		t.Fatalf("expected AWS provider layer to win over terraform tool layer, got %T (type %q)", ce, ce.Type())
 	}
 }

--- a/services/ctl-api/internal/app/runners/errparse/terraform/error.go
+++ b/services/ctl-api/internal/app/runners/errparse/terraform/error.go
@@ -1,0 +1,173 @@
+// Package terraform holds tool-layer CompositeError parsers for terraform jobs.
+// They register at errparse.LayerTool so a provider-specific cause (e.g. an AWS
+// IAM denial parsed at LayerProvider) still wins, but any other terraform
+// diagnostic yields a clean, structured error instead of falling through to the
+// raw generic dump. This is the first tool-layer parser; more specific
+// terraform causes (state lock, backend init, ...) can register alongside it.
+package terraform
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+// TerraformErrorType is the discriminator for a terraform diagnostic that no
+// provider-layer parser recognised.
+const TerraformErrorType compositeerrors.Type = "terraform.error"
+
+const (
+	// maxHeadline bounds the one-line message; full detail lives in the output.
+	maxHeadline = 240
+	// maxBody bounds the stored output so a pathological log can't bloat the
+	// JSONB payload.
+	maxBody = 8000
+	// maxErrors caps how many distinct summaries we keep for the list section.
+	maxErrors = 20
+)
+
+// TerraformError is the tool-layer payload: the terraform "Error:" summaries
+// extracted from the diagnostics, plus the cleaned output for context.
+type TerraformError struct {
+	// Summary is the first terraform error summary (the text after "Error:").
+	Summary string `json:"summary"`
+	// Errors lists every distinct error summary when terraform reported more
+	// than one. Empty when there is only the single Summary.
+	Errors []string `json:"errors,omitempty"`
+	// Output is the cleaned, possibly-truncated diagnostic output.
+	Output string `json:"output,omitempty"`
+}
+
+var _ compositeerrors.CompositeError = (*TerraformError)(nil)
+
+// Error returns the first error summary as the headline, noting the count when
+// terraform reported several. The summary is truncated first so the "+N more"
+// suffix is never cut off.
+func (e *TerraformError) Error() string {
+	h := truncate(e.Summary, maxHeadline)
+	if n := len(e.Errors); n > 1 {
+		h = fmt.Sprintf("%s (+%d more errors)", h, n-1)
+	}
+	return h
+}
+
+func (e *TerraformError) Type() compositeerrors.Type { return TerraformErrorType }
+func (e *TerraformError) Severity() compositeerrors.Severity {
+	return compositeerrors.SeverityError
+}
+
+// Sections lists every summary when there are several (the headline shows only
+// the first), then the cleaned diagnostic output for full context.
+func (e *TerraformError) Sections() []compositeerrors.Section {
+	var sections []compositeerrors.Section
+
+	if len(e.Errors) > 1 {
+		var b strings.Builder
+		for _, s := range e.Errors {
+			b.WriteString("- ")
+			b.WriteString(s)
+			b.WriteString("\n")
+		}
+		sections = append(sections, compositeerrors.Section{
+			Heading: "Errors",
+			Body:    strings.TrimRight(b.String(), "\n"),
+		})
+	}
+
+	if e.Output != "" {
+		sections = append(sections, compositeerrors.Section{
+			Heading: "Output",
+			Body:    "```\n" + e.Output + "\n```",
+		})
+	}
+
+	return sections
+}
+
+// errorParser recognises terraform "Error:" diagnostics in a terraform job's
+// raw output.
+type errorParser struct{}
+
+func (errorParser) Layer() errparse.Layer  { return errparse.LayerTool }
+func (errorParser) Tools() []errparse.Tool { return []errparse.Tool{errparse.ToolTerraform} }
+
+// Signals gates on the presence of a terraform diagnostic. "Error:" is broad,
+// but the parser is already bucketed to terraform jobs, where its presence
+// reliably marks a diagnostic block.
+func (errorParser) Signals() []string                      { return []string{"Error:"} }
+func (errorParser) Applicable(*errparse.ParseContext) bool { return true }
+
+func (errorParser) Parse(ctx *errparse.ParseContext) compositeerrors.CompositeError {
+	lines := cleanedLines(ctx.Raw)
+	summaries := errorSummaries(lines)
+	if len(summaries) == 0 {
+		return nil
+	}
+
+	e := &TerraformError{
+		Summary: summaries[0],
+		Output:  truncate(strings.Join(lines, "\n"), maxBody),
+	}
+	if len(summaries) > 1 {
+		e.Errors = summaries
+	}
+	return e
+}
+
+func init() {
+	errparse.Register(errorParser{})
+}
+
+// errorSummaries returns the distinct text following each terraform "Error:"
+// diagnostic line, in order of first appearance.
+func errorSummaries(lines []string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, l := range lines {
+		s, ok := strings.CutPrefix(l, "Error:")
+		if !ok {
+			continue
+		}
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+		if len(out) >= maxErrors {
+			break
+		}
+	}
+	return out
+}
+
+// cleanedLines returns the non-blank lines of raw, each trimmed of surrounding
+// space and terraform's "│" box-drawing prefix.
+func cleanedLines(raw string) []string {
+	var out []string
+	for _, line := range strings.Split(raw, "\n") {
+		t := strings.TrimSpace(line)
+		t = strings.TrimPrefix(t, "│")
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// truncate caps s to n runes (not bytes) so it never splits a multi-byte rune
+// into invalid UTF-8, appending an ellipsis when it cuts.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n]) + "…"
+}

--- a/services/ctl-api/internal/app/runners/errparse/terraform/error_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/terraform/error_test.go
@@ -1,0 +1,112 @@
+package terraform
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+func readFixture(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("unable to read fixture %s: %v", name, err)
+	}
+	return string(b)
+}
+
+func parse(raw string) compositeerrors.CompositeError {
+	return errorParser{}.Parse(&errparse.ParseContext{Raw: raw})
+}
+
+func TestParse_SingleError(t *testing.T) {
+	ce := parse(readFixture(t, "invalid_reference.txt"))
+	if ce == nil {
+		t.Fatal("expected a composite error, got nil")
+	}
+	e, ok := ce.(*TerraformError)
+	if !ok {
+		t.Fatalf("expected *TerraformError, got %T", ce)
+	}
+	if e.Summary != "Reference to undeclared resource" {
+		t.Errorf("summary = %q", e.Summary)
+	}
+	if len(e.Errors) != 0 {
+		t.Errorf("expected no Errors list for a single error, got %v", e.Errors)
+	}
+	if ce.Error() != "Reference to undeclared resource" {
+		t.Errorf("headline = %q", ce.Error())
+	}
+	if ce.Type() != TerraformErrorType {
+		t.Errorf("type = %q", ce.Type())
+	}
+
+	headings := map[string]string{}
+	for _, s := range ce.Sections() {
+		headings[s.Heading] = s.Body
+	}
+	if _, ok := headings["Errors"]; ok {
+		t.Error("single error should not render an Errors list section")
+	}
+	out, ok := headings["Output"]
+	if !ok {
+		t.Fatal("expected an Output section")
+	}
+	// The output preserves the detail (with the "│" box-drawing stripped) and
+	// drops our own wrapper is fine to retain — but the terraform detail must
+	// survive.
+	if !strings.Contains(out, `A managed resource "aws_subnet" "main" has not been declared`) {
+		t.Errorf("Output missing terraform detail: %q", out)
+	}
+	if strings.Contains(out, "│") {
+		t.Errorf("Output still carries box-drawing: %q", out)
+	}
+}
+
+func TestParse_MultipleErrors(t *testing.T) {
+	ce := parse(readFixture(t, "multiple_bucket_errors.txt"))
+	if ce == nil {
+		t.Fatal("expected a composite error, got nil")
+	}
+	e := ce.(*TerraformError)
+	if len(e.Errors) != 2 {
+		t.Fatalf("expected 2 distinct errors, got %d: %v", len(e.Errors), e.Errors)
+	}
+	if !strings.HasPrefix(e.Summary, "creating S3 Bucket (acme-logs)") {
+		t.Errorf("summary = %q", e.Summary)
+	}
+	if !strings.Contains(ce.Error(), "(+1 more errors)") {
+		t.Errorf("headline should note the extra error: %q", ce.Error())
+	}
+
+	var errorsSection string
+	for _, s := range ce.Sections() {
+		if s.Heading == "Errors" {
+			errorsSection = s.Body
+		}
+	}
+	if errorsSection == "" {
+		t.Fatal("expected an Errors list section")
+	}
+	if !strings.Contains(errorsSection, "acme-logs") || !strings.Contains(errorsSection, "acme-data") {
+		t.Errorf("Errors section missing summaries: %q", errorsSection)
+	}
+}
+
+func TestParse_NoTerraformError(t *testing.T) {
+	cases := []string{
+		"",
+		"terraform run errored",
+		"job step errored unable to execute job: exit status 1",
+		"error running apply: exit status 1",
+	}
+	for _, in := range cases {
+		if ce := parse(in); ce != nil {
+			t.Errorf("parse(%q) = %v, want nil (no Error: diagnostic)", in, ce)
+		}
+	}
+}

--- a/services/ctl-api/internal/app/runners/errparse/terraform/testdata/invalid_reference.txt
+++ b/services/ctl-api/internal/app/runners/errparse/terraform/testdata/invalid_reference.txt
@@ -1,0 +1,10 @@
+╷
+│ Error: Reference to undeclared resource
+│
+│   on main.tf line 12, in resource "aws_instance" "web":
+│   12:   subnet_id = aws_subnet.main.id
+│
+│ A managed resource "aws_subnet" "main" has not been declared in the root module.
+╵
+terraform run errored
+job step errored unable to execute job: unable to execute apply-plan run: exit status 1

--- a/services/ctl-api/internal/app/runners/errparse/terraform/testdata/multiple_bucket_errors.txt
+++ b/services/ctl-api/internal/app/runners/errparse/terraform/testdata/multiple_bucket_errors.txt
@@ -1,0 +1,4 @@
+Error: creating S3 Bucket (acme-logs): BucketAlreadyOwnedByYou: Your previous request to create the named bucket succeeded and you already own it
+Error: creating S3 Bucket (acme-data): InvalidBucketName: The specified bucket is not valid.
+terraform run errored
+job step errored unable to execute job: unable to execute apply-plan run: unable to execute: error running apply: exit status 1

--- a/services/ctl-api/internal/app/runners/service/create_runner_job_execution_result.go
+++ b/services/ctl-api/internal/app/runners/service/create_runner_job_execution_result.go
@@ -16,8 +16,9 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse"
-	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/aws"     // register AWS provider-layer parsers
-	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/generic" // register the generic fallback parser
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/aws"       // register AWS provider-layer parsers
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/generic"   // register the generic fallback parser
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/terraform" // register terraform tool-layer parsers
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
 )


### PR DESCRIPTION
Add the first LayerTool parser to the runner-job errparse registry. It extracts terraform "Error:" diagnostics from a failed terraform job into a `terraform.error` composite: headline from the first summary (stripped of the `"Error:"` prefix), an Errors list when several are reported, and the cleaned diagnostic output for context.

It sits between the provider layer (an AWS IAM denial still wins) and the generic fallback (which now only catches failures with no terraform diagnostic at all), so terraform failures get a clean, structured card instead of a raw dump. Scoped to only terraform jobs.

<img width="1291" height="325" alt="Screenshot 2026-07-08 at 5 42 05 PM" src="https://github.com/user-attachments/assets/0e2c9564-be46-4a36-a340-ed5d21eeb12a" />