### PR TITLE
fix: pull private ECR images in control-plane builds

### DIFF
--- a/services/ctl-api/internal/app/components/worker/activities/save_fetch_image_metadata_plan.go
+++ b/services/ctl-api/internal/app/components/worker/activities/save_fetch_image_metadata_plan.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
+	assumerole "github.com/nuonco/nuon/pkg/aws/assume-role"
 	"github.com/nuonco/nuon/pkg/aws/credentials"
 	azurecredentials "github.com/nuonco/nuon/pkg/azure/credentials"
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
@@ -17,8 +18,9 @@ import (
 )
 
 type SaveFetchImageMetadataPlanRequest struct {
-	JobID   string `validate:"required"`
-	BuildID string `validate:"required"`
+	JobID               string `validate:"required"`
+	BuildID             string `validate:"required"`
+	IsControlPlaneBuild bool
 }
 
 // @temporal-gen-v2 activity
@@ -44,7 +46,7 @@ func (a *Activities) SaveFetchImageMetadataPlan(ctx context.Context, req *SaveFe
 		return fmt.Errorf("build %s does not have external image config", req.BuildID)
 	}
 
-	srcRepo, err := a.getSourceRepository(extImgCfg)
+	srcRepo, err := a.getSourceRepository(extImgCfg, req.IsControlPlaneBuild)
 	if err != nil {
 		return errors.Wrap(err, "unable to get source repository")
 	}
@@ -74,21 +76,34 @@ func (a *Activities) SaveFetchImageMetadataPlan(ctx context.Context, req *SaveFe
 	return nil
 }
 
