### PR TITLE
fix: optional cloudformation template bucket + fix runner kube auth on non-aws installs

### DIFF
--- a/pkg/kube/cluster_info.go
+++ b/pkg/kube/cluster_info.go
@@ -40,6 +40,13 @@ type ClusterInfo struct {
 
 	// If either an AWS auth or Azure auth is passed in, we will automatically use it to resolve credentials and set
 	// them in the environment.
+	//
+	// NOTE: keep this comment detached from the field below (blank line above the
+	// field). A doc comment on a $ref field makes go-swagger wrap the property in
+	// allOf and generate it as an inline struct VALUE instead of a pointer — a
+	// null aws_auth then round-trips to {} in the runner SDK and breaks kube auth
+	// on non-AWS installs.
+
 	AWSAuth   *awscredentials.Config   `json:"aws_auth" hcl:"aws_auth,block"`
 	AzureAuth *azurecredentials.Config `json:"azure_auth" hcl:"azure_auth,block"`
 	GCPAuth   *gcpcredentials.Config   `json:"gcp_auth", hcl:gcp_auth,block`

--- a/pkg/plans/types/composite_plan.go
+++ b/pkg/plans/types/composite_plan.go
@@ -7,6 +7,9 @@ import (
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
+
+	awscredentials "github.com/nuonco/nuon/pkg/aws/credentials"
+	"github.com/nuonco/nuon/pkg/kube"
 )
 
 type CompositePlan struct {
@@ -33,7 +36,49 @@ func CompositePlanFromAny(v any) (*CompositePlan, error) {
 		return nil, err
 	}
 
+	cp.pruneEmptyClusterAuth()
 	return &cp, nil
+}
+
+// pruneEmptyClusterAuth clears cluster-info auth configs that decoded as empty
+// objects. go-swagger generates ClusterInfo.aws_auth as an inline struct value
+// (not a pointer), so a null aws_auth from the API re-marshals as {} during the
+// round-trip above and would otherwise decode into a non-nil empty config,
+// routing kube auth down the AWS path on non-AWS installs.
+func (cp *CompositePlan) pruneEmptyClusterAuth() {
+	for _, ci := range cp.clusterInfos() {
+		if ci == nil {
+			continue
+		}
+		if ci.AWSAuth != nil && *ci.AWSAuth == (awscredentials.Config{}) {
+			ci.AWSAuth = nil
+		}
+	}
+}
+
+func (cp *CompositePlan) clusterInfos() []*kube.ClusterInfo {
+	infos := make([]*kube.ClusterInfo, 0, 6)
+	if dp := cp.DeployPlan; dp != nil {
+		if dp.HelmDeployPlan != nil {
+			infos = append(infos, dp.HelmDeployPlan.ClusterInfo)
+		}
+		if dp.TerraformDeployPlan != nil {
+			infos = append(infos, dp.TerraformDeployPlan.ClusterInfo)
+		}
+		if dp.KubernetesManifestDeployPlan != nil {
+			infos = append(infos, dp.KubernetesManifestDeployPlan.ClusterInfo)
+		}
+		if dp.PulumiDeployPlan != nil {
+			infos = append(infos, dp.PulumiDeployPlan.ClusterInfo)
+		}
+	}
+	if cp.ActionWorkflowRunPlan != nil {
+		infos = append(infos, cp.ActionWorkflowRunPlan.ClusterInfo)
+	}
+	if cp.SyncSecretsPlan != nil {
+		infos = append(infos, cp.SyncSecretsPlan.ClusterInfo)
+	}
+	return infos
 }
 
 // Inner returns the single populated sub-plan, or nil when the composite plan is

--- a/pkg/plans/types/composite_plan_test.go
+++ b/pkg/plans/types/composite_plan_test.go
@@ -1,0 +1,69 @@
+package plantypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
+)
+
+func TestCompositePlanFromAny_PrunesEmptyAWSAuth(t *testing.T) {
+	// Mirrors a GCP install plan after passing through the runner SDK:
+	// models.KubeClusterInfo.AwsAuth is a struct value, so a null aws_auth
+	// from the API re-marshals as {}.
+	sdkPlan := &models.PlantypesCompositePlan{
+		DeployPlan: &models.PlantypesDeployPlan{
+			Terraform: &models.PlantypesTerraformDeployPlan{
+				ClusterInfo: &models.KubeClusterInfo{
+					ID:       "gke-cluster",
+					Endpoint: "https://1.2.3.4",
+					GcpAuth: &models.GithubComNuoncoNuonPkgGcpCredentialsConfig{
+						ProjectID: "proj",
+						Region:    "us-central1",
+					},
+				},
+			},
+		},
+	}
+
+	cp, err := CompositePlanFromAny(sdkPlan)
+	require.NoError(t, err)
+	require.NotNil(t, cp.DeployPlan)
+	require.NotNil(t, cp.DeployPlan.TerraformDeployPlan)
+
+	ci := cp.DeployPlan.TerraformDeployPlan.ClusterInfo
+	require.NotNil(t, ci)
+	assert.Nil(t, ci.AWSAuth, "empty aws_auth from the SDK round-trip must be pruned")
+	require.NotNil(t, ci.GCPAuth)
+	assert.Equal(t, "proj", ci.GCPAuth.ProjectID)
+}
+
+func TestCompositePlanFromAny_KeepsPopulatedAWSAuth(t *testing.T) {
+	sdkPlan := map[string]any{
+		"deploy_plan": map[string]any{
+			"terraform": map[string]any{
+				"cluster_info": map[string]any{
+					"id": "eks-cluster",
+					"aws_auth": map[string]any{
+						"region": "us-west-2",
+						"assume_role": map[string]any{
+							"role_arn":     "arn:aws:iam::123:role/deploy",
+							"session_name": "deploy",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cp, err := CompositePlanFromAny(sdkPlan)
+	require.NoError(t, err)
+
+	ci := cp.DeployPlan.TerraformDeployPlan.ClusterInfo
+	require.NotNil(t, ci)
+	require.NotNil(t, ci.AWSAuth)
+	require.NotNil(t, ci.AWSAuth.AssumeRole)
+	assert.Equal(t, "arn:aws:iam::123:role/deploy", ci.AWSAuth.AssumeRole.RoleARN)
+}

--- a/sdks/nuon-go/models/kube_cluster_info.go
+++ b/sdks/nuon-go/models/kube_cluster_info.go
@@ -19,11 +19,8 @@ import (
 // swagger:model kube.ClusterInfo
 type KubeClusterInfo struct {
 
-	// If either an AWS auth or Azure auth is passed in, we will automatically use it to resolve credentials and set
-	// them in the environment.
-	AwsAuth struct {
-		GithubComNuoncoNuonPkgAwsCredentialsConfig
-	} `json:"aws_auth,omitempty"`
+	// aws auth
+	AwsAuth *GithubComNuoncoNuonPkgAwsCredentialsConfig `json:"aws_auth,omitempty"`
 
 	// azure auth
 	AzureAuth *GithubComNuoncoNuonPkgAzureCredentialsConfig `json:"azure_auth,omitempty"`
@@ -79,6 +76,21 @@ func (m *KubeClusterInfo) Validate(formats strfmt.Registry) error {
 func (m *KubeClusterInfo) validateAwsAuth(formats strfmt.Registry) error {
 	if swag.IsZero(m.AwsAuth) { // not required
 		return nil
+	}
+
+	if m.AwsAuth != nil {
+		if err := m.AwsAuth.Validate(formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("aws_auth")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("aws_auth")
+			}
+
+			return err
+		}
 	}
 
 	return nil
@@ -153,6 +165,26 @@ func (m *KubeClusterInfo) ContextValidate(ctx context.Context, formats strfmt.Re
 }
 
 func (m *KubeClusterInfo) contextValidateAwsAuth(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.AwsAuth != nil {
+
+		if swag.IsZero(m.AwsAuth) { // not required
+			return nil
+		}
+
+		if err := m.AwsAuth.ContextValidate(ctx, formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("aws_auth")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("aws_auth")
+			}
+
+			return err
+		}
+	}
 
 	return nil
 }

--- a/sdks/nuon-runner-go/models/kube_cluster_info.go
+++ b/sdks/nuon-runner-go/models/kube_cluster_info.go
@@ -19,11 +19,8 @@ import (
 // swagger:model kube.ClusterInfo
 type KubeClusterInfo struct {
 
-	// If either an AWS auth or Azure auth is passed in, we will automatically use it to resolve credentials and set
-	// them in the environment.
-	AwsAuth struct {
-		GithubComNuoncoNuonPkgAwsCredentialsConfig
-	} `json:"aws_auth,omitempty"`
+	// aws auth
+	AwsAuth *GithubComNuoncoNuonPkgAwsCredentialsConfig `json:"aws_auth,omitempty"`
 
 	// azure auth
 	AzureAuth *GithubComNuoncoNuonPkgAzureCredentialsConfig `json:"azure_auth,omitempty"`
@@ -79,6 +76,21 @@ func (m *KubeClusterInfo) Validate(formats strfmt.Registry) error {
 func (m *KubeClusterInfo) validateAwsAuth(formats strfmt.Registry) error {
 	if swag.IsZero(m.AwsAuth) { // not required
 		return nil
+	}
+
+	if m.AwsAuth != nil {
+		if err := m.AwsAuth.Validate(formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("aws_auth")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("aws_auth")
+			}
+
+			return err
+		}
 	}
 
 	return nil
@@ -153,6 +165,26 @@ func (m *KubeClusterInfo) ContextValidate(ctx context.Context, formats strfmt.Re
 }
 
 func (m *KubeClusterInfo) contextValidateAwsAuth(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.AwsAuth != nil {
+
+		if swag.IsZero(m.AwsAuth) { // not required
+			return nil
+		}
+
+		if err := m.AwsAuth.ContextValidate(ctx, formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("aws_auth")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("aws_auth")
+			}
+
+			return err
+		}
+	}
 
 	return nil
 }

--- a/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
@@ -327,7 +327,9 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		checksum = armResult.Checksum
 	}
 
-	if err := activities.AwaitUploadAWSCloudFormationStackVersionTemplate(ctx, &activities.UploadAWSCloudFormationStackVersionTemplateRequest{
+	if s.cfg.AWSCloudFormationStackTemplateBucket == "" {
+		workflow.GetLogger(ctx).Warn("cloudformation stack template bucket not configured, skipping s3 upload", "install_id", install.ID)
+	} else if err := activities.AwaitUploadAWSCloudFormationStackVersionTemplate(ctx, &activities.UploadAWSCloudFormationStackVersionTemplateRequest{
 		BucketKey: stackVersion.AWSBucketKey,
 		Template:  tmplByts,
 	}); err != nil {

--- a/services/ctl-api/internal/app/installs/worker/activities/create_install_stack_version.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/create_install_stack_version.go
@@ -59,9 +59,9 @@ func (a *Activities) CreateInstallStackVersion(ctx context.Context, req *CreateI
 		obj.AWSBucketKey = bucketKey
 
 		// Only generate S3-based template URL and CloudFormation quick link when
-		// running on AWS BYOC (S3 base URL is configured). On GCP BYOC, the
-		// template is uploaded to GCS and the URL is set after upload.
-		if a.cfg.AWSCloudFormationStackTemplateBaseURL != "" {
+		// the template bucket is configured; otherwise the install is
+		// Terraform-only and no template is uploaded.
+		if a.cfg.AWSCloudFormationStackTemplateBaseURL != "" && a.cfg.AWSCloudFormationStackTemplateBucket != "" {
 			templateURL := fmt.Sprintf("%s/%s", strings.TrimSuffix(a.cfg.AWSCloudFormationStackTemplateBaseURL, "/"), bucketKey)
 			obj.AWSBucketName = a.cfg.AWSCloudFormationStackTemplateBucket
 			obj.TemplateURL = templateURL

--- a/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
+++ b/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
@@ -279,7 +279,9 @@ func (w *Workflows) GenerateInstallStackVersion(ctx workflow.Context, sreq Gener
 		checksum = renderedTemplate.Checksum
 	}
 
-	if err := activities.AwaitUploadAWSCloudFormationStackVersionTemplate(ctx, &activities.UploadAWSCloudFormationStackVersionTemplateRequest{
+	if w.cfg.AWSCloudFormationStackTemplateBucket == "" {
+		workflow.GetLogger(ctx).Warn("cloudformation stack template bucket not configured, skipping s3 upload", "install_id", install.ID)
+	} else if err := activities.AwaitUploadAWSCloudFormationStackVersionTemplate(ctx, &activities.UploadAWSCloudFormationStackVersionTemplateRequest{
 		BucketKey: stackVersion.AWSBucketKey,
 		Template:  tmplByts,
 	}); err != nil {

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAWSDetails/AwaitAWSDetails.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAWSDetails/AwaitAWSDetails.stories.tsx
@@ -79,6 +79,26 @@ export const WithBothOptions = () => (
   </div>
 )
 
+const mockStackNoBucket = {
+  versions: [
+    {
+      terraform_contents: mockStackWithBoth.versions[0].terraform_contents,
+      terraform_checksum: 'sha256-abc',
+    },
+  ],
+} as any
+
+export const NoTemplateBucket = () => (
+  <div className="max-w-2xl p-4">
+    <AwaitAWSDetails
+      stack={mockStackNoBucket}
+      step={mockStep}
+      orgId="org-1"
+      installId="install-1"
+    />
+  </div>
+)
+
 export const TerraformProvider = () => (
   <div className="max-w-2xl p-4">
     <AwaitAWSDetails

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAWSDetails/AwaitAWSDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAWSDetails/AwaitAWSDetails.tsx
@@ -87,7 +87,7 @@ export const AwaitAWSDetails = ({
 
       {hasTerraform ? (
         <Tabs
-          initActiveTab="cloudformation"
+          initActiveTab={version?.template_url ? 'cloudformation' : 'terraform'}
           tabs={{
             cloudformation: (
               <CloudFormationTab
@@ -130,6 +130,20 @@ const CloudFormationTab = ({
   installAwsRegion,
 }: ICloudFormationTab) => {
   const templateUrl = version?.template_url
+
+  if (!templateUrl) {
+    return (
+      <div className="flex flex-col gap-4 pt-4">
+        <Card>
+          <Text variant="subtext" theme="neutral">
+            CloudFormation is unavailable for this install. Set up the stack
+            template bucket to enable it.
+          </Text>
+        </Card>
+      </div>
+    )
+  }
+
   const isS3Template =
     templateUrl?.includes('s3.amazonaws.com') || templateUrl?.includes('.s3.')
   const region =


### PR DESCRIPTION
When aws_cloudformation_stack_template_bucket is unset, skip the S3 template upload and quick-link generation instead of failing the workflow — installs proceed Terraform-only and the dashboard CFN tab shows a set-up-the-bucket message. Also fixes runner kube auth on GCP/Azure installs broken by #1849: the SDK's ClusterInfo.aws_auth was a struct value, so null re-marshaled as {} and decoded into a non-nil empty AWS config; CompositePlanFromAny now prunes it and the regenerated SDK models emit a pointer.