### PR TITLE
feat: agent skill for building vendor control plane integrations

### DIFF
--- a/exp/nuon-byoc-integration/README.md
+++ b/exp/nuon-byoc-integration/README.md
@@ -1,0 +1,40 @@
+# nuon-byoc-integration (experimental agent skill)
+
+An agent skill that integrates a vendor application with the Nuon BYOC
+`ctl-api`, so the vendor's customers can create and manage Nuon installs from the
+vendor-owned UI — without exposing Nuon credentials to the browser.
+
+It generates a **server-side proxy** (any language/framework) that holds the Nuon
+API token and forwards to `ctl-api`, plus **frontend components** that call the
+new proxy endpoints. First-class targets are Node/Express (server) and React
+(client); the design is language-agnostic and extends to any stack.
+
+## Layout
+
+```
+SKILL.md                         entry point: trigger + procedure
+references/                      language-neutral protocol (source of truth)
+  ctl-api.md                     endpoints, auth headers, error mapping, BYOC url
+  service-account-token.md       dedicated service-account token, least privilege
+  architecture-and-security.md   3-tier proxy model + security invariants
+  lifecycle.md                   async create → status polling
+  contracts/
+    install-create.md            POST /v1/apps/{app_id}/installs contract
+    install-inputs-schema.md     app input schema → dynamic form + whitelist
+adapters/                       per-stack idioms (additive)
+  node-express.md
+  react.md
+  _template.md                   copy to add a new language/framework
+assets/                         copyable reference-impl snippets
+  server/  nuonClient.js, installsRouter.js
+  client/  installsApi.js, CreateInstallForm.jsx, InstallStatus.jsx
+```
+
+## Status
+
+Experimental / first pass. Scope so far: **create an install** (+ dynamic input
+form + async status). Extend to deploy / update-inputs / teardown by adding
+files under `references/contracts/`.
+
+To promote to a real skill, move this directory to a skills location
+(`.claude/skills/`) once validated.

