### PR TITLE
docs: drop generated-files claim from 038 schema-endpoint item

### DIFF
--- a/docs/updates/038-spacelift-and-cli-automation.mdx
+++ b/docs/updates/038-spacelift-and-cli-automation.mdx
@@ -82,6 +82,5 @@ Fixes that make the `nuon` CLI more reliable when you drive it headlessly from C
 - **Config schemas are now satisfiable**, so you can validate app config against them in CI or an editor. Previously the typed schemas (`container-image`, `helm`, `kubernetes-manifest`, and the rest) could never validate any document.
 - **Each config file type now has its own schema endpoint** — `GET /v1/general/config-schema/{type}`:
   - Fetch a single type directly, e.g. `/config-schema/helm` or `/config-schema/sandbox`.
-  - Generated config files now reference these per-type URLs.
   - Each type's schema carries its own `$id`, so editors and validators that cache schemas by URL resolve every config type distinctly instead of collapsing them onto one entry.
   - The older single-URL form still works for backward compatibility: `config-schema?type=helm`, with `?source=` accepted as a deprecated alias that returns a deprecation header instead of an HTTP 400.


### PR DESCRIPTION
The 038 changelog stated generated config files reference the new per-type schema URLs. In practice the flat/starter templates most users generate carry no `#:schema` header at all (only the per-type component templates do), so the claim overstated it. Removes that sub-bullet; the per-type endpoint description and backward-compat note are unchanged.