### PR TITLE
fix: (composite errors): render error sections as per thier kind

### DIFF
--- a/services/ctl-api/internal/app/runners/errparse/aws/permission.go
+++ b/services/ctl-api/internal/app/runners/errparse/aws/permission.go
@@ -74,38 +74,29 @@ func (e *AWSPermissionError) Hints() compositeerrors.Hints {
 // statement granting the missing action.
 func (e *AWSPermissionError) Sections() []compositeerrors.Section {
 	sections := []compositeerrors.Section{
-		{
-			Heading: "Why",
-			Body:    "The IAM principal used by this deployment was denied a permission required to perform the operation. This usually means the permission is not granted, but it can also be an explicit deny, a service control policy (SCP), or a permissions boundary. Grant or unblock the permission for the principal and retry.",
-		},
+		compositeerrors.MarkdownSection("Why", "The IAM principal used by this deployment was denied a permission required to perform the operation. This usually means the permission is not granted, but it can also be an explicit deny, a service control policy (SCP), or a permissions boundary. Grant or unblock the permission for the principal and retry."),
 	}
 
 	if e.RawMessage != "" {
-		sections = append(sections, compositeerrors.Section{
-			Heading: "AWS response",
-			Body:    "```\n" + e.RawMessage + "\n```",
-		})
+		sections = append(sections, compositeerrors.CodeSection("AWS response", e.RawMessage))
 	}
 
 	if e.Principal != "" || e.Resource != "" {
 		var lines []string
 		if e.Principal != "" {
-			lines = append(lines, fmt.Sprintf("Principal: `%s`", e.Principal))
+			lines = append(lines, fmt.Sprintf("Principal: %s", e.Principal))
 		}
 		if e.Resource != "" {
-			lines = append(lines, fmt.Sprintf("Resource: `%s`", e.Resource))
+			lines = append(lines, fmt.Sprintf("Resource: %s", e.Resource))
 		}
-		sections = append(sections, compositeerrors.Section{
-			Heading: "Context",
-			Body:    strings.Join(lines, "\n\n"),
-		})
+		sections = append(sections, compositeerrors.TextSection("Context", strings.Join(lines, "\n")))
 	}
 
 	if e.Action != "" {
-		sections = append(sections, compositeerrors.Section{
-			Heading: "How to fix",
-			Body:    "Add the following to the role used by this deployment:\n\n```json\n" + e.policyStatementJSON() + "\n```",
-		})
+		sections = append(sections,
+			compositeerrors.MarkdownSection("How to fix", "Add the following statement to the role used by this deployment:"),
+			compositeerrors.CodeSection("IAM policy statement", e.policyStatementJSON()),
+		)
 	}
 
 	return sections

--- a/services/ctl-api/internal/app/runners/errparse/aws/permission_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/aws/permission_test.go
@@ -134,17 +134,17 @@ func TestParse_S3AccessDenied_PermissionsBoundary(t *testing.T) {
 		t.Errorf("resource %q still carries quotes", e.Resource)
 	}
 	// The generated policy statement must embed the clean ARN, not a quoted one.
-	fix := ""
+	policy := ""
 	for _, s := range e.Sections() {
-		if s.Heading == "How to fix" {
-			fix = s.Body
+		if s.Heading == "IAM policy statement" {
+			policy = s.Body
 		}
 	}
-	if !strings.Contains(fix, `"arn:aws:s3:::inlgckaypxrqqlbs1t7axp26p8-nuon-clickhouse"`) {
-		t.Errorf("How to fix section missing clean resource ARN: %q", fix)
+	if !strings.Contains(policy, `"arn:aws:s3:::inlgckaypxrqqlbs1t7axp26p8-nuon-clickhouse"`) {
+		t.Errorf("IAM policy statement section missing clean resource ARN: %q", policy)
 	}
-	if strings.Contains(fix, `\"arn:aws:s3`) {
-		t.Errorf("How to fix section has a doubly-quoted resource: %q", fix)
+	if strings.Contains(policy, `\"arn:aws:s3`) {
+		t.Errorf("IAM policy statement section has a doubly-quoted resource: %q", policy)
 	}
 }
 
@@ -186,15 +186,15 @@ func TestSections_FullyPopulated(t *testing.T) {
 		headings[s.Heading] = s.Body
 	}
 
-	for _, want := range []string{"Why", "AWS response", "Context", "How to fix"} {
+	for _, want := range []string{"Why", "AWS response", "Context", "How to fix", "IAM policy statement"} {
 		if _, ok := headings[want]; !ok {
 			t.Errorf("missing section %q; got sections %v", want, headings)
 		}
 	}
 
-	fix := headings["How to fix"]
-	if !strings.Contains(fix, "s3:CreateBucket") || !strings.Contains(fix, "arn:aws:s3:::acme-prod-assets") {
-		t.Errorf("How to fix section missing action/resource: %q", fix)
+	policy := headings["IAM policy statement"]
+	if !strings.Contains(policy, "s3:CreateBucket") || !strings.Contains(policy, "arn:aws:s3:::acme-prod-assets") {
+		t.Errorf("IAM policy statement section missing action/resource: %q", policy)
 	}
 	if !strings.Contains(headings["Context"], "arn:aws:iam::123456789012:role/nuon-runner") {
 		t.Errorf("Context section missing principal: %q", headings["Context"])

--- a/services/ctl-api/internal/app/runners/errparse/generic/generic.go
+++ b/services/ctl-api/internal/app/runners/errparse/generic/generic.go
@@ -54,10 +54,7 @@ func (e *GenericError) Sections() []compositeerrors.Section {
 		return nil
 	}
 	return []compositeerrors.Section{
-		{
-			Heading: "Error output",
-			Body:    "```\n" + e.Body + "\n```",
-		},
+		compositeerrors.CodeSection("Error output", e.Body),
 	}
 }
 

--- a/services/ctl-api/internal/app/runners/errparse/helm/error.go
+++ b/services/ctl-api/internal/app/runners/errparse/helm/error.go
@@ -154,10 +154,9 @@ func (e *HelmError) Sections() []compositeerrors.Section {
 	if e.Output == "" {
 		return nil
 	}
-	return []compositeerrors.Section{{
-		Heading: "Output",
-		Body:    "```\n" + e.Output + "\n```",
-	}}
+	return []compositeerrors.Section{
+		compositeerrors.CodeSection("Output", e.Output),
+	}
 }
 
 // errorParser recognises helm failures in a helm job's raw output.

--- a/services/ctl-api/internal/app/runners/errparse/terraform/error.go
+++ b/services/ctl-api/internal/app/runners/errparse/terraform/error.go
@@ -64,23 +64,11 @@ func (e *TerraformError) Sections() []compositeerrors.Section {
 	var sections []compositeerrors.Section
 
 	if len(e.Errors) > 1 {
-		var b strings.Builder
-		for _, s := range e.Errors {
-			b.WriteString("- ")
-			b.WriteString(s)
-			b.WriteString("\n")
-		}
-		sections = append(sections, compositeerrors.Section{
-			Heading: "Errors",
-			Body:    strings.TrimRight(b.String(), "\n"),
-		})
+		sections = append(sections, compositeerrors.TextSection("Errors", strings.Join(e.Errors, "\n")))
 	}
 
 	if e.Output != "" {
-		sections = append(sections, compositeerrors.Section{
-			Heading: "Output",
-			Body:    "```\n" + e.Output + "\n```",
-		})
+		sections = append(sections, compositeerrors.CodeSection("Output", e.Output))
 	}
 
 	return sections

--- a/services/ctl-api/internal/app/runners/errparse/terraform/state_lock.go
+++ b/services/ctl-api/internal/app/runners/errparse/terraform/state_lock.go
@@ -47,15 +47,11 @@ func (e *StateLockError) Hints() compositeerrors.Hints {
 }
 
 func (e *StateLockError) Sections() []compositeerrors.Section {
-	sections := []compositeerrors.Section{{
-		Heading: "How to fix",
-		Body:    stateLockRemediation(e.target),
-	}}
+	sections := []compositeerrors.Section{
+		compositeerrors.MarkdownSection("How to fix", stateLockRemediation(e.target)),
+	}
 	if e.Output != "" {
-		sections = append(sections, compositeerrors.Section{
-			Heading: "Output",
-			Body:    "```\n" + e.Output + "\n```",
-		})
+		sections = append(sections, compositeerrors.CodeSection("Output", e.Output))
 	}
 	return sections
 }

--- a/services/ctl-api/internal/pkg/compositeerrors/error.go
+++ b/services/ctl-api/internal/pkg/compositeerrors/error.go
@@ -43,8 +43,49 @@ type CompositeError interface {
 	Sections() []Section
 }
 
-// Section is a heading + body attached to a CompositeError.
+// SectionKind tells the renderer how to interpret a Section body, and — for
+// security — whether the body is trusted. Untrusted content (raw tool output,
+// values extracted from an error) must never be rendered as markdown: the
+// dashboard's markdown pipeline enables raw HTML and runs custom-component
+// extraction over the string, so a crafted payload could escape a code fence
+// and inject content. Use SectionText/SectionCode for anything derived from
+// tool output, and reserve SectionMarkdown for hand-authored, trusted prose.
+type SectionKind string
+
+const (
+	// SectionMarkdown renders the body as markdown. Only for trusted, code-
+	// authored content. It is also the assumed kind for legacy records that
+	// predate this field.
+	SectionMarkdown SectionKind = "markdown"
+	// SectionText renders the body as escaped plain text, preserving
+	// whitespace. Safe for untrusted single- or multi-line values.
+	SectionText SectionKind = "text"
+	// SectionCode renders the body as an escaped monospace code block. Safe for
+	// untrusted raw output (terraform/helm logs, an AWS response, ...).
+	SectionCode SectionKind = "code"
+)
+
+// Section is a heading + body attached to a CompositeError. Kind controls how
+// the body is rendered and whether it is treated as trusted (see SectionKind).
 type Section struct {
-	Heading string `json:"heading"`
-	Body    string `json:"body"`
+	Heading string      `json:"heading"`
+	Body    string      `json:"body"`
+	Kind    SectionKind `json:"kind,omitempty"`
+}
+
+// MarkdownSection builds a trusted, markdown-rendered section. Only pass
+// hand-authored, code-controlled content — never raw tool output.
+func MarkdownSection(heading, body string) Section {
+	return Section{Heading: heading, Body: body, Kind: SectionMarkdown}
+}
+
+// TextSection builds an escaped plain-text section. Safe for untrusted values.
+func TextSection(heading, body string) Section {
+	return Section{Heading: heading, Body: body, Kind: SectionText}
+}
+
+// CodeSection builds an escaped monospace code section. Safe for untrusted raw
+// output; do not wrap the body in markdown fences.
+func CodeSection(heading, body string) Section {
+	return Section{Heading: heading, Body: body, Kind: SectionCode}
 }

--- a/services/dashboard-ui/client/components/common/CompositeError/CompositeError.stories.tsx
+++ b/services/dashboard-ui/client/components/common/CompositeError/CompositeError.stories.tsx
@@ -147,3 +147,28 @@ const policyViolationInfo: TCompositeError = {
 export const PolicyAdvisories = () => (
   <CompositeError error={policyViolationInfo} />
 )
+
+const sectionKinds: TCompositeError = {
+  type: 'terraform.state_lock',
+  severity: 'error',
+  message: 'Terraform could not acquire the state lock',
+  sections: [
+    {
+      heading: 'How to fix',
+      kind: 'markdown',
+      body: 'Force-unlock the workspace, then retry:\n\n```\nnuon terraform sandbox force-unlock <LOCK_ID>\n```',
+    },
+    {
+      heading: 'Context',
+      kind: 'text',
+      body: 'Principal: arn:aws:iam::123456789012:role/nuon-runner\nResource: arn:aws:s3:::acme-prod-assets',
+    },
+    {
+      heading: 'Output',
+      kind: 'code',
+      body: 'Error: Error acquiring the state lock\n\nLock Info:\n  ID:        9f3c1a2b-...\n  Operation: OperationTypeApply\n  Who:       root@ip-10-128-128-200',
+    },
+  ],
+}
+
+export const SectionKinds = () => <CompositeError error={sectionKinds} />

--- a/services/dashboard-ui/client/components/common/CompositeError/CompositeError.tsx
+++ b/services/dashboard-ui/client/components/common/CompositeError/CompositeError.tsx
@@ -1,8 +1,14 @@
 import { Badge } from '@/components/common/Badge'
 import { Banner } from '@/components/common/Banner'
+import { CodeBlock } from '@/components/common/CodeBlock'
 import { Markdown } from '@/components/common/Markdown'
 import { Text } from '@/components/common/Text'
-import type { TCompositeError, TCompositeErrorSeverity, TTheme } from '@/types'
+import type {
+  TCompositeError,
+  TCompositeErrorSection,
+  TCompositeErrorSeverity,
+  TTheme,
+} from '@/types'
 
 interface ICompositeError {
   error: TCompositeError
@@ -13,6 +19,30 @@ const SEVERITY_THEME: Record<TCompositeErrorSeverity, TTheme> = {
   error: 'error',
   warning: 'warn',
   info: 'info',
+}
+
+const SectionBody = ({ section }: { section: TCompositeErrorSection }) => {
+  const body = section?.body ?? ''
+  if (!body.trim()) {
+    return null
+  }
+
+  switch (section?.kind) {
+    case 'code':
+      return (
+        <CodeBlock language="text" showCopy>
+          {body}
+        </CodeBlock>
+      )
+    case 'text':
+      return (
+        <Text variant="subtext" className="whitespace-pre-wrap break-words">
+          {body}
+        </Text>
+      )
+    default:
+      return <Markdown content={body} variant="compact" />
+  }
 }
 
 export const CompositeError = ({ error }: ICompositeError) => {
@@ -48,7 +78,7 @@ export const CompositeError = ({ error }: ICompositeError) => {
             {section?.heading ? (
               <Text weight="strong">{section.heading}</Text>
             ) : null}
-            <Markdown content={section?.body} variant="compact" />
+            <SectionBody section={section} />
           </div>
         ))}
       </div>

--- a/services/dashboard-ui/client/types/ctl-api.types.ts
+++ b/services/dashboard-ui/client/types/ctl-api.types.ts
@@ -220,6 +220,8 @@ export type TCompositeErrorSeverity =
   components['schemas']['compositeerrors.Severity']
 export type TCompositeErrorSection =
   components['schemas']['compositeerrors.Section']
+export type TCompositeErrorSectionKind =
+  components['schemas']['compositeerrors.SectionKind']
 export type TCompositeError =
   components['schemas']['compositeerrors.CompositeErrorData']
 

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -5988,7 +5988,10 @@ export interface components {
     "compositeerrors.Section": {
       body?: string;
       heading?: string;
+      kind?: components["schemas"]["compositeerrors.SectionKind"];
     };
+    /** @enum {string} */
+    "compositeerrors.SectionKind": "markdown" | "text" | "code";
     /** @enum {string} */
     "compositeerrors.Severity": "fatal" | "error" | "warning" | "info";
     /** @enum {string} */


### PR DESCRIPTION
Composite error sections were always rendered as markdown, so raw tool output (terraform/helm logs, AWS responses) and values extracted from errors were embedded in the dashboard's markdown pipeline. That pipeline enables raw HTML and runs custom-component extraction over the string, so crafted output could escape its code fence and inject content.

Add a `Kind` to `compositeerrors.Section` (`markdown`/`text`/`code`) with `MarkdownSection`/`TextSection`/`CodeSection` constructors, and classify each parser section by trust: raw output and extracted values now use code/text (escaped, no markdown), while only hand-authored prose stays markdown. The dashboard renders code via `CodeBlock` and text as escaped, whitespace- preserving text; markdown (and legacy sections without a kind) keep the existing renderer.

Legacy persisted records are unaffected: a missing kind renders as markdown.