### PR TITLE
fix: qualify and upsert Cloud DNS NS delegation records

### DIFF
--- a/services/ctl-api/internal/app/installs/worker/dns/delegate_dns.go
+++ b/services/ctl-api/internal/app/installs/worker/dns/delegate_dns.go
@@ -62,19 +62,21 @@ func (a *Activities) upsertCloudDNSRecords(ctx context.Context, req DelegateDNSR
 		return fmt.Errorf("unable to create Cloud DNS client: %w", err)
 	}
 
-	// ensure domain has trailing dot (Cloud DNS format)
-	domain := req.Domain
-	if len(domain) > 0 && domain[len(domain)-1] != '.' {
-		domain += "."
+	// Cloud DNS requires both the record name and NS rrdata to be
+	// fully-qualified with a trailing dot; Route53 hands back nameservers
+	// without one.
+	nameservers := make([]string, len(req.NameServers))
+	for i, ns := range req.NameServers {
+		nameservers[i] = ensureTrailingDot(ns)
 	}
 
 	change := &googledns.Change{
 		Additions: []*googledns.ResourceRecordSet{
 			{
-				Name:    domain,
+				Name:    ensureTrailingDot(req.Domain),
 				Type:    "NS",
 				Ttl:     3600,
-				Rrdatas: req.NameServers,
+				Rrdatas: nameservers,
 			},
 		},
 	}

--- a/services/ctl-api/internal/app/installs/worker/dns/provision.go
+++ b/services/ctl-api/internal/app/installs/worker/dns/provision.go
@@ -51,3 +51,10 @@ func (w Wkflow) ProvisionDNSDelegation(ctx workflow.Context, req *ProvisionDNSDe
 
 	return &ProvisionDNSDelegationResponse{}, nil
 }
+
+func ensureTrailingDot(s string) string {
+	if s == "" || strings.HasSuffix(s, ".") {
+		return s
+	}
+	return s + "."
+}


### PR DESCRIPTION
Follow-up to #1929. Two fixes to install DNS delegation into GCP Cloud DNS parent zones (e.g. Lovable BYOC `installs.lovable.dev`):

1. Cloud DNS requires NS rrdata to be fully-qualified; Route53 nameservers (AWS installs) come without a trailing dot, so Cloud DNS returned 400. Qualify each nameserver.
2. The GCP path used additions-only, so retries/reprovisions failed with 409 alreadyExists. Make it a true upsert (delete existing + add in one change, no-op when unchanged).