--- a/exp/nuon-byoc-integration/SKILL.md
+++ b/exp/nuon-byoc-integration/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: nuon-byoc-integration
+description: >-
+  Integrate a vendor application with the Nuon BYOC ctl-api so the vendor's own
+  customers can create and manage Nuon installs from the vendor-owned UI. Adds a
+  server-side proxy (any language/framework) that holds the Nuon API token and
+  forwards requests to ctl-api, then wires up frontend components that call the
+  new proxy endpoints. Use when the user wants their app/customers to create
+  installs, drive installs, or otherwise talk to a Nuon BYOC control plane from
+  their own product. Trigger phrases: "integrate my app with Nuon", "let
+  customers create installs from my UI", "proxy the ctl-api", "add a create
+  install button".
+---
+
+# Nuon BYOC Integration
+
+Build an integration that lets a vendor's customers create and manage Nuon
+installs from the vendor's own product, without ever exposing Nuon credentials
+to the browser.
+
+## The architecture (always)
+
+```
+┌────────────┐   /api/... (vendor)   ┌─────────────────┐   /v1/... (ctl-api)   ┌──────────┐
+│ Vendor UI  │ ────────────────────▶ │  Vendor server  │ ────────────────────▶ │  Nuon    │
+│ (customer) │                       │  (proxy)        │  Bearer + X-Nuon-Org  │  ctl-api │
+└────────────┘                       └─────────────────┘                       └──────────┘
+```
+
+Three tiers, three properties that MUST hold:
+
+1. The Nuon API token and org ID live **only** on the vendor server. Never in
+   the browser bundle, never returned to the client.
+2. The proxy **authorizes the customer** (vendor's own tenant model) before
+   forwarding, and owns the sensitive fields (`app_id`, cloud account block).
+3. The customer supplies only a **whitelisted** subset of the ctl-api payload
+   (`name` + declared inputs).
+
+Read `references/architecture-and-security.md` before generating any code — it
+is the contract the whole integration is built against and is fully
+language-neutral.
+
+## This skill is language- and framework-agnostic
+
+Do NOT assume Node, TypeScript, Express, or React. The `references/` directory
+is pure protocol (HTTP, auth, payloads, lifecycle, security) and applies to any
+stack. The `adapters/` directory holds idioms for specific stacks and is
+additive — Node/Express and React ship as the reference implementations, but you
+can and should generate a correct integration for an unknown stack from the
+references + the repo's own conventions, marking anything uncertain with
+explicit `TODO` comments.
+
+## Procedure
+
+Follow these steps in order. Track them with tasks if the integration is large.
+
+### 1. Detect the stack (do not assume)
+
+Inspect the repo to determine:
+
+- **Language**: `package.json` (Node), `go.mod` (Go), `pyproject.toml` /
+  `requirements.txt` (Python), `Gemfile` (Ruby), `pom.xml` / `build.gradle`
+  (Java/Kotlin), `composer.json` (PHP), etc.
+- **Server framework**: e.g. Express/Fastify/Nest/Next (Node); Gin/Echo/net-http
+  (Go); FastAPI/Flask/Django (Python); Rails/Sinatra (Ruby).
+- **Frontend framework**: React/Vue/Svelte/Angular, or none.
+- **Conventions**: how routes are declared, how config/secrets are read, what
+  validation library exists, what HTTP client the frontend already uses, TS vs
+  JS.
+
+If an `adapters/<lang>-<framework>.md` exists for the detected stack, load it.
+Otherwise generate from `references/` + observed conventions.
+
+### 2. Provision a service-account token for the server
+
+The server authenticates to ctl-api with a long-lived token. It MUST be a
+**dedicated service-account token**, not a developer's personal token. Minting it
+requires admin credentials and the token must never pass through the skill, so
+**the skill does not create the token — it displays directions the user runs
+themselves.** See `references/service-account-token.md`.
+
+1. **Confirm the control plane first (BYOC — not always `api.nuon.co`).** Run
+   `nuon --help`; it prints `✅ You are logged into <api_url>.` (also in `~/.nuon`
+   as `api_url`). Show that URL to the user and confirm it is the control plane
+   they want to integrate with. If not, have them `nuon auth login` against the
+   correct one, or use the URL they specify. This URL becomes `NUON_API_URL` —
+   never assume or hardcode it.
+2. **Display the service-account-token directions.** Show the user the two-step
+   admin-API flow with ready-to-paste curl commands (fill in the placeholders you
+   know — `ORG_ID`, and the admin API base if the user gave it):
+
+   ```bash
+   # Set these first:
+   ADMIN_API_URL=...            # BYOC admin API base (ask the user; not the public API)
+   ADMIN_EMAIL=...              # an admin account email you control
+   ORG_ID=<org_id>
+
+   # 1) Create (or fetch) the org service account — idempotent, empty body:
+   curl -sS -X POST "$ADMIN_API_URL/v1/orgs/$ORG_ID/admin-service-account" \
+     -H "X-Nuon-Admin-Email: $ADMIN_EMAIL" -H "Content-Type: application/json" -d '{}'
+   #   → note the returned "email" / "subject"
+
+   # 2) Mint a long-lived static token for that service account:
+   curl -sS -X POST "$ADMIN_API_URL/v1/general/admin-static-token" \
+     -H "X-Nuon-Admin-Email: $ADMIN_EMAIL" -H "Content-Type: application/json" \
+     -d '{"email_or_subject":"'"$ORG_ID"'-admin-service-account@serviceaccount.nuon.co","duration":"8760h"}'
+   #   → { "api_token": "<token>" }  ← this is NUON_API_TOKEN
+   ```
+
+   Tell the user this service account is granted **org-admin** (note the blast
+   radius). Do not run these commands for them and do not ask them to paste the
+   token back to you.
+3. **Never bake the token into the repo.** The user places the `api_token` into
+   the project's secret mechanism as `NUON_API_TOKEN` themselves; keep `.env`
+   gitignored. A personal `~/.nuon` token is acceptable ONLY for local
+   verification, never for the committed/deployed integration — flag this
+   explicitly.
+
+### 3. Confirm what else can't be inferred
+
+Ask ONLY for what the repo doesn't reveal:
+
+- The target Nuon `app_id` and `org_id`. `org_id` / `app_id` are also in
+  `~/.nuon` / discoverable via `nuon apps list`.
+- The app's **cloud platform** (aws / azure / gcp) — determines the account
+  block in the create payload.
+- Where the customer's tenant→app authorization should hook into their existing
+  auth/session model.
+
+Do not ask for anything already discoverable in the repo or via the app schema.
+
+### 4. Fetch the install-input schema
+
+Install form fields are rendered **dynamically from the app's input schema**, not
+hardcoded. Retrieve the schema (see `references/contracts/install-inputs-schema.md`)
+via the `nuon` CLI / MCP, or plan the proxy's schema endpoint to fetch it live.
+Use it to drive both the generated form and the server-side input whitelist.
+
+### 5. Generate the server proxy
+
+Per `references/contracts/install-create.md` and the relevant adapter:
+
+- A small Nuon HTTP client that injects `Authorization: Bearer <token>` and
+  `X-Nuon-Org-ID: <org>` and normalizes ctl-api errors.
+- `POST /api/installs` — validate body, authorize caller, whitelist inputs,
+  inject server-owned `app_id` + cloud account, call ctl-api, map errors.
+- `GET /api/install-inputs` — proxy the app input schema so the UI can render
+  fields (keeps the token server-side).
+- `GET /api/installs/:id` — proxy install status for the async lifecycle.
+- A tenant-authorization step, clearly marked where the human must enforce their
+  own tenant→app mapping. Never generate a pass-through-everything proxy.
+
+### 6. Generate the frontend
+
+Per the frontend adapter:
+
+- A typed API layer calling the vendor proxy (not ctl-api directly).
+- A create-install form whose fields are rendered dynamically from the input
+  schema (types, required, defaults, sensitive→masked).
+- Create action with pending/disabled state, then success → navigate to a status
+  view that polls `GET /api/installs/:id` (creation is async).
+- Error surfacing from the mapped proxy errors.
+
+### 7. Verify
+
+Build/typecheck the project. Optionally dry-run the proxy against Nuon using the
+`nuon` CLI `--read-only` guardrail or a test org before wiring the write path.
+
+### 8. Report
+
+List generated files, the security TODOs the human must complete (tenant auth,
+secret storage), and how to extend to more operations (deploy, teardown) by
+adding contract files.
+
+## Extending
+
+- **New language/framework**: copy `adapters/_template.md`, fill in the idioms.
+  References are reused unchanged.
+- **New operation** (deploy, teardown, status detail): add a file under
+  `references/contracts/` following `install-create.md`, then generate against it.

--- a/exp/nuon-byoc-integration/adapters/_template.md
+++ b/exp/nuon-byoc-integration/adapters/_template.md
@@ -1,0 +1,45 @@
+# Adapter: <language> + <framework>
+
+Copy this file to `adapters/<lang>-<framework>.md` to teach the skill a new
+stack. The `references/` contract is reused unchanged — only fill in idioms.
+
+## Config & secrets
+
+How this stack reads config / secrets. Which mechanism holds `NUON_API_TOKEN`,
+`NUON_ORG_ID`, `NUON_APP_ID`, `NUON_API_URL`, `NUON_CLOUD_PLATFORM`.
+
+## Nuon client wrapper
+
+Idiomatic HTTP client for this language that injects `Authorization: Bearer` +
+`X-Nuon-Org-ID`, sets JSON content type, and normalizes errors with the upstream
+status. (See `references/ctl-api.md`.)
+
+## Routes / handlers
+
+How routes are declared in this framework. Implement:
+- `GET  /api/install-inputs`  (proxy input schema, customer-facing only:
+  `source == "customer"` and not `internal`)
+- `POST /api/installs`        (authorize → whitelist → inject → forward)
+- `GET  /api/installs/:id`    (tenant-scoped status read)
+
+Handler logic is identical across stacks — see
+`references/contracts/install-create.md` pseudocode.
+
+## Validation
+
+Idiomatic validation library. Build the input validator dynamically from the app
+input schema.
+
+## Authorization
+
+Where `authorizeCreate` / `authorizeReadInstall` hook into this framework's
+session/tenant model. Mark clearly as required TODOs.
+
+## Frontend (if applicable)
+
+If this stack owns the UI too, describe the framework's data-fetching + form
+idioms mirroring `adapters/react.md`.
+
+## Gotchas
+
+Anything stack-specific (async model, secret injection, CORS, etc.).

--- a/exp/nuon-byoc-integration/adapters/node-express.md
+++ b/exp/nuon-byoc-integration/adapters/node-express.md
@@ -1,0 +1,52 @@
+# Adapter: Node + Express (server)
+
+Reference implementation of the proxy for a Node/Express server. Idioms only —
+the contract lives in `references/`. Copyable snippets are in `assets/server/`.
+
+## Config & secrets
+
+Read from env (or the repo's existing config module — match it):
+
+```
+NUON_API_URL   (default https://ctl.prod.nuon.co)
+NUON_API_TOKEN (secret — never sent to client)
+NUON_ORG_ID
+NUON_APP_ID
+NUON_CLOUD_PLATFORM  (aws | azure | gcp)
+```
+
+If the repo uses `dotenv` / a config loader / a secrets manager, wire into that
+instead of raw `process.env`.
+
+## Nuon client wrapper
+
+See `assets/server/nuonClient.js`. A `fetch` wrapper that:
+
+- injects `Authorization: Bearer ${NUON_API_TOKEN}` and `X-Nuon-Org-ID`,
+- sets JSON content type,
+- throws a normalized error carrying the upstream status for the route to map.
+
+## Routes
+
+See `assets/server/installsRouter.js`. Mount under `/api`:
+
+- `GET  /api/install-inputs` → `GET /v1/apps/{app_id}/input-latest-config`,
+  returning only customer-facing inputs (`source == "customer"`, and not
+  `internal`) — see `references/contracts/install-inputs-schema.md`.
+- `POST /api/installs` → validate, `authorizeCreate` (TODO stub), whitelist
+  inputs against the schema, inject cloud account + tenant label, forward.
+- `GET  /api/installs/:id` → tenant-scoped read of `GET /v1/installs/{id}`.
+
+## Validation
+
+Use the repo's existing validator (`zod`, `joi`, `express-validator`). If none
+exists and it's a TS project, `zod` is a good default. Build the input schema for
+validation dynamically from the fetched app input schema, not a static object.
+
+## Notes
+
+- Keep `authorizeCreate` / `authorizeReadInstall` as clearly-marked TODO
+  functions wired to the repo's session/tenant model — do not ship them as
+  no-ops silently.
+- If the project is Fastify/Nest/Next instead, keep this structure and translate
+  route registration + middleware idioms; the handler logic is identical.

--- a/exp/nuon-byoc-integration/adapters/react.md
+++ b/exp/nuon-byoc-integration/adapters/react.md
@@ -1,0 +1,44 @@
+# Adapter: React (frontend)
+
+Reference implementation of the customer-facing UI. Idioms only — the flow lives
+in `references/lifecycle.md`. Copyable snippets are in `assets/client/`.
+
+## API layer
+
+See `assets/client/installsApi.js`. Typed calls to the vendor proxy (NOT
+ctl-api):
+
+- `getInstallInputs()` → `GET /api/install-inputs`
+- `createInstall({ name, inputs })` → `POST /api/installs`
+- `getInstall(id)` → `GET /api/installs/:id`
+
+If the repo uses React Query / SWR, wrap these as hooks
+(`useInstallInputs`, `useCreateInstall`, `useInstall(id)` with polling).
+Otherwise use `useEffect` + local state.
+
+## Dynamic form
+
+See `assets/client/CreateInstallForm.jsx`. Renders fields from the fetched input
+schema:
+
+- one control per input, chosen by `type` (text / number / checkbox),
+- `display_name` as label, `description` as helper text,
+- `required` enforced client-side, `default` prefilled,
+- `sensitive` → password-style masked input,
+- inputs sorted by `index`, optionally grouped by `input_groups`.
+
+Submit builds `{ name, inputs }` (coerce values to strings) and calls
+`createInstall`. Disable the button while pending. On success, navigate to the
+status view with the returned install `id`.
+
+## Status view (async)
+
+See `assets/client/InstallStatus.jsx`. Polls `getInstall(id)` every ~5s, shows
+`sandbox_status` / `runner_status`, stops polling on a terminal state, renders
+provisioning / ready / error states.
+
+## Notes
+
+- Match the repo's component conventions (design system, form primitives, router).
+  Reuse existing inputs/buttons rather than dropping in bespoke markup.
+- The client never sees Nuon credentials or the ctl-api URL.

--- a/exp/nuon-byoc-integration/assets/client/CreateInstallForm.jsx
+++ b/exp/nuon-byoc-integration/assets/client/CreateInstallForm.jsx
@@ -1,0 +1,86 @@
+// Create-install form. Fields are rendered dynamically from the app's input
+// schema (getInstallInputs) — nothing hardcoded.
+
+import { useEffect, useState } from "react";
+import { getInstallInputs, createInstall } from "./installsApi";
+
+function fieldControl(def, value, onChange) {
+  const common = {
+    id: def.name,
+    value: value ?? "",
+    required: def.required,
+    onChange: (e) =>
+      onChange(def.name, def.type === "bool" ? e.target.checked : e.target.value),
+  };
+  if (def.type === "bool") {
+    return <input type="checkbox" checked={!!value} {...common} value={undefined} />;
+  }
+  if (def.type === "number") return <input type="number" {...common} />;
+  if (def.sensitive) return <input type="password" {...common} />;
+  return <input type="text" {...common} />;
+}
+
+export function CreateInstallForm({ onCreated }) {
+  const [schema, setSchema] = useState(null);
+  const [name, setName] = useState("");
+  const [values, setValues] = useState({});
+  const [error, setError] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    getInstallInputs()
+      .then((s) => {
+        setSchema(s);
+        const defaults = {};
+        for (const i of s.inputs) if (i.default != null) defaults[i.name] = i.default;
+        setValues(defaults);
+      })
+      .catch((e) => setError(e.message));
+  }, []);
+
+  if (error && !schema) return <p role="alert">Failed to load: {error}</p>;
+  if (!schema) return <p>Loading…</p>;
+
+  const inputs = [...schema.inputs].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+
+  const setValue = (k, v) => setValues((prev) => ({ ...prev, [k]: v }));
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const install = await createInstall({ name, inputs: values });
+      onCreated?.(install);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      <label htmlFor="install-name">Install name</label>
+      <input
+        id="install-name"
+        value={name}
+        required
+        onChange={(e) => setName(e.target.value)}
+      />
+
+      {inputs.map((def) => (
+        <div key={def.name}>
+          <label htmlFor={def.name}>{def.display_name || def.name}</label>
+          {def.description && <p>{def.description}</p>}
+          {fieldControl(def, values[def.name], setValue)}
+        </div>
+      ))}
+
+      {error && <p role="alert">{error}</p>}
+      <button type="submit" disabled={submitting}>
+        {submitting ? "Creating…" : "Create"}
+      </button>
+    </form>
+  );
+}

