### PR TITLE
fix: Validate unique custom_nested_stacks index; bound template fetch timeout

### DIFF
--- a/pkg/config/app_stack.go
+++ b/pkg/config/app_stack.go
@@ -186,6 +186,7 @@ func (a *StackConfig) parse() error {
 			}
 		}
 	}
+	seenIndices := map[int]string{}
 	for i, stack := range a.CustomNestedStacks {
 		if stack.Name == "" {
 			return ErrConfig{
@@ -199,6 +200,13 @@ func (a *StackConfig) parse() error {
 				Err:         fmt.Errorf("custom_nested_stacks[%d] (%s): template_url is required", i, stack.Name),
 			}
 		}
+		if prev, exists := seenIndices[stack.Index]; exists {
+			return ErrConfig{
+				Description: fmt.Sprintf("custom_nested_stacks: index %d is used by both %q and %q; each stack must have a unique index", stack.Index, prev, stack.Name),
+				Err:         fmt.Errorf("custom_nested_stacks: index %d is used by both %q and %q; each stack must have a unique index", stack.Index, prev, stack.Name),
+			}
+		}
+		seenIndices[stack.Index] = stack.Name
 		for paramName, paramValue := range stack.Parameters {
 			if _, err := ParseInstallInputReference(paramValue); err != nil {
 				return ErrConfig{

--- a/pkg/config/app_stack_test.go
+++ b/pkg/config/app_stack_test.go
@@ -44,6 +44,38 @@ func TestStackConfig_Parse_ValidCustomNestedStacks(t *testing.T) {
 	require.NoError(t, cfg.parse())
 }
 
+func TestStackConfig_Parse_DuplicateIndex(t *testing.T) {
+	cfg := &StackConfig{
+		Type:                    "aws-cloudformation",
+		Name:                    "my-stack",
+		Description:             "test stack",
+		VPCNestedTemplateURL:    "https://s3.amazonaws.com/bucket/vpc.yaml",
+		RunnerNestedTemplateURL: "https://s3.amazonaws.com/bucket/runner.yaml",
+		CustomNestedStacks: []CustomNestedStack{
+			{Name: "preview_bucket", TemplateURL: "./cloudformation/s3-bucket/stack.yaml", Index: 0},
+			{Name: "rds_subnet", TemplateURL: "./cloudformation/rds-subnet/stack.yaml", Index: 0},
+		},
+	}
+	err := cfg.parse()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unique index")
+}
+
+func TestStackConfig_Parse_UniqueIndices(t *testing.T) {
+	cfg := &StackConfig{
+		Type:                    "aws-cloudformation",
+		Name:                    "my-stack",
+		Description:             "test stack",
+		VPCNestedTemplateURL:    "https://s3.amazonaws.com/bucket/vpc.yaml",
+		RunnerNestedTemplateURL: "https://s3.amazonaws.com/bucket/runner.yaml",
+		CustomNestedStacks: []CustomNestedStack{
+			{Name: "preview_bucket", TemplateURL: "./cloudformation/s3-bucket/stack.yaml", Index: 0},
+			{Name: "rds_subnet", TemplateURL: "./cloudformation/rds-subnet/stack.yaml", Index: 1},
+		},
+	}
+	require.NoError(t, cfg.parse())
+}
+
 func TestStackConfig_Parse_AWSCloudFormation_MissingVPCTemplateURL(t *testing.T) {
 	cfg := &StackConfig{
 		Type:                    "aws-cloudformation",

--- a/pkg/config/validate/validate_custom_nested_stacks.go
+++ b/pkg/config/validate/validate_custom_nested_stacks.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -17,8 +18,10 @@ type cfnOutputsShape struct {
 	Outputs map[string]struct{} `yaml:"Outputs" json:"Outputs"`
 }
 
+var templateOutputsClient = &http.Client{Timeout: 30 * time.Second}
+
 func fetchTemplateOutputs(templateURL string) (map[string]struct{}, error) {
-	resp, err := http.Get(templateURL)
+	resp, err := templateOutputsClient.Get(templateURL)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/awslabs/goformation/v7/cloudformation"
 	nestedcloudformation "github.com/awslabs/goformation/v7/cloudformation/cloudformation"
@@ -83,8 +84,10 @@ type cfnTemplateShape struct {
 	Outputs map[string]struct{} `yaml:"Outputs"`
 }
 
+var templateFetchClient = &http.Client{Timeout: 30 * time.Second}
+
 func (tpl *Templates) fetchTemplate(templateURL string) (*cfnTemplateShape, error) {
-	resp, err := http.Get(templateURL)
+	resp, err := templateFetchClient.Get(templateURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Duplicate `custom_nested_stacks` indices passed `nuon apps sync` but wedged `generate-install-stack-version` (AutoRetry churn → parked flow), since uniqueness was only enforced in the CFN renderer. Now validated at parse/sync time so it fails fast. Also bounds the previously timeout-less `http.Get` template fetches (render + validate paths) so an unreachable template URL errors instead of hanging the render activity.