### PR TITLE
feat: hide stack provider changelog

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -292,7 +292,6 @@
         "icon": "clock-rotate-left",
         "pages": [
           "updates/updates",
-          "updates/038-stack-terraform-provider",
           "updates/037-split-install-stack-tfvars",
           "updates/036-toggleable-components",
           "updates/035-runbooks-and-readmes",

--- a/docs/updates/updates.mdx
+++ b/docs/updates/updates.mdx
@@ -7,9 +7,6 @@ boost: 0.4
 <Note>Nuon issues new Releases frequently, so we recommend you visit the Changelog regularly.</Note>
 
 <CardGroup cols={2}>
-  <Card title="038 - Terraform stack provider" icon="code" href="/updates/038-stack-terraform-provider">
-    First-class support for building stack templates in Terraform.
-  </Card>
   <Card title="037 - Split install stack tfvars" icon="cloud" href="/updates/037-split-install-stack-tfvars">
     Install stack Terraform config is now split into inputs.auto.tfvars and secrets.auto.tfvars, applied with a plain terraform apply.
   </Card>


### PR DESCRIPTION
## Summary

Since we're holding on this we shouldn't leave the changelog up. Hiding for now.