### PR TITLE
fix: stack provider fixes

### DIFF
--- a/sdks/stack/internal/core/config_aws.go
+++ b/sdks/stack/internal/core/config_aws.go
@@ -12,6 +12,10 @@ type AWSConfig struct {
 	// getClusterName: install input "cluster_name" if set, else install_id.
 	ClusterName string `json:"cluster_name,omitempty"`
 
+	// RunnerMachineType is the EC2 instance type for the runner host, from the
+	// app runner config (default per platform). Nuon-generated, not customer-set.
+	RunnerMachineType string `json:"runner_machine_type,omitempty"`
+
 	// NuonSupportIAMRoleARNs lists Nuon control-plane IAM role ARNs that may
 	// assume the operation roles. Empty falls back to the customer's account
 	// root, matching the TF module's control_plane_assume default.

--- a/services/ctl-api/internal/app/installer_sdk_config.go
+++ b/services/ctl-api/internal/app/installer_sdk_config.go
@@ -28,8 +28,9 @@ type InstallerSDKConfig struct {
 
 // InstallerSDKAWSConfig mirrors sdks/stack core.AWSConfig.
 type InstallerSDKAWSConfig struct {
-	Region      string `json:"region,omitempty"`
-	ClusterName string `json:"cluster_name,omitempty"`
+	Region            string `json:"region,omitempty"`
+	ClusterName       string `json:"cluster_name,omitempty"`
+	RunnerMachineType string `json:"runner_machine_type,omitempty"`
 
 	NuonSupportIAMRoleARNs []string `json:"nuon_support_iam_role_arns,omitempty"`
 
@@ -57,6 +58,7 @@ type InstallerSDKGCPConfig struct {
 	// provision time via the CLI. ctl-api only emits the Nuon-generated inputs.
 	RunnerInitScriptURL string `json:"runner_init_script_url,omitempty"`
 	RunnerAPIToken      string `json:"runner_api_token,omitempty"`
+	RunnerMachineType   string `json:"runner_machine_type,omitempty"`
 
 	ProvisionPermissions      []string `json:"provision_permissions,omitempty"`
 	ProvisionPredefinedRole   string   `json:"provision_predefined_role,omitempty"`

--- a/services/ctl-api/internal/app/installs/service/build_installer_sdk_config.go
+++ b/services/ctl-api/internal/app/installs/service/build_installer_sdk_config.go
@@ -122,6 +122,14 @@ func (s *service) buildInstallerSDKConfig(ctx context.Context, installID string)
 		Secrets:             secrets,
 	}
 
+	// Runner machine/instance type from the app runner config, falling back to
+	// the platform default — mirrors generate_install_stack_version's classic
+	// tfvars path so both flows resolve the same type.
+	instanceType := appCfg.RunnerConfig.InstanceType
+	if instanceType == "" {
+		instanceType = app.DefaultInstanceTypeForPlatform(appCfg.RunnerConfig.CloudPlatform)
+	}
+
 	switch appCfg.RunnerConfig.Type {
 	case app.AppRunnerTypeAWS:
 		if install.AWSAccount == nil || install.AWSAccount.Region == "" {
@@ -162,8 +170,9 @@ func (s *service) buildInstallerSDKConfig(ctx context.Context, installID string)
 
 		cfg.Cloud = "aws"
 		cfg.AWS = &app.InstallerSDKAWSConfig{
-			Region:      install.AWSAccount.Region,
-			ClusterName: clusterName,
+			Region:            install.AWSAccount.Region,
+			ClusterName:       clusterName,
+			RunnerMachineType: instanceType,
 
 			NuonSupportIAMRoleARNs: supportARNs,
 
@@ -204,6 +213,7 @@ func (s *service) buildInstallerSDKConfig(ctx context.Context, installID string)
 		cfg.GCP = &app.InstallerSDKGCPConfig{
 			RunnerInitScriptURL: initScriptURL,
 			RunnerAPIToken:      token.Token,
+			RunnerMachineType:   instanceType,
 
 			ProvisionPermissions:      prov.Permissions,
 			ProvisionPredefinedRole:   prov.PredefinedRole,

--- a/services/ctl-api/internal/app/installs/service/get_install_stack_version_config.go
+++ b/services/ctl-api/internal/app/installs/service/get_install_stack_version_config.go
@@ -58,19 +58,22 @@ func (s *service) GetInstallStackVersionConfig(ctx *gin.Context) {
 	}
 	cfg.PhoneHomeURL = stackVersion.PhoneHomeURL
 
-	// Merge the install's latest stored input values: a missing inputs row is
-	// not an error.
+	// Fill in the install's latest stored values for the customer-source inputs
+	// that buildInstallerSDKConfig already seeded (names with empty values). Only
+	// update existing keys — vendor-source inputs are intentionally excluded from
+	// install_inputs, matching the classic tfvars renderer. A missing inputs row
+	// is not an error.
 	var ins app.InstallInputs
 	if err := s.db.WithContext(reqCtx).
 		Where(app.InstallInputs{InstallID: stackVersion.InstallID}).
 		Order("created_at DESC").
 		Limit(1).
 		First(&ins).Error; err == nil {
-		if cfg.InstallInputs == nil {
-			cfg.InstallInputs = map[string]string{}
-		}
 		for k, v := range ins.Values {
-			if v != nil {
+			if v == nil {
+				continue
+			}
+			if _, ok := cfg.InstallInputs[k]; ok {
 				cfg.InstallInputs[k] = *v
 			}
 		}


### PR DESCRIPTION
## Summary

A couple small fixes from testing the new install stacks using the stack provider.

- Vendor-sourced inputs were being read by the stack sdk and sent back in the stack outputs. This doesn't cause any problems but is unecessary.
- The runner machine type was not being sent in the stack config. The templates were falling back on the default for their platforms.