### PR TITLE
fix: (ctl-api) refactor and harden composite error construction

### DIFF
--- a/services/ctl-api/internal/app/installs/deployerrors/component_build_unavailable_error_test.go
+++ b/services/ctl-api/internal/app/installs/deployerrors/component_build_unavailable_error_test.go
@@ -55,7 +55,10 @@ func TestComponentBuildUnavailableError_Missing(t *testing.T) {
 		t.Errorf("Error() = %q, want it to mention the component", got)
 	}
 
-	data := compositeerrors.New(e)
+	data, err := compositeerrors.New(e)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if data.Type != ComponentBuildUnavailableErrorType {
 		t.Errorf("New().Type = %q, want %q", data.Type, ComponentBuildUnavailableErrorType)
 	}

--- a/services/ctl-api/internal/app/installs/worker/activities/record_deploy_build_unavailable_composite_error.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/record_deploy_build_unavailable_composite_error.go
@@ -58,7 +58,11 @@ func (a *Activities) RecordDeployBuildUnavailableCompositeError(ctx context.Cont
 		opts = append(opts, compositeerrors.WithSource("component_builds", req.BuildID))
 	}
 
-	data := compositeerrors.New(ce, opts...)
+	data, err := compositeerrors.New(ce, opts...)
+	if err != nil {
+		l.Warn("unable to build build-unavailable composite error; skipping", zap.Error(err))
+		return nil
+	}
 	res := a.db.WithContext(ctx).
 		Model(&app.InstallDeploy{ID: req.DeployID}).
 		Select("composite_error").

--- a/services/ctl-api/internal/app/runners/errparse/ahocorasick.go
+++ b/services/ctl-api/internal/app/runners/errparse/ahocorasick.go
@@ -6,7 +6,7 @@ package errparse
 // regardless of how many patterns (error signatures) are registered, which is
 // what lets the provider layer grow without bound.
 //