-func (a *Activities) getSourceRepository(cfg *app.ExternalImageComponentConfig) (*configs.OCIRegistryRepository, error) {
+func (a *Activities) getSourceRepository(cfg *app.ExternalImageComponentConfig, isControlPlaneBuild bool) (*configs.OCIRegistryRepository, error) {
 	if cfg.AWSECRImageConfig != nil {
+		assumeRole := &credentials.AssumeRoleConfig{
+			RoleARN:                cfg.AWSECRImageConfig.IAMRoleARN,
+			SessionName:            "fetch-image-metadata",
+			SessionDurationSeconds: 30 * 60,
+			UseGCPOIDC:             a.cfg.IsGCP(),
+		}
+
+		// Control-plane metadata jobs run as the ctl-api pod identity, which
+		// the vendor's ECR pull role does not trust — vendors grant the Nuon
+		// management account, so hop through the management role first (the
+		// identity the org runner presented as). Org-runner jobs run in the
+		// customer account and assume the pull role directly.
+		if isControlPlaneBuild && a.cfg.CloudProvider == "aws" && a.cfg.ManagementIAMRoleARN != "" {
+			assumeRole.TwoStepConfig = &assumerole.TwoStepConfig{
+				IAMRoleARN: a.cfg.ManagementIAMRoleARN,
+			}
+		}
+
 		return &configs.OCIRegistryRepository{
 			RegistryType: configs.OCIRegistryTypeECR,
 			Repository:   cfg.ImageURL,
 			Region:       cfg.AWSECRImageConfig.AWSRegion,
 
 			ECRAuth: &credentials.Config{
-				Region: cfg.AWSECRImageConfig.AWSRegion,
-				AssumeRole: &credentials.AssumeRoleConfig{
-					RoleARN:                cfg.AWSECRImageConfig.IAMRoleARN,
-					SessionName:            "fetch-image-metadata",
-					SessionDurationSeconds: 30 * 60,
-					UseGCPOIDC:             a.cfg.IsGCP(),
-				},
+				Region:     cfg.AWSECRImageConfig.AWSRegion,
+				AssumeRole: assumeRole,
 			},
 		}, nil
 	}

--- a/services/ctl-api/internal/app/components/worker/evaluate_external_image_policy.go
+++ b/services/ctl-api/internal/app/components/worker/evaluate_external_image_policy.go
@@ -71,8 +71,9 @@ func (w *Workflows) evaluateExternalImagePolicy(ctx workflow.Context, buildID, b
 
 	// Save the job plan
 	if err := activities.AwaitSaveFetchImageMetadataPlan(ctx, &activities.SaveFetchImageMetadataPlanRequest{
-		JobID:   metadataJob.ID,
-		BuildID: buildID,
+		JobID:               metadataJob.ID,
+		BuildID:             buildID,
+		IsControlPlaneBuild: metadataJob.Executor == app.RunnerJobExecutorControlPlane,
 	}); err != nil {
 		w.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, truncateErrorMessage("unable to save metadata job plan", err))
 		w.updateJobStatusForPolicyFailure(ctx, buildJobID, "unable to save metadata job plan")

--- a/services/ctl-api/internal/app/components/worker/exec_build.go
+++ b/services/ctl-api/internal/app/components/worker/exec_build.go
@@ -64,10 +64,12 @@ func (w *Workflows) execBuild(ctx workflow.Context, compID, buildID string, curr
 	}
 
 	runPlan, err := plan.AwaitCreateComponentBuildPlan(ctx, &plan.CreateComponentBuildPlanRequest{
-		ComponentID:      comp.ID,
-		ComponentBuildID: buildID,
-		WorkflowID:       fmt.Sprintf("%s-create-build-plan", workflow.GetInfo(ctx).WorkflowExecution.ID),
-		CloudProvider:    w.cfg.CloudProvider,
+		ComponentID:          comp.ID,
+		ComponentBuildID:     buildID,
+		WorkflowID:           fmt.Sprintf("%s-create-build-plan", workflow.GetInfo(ctx).WorkflowExecution.ID),
+		CloudProvider:        w.cfg.CloudProvider,
+		ManagementIAMRoleARN: w.cfg.ManagementIAMRoleARN,
+		IsControlPlaneBuild:  runnerJob.Executor == app.RunnerJobExecutorControlPlane,
 	})
 	if err != nil {
 		w.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to get component build plan")

--- a/services/ctl-api/internal/app/components/worker/plan/plan_container_image_build.go
+++ b/services/ctl-api/internal/app/components/worker/plan/plan_container_image_build.go
@@ -9,6 +9,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/pkg/errors"
 
+	assumerole "github.com/nuonco/nuon/pkg/aws/assume-role"
 	"github.com/nuonco/nuon/pkg/aws/credentials"
 	azurecredentials "github.com/nuonco/nuon/pkg/azure/credentials"
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
@@ -85,19 +86,32 @@ func (b *Planner) getSourceRepository(cfg *app.ExternalImageComponentConfig) (*c
 	}
 
 	if cfg.AWSECRImageConfig != nil {
+		assumeRole := &credentials.AssumeRoleConfig{
+			RoleARN:                cfg.AWSECRImageConfig.IAMRoleARN,
+			SessionName:            "container-image-build",
+			SessionDurationSeconds: 30 * 60,
+			UseGCPOIDC:             b.cloudProvider == "gcp",
+		}
+
+		// Control-plane builds run as the ctl-api pod identity, which the
+		// vendor's ECR pull role does not trust — vendors grant the Nuon
+		// management account, so hop through the management role first (the
+		// identity the org runner presented as). Org-runner builds run in the
+		// customer account and assume the pull role directly.
+		if b.isControlPlaneBuild && b.cloudProvider == "aws" && b.managementIAMRoleARN != "" {
+			assumeRole.TwoStepConfig = &assumerole.TwoStepConfig{
+				IAMRoleARN: b.managementIAMRoleARN,
+			}
+		}
+
 		return &configs.OCIRegistryRepository{
 			RegistryType: configs.OCIRegistryTypeECR,
 			Repository:   cfg.ImageURL,
 			Region:       cfg.AWSECRImageConfig.AWSRegion,
 
 			ECRAuth: &credentials.Config{
-				Region: cfg.AWSECRImageConfig.AWSRegion,
-				AssumeRole: &credentials.AssumeRoleConfig{
-					RoleARN:                cfg.AWSECRImageConfig.IAMRoleARN,
-					SessionName:            "container-image-build",
-					SessionDurationSeconds: 30 * 60,
-					UseGCPOIDC:             b.cloudProvider == "gcp",
-				},
+				Region:     cfg.AWSECRImageConfig.AWSRegion,
+				AssumeRole: assumeRole,
 			},
 		}, nil
 	}

--- a/services/ctl-api/internal/app/components/worker/plan/planner.go
+++ b/services/ctl-api/internal/app/components/worker/plan/planner.go
@@ -6,8 +6,10 @@ import (
 )
 
 type Planner struct {
-	v             *validator.Validate
-	cloudProvider string
+	v                    *validator.Validate
+	cloudProvider        string
+	managementIAMRoleARN string
+	isControlPlaneBuild  bool
 }
 
 type Params struct {

--- a/services/ctl-api/internal/app/components/worker/plan/workflow_component_build_plan.go
+++ b/services/ctl-api/internal/app/components/worker/plan/workflow_component_build_plan.go
@@ -10,8 +10,10 @@ type CreateComponentBuildPlanRequest struct {
 	ComponentID      string
 	ComponentBuildID string
 
-	WorkflowID    string
-	CloudProvider string
+	WorkflowID           string
+	CloudProvider        string
+	ManagementIAMRoleARN string
+	IsControlPlaneBuild  bool
 }
 
 // @temporal-gen-v2 workflow
@@ -20,6 +22,10 @@ type CreateComponentBuildPlanRequest struct {
 // @task-queue "api"
 // @id-template {{.Req.WorkflowID}}
 func CreateComponentBuildPlan(ctx workflow.Context, req *CreateComponentBuildPlanRequest) (*plantypes.BuildPlan, error) {
-	p := Planner{cloudProvider: req.CloudProvider}
+	p := Planner{
+		cloudProvider:        req.CloudProvider,
+		managementIAMRoleARN: req.ManagementIAMRoleARN,
+		isControlPlaneBuild:  req.IsControlPlaneBuild,
+	}
 	return p.createComponentBuildPlan(ctx, req)
 }


### PR DESCRIPTION
Control-plane component builds now pull private ECR source images by hopping through the Nuon management account; org-runner, GCP, and Azure paths are unchanged. 