### PR TITLE
fix: stack sdk fixes

### DIFF
--- a/sdks/stack/installer.go
+++ b/sdks/stack/installer.go
@@ -5,26 +5,23 @@ import (
 	"fmt"
 )
 
-// FetchConfig reads the rendered install-stack configuration for the stack
-// version identified by the create-run URL, without creating a run or mutating
-// any state. It feeds the Terraform provider's nuon_stack data source, which
-// passes the config to an install-stacks module in place of tfvars. The URL is
-// the /v1/stack-runs/{phone_home_id} form the dashboard renders.
+// FetchConfig reads the rendered install-stack config for the stack version
+// identified by the create-run URL.
 func FetchConfig(ctx context.Context, url string) (*Config, error) {
 	base, phoneHomeID, err := parseURL(url)
 	if err != nil {
 		return nil, err
 	}
 	client := newRunClient(runClientConfig{
-		CtlAPIURL:   base,
-		PhoneHomeID: phoneHomeID,
+		RunnerAPIURL: base,
+		PhoneHomeID:  phoneHomeID,
 	})
 	cfg, err := client.fetchConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fetch stack config: %w", err)
 	}
 	if cfg == nil {
-		return nil, fmt.Errorf("fetch stack config: ctl-api returned no config block")
+		return nil, fmt.Errorf("fetch stack config: runner api returned no config block")
 	}
 	return cfg, nil
 }

--- a/sdks/stack/phone_home.go
+++ b/sdks/stack/phone_home.go
@@ -7,16 +7,9 @@ import (
 	"strings"
 )
 
