### PR TITLE
fix: set region and other env vars for azure

### DIFF
--- a/services/ctl-api/internal/app/installs/worker/plan/plan_sandbox_run.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_sandbox_run.go
@@ -303,6 +303,10 @@ func (p *Planner) getSandboxRunEnvVars(appCfg *app.AppConfig) map[string]string 
 	case app.AppRunnerTypeGCP:
 		envVars["GOOGLE_PROJECT"] = "{{.nuon.install_stack.outputs.project_id}}"
 		envVars["GOOGLE_REGION"] = "{{.nuon.install_stack.outputs.region}}"
+	case app.AppRunnerTypeAzure:
+		envVars["ARM_SUBSCRIPTION_ID"] = "{{.nuon.install_stack.outputs.subscription_id}}"
+		envVars["ARM_TENANT_ID"] = "{{.nuon.install_stack.outputs.subscription_tenant_id}}"
+		envVars["ARM_LOCATION"] = "{{.nuon.install_stack.outputs.resource_group_location}}"
 	}
 
 	return envVars


### PR DESCRIPTION
## Summary

Inject Azure env vars into the sandbox plan, consistent with AWS and GCP. This will obviate the need to pass the region to sandboxes via a Nuon interpolated variable.