### PR TITLE
fix: restore control-plane component builds

### DIFF
--- a/pkg/runner/controlplane/client_adapter.go
+++ b/pkg/runner/controlplane/client_adapter.go
@@ -36,9 +36,6 @@ func (c *clientAdapter) TailJobs(context.Context, models.AppRunnerJobGroup, time
 func (c *clientAdapter) GetJob(context.Context, string) (*models.AppRunnerJob, error) {
 	return nil, unsupported("GetJob")
 }
-func (c *clientAdapter) GetJobCompositePlan(context.Context, string) (*models.PlantypesCompositePlan, error) {
-	return nil, unsupported("GetJobCompositePlan")
-}
 func (c *clientAdapter) UpdateJob(context.Context, string, *models.ServiceUpdateRunnerJobRequest) (*models.AppRunnerJob, error) {
 	return nil, unsupported("UpdateJob")
 }

--- a/pkg/runner/controlplane/executor.go
+++ b/pkg/runner/controlplane/executor.go
@@ -33,6 +33,7 @@ import (
 
 type Client interface {
 	GetJobPlanJSON(ctx context.Context, jobID string) (string, error)
+	GetJobCompositePlan(ctx context.Context, jobID string) (*models.PlantypesCompositePlan, error)
 	UpdateJobExecution(ctx context.Context, jobID, executionID string, req *models.ServiceUpdateRunnerJobExecutionRequest) (*models.AppRunnerJobExecution, error)
 	CreateJobExecutionResult(ctx context.Context, jobID, executionID string, req *models.ServiceCreateRunnerJobExecutionResultRequest) (*models.AppRunnerJobExecutionResult, error)
 	CreateJobExecutionOutputs(ctx context.Context, jobID, executionID string, req *models.ServiceCreateRunnerJobExecutionOutputsRequest) (*models.AppRunnerJobExecutionOutputs, error)

--- a/pkg/runner/controlplane/executor_test.go
+++ b/pkg/runner/controlplane/executor_test.go
@@ -8,18 +8,25 @@ import (
 )
 
 type fakeClient struct {
-	planJSON string
+	planJSON      string
+	compositePlan *models.PlantypesCompositePlan
 
-	planCalls    int
-	outputs      any
-	resultCalls  int
-	statuses     []models.AppRunnerJobExecutionStatus
-	outputsCalls int
+	planCalls          int
+	compositePlanCalls int
+	outputs            any
+	resultCalls        int
+	statuses           []models.AppRunnerJobExecutionStatus
+	outputsCalls       int
 }
 
 func (c *fakeClient) GetJobPlanJSON(ctx context.Context, jobID string) (string, error) {
 	c.planCalls++
 	return c.planJSON, nil
+}
+
+func (c *fakeClient) GetJobCompositePlan(ctx context.Context, jobID string) (*models.PlantypesCompositePlan, error) {
+	c.compositePlanCalls++
+	return c.compositePlan, nil
 }
 
 func (c *fakeClient) UpdateJobExecution(ctx context.Context, jobID, executionID string, req *models.ServiceUpdateRunnerJobExecutionRequest) (*models.AppRunnerJobExecution, error) {
@@ -86,7 +93,8 @@ func TestExecuteSandboxBuildShortCircuits(t *testing.T) {
 
 func TestExecuteNonSandboxDoesNotShortCircuit(t *testing.T) {
 	client := &fakeClient{
-		planJSON: `{"sandbox_mode":{"enabled":false}}`,
+		planJSON:      `{"sandbox_mode":{"enabled":false}}`,
+		compositePlan: &models.PlantypesCompositePlan{BuildPlan: &models.PlantypesBuildPlan{}},
 	}
 	e, err := NewExecutor(client, nil, Config{})
 	if err != nil {
@@ -101,6 +109,9 @@ func TestExecuteNonSandboxDoesNotShortCircuit(t *testing.T) {
 	// short-circuit as a sandbox build (no outputs/result written).
 	_ = e.Execute(context.Background(), job, execution)
 
+	if client.compositePlanCalls != 1 {
+		t.Errorf("expected composite plan fetched exactly once, got %d", client.compositePlanCalls)
+	}
 	if client.outputsCalls != 0 {
 		t.Errorf("non-sandbox build should not write sandbox outputs, got %d", client.outputsCalls)
 	}

--- a/services/ctl-api/internal/app/runner_job_plan.go
+++ b/services/ctl-api/internal/app/runner_job_plan.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"gorm.io/gorm"
@@ -83,4 +84,47 @@ func (r *RunnerJobPlan) GetCompositePlan(ctx context.Context, blobRead bool) (*p
 	}
 
 	return &r.CompositePlan, false
+}
+
+func (r *RunnerJobPlan) DeriveCompositePlan(runnerJob *RunnerJob) (*plantypes.CompositePlan, error) {
+	var compositePlan plantypes.CompositePlan
+	switch runnerJob.Group {
+	case RunnerJobGroupSync:
+		switch runnerJob.Type {
+		case RunnerJobTypeOCISync, RunnerJobTypeNOOPSync:
+			if err := json.Unmarshal([]byte(r.PlanJSON), &compositePlan.SyncOCIPlan); err != nil {
+				return nil, fmt.Errorf("unable to unmarshal sync oci plan: %w", err)
+			}
+		case RunnerJobTypeSandboxSyncSecrets:
+			if err := json.Unmarshal([]byte(r.PlanJSON), &compositePlan.SyncSecretsPlan); err != nil {
+				return nil, fmt.Errorf("unable to unmarshal sync secret plan: %w", err)
+			}
+		case RunnerJobTypeFetchImageMetadata:
+			if err := json.Unmarshal([]byte(r.PlanJSON), &compositePlan.FetchImageMetadataPlan); err != nil {
+				return nil, fmt.Errorf("unable to unmarshal fetch image metadata plan: %w", err)
+			}
+		default:
+			return nil, fmt.Errorf("unknown sync job type: %s", runnerJob.Type)
+		}
+	case RunnerJobGroupBuild:
+		if err := json.Unmarshal([]byte(r.PlanJSON), &compositePlan.BuildPlan); err != nil {
+			return nil, fmt.Errorf("unable to unmarshal build plan: %w", err)
+		}
+	case RunnerJobGroupDeploy:
+		if err := json.Unmarshal([]byte(r.PlanJSON), &compositePlan.DeployPlan); err != nil {
+			return nil, fmt.Errorf("unable to unmarshal deploy plan: %w", err)
+		}
+	case RunnerJobGroupActions:
+		if err := json.Unmarshal([]byte(r.PlanJSON), &compositePlan.ActionWorkflowRunPlan); err != nil {
+			return nil, fmt.Errorf("unable to unmarshal action plan: %w", err)
+		}
+	case RunnerJobGroupSandbox:
+		if err := json.Unmarshal([]byte(r.PlanJSON), &compositePlan.SandboxRunPlan); err != nil {
+			return nil, fmt.Errorf("unable to unmarshal sandbox plan: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unknown runner job group: %s", runnerJob.Group)
+	}
+
+	return &compositePlan, nil
 }

--- a/services/ctl-api/internal/app/runners/service/get_runner_job_composite_plan.go
+++ b/services/ctl-api/internal/app/runners/service/get_runner_job_composite_plan.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -79,7 +78,7 @@ func (s *service) getRunnerJobCompositePlan(ctx context.Context, runnerJobID str
 		return nil, fmt.Errorf("unable to get job: %w", res.Error)
 	}
 
-	return s.deriveCompositePlan(&runnerPlan, &runnerJob)
+	return runnerPlan.DeriveCompositePlan(&runnerJob)
 }
 
 func (s *service) getOrgRunnerJobCompositePlan(ctx context.Context, runnerJobID string, orgID string) (*plantypes.CompositePlan, error) {
@@ -113,56 +112,5 @@ func (s *service) getOrgRunnerJobCompositePlan(ctx context.Context, runnerJobID 
 		return nil, fmt.Errorf("unable to get job: %w", res.Error)
 	}
 
-	return s.deriveCompositePlan(&runnerPlan, &runnerJob)
-}
-
-func (s *service) deriveCompositePlan(runnerPlan *app.RunnerJobPlan, runnerJob *app.RunnerJob) (*plantypes.CompositePlan, error) {
-
-	var compositePlan plantypes.CompositePlan
-	switch runnerJob.Group {
-	case app.RunnerJobGroupSync:
-		switch runnerJob.Type {
-		case app.RunnerJobTypeOCISync, app.RunnerJobTypeNOOPSync:
-			err := json.Unmarshal([]byte(runnerPlan.PlanJSON), &compositePlan.SyncOCIPlan)
-			if err != nil {
-				return nil, fmt.Errorf("unable to unmarshal sync oci plan: %w", err)
-			}
-		case app.RunnerJobTypeSandboxSyncSecrets:
-			err := json.Unmarshal([]byte(runnerPlan.PlanJSON), &compositePlan.SyncSecretsPlan)
-			if err != nil {
-				return nil, fmt.Errorf("unable to unmarshal sync secret plan: %w", err)
-			}
-		case app.RunnerJobTypeFetchImageMetadata:
-			err := json.Unmarshal([]byte(runnerPlan.PlanJSON), &compositePlan.FetchImageMetadataPlan)
-			if err != nil {
-				return nil, fmt.Errorf("unable to unmarshal fetch image metadata plan: %w", err)
-			}
-		default:
-			return nil, fmt.Errorf("unknown sync job type: %s", runnerJob.Type)
-		}
-	case app.RunnerJobGroupBuild:
-		err := json.Unmarshal([]byte(runnerPlan.PlanJSON), &compositePlan.BuildPlan)
-		if err != nil {
-			return nil, fmt.Errorf("unable to unmarshal build plan: %w", err)
-		}
-	case app.RunnerJobGroupDeploy:
-		err := json.Unmarshal([]byte(runnerPlan.PlanJSON), &compositePlan.DeployPlan)
-		if err != nil {
-			return nil, fmt.Errorf("unable to unmarshal deploy plan: %w", err)
-		}
-	case app.RunnerJobGroupActions:
-		err := json.Unmarshal([]byte(runnerPlan.PlanJSON), &compositePlan.ActionWorkflowRunPlan)
-		if err != nil {
-			return nil, fmt.Errorf("unable to unmarshal action plan: %w", err)
-		}
-	case app.RunnerJobGroupSandbox:
-		err := json.Unmarshal([]byte(runnerPlan.PlanJSON), &compositePlan.SandboxRunPlan)
-		if err != nil {
-			return nil, fmt.Errorf("unable to unmarshal sandbox plan: %w", err)
-		}
-	default:
-		return nil, fmt.Errorf("unknown runner job group: %s", runnerJob.Group)
-	}
-
-	return &compositePlan, nil
+	return runnerPlan.DeriveCompositePlan(&runnerJob)
 }

--- a/services/ctl-api/internal/pkg/workflows/controlplanejob/activities.go
+++ b/services/ctl-api/internal/pkg/workflows/controlplanejob/activities.go
@@ -148,6 +148,35 @@ func (a *Activities) GetJobPlanJSON(ctx context.Context, jobID string) (string, 
 	return plan.PlanJSON, nil
 }
 
+func (a *Activities) GetJobCompositePlan(ctx context.Context, jobID string) (*models.PlantypesCompositePlan, error) {
+	var plan app.RunnerJobPlan
+	if err := a.db.WithContext(ctx).Where(&app.RunnerJobPlan{RunnerJobID: jobID}).First(&plan).Error; err != nil {
+		return nil, fmt.Errorf("unable to get runner job plan: %w", err)
+	}
+
+	compositePlan, _ := plan.GetCompositePlan(ctx, a.cfg.BlobReadEnabled)
+	if compositePlan.IsEmpty() {
+		job, err := a.getJob(ctx, jobID)
+		if err != nil {
+			return nil, err
+		}
+		compositePlan, err = plan.DeriveCompositePlan(job)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	contents, err := json.Marshal(compositePlan)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal composite plan: %w", err)
+	}
+	var result models.PlantypesCompositePlan
+	if err := json.Unmarshal(contents, &result); err != nil {
+		return nil, fmt.Errorf("unable to convert composite plan: %w", err)
+	}
+	return &result, nil
+}
+
 func (a *Activities) UpdateJobExecution(ctx context.Context, jobID, executionID string, req *models.ServiceUpdateRunnerJobExecutionRequest) (*models.AppRunnerJobExecution, error) {
 	updates := app.RunnerJobExecution{Status: app.RunnerJobExecutionStatus(req.Status)}
 	if req.StatusDescription != "" {


### PR DESCRIPTION
## Summary

Control-plane component builds can fetch blob-backed composite plans again. Builds no longer fail at the fetching step when they run on control-plane workers.

## What you can do after this PR

**Run component builds on control-plane workers.** Helm, Terraform, Pulumi, Kubernetes manifest, container image, sandbox, and image metadata jobs can retrieve the composite plan required by their shared build handlers.

## What stays the same

Plans fall back to the legacy JSONB value when blob reads are disabled or unavailable. Older rows with neither representation continue to derive the composite plan from the original plan JSON, so no migration or backfill is required.