-// PhoneHome reports the result of an install-stack run to ctl-api over the
-// public phone-home endpoint. It feeds the Terraform provider's
-// stack_phone_home resource, which lets an install-stacks module report run
-// status through the provider instead of constructing the HTTP request itself.
-//
-// apiURL is the base URL up to but excluding /v1 (e.g. https://api.nuon.co).
-// payload is the JSON body the module assembled; the caller is responsible for
-// setting request_type and phone_home_type. The per-install phone_home_id in
-// the path is the secret, mirroring FetchConfig.
-func PhoneHome(ctx context.Context, apiURL, installID, phoneHomeID string, payload map[string]any) error {
+// PhoneHome sends install stack outputs to the control plane.
+// This will update the install state, and mark the stack operation as complete.
+func PhoneHome(ctx context.Context, runnerAPIURL, installID, phoneHomeID string, payload map[string]any) error {
 	if strings.TrimSpace(installID) == "" {
 		return fmt.Errorf("phone home: install_id is required")
 	}
@@ -24,8 +17,8 @@ func PhoneHome(ctx context.Context, apiURL, installID, phoneHomeID string, paylo
 		return fmt.Errorf("phone home: phone_home_id is required")
 	}
 	client := newRunClient(runClientConfig{
-		CtlAPIURL:   apiURL,
-		PhoneHomeID: phoneHomeID,
+		RunnerAPIURL: runnerAPIURL,
+		PhoneHomeID:  phoneHomeID,
 	})
 	if err := client.phoneHome(ctx, installID, payload); err != nil {
 		return fmt.Errorf("phone home: %w", err)
@@ -33,12 +26,10 @@ func PhoneHome(ctx context.Context, apiURL, installID, phoneHomeID string, paylo
 	return nil
 }
 
-// phoneHome POSTs the run report to
-// /v1/installs/{install_id}/phone-home/{phone_home_id}.
 func (c *runClient) phoneHome(ctx context.Context, installID string, payload map[string]any) error {
 	url := fmt.Sprintf(
 		"%s/v1/installs/%s/phone-home/%s",
-		strings.TrimSuffix(c.cfg.CtlAPIURL, "/"),
+		strings.TrimSuffix(c.cfg.RunnerAPIURL, "/"),
 		installID,
 		c.cfg.PhoneHomeID,
 	)

--- a/sdks/stack/run_client.go
+++ b/sdks/stack/run_client.go
@@ -11,17 +11,14 @@ import (
 	"time"
 )
 
-// runClientConfig configures the run client. CtlAPIURL + PhoneHomeID are required.
+// runClientConfig configures the run client. RunnerAPIURL + PhoneHomeID are required.
 type runClientConfig struct {
-	CtlAPIURL   string // base URL, e.g. https://api.nuon.co
-	PhoneHomeID string // per-stack-version secret, in the URL path
-	HTTPClient  *http.Client
+	RunnerAPIURL string // runner API base URL, e.g. https://runner.nuon.co
+	PhoneHomeID  string // per-stack-version secret, in the URL path
+	HTTPClient   *http.Client
 }
 
-// runClient is the small HTTP client for the ctl-api stack-run endpoints. The
-// endpoints are public and mirror the phone-home pattern: the per-stack-version
-// phone_home_id sits in the URL path as the secret. No Authorization header, no
-// Nuon API token.
+// runClient is the HTTP client for the runner API stack-run endpoints.
 type runClient struct {
 	cfg runClientConfig
 	hc  *http.Client
@@ -30,28 +27,21 @@ type runClient struct {
 func newRunClient(cfg runClientConfig) *runClient {
 	hc := cfg.HTTPClient
 	if hc == nil {
-		// Per-attempt timeout is intentionally short. doWithRetry retries up
-		// to 5 times with capped backoff, so total wall time on a hard outage
-		// is ~60s — long enough to ride out a brief network blip, short
-		// enough to fail fast when ctl-api is genuinely unreachable.
 		hc = &http.Client{Timeout: 10 * time.Second}
 	}
 	return &runClient{cfg: cfg, hc: hc}
 }
 
-// configResponse mirrors the ctl-api GET /config response: just the rendered
-// config block, no run. Used by FetchConfig for read-only callers (the
-// Terraform provider's nuon_stack data source).
+// configResponse mirrors the runner API GET /config response
 type configResponse struct {
 	Config *Config `json:"config"`
 }
 
 // fetchConfig reads the rendered install-stack config for the stack version
-// without creating a run or mutating any state (GET, side-effect free).
 func (c *runClient) fetchConfig(ctx context.Context) (*Config, error) {
 	url := fmt.Sprintf(
 		"%s/v1/stack-runs/%s/config",
-		strings.TrimSuffix(c.cfg.CtlAPIURL, "/"),
+		strings.TrimSuffix(c.cfg.RunnerAPIURL, "/"),
 		c.cfg.PhoneHomeID,
 	)
 	var out configResponse
@@ -61,10 +51,8 @@ func (c *runClient) fetchConfig(ctx context.Context) (*Config, error) {
 	return out.Config, nil
 }
 
-// doWithRetry retries up to 5 times with capped exponential backoff on
-// transient failures (network errors and 5xx). 4xx errors are returned
-// immediately. The backoff caps at 8s so total wall time on a hard outage
-// stays bounded.
+// doWithRetry retries up to 5 times with capped exponential backoff (max 8s) on
+// transient failures (network errors and 5xx). 4xx errors return immediately.
 func (c *runClient) doWithRetry(ctx context.Context, method, url string, body, out any) error {
 	const maxAttempts = 5
 	const maxDelay = 8 * time.Second
@@ -115,9 +103,9 @@ func (c *runClient) doWithRetry(ctx context.Context, method, url string, body, o
 			return nil
 		}
 		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
-			return fmt.Errorf("ctl-api %d: %s", resp.StatusCode, string(respBody))
+			return fmt.Errorf("runner api %d: %s", resp.StatusCode, string(respBody))
 		}
-		lastErr = fmt.Errorf("ctl-api %d: %s", resp.StatusCode, string(respBody))
+		lastErr = fmt.Errorf("runner api %d: %s", resp.StatusCode, string(respBody))
 	}
-	return fmt.Errorf("could not reach ctl-api at %s after %d attempts: %w", c.cfg.CtlAPIURL, maxAttempts, lastErr)
+	return fmt.Errorf("could not reach runner api at %s after %d attempts: %w", c.cfg.RunnerAPIURL, maxAttempts, lastErr)
 }

--- a/services/ctl-api/internal/app/installs/service/service.go
+++ b/services/ctl-api/internal/app/installs/service/service.go
@@ -324,6 +324,11 @@ func (s *service) RegisterRunnerRoutes(api *gin.Engine) error {
 	// provider's nuon_stack data source. Public: the per-stack-version
 	// phone_home_id in the URL path is the secret.
 	api.GET("/v1/stack-runs/:phone_home_id/config", s.GetInstallStackVersionConfig)
+
+	// phone home reported by the install stack over the runner API. The
+	// per-stack-version phone_home_id in the URL path is the secret; the route
+	// is already in the public whitelist, so no runner token is required.
+	api.POST("/v1/installs/:install_id/phone-home/:phone_home_id", s.InstallPhoneHome)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Stack SDK fixes from testing:

- Copy the phone home URL to the runner API (this change was lost when creating a new branch.) The URL on the public API is untouched for backwards compatibility.
- Update the Stack SDK code to reflect that it now uses the runner API.