### PR TITLE
feat: support Azure managed identity pulling GAR images

### DIFF
--- a/docs/guides/container-image-components.mdx
+++ b/docs/guides/container-image-components.mdx
@@ -160,6 +160,7 @@ section that matches your registry and the deployment kind your customers are us
 | AWS ECR | Self-hosted on GCP | [AWS ECR from a Self-Hosted-on-GCP Customer](#aws-ecr-from-a-self-hosted-on-gcp-customer) |
 | GCP Artifact Registry | Nuon-hosted (AWS) | [GAR for Nuon-hosted (AWS) customers](#gar-for-nuon-hosted-aws-customers) |
 | GCP Artifact Registry | Self-hosted on GCP | [GCP GAR Access](#gcp-gar-access) |
+| GCP Artifact Registry | Self-hosted on Azure | [GAR for Nuon self-hosted (Azure) customers](#gar-for-nuon-self-hosted-azure-customers) |
 
 If you have customers on both deployments, you can set both inputs on the same role or service account. Both modules add the new principals alongside any existing ones.
 
@@ -302,6 +303,39 @@ Requires `nuonco/gar-access/google` version `0.2.0` or later.
 In the customer's component config, set `gcp_gar.service_account_email` to the GAR-access SA email, and set
 `gcp_gar.workload_identity_provider` to the provider path for that customer's AWS account from the module's
 `workload_identity_provider_paths` output.
+
+#### GAR for Nuon self-hosted (Azure) customers
+
+If some of your customers run Nuon self-hosted on Azure, pass each customer's Azure user-assigned managed identity via
+`azure_principals`. You can use it alongside `customer_principals` and `aws_principals`. The module sets up a Workload
+Identity Pool and an OIDC provider per identity — trusting the Entra ID issuer for its tenant — and lets the federated
+identity impersonate the GAR-access SA.
+
+```hcl
+module "nuon_gar_access" {
+  source = "nuonco/gar-access/google"
+
+  project_id          = "<your-gcp-project>"
+  repository_location = "us-central1"
+  repositories        = ["<repo-name>"]
+
+  azure_principals = [
+    {
+      tenant_id    = "<azure-tenant-id>"
+      principal_id = "<managed-identity-principal-id>"
+    },
+  ]
+}
+
+output "azure_workload_identity_provider_paths" {
+  value = module.nuon_gar_access.azure_workload_identity_provider_paths
+}
+```
+
+`principal_id` is the managed identity's principal (object) ID — the `sub` claim Nuon's Azure ctl-api presents. In the
+customer's component config, set `gcp_gar.service_account_email` to the GAR-access SA email, and set
+`gcp_gar.workload_identity_provider` to the provider path for that customer's identity from the module's
+`azure_workload_identity_provider_paths` output.
 
 See the full set of `gcp_gar` fields in the [container-image config reference](/config-ref/container-image#gcp_gar).
 

--- a/services/ctl-api/internal/app/components/worker/activities/fetch_image_metadata.go
+++ b/services/ctl-api/internal/app/components/worker/activities/fetch_image_metadata.go
@@ -15,7 +15,6 @@ import (
 	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
-	"golang.org/x/oauth2/google"
 )
 
 type FetchImageMetadataRequest struct {
@@ -136,21 +135,19 @@ func (a *Activities) getACRAuth(ctx context.Context, acrCfg *app.AzureACRImageCo
 }
 
 func (a *Activities) getGARAuth(ctx context.Context, garCfg *app.GCPGARImageConfig) (*metadata.RegistryAuth, error) {
-	ts, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	tok, err := a.GetGARAccessToken(ctx, &GetGARAccessTokenRequest{
+		ServiceAccountEmail:      garCfg.ServiceAccountEmail,
+		WorkloadIdentityProvider: garCfg.WorkloadIdentityProvider,
+	})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to get GCP token source for GAR")
-	}
-
-	token, err := ts.Token()
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get GCP access token for GAR")
+		return nil, errors.Wrap(err, "unable to get GAR access token")
 	}
 
 	host := garCfg.GCPRegion + "-docker.pkg.dev"
 	return &metadata.RegistryAuth{
 		ServerAddress: "https://" + host,
-		Username:      "oauth2accesstoken",
-		Password:      token.AccessToken,
+		Username:      tok.Username,
+		Password:      tok.Password,
 	}, nil
 }
 

--- a/services/ctl-api/internal/app/components/worker/activities/get_gar_access_token.go
+++ b/services/ctl-api/internal/app/components/worker/activities/get_gar_access_token.go
@@ -4,11 +4,21 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/google/externalaccount"
 	"google.golang.org/api/impersonate"
+
+	azurecredentials "github.com/nuonco/nuon/pkg/azure/credentials"
+	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
 )
+
+// azureTokenExchangeAudience is the audience the Azure managed identity token is
+// minted for. It must match the `allowed_audiences` on the GCP Workload
+// Identity provider created by the `nuonco/gar-access/google` Terraform module.
+const azureTokenExchangeAudience = "api://AzureADTokenExchange"
 
 type GetGARAccessTokenRequest struct {
 	ServiceAccountEmail      string
@@ -26,6 +36,9 @@ func (a *Activities) GetGARAccessToken(ctx context.Context, req *GetGARAccessTok
 	scopes := []string{"https://www.googleapis.com/auth/cloud-platform"}
 
 	if req.WorkloadIdentityProvider != "" {
+		if a.cfg.IsAzure() {
+			return a.getGARTokenViaAzureFederation(ctx, req, scopes)
+		}
 		return a.getGARTokenViaFederation(ctx, req, scopes)
 	}
 
@@ -98,6 +111,61 @@ func (a *Activities) getGARTokenViaFederation(ctx context.Context, req *GetGARAc
 		SubjectTokenType:               "urn:ietf:params:aws:token-type:aws4_request",
 		Scopes:                         scopes,
 		AwsSecurityCredentialsSupplier: &awsCredentialSupplier{region: region},
+	}
+
+	if req.ServiceAccountEmail != "" {
+		cfg.ServiceAccountImpersonationURL = fmt.Sprintf(
+			"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken",
+			req.ServiceAccountEmail,
+		)
+	}
+
+	ts, err := externalaccount.NewTokenSource(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create federated token source: %w", err)
+	}
+
+	token, err := ts.Token()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get federated token: %w", err)
+	}
+
+	return &GARAccessToken{Username: "oauth2accesstoken", Password: token.AccessToken}, nil
+}
+
+// azureSubjectTokenSupplier feeds the Azure managed-identity OIDC token to GCP's
+// STS as the subject token to exchange for a GAR access token.
+type azureSubjectTokenSupplier struct {
+	cred  azcore.TokenCredential
+	scope string
+}
+
+func (s *azureSubjectTokenSupplier) SubjectToken(ctx context.Context, _ externalaccount.SupplierOptions) (string, error) {
+	tok, err := s.cred.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{s.scope}})
+	if err != nil {
+		return "", fmt.Errorf("unable to get azure token: %w", err)
+	}
+	return tok.Token, nil
+}
+
+func (a *Activities) getGARTokenViaAzureFederation(ctx context.Context, req *GetGARAccessTokenRequest, scopes []string) (*GARAccessToken, error) {
+	l := temporalzap.GetActivityLogger(ctx)
+
+	cred, err := azurecredentials.Fetch(ctx, l)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get azure credentials: %w", err)
+	}
+
+	audience := fmt.Sprintf("//iam.googleapis.com/%s", req.WorkloadIdentityProvider)
+
+	cfg := externalaccount.Config{
+		Audience:         audience,
+		SubjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
+		Scopes:           scopes,
+		SubjectTokenSupplier: &azureSubjectTokenSupplier{
+			cred:  cred,
+			scope: azureTokenExchangeAudience + "/.default",
+		},
 	}
 
 	if req.ServiceAccountEmail != "" {


### PR DESCRIPTION
Adds an Azure→GCP Workload Identity Federation path so a self-hosted-on-Azure ctl-api can pull external-image components from a customer's private GAR, mirroring the existing GAR→AWS support. `GetGARAccessToken` now federates an Azure managed identity when the management plane runs on Azure, and the policy metadata fetch reuses the same token logic (which also fixes the AWS-hosted case). Pairs with nuonco/terraform-google-gar-access#3 (the `azure_principals` module input).