### PR TITLE
fix: respect app branch Slack preferences

### DIFF
--- a/services/ctl-api/internal/pkg/interests/classify.go
+++ b/services/ctl-api/internal/pkg/interests/classify.go
@@ -339,6 +339,15 @@ func workflowResolution(wfType string) (ResourceKind, string, bool) {
 // good enough for the common case where a workflow's steps share a single
 // target kind (e.g. every step in a deploy_components workflow is a deploy).
 func stepResolution(stepTargetType, parentWorkflowType string) (ResourceKind, string, bool) {
+	// App-branch interests govern the whole workflow, including steps whose
+	// underlying targets are components, actions, or other resource types.
+	switch parentWorkflowType {
+	case "app_branches_manual_update",
+		"app_branches_config_repo_update",
+		"app_branches_component_repo_update":
+		return ResourceAppBranches, "run", true
+	}
+
 	if stepTargetType == "" {
 		return stepResolutionFromParent(parentWorkflowType)
 	}

--- a/services/ctl-api/internal/pkg/interests/interests_test.go
+++ b/services/ctl-api/internal/pkg/interests/interests_test.go
@@ -679,6 +679,22 @@ func TestStepResolution(t *testing.T) {
 			wantOK:         true,
 		},
 		{
+			name:           "deploy step inside app branch workflow → app_branches.run",
+			stepTargetType: stepTargetInstallDeploy,
+			parentWfType:   "app_branches_manual_update",
+			wantResource:   ResourceAppBranches,
+			wantOp:         "run",
+			wantOK:         true,
+		},
+		{
+			name:           "action step inside app branch workflow → app_branches.run",
+			stepTargetType: stepTargetInstallActionWorkflowRun,
+			parentWfType:   "app_branches_component_repo_update",
+			wantResource:   ResourceAppBranches,
+			wantOp:         "run",
+			wantOK:         true,
+		},
+		{
 			name:           "action workflow run step → actions.run",
 			stepTargetType: stepTargetInstallActionWorkflowRun,
 			parentWfType:   "provision",


### PR DESCRIPTION
## Summary

Slack channel subscriptions now apply app branch event preferences to the entire app branch workflow, including nested component and action steps. Turning off app branch lifecycle events prevents those steps from creating a "Running app branch" thread.

## What stays the same

Steps in other workflow types continue to follow their target resource preferences. App branch config sync notifications remain independently selectable.