### PR TITLE
feat: fixes for the `nuon app builds` command

### DIFF
--- a/bins/cli/cmd/apps.go
+++ b/bins/cli/cmd/apps.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
@@ -201,11 +202,20 @@ func (c *cli) appsCmd() *cobra.Command {
 		buildConfigID string
 	)
 	buildCmd := &cobra.Command{
-		Use:               "build",
-		Short:             "Build all components for an app config",
-		Long:              "Triggers a workflow that builds all components defined in the app config. If no config ID is provided, uses the latest config.",
-		PersistentPreRunE: c.persistentPreRunE,
-		Annotations:       tuiAnnotation(TUIAltScreen),
+		Use:         "build",
+		Short:       "Build all components for an app config [preview]",
+		Long:        "Triggers a workflow that builds all components defined in the app config. If no config ID is provided, uses the latest config.",
+		Hidden:      true,
+		Annotations: tuiAnnotation(TUIAltScreen),
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := c.persistentPreRunE(cmd, args); err != nil {
+				return err
+			}
+			if !c.cfg.Preview {
+				return fmt.Errorf("[NUON_PREVIEW=false] apps build is a preview feature, set NUON_PREVIEW=true to enable")
+			}
+			return nil
+		},
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			svc := apps.New(c.v, c.apiClient, c.cfg)
 			return svc.Build(cmd.Context(), buildAppID, buildConfigID)

--- a/bins/cli/internal/ui/v3/workflow/data.go
+++ b/bins/cli/internal/ui/v3/workflow/data.go
@@ -83,12 +83,19 @@ func (m *model) handleWorkflowFetched(msg workflowFetchedMsg) tea.Cmd {
 	workflow := msg.workflow
 	err := msg.err
 	if err != nil {
+		// Surface the error so an initial load that never succeeds shows the
+		// error instead of spinning forever (viewContent renders m.error when
+		// no workflow has loaded yet).
+		if m.workflow == nil {
+			m.error = err
+		}
 		m.setLogMessage(fmt.Sprintf("[error] failed to fetch data: %s", err), "error")
 		return nil
 	} else if workflow == nil {
 		m.setLogMessage("something unexpected has taken place", "error")
 		return nil
 	}
+	m.error = nil
 	m.workflow = workflow
 	if msg.policies != nil {
 		policyNames := make(map[string]string)

--- a/bins/cli/internal/ui/v3/workflow/empty_steps_test.go
+++ b/bins/cli/internal/ui/v3/workflow/empty_steps_test.go
@@ -1,0 +1,66 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	"github.com/nuonco/nuon/sdks/nuon-go/models"
+)
+
+func TestEmptyStepsViewReportsStatus(t *testing.T) {
+	testCases := []struct {
+		name     string
+		status   models.AppStatus
+		contains string
+	}{
+		{"in progress", models.AppStatusInDashProgress, "no steps yet"},
+		{"success", models.AppStatusSuccess, "finished with no steps"},
+		{"error", models.AppStatusError, "finished with no steps"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := model{
+				stepDetail: viewport.New(viewport.WithWidth(100), viewport.WithHeight(20)),
+				workflow: &models.AppWorkflow{
+					Status: &models.AppCompositeStatus{Status: tc.status},
+				},
+			}
+
+			out := m.emptyStepsView()
+			if strings.Contains(out, "Loading") || strings.Contains(out, "loading") {
+				t.Fatalf("empty-steps view must not show a loading state, got:\n%s", out)
+			}
+			if !strings.Contains(out, tc.contains) {
+				t.Fatalf("expected %q in empty-steps view, got:\n%s", tc.contains, out)
+			}
+		})
+	}
+}
+
+// TestPopulateStepDetailViewNoLongerSpinsWhenFetched guards the reported bug:
+// once a workflow has been fetched, a zero-step workflow must render a terminal
+// message rather than "Loading ..." forever.
+func TestPopulateStepDetailViewNoLongerSpinsWhenFetched(t *testing.T) {
+	m := &model{
+		stepDetail: viewport.New(viewport.WithWidth(100), viewport.WithHeight(20)),
+		workflow: &models.AppWorkflow{
+			Status: &models.AppCompositeStatus{Status: models.AppStatusInDashProgress},
+		},
+	}
+
+	m.populateStepDetailView(false)
+	if strings.Contains(m.stepDetail.View(), "Loading ...") {
+		t.Fatal("fetched zero-step workflow must not render the loading placeholder")
+	}
+
+	// no workflow yet: loading is still the correct state
+	loadingModel := &model{
+		stepDetail: viewport.New(viewport.WithWidth(100), viewport.WithHeight(20)),
+	}
+	loadingModel.populateStepDetailView(false)
+	if !strings.Contains(loadingModel.stepDetail.View(), "Loading") {
+		t.Fatal("pre-fetch state should still show loading")
+	}
+}

