### PR TITLE
fix: normalize trailing dot in DNS delegation root domain check

### DIFF
--- a/services/ctl-api/internal/app/installs/worker/dns/provision.go
+++ b/services/ctl-api/internal/app/installs/worker/dns/provision.go
@@ -28,7 +28,12 @@ func (w Wkflow) ProvisionDNSDelegation(ctx workflow.Context, req *ProvisionDNSDe
 		return nil, fmt.Errorf("invalid request: %w", err)
 	}
 
-	if !strings.Contains(req.Domain, w.cfg.DNSRootDomain) {
+	// DNS names from cloud providers (e.g. GCP Cloud DNS) may carry a trailing
+	// dot; normalize both sides so the delegation isn't silently skipped on a
+	// dot-only mismatch.
+	domain := strings.TrimSuffix(req.Domain, ".")
+	rootDomain := strings.TrimSuffix(w.cfg.DNSRootDomain, ".")
+	if !strings.Contains(domain, rootDomain) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Two bugs blocked install DNS delegation into GCP Cloud DNS parent zones (e.g. Lovable BYOC `installs.lovable.dev`).

1. `DNS_ROOT_DOMAIN` carries GCP's trailing dot, so the `strings.Contains` guard never matched the dot-less install domain and delegation was silently skipped for every install. Normalize both sides.
2. Cloud DNS requires NS rrdata to be fully-qualified; Route53 nameservers (AWS installs) come without a trailing dot, so Cloud DNS returned 400. Qualify each nameserver.