-// It answers only "which patterns are present" (a set), not where — that is all
+// It answers only "which patterns are present" (a set), not where, which is all
 // the registry needs to decide which parsers are candidates.
 type ahoCorasick struct {
 	next    []map[byte]int // goto transitions per node

--- a/services/ctl-api/internal/app/runners/errparse/aws/permission.go
+++ b/services/ctl-api/internal/app/runners/errparse/aws/permission.go
@@ -64,9 +64,7 @@ func (e *AWSPermissionError) Severity() compositeerrors.Severity {
 // surfacing the actionable error. The step is parked for manual retry once the
 // user grants the permission.
 func (e *AWSPermissionError) Hints() compositeerrors.Hints {
-	return compositeerrors.Hints{
-		compositeerrors.HintSkipAutoRetry: "true",
-	}
+	return compositeerrors.NewHints().WithSkipAutoRetry()
 }
 
 // Sections returns the structured detail rendered in the dashboard: what AWS
@@ -150,9 +148,10 @@ type permissionParser struct{}
 func (permissionParser) Layer() errparse.Layer { return errparse.LayerProvider }
 
 // Tools is nil (tool-agnostic): an AWS IAM denial is a provider-level failure
-// that surfaces across tools — terraform and pulumi provisioning, an ECR push
-// from a docker/oci build, etc. — so it must not be bucketed to a single tool.
-// The AWS signals plus the provider check in Applicable are the real gates.
+// that surfaces across tools, such as terraform and pulumi provisioning or an
+// ECR push from a docker/oci build, so it must not be bucketed to a single
+// tool. The AWS signals plus the provider check in Applicable are the real
+// gates.
 func (permissionParser) Tools() []errparse.Tool { return nil }
 func (permissionParser) Signals() []string {
 	return []string{

--- a/services/ctl-api/internal/app/runners/errparse/aws/permission_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/aws/permission_test.go
@@ -113,8 +113,8 @@ func TestParse_UnauthorizedOperation(t *testing.T) {
 // runner captured from a broken-provision deploy: plain log-capture lines (no
 // terraform box-drawing), a quoted resource ARN, and the "explicit deny in a
 // permissions boundary" phrasing. It guards the quote-stripping in
-// cleanResource — a quoted ARN would otherwise produce a malformed IAM policy
-// statement in the "How to fix" section.
+// cleanResource, since a quoted ARN would otherwise produce a malformed IAM
+// policy statement in the "How to fix" section.
 func TestParse_S3AccessDenied_PermissionsBoundary(t *testing.T) {
 	ce := parse(readFixture(t, "s3_access_denied_permissions_boundary.txt"))
 	if ce == nil {

--- a/services/ctl-api/internal/app/runners/errparse/errparse.go
+++ b/services/ctl-api/internal/app/runners/errparse/errparse.go
@@ -3,7 +3,7 @@
 //
 // Parsing is hierarchical: a single failure blob is a stack of nested errors
 // (cloud-provider inside tool inside orchestration), and we want to surface the
-// most specific layer — "Missing IAM permission s3:CreateBucket", not
+// most specific layer, "Missing IAM permission s3:CreateBucket" rather than
 // "terraform apply failed". Parsers therefore declare a Layer, and the registry
 // tries the deepest (provider) layer first, then tool, then a generic
 // emit-the-body fallback.
@@ -13,7 +13,7 @@
 // index) and the Signals that must be physically present in the text (a single
 // compiled multi-pattern scan). A parser's expensive Parse only runs when its
 // facet gate passes and one of its signals is present, so per-error cost is a
-// function of the text length and the handful of matched candidates — not the
+// function of the text length and the handful of matched candidates, not the
 // total number of registered parsers.
 package errparse
 

--- a/services/ctl-api/internal/app/runners/errparse/helm/error.go
+++ b/services/ctl-api/internal/app/runners/errparse/helm/error.go
@@ -6,7 +6,7 @@
 //
 // The runner drives helm through the Go SDK (helm.sh/helm/v4 pkg/action), not
 // the CLI, so the familiar "INSTALLATION FAILED"/"UPGRADE FAILED" phase
-// prefixes never appear — those are added only by helm's cmd layer. What is
+// prefixes never appear, since those are added only by helm's cmd layer. What is
 // reliably present is the runner's own wrapper around the SDK error
 // ("unable to upgrade helm release: <sdk error>", "unable to execute with
 // dry-run: <sdk error>"). The parser leads the headline at the SDK error by
@@ -71,7 +71,7 @@ var wrappers = []string{"helm release:", "with dry-run:"}
 
 // causes are verified helm v4 SDK (pkg/action, pkg/kube) error substrings, used
 // as a backup anchor when the captured output does not carry the runner wrapper
-// (e.g. only a log line was retained). Every entry is helm-specific — generic
+// (e.g. only a log line was retained). Every entry is helm-specific; generic
 // kubernetes phrases like "timed out waiting for the condition" are
 // deliberately excluded, since they can appear in streamed pod logs before the
 // real cause and would produce a misleading headline. (That phrase is still
@@ -104,7 +104,7 @@ type classifier struct {
 
 // skipRetry marks a deterministic failure a blind retry cannot fix, so the
 // orchestrator parks the step for manual retry instead of burning attempts.
-var skipRetry = compositeerrors.Hints{compositeerrors.HintSkipAutoRetry: "true"}
+var skipRetry = compositeerrors.NewHints().WithSkipAutoRetry()
 
 var classifiers = []classifier{
 	{HelmOwnershipConflictType, skipRetry, contains("exists and cannot be imported into the current release", "invalid ownership metadata")},

--- a/services/ctl-api/internal/app/runners/errparse/registry.go
+++ b/services/ctl-api/internal/app/runners/errparse/registry.go
@@ -15,7 +15,7 @@ import (
 // Registration is expected to happen entirely at init time (parser packages
 // blank-imported at the chokepoint). Register panics if called after the first
 // Parse, because a late parser would be silently dropped from the already-built
-// buckets — a bug that is far easier to catch as a panic than as a parser that
+// buckets. That bug is far easier to catch as a panic than as a parser that
 // mysteriously never fires.
 //
 // Parsers are referenced by their index into r.parsers everywhere (buckets,

--- a/services/ctl-api/internal/app/runners/errparse/terraform/error_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/terraform/error_test.go
@@ -56,8 +56,8 @@ func TestParse_SingleError(t *testing.T) {
 	if !ok {
 		t.Fatal("expected an Output section")
 	}
-	// The output preserves the detail (with the "│" box-drawing stripped) and
-	// drops our own wrapper is fine to retain — but the terraform detail must
+	// The output preserves the terraform detail (with the "│" box-drawing
+	// stripped); our own wrapper may be retained, but the terraform detail must
 	// survive.
 	if !strings.Contains(out, `A managed resource "aws_subnet" "main" has not been declared`) {
 		t.Errorf("Output missing terraform detail: %q", out)

--- a/services/ctl-api/internal/app/runners/errparse/terraform/state_lock.go
+++ b/services/ctl-api/internal/app/runners/errparse/terraform/state_lock.go
@@ -22,7 +22,7 @@ const stateLockSignal = "acquiring the state lock"
 
 // StateLockError is the payload for a terraform state-lock failure. The detailed
 // lock info (ID, who, path) is emitted to the log stream, not the captured error
-// output, so it is not available here — Output carries whatever context was
+// output, so it is not available here; Output carries whatever context was
 // captured. target ("sandbox"/"component"/"") tailors the force-unlock command
 // in the remediation.
 type StateLockError struct {
@@ -43,7 +43,7 @@ func (e *StateLockError) Severity() compositeerrors.Severity {
 }
 
 func (e *StateLockError) Hints() compositeerrors.Hints {
-	return compositeerrors.Hints{compositeerrors.HintSkipAutoRetry: "true"}
+	return compositeerrors.NewHints().WithSkipAutoRetry()
 }
 
 func (e *StateLockError) Sections() []compositeerrors.Section {

--- a/services/ctl-api/internal/app/runners/service/create_runner_job_execution_result.go
+++ b/services/ctl-api/internal/app/runners/service/create_runner_job_execution_result.go
@@ -172,7 +172,7 @@ const metricCompositeErrorParse = "runner.composite_error_parse"
 // parseCompositeError and emits exactly one metric per failed result so parse
 // coverage is observable without any per-parser wiring.
 func (s *service) parseResultCompositeError(req *CreateRunnerJobExecutionResultRequest, runnerJob *app.RunnerJob) *compositeerrors.CompositeErrorData {
-	ce := parseCompositeError(req, runnerJob)
+	ce := s.parseCompositeError(req, runnerJob)
 	if !req.Success {
 		// Default empty facets to "unknown" so Datadog never sees a bare
 		// "tool:" tag; matched_type stays "miss" for a nil/typeless parse.
@@ -207,7 +207,7 @@ func (s *service) parseResultCompositeError(req *CreateRunnerJobExecutionResultR
 // It is best-effort: a success, a missing message, or a parse miss yields nil,
 // leaving the plain-string status description in place. Source is set to the
 // runner job's owner so a future view can join errors back to their subject.
-func parseCompositeError(req *CreateRunnerJobExecutionResultRequest, runnerJob *app.RunnerJob) *compositeerrors.CompositeErrorData {
+func (s *service) parseCompositeError(req *CreateRunnerJobExecutionResultRequest, runnerJob *app.RunnerJob) *compositeerrors.CompositeErrorData {
 	if req.Success {
 		return nil
 	}
@@ -229,7 +229,15 @@ func parseCompositeError(req *CreateRunnerJobExecutionResultRequest, runnerJob *
 		return nil
 	}
 
-	return compositeerrors.New(ce, compositeerrors.WithSource(runnerJob.OwnerType, runnerJob.OwnerID))
+	data, err := compositeerrors.New(ce, compositeerrors.WithSource(runnerJob.OwnerType, runnerJob.OwnerID))
+	if err != nil {
+		s.l.Warn("unable to build composite error; omitting enrichment",
+			zap.String("runner_job_id", runnerJob.ID),
+			zap.String("composite_error_type", string(ce.Type())),
+			zap.Error(err))
+		return nil
+	}
+	return data
 }
 
 const (

--- a/services/ctl-api/internal/app/runners/service/parse_result_composite_error_test.go
+++ b/services/ctl-api/internal/app/runners/service/parse_result_composite_error_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+	"go.uber.org/zap"
 )
 
 func ptr(s string) *string { return &s }
@@ -37,6 +38,7 @@ func hasTag(tags []string, want string) bool {
 }
 
 func TestParseResultCompositeError(t *testing.T) {
+	s := &service{l: zap.NewNop()}
 	job := &app.RunnerJob{OwnerType: "install_deploys", OwnerID: "idpl_123"}
 
 	awsMsg := "Error: creating S3 Bucket: AccessDenied: User: " +
@@ -48,14 +50,14 @@ func TestParseResultCompositeError(t *testing.T) {
 			Success:       true,
 			ErrorMetadata: map[string]*string{"message": ptr(awsMsg)},
 		}
-		if got := parseCompositeError(req, job); got != nil {
+		if got := s.parseCompositeError(req, job); got != nil {
 			t.Fatalf("expected nil on success, got %+v", got)
 		}
 	})
 
 	t.Run("no message yields nil", func(t *testing.T) {
 		req := &CreateRunnerJobExecutionResultRequest{Success: false}
-		if got := parseCompositeError(req, job); got != nil {
+		if got := s.parseCompositeError(req, job); got != nil {
 			t.Fatalf("expected nil when no message, got %+v", got)
 		}
 	})
@@ -65,7 +67,7 @@ func TestParseResultCompositeError(t *testing.T) {
 			Success:       false,
 			ErrorMetadata: map[string]*string{"message": ptr("some unrelated failure")},
 		}
-		got := parseCompositeError(req, job)
+		got := s.parseCompositeError(req, job)
 		if got == nil {
 			t.Fatal("expected the generic fallback to produce a composite error")
 		}
@@ -82,7 +84,7 @@ func TestParseResultCompositeError(t *testing.T) {
 			Success:       false,
 			ErrorMetadata: map[string]*string{"message": ptr(awsMsg)},
 		}
-		got := parseCompositeError(req, job)
+		got := s.parseCompositeError(req, job)
 		if got == nil {
 			t.Fatal("expected a composite error, got nil")
 		}
@@ -108,7 +110,7 @@ func TestParseResultCompositeError(t *testing.T) {
 				"error_output": ptr(awsMsg),
 			},
 		}
-		got := parseCompositeError(req, job)
+		got := s.parseCompositeError(req, job)
 		if got == nil || got.Type != "terraform.aws_permission" {
 			t.Fatalf("expected AWS permission parsed from error_output, got %+v", got)
 		}
@@ -129,7 +131,7 @@ func TestParseResultCompositeError_Metric(t *testing.T) {
 
 	t.Run("specific match tags the matched type", func(t *testing.T) {
 		mw := &fakeMetricsWriter{}
-		s := &service{mw: mw}
+		s := &service{mw: mw, l: zap.NewNop()}
 		s.parseResultCompositeError(&CreateRunnerJobExecutionResultRequest{
 			Success:       false,
 			ErrorMetadata: map[string]*string{"message": ptr(awsMsg)},
@@ -151,7 +153,7 @@ func TestParseResultCompositeError_Metric(t *testing.T) {
 
 	t.Run("parse miss is tagged generic", func(t *testing.T) {
 		mw := &fakeMetricsWriter{}
-		s := &service{mw: mw}
+		s := &service{mw: mw, l: zap.NewNop()}
 		s.parseResultCompositeError(&CreateRunnerJobExecutionResultRequest{
 			Success:       false,
 			ErrorMetadata: map[string]*string{"message": ptr("some unrelated failure")},
@@ -167,7 +169,7 @@ func TestParseResultCompositeError_Metric(t *testing.T) {
 
 	t.Run("empty output is tagged miss", func(t *testing.T) {
 		mw := &fakeMetricsWriter{}
-		s := &service{mw: mw}
+		s := &service{mw: mw, l: zap.NewNop()}
 		s.parseResultCompositeError(&CreateRunnerJobExecutionResultRequest{Success: false}, tfDeploy)
 
 		if len(mw.incrs) != 1 {
@@ -180,7 +182,7 @@ func TestParseResultCompositeError_Metric(t *testing.T) {
 
 	t.Run("unknown tool falls back to unknown tag", func(t *testing.T) {
 		mw := &fakeMetricsWriter{}
-		s := &service{mw: mw}
+		s := &service{mw: mw, l: zap.NewNop()}
 		s.parseResultCompositeError(&CreateRunnerJobExecutionResultRequest{
 			Success:       false,
 			ErrorMetadata: map[string]*string{"message": ptr("boom")},
@@ -193,7 +195,7 @@ func TestParseResultCompositeError_Metric(t *testing.T) {
 
 	t.Run("success emits no metric", func(t *testing.T) {
 		mw := &fakeMetricsWriter{}
-		s := &service{mw: mw}
+		s := &service{mw: mw, l: zap.NewNop()}
 		s.parseResultCompositeError(&CreateRunnerJobExecutionResultRequest{Success: true}, tfDeploy)
 
 		if len(mw.incrs) != 0 {

--- a/services/ctl-api/internal/pkg/compositeerrors/embedded.go
+++ b/services/ctl-api/internal/pkg/compositeerrors/embedded.go
@@ -59,27 +59,45 @@ func WithSource(sourceType, sourceID string) Option {
 
 // New constructs a CompositeErrorData from a typed CompositeError. The
 // implementation's data, headline message, sections, and (optionally) hints
-// are captured at this point and frozen on the resulting record. Options apply
-// record-site context such as provenance.
-func New(e CompositeError, opts ...Option) *CompositeErrorData {
-	data, _ := json.Marshal(e)
+// are captured at this point and frozen on the resulting record. Sections and
+// Hints are copied so a shared source (e.g. a package-level default hints bag)
+// cannot be mutated through the persisted record. Options apply record-site
+// context such as provenance.
+//
+// It returns an error when the typed payload cannot be marshalled, so a
+// serialization failure surfaces at the call site instead of silently
+// persisting a record with a null payload.
+func New(e CompositeError, opts ...Option) (*CompositeErrorData, error) {
+	data, err := json.Marshal(e)
+	if err != nil {
+		return nil, fmt.Errorf("compositeerrors: marshal %T payload: %w", e, err)
+	}
 	d := &CompositeErrorData{
 		Version:  SchemaVersion,
 		Type:     e.Type(),
 		Severity: e.Severity(),
 		Message:  e.Error(),
-		Sections: e.Sections(),
+		Sections: cloneSections(e.Sections()),
 		Data:     data,
 	}
 	if hp, ok := e.(HintsProvider); ok {
-		if hints := hp.Hints(); len(hints) > 0 {
-			d.Hints = hints
-		}
+		d.Hints = hp.Hints().Clone()
 	}
 	for _, opt := range opts {
 		opt(d)
 	}
-	return d
+	return d, nil
+}
+
+// cloneSections returns a copy of s, or nil when empty. Section fields are all
+// value types, so a slice copy fully detaches the result from the source.
+func cloneSections(s []Section) []Section {
+	if len(s) == 0 {
+		return nil
+	}
+	out := make([]Section, len(s))
+	copy(out, s)
+	return out
 }
 
 // Scan implements database/sql.Scanner.

--- a/services/ctl-api/internal/pkg/compositeerrors/embedded_test.go
+++ b/services/ctl-api/internal/pkg/compositeerrors/embedded_test.go
@@ -1,0 +1,63 @@
+package compositeerrors
+
+import "testing"
+
+// unmarshalableError carries a field json.Marshal cannot encode, so New() must
+// surface the marshal failure instead of persisting a record with a null typed
+// payload.
+type unmarshalableError struct {
+	Ch chan int `json:"ch"`
+}
+
+func (unmarshalableError) Error() string       { return "bad" }
+func (unmarshalableError) Type() Type          { return "test.unmarshalable" }
+func (unmarshalableError) Severity() Severity  { return SeverityError }
+func (unmarshalableError) Sections() []Section { return nil }
+
+func TestNew_ReturnsErrorOnUnmarshalablePayload(t *testing.T) {
+	d, err := New(unmarshalableError{})
+	if err == nil {
+		t.Fatal("expected an error for an unmarshalable payload")
+	}
+	if d != nil {
+		t.Fatalf("expected nil record on error, got %+v", d)
+	}
+}
+
+// sectionedError returns a caller-owned slice from Sections() so the test can
+// confirm New() detaches its copy from the source.
+type sectionedError struct{ sections []Section }
+
+func (sectionedError) Error() string         { return "boom" }
+func (sectionedError) Type() Type            { return "test.sectioned" }
+func (sectionedError) Severity() Severity    { return SeverityError }
+func (e sectionedError) Sections() []Section { return e.sections }
+
+func TestNew_FreezesHintsAndSectionsFromSource(t *testing.T) {
+	t.Run("hints detached from a shared source map", func(t *testing.T) {
+		shared := NewHints().WithSkipAutoRetry()
+		d, err := New(hintedError{hints: shared})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !d.Hints.SkipAutoRetry() {
+			t.Fatal("expected the hint to be captured")
+		}
+		shared[HintSkipAutoRetry] = "false"
+		if !d.Hints.SkipAutoRetry() {
+			t.Fatal("persisted hints must not observe a mutation of the source map")
+		}
+	})
+
+	t.Run("sections detached from the source slice", func(t *testing.T) {
+		src := []Section{CodeSection("Output", "original")}
+		d, err := New(sectionedError{sections: src})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		src[0].Body = "mutated"
+		if d.Sections[0].Body != "original" {
+			t.Fatalf("persisted section must not observe a mutation of the source slice, got %q", d.Sections[0].Body)
+		}
+	})
+}

--- a/services/ctl-api/internal/pkg/compositeerrors/error.go
+++ b/services/ctl-api/internal/pkg/compositeerrors/error.go
@@ -2,10 +2,10 @@
 // across the Nuon platform.
 //
 // A CompositeError is a regular Go error (it satisfies the standard error
-// interface) plus typed metadata — a discriminator, a severity, and an
-// optional list of structured Sections — that lets the dashboard present a
-// rich, opinionated view without losing the ability to be returned through
-// the call stack like any other error.
+// interface) plus typed metadata: a discriminator, a severity, and an optional
+// list of structured Sections. That metadata lets the dashboard present a rich,
+// opinionated view without losing the ability to be returned through the call
+// stack like any other error.
 //
 // Composite errors are persisted by attaching a CompositeErrorData JSONB
 // column to owner rows (component builds, sandbox runs, deploys, action runs, ..)
@@ -33,18 +33,18 @@ const (
 // standard error interface (Error() returns the headline message), plus
 // metadata used to persist and present the error in the dashboard.
 type CompositeError interface {
-	error // headline — the one-line message users see
+	error // headline, the one-line message users see
 
 	Type() Type
 	Severity() Severity
 
 	// Sections returns optional structured detail (what / why / fix).
-	// Returning nil is fine — the headline alone is a valid view.
+	// Returning nil is fine; the headline alone is a valid view.
 	Sections() []Section
 }
 
-// SectionKind tells the renderer how to interpret a Section body, and — for
-// security — whether the body is trusted. Untrusted content (raw tool output,
+// SectionKind tells the renderer how to interpret a Section body, and, for
+// security, whether the body is trusted. Untrusted content (raw tool output,
 // values extracted from an error) must never be rendered as markdown: the
 // dashboard's markdown pipeline enables raw HTML and runs custom-component
 // extraction over the string, so a crafted payload could escape a code fence
@@ -74,7 +74,7 @@ type Section struct {
 }
 
 // MarkdownSection builds a trusted, markdown-rendered section. Only pass
-// hand-authored, code-controlled content — never raw tool output.
+// hand-authored, code-controlled content, never raw tool output.
 func MarkdownSection(heading, body string) Section {
 	return Section{Heading: heading, Body: body, Kind: SectionMarkdown}
 }

--- a/services/ctl-api/internal/pkg/compositeerrors/hints.go
+++ b/services/ctl-api/internal/pkg/compositeerrors/hints.go
@@ -70,6 +70,53 @@ func (h Hints) DocsURL() string {
 	return h[HintDocsURL]
 }
 
+// Clone returns a shallow copy of the bag, or nil when empty. Use it before
+// mutating a Hints value that may be shared (e.g. a package-level default).
+func (h Hints) Clone() Hints {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(Hints, len(h))
+	for k, v := range h {
+		out[k] = v
+	}
+	return out
+}
+
+// NewHints returns an empty bag ready for the With* setters. Prefer the typed
+// setters over raw map literals so canonical keys and value formats stay
+// correct (a misspelled key or malformed value silently becomes a no-op).
+func NewHints() Hints { return Hints{} }
+
+// WithSkipAutoRetry marks the failure so the orchestrator parks the step for
+// manual retry instead of auto-retrying.
+func (h Hints) WithSkipAutoRetry() Hints {
+	h[HintSkipAutoRetry] = "true"
+	return h
+}
+
+// WithTerminal marks the failure as not retryable at all.
+func (h Hints) WithTerminal() Hints {
+	h[HintTerminal] = "true"
+	return h
+}
+
+// WithRequeueAfter sets the back-off before retrying. A negative duration is
+// ignored so the bag never carries a malformed value.
+func (h Hints) WithRequeueAfter(d time.Duration) Hints {
+	if d < 0 {
+		return h
+	}
+	h[HintRequeueAfter] = strconv.Itoa(int(d.Seconds()))
+	return h
+}
+
+// WithDocsURL attaches a documentation link the UI may surface as "learn more".
+func (h Hints) WithDocsURL(url string) Hints {
+	h[HintDocsURL] = url
+	return h
+}
+
 // HintsProvider is an optional capability implemented by typed CompositeError
 // values that want to attach hints. New() captures Hints() at write time, the
 // same way it captures Sections().

--- a/services/ctl-api/internal/pkg/compositeerrors/hints_test.go
+++ b/services/ctl-api/internal/pkg/compositeerrors/hints_test.go
@@ -76,9 +76,33 @@ func (plainError) Type() Type          { return "test.plain" }
 func (plainError) Severity() Severity  { return SeverityWarning }
 func (plainError) Sections() []Section { return nil }
 
+func TestHintsWriters(t *testing.T) {
+	h := NewHints().WithSkipAutoRetry().WithTerminal().WithDocsURL("https://docs.nuon.co/x").WithRequeueAfter(5 * time.Minute)
+
+	if !h.SkipAutoRetry() {
+		t.Error("expected skip_auto_retry set")
+	}
+	if !h.Terminal() {
+		t.Error("expected terminal set")
+	}
+	if h.DocsURL() != "https://docs.nuon.co/x" {
+		t.Errorf("docs_url = %q", h.DocsURL())
+	}
+	if d, ok := h.RequeueAfter(); !ok || d != 5*time.Minute {
+		t.Errorf("requeue_after = %v ok=%v", d, ok)
+	}
+
+	if _, ok := NewHints().WithRequeueAfter(-1 * time.Second).RequeueAfter(); ok {
+		t.Error("a negative duration must leave requeue_after unset")
+	}
+}
+
 func TestNewCapturesVersionHintsAndSource(t *testing.T) {
 	t.Run("captures version and hints", func(t *testing.T) {
-		d := New(hintedError{hints: Hints{HintSkipAutoRetry: "true"}})
+		d, err := New(hintedError{hints: Hints{HintSkipAutoRetry: "true"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if d.Version != SchemaVersion {
 			t.Fatalf("expected version %d, got %d", SchemaVersion, d.Version)
 		}
@@ -88,21 +112,30 @@ func TestNewCapturesVersionHintsAndSource(t *testing.T) {
 	})
 
 	t.Run("no hints when provider absent", func(t *testing.T) {
-		d := New(plainError{})
+		d, err := New(plainError{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if d.Hints != nil {
 			t.Fatalf("expected nil hints, got %v", d.Hints)
 		}
 	})
 
 	t.Run("empty hints not stored", func(t *testing.T) {
-		d := New(hintedError{hints: Hints{}})
+		d, err := New(hintedError{hints: Hints{}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if d.Hints != nil {
 			t.Fatalf("expected nil hints for empty bag, got %v", d.Hints)
 		}
 	})
 
 	t.Run("WithSource records provenance", func(t *testing.T) {
-		d := New(plainError{}, WithSource("runner_job_execution_results", "rje_123"))
+		d, err := New(plainError{}, WithSource("runner_job_execution_results", "rje_123"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if d.SourceType != "runner_job_execution_results" || d.SourceID != "rje_123" {
 			t.Fatalf("unexpected source: %s/%s", d.SourceType, d.SourceID)
 		}


### PR DESCRIPTION
Propagate typed-payload marshal failures from compositeerrors.New instead of silently storing a record with a null payload, snapshot Sections and Hints so a shared source (e.g. helm's package-level hints) can't be mutated through a persisted record, and add typed hint builders (NewHints + With* setters) so parsers stop hand-building raw map literals.

Existing composite-error implementations are JSON-safe and no current path mutates shared hints; these changes enforce the invariants for future implementations.