### PR TITLE
fix: more app config schema fixes

### DIFF
--- a/docs/config-ref/break-glass.mdx
+++ b/docs/config-ref/break-glass.mdx
@@ -11,22 +11,18 @@ title: 'Break Glass'
 
 | Property | Description | Values | Example |
 |----------|----------|----------|----------|
+| **`role`**<br/>[array](#role) | Roles to be used for breaking glass. | **Optional** | - |
+
+### `role`
+
+| Property | Description | Values | Example |
+|----------|----------|----------|----------|
 | **`name`**<br/>string | name of the role Name used for the role in the target cloud platform. Supports Go templating using standard template variables (e.g., \{\{.nuon.install.id\}\}) | **✅ Required** | `"app-{{.nuon.install.id}}-role"`, `"admin-role"` |
 | **`description`**<br/>string | description of the role Human-readable description that explains the role's purpose. Rendered in the installer to customers. Supports templating | **✅ Required** | `"Provides S3 bucket access for the application"`, `"Database migration role with elevated permissions"` |
-| **`policies`**<br/>[array](#policies) | policy definitions for the role List of policies to attach to the role. Each policy defines cloud-specific permissions (AWS IAM policies, GCP IAM permissions, or GCP predefined roles) | **✅ Required** | - |
+| **`policies`**<br/>array | policy definitions for the role List of policies to attach to the role. Each policy defines cloud-specific permissions (AWS IAM policies, GCP IAM permissions, or GCP predefined roles) | **✅ Required** | - |
 | **`type`**<br/>string | role type in permission directory Used when defining permissions in a directory. Indicates when the role is active (provision, maintenance, or deprovision). Supports templating | **Optional** | `"provision"`, `"maintenance"`, `"deprovision"` |
 | **`cloud_platform`**<br/>string | target cloud platform Cloud platform this role targets. Determines which downstream renderer processes the role (e.g., AWS CloudFormation vs GCP IAM). Defaults to aws if omitted | **Optional**<br/>`"aws"`, `"azure"`, `"gcp"` | `"aws"`, `"gcp"` |
 | **`display_name`**<br/>string | display name of the role Human-readable display name shown in the installer UI. Supports templating | **Optional** | `"Application S3 Access"`, `"Database Admin"` |
 | **`permissions_boundary`**<br/>string | [AWS] permissions boundary policy [AWS only] Optional ARN of a permissions boundary policy. Limits the maximum permissions the role can have. Supports templating and external file sources: HTTP(S) ... | **Optional** | `"./provision_boundary.json"`, `"./maintenance_boundary.json"` |
 | **`enabled_in_stack`**<br/>boolean | whether the role is enabled by default in the install stack Controls the default value of the Enable parameter for this role in the install stack (CloudFormation parameter or Terraform variable, de... | **Optional** | - |
-
-### `policies`
-
-| Property | Description | Values | Example |
-|----------|----------|----------|----------|
-| **`name`**<br/>string | policy name Name for the policy. Used across all cloud platforms when creating the permission grant. Supports Nuon templating | **✅ Required** | `"app-{{.nuon.install.id}}-policy"`, `"s3-access-policy"` |
-| **`managed_policy_name`**<br/>string | [AWS] managed policy name [AWS only] Name or ARN of an AWS managed policy to attach to the IAM role. Mutually exclusive with contents | **Optional** | `"AmazonS3FullAccess"`, `"ReadOnlyAccess"` |
-| **`contents`**<br/>string | [AWS] inline policy document [AWS only] JSON policy document defining inline IAM permissions. Mutually exclusive with managed_policy_name. Supports Nuon templating and external file sources: HTTP(S... | **Optional** | `"{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"s3:*\",\"Resource\":\"*\"}]}"` |
-| **`gcp_permissions`**<br/>array | [GCP] individual permissions [GCP only] List of individual GCP IAM permission strings to include in a custom role bound to the service account. Use this for fine-grained permission control. Mutuall... | **Optional** | `"compute.instances.get"`, `"storage.objects.list"` |
-| **`gcp_predefined_role`**<br/>string | [GCP] predefined role [GCP only] Name of a GCP predefined role to bind to the service account. This is the GCP equivalent of AWS managed policies — a Google-managed bundle of permissions. Mutually ... | **Optional** | `"roles/editor"`, `"roles/owner"` |
 

--- a/pkg/config/action_config.go
+++ b/pkg/config/action_config.go
@@ -58,6 +58,8 @@ func (a ActionConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Long("The action name is displayed in the Actions tab of the Nuon dashboard").
 		Example("http_healthcheck").
 		Example("database_migration").
+		Field("labels").Short("key/value labels for the action").
+		Long("Arbitrary key/value metadata used to group and categorize actions").
 		Field("timeout").Short("timeout for action execution").Required().
 		Long("Maximum time the action can run. Maximum allowed is 30 minutes. Must be a valid Go duration string (e.g., 30s, 5m, 30m)").
 		Example("15s").

--- a/pkg/config/schema/flatten.go
+++ b/pkg/config/schema/flatten.go
@@ -64,6 +64,9 @@ func flattenedComponentSchema(typedConfig any, componentTypes ...config.Componen
 	}
 
 	merged := &jsonschema.Schema{
+		// Carry the typed config's reflected root $id onto the merged schema.
+		// Schema-aware editors can key their schema cache by ID.
+		ID:                   typedRoot.ID,
 		Version:              compRoot.Version,
 		Type:                 "object",
 		Title:                typed.Title,

--- a/pkg/config/schema/flatten_test.go
+++ b/pkg/config/schema/flatten_test.go
@@ -289,11 +289,7 @@ func TestComponentSchemasAreFlattened(t *testing.T) {
 }
 
 // TestComponentSchemasHaveUniqueIDs guards against the flattened component
-// schemas shipping without a root $id. Reflected schemas each carry a unique
-// package-derived $id, but the hand-built merged component schemas previously
-// had none. Schema-aware editors key their schema cache by $id; several
-// $id-less schemas collapse into one entry and the wrong schema gets applied
-// to unrelated files.
+// schemas shipping without a root $id.
 func TestComponentSchemasHaveUniqueIDs(t *testing.T) {
 	seen := make(map[string]string)
 	for _, schemaType := range []string{

--- a/pkg/config/schema/flatten_test.go
+++ b/pkg/config/schema/flatten_test.go
@@ -287,3 +287,29 @@ func TestComponentSchemasAreFlattened(t *testing.T) {
 		})
 	}
 }
+
+// TestComponentSchemasHaveUniqueIDs guards against the flattened component
+// schemas shipping without a root $id. Reflected schemas each carry a unique
+// package-derived $id, but the hand-built merged component schemas previously
+// had none. Schema-aware editors key their schema cache by $id; several
+// $id-less schemas collapse into one entry and the wrong schema gets applied
+// to unrelated files.
+func TestComponentSchemasHaveUniqueIDs(t *testing.T) {
+	seen := make(map[string]string)
+	for _, schemaType := range []string{
+		"container-image", "docker-build", "helm", "job", "kubernetes-manifest", "terraform",
+	} {
+		schm, err := LookupSchemaType(schemaType)
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := string(schm.ID)
+		if id == "" {
+			t.Fatalf("%s schema must declare a root $id", schemaType)
+		}
+		if prev, ok := seen[id]; ok {
+			t.Fatalf("%s and %s share $id %q; each schema type must be unique", prev, schemaType, id)
+		}
+		seen[id] = schemaType
+	}
+}

--- a/pkg/config/schema/types.go
+++ b/pkg/config/schema/types.go
@@ -28,6 +28,7 @@ var SchemaMapping = map[string]func() (*jsonschema.Schema, error){
 	"kubernetes-contexts": KubernetesContextsConfigSchema,
 	"kubernetes-manifest": KubernetesManifestConfigSchema,
 	"metadata":            MetadataConfigSchema,
+	"permission":          PermissionSchema,
 	"permissions":         PermissionsConfigSchema,
 	"policy":              PolicyConfigSchema,
 	"policies":            PoliciesConfigSchema,
@@ -266,6 +267,23 @@ func MetadataConfigSchema() (*jsonschema.Schema, error) {
 	}
 
 	return r.Reflect(config.MetadataConfig{}), nil
+}
+
+// PermissionSchema is the schema for a single IAM role file, as used by the
+// permissions/ and break_glass/ directory forms (each file is one
+// AppAWSIAMRole). PermissionsConfigSchema, by contrast, covers the collection
+// form (a single permissions.toml holding provision_role/roles/etc.).
+func PermissionSchema() (*jsonschema.Schema, error) {
+	if err := ValidateJSONSchemaExtend(config.AppAWSIAMRole{}); err != nil {
+		return nil, errors.Wrap(err, "AppAWSIAMRole validation failed")
+	}
+
+	r, err := reflector()
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Reflect(config.AppAWSIAMRole{}), nil
 }
 
 func PermissionsConfigSchema() (*jsonschema.Schema, error) {

--- a/pkg/config/schema/types.go
+++ b/pkg/config/schema/types.go
@@ -271,8 +271,7 @@ func MetadataConfigSchema() (*jsonschema.Schema, error) {
 
 // PermissionSchema is the schema for a single IAM role file, as used by the
 // permissions/ and break_glass/ directory forms (each file is one
-// AppAWSIAMRole). PermissionsConfigSchema, by contrast, covers the collection
-// form (a single permissions.toml holding provision_role/roles/etc.).
+// AppAWSIAMRole).
 func PermissionSchema() (*jsonschema.Schema, error) {
 	if err := ValidateJSONSchemaExtend(config.AppAWSIAMRole{}); err != nil {
 		return nil, errors.Wrap(err, "AppAWSIAMRole validation failed")

--- a/pkg/config/schema/types.go
+++ b/pkg/config/schema/types.go
@@ -104,8 +104,8 @@ func AppConfigSchema() (*jsonschema.Schema, error) {
 }
 
 func BreakGlassConfigSchema() (*jsonschema.Schema, error) {
-	if err := ValidateJSONSchemaExtend(config.AppAWSIAMRole{}); err != nil {
-		return nil, errors.Wrap(err, "AppAWSIAMRole validation failed")
+	if err := ValidateJSONSchemaExtend(config.BreakGlass{}); err != nil {
+		return nil, errors.Wrap(err, "BreakGlass validation failed")
 	}
 
 	r, err := reflector()
@@ -113,7 +113,7 @@ func BreakGlassConfigSchema() (*jsonschema.Schema, error) {
 		return nil, err
 	}
 
-	return r.Reflect(config.AppAWSIAMRole{}), nil
+	return r.Reflect(config.BreakGlass{}), nil
 }
 
 func InputGroupSchema() (*jsonschema.Schema, error) {

--- a/pkg/config/schema/types_test.go
+++ b/pkg/config/schema/types_test.go
@@ -46,6 +46,27 @@ func TestAllSchemasHaveJSONSchemaExtend(t *testing.T) {
 	}
 }
 
+// TestPermissionVsPermissionsSchemas guards the singular/collection split: the
+// permissions/ directory form is a single AppAWSIAMRole per file ("permission"),
+// while permissions.toml is the PermissionsConfig collection ("permissions").
+// They must be distinct schemas with distinct $ids.
+func TestPermissionVsPermissionsSchemas(t *testing.T) {
+	single, err := LookupSchemaType("permission")
+	if err != nil || single == nil {
+		t.Fatalf("permission schema unavailable: %v", err)
+	}
+	collection, err := LookupSchemaType("permissions")
+	if err != nil || collection == nil {
+		t.Fatalf("permissions schema unavailable: %v", err)
+	}
+	if single.ID == "" {
+		t.Fatal("permission schema must declare a root $id")
+	}
+	if single.ID == collection.ID {
+		t.Fatalf("permission and permissions must not share $id %q", single.ID)
+	}
+}
+
 func TestLookupSchemaTypeNormalizesUnderscores(t *testing.T) {
 	tests := []struct {
 		typ   string

--- a/pkg/config/schema/types_test.go
+++ b/pkg/config/schema/types_test.go
@@ -49,7 +49,6 @@ func TestAllSchemasHaveJSONSchemaExtend(t *testing.T) {
 // TestPermissionVsPermissionsSchemas guards the singular/collection split: the
 // permissions/ directory form is a single AppAWSIAMRole per file ("permission"),
 // while permissions.toml is the PermissionsConfig collection ("permissions").
-// They must be distinct schemas with distinct $ids.
 func TestPermissionVsPermissionsSchemas(t *testing.T) {
 	single, err := LookupSchemaType("permission")
 	if err != nil || single == nil {

--- a/pkg/config/shared_iam_policy.go
+++ b/pkg/config/shared_iam_policy.go
@@ -9,7 +9,10 @@ import (
 
 type AppAWSIAMPolicy struct {
 	ManagedPolicyName string `mapstructure:"managed_policy_name,omitempty" toml:"managed_policy_name,omitempty"`
-	Name              string `mapstructure:"name" toml:"name" jsonschema:"required"`
+	// Name is optional: a managed_policy_name attachment identifies itself, so a
+	// bare AWS managed policy needs no separate name. The runtime does not
+	// require it (see parse below).
+	Name string `mapstructure:"name,omitempty" toml:"name,omitempty"`
 
 	Contents string `mapstructure:"contents" toml:"contents" features:"template,get"`
 
@@ -19,8 +22,8 @@ type AppAWSIAMPolicy struct {
 
 func (a AppAWSIAMPolicy) JSONSchemaExtend(schema *jsonschema.Schema) {
 	NewSchemaBuilder(schema).
-		Field("name").Short("policy name").Required().
-		Long("Name for the policy. Used across all cloud platforms when creating the permission grant. Supports Nuon templating").
+		Field("name").Short("policy name").
+		Long("Name for the policy. Used across all cloud platforms when creating the permission grant. Optional for a bare AWS managed_policy_name attachment, which needs no separate name. Supports Nuon templating").
 		Example("app-{{.nuon.install.id}}-policy").
 		Example("s3-access-policy").
 		Field("managed_policy_name").Short("[AWS] managed policy name").OneOfRequired("aws_policy").


### PR DESCRIPTION
## Summary

Fixes for a couple more bugs I found testing the schemas with the BYOC configs.

- Some TOML LSPs cache each type schema based on the UID defined in the schema (Tombi, for example). Ours was lacking the UIDs, so these LSPs would use whatever type was cached first for all files.
- The schema for the break_glass type was for a single role definition.
- The labels attribute was missing a description.
- Schema was missing an attribute for the optional "name" attribute on named roles