### PR TITLE
fix: prune empty cluster_info from composite plan

### DIFF
--- a/pkg/plans/types/action_workflow_run.go
+++ b/pkg/plans/types/action_workflow_run.go
@@ -20,7 +20,13 @@ type ActionWorkflowRunPlan struct {
 	OverrideEnvVars map[string]string            `json:"override_env_vars"`
 	Timeout         time.Duration                `json:"timeout,omitempty" swaggertype:"primitive,integer"`
 
-	// optional fields based on the configuration
+	// Optional fields based on the configuration.
+	//
+	// NOTE: keep this comment detached from the field below (blank line above
+	// the field) — a doc comment on a $ref field makes go-swagger generate the
+	// SDK model field as an inline struct VALUE, so a null cluster_info
+	// round-trips to {} in the runner and becomes a non-nil empty ClusterInfo.
+
 	ClusterInfo *kube.ClusterInfo        `json:"cluster_info,block"`
 	AWSAuth     *awscredentials.Config   `json:"aws_auth,omitempty"`
 	AzureAuth   *azurecredentials.Config `json:"azure_auth,omitempty"`

--- a/pkg/plans/types/composite_plan.go
+++ b/pkg/plans/types/composite_plan.go
@@ -36,49 +36,64 @@ func CompositePlanFromAny(v any) (*CompositePlan, error) {
 		return nil, err
 	}
 
-	cp.pruneEmptyClusterAuth()
+	cp.pruneEmptyClusterInfo()
 	return &cp, nil
 }
 
-// pruneEmptyClusterAuth clears cluster-info auth configs that decoded as empty
-// objects. go-swagger generates ClusterInfo.aws_auth as an inline struct value
-// (not a pointer), so a null aws_auth from the API re-marshals as {} during the
-// round-trip above and would otherwise decode into a non-nil empty config,
-// routing kube auth down the AWS path on non-AWS installs.
-func (cp *CompositePlan) pruneEmptyClusterAuth() {
-	for _, ci := range cp.clusterInfos() {
-		if ci == nil {
-			continue
-		}
-		if ci.AWSAuth != nil && *ci.AWSAuth == (awscredentials.Config{}) {
-			ci.AWSAuth = nil
-		}
-	}
-}
-
-func (cp *CompositePlan) clusterInfos() []*kube.ClusterInfo {
-	infos := make([]*kube.ClusterInfo, 0, 6)
+// pruneEmptyClusterInfo clears cluster infos (and their auth configs) that
+// decoded as empty objects. go-swagger generates a $ref field that carries a
+// doc comment as an inline struct VALUE (not a pointer) in the SDK models, so a
+// null aws_auth or cluster_info from the API re-marshals as {} during the
+// round-trip above and would otherwise decode into a non-nil empty struct —
+// routing kube auth down the AWS path on non-AWS installs, or making the runner
+// write a kubeconfig for a sandbox that has no cluster at all.
+func (cp *CompositePlan) pruneEmptyClusterInfo() {
 	if dp := cp.DeployPlan; dp != nil {
 		if dp.HelmDeployPlan != nil {
-			infos = append(infos, dp.HelmDeployPlan.ClusterInfo)
+			dp.HelmDeployPlan.ClusterInfo = pruneClusterInfo(dp.HelmDeployPlan.ClusterInfo)
 		}
 		if dp.TerraformDeployPlan != nil {
-			infos = append(infos, dp.TerraformDeployPlan.ClusterInfo)
+			dp.TerraformDeployPlan.ClusterInfo = pruneClusterInfo(dp.TerraformDeployPlan.ClusterInfo)
 		}
 		if dp.KubernetesManifestDeployPlan != nil {
-			infos = append(infos, dp.KubernetesManifestDeployPlan.ClusterInfo)
+			dp.KubernetesManifestDeployPlan.ClusterInfo = pruneClusterInfo(dp.KubernetesManifestDeployPlan.ClusterInfo)
 		}
 		if dp.PulumiDeployPlan != nil {
-			infos = append(infos, dp.PulumiDeployPlan.ClusterInfo)
+			dp.PulumiDeployPlan.ClusterInfo = pruneClusterInfo(dp.PulumiDeployPlan.ClusterInfo)
 		}
 	}
 	if cp.ActionWorkflowRunPlan != nil {
-		infos = append(infos, cp.ActionWorkflowRunPlan.ClusterInfo)
+		cp.ActionWorkflowRunPlan.ClusterInfo = pruneClusterInfo(cp.ActionWorkflowRunPlan.ClusterInfo)
 	}
 	if cp.SyncSecretsPlan != nil {
-		infos = append(infos, cp.SyncSecretsPlan.ClusterInfo)
+		cp.SyncSecretsPlan.ClusterInfo = pruneClusterInfo(cp.SyncSecretsPlan.ClusterInfo)
 	}
-	return infos
+}
+
+func pruneClusterInfo(ci *kube.ClusterInfo) *kube.ClusterInfo {
+	if ci == nil {
+		return nil
+	}
+	if ci.AWSAuth != nil && *ci.AWSAuth == (awscredentials.Config{}) {
+		ci.AWSAuth = nil
+	}
+	if clusterInfoIsZero(ci) {
+		return nil
+	}
+	return ci
+}
+
+func clusterInfoIsZero(ci *kube.ClusterInfo) bool {
+	return ci.ID == "" &&
+		ci.Endpoint == "" &&
+		ci.CAData == "" &&
+		len(ci.EnvVars) == 0 &&
+		ci.KubeConfig == "" &&
+		ci.AWSAuth == nil &&
+		ci.AzureAuth == nil &&
+		ci.GCPAuth == nil &&
+		!ci.Inline &&
+		ci.TrustedRoleARN == ""
 }
 
 // Inner returns the single populated sub-plan, or nil when the composite plan is

--- a/pkg/plans/types/composite_plan_test.go
+++ b/pkg/plans/types/composite_plan_test.go
@@ -40,6 +40,25 @@ func TestCompositePlanFromAny_PrunesEmptyAWSAuth(t *testing.T) {
 	assert.Equal(t, "proj", ci.GCPAuth.ProjectID)
 }
 
+func TestCompositePlanFromAny_PrunesEmptyClusterInfo(t *testing.T) {
+	// Mirrors an action workflow run plan for a sandbox with no cluster:
+	// models.PlantypesActionWorkflowRunPlan.ClusterInfo is a struct value, so a
+	// null cluster_info from the API re-marshals as {} (with an empty aws_auth
+	// under the old SDK models).
+	sdkPlan := map[string]any{
+		"action_workflow_run_plan": map[string]any{
+			"id":           "run-1",
+			"install_id":   "inst-1",
+			"cluster_info": map[string]any{"aws_auth": map[string]any{}},
+		},
+	}
+
+	cp, err := CompositePlanFromAny(sdkPlan)
+	require.NoError(t, err)
+	require.NotNil(t, cp.ActionWorkflowRunPlan)
+	assert.Nil(t, cp.ActionWorkflowRunPlan.ClusterInfo, "empty cluster_info from the SDK round-trip must be pruned")
+}
+
 func TestCompositePlanFromAny_KeepsPopulatedAWSAuth(t *testing.T) {
 	sdkPlan := map[string]any{
 		"deploy_plan": map[string]any{


### PR DESCRIPTION
Follow-up to #1880: the action workflow plan's cluster_info is also a struct value in the SDK models, so a null cluster_info (sandbox with no cluster) round-trips to {} and the runner fails with "missing auth configuration". CompositePlanFromAny now prunes fully-empty cluster infos to nil; SDK regen will make the field a pointer.