### PR TITLE
fix: Accept nil env vars in shell hooks

### DIFF
--- a/pkg/terraform/hooks/shell/shell.go
+++ b/pkg/terraform/hooks/shell/shell.go
@@ -23,7 +23,7 @@ type shell struct {
 	v       *validator.Validate
 	rootDir string
 
-	EnvVars map[string]string `validate:"required"`
+	EnvVars map[string]string
 	Auth    *credentials.Config
 }
 
@@ -38,6 +38,9 @@ func New(v *validator.Validate, opts ...shellOption) (*shell, error) {
 		if err := opt(s); err != nil {
 			return nil, fmt.Errorf("unable to set %d option: %w", idx, err)
 		}
+	}
+	if s.EnvVars == nil {
+		s.EnvVars = map[string]string{}
 	}
 	if err := s.v.Struct(s); err != nil {
 		return nil, err

--- a/pkg/terraform/hooks/shell/shell_test.go
+++ b/pkg/terraform/hooks/shell/shell_test.go
@@ -1,0 +1,15 @@
+package shell
+
+import (
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_NormalizesNilEnvVars(t *testing.T) {
+	s, err := New(validator.New(), WithEnvVars(nil))
+	require.NoError(t, err)
+	assert.NotNil(t, s.EnvVars, "nil env vars must normalize to an empty map so setCredentials can merge into it")
+}


### PR DESCRIPTION
Sandbox run plans can have hooks enabled with no env vars: Azure runner apps get no injected vars (AWS/GCP always get a region var), and an empty env-var map is dropped by omitempty during the composite-plan JSON round-trip introduced in 0.19.1054, so it reaches the runner as nil. The required validation then fails every sandbox terraform run with 'unable to get hooks' before terraform executes.

Drop the required tag and normalize nil to an empty map so setCredentials can merge into it.