--- a/exp/nuon-byoc-integration/assets/client/InstallStatus.jsx
+++ b/exp/nuon-byoc-integration/assets/client/InstallStatus.jsx
@@ -1,0 +1,51 @@
+// Install status view — polls the proxy until the install reaches a terminal
+// state. Creation is async (see references/lifecycle.md).
+
+import { useEffect, useRef, useState } from "react";
+import { getInstall } from "./installsApi";
+
+const TERMINAL = new Set(["active", "healthy", "error", "failed"]);
+
+export function InstallStatus({ installId }) {
+  const [install, setInstall] = useState(null);
+  const [error, setError] = useState(null);
+  const timer = useRef(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const data = await getInstall(installId);
+        if (cancelled) return;
+        setInstall(data);
+        const done =
+          TERMINAL.has(data.sandbox_status) && TERMINAL.has(data.runner_status);
+        if (!done) timer.current = setTimeout(poll, 5000);
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+      }
+    }
+
+    poll();
+    return () => {
+      cancelled = true;
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [installId]);
+
+  if (error) return <p role="alert">{error}</p>;
+  if (!install) return <p>Loading…</p>;
+
+  return (
+    <div>
+      <h2>{install.name}</h2>
+      <dl>
+        <dt>Sandbox</dt>
+        <dd>{install.sandbox_status || "provisioning…"}</dd>
+        <dt>Runner</dt>
+        <dd>{install.runner_status || "provisioning…"}</dd>
+      </dl>
+    </div>
+  );
+}

