### PR TITLE
fix: move audit logs and pending approvals to read replica

### DIFF
--- a/services/ctl-api/internal/app/installs/helpers/get_install_audit_logs.go
+++ b/services/ctl-api/internal/app/installs/helpers/get_install_audit_logs.go
@@ -23,6 +23,7 @@ func (h *Helpers) GetInstallAuditLogs(ctx context.Context, installID string, sta
 	res := h.db.WithContext(ctx).
 		Scopes(
 			scopes.WithOverrideTable(views.CurrentViewName(h.db, &app.InstallAuditLog{})),
+			scopes.ForceReplica,
 		).
 		Order("time_stamp ASC").
 		Limit(defaultInstallAuditLogsLimit).

--- a/services/ctl-api/internal/app/installs/service/get_org_pending_approvals.go
+++ b/services/ctl-api/internal/app/installs/service/get_org_pending_approvals.go
@@ -52,7 +52,7 @@ func (s *service) getOrgPendingApprovals(ctx *gin.Context, orgID string) ([]app.
 	var approvals []app.WorkflowStepApproval
 	res := s.db.WithContext(ctx).
 		Omit("contents").
-		Scopes(scopes.WithOffsetPagination).
+		Scopes(scopes.WithOffsetPagination, scopes.ForceReplica).
 		Joins("LEFT JOIN installs ON installs.id = install_workflow_step_approvals.owner_id AND install_workflow_step_approvals.owner_type = 'installs'").
 		Where("install_workflow_step_approvals.owner_type != 'installs' OR installs.deleted_at = 0").
 		Where("install_workflow_step_approvals.deleted_at = 0").


### PR DESCRIPTION
moving pending approvals and our get audit logs to use the read replica instance