--- a/bins/cli/internal/ui/v3/workflow/header.go
+++ b/bins/cli/internal/ui/v3/workflow/header.go
@@ -85,7 +85,7 @@ func (m model) headerView() string {
 		unless it's loading, in which case we render a single row
 	*/
 	content := ""
-	if len(m.steps) == 0 {
+	if m.workflow == nil {
 		content += m.spinner.View() + " loading ..."
 		m.header.SetContent(content)
 		return appStyle.Render(m.header.View())

--- a/bins/cli/internal/ui/v3/workflow/step_detail_view.go
+++ b/bins/cli/internal/ui/v3/workflow/step_detail_view.go
@@ -213,11 +213,57 @@ func (m model) stepDetailViewInstallStack() string {
 	return s
 }
 
+// emptyStepsView renders a terminal message for a workflow that has been
+// fetched but has no steps, so the TUI does not spin indefinitely.
+func (m model) emptyStepsView() string {
+	status := ""
+	if m.workflow != nil && m.workflow.Status != nil {
+		status = string(m.workflow.Status.Status)
+	}
+
+	msg := "This workflow has no steps."
+	if isTerminalStatus(status) {
+		msg = fmt.Sprintf("This workflow finished with no steps (status: %s).", status)
+	} else if status != "" {
+		msg = fmt.Sprintf("This workflow has no steps yet (status: %s).", status)
+	}
+
+	body := lipgloss.JoinVertical(
+		lipgloss.Center,
+		msg,
+		"",
+		styles.HelpStyle.Render("Press [q] or [esc] to quit."),
+	)
+	return common.FullPageDialog(common.FullPageDialogRequest{
+		Width:   m.stepDetail.Width(),
+		Height:  m.stepDetail.Height(),
+		Padding: 2,
+		Content: body,
+		Level:   "info",
+	})
+}
+
+func isTerminalStatus(status string) bool {
+	switch models.AppStatus(status) {
+	case models.AppStatusSuccess, models.AppStatusError, models.AppStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
 func (m *model) populateStepDetailView(goToTop bool) {
-	// loading states: exit early
-	if len(m.steps) == 0 {
+	// loading state: no workflow fetched yet
+	if m.workflow == nil {
 		s := "\n\n\tLoading ...\n"
 		m.stepDetail.SetContent(s)
+		return
+	}
+
+	// fetched, but the workflow has no steps: render a terminal empty state
+	// instead of spinning forever (e.g. a build workflow with no components).
+	if len(m.steps) == 0 {
+		m.stepDetail.SetContent(m.emptyStepsView())
 		return
 	}
 

--- a/services/ctl-api/internal/app/components/helpers/get_component_by_id.go
+++ b/services/ctl-api/internal/app/components/helpers/get_component_by_id.go
@@ -9,8 +9,12 @@ import (
 
 func (s *Helpers) GetComponentByID(ctx context.Context, componentID string) (*app.Component, error) {
 	cmp := app.Component{}
+	// created_by_id and org_id are required by callers that set the account/org
+	// context from the returned component before writing records (e.g. the
+	// CreateComponentBuild activity, which otherwise inserts a build with a null
+	// created_by_id and violates the NOT NULL constraint).
 	res := s.db.WithContext(ctx).
-		Select("id, name").
+		Select("id, name, created_by_id, org_id").
 		Where(app.Component{ID: componentID}).
 		First(&cmp)
 	if res.Error != nil {


### PR DESCRIPTION
## Summary

The `nuon app builds` command wasn't working. It would start a workflow, but the TUI would hang in a loading state. This PR makes a few fixes to get it working again. It also puts it back behind the `NUON_PREVIEW` flag until we've dogfooded it a bit more.