--- a/exp/nuon-byoc-integration/assets/client/installsApi.js
+++ b/exp/nuon-byoc-integration/assets/client/installsApi.js
@@ -1,0 +1,25 @@
+// Frontend API layer — calls the VENDOR proxy, never ctl-api directly.
+// No Nuon credentials ever reach this code.
+
+async function json(res) {
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error || `request failed (${res.status})`);
+  return body;
+}
+
+export function getInstallInputs() {
+  return fetch("/api/install-inputs", { credentials: "include" }).then(json);
+}
+
+export function createInstall({ name, inputs }) {
+  return fetch("/api/installs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ name, inputs }),
+  }).then(json);
+}
+
+export function getInstall(id) {
+  return fetch(`/api/installs/${id}`, { credentials: "include" }).then(json);
+}

--- a/exp/nuon-byoc-integration/assets/server/installsRouter.js
+++ b/exp/nuon-byoc-integration/assets/server/installsRouter.js
@@ -1,0 +1,147 @@
+// Express router that proxies the customer-facing install surface to ctl-api.
+// Mount with: app.use("/api", installsRouter)
+//
+// Security invariants (see references/architecture-and-security.md):
+//   - Nuon token/org stay server-side (in nuonClient).
+//   - Every route authorizes the customer before forwarding.
+//   - Customer input is whitelisted to the app's declared inputs.
+//   - app_id + cloud account + tenant labels are server-owned.
+
+const express = require("express");
+const { nuon, NuonError } = require("./nuonClient");
+
+const APP_ID = process.env.NUON_APP_ID;
+const CLOUD_PLATFORM = process.env.NUON_CLOUD_PLATFORM || "aws"; // aws|azure|gcp
+
+const router = express.Router();
+
+// TODO: replace with your real session/tenant model.
+function getCustomer(req) {
+  // e.g. return req.session.customer
+  return req.customer;
+}
+
+// TODO: enforce your tenant → app authorization.
+function authorizeCreate(customer /*, appId */) {
+  if (!customer) {
+    const e = new Error("unauthorized");
+    e.status = 401;
+    throw e;
+  }
+  // e.g. assert customer may create installs for APP_ID
+}
+
+// TODO: enforce that this customer owns this install.
+function authorizeReadInstall(customer /*, installId */) {
+  if (!customer) {
+    const e = new Error("unauthorized");
+    e.status = 401;
+    throw e;
+  }
+}
+
+// Only inputs the vendor marked `source: "customer"` are shown to and accepted
+// from the customer. `vendor` inputs (the default) resolve from the app config
+// server-side and must never be settable by the browser.
+function customerFacingInputs(schema) {
+  return (schema.inputs || []).filter((i) => i.source === "customer" && !i.internal);
+}
+
+function mapNuonError(err, res) {
+  if (err instanceof NuonError) {
+    console.error("ctl-api error", err.status, err.body);
+    const map = { 400: 422, 401: 502, 403: 502, 404: 404, 409: 409 };
+    const status = map[err.status] || 502;
+    return res.status(status).json({ error: "install request failed" });
+  }
+  const status = err.status || 500;
+  return res.status(status).json({ error: err.message || "server error" });
+}
+
+// GET /api/install-inputs — dynamic form schema (internal inputs stripped)
+router.get("/install-inputs", async (req, res) => {
+  try {
+    authorizeReadInstall(getCustomer(req));
+    const schema = await nuon.getAppInputSchema(APP_ID);
+    res.json({ inputs: customerFacingInputs(schema), input_groups: schema.input_groups || [] });
+  } catch (err) {
+    mapNuonError(err, res);
+  }
+});
+
+// POST /api/installs — create an install
+router.post("/installs", async (req, res) => {
+  try {
+    const customer = getCustomer(req);
+    authorizeCreate(customer, APP_ID);
+
+    const { name, inputs = {} } = req.body || {};
+    if (typeof name !== "string" || !name.trim()) {
+      return res.status(422).json({ error: "name is required" });
+    }
+
+    const schema = await nuon.getAppInputSchema(APP_ID);
+    const allowed = customerFacingInputs(schema);
+    const allowedNames = new Set(allowed.map((i) => i.name));
+
+    // reject unknown keys
+    const unknown = Object.keys(inputs).filter((k) => !allowedNames.has(k));
+    if (unknown.length) {
+      return res.status(422).json({ error: `unknown inputs: ${unknown.join(", ")}` });
+    }
+
+    // required + default + coerce to string
+    const finalInputs = {};
+    for (const def of allowed) {
+      let v = inputs[def.name];
+      if (v === undefined || v === "") v = def.default;
+      if ((v === undefined || v === "") && def.required) {
+        return res.status(422).json({ error: `missing required input: ${def.name}` });
+      }
+      if (v !== undefined && v !== "") finalInputs[def.name] = String(v);
+    }
+
+    const payload = {
+      name: name.trim(),
+      inputs: finalInputs,
+      [`${CLOUD_PLATFORM}_account`]: getServerCloudAccount(customer), // TODO
+      labels: { tenant_id: String(customer.tenantId) }, // TODO: your tenant id
+    };
+
+    const install = await nuon.createInstall(APP_ID, payload);
+    res.status(201).json({
+      id: install.id,
+      name: install.name,
+      sandbox_status: install.sandbox_status,
+      runner_status: install.runner_status,
+      created_at: install.created_at,
+    });
+  } catch (err) {
+    mapNuonError(err, res);
+  }
+});
+
+// GET /api/installs/:id — status polling (tenant-scoped)
+router.get("/installs/:id", async (req, res) => {
+  try {
+    authorizeReadInstall(getCustomer(req), req.params.id);
+    const install = await nuon.getInstall(req.params.id);
+    res.json({
+      id: install.id,
+      name: install.name,
+      sandbox_status: install.sandbox_status,
+      runner_status: install.runner_status,
+      composite_component_status: install.composite_component_status,
+    });
+  } catch (err) {
+    mapNuonError(err, res);
+  }
+});
+
+// TODO: return the cloud account block the install should deploy into.
+// This is server-owned config, NOT customer input.
+function getServerCloudAccount(/* customer */) {
+  throw new Error("getServerCloudAccount not implemented");
+}
+
+module.exports = router;

