### PR TITLE
fix: boost pulumi search results

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -249,6 +249,7 @@
               "configuration-files",
               {
                 "group": "Component Types",
+                "boost": 2.5,
                 "pages": [
                   "config-ref/container-image",
                   "config-ref/docker-build",


### PR DESCRIPTION
## Summary

The most relevant pages, specifically the config references, wasn't high enough in the search results when searching for "pulumi". This PR boosts it up higher.