### PR TITLE
feat: swap to s3blob read on dual writes

### DIFF
--- a/bins/cli/internal/services/installs/workflows.go
+++ b/bins/cli/internal/services/installs/workflows.go
@@ -11,8 +11,36 @@ import (
 	"github.com/nuonco/nuon/bins/cli/internal/ui"
 	"github.com/nuonco/nuon/bins/cli/internal/ui/bubbles"
 	"github.com/nuonco/nuon/pkg/cli/styles"
+	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/sdks/nuon-go/models"
 )
+
+// getRunnerJobPlanJSON fetches the composite plan for a runner job and returns
+// the single populated inner plan as JSON, matching the shape the plan diff
+// formatter expects. Returns "" when there is no plan.
+func (s *Service) getRunnerJobPlanJSON(ctx context.Context, runnerJobID string) (string, error) {
+	cp, err := s.api.GetRunnerJobCompositePlan(ctx, runnerJobID)
+	if err != nil {
+		return "", err
+	}
+
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return "", err
+	}
+
+	inner := composite.Inner()
+	if inner == nil {
+		return "", nil
+	}
+
+	planJSON, err := json.Marshal(inner)
+	if err != nil {
+		return "", err
+	}
+
+	return string(planJSON), nil
+}
 
 func (s *Service) workflowsJSON(ctx context.Context, installID, workflowID string) error {
 	if installID == "" {
@@ -197,7 +225,7 @@ func (s *Service) confirmStepAction(ctx context.Context, installID, workflowID, 
 		if err == nil {
 			deploy, err := s.api.GetInstallDeploy(ctx, resolvedInstallID, step.StepTargetID)
 			if err == nil && len(deploy.RunnerJobs) > 0 {
-				plan, err := s.api.GetRunnerJobPlan(ctx, deploy.RunnerJobs[0].ID)
+				plan, err := s.getRunnerJobPlanJSON(ctx, deploy.RunnerJobs[0].ID)
 				if err == nil && plan != "" {
 					formatted, err := plandiff.FormatPlan(plan)
 					if err == nil {
@@ -581,7 +609,7 @@ func (s *Service) WorkflowStepPlan(ctx context.Context, installID, workflowID, s
 	}
 
 	runnerJob := deploy.RunnerJobs[0]
-	plan, err := s.api.GetRunnerJobPlan(ctx, runnerJob.ID)
+	plan, err := s.getRunnerJobPlanJSON(ctx, runnerJob.ID)
 	if err != nil {
 		return view.Error(err)
 	}

--- a/bins/runner/internal/jobs/actions/workflow/fetch.go
+++ b/bins/runner/internal/jobs/actions/workflow/fetch.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/pkg/errors"
 
@@ -22,17 +21,20 @@ func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecut
 
 	// fetch the plan json
 	l.Info("fetching actions job plan")
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	// parse the plan
-	var plan plantypes.ActionWorkflowRunPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse action workflow run plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
-	h.state.plan = &plan
+	if composite.ActionWorkflowRunPlan == nil {
+		return errors.New("composite plan missing action workflow run plan")
+	}
+	plan := composite.ActionWorkflowRunPlan
+	h.state.plan = plan
 
 	h.state.auth = &pkgplantypes.PlanAuth{
 		AWSAuth:   plan.AWSAuth,

--- a/bins/runner/internal/jobs/build/docker/fetch.go
+++ b/bins/runner/internal/jobs/build/docker/fetch.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 	"github.com/pkg/errors"
@@ -20,19 +19,22 @@ func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecut
 	h.state = &handlerState{}
 
 	l.Info("fetching job plan")
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	// parse the plan
 	l.Info("parsing job plan")
-	var plan plantypes.BuildPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse sandbox workflow run plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
+	if composite.BuildPlan == nil {
+		return errors.New("composite plan missing build plan")
+	}
+	plan := composite.BuildPlan
 
-	h.state.plan = &plan
+	h.state.plan = plan
 	h.state.jobID = job.ID
 	h.state.jobExecutionID = jobExecution.ID
 	h.state.cfg = plan.DockerBuildPlan

--- a/bins/runner/internal/jobs/deploy/helm/fetch.go
+++ b/bins/runner/internal/jobs/deploy/helm/fetch.go
@@ -2,7 +2,6 @@ package helm
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
@@ -22,17 +21,20 @@ func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecut
 	h.state = &handlerState{}
 
 	l.Info("fetching helm job plan")
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	// parse the plan
-	var plan plantypes.DeployPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse sandbox workflow run plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
-	h.state.plan = &plan
+	if composite.DeployPlan == nil {
+		return errors.New("composite plan missing deploy plan")
+	}
+	plan := composite.DeployPlan
+	h.state.plan = plan
 
 	h.state.auth = &pkgplantypes.PlanAuth{
 		AWSAuth:   plan.HelmDeployPlan.AWSAuth,

--- a/bins/runner/internal/jobs/deploy/kubernetes_manifest/fetch.go
+++ b/bins/runner/internal/jobs/deploy/kubernetes_manifest/fetch.go
@@ -2,7 +2,6 @@ package kubernetes_manifest
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
@@ -23,17 +22,20 @@ func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecut
 	h.state = &handlerState{}
 
 	l.Info("fetching kubernetes manifest job plan")
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	// parse the plan
-	var plan plantypes.DeployPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse sandbox workflow run plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
-	h.state.plan = &plan
+	if composite.DeployPlan == nil {
+		return errors.New("composite plan missing deploy plan")
+	}
+	plan := composite.DeployPlan
+	h.state.plan = plan
 
 	h.state.auth = &pkgplantypes.PlanAuth{
 		AWSAuth:   plan.KubernetesManifestDeployPlan.AWSAuth,

--- a/bins/runner/internal/jobs/deploy/pulumi/fetch.go
+++ b/bins/runner/internal/jobs/deploy/pulumi/fetch.go
@@ -2,7 +2,6 @@ package pulumi
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
@@ -23,16 +22,20 @@ func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecut
 	h.state = &handlerState{}
 
 	l.Info("fetching pulumi job plan")
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	var plan plantypes.DeployPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse deploy plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
-	h.state.plan = &plan
+	if composite.DeployPlan == nil {
+		return errors.New("composite plan missing deploy plan")
+	}
+	plan := composite.DeployPlan
+	h.state.plan = plan
 
 	h.state.auth = &pkgplantypes.PlanAuth{
 		AWSAuth:   plan.PulumiDeployPlan.AWSAuth,

--- a/bins/runner/internal/jobs/deploy/terraform/fetch.go
+++ b/bins/runner/internal/jobs/deploy/terraform/fetch.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
@@ -23,17 +22,20 @@ func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecut
 	h.state = &handlerState{}
 
 	l.Info("fetching terraform job plan")
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	// parse the plan
-	var plan plantypes.DeployPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse sandbox workflow run plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
-	h.state.plan = &plan
+	if composite.DeployPlan == nil {
+		return errors.New("composite plan missing deploy plan")
+	}
+	plan := composite.DeployPlan
+	h.state.plan = plan
 
 	h.state.auth = &pkgplantypes.PlanAuth{
 		AWSAuth:   plan.TerraformDeployPlan.AWSAuth,

--- a/bins/runner/internal/jobs/sandbox/pulumi/fetch.go
+++ b/bins/runner/internal/jobs/sandbox/pulumi/fetch.go
@@ -2,7 +2,6 @@ package pulumi
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/pkg/errors"
@@ -24,16 +23,20 @@ func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecut
 	h.state = &handlerState{}
 
 	l.Info("fetching pulumi sandbox job plan")
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	var plan plantypes.SandboxRunPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse sandbox run plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
-	h.state.plan = &plan
+	if composite.SandboxRunPlan == nil {
+		return errors.New("composite plan missing sandbox run plan")
+	}
+	plan := composite.SandboxRunPlan
+	h.state.plan = plan
 
 	if plan.PulumiBackend == nil {
 		return errors.New("sandbox run plan does not contain a pulumi backend")

--- a/bins/runner/internal/jobs/sandbox/sync_secrets/fetch.go
+++ b/bins/runner/internal/jobs/sandbox/sync_secrets/fetch.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 	"github.com/pkg/errors"
@@ -21,17 +20,20 @@ func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecut
 	h.state = &handlerState{}
 
 	l.Info("fetching sync secrets job plan")
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	// parse the plan
-	var plan plantypes.SyncSecretsPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse sandbox workflow run plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
-	h.state.plan = &plan
+	if composite.SyncSecretsPlan == nil {
+		return errors.New("composite plan missing sync secrets plan")
+	}
+	plan := composite.SyncSecretsPlan
+	h.state.plan = plan
 
 	if h.state.plan.ClusterInfo != nil {
 		h.state.plan.ClusterInfo.WithAWSAuth(h.state.plan.AWSAuth)

--- a/bins/runner/internal/jobs/sandbox/terraform/fetch.go
+++ b/bins/runner/internal/jobs/sandbox/terraform/fetch.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
@@ -23,17 +22,20 @@ func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecut
 	h.state = &handlerState{}
 
 	l.Info("fetching sandbox job plan")
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	// parse the plan
-	var plan plantypes.SandboxRunPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse sandbox workflow run plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
-	h.state.plan = &plan
+	if composite.SandboxRunPlan == nil {
+		return errors.New("composite plan missing sandbox run plan")
+	}
+	plan := composite.SandboxRunPlan
+	h.state.plan = plan
 
 	// Auth is now stored in the plan itself, not the composite plan
 	h.state.auth = &pkgplantypes.PlanAuth{

--- a/bins/runner/internal/jobs/sandboxhandler/handler.go
+++ b/bins/runner/internal/jobs/sandboxhandler/handler.go
@@ -398,15 +398,19 @@ func (h *Handler) execActionSandboxStep(ctx context.Context, job *models.AppRunn
 	}
 
 	l.Info("fetching actions job plan")
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return cockerrors.Wrap(err, "unable to get job plan")
 	}
 
-	var plan plantypes.ActionWorkflowRunPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return cockerrors.Wrap(err, "unable to parse action workflow run plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return cockerrors.Wrap(err, "unable to parse composite plan")
 	}
+	if composite.ActionWorkflowRunPlan == nil {
+		return cockerrors.New("composite plan missing action workflow run plan")
+	}
+	plan := composite.ActionWorkflowRunPlan
 
 	run, err := h.apiClient.GetInstallActionWorkflowRun(ctx, plan.InstallID, plan.ID)
 	if err != nil {
@@ -525,14 +529,23 @@ func (h *Handler) writeSandboxResults(ctx context.Context) error {
 }
 
 func (h *Handler) getSandboxModePlan(ctx context.Context) (*plantypes.MinSandboxMode, error) {
-	var plan plantypes.MinSandboxMode
-
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, h.job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, h.job.ID)
 	if err != nil {
 		return nil, cockerrors.Wrap(err, "unable to get job plan")
 	}
 
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return nil, cockerrors.Wrap(err, "unable to parse composite plan")
+	}
+
+	planJSON, err := json.Marshal(composite.Inner())
+	if err != nil {
+		return nil, cockerrors.Wrap(err, "unable to marshal sandbox plan")
+	}
+
+	var plan plantypes.MinSandboxMode
+	if err := json.Unmarshal(planJSON, &plan); err != nil {
 		return nil, cockerrors.Wrap(err, "unable to convert to sandbox plan")
 	}
 

--- a/bins/runner/internal/jobs/sync/oci/fetch.go
+++ b/bins/runner/internal/jobs/sync/oci/fetch.go
@@ -2,7 +2,6 @@ package containerimage
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 	"github.com/pkg/errors"
@@ -13,17 +12,20 @@ import (
 func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecution *models.AppRunnerJobExecution) error {
 	h.state = &handlerState{}
 
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	// parse the plan
-	var plan plantypes.SyncOCIPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse sandbox workflow run plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
-	h.state.plan = &plan
+	if composite.SyncOCIPlan == nil {
+		return errors.New("composite plan missing sync oci plan")
+	}
+	plan := composite.SyncOCIPlan
+	h.state.plan = plan
 
 	h.state.jobID = job.ID
 	h.state.jobExecutionID = jobExecution.ID

--- a/pkg/plans/types/composite_plan.go
+++ b/pkg/plans/types/composite_plan.go
@@ -19,6 +19,46 @@ type CompositePlan struct {
 	SandboxRunPlan         *SandboxRunPlan         `json:"sandbox_run_plan,omitempty"`
 }
 
+// CompositePlanFromAny converts any composite-plan-shaped value (e.g. a
+// generated SDK model) into a CompositePlan via a JSON round-trip. Both the SDK
+// models and this type derive from the same schema, so the tags line up.
+func CompositePlanFromAny(v any) (*CompositePlan, error) {
+	bytes, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	var cp CompositePlan
+	if err := json.Unmarshal(bytes, &cp); err != nil {
+		return nil, err
+	}
+
+	return &cp, nil
+}
+
+// Inner returns the single populated sub-plan, or nil when the composite plan is
+// empty. Exactly one sub-plan is set per job.
+func (cp *CompositePlan) Inner() any {
+	switch {
+	case cp.BuildPlan != nil:
+		return cp.BuildPlan
+	case cp.DeployPlan != nil:
+		return cp.DeployPlan
+	case cp.ActionWorkflowRunPlan != nil:
+		return cp.ActionWorkflowRunPlan
+	case cp.SyncSecretsPlan != nil:
+		return cp.SyncSecretsPlan
+	case cp.SyncOCIPlan != nil:
+		return cp.SyncOCIPlan
+	case cp.FetchImageMetadataPlan != nil:
+		return cp.FetchImageMetadataPlan
+	case cp.SandboxRunPlan != nil:
+		return cp.SandboxRunPlan
+	default:
+		return nil
+	}
+}
+
 func (cp CompositePlan) Value() (driver.Value, error) {
 	if cp.IsEmpty() {
 		return nil, nil

--- a/pkg/runner/jobs/build/containerimage/fetch.go
+++ b/pkg/runner/jobs/build/containerimage/fetch.go
@@ -2,7 +2,6 @@ package containerimage
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 	"github.com/pkg/errors"
@@ -20,19 +19,22 @@ func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecut
 	h.state = &handlerState{}
 
 	l.Info("fetching job plan")
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	// parse the plan
 	l.Info("parsing job plan")
-	var plan plantypes.BuildPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse sandbox workflow run plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
+	if composite.BuildPlan == nil {
+		return errors.New("composite plan missing build plan")
+	}
+	plan := composite.BuildPlan
 
-	h.state.plan = &plan
+	h.state.plan = plan
 	h.state.jobID = job.ID
 	h.state.jobExecutionID = jobExecution.ID
 	h.state.cfg = plan.ContainerImagePullPlan

--- a/pkg/runner/jobs/build/helm/fetch.go
+++ b/pkg/runner/jobs/build/helm/fetch.go
@@ -2,7 +2,6 @@ package helm
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 	"github.com/pkg/errors"
@@ -20,19 +19,22 @@ func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecut
 	h.state = &handlerState{}
 
 	l.Info("fetching job plan")
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	// parse the plan
 	l.Info("parsing job plan")
-	var plan plantypes.BuildPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse sandbox workflow run plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
+	if composite.BuildPlan == nil {
+		return errors.New("composite plan missing build plan")
+	}
+	plan := composite.BuildPlan
 
-	h.state.plan = &plan
+	h.state.plan = plan
 	h.state.jobID = job.ID
 	h.state.jobExecutionID = jobExecution.ID
 	h.state.cfg = plan.HelmBuildPlan

--- a/pkg/runner/jobs/build/kubernetes_manifest/fetch.go
+++ b/pkg/runner/jobs/build/kubernetes_manifest/fetch.go
@@ -2,7 +2,6 @@ package kubernetes_manifest
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 	"github.com/pkg/errors"
@@ -20,18 +19,22 @@ func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecut
 	h.state = &handlerState{}
 
 	l.Info("fetching job plan")
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
 	l.Info("parsing job plan")
-	var plan plantypes.BuildPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse build plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
+	if composite.BuildPlan == nil {
+		return errors.New("composite plan missing build plan")
+	}
+	plan := composite.BuildPlan
 
-	h.state.plan = &plan
+	h.state.plan = plan
 	h.state.jobID = job.ID
 	h.state.jobExecutionID = jobExecution.ID
 	h.state.cfg = plan.KubernetesManifestBuildPlan

--- a/pkg/runner/jobs/build/pulumi/fetch.go
+++ b/pkg/runner/jobs/build/pulumi/fetch.go
@@ -2,7 +2,6 @@ package pulumi
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 	"github.com/pkg/errors"
@@ -13,17 +12,21 @@ import (
 func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecution *models.AppRunnerJobExecution) error {
 	h.state = &handlerState{}
 
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	var plan plantypes.BuildPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse build plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
+	if composite.BuildPlan == nil {
+		return errors.New("composite plan missing build plan")
+	}
+	plan := composite.BuildPlan
 
-	h.state.plan = &plan
+	h.state.plan = plan
 	h.state.jobID = job.ID
 	h.state.jobExecutionID = jobExecution.ID
 	h.state.cfg = plan.PulumiBuildPlan

--- a/pkg/runner/jobs/build/sandbox/fetch.go
+++ b/pkg/runner/jobs/build/sandbox/fetch.go
@@ -2,7 +2,6 @@ package sandbox
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/pkg/errors"
 
@@ -13,17 +12,21 @@ import (
 func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecution *models.AppRunnerJobExecution) error {
 	h.state = &handlerState{}
 
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	var plan plantypes.BuildPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse sandbox build plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
+	if composite.BuildPlan == nil {
+		return errors.New("composite plan missing build plan")
+	}
+	plan := composite.BuildPlan
 
-	h.state.plan = &plan
+	h.state.plan = plan
 	h.state.jobID = job.ID
 	h.state.jobExecutionID = jobExecution.ID
 	h.state.cfg = plan.TerraformBuildPlan

--- a/pkg/runner/jobs/build/terraform/fetch.go
+++ b/pkg/runner/jobs/build/terraform/fetch.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 	"github.com/pkg/errors"
@@ -13,18 +12,21 @@ import (
 func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecution *models.AppRunnerJobExecution) error {
 	h.state = &handlerState{}
 
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
-	// parse the plan
-	var plan plantypes.BuildPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
-		return errors.Wrap(err, "unable to parse sandbox workflow run plan")
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
 	}
+	if composite.BuildPlan == nil {
+		return errors.New("composite plan missing build plan")
+	}
+	plan := composite.BuildPlan
 
-	h.state.plan = &plan
+	h.state.plan = plan
 	h.state.jobID = job.ID
 	h.state.jobExecutionID = jobExecution.ID
 	h.state.cfg = plan.TerraformBuildPlan

--- a/pkg/runner/jobs/sync/imagemetadata/fetch.go
+++ b/pkg/runner/jobs/sync/imagemetadata/fetch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 	"github.com/pkg/errors"
 )
@@ -11,13 +12,26 @@ import (
 func (h *handler) Fetch(ctx context.Context, job *models.AppRunnerJob, jobExecution *models.AppRunnerJobExecution) error {
 	h.state = &handlerState{}
 
-	planJSON, err := h.apiClient.GetJobPlanJSON(ctx, job.ID)
+	cp, err := h.apiClient.GetJobCompositePlan(ctx, job.ID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get job plan")
 	}
 
+	composite, err := plantypes.CompositePlanFromAny(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse composite plan")
+	}
+	if composite.FetchImageMetadataPlan == nil {
+		return errors.New("composite plan missing fetch image metadata plan")
+	}
+
+	planJSON, err := json.Marshal(composite.FetchImageMetadataPlan)
+	if err != nil {
+		return errors.Wrap(err, "unable to marshal fetch image metadata plan")
+	}
+
 	var plan FetchImageMetadataPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
+	if err := json.Unmarshal(planJSON, &plan); err != nil {
 		return errors.Wrap(err, "unable to parse fetch image metadata plan")
 	}
 	h.state.plan = &plan

--- a/sdks/nuon-go/client.go
+++ b/sdks/nuon-go/client.go
@@ -223,7 +223,9 @@ type Client interface {
 	GetRunnerRecentHealthChecks(ctx context.Context, runnerID string, processID string) ([]*models.AppRunnerHealthCheck, error)
 
 	// runner job plan
+	// Deprecated: use GetRunnerJobCompositePlan.
 	GetRunnerJobPlan(ctx context.Context, runnerJobID string) (string, error)
+	GetRunnerJobCompositePlan(ctx context.Context, runnerJobID string) (*models.PlantypesCompositePlan, error)
 
 	// install stacks
 	GetInstallStack(ctx context.Context, installID string) (*models.AppInstallStack, error)

--- a/sdks/nuon-go/install_deploys.go
+++ b/sdks/nuon-go/install_deploys.go
@@ -63,6 +63,8 @@ func (c *client) GetInstallDeploy(ctx context.Context, installID string, deployI
 	return resp.Payload, nil
 }
 
+// Deprecated: use GetRunnerJobCompositePlan, which reads the composite plan
+// from blob storage. This returns the legacy plan_json column.
 func (c *client) GetRunnerJobPlan(ctx context.Context, runnerJobID string) (string, error) {
 	resp, err := c.genClient.Operations.GetRunnerJobPlan(&operations.GetRunnerJobPlanParams{
 		RunnerJobID: runnerJobID,
@@ -70,6 +72,18 @@ func (c *client) GetRunnerJobPlan(ctx context.Context, runnerJobID string) (stri
 	}, c.getOrgIDAuthInfo())
 	if err != nil {
 		return "", err
+	}
+
+	return resp.Payload, nil
+}
+
+func (c *client) GetRunnerJobCompositePlan(ctx context.Context, runnerJobID string) (*models.PlantypesCompositePlan, error) {
+	resp, err := c.genClient.Operations.GetRunnerJobCompositePlan(&operations.GetRunnerJobCompositePlanParams{
+		RunnerJobID: runnerJobID,
+		Context:     ctx,
+	}, c.getOrgIDAuthInfo())
+	if err != nil {
+		return nil, err
 	}
 
 	return resp.Payload, nil

--- a/sdks/nuon-go/models/app_runner_job_plan.go
+++ b/sdks/nuon-go/models/app_runner_job_plan.go
@@ -7,7 +7,6 @@ package models
 
 import (
 	"context"
-	stderrors "errors"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -19,8 +18,11 @@ import (
 // swagger:model app.RunnerJobPlan
 type AppRunnerJobPlan struct {
 
-	// composite plan
-	CompositePlan *PlantypesCompositePlan `json:"composite_plan,omitempty"`
+	// Deprecated: composite plans are read from CompositePlanBlob (S3). This
+	// jsonb column is retained only as a fallback for rows not yet backfilled.
+	CompositePlan struct {
+		PlantypesCompositePlan
+	} `json:"composite_plan,omitempty"`
 
 	// created at
 	CreatedAt string `json:"created_at,omitempty"`
@@ -63,21 +65,6 @@ func (m *AppRunnerJobPlan) validateCompositePlan(formats strfmt.Registry) error 
 		return nil
 	}
 
-	if m.CompositePlan != nil {
-		if err := m.CompositePlan.Validate(formats); err != nil {
-			ve := new(errors.Validation)
-			if stderrors.As(err, &ve) {
-				return ve.ValidateName("composite_plan")
-			}
-			ce := new(errors.CompositeError)
-			if stderrors.As(err, &ce) {
-				return ce.ValidateName("composite_plan")
-			}
-
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -96,26 +83,6 @@ func (m *AppRunnerJobPlan) ContextValidate(ctx context.Context, formats strfmt.R
 }
 
 func (m *AppRunnerJobPlan) contextValidateCompositePlan(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.CompositePlan != nil {
-
-		if swag.IsZero(m.CompositePlan) { // not required
-			return nil
-		}
-
-		if err := m.CompositePlan.ContextValidate(ctx, formats); err != nil {
-			ve := new(errors.Validation)
-			if stderrors.As(err, &ve) {
-				return ve.ValidateName("composite_plan")
-			}
-			ce := new(errors.CompositeError)
-			if stderrors.As(err, &ce) {
-				return ce.ValidateName("composite_plan")
-			}
-
-			return err
-		}
-	}
 
 	return nil
 }

--- a/sdks/nuon-runner-go/client.go
+++ b/sdks/nuon-runner-go/client.go
@@ -74,6 +74,7 @@ type Client interface {
 	GetJobs(ctx context.Context, grp models.AppRunnerJobGroup, status models.AppRunnerJobStatus, limit *int64) ([]*models.AppRunnerJob, error)
 	TailJobs(ctx context.Context, grp models.AppRunnerJobGroup, wait time.Duration) ([]*models.AppRunnerJob, error)
 	GetJob(ctx context.Context, jobID string) (*models.AppRunnerJob, error)
+	// Deprecated: use GetJobCompositePlan.
 	GetJobPlanJSON(ctx context.Context, jobID string) (string, error)
 	GetJobCompositePlan(ctx context.Context, jobID string) (*models.PlantypesCompositePlan, error)
 	UpdateJob(ctx context.Context, jobID string, req *models.ServiceUpdateRunnerJobRequest) (*models.AppRunnerJob, error)

--- a/sdks/nuon-runner-go/jobs.go
+++ b/sdks/nuon-runner-go/jobs.go
@@ -85,6 +85,8 @@ func (c *client) GetJobCompositePlan(ctx context.Context, jobID string) (*models
 	return resp.Payload, nil
 }
 
+// Deprecated: use GetJobCompositePlan, which reads the composite plan from blob
+// storage. This returns the legacy plan_json column.
 func (c *client) GetJobPlanJSON(ctx context.Context, jobID string) (string, error) {
 	resp, err := c.genClient.Operations.GetRunnerJobPlan(&operations.GetRunnerJobPlanParams{
 		RunnerJobID: jobID,

--- a/sdks/nuon-runner-go/models/app_runner_job_plan.go
+++ b/sdks/nuon-runner-go/models/app_runner_job_plan.go
@@ -7,7 +7,6 @@ package models
 
 import (
 	"context"
-	stderrors "errors"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -19,8 +18,11 @@ import (
 // swagger:model app.RunnerJobPlan
 type AppRunnerJobPlan struct {
 
-	// composite plan
-	CompositePlan *PlantypesCompositePlan `json:"composite_plan,omitempty"`
+	// Deprecated: composite plans are read from CompositePlanBlob (S3). This
+	// jsonb column is retained only as a fallback for rows not yet backfilled.
+	CompositePlan struct {
+		PlantypesCompositePlan
+	} `json:"composite_plan,omitempty"`
 
 	// created at
 	CreatedAt string `json:"created_at,omitempty"`
@@ -63,21 +65,6 @@ func (m *AppRunnerJobPlan) validateCompositePlan(formats strfmt.Registry) error 
 		return nil
 	}
 
-	if m.CompositePlan != nil {
-		if err := m.CompositePlan.Validate(formats); err != nil {
-			ve := new(errors.Validation)
-			if stderrors.As(err, &ve) {
-				return ve.ValidateName("composite_plan")
-			}
-			ce := new(errors.CompositeError)
-			if stderrors.As(err, &ce) {
-				return ce.ValidateName("composite_plan")
-			}
-
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -96,26 +83,6 @@ func (m *AppRunnerJobPlan) ContextValidate(ctx context.Context, formats strfmt.R
 }
 
 func (m *AppRunnerJobPlan) contextValidateCompositePlan(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.CompositePlan != nil {
-
-		if swag.IsZero(m.CompositePlan) { // not required
-			return nil
-		}
-
-		if err := m.CompositePlan.ContextValidate(ctx, formats); err != nil {
-			ve := new(errors.Validation)
-			if stderrors.As(err, &ve) {
-				return ve.ValidateName("composite_plan")
-			}
-			ce := new(errors.CompositeError)
-			if stderrors.As(err, &ce) {
-				return ce.ValidateName("composite_plan")
-			}
-
-			return err
-		}
-	}
 
 	return nil
 }

--- a/services/ctl-api/internal/app/general/service/admin_backfill_blobs.go
+++ b/services/ctl-api/internal/app/general/service/admin_backfill_blobs.go
@@ -30,7 +30,7 @@ type AdminBackfillBlobsRequest struct {
 // @Summary				backfill dual-write blobs to S3
 // @Description			Starts an orchestrator workflow that enumerates the day-buckets of existing dual-write rows and mirrors each day's rows into S3 blob storage, throttled to the configured per-second S3 write rate. Re-running drains any remaining backlog; an already-running backfill is reused rather than duplicated.
 // @Description
-// @Description			Supported tables: install_states, install_workflow_step_approvals, runner_job_plans, runner_job_execution_outputs, terraform_workspace_states. Leave `tables` empty (or omit the body) to process all of them.
+// @Description			Supported tables: install_states, install_workflow_step_approvals, runner_job_plans, runner_job_execution_outputs, terraform_workspace_states, terraform_workspace_state_jsons. Leave `tables` empty (or omit the body) to process all of them.
 // @Tags					general/admin
 // @Accept					json
 // @Produce				json

--- a/services/ctl-api/internal/app/general/worker/activities/backfill_blobs.go
+++ b/services/ctl-api/internal/app/general/worker/activities/backfill_blobs.go
@@ -28,6 +28,7 @@ var blobBackfillTargets = map[string]blobBackfillTarget{
 	"runner_job_plans":                {originColumn: "composite_plan", blobColumn: "composite_plan_blob", jsonSemantic: true},
 	"runner_job_execution_outputs":    {originColumn: "outputs", blobColumn: "outputs_blob", jsonSemantic: true},
 	"terraform_workspace_states":      {originColumn: "contents", blobColumn: "contents_blob", binary: true},
+	"terraform_workspace_state_jsons": {originColumn: "contents", blobColumn: "contents_blob", binary: true, noSoftDelete: true},
 }
 
 type blobBackfillTarget struct {
@@ -41,6 +42,9 @@ type blobBackfillTarget struct {
 	// text (a ::text cast would yield Postgres hex escapes, not the bytes), and
 	// compared byte-for-byte.
 	binary bool
+	// noSoftDelete marks a table without a deleted_at column, so the
+	// "deleted_at = 0" predicate must be skipped (it would be a SQL error).
+	noSoftDelete bool
 }
 
 // contentExpr selects the origin column's bytes: raw for bytea, ::text otherwise.
@@ -49,6 +53,15 @@ func (t blobBackfillTarget) contentExpr() string {
 		return t.originColumn
 	}
 	return t.originColumn + "::text"
+}
+
+// applyNotDeleted adds the soft-delete predicate unless the target's table has
+// no deleted_at column.
+func (t blobBackfillTarget) applyNotDeleted(q *gorm.DB) *gorm.DB {
+	if t.noSoftDelete {
+		return q
+	}
+	return q.Where("deleted_at = 0")
 }
 
 type BackfillBlobsRequest struct {
@@ -109,8 +122,8 @@ func (a *Activities) BackfillBlobs(ctx context.Context, req BackfillBlobsRequest
 		Table(req.Table).
 		Select(fmt.Sprintf("id, org_id, created_by_id, %s AS content", target.contentExpr())).
 		Where(fmt.Sprintf("%s IS NULL", target.blobColumn)).
-		Where(fmt.Sprintf("%s IS NOT NULL", target.originColumn)).
-		Where("deleted_at = 0")
+		Where(fmt.Sprintf("%s IS NOT NULL", target.originColumn))
+	q = target.applyNotDeleted(q)
 	q, err := whereDay(q, req.Day)
 	if err != nil {
 		return nil, err
@@ -188,7 +201,7 @@ func (a *Activities) ListBackfillDays(ctx context.Context, req ListBlobDaysReque
 		return nil, fmt.Errorf("unsupported blob backfill table: %q", req.Table)
 	}
 
-	days, err := a.listBlobDays(ctx, req.Table, fmt.Sprintf("%s IS NULL", target.blobColumn), target.originColumn)
+	days, err := a.listBlobDays(ctx, req.Table, target, fmt.Sprintf("%s IS NULL", target.blobColumn))
 	if err != nil {
 		return nil, err
 	}
@@ -198,12 +211,12 @@ func (a *Activities) ListBackfillDays(ctx context.Context, req ListBlobDaysReque
 // listBlobDays returns the distinct UTC days with a non-null origin column,
 // optionally narrowed by blobPredicate. table/predicate/column come only from the
 // whitelist map — never request input — since they are interpolated into SQL.
-func (a *Activities) listBlobDays(ctx context.Context, table, blobPredicate, originColumn string) ([]string, error) {
+func (a *Activities) listBlobDays(ctx context.Context, table string, target blobBackfillTarget, blobPredicate string) ([]string, error) {
 	q := a.db.WithContext(ctx).
 		Table(table).
 		Distinct(fmt.Sprintf("to_char(created_at AT TIME ZONE 'UTC', '%s') AS day", pgDayFormat)).
-		Where(fmt.Sprintf("%s IS NOT NULL", originColumn)).
-		Where("deleted_at = 0")
+		Where(fmt.Sprintf("%s IS NOT NULL", target.originColumn))
+	q = target.applyNotDeleted(q)
 	if blobPredicate != "" {
 		q = q.Where(blobPredicate)
 	}

--- a/services/ctl-api/internal/app/general/worker/activities/verify_blobs.go
+++ b/services/ctl-api/internal/app/general/worker/activities/verify_blobs.go
@@ -68,8 +68,8 @@ func (a *Activities) VerifyBlobs(ctx context.Context, req VerifyBlobsRequest) (*
 	q := a.db.WithContext(ctx).
 		Table(req.Table).
 		Select(fmt.Sprintf("id, %s::text AS blob_meta, %s AS content", target.blobColumn, target.contentExpr())).
-		Where(fmt.Sprintf("%s IS NOT NULL", target.originColumn)).
-		Where("deleted_at = 0")
+		Where(fmt.Sprintf("%s IS NOT NULL", target.originColumn))
+	q = target.applyNotDeleted(q)
 	q, err := whereDay(q, req.Day)
 	if err != nil {
 		return nil, err
@@ -171,7 +171,7 @@ func (a *Activities) ListVerifyDays(ctx context.Context, req ListBlobDaysRequest
 		return nil, fmt.Errorf("unsupported blob verify table: %q", req.Table)
 	}
 
-	days, err := a.listBlobDays(ctx, req.Table, "", target.originColumn)
+	days, err := a.listBlobDays(ctx, req.Table, target, "")
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/general/worker/backfill_blobs_workflow.go
+++ b/services/ctl-api/internal/app/general/worker/backfill_blobs_workflow.go
@@ -27,6 +27,7 @@ var defaultBlobBackfillTables = []string{
 	"runner_job_plans",
 	"runner_job_execution_outputs",
 	"terraform_workspace_states",
+	"terraform_workspace_state_jsons",
 }
 
 // BackfillBlobs enumerates the day-buckets with un-mirrored rows and drains them

--- a/services/ctl-api/internal/app/install_state.go
+++ b/services/ctl-api/internal/app/install_state.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -123,6 +125,24 @@ func (a *InstallState) BeforeCreate(tx *gorm.DB) error {
 	}
 
 	return nil
+}
+
+// GetState returns the install state. When blobRead is enabled it prefers the S3
+// blob, falling back to the legacy jsonb column when the blob is unset or
+// unreadable. When disabled it always reads the legacy column. The second return
+// reports whether the state came from the blob. Archived rows null out the
+// column, so the blob is their only source.
+func (i *InstallState) GetState(ctx context.Context, blobRead bool) (*state.State, bool) {
+	if blobRead {
+		if raw, err := i.StateBlob.Get(ctx); err == nil && raw != "" {
+			var st state.State
+			if err := json.Unmarshal([]byte(raw), &st); err == nil {
+				return &st, true
+			}
+		}
+	}
+
+	return i.State, false
 }
 
 func (i *InstallState) UseView() bool {

--- a/services/ctl-api/internal/app/installs/helpers/get_install_state.go
+++ b/services/ctl-api/internal/app/installs/helpers/get_install_state.go
@@ -26,7 +26,12 @@ func (h *Helpers) GetInstallState(ctx context.Context, installID string, redacte
 
 	latestState, err := h.getLatestInstallStateRow(ctx, installID)
 	if err == nil {
-		es := latestState.State
+		es, fromBlob := latestState.GetState(ctx, h.cfg.BlobReadEnabled)
+		if fromBlob {
+			cctx.GetLogger(ctx, h.l).Debug("read install state from blob",
+				zap.String("install_id", installID),
+				zap.String("state_id", latestState.ID))
+		}
 		switch {
 		case !latestState.StaleAt.Empty() && len(latestState.StalePartials) > 0:
 			es, err = h.regenerateStalePartials(ctx, latestState, redacted, skipVersionCheck)
@@ -313,7 +318,11 @@ func (h *Helpers) getLatestInstallStateRow(ctx context.Context, installID string
 // regenerateStalePartials regenerates only the partials listed in row.StalePartials, merges them into
 // the cached state, persists the result in place (clearing the stale markers), and returns it.
 func (h *Helpers) regenerateStalePartials(ctx context.Context, row *app.InstallState, redacted, skipVersionCheck bool) (*state.State, error) {
-	is := row.State
+	is, fromBlob := row.GetState(ctx, h.cfg.BlobReadEnabled)
+	if fromBlob {
+		cctx.GetLogger(ctx, h.l).Debug("read install state from blob (stale partials)",
+			zap.String("state_id", row.ID))
+	}
 	if is == nil {
 		is = state.New()
 	}

--- a/services/ctl-api/internal/app/installs/service/get_install_state_history.go
+++ b/services/ctl-api/internal/app/installs/service/get_install_state_history.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 
 	_ "github.com/nuonco/nuon/pkg/types/state"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -53,6 +54,16 @@ func (s *service) getInstallStateHistory(ctx *gin.Context, installID string) ([]
 	states, err := db.HandlePaginatedResponse(ctx, states)
 	if err != nil {
 		return nil, fmt.Errorf("unable to handle paginated response: %w", err)
+	}
+
+	for _, st := range states {
+		contents, fromBlob := st.GetState(ctx, s.cfg.BlobReadEnabled)
+		st.State = contents
+		if fromBlob {
+			s.l.Debug("read install state from blob",
+				zap.String("install_id", installID),
+				zap.String("state_id", st.ID))
+		}
 	}
 
 	return states, nil

--- a/services/ctl-api/internal/app/installs/service/get_workflow_step_approval_contents.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow_step_approval_contents.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 )
@@ -57,8 +58,15 @@ func (s *service) GetWorkflowStepApprovalContents(ctx *gin.Context) {
 	var buf bytes.Buffer
 	gzipWriter := gzip.NewWriter(&buf)
 
+	contents, fromBlob := approval.GetContents(ctx, s.cfg.BlobReadEnabled)
+	if fromBlob {
+		s.l.Debug("read workflow step approval contents from blob",
+			zap.String("approval_id", approvalID),
+			zap.Int("bytes", len(contents)))
+	}
+
 	// Write the contents to the gzip writer
-	_, err = gzipWriter.Write([]byte(approval.Contents))
+	_, err = gzipWriter.Write([]byte(contents))
 	if err != nil {
 		ctx.Error(errors.Wrap(err, "unable to gzip approval contents"))
 		return

--- a/services/ctl-api/internal/app/runner_job_execution_outputs.go
+++ b/services/ctl-api/internal/app/runner_job_execution_outputs.go
@@ -70,9 +70,16 @@ func (r *RunnerJobExecutionOutputs) BeforeCreate(tx *gorm.DB) error {
 }
 
 func (r *RunnerJobExecutionOutputs) AfterQuery(tx *gorm.DB) error {
-	if len(r.Outputs) > 0 {
+	raw := r.Outputs
+	if blobstore.IsBlobReadEnabled(tx.Statement.Context) {
+		if v, err := r.OutputsBlob.Get(tx.Statement.Context); err == nil && v != "" {
+			raw = []byte(v)
+		}
+	}
+
+	if len(raw) > 0 {
 		var outputs map[string]interface{}
-		if err := json.Unmarshal(r.Outputs, &outputs); err != nil {
+		if err := json.Unmarshal(raw, &outputs); err != nil {
 			return errors.Wrap(err, "unable to parse outputs json")
 		}
 		r.ParsedOutputs = outputs

--- a/services/ctl-api/internal/app/runner_job_plan.go
+++ b/services/ctl-api/internal/app/runner_job_plan.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+	"encoding/json"
 	"time"
 
 	"gorm.io/gorm"
@@ -27,7 +29,9 @@ type RunnerJobPlan struct {
 
 	RunnerJobID string `json:"runner_job_id,omitzero" gorm:"defaultnull;notnull;index:idx_runner_job_plan,unique" temporaljson:"runner_job_id,omitzero,omitempty"`
 
-	PlanJSON          string                  `json:"plan_json,omitzero" temporaljson:"plan_json,omitzero,omitempty"`
+	PlanJSON string `json:"plan_json,omitzero" temporaljson:"plan_json,omitzero,omitempty"`
+	// Deprecated: composite plans are read from CompositePlanBlob (S3). This
+	// jsonb column is retained only as a fallback for rows not yet backfilled.
 	CompositePlan     plantypes.CompositePlan `json:"composite_plan,omitzero" gorm:"type:jsonb" temporaljson:"composite_plan,omitzero,omitempty"`
 	CompositePlanBlob *blobstore.Blob         `json:"-" temporaljson:"-"`
 }
@@ -61,4 +65,22 @@ func (r *RunnerJobPlan) BeforeCreate(tx *gorm.DB) error {
 	}
 
 	return nil
+}
+
+// GetCompositePlan returns the composite plan. When blobRead is enabled it reads
+// from the S3 blob, falling back to the legacy jsonb column when the blob is
+// unset or unreadable (rows not yet backfilled). When disabled it always reads
+// the legacy column. The second return reports whether the plan came from the
+// blob.
+func (r *RunnerJobPlan) GetCompositePlan(ctx context.Context, blobRead bool) (*plantypes.CompositePlan, bool) {
+	if blobRead {
+		if raw, err := r.CompositePlanBlob.Get(ctx); err == nil && raw != "" {
+			var cp plantypes.CompositePlan
+			if err := json.Unmarshal([]byte(raw), &cp); err == nil {
+				return &cp, true
+			}
+		}
+	}
+
+	return &r.CompositePlan, false
 }

--- a/services/ctl-api/internal/app/runners/helpers/helpers.go
+++ b/services/ctl-api/internal/app/runners/helpers/helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	emitterclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/emitter/client"
@@ -25,6 +26,7 @@ type Params struct {
 	QueueClient    *queueclient.Client
 	EmitterClient  *emitterclient.Client
 	FeaturesClient *features.Features
+	BlobSvc        blobstore.Service
 }
 
 type Helpers struct {
@@ -37,6 +39,7 @@ type Helpers struct {
 	queueClient    *queueclient.Client
 	emitterClient  *emitterclient.Client
 	featuresClient *features.Features
+	blobSvc        blobstore.Service
 }
 
 func New(params Params) *Helpers {
@@ -50,5 +53,6 @@ func New(params Params) *Helpers {
 		queueClient:    params.QueueClient,
 		emitterClient:  params.EmitterClient,
 		featuresClient: params.FeaturesClient,
+		blobSvc:        params.BlobSvc,
 	}
 }

--- a/services/ctl-api/internal/app/runners/helpers/terraform_state_json.go
+++ b/services/ctl-api/internal/app/runners/helpers/terraform_state_json.go
@@ -3,8 +3,13 @@ package helpers
 import (
 	"context"
 
-	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
 )
 
 func (s *Helpers) GetTerraformStateJSON(ctx context.Context, workspaceID string) ([]byte, error) {
@@ -22,16 +27,18 @@ func (s *Helpers) GetTerraformStateJSON(ctx context.Context, workspaceID string)
 		return nil, res.Error
 	}
 
-	return tfs.Contents, nil
+	contents, fromBlob := tfs.GetContents(blobstore.WithBlobService(ctx, s.blobSvc), s.cfg.BlobReadEnabled)
+	if fromBlob {
+		s.l.Debug("read terraform workspace state json contents from blob",
+			zap.String("workspace_id", workspaceID),
+			zap.String("state_id", tfs.ID),
+			zap.Int("bytes", len(contents)))
+	}
+
+	return contents, nil
 }
 
 func (s *Helpers) CreateStateJSON(ctx context.Context, workspaceID string, jobID *string, contents []byte) error {
-	tfs := &app.TerraformWorkspaceStateJSON{
-		WorkspaceID: workspaceID,
-		RunnerJobID: jobID,
-		Contents:    contents,
-	}
-
 	workspace := &app.TerraformWorkspace{}
 	resCheck := s.db.WithContext(ctx).
 		First(workspace, "id = ?", workspaceID)
@@ -39,7 +46,19 @@ func (s *Helpers) CreateStateJSON(ctx context.Context, workspaceID string, jobID
 		return resCheck.Error
 	}
 
-	tfs.OrgID = workspace.OrgID
+	tfs := &app.TerraformWorkspaceStateJSON{
+		WorkspaceID:  workspaceID,
+		RunnerJobID:  jobID,
+		Contents:     contents,
+		ContentsBlob: &blobstore.Blob{},
+		OrgID:        workspace.OrgID,
+	}
+	tfs.ContentsBlob.Set(string(contents))
+
+	ctx = blobstore.WithBlobService(ctx, s.blobSvc)
+	if keys.OrgIDFromContext(ctx) == "" {
+		ctx = cctx.SetOrgIDContext(ctx, workspace.OrgID)
+	}
 
 	res := s.db.WithContext(ctx).Create(tfs)
 	if res.Error != nil {

--- a/services/ctl-api/internal/app/runners/service/get_runner_job_composite_plan.go
+++ b/services/ctl-api/internal/app/runners/service/get_runner_job_composite_plan.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -57,8 +58,14 @@ func (s *service) getRunnerJobCompositePlan(ctx context.Context, runnerJobID str
 		return nil, fmt.Errorf("unable to get job plan: %w", res.Error)
 	}
 
-	if !runnerPlan.CompositePlan.IsEmpty() {
-		return &runnerPlan.CompositePlan, nil
+	cp, fromBlob := runnerPlan.GetCompositePlan(ctx, s.cfg.BlobReadEnabled)
+	if fromBlob {
+		s.l.Debug("read composite plan from blob",
+			zap.String("runner_job_id", runnerJobID),
+			zap.String("plan_id", runnerPlan.ID))
+	}
+	if !cp.IsEmpty() {
+		return cp, nil
 	}
 
 	// if empty derive from plan json
@@ -85,8 +92,15 @@ func (s *service) getOrgRunnerJobCompositePlan(ctx context.Context, runnerJobID 
 		return nil, fmt.Errorf("unable to get job plan: %w", res.Error)
 	}
 
-	if !runnerPlan.CompositePlan.IsEmpty() {
-		return &runnerPlan.CompositePlan, nil
+	cp, fromBlob := runnerPlan.GetCompositePlan(ctx, s.cfg.BlobReadEnabled)
+	if fromBlob {
+		s.l.Debug("read composite plan from blob",
+			zap.String("runner_job_id", runnerJobID),
+			zap.String("org_id", orgID),
+			zap.String("plan_id", runnerPlan.ID))
+	}
+	if !cp.IsEmpty() {
+		return cp, nil
 	}
 
 	// if empty derive from plan json

--- a/services/ctl-api/internal/app/runners/service/get_terraform_state.go
+++ b/services/ctl-api/internal/app/runners/service/get_terraform_state.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
@@ -38,10 +39,22 @@ func (s *service) GetTerraformCurrentStateData(ctx *gin.Context) {
 		return
 	}
 
-	if state == nil || state.Contents == nil || len(state.Contents) == 0 {
+	if state == nil {
 		ctx.JSON(http.StatusNoContent, "")
 		return
 	}
 
-	ctx.String(http.StatusOK, string(state.Contents))
+	contents, fromBlob := state.GetContents(ctx, s.cfg.BlobReadEnabled)
+	if fromBlob {
+		s.l.Debug("read terraform workspace state contents from blob",
+			zap.String("workspace_id", workspaceID),
+			zap.String("state_id", state.ID),
+			zap.Int("bytes", len(contents)))
+	}
+	if len(contents) == 0 {
+		ctx.JSON(http.StatusNoContent, "")
+		return
+	}
+
+	ctx.String(http.StatusOK, string(contents))
 }

--- a/services/ctl-api/internal/app/runners/service/get_terraform_states_json_by_id.go
+++ b/services/ctl-api/internal/app/runners/service/get_terraform_states_json_by_id.go
@@ -12,7 +12,9 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 )
 
 // @ID						GetTerraformWorkspaceStatesJSONByIDV2
@@ -109,6 +111,15 @@ func (s *service) GetTerraformStatesJSONById(ctx *gin.Context, workspaceID strin
 		Where("id = ? and workspace_id = ?", stateID, workspaceID).First(state)
 	if res.Error != nil {
 		return nil, fmt.Errorf("unable to get terraform state: %w", res.Error)
+	}
+
+	contents, fromBlob := state.GetContents(blobstore.WithBlobService(ctx, s.blobSvc), s.cfg.BlobReadEnabled)
+	state.Contents = contents
+	if fromBlob {
+		s.l.Debug("read terraform workspace state json contents from blob",
+			zap.String("workspace_id", workspaceID),
+			zap.String("state_id", state.ID),
+			zap.Int("bytes", len(contents)))
 	}
 
 	return state, nil

--- a/services/ctl-api/internal/app/terraform_workspace_state.go
+++ b/services/ctl-api/internal/app/terraform_workspace_state.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"database/sql/driver"
 	"encoding/json"
 	"time"
@@ -72,6 +73,20 @@ func (t *TerraformWorkspaceState) BeforeCreate(tx *gorm.DB) (err error) {
 	}
 
 	return nil
+}
+
+// GetContents returns the state contents. When blobRead is enabled it prefers
+// the S3 blob, falling back to the legacy bytea column when the blob is unset or
+// unreadable. When disabled it always reads the legacy column. The second return
+// reports whether the contents came from the blob.
+func (t *TerraformWorkspaceState) GetContents(ctx context.Context, blobRead bool) ([]byte, bool) {
+	if blobRead {
+		if raw, err := t.ContentsBlob.Get(ctx); err == nil && raw != "" {
+			return []byte(raw), true
+		}
+	}
+
+	return t.Contents, false
 }
 
 func (i *TerraformWorkspaceState) UseView() bool {

--- a/services/ctl-api/internal/app/terraform_workspace_state_json.go
+++ b/services/ctl-api/internal/app/terraform_workspace_state_json.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"context"
 	"time"
 
 	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/indexes"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
 	"gorm.io/gorm"
@@ -17,7 +19,8 @@ type TerraformWorkspaceStateJSON struct {
 	CreatedAt time.Time `json:"created_at,omitzero" gorm:"notnull" temporaljson:"created_at,omitzero,omitempty"`
 	UpdatedAt time.Time `json:"updated_at,omitzero" gorm:"notnull" temporaljson:"updated_at,omitzero,omitempty"`
 
-	Contents []byte `json:"contents,omitzero" gorm:"type:bytea" temporaljson:"contents,omitzero,omitempty"`
+	Contents     []byte          `json:"contents,omitzero" gorm:"type:bytea" temporaljson:"contents,omitzero,omitempty"`
+	ContentsBlob *blobstore.Blob `json:"-" temporaljson:"-"`
 
 	OrgID string `json:"org_id,omitzero" gorm:"default:null" temporaljson:"org_id,omitzero,omitempty"`
 	Org   Org    `json:"-" temporaljson:"org,omitzero,omitempty"`
@@ -54,5 +57,23 @@ func (t *TerraformWorkspaceStateJSON) BeforeCreate(tx *gorm.DB) (err error) {
 		t.OrgID = orgIDFromContext(tx.Statement.Context)
 	}
 
+	if err := t.ContentsBlob.BeforeCreate(tx); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// GetContents returns the state contents. When blobRead is enabled it prefers
+// the S3 blob, falling back to the legacy bytea column when the blob is unset or
+// unreadable. When disabled it always reads the legacy column. The second return
+// reports whether the contents came from the blob.
+func (t *TerraformWorkspaceStateJSON) GetContents(ctx context.Context, blobRead bool) ([]byte, bool) {
+	if blobRead {
+		if raw, err := t.ContentsBlob.Get(ctx); err == nil && raw != "" {
+			return []byte(raw), true
+		}
+	}
+
+	return t.Contents, false
 }

--- a/services/ctl-api/internal/app/workflow_step_approval.go
+++ b/services/ctl-api/internal/app/workflow_step_approval.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"database/sql"
 	"time"
 
@@ -90,6 +91,20 @@ func (c *WorkflowStepApproval) AfterQuery(tx *gorm.DB) error {
 	c.WorkflowStepID = c.InstallWorkflowStep.ID
 	c.WorkflowStep = c.InstallWorkflowStep
 	return nil
+}
+
+// GetContents returns the approval contents. When blobRead is enabled it prefers
+// the S3 blob, falling back to the legacy column when the blob is unset or
+// unreadable. When disabled it always reads the legacy column. The second return
+// reports whether the contents came from the blob.
+func (c *WorkflowStepApproval) GetContents(ctx context.Context, blobRead bool) (string, bool) {
+	if blobRead {
+		if raw, err := c.ContentsBlob.Get(ctx); err == nil && raw != "" {
+			return raw, true
+		}
+	}
+
+	return c.Contents, false
 }
 
 func (c *WorkflowStepApproval) Indexes(db *gorm.DB) []migrations.Index {

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -421,6 +421,11 @@ type Config struct {
 	// BlobBackfillRatePerSecond caps how many S3 PUTs/sec the blob backfill activity issues. Defaults to 500 when unset.
 	BlobBackfillRatePerSecond int `config:"blob_backfill_rate_per_second"`
 
+	// BlobReadEnabled gates reading large fields from the S3 blob. When false
+	// (default) reads fall back to the legacy column. Currently gates composite
+	// plan reads.
+	BlobReadEnabled bool `config:"blob_read_enabled"`
+
 	// Slack auto-link reconciler. TeamID + OrgLabelKey must both be set;
 	// ChannelID is optional and seeds a default org-wide subscription per link.
 	SlackAutoLinkTeamID        string `config:"slack_auto_link_team_id"`

--- a/services/ctl-api/internal/interceptors/cctx/activity_interceptor.go
+++ b/services/ctl-api/internal/interceptors/cctx/activity_interceptor.go
@@ -14,8 +14,9 @@ var _ interceptor.ActivityInboundInterceptor = (*actInterceptor)(nil)
 type actInterceptor struct {
 	interceptor.ActivityInboundInterceptorBase
 
-	blobSvc blobstore.Service
-	l       *zap.Logger
+	blobSvc         blobstore.Service
+	l               *zap.Logger
+	blobReadEnabled bool
 }
 
 func (a *actInterceptor) Init(outbound interceptor.ActivityOutboundInterceptor) error {
@@ -28,6 +29,7 @@ func (a *actInterceptor) ExecuteActivity(
 ) (interface{}, error) {
 	// Add blobstore service to context
 	ctx = blobstore.WithBlobService(ctx, a.blobSvc)
+	ctx = blobstore.WithBlobReadEnabled(ctx, a.blobReadEnabled)
 
 	// Continue with execution
 	return a.Next.ExecuteActivity(ctx, in)

--- a/services/ctl-api/internal/interceptors/cctx/cctx.go
+++ b/services/ctl-api/internal/interceptors/cctx/cctx.go
@@ -4,12 +4,14 @@ import (
 	"go.temporal.io/sdk/interceptor"
 	"go.uber.org/zap"
 
+	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
 )
 
-func New(l *zap.Logger, blobSvc blobstore.Service) interceptor.WorkerInterceptor {
+func New(l *zap.Logger, blobSvc blobstore.Service, cfg *internal.Config) interceptor.WorkerInterceptor {
 	return &workerInterceptor{
-		blobSvc: blobSvc,
-		l:       l,
+		blobSvc:         blobSvc,
+		l:               l,
+		blobReadEnabled: cfg.BlobReadEnabled,
 	}
 }

--- a/services/ctl-api/internal/interceptors/cctx/worker_interceptor.go
+++ b/services/ctl-api/internal/interceptors/cctx/worker_interceptor.go
@@ -15,8 +15,9 @@ var (
 )
 
 type workerInterceptor struct {
-	blobSvc blobstore.Service
-	l       *zap.Logger
+	blobSvc         blobstore.Service
+	l               *zap.Logger
+	blobReadEnabled bool
 
 	interceptor.InterceptorBase
 }
@@ -27,10 +28,11 @@ func (w *workerInterceptor) InterceptActivity(
 	next interceptor.ActivityInboundInterceptor,
 ) interceptor.ActivityInboundInterceptor {
 	return &actInterceptor{
-		interceptor.ActivityInboundInterceptorBase{
+		ActivityInboundInterceptorBase: interceptor.ActivityInboundInterceptorBase{
 			Next: next,
 		},
-		w.blobSvc,
-		w.l,
+		blobSvc:         w.blobSvc,
+		l:               w.l,
+		blobReadEnabled: w.blobReadEnabled,
 	}
 }

--- a/services/ctl-api/internal/middlewares/blob/middleware.go
+++ b/services/ctl-api/internal/middlewares/blob/middleware.go
@@ -4,12 +4,14 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 
+	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
 )
 
 type middleware struct {
-	l   *zap.Logger
-	svc blobstore.Service
+	l               *zap.Logger
+	svc             blobstore.Service
+	blobReadEnabled bool
 }
 
 func (m middleware) Name() string {
@@ -18,16 +20,17 @@ func (m middleware) Name() string {
 
 func (m middleware) Handler() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		ctx.Request = ctx.Request.WithContext(
-			blobstore.WithBlobService(ctx.Request.Context(), m.svc),
-		)
+		reqCtx := blobstore.WithBlobService(ctx.Request.Context(), m.svc)
+		reqCtx = blobstore.WithBlobReadEnabled(reqCtx, m.blobReadEnabled)
+		ctx.Request = ctx.Request.WithContext(reqCtx)
 		ctx.Next()
 	}
 }
 
-func New(l *zap.Logger, svc blobstore.Service) *middleware {
+func New(l *zap.Logger, svc blobstore.Service, cfg *internal.Config) *middleware {
 	return &middleware{
-		l:   l,
-		svc: svc,
+		l:               l,
+		svc:             svc,
+		blobReadEnabled: cfg.BlobReadEnabled,
 	}
 }

--- a/services/ctl-api/internal/pkg/blobstore/context.go
+++ b/services/ctl-api/internal/pkg/blobstore/context.go
@@ -10,6 +10,7 @@ type blobContextKey string
 
 const (
 	BlobWriteEnabledKey blobContextKey = "blob_write_enabled"
+	BlobReadEnabledKey  blobContextKey = "blob_read_enabled"
 	BlobAutoLoadKey     blobContextKey = "blob_auto_load"
 	BlobServiceKey      blobContextKey = "blob_service"
 )
@@ -17,6 +18,13 @@ const (
 // WithBlobWriteEnabled controls whether blobs upload to S3 on save
 func WithBlobWriteEnabled(ctx context.Context, enabled bool) context.Context {
 	return context.WithValue(ctx, BlobWriteEnabledKey, enabled)
+}
+
+// WithBlobReadEnabled controls whether blob-backed reads prefer the S3 blob.
+// When disabled, reads fall back to the legacy column. Used by hook-based reads
+// (e.g. GORM AfterQuery) that have no service call site to thread the flag through.
+func WithBlobReadEnabled(ctx context.Context, enabled bool) context.Context {
+	return context.WithValue(ctx, BlobReadEnabledKey, enabled)
 }
 
 // WithBlobAutoLoad controls whether blobs auto-load from S3 on query
@@ -40,6 +48,15 @@ func IsBlobWriteEnabled(ctx context.Context) bool {
 		return v.(bool)
 	}
 	return true // Default: enabled
+}
+
+// IsBlobReadEnabled checks if blob-backed reads are enabled (default: false).
+// Must be explicitly enabled, mirroring the BlobReadEnabled config gate.
+func IsBlobReadEnabled(ctx context.Context) bool {
+	if v := ctx.Value(BlobReadEnabledKey); v != nil {
+		return v.(bool)
+	}
+	return false
 }
 
 // IsBlobAutoLoad checks if auto-load is enabled (default: false)

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/webhook.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/webhook.go
@@ -124,13 +124,14 @@ type Params struct {
 }
 
 type WebhookSignalLifecycleHook struct {
-	l            *zap.Logger
-	httpClient   *http.Client
-	webhookURLs  []string
-	db           *gorm.DB
-	appURL       string
-	publicAPIURL string
-	mw           metrics.Writer
+	l               *zap.Logger
+	httpClient      *http.Client
+	webhookURLs     []string
+	db              *gorm.DB
+	appURL          string
+	publicAPIURL    string
+	mw              metrics.Writer
+	blobReadEnabled bool
 
 	// workflowCreatorCache holds workflowCreatorRow values keyed by workflow
 	// id. The underlying row is write-once, so entries never expire.
@@ -165,10 +166,12 @@ func NewWebhookSignalLifecycleHook(params Params) *WebhookSignalLifecycleHook {
 	webhookURLs := []string{}
 	appURL := ""
 	publicAPIURL := ""
+	blobReadEnabled := false
 	if params.Cfg != nil {
 		webhookURLs = params.Cfg.WebhookURLs
 		appURL = strings.TrimSpace(params.Cfg.AppURL)
 		publicAPIURL = strings.TrimSpace(params.Cfg.PublicAPIURL)
+		blobReadEnabled = params.Cfg.BlobReadEnabled
 	}
 
 	return &WebhookSignalLifecycleHook{
@@ -176,11 +179,12 @@ func NewWebhookSignalLifecycleHook(params Params) *WebhookSignalLifecycleHook {
 		httpClient: &http.Client{
 			Timeout: timeout,
 		},
-		webhookURLs:  normalizeWebhookURLs(webhookURLs),
-		db:           params.DB,
-		appURL:       appURL,
-		publicAPIURL: publicAPIURL,
-		mw:           params.MW,
+		webhookURLs:     normalizeWebhookURLs(webhookURLs),
+		db:              params.DB,
+		appURL:          appURL,
+		publicAPIURL:    publicAPIURL,
+		mw:              params.MW,
+		blobReadEnabled: blobReadEnabled,
 	}
 }
 
@@ -839,7 +843,7 @@ func (h *WebhookSignalLifecycleHook) buildApprovalEventData(ctx context.Context,
 		Approval: &approvalRef{
 			ID:          approval.ID,
 			Type:        string(approval.Type),
-			Plan:        truncateApprovalPlan(approval.Contents),
+			Plan:        truncateApprovalPlan(h.approvalContents(ctx, approval)),
 			RespondedBy: respondedBy,
 		},
 	}
@@ -897,6 +901,18 @@ func mapApprovalResponseTransition(t app.WorkflowStepResponseType) string {
 // truncateApprovalPlan trims a plan blob to approvalPlanExcerptMaxBytes,
 // appending an explicit "(truncated)" marker when truncation occurred so the
 // receiving consumer can render the right indicator.
+// approvalContents reads the approval plan, honoring the blob-read flag, and
+// logs when the read is served from the S3 blob.
+func (h *WebhookSignalLifecycleHook) approvalContents(ctx context.Context, approval *app.WorkflowStepApproval) string {
+	contents, fromBlob := approval.GetContents(ctx, h.blobReadEnabled)
+	if fromBlob {
+		h.l.Debug("read workflow step approval contents from blob",
+			zap.String("approval_id", approval.ID),
+			zap.Int("bytes", len(contents)))
+	}
+	return contents
+}
+
 func truncateApprovalPlan(plan string) string {
 	plan = strings.TrimSpace(plan)
 	if plan == "" {

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -5403,6 +5403,10 @@ export interface components {
     /** @enum {string} */
     "app.RunnerJobOperationType": "exec" | "build" | "create-apply-plan" | "create-teardown-plan" | "apply-plan" | "unknown";
     "app.RunnerJobPlan": {
+      /**
+       * @description Deprecated: composite plans are read from CompositePlanBlob (S3). This
+       * jsonb column is retained only as a fallback for rows not yet backfilled.
+       */
       composite_plan?: components["schemas"]["plantypes.CompositePlan"];
       created_at?: string;
       created_by_id?: string;


### PR DESCRIPTION
Switch dual-write reads to S3 blob behind a flag

Adds a blob_read_enabled config flag that switches the dual-write models from reading their legacy Postgres column to reading the S3 blob (with automatic fallback to the column when the blob is unset/unreadable). Defaults to off, so behavior is unchanged until the flag is flipped.