--- a/exp/nuon-byoc-integration/assets/server/nuonClient.js
+++ b/exp/nuon-byoc-integration/assets/server/nuonClient.js
@@ -1,0 +1,45 @@
+// Minimal Nuon ctl-api client. Server-side ONLY — holds the API token.
+// Injects Bearer auth + X-Nuon-Org-ID and normalizes errors.
+
+const NUON_API_URL = process.env.NUON_API_URL || "https://ctl.prod.nuon.co";
+const NUON_API_TOKEN = process.env.NUON_API_TOKEN;
+const NUON_ORG_ID = process.env.NUON_ORG_ID;
+
+if (!NUON_API_TOKEN || !NUON_ORG_ID) {
+  throw new Error("NUON_API_TOKEN and NUON_ORG_ID must be set (server-side).");
+}
+
+class NuonError extends Error {
+  constructor(status, body) {
+    super(`nuon ctl-api error: ${status}`);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function request(method, path, body) {
+  const res = await fetch(`${NUON_API_URL}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${NUON_API_TOKEN}`,
+      "X-Nuon-Org-ID": NUON_ORG_ID,
+      ...(body ? { "Content-Type": "application/json" } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const text = await res.text();
+  const parsed = text ? JSON.parse(text) : undefined;
+  if (!res.ok) throw new NuonError(res.status, parsed);
+  return parsed;
+}
+
+const nuon = {
+  getAppInputSchema: (appId) =>
+    request("GET", `/v1/apps/${appId}/input-latest-config`),
+  createInstall: (appId, payload) =>
+    request("POST", `/v1/apps/${appId}/installs`, payload),
+  getInstall: (installId) => request("GET", `/v1/installs/${installId}`),
+};
+
+module.exports = { nuon, NuonError };

--- a/exp/nuon-byoc-integration/references/architecture-and-security.md
+++ b/exp/nuon-byoc-integration/references/architecture-and-security.md
@@ -1,0 +1,66 @@
+# Architecture & security (language-neutral, non-negotiable)
+
+This is the contract every generated integration must satisfy, regardless of
+language or framework.
+
+## Three tiers
+
+```
+Customer's browser  ─▶  Vendor server (proxy)  ─▶  Nuon ctl-api
+   (untrusted)            (holds secrets)            (control plane)
+```
+
+- **Vendor UI** — operated by the vendor, used by their customers. Talks ONLY to
+  the vendor server. Knows nothing about Nuon credentials or the ctl-api URL.
+- **Vendor server** — operated by the vendor, hosted in their cloud account.
+  Holds the Nuon API token + org ID. Exposes a narrow `/api/...` surface and
+  proxies to ctl-api.
+- **Nuon ctl-api** — operated by Nuon, hosted in the vendor's cloud account
+  (usually the same account as the vendor server).
+
+## Security invariants (the proxy MUST enforce all of these)
+
+### 1. Credentials never reach the browser
+The Nuon token + org ID are read from the server's secret store / env only.
+They are never sent to the client, never embedded in the bundle, never returned
+in a response body. The ctl-api base URL also stays server-side.
+
+### 2. The customer is authorized before every forward
+The proxy maps the authenticated customer (the vendor's own session/tenant model)
+to what they may do:
+- Which `app_id` / `org` they may target.
+- Which installs they may read or mutate (tenant ownership).
+
+Generate this as a **required, explicit** step with a clear TODO where the human
+wires their tenant model. A proxy that forwards without an authorization check is
+a defect — do not generate one.
+
+### 3. Server owns sensitive fields; customer input is whitelisted
+The customer request contains only:
+- `name`
+- `inputs` — restricted to the keys declared in the app's input schema, and with
+  `internal` / non-`Sensitive`-appropriate handling per the schema.
+
+The server injects everything else: `app_id`, the cloud account block, tenant
+`labels`, `metadata`. The customer must not be able to set `app_id`, `labels`,
+`metadata`, `install_config`, or unknown input keys. Reject unknown keys rather
+than silently dropping them.
+
+### 4. Errors are mapped, not forwarded
+Upstream ctl-api errors are logged server-side and returned to the customer as
+sanitized, mapped messages (see `ctl-api.md`). Never leak raw upstream bodies.
+
+### 5. The write path is async
+Creating an install returns immediately with an install in a provisioning state.
+The UI must not present "created" as "ready" — it polls status (see
+`lifecycle.md`).
+
+## Minimal proxy surface for "create an install"
+
+| Vendor endpoint            | Forwards to                                | Notes                              |
+| -------------------------- | ------------------------------------------ | ---------------------------------- |
+| `GET  /api/install-inputs` | `GET /v1/apps/{app_id}/input-latest-config`| drives dynamic form; token hidden  |
+| `POST /api/installs`       | `POST /v1/apps/{app_id}/installs`          | authorize + whitelist + inject     |
+| `GET  /api/installs/:id`   | `GET /v1/installs/{install_id}`            | status polling; tenant-scoped read |
+
+`app_id` is a server config value, not a path/param the client controls.

--- a/exp/nuon-byoc-integration/references/contracts/install-create.md
+++ b/exp/nuon-byoc-integration/references/contracts/install-create.md
@@ -1,0 +1,84 @@
+# Contract: create an install
+
+`POST /v1/apps/{app_id}/installs`
+
+Language-neutral request/response contract. Combine with
+`install-inputs-schema.md` (drives `inputs`) and `architecture-and-security.md`
+(whitelist + injection rules).
+
+## Request body
+
+```jsonc
+{
+  "name": "acme-prod",              // REQUIRED. string. install display name.
+  "inputs": {                        // map<string,string>. keys MUST come from
+    "region": "us-west-2",           // the app input schema. values are strings.
+    "instance_size": "large"
+  },
+
+  // Exactly one cloud account block, matching the app's cloud_platform.
+  // SERVER-OWNED — never accept from the customer.
+  "aws_account":   { /* ...aws account fields... */ },
+  "azure_account": { /* ...azure account fields... */ },
+  "gcp_account":   { /* ...gcp account fields... */ },
+
+  // Optional, SERVER-OWNED:
+  "labels":         { "tenant_id": "cust_123" },  // key/value, merged into install
+  "metadata":       { /* HelpersInstallMetadata */ },
+  "install_config": { /* HelpersCreateInstallConfigParams — pin a config version */ }
+}
+```
+
+Field ownership:
+
+| Field                                  | Set by  | Notes                                        |
+| -------------------------------------- | ------- | -------------------------------------------- |
+| `name`                                 | customer| required; validate non-empty                 |
+| `inputs`                               | customer| whitelisted to schema keys only              |
+| `aws_account` / `azure_account` / `gcp_account` | server | one block, chosen by app cloud platform |
+| `labels`                               | server  | attach tenant identity here                  |
+| `metadata`, `install_config`           | server  | optional                                     |
+
+## Response (201/200)
+
+Returns the created install object. Key fields to return to the client:
+
+```jsonc
+{
+  "id": "install_...",
+  "name": "acme-prod",
+  "app_id": "app_...",
+  "cloud_platform": "aws",
+  "sandbox_status": "...",
+  "runner_status": "...",
+  "created_at": "..."
+}
+```
+
+Return `id` + status fields to the UI so it can transition to a status view and
+poll (`lifecycle.md`). Do NOT echo back server-owned secrets or the raw cloud
+account block.
+
+## Proxy handler outline (pseudocode, any language)
+
+```
+POST /api/installs (body: { name, inputs }):
+  customer = authenticate(request)                 # vendor's own session
+  authorizeCreate(customer, APP_ID)                # tenant → app mapping (TODO)
+
+  schema = getInputSchema(APP_ID)                  # cache OK
+  errors = validateAgainstSchema(body.inputs, schema)   # required, types, unknown keys
+  if body.name is empty or errors: return 422
+
+  ctlBody = {
+    name:   body.name,
+    inputs: pick(body.inputs, schema.inputNames),  # whitelist
+    <cloudPlatform>_account: SERVER_CLOUD_ACCOUNT, # injected
+    labels: { tenant_id: customer.tenantId },      # injected
+  }
+
+  resp = nuon.post(`/v1/apps/${APP_ID}/installs`, ctlBody)  # Bearer + X-Nuon-Org-ID
+  if !resp.ok: log(resp); return mapError(resp.status)
+
+  return 201 { id, name, sandbox_status, runner_status, created_at }
+```

--- a/exp/nuon-byoc-integration/references/contracts/install-inputs-schema.md
+++ b/exp/nuon-byoc-integration/references/contracts/install-inputs-schema.md
@@ -1,0 +1,77 @@
+# Contract: app install-input schema
+
+`GET /v1/apps/{app_id}/input-latest-config`
+
+Returns the app's declared install inputs. Use it to (a) render the create form
+dynamically and (b) build the server-side whitelist/validation. Never hardcode
+the field list — it drifts from the app config.
+
+## Response shape (relevant fields)
+
+```jsonc
+{
+  "id": "input_config_...",
+  "app_id": "app_...",
+  "input_groups": [ { "id": "...", "name": "...", "display_name": "..." } ],
+  "inputs": [
+    {
+      "name": "region",              // key used in the install `inputs` map
+      "display_name": "AWS Region",  // label for the form
+      "description": "Region to deploy into",
+      "type": "string",             // string | number | bool | yaml | hcl | json ...
+      "required": true,
+      "default": "us-west-2",
+      "sensitive": false,            // if true, mask in the UI, don't log
+      "internal": true,              // if true, NOT customer-facing — exclude
+      "source": "customer",          // "customer" | "vendor" (defaults to "vendor")
+      "group_id": "...",             // optional grouping
+      "index": 0                     // display order
+    }
+  ]
+}
+```
+
+## How each field drives generation
+
+| Field          | Form behavior                          | Server behavior                          |
+| -------------- | -------------------------------------- | ---------------------------------------- |
+| `name`         | field key; sent in `inputs` map        | whitelist key; reject anything not listed|
+| `display_name` | field label (fallback to `name`)       | —                                        |
+| `description`  | helper text                            | —                                        |
+| `type`         | input control (text/number/checkbox)   | coerce/validate value type               |
+| `required`     | required field, block submit if empty  | reject if missing                        |
+| `default`      | prefill                                | apply if omitted                         |
+| `sensitive`    | masked input, never logged             | never log value                          |
+| `internal`     | **exclude from the form entirely**     | reject if customer supplies it           |
+| `source`       | render ONLY `source == "customer"`     | whitelist = customer inputs only; reject vendor inputs from the browser |
+| `index`        | sort order                             | —                                        |
+| `group_id`     | group fields under `input_groups`      | —                                        |
+
+### `source` is the primary customer/vendor split
+
+Every input has `source`: `"customer"` (the vendor chose to expose it to their
+customers) or `"vendor"` (the default — the vendor sets it, or it falls back to
+the app-config default). **The customer-facing UI and the server whitelist must
+include only `source == "customer"` inputs.** Vendor inputs are never rendered to
+or accepted from the customer; they resolve from the app config server-side. Do
+not rely on the name (e.g. the `nuon_component_override_v1_` prefix) to decide —
+use `source`. Combine with `internal` (still always excluded):
+
+```
+customerFacing = inputs.filter(i => i.source === "customer" && !i.internal)
+```
+
+An app may expose zero customer inputs — then the form shows only the install
+name, which is correct.
+
+Values are transmitted to ctl-api as **strings** in the `inputs` map — coerce
+UI values (numbers, booleans) to their string form when building the request.
+
+## Retrieval options
+
+- **At runtime (recommended):** the proxy's `GET /api/install-inputs` endpoint
+  fetches this live (with the server-side token) and returns only the
+  customer-facing subset (`source == "customer"` and not `internal`).
+- **At build time (exploration):** `nuon --output json apps input-config
+  --app-id <app_id>` shows the input definitions (incl. `source`) for confirming
+  shapes while generating code.

--- a/exp/nuon-byoc-integration/references/ctl-api.md
+++ b/exp/nuon-byoc-integration/references/ctl-api.md
@@ -1,0 +1,83 @@
+# ctl-api reference (protocol, language-neutral)
+
+The Nuon control-plane API. Everything here is plain HTTP + JSON — applies to any
+language.
+
+## Base URL (BYOC — varies per deployment, NEVER assume)
+
+Nuon is a BYOC platform: the control plane a customer integrates with is **not
+always** `api.nuon.co`. It may be a Nuon-managed multi-tenant gateway
+(`https://api.nuon.co`) or a dedicated/self-hosted BYOC control plane on the
+vendor's own domain. **Always confirm the target API URL with the user before
+generating anything.**
+
+How to discover the current URL:
+
+- `nuon --help` prints `✅ You are logged into <api_url>.` — this is the URL the
+  CLI (and therefore your exploration commands) is currently pointed at.
+- It is also stored in `~/.nuon` as `api_url`.
+
+Confirm with the user that this is the control plane they want the integration
+to target. If not, they must `nuon auth login` against the correct URL (or you
+must use the URL they specify) before proceeding.
+
+- The chosen URL is wired into the generated server as a `NUON_API_URL` (or
+  equivalent) env var. Never hardcode it.
+
+## Authentication
+
+Every request carries two headers:
+
+| Header           | Value                       | Source                    |
+| ---------------- | --------------------------- | ------------------------- |
+| `Authorization`  | `Bearer <NUON_API_TOKEN>`   | vendor server secret      |
+| `X-Nuon-Org-ID`  | `<NUON_ORG_ID>`             | vendor server config      |
+
+Also set `Content-Type: application/json` on requests with a body.
+
+These credentials scope to a Nuon org and grant broad control-plane access. They
+MUST stay server-side (see `architecture-and-security.md`).
+
+## Error envelope
+
+Non-2xx responses return a JSON body. Normalize it in the client wrapper to a
+consistent shape for the rest of your code. Map upstream status codes:
+
+| ctl-api status | Meaning                         | Suggested proxy response |
+| -------------- | ------------------------------- | ------------------------ |
+| 400            | invalid request body            | 422 to client            |
+| 401 / 403      | bad/again token, org mismatch   | 500 / 502 (never leak)   |
+| 404            | app/install not found           | 404                      |
+| 409            | conflict (e.g. duplicate name)  | 409                      |
+| 5xx            | upstream failure                | 502                      |
+
+Never forward the raw ctl-api error body to the customer — it can reveal org
+internals. Log it server-side, return a mapped, sanitized message.
+
+## Endpoints used by this integration
+
+| Purpose                  | Method + path                                   |
+| ------------------------ | ----------------------------------------------- |
+| Mint service-acct token  | `POST {admin_api_url}/v1/general/admin-static-token` (admin API; see `service-account-token.md`) |
+| App input schema (latest)| `GET  /v1/apps/{app_id}/input-latest-config`    |
+| Create install           | `POST /v1/apps/{app_id}/installs`               |
+| Get install (status)     | `GET  /v1/installs/{install_id}`                |
+| List app installs        | `GET  /v1/apps/{app_id}/installs`               |
+| Current install inputs   | `GET  /v1/installs/{install_id}/inputs/current` |
+| Update install inputs    | `POST /v1/installs/{install_id}/inputs`         |
+
+Payload/response shapes for the create + input-schema flows are in
+`contracts/install-create.md` and `contracts/install-inputs-schema.md`.
+
+## Verifying against a real org
+
+The `nuon` CLI drives the same API and is the fastest way to confirm shapes:
+
+```bash
+nuon --output json apps list
+nuon --output json apps get <app_id>          # includes input schema
+nuon --read-only ...                           # guardrail: blocks all writes
+```
+
+Use `--read-only` (or `NUON_READ_ONLY=1`) while exploring so you can't mutate
+state. Auth comes from `~/.nuon` (`nuon auth login`).

--- a/exp/nuon-byoc-integration/references/lifecycle.md
+++ b/exp/nuon-byoc-integration/references/lifecycle.md
@@ -1,0 +1,45 @@
+# Install lifecycle (language-neutral)
+
+Creating an install is asynchronous. `POST /v1/apps/{app_id}/installs` returns a
+`201`/`200` with an install object almost immediately, but the install is not yet
+provisioned — a sandbox is created, then components deploy. The UI must reflect
+this.
+
+## Status fields on the install object
+
+The install object (`GET /v1/installs/{install_id}`) exposes several status
+axes — surface the ones relevant to the flow:
+
+| Field                                  | Meaning                                    |
+| -------------------------------------- | ------------------------------------------ |
+| `sandbox_status`                       | provisioning state of the install sandbox  |
+| `runner_status`                        | health of the install's runner             |
+| `composite_component_status`           | rolled-up status across components          |
+| `component_statuses`                   | per-component map                           |
+| `install_states`                       | historical state transitions               |
+
+`sandbox_status` / `runner_status` are the most useful for a "is my install
+ready?" indicator right after creation.
+
+## Recommended UI flow after create
+
+1. `POST /api/installs` → returns `{ id, name, sandbox_status, ... }`.
+2. Navigate to a status view keyed by install `id`.
+3. Poll `GET /api/installs/:id` on an interval (e.g. every 5–10s) until the
+   sandbox/runner reach a terminal healthy state, then stop polling.
+4. Show clear intermediate ("Provisioning…"), success, and error states.
+
+Do not block the create request waiting for provisioning to finish — it can take
+minutes.
+
+## Beyond create (future contract files)
+
+The same proxy pattern extends to:
+
+- **Deploy** components into an install.
+- **Update inputs** (`POST /v1/installs/{install_id}/inputs`).
+- **Teardown / delete** the install.
+
+Each becomes its own file under `contracts/` and its own narrow, authorized proxy
+endpoint. Keep the whitelist + tenant-authorization + error-mapping invariants
+identical for every one.

--- a/exp/nuon-byoc-integration/references/service-account-token.md
+++ b/exp/nuon-byoc-integration/references/service-account-token.md
@@ -1,0 +1,74 @@
+# Service-account token for the server (language-neutral)
+
+The vendor server authenticates to ctl-api with a long-lived bearer token
+(`NUON_API_TOKEN`). Getting this credential right is a security decision, not a
+config detail.
+
+## Use a dedicated service account — not a person's token
+
+- Nuon accounts have types; automation should use an `AccountType=Service`
+  account, distinct from a human (`Auth0`) account.
+- A service-account token is not tied to an individual, survives people leaving,
+  and can be scoped and rotated independently.
+- **Never ship a developer's personal token** (e.g. the one in `~/.nuon` from
+  `nuon auth login`). That token is fine ONLY for local, throwaway verification
+  while building the integration — never for the committed or deployed server.
+
+## How the token is issued — the admin API (two steps)
+
+A vendor operating a BYOC control plane has access to its **admin API** and mints
+a durable token in two calls: create a service account, then create a static
+token for it. **The skill does not run these for the user** — it displays the
+directions and ready-to-paste curl commands, and the user runs them (they hold
+the admin credentials and the token must not pass through the skill).
+
+Both endpoints live on the **admin API**, not the public API:
+
+- `admin_api_url` is the control plane's admin API base — separate from the
+  public API and network-restricted. Per-deployment (BYOC); confirm with the
+  user, do not assume.
+- In-request auth is the `X-Nuon-Admin-Email` header naming an existing admin
+  account; the real gate is network access to the admin API.
+
+### Step 1 — create (or fetch) the service account
+
+`POST {admin_api_url}/v1/orgs/{org_id}/admin-service-account` (empty body). It is
+idempotent — returns the existing account if already created. The account's email
+is `{org_id}-admin-service-account@serviceaccount.nuon.co`, and it is granted the
+**org-admin** role for that org (this endpoint does not offer finer scoping; note
+the blast radius to the user).
+
+```bash
+curl -sS -X POST "$ADMIN_API_URL/v1/orgs/$ORG_ID/admin-service-account" \
+  -H "X-Nuon-Admin-Email: $ADMIN_EMAIL" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+# → { "id": "...", "email": "<org_id>-admin-service-account@serviceaccount.nuon.co",
+#     "subject": "<org_id>-admin-service-account", ... }
+```
+
+### Step 2 — mint a static token for that account
+
+`POST {admin_api_url}/v1/general/admin-static-token` with the service account's
+email (or subject) from step 1. `duration` is optional (defaults to 1 year).
+
+```bash
+curl -sS -X POST "$ADMIN_API_URL/v1/general/admin-static-token" \
+  -H "X-Nuon-Admin-Email: $ADMIN_EMAIL" \
+  -H "Content-Type: application/json" \
+  -d '{"email_or_subject":"'"$ORG_ID"'-admin-service-account@serviceaccount.nuon.co","duration":"8760h"}'
+# → { "api_token": "<token>" }
+```
+
+The returned `api_token` is a long-lived `TokenTypeStatic` token. The user puts it
+into the server's secret store as `NUON_API_TOKEN` (see Storage below). If the
+vendor prefers, the dashboard equivalent (Org settings → API tokens) also works.
+
+## Storage
+
+- Put the token in the project's existing secret mechanism (env var, secrets
+  manager, platform secret) as `NUON_API_TOKEN`. Keep `.env` gitignored.
+- The token is read server-side only and never returned to the browser
+  (see `architecture-and-security.md`).
+- Plan for rotation: the token can expire or be revoked; the server should fail
+  clearly (surface a mapped 502) rather than silently.


### PR DESCRIPTION
## Summary

Experimenting with an agent skill for building customer-facing integrations against the Nuon control plane.

While Typescript/React are an obvious first target, we want this to be agnostic to languages and frameworks. The skill focuses on adherence to the Nuon API contract and architectural best practices, while aiming to be flexible about how the client app's API handlers are built, and how the UI is designed.