### PR TITLE
refactor: (ctl-api) sort errparse candidates before gating

### DIFF
--- a/services/ctl-api/internal/app/runners/errparse/registry.go
+++ b/services/ctl-api/internal/app/runners/errparse/registry.go
@@ -169,23 +169,25 @@ func (r *Registry) Parse(ctx *ParseContext) compositeerrors.CompositeError {
 		collect(r.all)
 	}
 
-	applicable := candidates[:0]
-	for _, idx := range candidates {
-		if r.parsers[idx].Applicable(ctx) {
-			applicable = append(applicable, idx)
-		}
-	}
-
-	sort.SliceStable(applicable, func(i, j int) bool {
-		li, lj := r.parsers[applicable[i]].Layer(), r.parsers[applicable[j]].Layer()
+	// Order candidates by layer (then registration order) up front, then check
+	// Applicable and Parse in that order so the most specific parser is
+	// consulted first. Evaluating the gates lazily in priority order means a
+	// higher-priority match short-circuits every lower-priority parser,
+	// including any lazy provider lookup their Applicable would trigger.
+	sort.SliceStable(candidates, func(i, j int) bool {
+		li, lj := r.parsers[candidates[i]].Layer(), r.parsers[candidates[j]].Layer()
 		if li != lj {
 			return li < lj
 		}
-		return applicable[i] < applicable[j]
+		return candidates[i] < candidates[j]
 	})
 
-	for _, idx := range applicable {
-		if ce := r.parsers[idx].Parse(ctx); ce != nil {
+	for _, idx := range candidates {
+		p := r.parsers[idx]
+		if !p.Applicable(ctx) {
+			continue
+		}
+		if ce := p.Parse(ctx); ce != nil {
 			return ce
 		}
 	}

--- a/services/ctl-api/internal/app/runners/errparse/registry_test.go
+++ b/services/ctl-api/internal/app/runners/errparse/registry_test.go
@@ -131,6 +131,33 @@ func TestRegistry_SameLayerTieBreakByRegistrationOrder(t *testing.T) {
 	}
 }
 
+// TestRegistry_HigherLayerSkipsLowerProviderGate proves the dispatch order:
+// candidates are consulted in layer order, so a higher-priority match returns
+// before any lower-priority parser's Applicable runs. A provider-gated parser
+// below the winner therefore never triggers its lazy provider lookup.
+func TestRegistry_HigherLayerSkipsLowerProviderGate(t *testing.T) {
+	resolved := 0
+	r := &Registry{}
+	// Winner: higher priority (lower layer number), no provider gate.
+	r.Register(fakeParser{id: "winner", layer: LayerToolSpecific, tools: []Tool{ToolTerraform}, signals: []string{"boom"}, applicable: true})
+	// Lower priority, provider-gated: its Applicable would resolve the provider.
+	r.Register(NewParser(LayerTool, func(*ParseContext) compositeerrors.CompositeError { return fakeError{id: "loser"} },
+		WithSignals("boom"), WithProviders(ProviderAWS)))
+
+	ctx := &ParseContext{
+		Raw:             "boom",
+		Tool:            ToolTerraform,
+		ResolveProvider: func() Provider { resolved++; return ProviderAWS },
+	}
+	ce := r.Parse(ctx)
+	if ce == nil || ce.Error() != "winner" {
+		t.Fatalf("expected winner, got %v", ce)
+	}
+	if resolved != 0 {
+		t.Errorf("provider resolved %d times; a higher-layer match must skip the lower provider gate", resolved)
+	}
+}
+
 func TestRegister_PanicsAfterBuild(t *testing.T) {
 	r := &Registry{}
 	r.Register(fakeParser{id: "p", layer: LayerProvider, tools: []Tool{ToolTerraform}, signals: []string{"boom"}, applicable: true})


### PR DESCRIPTION
Dispatch previously ran every matched candidate's Applicable to filter, then sorted, then parsed. Sort candidates by layer (then registration order) first and evaluate Applicable and Parse lazily in that order, so a higher-priority match short-circuits every lower-priority parser, including any lazy provider lookup their Applicable would trigger. Behavior is otherwise unchanged: the winner is still the most specific applicable parser that produces a match.

Add a test proving a higher-layer match skips a lower-layer provider-gated parser's provider resolution.