### PR TITLE
refactor: (ctl-api) add declarative errparse parser builder

### DIFF
--- a/services/ctl-api/internal/app/runners/errparse/aws/permission.go
+++ b/services/ctl-api/internal/app/runners/errparse/aws/permission.go
@@ -141,38 +141,9 @@ var awsPermissionPatterns = []*regexp.Regexp{
 	),
 }
 
-// permissionParser recognises AWS IAM permission failures in a runner job's
-// raw output.
-type permissionParser struct{}
-
-func (permissionParser) Layer() errparse.Layer { return errparse.LayerProvider }
-
-// Tools is nil (tool-agnostic): an AWS IAM denial is a provider-level failure
-// that surfaces across tools, such as terraform and pulumi provisioning or an
-// ECR push from a docker/oci build, so it must not be bucketed to a single
-// tool. The AWS signals plus the provider check in Applicable are the real
-// gates.
-func (permissionParser) Tools() []errparse.Tool { return nil }
-func (permissionParser) Signals() []string {
-	return []string{
-		"AccessDenied",
-		"UnauthorizedOperation",
-		"not authorized to perform",
-		"AuthorizationError",
-	}
-}
-
-// Applicable gates on the cloud provider, failing open on unknown.
-func (permissionParser) Applicable(ctx *errparse.ParseContext) bool {
-	switch ctx.Provider() {
-	case errparse.ProviderAWS, errparse.ProviderUnknown:
-		return true
-	default:
-		return false
-	}
-}
-
-func (permissionParser) Parse(ctx *errparse.ParseContext) compositeerrors.CompositeError {
+// parsePermission recognises AWS IAM permission failures in a runner job's raw
+// output.
+func parsePermission(ctx *errparse.ParseContext) compositeerrors.CompositeError {
 	raw := ctx.Raw
 	for _, re := range awsPermissionPatterns {
 		match := re.FindStringSubmatch(raw)
@@ -196,8 +167,20 @@ func (permissionParser) Parse(ctx *errparse.ParseContext) compositeerrors.Compos
 	return nil
 }
 
+// An AWS IAM denial is a provider-level failure that surfaces across tools
+// (terraform and pulumi provisioning, an ECR push from a docker/oci build), so
+// the parser is registered tool-agnostic; the AWS signals plus the provider
+// gate are the real filters.
 func init() {
-	errparse.Register(permissionParser{})
+	errparse.Register(errparse.NewParser(errparse.LayerProvider, parsePermission,
+		errparse.WithSignals(
+			"AccessDenied",
+			"UnauthorizedOperation",
+			"not authorized to perform",
+			"AuthorizationError",
+		),
+		errparse.WithProviders(errparse.ProviderAWS),
+	))
 }
 
 func groupMap(re *regexp.Regexp, match []string) map[string]string {

--- a/services/ctl-api/internal/app/runners/errparse/aws/permission_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/aws/permission_test.go
@@ -22,7 +22,7 @@ func readFixture(t *testing.T, name string) string {
 // parse runs the permission parser directly against raw text, the way the
 // registry would once its signal gate passes.
 func parse(raw string) compositeerrors.CompositeError {
-	return permissionParser{}.Parse(&errparse.ParseContext{Raw: raw})
+	return parsePermission(&errparse.ParseContext{Raw: raw})
 }
 
 func TestParse_AccessDenied(t *testing.T) {

--- a/services/ctl-api/internal/app/runners/errparse/builder.go
+++ b/services/ctl-api/internal/app/runners/errparse/builder.go
@@ -1,0 +1,140 @@
+package errparse
+
+import (
+	"slices"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+// ParserFunc is the core recognise-and-classify behaviour of a parser: it
+// attempts to produce a typed error from ctx, or returns nil to defer to the
+// next candidate.
+type ParserFunc func(*ParseContext) compositeerrors.CompositeError
+
+// NewParser builds a Parser from its layer and parse behaviour plus optional
+// facets. It covers the common case where a parser's gating is static, so a
+// parser package registers a free function instead of a bespoke type with five
+// one-line methods.
+//
+// The registration models a three-stage candidate pipeline (cheapest first),
+// with layer as the tiebreak once several parsers match:
+//
+//	WithTools      structural bucket, considered before any text scan
+//	WithSignals /  substrings that must be present (one cheap scan), or
+//	AlwaysCandidate opt out of signal gating (the generic fallback)
+//	WithProviders  lazy provider gate applied after a signal match
+//	layer          precedence when several parsers still match
+//
+// layer and parse are required: there is no safe zero value for layer (the zero
+// Layer is LayerProvider) and a nil parse panics. Exactly one of WithSignals or
+// AlwaysCandidate must be given, so a parser that simply forgot its signals is
+// rejected rather than silently running against every job.
+//
+// The Parser interface remains the underlying contract; implement it directly
+// when a parser must hold state or gate on facets these options do not cover
+// (Operation, Group, Owner).
+func NewParser(layer Layer, parse ParserFunc, opts ...Option) Parser {
+	if parse == nil {
+		panic("errparse: NewParser called with nil parse func")
+	}
+	p := &builtParser{layer: layer, parse: parse}
+	for _, opt := range opts {
+		if opt == nil {
+			panic("errparse: NewParser called with a nil Option")
+		}
+		opt(p)
+	}
+	if p.alwaysCandidate == p.signalsSet {
+		panic("errparse: parser must set exactly one of WithSignals or AlwaysCandidate")
+	}
+	return p
+}
+
+// Option customizes a Parser built by NewParser.
+type Option func(*builtParser)
+
+// WithTools restricts the parser to the given execution tools, so it is never
+// considered for a job run by another tool. With no WithTools the parser is
+// tool-agnostic (considered for every job).
+func WithTools(tools ...Tool) Option {
+	cloned := slices.Clone(tools)
+	return func(p *builtParser) { p.tools = cloned }
+}
+
+// WithSignals gates the parser on substrings that must be present in the raw
+// text; the parser's Parse only runs once one is found. At least one signal is
+// required (use AlwaysCandidate for a deliberately signal-less parser).
+func WithSignals(signals ...string) Option {
+	if len(signals) == 0 {
+		panic("errparse: WithSignals called with no signals (use AlwaysCandidate for a signal-less parser)")
+	}
+	cloned := slices.Clone(signals)
+	return func(p *builtParser) {
+		p.signals = cloned
+		p.signalsSet = true
+	}
+}
+
+// AlwaysCandidate opts the parser out of signal gating so it is a candidate for
+// every job. It exists for the generic fallback; a normal parser should gate on
+// WithSignals so it is not run against unrelated failures.
+func AlwaysCandidate() Option {
+	return func(p *builtParser) { p.alwaysCandidate = true }
+}
+
+// WithProviders gates the parser on the cloud provider the job targeted. The
+// gate is applied after a signal match (provider resolution is a lazy lookup)
+// and fails open: a job whose provider cannot be resolved still passes, so
+// provider gating is only ever a false-positive guard. Passing no providers or
+// ProviderUnknown is a configuration mistake and panics.
+func WithProviders(providers ...Provider) Option {
+	if len(providers) == 0 {
+		panic("errparse: WithProviders called with no providers")
+	}
+	for _, pr := range providers {
+		if pr == ProviderUnknown {
+			panic("errparse: WithProviders called with ProviderUnknown (an unresolved provider already fails open)")
+		}
+	}
+	cloned := slices.Clone(providers)
+	return func(p *builtParser) { p.providers = cloned }
+}
+
+// builtParser is the Parser implementation backing NewParser.
+type builtParser struct {
+	layer     Layer
+	tools     []Tool
+	signals   []string
+	providers []Provider
+	parse     ParserFunc
+
+	// signalsSet and alwaysCandidate record which signal-gating option was
+	// chosen so NewParser can require exactly one. An empty signals slice is
+	// otherwise ambiguous between "forgot signals" and "deliberately none".
+	signalsSet      bool
+	alwaysCandidate bool
+}
+
+var _ Parser = (*builtParser)(nil)
+
+func (p *builtParser) Layer() Layer      { return p.layer }
+func (p *builtParser) Tools() []Tool     { return p.tools }
+func (p *builtParser) Signals() []string { return p.signals }
+
+// Applicable applies the declared provider gate, failing open on an
+// unresolved provider so the fail-open contract lives in one place instead of
+// being hand-rolled by every parser.
+func (p *builtParser) Applicable(ctx *ParseContext) bool {
+	if len(p.providers) == 0 {
+		return true
+	}
+	provider := ctx.Provider()
+	if provider == ProviderUnknown {
+		return true
+	}
+	return slices.Contains(p.providers, provider)
+}
+
+func (p *builtParser) Parse(ctx *ParseContext) compositeerrors.CompositeError {
+	return p.parse(ctx)
+}

--- a/services/ctl-api/internal/app/runners/errparse/builder_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/builder_test.go
@@ -1,0 +1,90 @@
+package errparse
+
+import (
+	"testing"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+func nilParse(*ParseContext) compositeerrors.CompositeError { return nil }
+
+func TestNewParser_Defaults(t *testing.T) {
+	p := NewParser(LayerTool, nilParse, WithSignals("boom"))
+
+	if p.Layer() != LayerTool {
+		t.Errorf("layer = %d, want %d", p.Layer(), LayerTool)
+	}
+	if p.Tools() != nil {
+		t.Errorf("tools = %v, want nil (tool-agnostic)", p.Tools())
+	}
+	if got := p.Signals(); len(got) != 1 || got[0] != "boom" {
+		t.Errorf("signals = %v", got)
+	}
+	if !p.Applicable(&ParseContext{}) {
+		t.Error("Applicable should default to true when no providers are set")
+	}
+}
+
+func TestNewParser_AlwaysCandidate(t *testing.T) {
+	p := NewParser(LayerGeneric, nilParse, AlwaysCandidate())
+	if p.Signals() != nil {
+		t.Errorf("signals = %v, want nil for an always-candidate parser", p.Signals())
+	}
+}
+
+func TestNewParser_ProviderGate(t *testing.T) {
+	p := NewParser(LayerProvider, nilParse, WithSignals("boom"), WithProviders(ProviderAWS))
+
+	cases := []struct {
+		provider Provider
+		want     bool
+	}{
+		{ProviderAWS, true},
+		{ProviderUnknown, true}, // fails open
+		{ProviderAzure, false},
+		{ProviderGCP, false},
+	}
+	for _, tc := range cases {
+		ctx := &ParseContext{ResolveProvider: func() Provider { return tc.provider }}
+		if got := p.Applicable(ctx); got != tc.want {
+			t.Errorf("Applicable(provider=%q) = %v, want %v", tc.provider, got, tc.want)
+		}
+	}
+}
+
+func TestNewParser_ProviderGateNotResolvedWithoutCall(t *testing.T) {
+	// A parser with no provider gate must never trigger provider resolution.
+	resolved := false
+	p := NewParser(LayerTool, nilParse, WithSignals("boom"))
+	ctx := &ParseContext{ResolveProvider: func() Provider { resolved = true; return ProviderAWS }}
+	if !p.Applicable(ctx) {
+		t.Error("expected always-applicable without a provider gate")
+	}
+	if resolved {
+		t.Error("provider resolver called for a parser with no provider gate")
+	}
+}
+
+func TestNewParser_Panics(t *testing.T) {
+	cases := map[string]func(){
+		"nil parse":        func() { NewParser(LayerTool, nil, WithSignals("x")) },
+		"no signal choice": func() { NewParser(LayerTool, nilParse) },
+		"both signal choices": func() {
+			NewParser(LayerTool, nilParse, WithSignals("x"), AlwaysCandidate())
+		},
+		"empty signals":    func() { WithSignals() },
+		"empty providers":  func() { WithProviders() },
+		"unknown provider": func() { WithProviders(ProviderUnknown) },
+		"nil option":       func() { NewParser(LayerTool, nilParse, nil) },
+	}
+	for name, fn := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("expected panic for %q", name)
+				}
+			}()
+			fn()
+		})
+	}
+}

--- a/services/ctl-api/internal/app/runners/errparse/generic/generic.go
+++ b/services/ctl-api/internal/app/runners/errparse/generic/generic.go
@@ -58,17 +58,10 @@ func (e *GenericError) Sections() []compositeerrors.Section {
 	}
 }
 
-// genericParser is the tool-agnostic, always-candidate fallback. It has no
-// signals (always a candidate) and no tools (considered for every job), and
-// sits at LayerGeneric so specific parsers always win.
-type genericParser struct{}
-
-func (genericParser) Layer() errparse.Layer                  { return errparse.LayerGeneric }
-func (genericParser) Tools() []errparse.Tool                 { return nil }
-func (genericParser) Signals() []string                      { return nil }
-func (genericParser) Applicable(*errparse.ParseContext) bool { return true }
-
-func (genericParser) Parse(ctx *errparse.ParseContext) compositeerrors.CompositeError {
+// parseGeneric is the tool-agnostic, always-candidate fallback. Registered with
+// no signals (always a candidate) and no tools (considered for every job) at
+// LayerGeneric, so specific parsers always win.
+func parseGeneric(ctx *errparse.ParseContext) compositeerrors.CompositeError {
 	body := cleanBody(ctx.Raw)
 	if body == "" {
 		return nil
@@ -77,7 +70,9 @@ func (genericParser) Parse(ctx *errparse.ParseContext) compositeerrors.Composite
 }
 
 func init() {
-	errparse.Register(genericParser{})
+	errparse.Register(errparse.NewParser(errparse.LayerGeneric, parseGeneric,
+		errparse.AlwaysCandidate(),
+	))
 }
 
 // cleanBody normalises raw error output for display: it strips the terraform

--- a/services/ctl-api/internal/app/runners/errparse/generic/generic_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/generic/generic_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func parse(raw string) compositeerrors.CompositeError {
-	return genericParser{}.Parse(&errparse.ParseContext{Raw: raw})
+	return parseGeneric(&errparse.ParseContext{Raw: raw})
 }
 
 func TestParse_SingleLine(t *testing.T) {

--- a/services/ctl-api/internal/app/runners/errparse/helm/error.go
+++ b/services/ctl-api/internal/app/runners/errparse/helm/error.go
@@ -159,19 +159,14 @@ func (e *HelmError) Sections() []compositeerrors.Section {
 	}
 }
 
-// errorParser recognises helm failures in a helm job's raw output.
-type errorParser struct{}
-
-func (errorParser) Layer() errparse.Layer  { return errparse.LayerTool }
-func (errorParser) Tools() []errparse.Tool { return []errparse.Tool{errparse.ToolHelm} }
-
-func (errorParser) Signals() []string {
+// signals gates the parser on the runner wrapper prefixes plus the verified SDK
+// cause substrings.
+func signals() []string {
 	return append(append([]string{}, wrappers...), causes...)
 }
 
-func (errorParser) Applicable(*errparse.ParseContext) bool { return true }
-
-func (errorParser) Parse(ctx *errparse.ParseContext) compositeerrors.CompositeError {
+// parseError recognises helm failures in a helm job's raw output.
+func parseError(ctx *errparse.ParseContext) compositeerrors.CompositeError {
 	lines := cleanedLines(ctx.Raw)
 
 	summary := wrapperSummary(lines)
@@ -203,7 +198,10 @@ func (errorParser) Parse(ctx *errparse.ParseContext) compositeerrors.CompositeEr
 }
 
 func init() {
-	errparse.Register(errorParser{})
+	errparse.Register(errparse.NewParser(errparse.LayerTool, parseError,
+		errparse.WithTools(errparse.ToolHelm),
+		errparse.WithSignals(signals()...),
+	))
 }
 
 // wrapperSummary returns the SDK error that follows the runner's helm wrapper on

--- a/services/ctl-api/internal/app/runners/errparse/helm/error_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/helm/error_test.go
@@ -20,7 +20,7 @@ func readFixture(t *testing.T, name string) string {
 }
 
 func parse(raw string) compositeerrors.CompositeError {
-	return errorParser{}.Parse(&errparse.ParseContext{Raw: raw})
+	return parseError(&errparse.ParseContext{Raw: raw})
 }
 
 func helmErr(t *testing.T, ce compositeerrors.CompositeError) *HelmError {

--- a/services/ctl-api/internal/app/runners/errparse/terraform/error.go
+++ b/services/ctl-api/internal/app/runners/errparse/terraform/error.go
@@ -74,20 +74,11 @@ func (e *TerraformError) Sections() []compositeerrors.Section {
 	return sections
 }
 
-// errorParser recognises terraform "Error:" diagnostics in a terraform job's
-// raw output.
-type errorParser struct{}
-
-func (errorParser) Layer() errparse.Layer  { return errparse.LayerTool }
-func (errorParser) Tools() []errparse.Tool { return []errparse.Tool{errparse.ToolTerraform} }
-
-// Signals gates on the presence of a terraform diagnostic. "Error:" is broad,
-// but the parser is already bucketed to terraform jobs, where its presence
-// reliably marks a diagnostic block.
-func (errorParser) Signals() []string                      { return []string{"Error:"} }
-func (errorParser) Applicable(*errparse.ParseContext) bool { return true }
-
-func (errorParser) Parse(ctx *errparse.ParseContext) compositeerrors.CompositeError {
+// parseError recognises terraform "Error:" diagnostics in a terraform job's raw
+// output. It is registered at LayerTool and gated to terraform jobs by the
+// "Error:" signal; that signal is broad, but the parser only ever runs on
+// terraform jobs where its presence reliably marks a diagnostic block.
+func parseError(ctx *errparse.ParseContext) compositeerrors.CompositeError {
 	lines := cleanedLines(ctx.Raw)
 	summaries := errorSummaries(lines)
 	if len(summaries) == 0 {
@@ -107,7 +98,10 @@ func (errorParser) Parse(ctx *errparse.ParseContext) compositeerrors.CompositeEr
 }
 
 func init() {
-	errparse.Register(errorParser{})
+	errparse.Register(errparse.NewParser(errparse.LayerTool, parseError,
+		errparse.WithTools(errparse.ToolTerraform),
+		errparse.WithSignals("Error:"),
+	))
 }
 
 // errorSummaries returns the distinct text following each terraform "Error:"

--- a/services/ctl-api/internal/app/runners/errparse/terraform/error_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/terraform/error_test.go
@@ -20,7 +20,7 @@ func readFixture(t *testing.T, name string) string {
 }
 
 func parse(raw string) compositeerrors.CompositeError {
-	return errorParser{}.Parse(&errparse.ParseContext{Raw: raw})
+	return parseError(&errparse.ParseContext{Raw: raw})
 }
 
 func TestParse_SingleError(t *testing.T) {

--- a/services/ctl-api/internal/app/runners/errparse/terraform/state_lock.go
+++ b/services/ctl-api/internal/app/runners/errparse/terraform/state_lock.go
@@ -56,17 +56,11 @@ func (e *StateLockError) Sections() []compositeerrors.Section {
 	return sections
 }
 
-// stateLockParser recognises a terraform state-lock failure and yields a
-// dedicated composite error. It registers independently of the terraform
-// catch-all so the two classifiers stay decoupled.
-type stateLockParser struct{}
-
-func (stateLockParser) Layer() errparse.Layer                  { return errparse.LayerToolSpecific }
-func (stateLockParser) Tools() []errparse.Tool                 { return []errparse.Tool{errparse.ToolTerraform} }
-func (stateLockParser) Signals() []string                      { return []string{stateLockSignal} }
-func (stateLockParser) Applicable(*errparse.ParseContext) bool { return true }
-
-func (stateLockParser) Parse(ctx *errparse.ParseContext) compositeerrors.CompositeError {
+// parseStateLock recognises a terraform state-lock failure and yields a
+// dedicated composite error. It registers at LayerToolSpecific, independently of
+// the terraform catch-all, so the two classifiers stay decoupled and the more
+// specific state-lock parser wins the tie.
+func parseStateLock(ctx *errparse.ParseContext) compositeerrors.CompositeError {
 	lines := cleanedLines(ctx.Raw)
 	if !containsStateLock(lines) {
 		return nil
@@ -78,7 +72,10 @@ func (stateLockParser) Parse(ctx *errparse.ParseContext) compositeerrors.Composi
 }
 
 func init() {
-	errparse.Register(stateLockParser{})
+	errparse.Register(errparse.NewParser(errparse.LayerToolSpecific, parseStateLock,
+		errparse.WithTools(errparse.ToolTerraform),
+		errparse.WithSignals(stateLockSignal),
+	))
 }
 
 // containsStateLock reports whether any cleaned line carries the state-lock

--- a/services/ctl-api/internal/app/runners/errparse/terraform/state_lock_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/terraform/state_lock_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
 )
 
-func parseStateLock(raw string) compositeerrors.CompositeError {
-	return stateLockParser{}.Parse(&errparse.ParseContext{Raw: raw})
+func parseStateLockRaw(raw string) compositeerrors.CompositeError {
+	return parseStateLock(&errparse.ParseContext{Raw: raw})
 }
 
 func TestParse_StateLock(t *testing.T) {
-	ce := parseStateLock(readFixture(t, "state_lock.txt"))
+	ce := parseStateLockRaw(readFixture(t, "state_lock.txt"))
 	if ce == nil {
 		t.Fatal("expected a composite error, got nil")
 	}
@@ -63,7 +63,7 @@ func TestParse_StateLock(t *testing.T) {
 // not swallow a normal terraform diagnostic.
 func TestParse_OrdinaryErrorIsNotStateLock(t *testing.T) {
 	raw := readFixture(t, "invalid_reference.txt")
-	if ce := parseStateLock(raw); ce != nil {
+	if ce := parseStateLockRaw(raw); ce != nil {
 		t.Fatalf("state-lock parser must defer on an ordinary error, got %T", ce)
 	}
 	if _, ok := parse(raw).(*TerraformError); !ok {


### PR DESCRIPTION
Replace each parser's bespoke 5-method struct with `NewParser(layer, parse, ...opts)`, a builder covering the common case where gating is static. Each parser package now registers a free parseX function instead of a type with five one-line methods.

Gating is declarative and cost-ordered: `WithTools` (structural bucket), `WithSignals` / `AlwaysCandidate` (cheap text prefilter, exactly one required), `WithProviders` (lazy provider gate). The provider gate centralizes the fail-open-on-unknown rule that every parser previously hand-rolled, so it can no longer be forgotten. `NewParser` panics on init-time misuse (nil parse, no signal choice, empty/unknown providers).

The `Parser` interface stays the underlying contract for genuinely stateful parsers or gating these options do not cover.