### PR TITLE
fix: shared org-runner SA mode

### DIFF
--- a/services/ctl-api/internal/app/orgs/worker/iam/gcp_service_account.go
+++ b/services/ctl-api/internal/app/orgs/worker/iam/gcp_service_account.go
@@ -19,6 +19,10 @@ type CreateGCPServiceAccountRequest struct {
 	GARRepositoryURL      string `validate:"required"`
 	K8sNamespace          string // Runner ID used as namespace; empty skips WI binding
 	K8sServiceAccountName string // K8s SA name; empty skips WI binding
+	// SharedServiceAccountEmail switches to the shared org-runner SA: no SA is
+	// created and no GAR grant is made (both happen at install-stack /
+	// component-deploy time); only the per-org WI binding is appended.
+	SharedServiceAccountEmail string
 }
 
 type CreateGCPServiceAccountResponse struct {
@@ -39,23 +43,26 @@ func (a *Activities) CreateGCPServiceAccount(ctx context.Context, req *CreateGCP
 		return nil, fmt.Errorf("unable to create IAM service: %w", err)
 	}
 
-	saName := truncateGCPServiceAccountID(req.OrgID)
-	saEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", saName, req.ProjectID)
-	projectResource := fmt.Sprintf("projects/%s", req.ProjectID)
+	saEmail := req.SharedServiceAccountEmail
+	if saEmail == "" {
+		saName := truncateGCPServiceAccountID(req.OrgID)
+		saEmail = fmt.Sprintf("%s@%s.iam.gserviceaccount.com", saName, req.ProjectID)
+		projectResource := fmt.Sprintf("projects/%s", req.ProjectID)
 
-	// Create the service account. 409 means it already exists — that's fine.
-	_, createErr := iamService.Projects.ServiceAccounts.Create(projectResource, &iam.CreateServiceAccountRequest{
-		AccountId: saName,
-		ServiceAccount: &iam.ServiceAccount{
-			DisplayName: fmt.Sprintf("Nuon org runner %s", req.OrgID),
-		},
-	}).Context(ctx).Do()
-	if createErr != nil && !isGoogleAPIError(createErr, 409) {
-		return nil, fmt.Errorf("unable to create service account: %w", createErr)
-	}
-	// GCP IAM is eventually consistent — brief pause before setting bindings.
-	if createErr == nil {
-		time.Sleep(5 * time.Second)
+		// Create the service account. 409 means it already exists — that's fine.
+		_, createErr := iamService.Projects.ServiceAccounts.Create(projectResource, &iam.CreateServiceAccountRequest{
+			AccountId: saName,
+			ServiceAccount: &iam.ServiceAccount{
+				DisplayName: fmt.Sprintf("Nuon org runner %s", req.OrgID),
+			},
+		}).Context(ctx).Do()
+		if createErr != nil && !isGoogleAPIError(createErr, 409) {
+			return nil, fmt.Errorf("unable to create service account: %w", createErr)
+		}
+		// GCP IAM is eventually consistent — brief pause before setting bindings.
+		if createErr == nil {
+			time.Sleep(5 * time.Second)
+		}
 	}
 
 	// Add Workload Identity binding if K8s namespace and SA name are provided.
@@ -102,6 +109,13 @@ func (a *Activities) CreateGCPServiceAccount(ctx context.Context, req *CreateGCP
 		if err != nil {
 			return nil, fmt.Errorf("unable to set Workload Identity binding: %w", err)
 		}
+	}
+
+	// The shared SA carries its GAR access from deploy-time bindings.
+	if req.SharedServiceAccountEmail != "" {
+		return &CreateGCPServiceAccountResponse{
+			ServiceAccountEmail: saEmail,
+		}, nil
 	}
 
 	// Grant the service account Artifact Registry writer on the management

--- a/services/ctl-api/internal/app/orgs/worker/iam/provision.go
+++ b/services/ctl-api/internal/app/orgs/worker/iam/provision.go
@@ -41,11 +41,12 @@ func (w Wkflow) ProvisionIAM(ctx workflow.Context, req *ProvisionIAMRequest) (*P
 		ctx = workflow.WithActivityOptions(ctx, activityOpts)
 
 		gcpReq := CreateGCPServiceAccountRequest{
-			ProjectID:             w.cfg.ManagementAccountID,
-			OrgID:                 req.OrgID,
-			GARRepositoryURL:      w.cfg.ManagementGARRepositoryURL,
-			K8sNamespace:          req.RunnerID,
-			K8sServiceAccountName: fmt.Sprintf("runner-%s", req.OrgID),
+			ProjectID:                 w.cfg.ManagementAccountID,
+			OrgID:                     req.OrgID,
+			GARRepositoryURL:          w.cfg.ManagementGARRepositoryURL,
+			K8sNamespace:              req.RunnerID,
+			K8sServiceAccountName:     fmt.Sprintf("runner-%s", req.OrgID),
+			SharedServiceAccountEmail: w.cfg.ManagementGCPOrgRunnerSAEmail,
 		}
 		_, err := AwaitCreateGCPServiceAccount(ctx, &gcpReq)
 		if err != nil {

--- a/services/ctl-api/internal/app/runners/helpers/create_runner_group.go
+++ b/services/ctl-api/internal/app/runners/helpers/create_runner_group.go
@@ -153,7 +153,10 @@ func (h *Helpers) CreateOrgRunnerGroup(ctx context.Context, org *app.Org) (*app.
 	var orgAzureClientID string
 	switch h.cfg.CloudProvider {
 	case string(app.CloudPlatformGCP):
-		orgGCPServiceAccount = fmt.Sprintf("%s@%s.iam.gserviceaccount.com", org.ID, h.cfg.ManagementAccountID)
+		orgGCPServiceAccount = h.cfg.ManagementGCPOrgRunnerSAEmail
+		if orgGCPServiceAccount == "" {
+			orgGCPServiceAccount = fmt.Sprintf("%s@%s.iam.gserviceaccount.com", org.ID, h.cfg.ManagementAccountID)
+		}
 	case string(app.CloudPlatformAzure):
 		// Azure per-org managed identity is created by ProvisionIAM workflow.
 		// OrgAzureClientID is populated after IAM provisioning completes.

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -334,7 +334,10 @@ type Config struct {
 
 	// GCP management (not required for AWS)
 	ManagementGARRepositoryURL string `config:"management_gar_repository_url"`
-	GCSInstallTemplateBucket   string `config:"gcs_install_template_bucket"`
+	// When set, org runners share this stack-created SA (WI bindings appended
+	// per org) instead of ctl-api creating one SA per org at runtime.
+	ManagementGCPOrgRunnerSAEmail string `config:"management_gcp_org_runner_sa_email"`
+	GCSInstallTemplateBucket      string `config:"gcs_install_template_bucket"`
 
 	// Azure management (not required for AWS/GCP)
 	ManagementACRRegistryURL      string `config:"management_acr_registry_url"`

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -78,9 +78,7 @@ func init() {
 	config.RegisterDefault("org_runner_instance_type", "t3a.medium")
 
 	config.RegisterDefault("aws_cloudformation_stack_template_bucket_region", "us-east-1")
-	config.RegisterDefault("gcp_stack_template_bucket", "nuon-install-templates-gcp")
 	config.RegisterDefault("blob_storage_provider", "s3")
-	config.RegisterDefault("gcp_stack_template_base_url", "https://storage.googleapis.com/nuon-install-templates-gcp")
 	config.RegisterDefault("org_creation_email_allow_list", "nuon.co")
 	config.RegisterDefault("temporal_dataconverter_large_payload_size", 1024*128)
 	config.RegisterDefault("large_payload_type", "blob")
@@ -337,7 +335,6 @@ type Config struct {
 	// When set, org runners share this stack-created SA (WI bindings appended
 	// per org) instead of ctl-api creating one SA per org at runtime.
 	ManagementGCPOrgRunnerSAEmail string `config:"management_gcp_org_runner_sa_email"`
-	GCSInstallTemplateBucket      string `config:"gcs_install_template_bucket"`
 
 	// Azure management (not required for AWS/GCP)
 	ManagementACRRegistryURL      string `config:"management_acr_registry_url"`


### PR DESCRIPTION
org creation appends WI bindings to a stack-created SA instead of creating per-org SAs; opt-in via management_gcp_org_runner_sa_email