### PR TITLE
fix: impersonated runner auth, per-policy roles, repo-scoped gar

### DIFF
--- a/bins/runner/internal/jobs/actions/workflow/env.go
+++ b/bins/runner/internal/jobs/actions/workflow/env.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/pkg/aws/credentials"
+	gcpcredentials "github.com/nuonco/nuon/pkg/gcp/credentials"
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/pkg/kube/config"
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
@@ -43,6 +44,19 @@ func (h *handler) getBuiltInEnv(ctx context.Context, cfg *models.AppActionWorkfl
 		}
 
 		env = generics.MergeMap(env, awsEnv)
+	}
+
+	if h.state.auth.GCPAuth != nil {
+		gcpEnv, err := gcpcredentials.FetchEnv(ctx, h.state.auth.GCPAuth)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to get GCP credentials")
+		}
+
+		if h.state.auth.GCPAuth.ImpersonateServiceAccount != "" {
+			gcpEnv["CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT"] = h.state.auth.GCPAuth.ImpersonateServiceAccount
+		}
+
+		env = generics.MergeMap(env, gcpEnv)
 	}
 
 	return env, nil

--- a/pkg/kube/cluster_info.go
+++ b/pkg/kube/cluster_info.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/impersonate"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -176,9 +177,22 @@ func ConfigForCluster(ctx context.Context, cInfo *ClusterInfo) (*rest.Config, er
 	}
 
 	if cInfo.GCPAuth != nil {
-		ts, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
-		if err != nil {
-			return nil, fmt.Errorf("unable to get GCP token source for K8s auth: %w", err)
+		var ts oauth2.TokenSource
+		if cInfo.GCPAuth.ImpersonateServiceAccount != "" {
+			// K8s auth must run as the operation role SA, not the runner SA — the runner SA
+			// holds no container permissions.
+			ts, err = impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+				TargetPrincipal: cInfo.GCPAuth.ImpersonateServiceAccount,
+				Scopes:          []string{"https://www.googleapis.com/auth/cloud-platform"},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("unable to get impersonated GCP token source for K8s auth: %w", err)
+			}
+		} else {
+			ts, err = google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+			if err != nil {
+				return nil, fmt.Errorf("unable to get GCP token source for K8s auth: %w", err)
+			}
 		}
 
 		cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
@@ -187,12 +201,21 @@ func ConfigForCluster(ctx context.Context, cInfo *ClusterInfo) (*rest.Config, er
 
 		// Use gke-gcloud-auth-plugin if available (install runners in customer clusters),
 		// otherwise rely on oauth2 WrapTransport via Workload Identity (org runners in our cluster).
+		// The exec provider is what gets serialized into kubeconfigs for action workflows, so it
+		// carries the impersonation target via gcloud's env var.
 		if _, err := exec.LookPath("gke-gcloud-auth-plugin"); err == nil {
-			cfg.ExecProvider = &clientcmdapi.ExecConfig{
+			execCfg := &clientcmdapi.ExecConfig{
 				APIVersion:      "client.authentication.k8s.io/v1beta1",
 				Command:         "gke-gcloud-auth-plugin",
 				InteractiveMode: clientcmdapi.NeverExecInteractiveMode,
 			}
+			if cInfo.GCPAuth.ImpersonateServiceAccount != "" {
+				execCfg.Env = []clientcmdapi.ExecEnvVar{{
+					Name:  "CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT",
+					Value: cInfo.GCPAuth.ImpersonateServiceAccount,
+				}}
+			}
+			cfg.ExecProvider = execCfg
 		} else {
 			cfg.ExecProvider = nil
 		}

--- a/pkg/kube/cluster_info.go
+++ b/pkg/kube/cluster_info.go
@@ -181,9 +181,15 @@ func ConfigForCluster(ctx context.Context, cInfo *ClusterInfo) (*rest.Config, er
 		if cInfo.GCPAuth.ImpersonateServiceAccount != "" {
 			// K8s auth must run as the operation role SA, not the runner SA — the runner SA
 			// holds no container permissions.
+			// userinfo.email is required for GKE to map the token to the SA's
+			// IAM identity; without it the apiserver sees an unmappable numeric
+			// principal and denies everything.
 			ts, err = impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
 				TargetPrincipal: cInfo.GCPAuth.ImpersonateServiceAccount,
-				Scopes:          []string{"https://www.googleapis.com/auth/cloud-platform"},
+				Scopes: []string{
+					"https://www.googleapis.com/auth/cloud-platform",
+					"https://www.googleapis.com/auth/userinfo.email",
+				},
 			})
 			if err != nil {
 				return nil, fmt.Errorf("unable to get impersonated GCP token source for K8s auth: %w", err)

--- a/pkg/runner/registry/gar/fetch.go
+++ b/pkg/runner/registry/gar/fetch.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/impersonate"
 
 	"github.com/nuonco/nuon/pkg/plugins/configs"
 	pkgctx "github.com/nuonco/nuon/pkg/runner/ctx"
@@ -36,13 +39,26 @@ func FetchAccessInfo(ctx context.Context, cfg *configs.OCIRegistryRepository) (*
 		}, nil
 	}
 
-	l.Info("getting GAR access token using application default credentials")
-	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
-	if err != nil {
-		return nil, fmt.Errorf("unable to find default credentials: %w", err)
+	var tokenSource oauth2.TokenSource
+	if cfg.ServiceAccountEmail != "" {
+		l.Info("getting GAR access token via impersonation", zap.String("service_account", cfg.ServiceAccountEmail))
+		tokenSource, err = impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+			TargetPrincipal: cfg.ServiceAccountEmail,
+			Scopes:          []string{"https://www.googleapis.com/auth/cloud-platform"},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("unable to create impersonated credentials: %w", err)
+		}
+	} else {
+		l.Info("getting GAR access token using application default credentials")
+		creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+		if err != nil {
+			return nil, fmt.Errorf("unable to find default credentials: %w", err)
+		}
+		tokenSource = creds.TokenSource
 	}
 
-	token, err := creds.TokenSource.Token()
+	token, err := tokenSource.Token()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get access token: %w", err)
 	}

--- a/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/oci_registry_repository.go
@@ -137,6 +137,9 @@ func (p *Planner) getInstallRegistryRepositoryConfig(
 		}
 		cfg.LoginServer = loginServer
 		cfg.Region = stack.InstallStackOutputs.GCPStackOutputs.Region
+		if cloudAuth.GCP != nil {
+			cfg.ServiceAccountEmail = cloudAuth.GCP.ImpersonateServiceAccount
+		}
 	}
 
 	return cfg, nil

--- a/services/ctl-api/internal/app/orgs/worker/iam/gcp_service_account.go
+++ b/services/ctl-api/internal/app/orgs/worker/iam/gcp_service_account.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
-	crm "google.golang.org/api/cloudresourcemanager/v1"
+	artifactregistry "google.golang.org/api/artifactregistry/v1"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
@@ -15,6 +16,7 @@ import (
 type CreateGCPServiceAccountRequest struct {
 	ProjectID             string `validate:"required"`
 	OrgID                 string `validate:"required"`
+	GARRepositoryURL      string `validate:"required"`
 	K8sNamespace          string // Runner ID used as namespace; empty skips WI binding
 	K8sServiceAccountName string // K8s SA name; empty skips WI binding
 }
@@ -102,9 +104,10 @@ func (a *Activities) CreateGCPServiceAccount(ctx context.Context, req *CreateGCP
 		}
 	}
 
-	// Grant the service account Artifact Registry writer at the project level
-	// so the org runner can push and pull build artifacts from GAR.
-	if err := addProjectIAMBinding(ctx, req.ProjectID, "roles/artifactregistry.writer", fmt.Sprintf("serviceAccount:%s", saEmail)); err != nil {
+	// Grant the service account Artifact Registry writer on the management
+	// repository only. A project-level grant would require ctl-api to hold
+	// projectIamAdmin, a one-hop escalation to owner.
+	if err := addGARRepositoryIAMBinding(ctx, req.GARRepositoryURL, "roles/artifactregistry.writer", fmt.Sprintf("serviceAccount:%s", saEmail)); err != nil {
 		return nil, fmt.Errorf("unable to grant GAR writer: %w", err)
 	}
 
@@ -113,36 +116,53 @@ func (a *Activities) CreateGCPServiceAccount(ctx context.Context, req *CreateGCP
 	}, nil
 }
 
-func addProjectIAMBinding(ctx context.Context, projectID, role, member string) error {
-	crmService, err := crm.NewService(ctx, option.WithScopes(crm.CloudPlatformScope))
+// garRepositoryResource converts a repository URL like
+// "us-west1-docker.pkg.dev/my-project/my-repo" into the API resource name
+// "projects/my-project/locations/us-west1/repositories/my-repo".
+func garRepositoryResource(repoURL string) (string, error) {
+	parts := strings.Split(strings.TrimSuffix(repoURL, "/"), "/")
+	if len(parts) < 3 || !strings.HasSuffix(parts[0], "-docker.pkg.dev") {
+		return "", fmt.Errorf("unexpected GAR repository URL %q", repoURL)
+	}
+	location := strings.TrimSuffix(parts[0], "-docker.pkg.dev")
+	return fmt.Sprintf("projects/%s/locations/%s/repositories/%s", parts[1], location, parts[2]), nil
+}
+
+func addGARRepositoryIAMBinding(ctx context.Context, repoURL, role, member string) error {
+	resource, err := garRepositoryResource(repoURL)
 	if err != nil {
-		return fmt.Errorf("unable to create CRM service: %w", err)
+		return err
 	}
 
-	policy, err := crmService.Projects.GetIamPolicy(projectID, &crm.GetIamPolicyRequest{}).Context(ctx).Do()
+	arService, err := artifactregistry.NewService(ctx, option.WithScopes(artifactregistry.CloudPlatformScope))
 	if err != nil {
-		return fmt.Errorf("unable to get project IAM policy: %w", err)
+		return fmt.Errorf("unable to create Artifact Registry service: %w", err)
 	}
 
-	// Check if binding already exists
+	repos := arService.Projects.Locations.Repositories
+	policy, err := repos.GetIamPolicy(resource).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("unable to get repository IAM policy: %w", err)
+	}
+
 	for _, binding := range policy.Bindings {
 		if binding.Role == role {
 			for _, m := range binding.Members {
 				if m == member {
-					return nil // already bound
+					return nil
 				}
 			}
 			binding.Members = append(binding.Members, member)
-			_, err := crmService.Projects.SetIamPolicy(projectID, &crm.SetIamPolicyRequest{Policy: policy}).Context(ctx).Do()
+			_, err := repos.SetIamPolicy(resource, &artifactregistry.SetIamPolicyRequest{Policy: policy}).Context(ctx).Do()
 			return err
 		}
 	}
 
-	policy.Bindings = append(policy.Bindings, &crm.Binding{
+	policy.Bindings = append(policy.Bindings, &artifactregistry.Binding{
 		Role:    role,
 		Members: []string{member},
 	})
-	_, err = crmService.Projects.SetIamPolicy(projectID, &crm.SetIamPolicyRequest{Policy: policy}).Context(ctx).Do()
+	_, err = repos.SetIamPolicy(resource, &artifactregistry.SetIamPolicyRequest{Policy: policy}).Context(ctx).Do()
 	return err
 }
 

--- a/services/ctl-api/internal/app/orgs/worker/iam/gcp_service_account_test.go
+++ b/services/ctl-api/internal/app/orgs/worker/iam/gcp_service_account_test.go
@@ -1,0 +1,24 @@
+package orgiam
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGARRepositoryResource(t *testing.T) {
+	resource, err := garRepositoryResource("us-west1-docker.pkg.dev/my-project/my-repo")
+	require.NoError(t, err)
+	assert.Equal(t, "projects/my-project/locations/us-west1/repositories/my-repo", resource)
+
+	resource, err = garRepositoryResource("europe-west4-docker.pkg.dev/proj/repo/")
+	require.NoError(t, err)
+	assert.Equal(t, "projects/proj/locations/europe-west4/repositories/repo", resource)
+
+	_, err = garRepositoryResource("us-west1-docker.pkg.dev/my-project")
+	assert.Error(t, err)
+
+	_, err = garRepositoryResource("gcr.io/my-project/my-repo")
+	assert.Error(t, err)
+}

--- a/services/ctl-api/internal/app/orgs/worker/iam/provision.go
+++ b/services/ctl-api/internal/app/orgs/worker/iam/provision.go
@@ -43,6 +43,7 @@ func (w Wkflow) ProvisionIAM(ctx workflow.Context, req *ProvisionIAMRequest) (*P
 		gcpReq := CreateGCPServiceAccountRequest{
 			ProjectID:             w.cfg.ManagementAccountID,
 			OrgID:                 req.OrgID,
+			GARRepositoryURL:      w.cfg.ManagementGARRepositoryURL,
 			K8sNamespace:          req.RunnerID,
 			K8sServiceAccountName: fmt.Sprintf("runner-%s", req.OrgID),
 		}

--- a/services/ctl-api/internal/pkg/stacks/gcp/render.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/render.go
@@ -14,10 +14,17 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
 )
 
+// GCPPolicyTemplateInput holds one policy rendered as its own custom role,
+// mirroring how AWS attaches each policy separately instead of merging.
+type GCPPolicyTemplateInput struct {
+	Name        string
+	Permissions string
+}
+
 // GCPRoleTemplateInput holds the per-role data rendered into the template.
 type GCPRoleTemplateInput struct {
 	Name           string
-	Permissions    string
+	Policies       []GCPPolicyTemplateInput
 	PredefinedRole string
 }
 
@@ -52,9 +59,9 @@ type GCPTemplateInput struct {
 	GCPProjectID string
 	GCPRegion    string
 
-	ProvisionPermissions   string
-	MaintenancePermissions string
-	DeprovisionPermissions string
+	ProvisionPolicies   []GCPPolicyTemplateInput
+	MaintenancePolicies []GCPPolicyTemplateInput
+	DeprovisionPolicies []GCPPolicyTemplateInput
 
 	ProvisionPredefinedRole   string
 	MaintenancePredefinedRole string
@@ -78,7 +85,7 @@ func Render(inputs *stacks.TemplateInput) ([]byte, string, error) {
 		return nil, "", errors.Wrap(err, "unable to parse gcp secrets template")
 	}
 
-	prov, maint, deprov, provPredefined, maintPredefined, deprovPredefined := extractGCPStandardPermissions(inputs.AppCfg)
+	prov, maint, deprov, provPredefined, maintPredefined, deprovPredefined := extractGCPStandardPolicies(inputs.AppCfg)
 	breakGlassRoles := extractGCPRolesFromList(inputs.AppCfg.BreakGlassConfig.Roles)
 	customRoles := extractGCPRolesFromList(inputs.AppCfg.PermissionsConfig.CustomRoles)
 
@@ -123,9 +130,9 @@ func Render(inputs *stacks.TemplateInput) ([]byte, string, error) {
 		TemplateInput:             inputs,
 		GCPProjectID:              gcpProjectID,
 		GCPRegion:                 gcpRegion,
-		ProvisionPermissions:      prov,
-		MaintenancePermissions:    maint,
-		DeprovisionPermissions:    deprov,
+		ProvisionPolicies:         prov,
+		MaintenancePolicies:       maint,
+		DeprovisionPolicies:       deprov,
 		ProvisionPredefinedRole:   provPredefined,
 		MaintenancePredefinedRole: maintPredefined,
 		DeprovisionPredefinedRole: deprovPredefined,
@@ -210,12 +217,8 @@ func Render(inputs *stacks.TemplateInput) ([]byte, string, error) {
 	return res, checksum, nil
 }
 
-// extractGCPStandardPermissions reads GCP IAM permissions for the standard roles (provision, maintenance, deprovision).
-func extractGCPStandardPermissions(appCfg *app.AppConfig) (provision, maintenance, deprovision, provPredefined, maintPredefined, deprovPredefined string) {
-	provision = "[]"
-	maintenance = "[]"
-	deprovision = "[]"
-
+// extractGCPStandardPolicies reads GCP IAM policies for the standard roles (provision, maintenance, deprovision).
+func extractGCPStandardPolicies(appCfg *app.AppConfig) (provision, maintenance, deprovision []GCPPolicyTemplateInput, provPredefined, maintPredefined, deprovPredefined string) {
 	if appCfg == nil {
 		return
 	}
@@ -225,33 +228,17 @@ func extractGCPStandardPermissions(appCfg *app.AppConfig) (provision, maintenanc
 			continue
 		}
 
-		perms, predefinedRole := extractRolePermissions(role)
-		if len(perms) == 0 && predefinedRole == "" {
-			continue
-		}
-
-		if len(perms) > 0 {
-			b, err := json.Marshal(perms)
-			if err != nil {
-				continue
-			}
-
-			switch role.Type {
-			case app.AWSIAMRoleTypeRunnerProvision:
-				provision = string(b)
-			case app.AWSIAMRoleTypeRunnerMaintenance:
-				maintenance = string(b)
-			case app.AWSIAMRoleTypeRunnerDeprovision:
-				deprovision = string(b)
-			}
-		}
+		policies, predefinedRole := extractRolePolicies(role)
 
 		switch role.Type {
 		case app.AWSIAMRoleTypeRunnerProvision:
+			provision = policies
 			provPredefined = predefinedRole
 		case app.AWSIAMRoleTypeRunnerMaintenance:
+			maintenance = policies
 			maintPredefined = predefinedRole
 		case app.AWSIAMRoleTypeRunnerDeprovision:
+			deprovision = policies
 			deprovPredefined = predefinedRole
 		}
 	}
@@ -268,23 +255,14 @@ func extractGCPRolesFromList(roles []app.AppAWSIAMRoleConfig) []GCPRoleTemplateI
 			continue
 		}
 
-		perms, predefinedRole := extractRolePermissions(role)
-		if len(perms) == 0 && predefinedRole == "" {
+		policies, predefinedRole := extractRolePolicies(role)
+		if len(policies) == 0 && predefinedRole == "" {
 			continue
-		}
-
-		permStr := "[]"
-		if len(perms) > 0 {
-			b, err := json.Marshal(perms)
-			if err != nil {
-				continue
-			}
-			permStr = string(b)
 		}
 
 		result = append(result, GCPRoleTemplateInput{
 			Name:           role.Name,
-			Permissions:    permStr,
+			Policies:       policies,
 			PredefinedRole: predefinedRole,
 		})
 	}
@@ -292,14 +270,34 @@ func extractGCPRolesFromList(roles []app.AppAWSIAMRoleConfig) []GCPRoleTemplateI
 	return result
 }
 
-func extractRolePermissions(role app.AppAWSIAMRoleConfig) ([]string, string) {
-	var perms []string
+// extractRolePolicies keeps each policy separate so the stack creates one
+// custom role per policy, matching the AWS one-policy-one-attachment shape.
+func extractRolePolicies(role app.AppAWSIAMRoleConfig) ([]GCPPolicyTemplateInput, string) {
+	var policies []GCPPolicyTemplateInput
 	var predefinedRole string
-	for _, policy := range role.Policies {
-		perms = append(perms, policy.GCPPermissions...)
+	for i, policy := range role.Policies {
 		if policy.GCPPredefinedRole != "" {
 			predefinedRole = policy.GCPPredefinedRole
 		}
+
+		if len(policy.GCPPermissions) == 0 {
+			continue
+		}
+
+		b, err := json.Marshal(policy.GCPPermissions)
+		if err != nil {
+			continue
+		}
+
+		name := policy.Name
+		if name == "" {
+			name = fmt.Sprintf("policy-%d", i)
+		}
+
+		policies = append(policies, GCPPolicyTemplateInput{
+			Name:        name,
+			Permissions: string(b),
+		})
 	}
-	return perms, predefinedRole
+	return policies, predefinedRole
 }

--- a/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
@@ -211,7 +211,7 @@ func TestRenderPermissions(t *testing.T) {
 
 		tfvars := extractTfvars(t, out)
 
-		for _, v := range []string{"provision_permissions", "maintenance_permissions", "deprovision_permissions"} {
+		for _, v := range []string{"provision_policies", "maintenance_policies", "deprovision_policies"} {
 			assert.Contains(t, tfvars, v+" ", "tfvars should contain %s", v)
 		}
 		assert.Contains(t, tfvars, "break_glass_roles = {\n}")
@@ -223,12 +223,37 @@ func TestRenderPermissions(t *testing.T) {
 
 		tfvars := extractTfvars(t, out)
 
-		for _, v := range []string{"provision_permissions", "maintenance_permissions", "deprovision_permissions"} {
+		for _, v := range []string{"provision_policies", "maintenance_policies", "deprovision_policies"} {
 			assert.Contains(t, tfvars, v+" ", "tfvars should contain %s", v)
 		}
 		assert.Contains(t, tfvars, `"emergency-access"`)
 		assert.Contains(t, tfvars, `["iam.roles.get"]`)
 		assert.Contains(t, tfvars, "enabled         = false")
+	})
+
+	t.Run("standard role policies stay separate", func(t *testing.T) {
+		inp := testInput()
+		inp.AppCfg.PermissionsConfig = app.AppPermissionsConfig{
+			Roles: []app.AppAWSIAMRoleConfig{
+				{
+					CloudPlatform: "gcp",
+					Type:          app.AWSIAMRoleTypeRunnerProvision,
+					Policies: []app.AppAWSIAMPolicyConfig{
+						{Name: "provision-network", GCPPermissions: []string{"compute.networks.create"}},
+						{Name: "provision-dns", GCPPermissions: []string{"dns.changes.create"}},
+						{Name: "provision-gke", GCPPredefinedRole: "roles/container.admin"},
+					},
+				},
+			},
+		}
+
+		out, _, err := Render(inp)
+		require.NoError(t, err)
+
+		tfvars := extractTfvars(t, out)
+		assert.Contains(t, tfvars, `"provision-network" = ["compute.networks.create"]`)
+		assert.Contains(t, tfvars, `"provision-dns" = ["dns.changes.create"]`)
+		assert.Contains(t, tfvars, `provision_predefined_role    = "roles/container.admin"`)
 	})
 }
 

--- a/services/ctl-api/internal/pkg/stacks/gcp/tmpl.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/tmpl.go
@@ -19,16 +19,32 @@ runner_init_script_url   = "{{.RunnerInitScriptURL}}"
 runner_machine_type      = "{{.Settings.AWSInstanceType}}"
 {{- end}}
 phone_home_url           = "{{.CloudFormationStackVersion.PhoneHomeURL}}"
-provision_permissions    = {{.ProvisionPermissions}}
-maintenance_permissions  = {{.MaintenancePermissions}}
-deprovision_permissions  = {{.DeprovisionPermissions}}
+provision_policies = {
+{{- range .ProvisionPolicies}}
+  "{{.Name}}" = {{.Permissions}}
+{{- end}}
+}
+maintenance_policies = {
+{{- range .MaintenancePolicies}}
+  "{{.Name}}" = {{.Permissions}}
+{{- end}}
+}
+deprovision_policies = {
+{{- range .DeprovisionPolicies}}
+  "{{.Name}}" = {{.Permissions}}
+{{- end}}
+}
 provision_predefined_role    = "{{.ProvisionPredefinedRole}}"
 maintenance_predefined_role  = "{{.MaintenancePredefinedRole}}"
 deprovision_predefined_role  = "{{.DeprovisionPredefinedRole}}"
 break_glass_roles = {
 {{- range .BreakGlassRoles}}
   "{{.Name}}" = {
-    permissions     = {{.Permissions}}
+    policies = {
+    {{- range .Policies}}
+      "{{.Name}}" = {{.Permissions}}
+    {{- end}}
+    }
     predefined_role = "{{.PredefinedRole}}"
     enabled         = false
   }
@@ -37,7 +53,11 @@ break_glass_roles = {
 custom_roles = {
 {{- range .CustomRoles}}
   "{{.Name}}" = {
-    permissions     = {{.Permissions}}
+    policies = {
+    {{- range .Policies}}
+      "{{.Name}}" = {{.Permissions}}
+    {{- end}}
+    }
     predefined_role = "{{.PredefinedRole}}"
     enabled         = true
   }

--- a/services/dashboard-ui/Dockerfile
+++ b/services/dashboard-ui/Dockerfile
@@ -81,6 +81,9 @@ COPY --from=build-server /dashboard-server /app/dashboard-server
 
 WORKDIR /app
 
+RUN adduser -D -u 65532 dashboard
+USER dashboard
+
 ARG VERSION
 ARG GIT_REF
 ENV VERSION=$VERSION

--- a/services/dashboard-ui/Dockerfile
+++ b/services/dashboard-ui/Dockerfile
@@ -81,9 +81,6 @@ COPY --from=build-server /dashboard-server /app/dashboard-server
 
 WORKDIR /app
 
-RUN adduser -D -u 65532 dashboard
-USER dashboard
-
 ARG VERSION
 ARG GIT_REF
 ENV VERSION=$VERSION


### PR DESCRIPTION
kube auth and action workflows used runner SA creds directly; needed for dropping runner roles/owner