### PR TITLE
chore: Centralize `errparse` parser registration and add a registry contract test runner

### DIFF
--- a/services/ctl-api/internal/app/runners/errparse/all/all.go
+++ b/services/ctl-api/internal/app/runners/errparse/all/all.go
@@ -1,0 +1,14 @@
+// Package all blank-imports every errparse parser package so their init()
+// registrations land in the default registry.
+//
+// It is the single authoritative wiring point. Import it for its side effects
+// wherever composite-error parsing must be enabled, and add any new parser
+// package here so every consumer picks it up.
+package all
+
+import (
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/aws"
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/generic"
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/helm"
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/terraform"
+)

--- a/services/ctl-api/internal/app/runners/errparse/dispatch_integration_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/dispatch_integration_test.go
@@ -6,17 +6,23 @@ import (
 	"testing"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse"
-	awsparse "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/aws"
-	genericparse "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/generic"
-	helmparse "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/helm"
-	tfparse "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/terraform"
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/all"
 )
 
-// This external test package imports both parser packages so their init()
-// registrations land in the default registry together, matching the chokepoint
-// wiring. It asserts the layer contract that only holds once specific and
-// generic parsers coexist: a specific provider-layer parser wins, and the
-// generic fallback catches everything else.
+// This external test package registers parsers solely through the errparse/all
+// manifest, the same wiring production uses, so the two can never drift.
+// Assertions match on the composite error's Type() discriminator rather than a
+// concrete parser type so no parser package is imported directly here. It
+// asserts the layer contract that only holds once specific and generic parsers
+// coexist: a specific provider-layer parser wins, and the generic fallback
+// catches everything else.
+const (
+	awsPermissionType  = "terraform.aws_permission"
+	genericType        = "generic"
+	terraformType      = "terraform.error"
+	terraformStateLock = "terraform.state_lock"
+	helmNameInUseType  = "helm.name_in_use"
+)
 
 func TestDefaultRegistry_SpecificBeatsGeneric(t *testing.T) {
 	raw, err := os.ReadFile(filepath.Join("aws", "testdata", "terraform_apply_access_denied.txt"))
@@ -28,7 +34,7 @@ func TestDefaultRegistry_SpecificBeatsGeneric(t *testing.T) {
 	if ce == nil {
 		t.Fatal("expected a match")
 	}
-	if _, ok := ce.(*awsparse.AWSPermissionError); !ok {
+	if ce.Type() != awsPermissionType {
 		t.Fatalf("expected AWS permission error to win over generic, got %T (type %q)", ce, ce.Type())
 	}
 }
@@ -38,7 +44,7 @@ func TestDefaultRegistry_GenericCatchesUnclassified(t *testing.T) {
 	if ce == nil {
 		t.Fatal("expected the generic fallback to match")
 	}
-	if _, ok := ce.(*genericparse.GenericError); !ok {
+	if ce.Type() != genericType {
 		t.Fatalf("expected generic fallback, got %T (type %q)", ce, ce.Type())
 	}
 }
@@ -53,7 +59,7 @@ func TestDefaultRegistry_ToolLayerOrdering(t *testing.T) {
 		t.Fatalf("read fixture: %v", err)
 	}
 	ce := errparse.Parse(&errparse.ParseContext{Raw: string(tfDiag), Tool: errparse.ToolTerraform})
-	if _, ok := ce.(*tfparse.TerraformError); !ok {
+	if ce.Type() != terraformType {
 		t.Fatalf("expected terraform tool-layer parser to win over generic, got %T (type %q)", ce, ce.Type())
 	}
 
@@ -61,7 +67,7 @@ func TestDefaultRegistry_ToolLayerOrdering(t *testing.T) {
 		"arn:aws:iam::123:role/nuon-runner is not authorized to perform: " +
 		"s3:CreateBucket on resource: arn:aws:s3:::acme"
 	ce = errparse.Parse(&errparse.ParseContext{Raw: awsBlob, Tool: errparse.ToolTerraform})
-	if _, ok := ce.(*awsparse.AWSPermissionError); !ok {
+	if ce.Type() != awsPermissionType {
 		t.Fatalf("expected AWS provider layer to win over terraform tool layer, got %T (type %q)", ce, ce.Type())
 	}
 }
@@ -76,7 +82,7 @@ func TestDefaultRegistry_StateLockBeatsTerraformCatchAll(t *testing.T) {
 		t.Fatalf("read fixture: %v", err)
 	}
 	ce := errparse.Parse(&errparse.ParseContext{Raw: string(raw), Tool: errparse.ToolTerraform})
-	if _, ok := ce.(*tfparse.StateLockError); !ok {
+	if ce.Type() != terraformStateLock {
 		t.Fatalf("expected state-lock parser to win over the terraform catch-all, got %T (type %q)", ce, ce.Type())
 	}
 }
@@ -88,7 +94,7 @@ func TestDefaultRegistry_HelmToolLayer(t *testing.T) {
 	helmErr := "job step errored unable to execute job: unable to upgrade helm release: " +
 		"cannot reuse a name that is still in use"
 	ce := errparse.Parse(&errparse.ParseContext{Raw: helmErr, Tool: errparse.ToolHelm})
-	if _, ok := ce.(*helmparse.HelmError); !ok {
+	if ce.Type() != helmNameInUseType {
 		t.Fatalf("expected helm tool-layer parser to win over generic, got %T (type %q)", ce, ce.Type())
 	}
 
@@ -96,7 +102,7 @@ func TestDefaultRegistry_HelmToolLayer(t *testing.T) {
 		"User: arn:aws:iam::123:role/nuon-runner is not authorized to perform: " +
 		"s3:CreateBucket on resource: arn:aws:s3:::acme"
 	ce = errparse.Parse(&errparse.ParseContext{Raw: awsBlob, Tool: errparse.ToolHelm})
-	if _, ok := ce.(*awsparse.AWSPermissionError); !ok {
+	if ce.Type() != awsPermissionType {
 		t.Fatalf("expected AWS provider layer to win over helm tool layer, got %T (type %q)", ce, ce.Type())
 	}
 }

--- a/services/ctl-api/internal/app/runners/errparse/dispatch_integration_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/dispatch_integration_test.go
@@ -7,102 +7,83 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/all"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/errparsetest"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
 )
 
-// This external test package registers parsers solely through the errparse/all
-// manifest, the same wiring production uses, so the two can never drift.
-// Assertions match on the composite error's Type() discriminator rather than a
-// concrete parser type so no parser package is imported directly here. It
-// asserts the layer contract that only holds once specific and generic parsers
-// coexist: a specific provider-layer parser wins, and the generic fallback
-// catches everything else.
+// This external test registers parsers solely through the errparse/all
+// manifest, the same wiring production uses, so the two can never drift. It runs
+// fixtures through the contract runner, which dispatches against the real
+// registry and enforces both the layer contract and the persistence
+// round-trip. Cases match on the winning composite error's Type() rather than a
+// concrete parser type so no parser package is imported directly here.
 const (
-	awsPermissionType  = "terraform.aws_permission"
-	genericType        = "generic"
-	terraformType      = "terraform.error"
-	terraformStateLock = "terraform.state_lock"
-	helmNameInUseType  = "helm.name_in_use"
+	awsPermissionType  compositeerrors.Type = "terraform.aws_permission"
+	genericType        compositeerrors.Type = "generic"
+	terraformType      compositeerrors.Type = "terraform.error"
+	terraformStateLock compositeerrors.Type = "terraform.state_lock"
+	helmNameInUseType  compositeerrors.Type = "helm.name_in_use"
 )
 
-func TestDefaultRegistry_SpecificBeatsGeneric(t *testing.T) {
-	raw, err := os.ReadFile(filepath.Join("aws", "testdata", "terraform_apply_access_denied.txt"))
+func readFixture(t *testing.T, tool, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(tool, "testdata", name))
 	if err != nil {
-		t.Fatalf("read fixture: %v", err)
+		t.Fatalf("read fixture %s/%s: %v", tool, name, err)
 	}
-
-	ce := errparse.Parse(&errparse.ParseContext{Raw: string(raw)})
-	if ce == nil {
-		t.Fatal("expected a match")
-	}
-	if ce.Type() != awsPermissionType {
-		t.Fatalf("expected AWS permission error to win over generic, got %T (type %q)", ce, ce.Type())
-	}
+	return string(b)
 }
 
-func TestDefaultRegistry_GenericCatchesUnclassified(t *testing.T) {
-	ce := errparse.Parse(&errparse.ParseContext{Raw: "helm upgrade failed: context deadline exceeded"})
-	if ce == nil {
-		t.Fatal("expected the generic fallback to match")
-	}
-	if ce.Type() != genericType {
-		t.Fatalf("expected generic fallback, got %T (type %q)", ce, ce.Type())
-	}
-}
-
-// TestDefaultRegistry_ToolLayerOrdering asserts the three-layer contract on a
-// terraform job: a terraform diagnostic that no provider parser recognises
-// yields the tool-layer parser (not the raw generic dump), while an AWS
-// permission blob on the same job is still won by the provider layer.
-func TestDefaultRegistry_ToolLayerOrdering(t *testing.T) {
-	tfDiag, err := os.ReadFile(filepath.Join("terraform", "testdata", "invalid_reference.txt"))
-	if err != nil {
-		t.Fatalf("read fixture: %v", err)
-	}
-	ce := errparse.Parse(&errparse.ParseContext{Raw: string(tfDiag), Tool: errparse.ToolTerraform})
-	if ce.Type() != terraformType {
-		t.Fatalf("expected terraform tool-layer parser to win over generic, got %T (type %q)", ce, ce.Type())
-	}
-
-	awsBlob := "Error: creating S3 Bucket (acme): AccessDenied: User: " +
+func TestDefaultRegistry_Contract(t *testing.T) {
+	awsTerraformBlob := "Error: creating S3 Bucket (acme): AccessDenied: User: " +
 		"arn:aws:iam::123:role/nuon-runner is not authorized to perform: " +
 		"s3:CreateBucket on resource: arn:aws:s3:::acme"
-	ce = errparse.Parse(&errparse.ParseContext{Raw: awsBlob, Tool: errparse.ToolTerraform})
-	if ce.Type() != awsPermissionType {
-		t.Fatalf("expected AWS provider layer to win over terraform tool layer, got %T (type %q)", ce, ce.Type())
-	}
-}
-
-// TestDefaultRegistry_StateLockBeatsTerraformCatchAll asserts that the
-// state-lock parser wins over the generic terraform catch-all: both are
-// candidates for a lock failure (each signals on the same diagnostic), and the
-// state-lock parser's more-specific layer must break the tie.
-func TestDefaultRegistry_StateLockBeatsTerraformCatchAll(t *testing.T) {
-	raw, err := os.ReadFile(filepath.Join("terraform", "testdata", "state_lock.txt"))
-	if err != nil {
-		t.Fatalf("read fixture: %v", err)
-	}
-	ce := errparse.Parse(&errparse.ParseContext{Raw: string(raw), Tool: errparse.ToolTerraform})
-	if ce.Type() != terraformStateLock {
-		t.Fatalf("expected state-lock parser to win over the terraform catch-all, got %T (type %q)", ce, ce.Type())
-	}
-}
-
-// TestDefaultRegistry_HelmToolLayer asserts the same three-layer contract on a
-// helm job: a recognised helm failure yields the tool-layer parser, while an
-// AWS permission blob on the same job is still won by the provider layer.
-func TestDefaultRegistry_HelmToolLayer(t *testing.T) {
-	helmErr := "job step errored unable to execute job: unable to upgrade helm release: " +
-		"cannot reuse a name that is still in use"
-	ce := errparse.Parse(&errparse.ParseContext{Raw: helmErr, Tool: errparse.ToolHelm})
-	if ce.Type() != helmNameInUseType {
-		t.Fatalf("expected helm tool-layer parser to win over generic, got %T (type %q)", ce, ce.Type())
-	}
-
-	awsBlob := "unable to upgrade helm release: creating S3 Bucket (acme): AccessDenied: " +
+	awsHelmBlob := "unable to upgrade helm release: creating S3 Bucket (acme): AccessDenied: " +
 		"User: arn:aws:iam::123:role/nuon-runner is not authorized to perform: " +
 		"s3:CreateBucket on resource: arn:aws:s3:::acme"
-	ce = errparse.Parse(&errparse.ParseContext{Raw: awsBlob, Tool: errparse.ToolHelm})
-	if ce.Type() != awsPermissionType {
-		t.Fatalf("expected AWS provider layer to win over helm tool layer, got %T (type %q)", ce, ce.Type())
-	}
+	helmNameInUse := "job step errored unable to execute job: unable to upgrade helm release: " +
+		"cannot reuse a name that is still in use"
+
+	errparsetest.Run(t, []errparsetest.Case{
+		{
+			Name:     "provider layer beats generic",
+			Raw:      readFixture(t, "aws", "terraform_apply_access_denied.txt"),
+			WantType: awsPermissionType,
+		},
+		{
+			Name:     "generic catches unclassified",
+			Raw:      "helm upgrade failed: context deadline exceeded",
+			WantType: genericType,
+		},
+		{
+			Name:     "terraform tool layer beats generic",
+			Raw:      readFixture(t, "terraform", "invalid_reference.txt"),
+			Tool:     errparse.ToolTerraform,
+			WantType: terraformType,
+		},
+		{
+			Name:     "provider layer beats terraform tool layer",
+			Raw:      awsTerraformBlob,
+			Tool:     errparse.ToolTerraform,
+			WantType: awsPermissionType,
+		},
+		{
+			Name:     "state-lock parser beats terraform catch-all",
+			Raw:      readFixture(t, "terraform", "state_lock.txt"),
+			Tool:     errparse.ToolTerraform,
+			WantType: terraformStateLock,
+		},
+		{
+			Name:     "helm tool layer beats generic",
+			Raw:      helmNameInUse,
+			Tool:     errparse.ToolHelm,
+			WantType: helmNameInUseType,
+		},
+		{
+			Name:     "provider layer beats helm tool layer",
+			Raw:      awsHelmBlob,
+			Tool:     errparse.ToolHelm,
+			WantType: awsPermissionType,
+		},
+	})
 }

--- a/services/ctl-api/internal/app/runners/errparse/errparsetest/contract.go
+++ b/services/ctl-api/internal/app/runners/errparse/errparsetest/contract.go
@@ -1,0 +1,113 @@
+// Package errparsetest provides a shared, table-driven contract runner for
+// errparse parsers. It dispatches fixtures through the real default registry
+// (the same path production uses) and enforces the invariants every parser must
+// satisfy: the expected type wins for a given input, and the resulting record
+// survives the GORM persistence round-trip as valid JSON.
+//
+// Overlap and layer-ordering cases are only meaningful when every competing
+// parser is registered, so full-registry contract runs must live in an external
+// test package (for example package aws_test) that blank-imports errparse/all.
+// An internal parser test (package aws) cannot blank-import errparse/all,
+// because all imports every parser package and would form a cycle; run from
+// there it would only see its own parser's registration, making overlap cases
+// pass spuriously. errparsetest itself does not import errparse/all, both to
+// avoid that cycle and to stay usable for parser-local checks.
+package errparsetest
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+// Case is one dispatch expectation. WantType is the discriminator of the
+// composite error that must win for Raw under the given facets; an empty
+// WantType asserts that no parser matches.
+type Case struct {
+	Name     string
+	Raw      string
+	Tool     errparse.Tool
+	Provider errparse.Provider
+	WantType compositeerrors.Type
+}
+
+// Run dispatches each case through the default registry and asserts the winning
+// type, then that the record persists and round-trips as valid JSON. Overlap
+// and layer-ordering expectations are expressed by giving the same input a
+// WantType of whichever parser must win.
+func Run(t *testing.T, cases []Case) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			pc := &errparse.ParseContext{Raw: tc.Raw, Tool: tc.Tool}
+			if tc.Provider != errparse.ProviderUnknown {
+				provider := tc.Provider
+				pc.ResolveProvider = func() errparse.Provider { return provider }
+			}
+
+			ce := errparse.Parse(pc)
+			if tc.WantType == "" {
+				if ce != nil {
+					t.Fatalf("expected no match, got %T (type %q)", ce, ce.Type())
+				}
+				return
+			}
+			if ce == nil {
+				t.Fatalf("expected type %q, got no match", tc.WantType)
+			}
+			if ce.Type() != tc.WantType {
+				t.Fatalf("winning type = %q, want %q (parser %T)", ce.Type(), tc.WantType, ce)
+			}
+
+			assertPersistable(t, ce)
+		})
+	}
+}
+
+// assertPersistable checks the composite error can be frozen into a record and
+// survive the driver.Valuer / sql.Scanner round-trip GORM uses for the jsonb
+// column, with its discriminator and typed payload intact. It compares payloads
+// by bytes in both directions so a dropped or altered payload (e.g. a "data":
+// null record that still carries the right type) cannot slip through.
+func assertPersistable(t *testing.T, ce compositeerrors.CompositeError) {
+	t.Helper()
+
+	rec, err := compositeerrors.New(ce)
+	if err != nil {
+		t.Fatalf("compositeerrors.New(%T): %v", ce, err)
+	}
+
+	wantData, err := json.Marshal(ce)
+	if err != nil {
+		t.Fatalf("marshal %T payload: %v", ce, err)
+	}
+	if !bytes.Equal(rec.Data, wantData) {
+		t.Fatalf("record Data = %s, want %s", rec.Data, wantData)
+	}
+
+	val, err := rec.Value()
+	if err != nil {
+		t.Fatalf("Value(): %v", err)
+	}
+	raw, ok := val.([]byte)
+	if !ok {
+		t.Fatalf("Value() returned %T, want []byte", val)
+	}
+	if !json.Valid(raw) {
+		t.Fatalf("persisted record is not valid JSON: %s", raw)
+	}
+
+	var round compositeerrors.CompositeErrorData
+	if err := round.Scan(raw); err != nil {
+		t.Fatalf("Scan(): %v", err)
+	}
+	if round.Type != ce.Type() {
+		t.Fatalf("round-trip type = %q, want %q", round.Type, ce.Type())
+	}
+	if !bytes.Equal(round.Data, rec.Data) {
+		t.Fatalf("round-trip Data = %s, want %s", round.Data, rec.Data)
+	}
+}

--- a/services/ctl-api/internal/app/runners/service/create_runner_job_execution_result.go
+++ b/services/ctl-api/internal/app/runners/service/create_runner_job_execution_result.go
@@ -16,10 +16,7 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse"
-	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/aws"       // register AWS provider-layer parsers
-	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/generic"   // register the generic fallback parser
-	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/helm"      // register helm tool-layer parsers
-	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/terraform" // register terraform tool-layer parsers
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/all" // register all errparse parsers
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
 )


### PR DESCRIPTION
## What

Two self-contained hardening changes to the composite-error parsing layer (`errparse`). No runtime behavior changes.

**1. Central import manifest (`errparse/all`)** — a single blank-import point for every parser package. The runner-result chokepoint and the dispatch tests now import this one manifest instead of listing parsers individually, so prod and test can't drift on which parsers are registered. Adding a parser touches one place.

**2. Contract test runner (`errparsetest`)** — a table-driven runner that dispatches fixtures through the real registry and asserts both the winning `Type()` and that the record survives the GORM jsonb round-trip (`New` → `Value` → `Scan`). Closes a gap where the old tests checked the winning type but never that the error actually persists. The dispatch integration test is rewritten as one declarative case table.

## Testing

- `go test ./services/ctl-api/internal/app/runners/errparse/... ./services/ctl-api/internal/app/runners/service/...`
- Verified the contract has teeth: dropping a parser from the manifest fails the test.