### PR TITLE
fix: gcp install roles permissions not visible due to missing preloads

### DIFF
--- a/services/ctl-api/internal/app/install_stack_outputs.go
+++ b/services/ctl-api/internal/app/install_stack_outputs.go
@@ -184,11 +184,11 @@ func (a *GCPStackOutputs) BreakGlassRoleID(name string) (string, error) {
 }
 
 func (a *GCPStackOutputs) CustomRoles() (map[string]string, error) {
-	return a.BreakGlassSAEmails, nil
+	return a.CustomSAEmails, nil
 }
 
 func (a *GCPStackOutputs) BreakGlassRoles() (map[string]string, error) {
-	return a.CustomSAEmails, nil
+	return a.BreakGlassSAEmails, nil
 }
 
 func (a *GCPStackOutputs) InstallInputValues() (map[string]string, error) {

--- a/services/ctl-api/internal/app/installs/service/get_latest_install_roles.go
+++ b/services/ctl-api/internal/app/installs/service/get_latest_install_roles.go
@@ -57,6 +57,7 @@ func (s *service) GetLatestInstallRoles(ctx *gin.Context) {
 	tx := s.db.WithContext(ctx).
 		Scopes(scopes.WithOffsetPagination).
 		Preload("AppRoleConfig").
+		Preload("AppRoleConfig.Policies").
 		Joins("JOIN app_awsiam_role_configs ON app_awsiam_role_configs.id = install_roles.app_role_config_id AND app_awsiam_role_configs.app_config_id = ?", install.AppConfigID).
 		Where("install_roles.install_id = ? AND install_roles.org_id = ?", installID, org.ID).
 		Order("install_roles.created_at DESC")


### PR DESCRIPTION
This change fixes missing install roles permissions information on install roles page due to missing preload. 
Also fixes issue where for gcp roles, break glass roles were coming in as custom and vice versa