### PR TITLE
fix: slugify github app name in connect url

### DIFF
--- a/services/dashboard-ui/client/components/vcs-connections/ConnectGithub/ConnectGithub.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ConnectGithub/ConnectGithub.tsx
@@ -28,6 +28,11 @@ export const ConnectGithubModal = ({
   const [isManualMode, setIsManualMode] = useState(false)
   const formRef = useRef<HTMLFormElement>(null)
 
+  const githubAppSlug = githubAppName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const formData = Object.fromEntries(new FormData(e.currentTarget))
@@ -71,7 +76,7 @@ export const ConnectGithubModal = ({
       {!isManualMode ? (
         <div className="flex flex-col gap-6">
           <Button
-            href={`https://github.com/apps/${githubAppName}/installations/new?state=${orgId}`}
+            href={`https://github.com/apps/${githubAppSlug}/installations/new?state=${orgId}`}
             variant="ghost"
             className="flex flex-col items-center justify-center gap-4 !p-8 rounded !h-auto !text-center !border-cool-grey-400 dark:!border-dark-grey-500"
           >

--- a/services/dashboard-ui/server/internal/handlers/connect.go
+++ b/services/dashboard-ui/server/internal/handlers/connect.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"regexp"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -11,6 +13,13 @@ import (
 	"github.com/nuonco/nuon/sdks/nuon-go/models"
 	"github.com/nuonco/nuon/services/dashboard-ui/server/internal"
 )
+
+var githubAppSlugPattern = regexp.MustCompile(`[^a-z0-9]+`)
+
+func githubAppSlug(name string) string {
+	slug := githubAppSlugPattern.ReplaceAllString(strings.ToLower(name), "-")
+	return strings.Trim(slug, "-")
+}
 
 type ConnectHandler struct {
 	cfg *internal.Config
@@ -38,7 +47,7 @@ func (h *ConnectHandler) StartConnectGithub(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "github app not configured"})
 		return
 	}
-	target := fmt.Sprintf("https://github.com/apps/%s/installations/new?state=%s", h.cfg.GithubAppName, orgID)
+	target := fmt.Sprintf("https://github.com/apps/%s/installations/new?state=%s", githubAppSlug(h.cfg.GithubAppName), orgID)
 	c.Redirect(http.StatusFound, target)
 }
 


### PR DESCRIPTION
The "New GitHub connection" flow interpolated the configured app name raw into the install URL, so a name with spaces produced a broken link. Slugify (lowercase, non-alphanumeric to hyphens) to match GitHub's app slug in both the client button and the BFF redirect endpoint.