### PR TITLE
fix: Surface missing management process warning on runner pages

### DIFF
--- a/services/ctl-api/internal/app/runner.go
+++ b/services/ctl-api/internal/app/runner.go
@@ -141,3 +141,13 @@ func (r *Runner) BeforeCreate(tx *gorm.DB) error {
 
 	return nil
 }
+
+const missingMngProcessWarning = "The management process is not running. Remote restart, upgrade, and shutdown are unavailable until it recovers."
+
+func (r *Runner) AfterQuery(tx *gorm.DB) error {
+	if missing, ok := r.StatusV2.Metadata["missing_mng_process"].(bool); ok && missing {
+		r.Warnings = append(r.Warnings, missingMngProcessWarning)
+	}
+
+	return nil
+}

--- a/services/dashboard-ui/client/components/runners/RunnerStatusBanner/RunnerStatusBanner.stories.tsx
+++ b/services/dashboard-ui/client/components/runners/RunnerStatusBanner/RunnerStatusBanner.stories.tsx
@@ -1,0 +1,18 @@
+export default {
+  title: 'Runners/RunnerStatusBanner',
+}
+
+import { RunnerStatusBanner } from './RunnerStatusBanner'
+
+const mngWarning =
+  'The management process is not running. Remote restart, upgrade, and shutdown are unavailable until it recovers.'
+
+export const Default = () => <RunnerStatusBanner warnings={[mngWarning]} />
+
+export const Multiple = () => (
+  <RunnerStatusBanner
+    warnings={[mngWarning, 'Runner version is behind the configured version.']}
+  />
+)
+
+export const Empty = () => <RunnerStatusBanner warnings={[]} />

--- a/services/dashboard-ui/client/components/runners/RunnerStatusBanner/RunnerStatusBanner.tsx
+++ b/services/dashboard-ui/client/components/runners/RunnerStatusBanner/RunnerStatusBanner.tsx
@@ -1,0 +1,15 @@
+import { Banner } from '@/components/common/Banner'
+
+export const RunnerStatusBanner = ({ warnings }: { warnings?: string[] }) => {
+  if (!warnings?.length) return null
+
+  return (
+    <div className="flex flex-col gap-2">
+      {warnings.map((warning, i) => (
+        <Banner key={i} theme="warn">
+          {warning}
+        </Banner>
+      ))}
+    </div>
+  )
+}

--- a/services/dashboard-ui/client/components/runners/RunnerStatusBanner/RunnerStatusBannerContainer.tsx
+++ b/services/dashboard-ui/client/components/runners/RunnerStatusBanner/RunnerStatusBannerContainer.tsx
@@ -1,0 +1,8 @@
+import { useRunner } from '@/hooks/use-runner'
+import { RunnerStatusBanner } from './RunnerStatusBanner'
+
+export const RunnerStatusBannerContainer = () => {
+  const { runner } = useRunner()
+
+  return <RunnerStatusBanner warnings={runner?.warnings} />
+}

--- a/services/dashboard-ui/client/components/runners/RunnerStatusBanner/index.ts
+++ b/services/dashboard-ui/client/components/runners/RunnerStatusBanner/index.ts
@@ -1,0 +1,2 @@
+export { RunnerStatusBannerContainer as RunnerStatusBanner } from './RunnerStatusBannerContainer'
+export { RunnerStatusBanner as RunnerStatusBannerComponent } from './RunnerStatusBanner'

--- a/services/dashboard-ui/client/views/install/Runner.tsx
+++ b/services/dashboard-ui/client/views/install/Runner.tsx
@@ -9,6 +9,7 @@ import {
   ProcessCardSkeleton,
 } from '@/components/runners/ProcessCard'
 import { RunnerRecentActivity } from '@/components/runners/RunnerRecentActivity'
+import { RunnerStatusBanner } from '@/components/runners/RunnerStatusBanner'
 import { ManagementDropdownContainer } from '@/components/runners/management/ManagementDropdown'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
@@ -64,6 +65,8 @@ const RunnerContent = ({
           <ManagementDropdownContainer isInstallRunner settings={settings} />
         )}
       </div>
+
+      <RunnerStatusBanner />
 
       <Text variant="base" weight="strong">
         Processes

--- a/services/dashboard-ui/client/views/org/BuildRunner.tsx
+++ b/services/dashboard-ui/client/views/org/BuildRunner.tsx
@@ -16,6 +16,7 @@ import {
   ProcessCard,
   ProcessCardSkeleton,
 } from '@/components/runners/ProcessCard'
+import { RunnerStatusBanner } from '@/components/runners/RunnerStatusBanner'
 import { ControlPlaneRecentActivity } from '@/components/runners/ControlPlaneRecentActivity'
 import { RunnerRecentActivity } from '@/components/runners/RunnerRecentActivity'
 import { ManagementDropdownContainer } from '@/components/runners/management/ManagementDropdown'
@@ -146,6 +147,8 @@ export const BuildRunner = () => {
 
           <PageContent>
             <PageSection>
+              <RunnerStatusBanner />
+
               <Text variant="base" weight="strong">
                 Processes
               </Text>


### PR DESCRIPTION
The `runner_healthcheck` signal records `missing_mng_process: true` in a runner's `status_v2.metadata` when an install runner's management (mng) process is gone, but nothing ever surfaced it — the parent status stays "active / runner healthy" and the dashboard rendered no runner-level warning.

Adds a `Runner.AfterQuery` hook that derives a human-readable warning into `warnings[]` from that metadata flag (so the CLI/API/webhooks see it too, always in sync), and renders `runner.warnings[]` as a banner at the top of the install and org build runner views.