### PR TITLE
fix: raise deadlock timeout in signal test suites to stop CI flake

### DIFF
--- a/services/ctl-api/internal/app/apps/signals/branches/appconfig/signal_test.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/appconfig/signal_test.go
@@ -3,10 +3,12 @@ package appconfig
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
 
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -25,6 +27,11 @@ func TestAppConfigSignalSuite(t *testing.T) {
 
 func (s *AppConfigSignalTestSuite) SetupTest() {
 	s.env = s.NewTestWorkflowEnvironment()
+	// Give the deadlock detector generous headroom so loaded CI runners don't
+	// false-positive on the 1s default while the workflow goroutine runs.
+	s.env.SetWorkerOptions(worker.Options{
+		DeadlockDetectionTimeout: time.Minute,
+	})
 }
 
 func (s *AppConfigSignalTestSuite) AfterTest(suiteName, testName string) {

--- a/services/ctl-api/internal/app/apps/signals/branches/planinstallgroup/signal_test.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/planinstallgroup/signal_test.go
@@ -2,11 +2,13 @@ package planinstallgroup
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
 
 	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -25,6 +27,11 @@ func TestPlanInstallGroupSuite(t *testing.T) {
 
 func (s *PlanInstallGroupTestSuite) SetupTest() {
 	s.env = s.NewTestWorkflowEnvironment()
+	// Give the deadlock detector generous headroom so loaded CI runners don't
+	// false-positive on the 1s default while the workflow goroutine runs.
+	s.env.SetWorkerOptions(worker.Options{
+		DeadlockDetectionTimeout: time.Minute,
+	})
 
 	// Register activities with string-based names so the test env can match them
 	// when called via method references with primitive (non-struct) arguments.


### PR DESCRIPTION
The `appconfig` and `planinstallgroup` signal test suites intermittently fail on CI with a `[TMPRL1101] Potential deadlock detected` error. It's a false positive: Temporal's test env kills a workflow task if the `root` goroutine runs >1s without yielding, and loaded CI runners occasionally cross that 1s default while running the mock machinery. Bumps `DeadlockDetectionTimeout` to 1m in both suites' `SetupTest`.