### PR TITLE
feat: (ctl-api) classify helm composite errors by failure type

### DIFF
--- a/services/ctl-api/internal/app/runners/errparse/helm/error.go
+++ b/services/ctl-api/internal/app/runners/errparse/helm/error.go
@@ -12,6 +12,13 @@
 // dry-run: <sdk error>"). The parser leads the headline at the SDK error by
 // stripping that wrapper, and falls back to a set of verified helm v4 SDK cause
 // strings when the wrapper is absent from the captured output.
+//
+// The anchored cause is then classified into a specific helm failure type
+// (helm.immutable_field, helm.ownership_conflict, ...) which carries a distinct
+// discriminator (for UI badging and the parse-coverage metric) and retry hints
+// (deterministic config errors set skip_auto_retry so the orchestrator parks
+// the step for manual retry instead of burning attempts). An unclassified helm
+// failure still yields the generic helm.error so it beats the raw dump.
 package helm
 
 import (
@@ -21,9 +28,31 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
 )
 
-// HelmErrorType is the discriminator for a helm failure that no provider-layer
-// parser recognised.
-const HelmErrorType compositeerrors.Type = "helm.error"
+const (
+	// HelmErrorType is the fallback discriminator for a helm failure that no
+	// specific classifier recognised.
+	HelmErrorType compositeerrors.Type = "helm.error"
+	// HelmImmutableFieldType is a rejected patch to an immutable/forbidden field
+	// (e.g. a StatefulSet selector), which a blind retry can never fix.
+	HelmImmutableFieldType compositeerrors.Type = "helm.immutable_field"
+	// HelmOwnershipConflictType is a resource that already exists and is not
+	// owned by this release, so it cannot be adopted.
+	HelmOwnershipConflictType compositeerrors.Type = "helm.ownership_conflict"
+	// HelmNameInUseType is a release name still held by another (often stuck)
+	// release.
+	HelmNameInUseType compositeerrors.Type = "helm.name_in_use"
+	// HelmNoDeployedReleaseType is an upgrade with no prior deployed release.
+	HelmNoDeployedReleaseType compositeerrors.Type = "helm.no_deployed_release"
+	// HelmHookFailedType is a lifecycle hook (pre/post install/upgrade) that
+	// failed; this can be transient so it stays auto-retryable.
+	HelmHookFailedType compositeerrors.Type = "helm.hook_failed"
+	// HelmWaitTimeoutType is a --wait timeout on resources becoming ready; often
+	// transient (image pull, scheduling) so it stays auto-retryable.
+	HelmWaitTimeoutType compositeerrors.Type = "helm.wait_timeout"
+	// HelmRenderErrorType is a chart render / manifest build failure (template
+	// execution, YAML, unknown kind), a deterministic config error.
+	HelmRenderErrorType compositeerrors.Type = "helm.render_error"
+)
 
 const (
 	// maxHeadline bounds the one-line message; full detail lives in the output.
@@ -40,17 +69,20 @@ const (
 // deploy/helm (operation_install.go / operation_upgrade.go).
 var wrappers = []string{"helm release:", "with dry-run:"}
 
-// causes are verified helm v4 SDK (pkg/action) error substrings, used as a
-// backup anchor when the captured output does not carry the runner wrapper
+// causes are verified helm v4 SDK (pkg/action, pkg/kube) error substrings, used
+// as a backup anchor when the captured output does not carry the runner wrapper
 // (e.g. only a log line was retained). Every entry is helm-specific — generic
 // kubernetes phrases like "timed out waiting for the condition" are
 // deliberately excluded, since they can appear in streamed pod logs before the
-// real cause and would produce a misleading headline.
+// real cause and would produce a misleading headline. (That phrase is still
+// used to classify an already-anchored cause below, just never to anchor one.)
 var causes = []string{
 	"cannot reuse a name that is still in use",
 	"exists and cannot be imported into the current release",
 	"invalid ownership metadata",
 	"unable to build kubernetes objects from",
+	"cannot patch",
+	"unable to recognize",
 	"failed pre-install",
 	"failed post-install",
 	"pre-upgrade hooks failed",
@@ -59,23 +91,64 @@ var causes = []string{
 	"has no deployed releases",
 	"another operation (install/upgrade/rollback) is in progress",
 	"chart dependencies processing failed",
+	"YAML parse error",
 }
 
-// HelmError is the tool-layer payload: the helm failure summary (the SDK error
-// with the runner's wrapper stripped) plus the cleaned output for context.
+// classifier maps an anchored cause to a specific helm failure type. The first
+// classifier whose match hits wins, so more specific ones are listed first.
+type classifier struct {
+	typ   compositeerrors.Type
+	hints compositeerrors.Hints
+	match func(summary string) bool
+}
+
+// skipRetry marks a deterministic failure a blind retry cannot fix, so the
+// orchestrator parks the step for manual retry instead of burning attempts.
+var skipRetry = compositeerrors.Hints{compositeerrors.HintSkipAutoRetry: "true"}
+
+var classifiers = []classifier{
+	{HelmOwnershipConflictType, skipRetry, contains("exists and cannot be imported into the current release", "invalid ownership metadata")},
+	{HelmImmutableFieldType, skipRetry, contains("field is immutable", "Forbidden: updates to")},
+	{HelmNameInUseType, skipRetry, contains("cannot reuse a name that is still in use")},
+	{HelmNoDeployedReleaseType, skipRetry, contains("has no deployed releases")},
+	{HelmRenderErrorType, skipRetry, contains("unable to build kubernetes objects from", "YAML parse error", "template:", "unable to recognize")},
+	{HelmHookFailedType, nil, contains("hooks failed", "failed pre-install", "failed post-install")},
+	{HelmWaitTimeoutType, nil, contains("timed out waiting for the condition")},
+}
+
+// contains returns a matcher that hits when the summary contains any of subs.
+func contains(subs ...string) func(string) bool {
+	return func(summary string) bool {
+		for _, s := range subs {
+			if strings.Contains(summary, s) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// HelmError is the tool-layer payload: the classified helm failure. Summary is
+// the SDK error with the runner's wrapper stripped; Reason is the specific
+// failure class (empty for the generic fallback); Output is the cleaned context.
 type HelmError struct {
-	// Summary is the helm failure cause, with the runner's wrapper prefix
-	// removed so it leads with the SDK error rather than the nesting.
+	Reason  string `json:"reason,omitempty"`
 	Summary string `json:"summary"`
-	// Output is the cleaned, possibly-truncated diagnostic output.
-	Output string `json:"output,omitempty"`
+	Output  string `json:"output,omitempty"`
+
+	typ   compositeerrors.Type
+	hints compositeerrors.Hints
 }
 
-var _ compositeerrors.CompositeError = (*HelmError)(nil)
+var (
+	_ compositeerrors.CompositeError = (*HelmError)(nil)
+	_ compositeerrors.HintsProvider  = (*HelmError)(nil)
+)
 
 func (e *HelmError) Error() string                      { return truncate(e.Summary, maxHeadline) }
-func (e *HelmError) Type() compositeerrors.Type         { return HelmErrorType }
+func (e *HelmError) Type() compositeerrors.Type         { return e.typ }
 func (e *HelmError) Severity() compositeerrors.Severity { return compositeerrors.SeverityError }
+func (e *HelmError) Hints() compositeerrors.Hints       { return e.hints }
 
 func (e *HelmError) Sections() []compositeerrors.Section {
 	if e.Output == "" {
@@ -110,10 +183,24 @@ func (errorParser) Parse(ctx *errparse.ParseContext) compositeerrors.CompositeEr
 		return nil
 	}
 
-	return &HelmError{
+	typ, hints := HelmErrorType, compositeerrors.Hints(nil)
+	for _, c := range classifiers {
+		if c.match(summary) {
+			typ, hints = c.typ, c.hints
+			break
+		}
+	}
+
+	e := &HelmError{
 		Summary: summary,
 		Output:  truncate(strings.Join(lines, "\n"), maxBody),
+		typ:     typ,
+		hints:   hints,
 	}
+	if typ != HelmErrorType {
+		e.Reason = strings.TrimPrefix(string(typ), "helm.")
+	}
+	return e
 }
 
 func init() {

--- a/services/ctl-api/internal/app/runners/errparse/helm/error_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/helm/error_test.go
@@ -23,8 +23,8 @@ func parse(raw string) compositeerrors.CompositeError {
 	return errorParser{}.Parse(&errparse.ParseContext{Raw: raw})
 }
 
-func TestParse_StripsRunnerWrapper(t *testing.T) {
-	ce := parse(readFixture(t, "reuse_name.txt"))
+func helmErr(t *testing.T, ce compositeerrors.CompositeError) *HelmError {
+	t.Helper()
 	if ce == nil {
 		t.Fatal("expected a composite error, got nil")
 	}
@@ -32,31 +32,57 @@ func TestParse_StripsRunnerWrapper(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *HelmError, got %T", ce)
 	}
+	return e
+}
+
+func TestParse_StripsRunnerWrapperAndClassifies(t *testing.T) {
+	ce := parse(readFixture(t, "reuse_name.txt"))
+	e := helmErr(t, ce)
 	if e.Summary != "cannot reuse a name that is still in use" {
 		t.Errorf("summary should be the SDK error with the runner wrapper stripped: %q", e.Summary)
 	}
 	if strings.Contains(e.Summary, "helm release") || strings.Contains(e.Summary, "unable to execute job") {
 		t.Errorf("summary should not carry the runner wrapper nesting: %q", e.Summary)
 	}
-	if ce.Type() != HelmErrorType {
-		t.Errorf("type = %q", ce.Type())
+	if ce.Type() != HelmNameInUseType {
+		t.Errorf("type = %q, want %q", ce.Type(), HelmNameInUseType)
+	}
+	if e.Reason != "name_in_use" {
+		t.Errorf("reason = %q", e.Reason)
 	}
 	if ce.Severity() != compositeerrors.SeverityError {
 		t.Errorf("severity = %q", ce.Severity())
+	}
+	if !e.Hints().SkipAutoRetry() {
+		t.Error("a name-in-use failure should set skip_auto_retry")
+	}
+}
+
+func TestParse_ImmutableField(t *testing.T) {
+	ce := parse(readFixture(t, "immutable_field.txt"))
+	e := helmErr(t, ce)
+	if ce.Type() != HelmImmutableFieldType {
+		t.Errorf("type = %q, want %q", ce.Type(), HelmImmutableFieldType)
+	}
+	if !strings.HasPrefix(e.Summary, `cannot patch "clickhouse"`) {
+		t.Errorf("summary = %q", e.Summary)
+	}
+	if !e.Hints().SkipAutoRetry() {
+		t.Error("an immutable-field failure should set skip_auto_retry")
 	}
 }
 
 func TestParse_OwnershipConflict(t *testing.T) {
 	ce := parse(readFixture(t, "ownership_conflict.txt"))
-	if ce == nil {
-		t.Fatal("expected a composite error, got nil")
+	e := helmErr(t, ce)
+	if ce.Type() != HelmOwnershipConflictType {
+		t.Errorf("type = %q, want %q", ce.Type(), HelmOwnershipConflictType)
 	}
-	e := ce.(*HelmError)
 	if !strings.HasPrefix(e.Summary, `ConfigMap "app-config"`) {
 		t.Errorf("summary = %q", e.Summary)
 	}
-	if !strings.Contains(e.Summary, "exists and cannot be imported into the current release") {
-		t.Errorf("summary missing the SDK cause: %q", e.Summary)
+	if !e.Hints().SkipAutoRetry() {
+		t.Error("an ownership conflict should set skip_auto_retry")
 	}
 
 	var output string
@@ -70,16 +96,27 @@ func TestParse_OwnershipConflict(t *testing.T) {
 	}
 }
 
+func TestParse_HookFailedIsRetryable(t *testing.T) {
+	ce := parse(readFixture(t, "hook_failed.txt"))
+	e := helmErr(t, ce)
+	if ce.Type() != HelmHookFailedType {
+		t.Errorf("type = %q, want %q", ce.Type(), HelmHookFailedType)
+	}
+	if e.Hints().SkipAutoRetry() {
+		t.Error("a hook failure can be transient and should stay auto-retryable")
+	}
+}
+
 // TestParse_WrapperWinsOverEarlierGenericLogLine is the key regression guard:
 // the generic phrase "timed out waiting for the condition" appears in earlier
 // streamed pod-log lines, but the headline must come from the runner's wrapper
 // line, not the first line that merely mentions a generic phrase.
 func TestParse_WrapperWinsOverEarlierGenericLogLine(t *testing.T) {
 	ce := parse(readFixture(t, "wait_timeout_with_pod_logs.txt"))
-	if ce == nil {
-		t.Fatal("expected a composite error, got nil")
+	e := helmErr(t, ce)
+	if ce.Type() != HelmWaitTimeoutType {
+		t.Errorf("type = %q, want %q", ce.Type(), HelmWaitTimeoutType)
 	}
-	e := ce.(*HelmError)
 	if e.Summary != "timed out waiting for the condition" {
 		t.Errorf("summary = %q", e.Summary)
 	}
@@ -89,16 +126,22 @@ func TestParse_WrapperWinsOverEarlierGenericLogLine(t *testing.T) {
 	if !strings.Contains(e.Output, "ImagePullBackOff") {
 		t.Errorf("Output should retain the streamed pod context: %q", e.Output)
 	}
+	if e.Hints().SkipAutoRetry() {
+		t.Error("a wait timeout is often transient and should stay auto-retryable")
+	}
 }
 
 func TestParse_DryRunTemplateError(t *testing.T) {
 	ce := parse(readFixture(t, "dry_run_template.txt"))
-	if ce == nil {
-		t.Fatal("expected a composite error, got nil")
+	e := helmErr(t, ce)
+	if ce.Type() != HelmRenderErrorType {
+		t.Errorf("type = %q, want %q", ce.Type(), HelmRenderErrorType)
 	}
-	e := ce.(*HelmError)
 	if !strings.HasPrefix(e.Summary, "template: mychart/templates/deployment.yaml") {
 		t.Errorf("summary should strip the dry-run wrapper and lead with the template error: %q", e.Summary)
+	}
+	if !e.Hints().SkipAutoRetry() {
+		t.Error("a render error is deterministic and should set skip_auto_retry")
 	}
 }
 
@@ -106,12 +149,26 @@ func TestParse_DryRunTemplateError(t *testing.T) {
 // runner wrapper but still carries a verified helm SDK cause string.
 func TestParse_CauseFallbackWithoutWrapper(t *testing.T) {
 	ce := parse("unable to build kubernetes objects from release manifest: error validating \"\": error validating data: apiVersion not set")
-	if ce == nil {
-		t.Fatal("expected a composite error, got nil")
+	e := helmErr(t, ce)
+	if ce.Type() != HelmRenderErrorType {
+		t.Errorf("type = %q, want %q", ce.Type(), HelmRenderErrorType)
 	}
-	e := ce.(*HelmError)
 	if !strings.HasPrefix(e.Summary, "unable to build kubernetes objects from release manifest") {
 		t.Errorf("summary = %q", e.Summary)
+	}
+}
+
+func TestParse_UnclassifiedHelmFailureFallsBackToGeneric(t *testing.T) {
+	ce := parse("unable to upgrade helm release: some novel helm failure we have not classified")
+	e := helmErr(t, ce)
+	if ce.Type() != HelmErrorType {
+		t.Errorf("type = %q, want the generic %q", ce.Type(), HelmErrorType)
+	}
+	if e.Reason != "" {
+		t.Errorf("generic fallback should have no reason, got %q", e.Reason)
+	}
+	if e.Hints().SkipAutoRetry() {
+		t.Error("generic helm failure should not force skip_auto_retry")
 	}
 }
 

--- a/services/ctl-api/internal/app/runners/errparse/helm/testdata/hook_failed.txt
+++ b/services/ctl-api/internal/app/runners/errparse/helm/testdata/hook_failed.txt
@@ -1,0 +1,2 @@
+running helm install
+unable to install helm release: failed pre-install: warning: Hook pre-install mychart/templates/migrate-job.yaml failed: 1 error occurred: job "db-migrate" failed: BackoffLimitExceeded

--- a/services/ctl-api/internal/app/runners/errparse/helm/testdata/immutable_field.txt
+++ b/services/ctl-api/internal/app/runners/errparse/helm/testdata/immutable_field.txt
@@ -1,0 +1,2 @@
+running helm upgrade
+unable to upgrade helm release: cannot patch "clickhouse" with kind StatefulSet: StatefulSet.apps "clickhouse" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden


### PR DESCRIPTION
This PR adds more specific types of helm failure modes as composite errors.

We now classify an anchored helm failure into a specific type, each grounded in verified helm v4 SDK strings, with the generic `helm.error` as fallback.

- `immutable_field`
- `ownership_conflict`
- `name_in_use`
- `no_deployed_release`
- `render_error`
- `hook_failed`
- `wait_timeout`

Deterministic config errors set the `skip_auto_retry` hint so the orchestrator parks the step for manual retry instead of burning attempts. The hook/wait failures stay auto-retryable since they can be transient.

Distinct types give the dashboard a badge and the parse metric a per-category backlog signal.