### PR TITLE
feat: notify when workflow steps need manual retry

### DIFF
--- a/services/ctl-api/internal/fxmodules/workers_shared.go
+++ b/services/ctl-api/internal/fxmodules/workers_shared.go
@@ -7,6 +7,7 @@ import (
 	cctxinterceptor "github.com/nuonco/nuon/services/ctl-api/internal/interceptors/cctx"
 	metricsinterceptor "github.com/nuonco/nuon/services/ctl-api/internal/interceptors/metrics"
 	validateinterceptor "github.com/nuonco/nuon/services/ctl-api/internal/interceptors/validate"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/workflowstepawaitingretry"
 	queue "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue"
 	queueactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/emitter"
@@ -69,6 +70,7 @@ var SharedWorkflowsModule = fx.Module("shared-workflows",
 	fx.Provide(handleractivities.New),
 	fx.Provide(emitteractivities.New),
 	fx.Provide(statusactivities.New),
+	fx.Provide(workflowstepawaitingretry.NewNotifier),
 	fx.Provide(controlplanejob.NewActivities),
 	fx.Provide(activities.New),
 	fx.Provide(onboardingactivities.New),

--- a/services/ctl-api/internal/pkg/flow/signals/workflowstepawaitingretry/init.go
+++ b/services/ctl-api/internal/pkg/flow/signals/workflowstepawaitingretry/init.go
@@ -1,0 +1,12 @@
+package workflowstepawaitingretry
+
+import (
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/catalog"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+func init() {
+	catalog.Register(SignalType, func() signal.Signal {
+		return &Signal{}
+	})
+}

--- a/services/ctl-api/internal/pkg/flow/signals/workflowstepawaitingretry/notifier.go
+++ b/services/ctl-api/internal/pkg/flow/signals/workflowstepawaitingretry/notifier.go
@@ -1,0 +1,142 @@
+package workflowstepawaitingretry
+
+import (
+	"context"
+
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
+)
+
+// Notifier dispatches outside workflow code so existing in-flight workflows
+// can use the new behavior without a Temporal version gate. Notification
+// failures must never fail the status update that triggered them.
+type Notifier struct {
+	db          *gorm.DB
+	queueClient *queueclient.Client
+	l           *zap.Logger
+}
+
+type NotifierParams struct {
+	fx.In
+
+	DB          *gorm.DB `name:"psql"`
+	QueueClient *queueclient.Client
+	L           *zap.Logger
+}
+
+func NewNotifier(params NotifierParams) statusactivities.FlowStatusNotifier {
+	return &Notifier{
+		db:          params.DB,
+		queueClient: params.QueueClient,
+		l:           params.L,
+	}
+}
+
+func (n *Notifier) FlowStatusUpdated(ctx context.Context, req statusactivities.UpdateStatusRequest) {
+	if req.Status.Status != app.StatusFailedPendingRetry {
+		return
+	}
+
+	l := n.l.With(zap.String("workflow_id", req.ID))
+
+	stepID, _ := req.Status.Metadata["step_id"].(string)
+	if stepID == "" {
+		l.Warn("awaiting-retry notification: flow status update has no step_id metadata")
+		return
+	}
+	l = l.With(zap.String("step_id", stepID))
+
+	var wf app.Workflow
+	if err := n.db.WithContext(ctx).Where(app.Workflow{ID: req.ID}).First(&wf).Error; err != nil {
+		l.Warn("awaiting-retry notification: unable to load workflow", zap.Error(err))
+		return
+	}
+	if wf.OwnerType != "installs" {
+		return
+	}
+
+	var step app.WorkflowStep
+	if err := n.db.WithContext(ctx).Where(app.WorkflowStep{ID: stepID}).First(&step).Error; err != nil {
+		l.Warn("awaiting-retry notification: unable to load workflow step", zap.Error(err))
+		return
+	}
+
+	errMessage, _ := step.Status.Metadata["reason"].(string)
+	if errMessage == "" {
+		errMessage = step.Status.StatusHumanDescription
+	}
+	retryIndex := intFromMetadata(step.Status.Metadata, "retry_index")
+	maxRetries := intFromMetadata(step.Status.Metadata, "max_retries")
+
+	if n.alreadyNotified(ctx, stepID, retryIndex) {
+		l.Debug("awaiting-retry notification: already enqueued for this retry index",
+			zap.Int("retry_index", retryIndex))
+		return
+	}
+
+	q, err := n.queueClient.GetQueueByOwnerAndName(ctx, wf.OwnerID, wf.OwnerType, installSignalsQueueName)
+	if err != nil {
+		l.Warn("awaiting-retry notification: unable to find install signals queue", zap.Error(err))
+		return
+	}
+
+	_, err = n.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+		QueueID: q.ID,
+		Signal: &Signal{
+			OrgID:        wf.OrgID,
+			InstallID:    wf.OwnerID,
+			WorkflowID:   wf.ID,
+			WorkflowType: string(wf.Type),
+			StepID:       step.ID,
+			StepName:     step.Name,
+			ErrMessage:   errMessage,
+			RetryIndex:   retryIndex,
+			MaxRetries:   maxRetries,
+		},
+		OwnerID:   step.ID,
+		OwnerType: (&app.WorkflowStep{}).TableName(),
+	})
+	if err != nil {
+		l.Warn("awaiting-retry notification: unable to enqueue signal", zap.Error(err))
+		return
+	}
+
+	l.Info("awaiting-retry notification enqueued", zap.Int("retry_index", retryIndex))
+}
+
+// alreadyNotified guards against a Temporal activity retry enqueueing the
+// same step retry twice.
+func (n *Notifier) alreadyNotified(ctx context.Context, stepID string, retryIndex int) bool {
+	var last app.QueueSignal
+	err := n.db.WithContext(ctx).
+		Where(app.QueueSignal{
+			OwnerID:   stepID,
+			OwnerType: (&app.WorkflowStep{}).TableName(),
+			Type:      SignalType,
+		}).
+		Order("created_at desc").
+		First(&last).Error
+	if err != nil {
+		return false
+	}
+
+	prev, ok := last.Signal.Signal.(*Signal)
+	return ok && prev.RetryIndex == retryIndex
+}
+
+func intFromMetadata(meta map[string]any, key string) int {
+	switch v := meta[key].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	}
+	return 0
+}

--- a/services/ctl-api/internal/pkg/flow/signals/workflowstepawaitingretry/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/workflowstepawaitingretry/signal.go
@@ -1,0 +1,79 @@
+package workflowstepawaitingretry
+
+import (
+	"github.com/pkg/errors"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+// SignalType identifies a workflow step parked awaiting manual retry.
+const SignalType signal.SignalType = "workflow-step-awaiting-retry"
+
+// installSignalsQueueName mirrors the constant in
+// services/ctl-api/internal/app/installs/helpers. Duplicated here as a
+// literal to avoid an import cycle (helpers imports signals via fx wiring).
+const installSignalsQueueName = "install-signals"
+
+type Signal struct {
+	OrgID        string `json:"org_id"`
+	InstallID    string `json:"install_id"`
+	WorkflowID   string `json:"workflow_id"`
+	WorkflowType string `json:"workflow_type"`
+	StepID       string `json:"step_id"`
+	StepName     string `json:"step_name"`
+
+	ErrMessage string `json:"err_message,omitempty"`
+
+	RetryIndex int `json:"retry_index"`
+	MaxRetries int `json:"max_retries,omitempty"`
+}
+
+var (
+	_ signal.Signal                     = (*Signal)(nil)
+	_ signal.SignalWithLifecycleContext = (*Signal)(nil)
+)
+
+func (s *Signal) Type() signal.SignalType {
+	return SignalType
+}
+
+func (s *Signal) LifecycleContext() signal.SignalLifecycleContext {
+	installID := &s.InstallID
+	if s.InstallID == "" {
+		installID = nil
+	}
+	return signal.SignalLifecycleContext{
+		OrgID:        s.OrgID,
+		InstallID:    installID,
+		Operation:    "workflow-step-awaiting-retry",
+		WorkflowID:   s.WorkflowID,
+		WorkflowType: s.WorkflowType,
+		StepID:       s.StepID,
+		OwnerID:      s.InstallID,
+		OwnerType:    "installs",
+		Metadata: map[string]any{
+			"awaiting_retry":         true,
+			"manual_action_required": true,
+			"terminal":               false,
+			"error":                  s.ErrMessage,
+			"step_name":              s.StepName,
+			"retry_index":            s.RetryIndex,
+			"max_retries":            s.MaxRetries,
+		},
+	}
+}
+
+func (s *Signal) Validate(ctx workflow.Context) error {
+	if s.WorkflowID == "" {
+		return errors.New("workflow_id is required")
+	}
+	if s.StepID == "" {
+		return errors.New("step_id is required")
+	}
+	return nil
+}
+
+func (s *Signal) Execute(_ workflow.Context) error {
+	return nil
+}

--- a/services/ctl-api/internal/pkg/interests/classify.go
+++ b/services/ctl-api/internal/pkg/interests/classify.go
@@ -24,11 +24,17 @@ const (
 	// has been quiet long enough (5 min) for processhealthcheck to give up on
 	// it; the classifier maps it onto (runners, inactive) so subscribers can
 	// opt into a notification.
-	signalTypeOnInactive      signal.SignalType = "on_inactive"
-	signalTypeStackRun        signal.SignalType = "stack-run"
-	signalTypeRoleChange      signal.SignalType = "role-change"
-	signalTypeInputsUpdated   signal.SignalType = "inputs-updated"
-	signalTypeAppConfigSynced signal.SignalType = "app-config-synced"
+	signalTypeOnInactive signal.SignalType = "on_inactive"
+	// signalTypeWorkflowStepAwaitingRetry mirrors the
+	// flow/signals/workflowstepawaitingretry SignalType. The carrier signal
+	// itself always succeeds (notification-only), so classification can't
+	// use the phase outcome — the event is unconditionally treated as a
+	// failure-flavoured, non-terminal "action required" emission.
+	signalTypeWorkflowStepAwaitingRetry signal.SignalType = "workflow-step-awaiting-retry"
+	signalTypeStackRun                  signal.SignalType = "stack-run"
+	signalTypeRoleChange                signal.SignalType = "role-change"
+	signalTypeInputsUpdated             signal.SignalType = "inputs-updated"
+	signalTypeAppConfigSynced           signal.SignalType = "app-config-synced"
 )
 
 // stepTargetType* mirror the WorkflowStepTargetType strings declared in
@@ -58,6 +64,7 @@ const (
 	eventClassApprovalRequest
 	eventClassApprovalResponse
 	eventClassDriftDetected
+	eventClassAwaitingRetry
 	eventClassRoleChange
 	eventClassInputsUpdated
 	eventClassConfigSynced
@@ -230,6 +237,22 @@ func classify(event signal.SignalPhaseEvent, outcome *signal.SignalPhaseOutcome,
 		f.Resource = res
 		f.Op = op
 		f.EventClass = eventClassDriftDetected
+		f.Resolved = true
+		return f
+
+	case signalTypeWorkflowStepAwaitingRetry:
+		// Same resource/op resolution as execute-workflow-step: the parked
+		// step's target type + parent workflow type land us on the taxonomy
+		// entry subscribers already filter by (components/deploy,
+		// sandboxes/provision, ...).
+		stepTarget := lookupStepTargetType(event, db)
+		res, op, ok := stepResolution(stepTarget, event.WorkflowType)
+		if !ok {
+			return f
+		}
+		f.Resource = res
+		f.Op = op
+		f.EventClass = eventClassAwaitingRetry
 		f.Resolved = true
 		return f
 
@@ -552,6 +575,13 @@ func slugsForFacts(f facts) []string {
 
 	case eventClassDriftDetected:
 		slugs = append(slugs, SlugEventDriftDetected)
+		return slugs
+
+	case eventClassAwaitingRetry:
+		// Projected as a failure: the step failed and parked. Deliberately
+		// no outcome:completion slug — the step is not terminal (a real
+		// lifecycle event follows once it's retried, skipped, or cancelled).
+		slugs = append(slugs, SlugEventLifecycleFailed, SlugOutcomeFailures)
 		return slugs
 
 	case eventClassRoleChange:

--- a/services/ctl-api/internal/pkg/interests/interests_test.go
+++ b/services/ctl-api/internal/pkg/interests/interests_test.go
@@ -91,6 +91,13 @@ func TestMatches(t *testing.T) {
 		StepID:       "iws_step_1",
 	}
 
+	awaitingRetryStep := signal.SignalPhaseEvent{
+		SignalType:   signalTypeWorkflowStepAwaitingRetry,
+		WorkflowType: "deploy_components",
+		Phase:        signal.SignalPhaseExecute,
+		StepID:       "iws_step_1",
+	}
+
 	successOutcome := &signal.SignalPhaseOutcome{Status: signal.SignalStatusSuccess}
 	failureOutcome := &signal.SignalPhaseOutcome{Status: signal.SignalStatusError}
 	cancelledOutcome := &signal.SignalPhaseOutcome{Status: signal.SignalStatusCancelled}
@@ -617,6 +624,60 @@ func TestMatches(t *testing.T) {
 			}},
 			want: false,
 		},
+		{
+			// The awaiting-retry carrier's own outcome is success — the
+			// matcher must still treat it as a failure event.
+			name:    "Awaiting-retry matches OutcomeFailures despite carrier success",
+			event:   awaitingRetryStep,
+			outcome: successOutcome,
+			in: Interests{Resources: map[ResourceKind]ResourceCfg{
+				ResourceComponents: {Outcome: OutcomeFailures},
+			}},
+			want: true,
+		},
+		{
+			name:    "Awaiting-retry matches OutcomeCompletion",
+			event:   awaitingRetryStep,
+			outcome: successOutcome,
+			in: Interests{Resources: map[ResourceKind]ResourceCfg{
+				ResourceComponents: {Outcome: OutcomeCompletion},
+			}},
+			want: true,
+		},
+		{
+			name:    "Awaiting-retry muted by OutcomeNone",
+			event:   awaitingRetryStep,
+			outcome: successOutcome,
+			in: Interests{Resources: map[ResourceKind]ResourceCfg{
+				ResourceComponents: {Outcome: OutcomeNone},
+			}},
+			want: false,
+		},
+		{
+			name:    "Awaiting-retry respects Ops filter (non-matching op)",
+			event:   awaitingRetryStep,
+			outcome: successOutcome,
+			in: Interests{Resources: map[ResourceKind]ResourceCfg{
+				ResourceComponents: {Ops: []string{"teardown"}, Outcome: OutcomeFailures},
+			}},
+			want: false,
+		},
+		{
+			name:    "Awaiting-retry dropped when resource not subscribed",
+			event:   awaitingRetryStep,
+			outcome: successOutcome,
+			in: Interests{Resources: map[ResourceKind]ResourceCfg{
+				ResourceSandboxes: {Outcome: OutcomeFailures},
+			}},
+			want: false,
+		},
+		{
+			name:    "Awaiting-retry matches AllEvents",
+			event:   awaitingRetryStep,
+			outcome: successOutcome,
+			in:      AllEvents(),
+			want:    true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -861,6 +922,41 @@ func TestClassifySlugs(t *testing.T) {
 				Phase:        signal.SignalPhaseExecute,
 			},
 			want: nil,
+		},
+		{
+			name: "awaiting-retry (deploy_components) → failed non-terminal slugs",
+			event: signal.SignalPhaseEvent{
+				SignalType:   signalTypeWorkflowStepAwaitingRetry,
+				WorkflowType: "deploy_components",
+				Phase:        signal.SignalPhaseExecute,
+				StepID:       "iws_x",
+			},
+			// The carrier signal itself succeeds; classification must still
+			// project a failure. No outcome:completion — the step isn't
+			// terminal yet.
+			outcome: &signal.SignalPhaseOutcome{Status: signal.SignalStatusSuccess},
+			want: []string{
+				"resource:components",
+				"op:components.deploy",
+				"event:lifecycle.failed",
+				"outcome:failures",
+			},
+		},
+		{
+			name: "awaiting-retry (provision) → sandboxes slugs via parent fallback",
+			event: signal.SignalPhaseEvent{
+				SignalType:   signalTypeWorkflowStepAwaitingRetry,
+				WorkflowType: "provision",
+				Phase:        signal.SignalPhaseExecute,
+				StepID:       "iws_x",
+			},
+			outcome: &signal.SignalPhaseOutcome{Status: signal.SignalStatusSuccess},
+			want: []string{
+				"resource:sandboxes",
+				"op:sandboxes.provision",
+				"event:lifecycle.failed",
+				"outcome:failures",
+			},
 		},
 		{
 			name: "drift-detected (drift_run) → components.drift slugs",

--- a/services/ctl-api/internal/pkg/interests/match.go
+++ b/services/ctl-api/internal/pkg/interests/match.go
@@ -80,6 +80,15 @@ func Matches(event signal.SignalPhaseEvent, outcome *signal.SignalPhaseOutcome, 
 		return cfg.ApprovalResponses
 	case eventClassDriftDetected:
 		return cfg.DriftDetected
+	case eventClassAwaitingRetry:
+		// Awaiting-retry is a failure-flavoured "action required" event: any
+		// subscriber who would receive a failed lifecycle event for this
+		// resource/op receives it (failures, completion, and all outcomes;
+		// only OutcomeNone suppresses it).
+		if len(cfg.Ops) > 0 && !contains(cfg.Ops, f.Op) {
+			return false
+		}
+		return cfg.Outcome != OutcomeNone
 	case eventClassRoleChange:
 		return cfg.RoleChanges
 	case eventClassInputsUpdated:

--- a/services/ctl-api/internal/pkg/queue/catalog/allsignals/allsignals.go
+++ b/services/ctl-api/internal/pkg/queue/catalog/allsignals/allsignals.go
@@ -147,4 +147,5 @@ import (
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeflow"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup"
+	_ "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/workflowstepawaitingretry"
 )

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/slack.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/slack.go
@@ -157,6 +157,7 @@ func (h *SlackSignalLifecycleHook) Supports(event signal.SignalPhaseEvent) bool 
 		signalTypeWorkflowStepApprovalRequest,
 		signalTypeWorkflowStepApprovalResponse,
 		signalTypeDriftDetected,
+		signalTypeWorkflowStepAwaitingRetry,
 		signalTypeStackRun,
 		signalTypeRoleChange,
 		signalTypeInputsUpdated,
@@ -178,7 +179,7 @@ func (h *SlackSignalLifecycleHook) BeforePhase(ctx context.Context, event signal
 	// matching comment in webhook.go. Drift-detected is a single-shot
 	// notification carrier (its Execute is a no-op) so a "started" emission
 	// would just produce a duplicate message right before the real one.
-	if isApprovalSignalType(event.SignalType) || isNotificationOnlySignalType(event.SignalType) {
+	if suppressesStartedEvent(event.SignalType) {
 		return signal.AllowPhaseDecision(), nil
 	}
 

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/slackrender/awaiting_retry_test.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/slackrender/awaiting_retry_test.go
@@ -1,0 +1,12 @@
+package slackrender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAwaitingRetryPresentation(t *testing.T) {
+	assert.Equal(t, "Awaiting manual retry", transitionPhrase(TransitionAwaitingRetry))
+	assert.Equal(t, "⚠️", statusEmoji(TransitionAwaitingRetry))
+}

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/slackrender/humanize.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/slackrender/humanize.go
@@ -136,6 +136,8 @@ func transitionPhrase(transition string) string {
 		return "Cancelled"
 	case TransitionRequested:
 		return "Awaiting approval"
+	case TransitionAwaitingRetry:
+		return "Awaiting manual retry"
 	case TransitionApproved:
 		return "Approved"
 	case TransitionRejected:

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/slackrender/message.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/slackrender/message.go
@@ -556,6 +556,8 @@ func statusEmoji(transition string) string {
 		return "❌"
 	case TransitionCancelled:
 		return "🚫"
+	case TransitionAwaitingRetry:
+		return "⚠️"
 	case TransitionRequested:
 		return "⏸️"
 	case TransitionApproved:

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/slackrender/types.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/slackrender/types.go
@@ -38,9 +38,10 @@ const (
 	TransitionFailed    = "failed"
 	TransitionCancelled = "cancelled"
 
-	TransitionRequested = "requested"
-	TransitionApproved  = "approved"
-	TransitionRejected  = "rejected"
+	TransitionRequested     = "requested"
+	TransitionApproved      = "approved"
+	TransitionRejected      = "rejected"
+	TransitionAwaitingRetry = "awaiting_retry"
 )
 
 // OwnerType values for WorkflowRef.OwnerType.

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/webhook.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/webhook.go
@@ -36,14 +36,15 @@ import (
 // multi-phase concepts (plan/apply), and inner signal type names are
 // deliberately NOT exposed.
 const (
-	cloudEventTypeWorkflow             = "com.nuon.workflow.lifecycle.v1"
-	cloudEventTypeWorkflowStep         = "com.nuon.workflow_step.lifecycle.v1"
-	cloudEventTypeWorkflowStepApproval = "com.nuon.workflow_step.approval.v1"
-	cloudEventTypeStackRun             = "com.nuon.stack.run.v1"
-	cloudEventTypeRoleChange           = "com.nuon.stack.role_change.v1"
-	cloudEventTypeInputsUpdated        = "com.nuon.stack.inputs_updated.v1"
-	cloudEventTypeAppConfigSynced      = "com.nuon.app.config_synced.v1"
-	cloudEventTypeUpdateAppConfig      = "com.nuon.install.app_config_updated.v1"
+	cloudEventTypeWorkflow                  = "com.nuon.workflow.lifecycle.v1"
+	cloudEventTypeWorkflowStep              = "com.nuon.workflow_step.lifecycle.v1"
+	cloudEventTypeWorkflowStepApproval      = "com.nuon.workflow_step.approval.v1"
+	cloudEventTypeWorkflowStepAwaitingRetry = "com.nuon.workflow_step.awaiting_retry.v1"
+	cloudEventTypeStackRun                  = "com.nuon.stack.run.v1"
+	cloudEventTypeRoleChange                = "com.nuon.stack.role_change.v1"
+	cloudEventTypeInputsUpdated             = "com.nuon.stack.inputs_updated.v1"
+	cloudEventTypeAppConfigSynced           = "com.nuon.app.config_synced.v1"
+	cloudEventTypeUpdateAppConfig           = "com.nuon.install.app_config_updated.v1"
 
 	kindWorkflow             = "workflow"
 	kindWorkflowStep         = "workflow_step"
@@ -76,6 +77,12 @@ const (
 	transitionRequested = "requested"
 	transitionApproved  = "approved"
 	transitionRejected  = "rejected"
+
+	// transitionAwaitingRetry is emitted on workflow_step.awaiting_retry.v1
+	// events when a step has failed and parked waiting for a manual retry,
+	// skip, or cancel. Non-terminal: the step's lifecycle event fires later
+	// once the workflow unblocks.
+	transitionAwaitingRetry = "awaiting_retry"
 )
 
 // signalTypeExecuteWorkflow matches the SignalType produced by
@@ -98,6 +105,12 @@ const (
 	// observed actual changes. Its lifecycle events are how subscribers who
 	// opted into per-resource `drift_detected: true` get notified.
 	signalTypeDriftDetected signal.SignalType = "drift-detected"
+	// signalTypeWorkflowStepAwaitingRetry mirrors workflowstepawaitingretry.
+	// SignalType — the notification-only signal enqueued when a workflow
+	// step fails and parks awaiting manual retry. Its successful after-phase
+	// is projected as a workflow_step.awaiting_retry.v1 event with a failed
+	// outcome sourced from the step's own error.
+	signalTypeWorkflowStepAwaitingRetry signal.SignalType = "workflow-step-awaiting-retry"
 
 	signalTypeStackRun        signal.SignalType = "stack-run"
 	signalTypeRoleChange      signal.SignalType = "role-change"
@@ -243,6 +256,7 @@ func (h *WebhookSignalLifecycleHook) Supports(event signal.SignalPhaseEvent) boo
 		signalTypeWorkflowStepApprovalRequest,
 		signalTypeWorkflowStepApprovalResponse,
 		signalTypeDriftDetected,
+		signalTypeWorkflowStepAwaitingRetry,
 		signalTypeStackRun,
 		signalTypeRoleChange,
 		signalTypeInputsUpdated,
@@ -265,7 +279,7 @@ func (h *WebhookSignalLifecycleHook) BeforePhase(ctx context.Context, event sign
 	// terminal (approved / rejected). Drift-detected is a single-shot
 	// notification (its Execute is a no-op) — a "started" emission would
 	// just produce a duplicate event before the real one. Skip both.
-	if isApprovalSignalType(event.SignalType) || isNotificationOnlySignalType(event.SignalType) {
+	if suppressesStartedEvent(event.SignalType) {
 		return signal.AllowPhaseDecision(), nil
 	}
 
@@ -288,6 +302,17 @@ func isNotificationOnlySignalType(t signal.SignalType) bool {
 		return true
 	}
 	return false
+}
+
+// suppressesStartedEvent reports whether a signal type's synthetic "started"
+// (before-phase) emission should be skipped. Awaiting-retry is listed here
+// but deliberately NOT in isNotificationOnlySignalType: that predicate also
+// routes Slack messages to standalone (flat) posts, while awaiting-retry
+// should thread into the workflow's existing Slack thread like a step event.
+func suppressesStartedEvent(t signal.SignalType) bool {
+	return isApprovalSignalType(t) ||
+		isNotificationOnlySignalType(t) ||
+		t == signalTypeWorkflowStepAwaitingRetry
 }
 
 func (h *WebhookSignalLifecycleHook) AfterPhase(ctx context.Context, event signal.SignalPhaseEvent, outcome signal.SignalPhaseOutcome) error {
@@ -505,6 +530,12 @@ func (h *WebhookSignalLifecycleHook) publish(ctx context.Context, event signal.S
 	case kindUpdateAppConfig:
 		ceType = cloudEventTypeUpdateAppConfig
 	}
+	// Awaiting-retry shares kind=workflow_step with the normal step
+	// lifecycle but gets its own CloudEvent type so consumers can route the
+	// "action required" case without parsing the transition.
+	if event.SignalType == signalTypeWorkflowStepAwaitingRetry {
+		ceType = cloudEventTypeWorkflowStepAwaitingRetry
+	}
 
 	subject := buildSubject(event, data)
 
@@ -617,12 +648,25 @@ func (h *WebhookSignalLifecycleHook) buildEventData(ctx context.Context, event s
 		return h.buildApprovalEventData(ctx, event, outcome)
 	}
 
+	// The awaiting-retry carrier only produces a public event from its
+	// successful after-phase: the before-phase is suppressed (see
+	// suppressesStartedEvent) and a failed/cancelled carrier means the
+	// notification itself broke — not something subscribers should see.
+	if event.SignalType == signalTypeWorkflowStepAwaitingRetry &&
+		(outcome == nil || outcome.Status != signal.SignalStatusSuccess) {
+		return lifecycleEventData{}, false
+	}
+
 	kind := kindWorkflow
-	if event.SignalType == signalTypeExecuteWorkflowStep {
+	if event.SignalType == signalTypeExecuteWorkflowStep ||
+		event.SignalType == signalTypeWorkflowStepAwaitingRetry {
 		kind = kindWorkflowStep
 	}
 
 	transition := mapTransition(event, outcome)
+	if event.SignalType == signalTypeWorkflowStepAwaitingRetry {
+		transition = transitionAwaitingRetry
+	}
 
 	data := lifecycleEventData{
 		Kind:       kind,
@@ -652,6 +696,21 @@ func (h *WebhookSignalLifecycleHook) buildEventData(ctx context.Context, event s
 
 	if outcome != nil {
 		data.Outcome = h.buildOutcome(event, outcome)
+	}
+
+	// The awaiting-retry carrier signal itself always succeeds (its Execute
+	// is a no-op) — the outcome subscribers care about is the parked step's
+	// real failure, carried in the signal's lifecycle metadata. Project it
+	// as a failed outcome and pass the metadata (retry_index, max_retries,
+	// awaiting_retry / manual_action_required flags) through verbatim.
+	if event.SignalType == signalTypeWorkflowStepAwaitingRetry {
+		data.Metadata = event.Metadata
+		if data.Outcome != nil {
+			data.Outcome.Status = statusFailed
+			if errMsg, _ := event.Metadata["error"].(string); errMsg != "" {
+				data.Outcome.Error = errMsg
+			}
+		}
 	}
 
 	// Enrich the step on workflow_step.lifecycle events AND on the

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/webhook_awaiting_retry_test.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/webhook_awaiting_retry_test.go
@@ -1,0 +1,120 @@
+package hooks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/hooks/slackrender"
+)
+
+func awaitingRetryEvent() signal.SignalPhaseEvent {
+	return signal.SignalPhaseEvent{
+		QueueSignalID: "sig_1",
+		SignalType:    signalTypeWorkflowStepAwaitingRetry,
+		Phase:         signal.SignalPhaseExecute,
+		OrgID:         "org_1",
+		OrgName:       "acme",
+		WorkflowID:    "wfl_1",
+		WorkflowType:  "deploy_components",
+		StepID:        "iws_1",
+		OwnerID:       "ins_1",
+		OwnerType:     "installs",
+		Metadata: map[string]any{
+			"awaiting_retry":         true,
+			"manual_action_required": true,
+			"terminal":               false,
+			"error":                  "terraform apply failed",
+			"step_name":              "deploy my-component",
+			"retry_index":            2,
+			"max_retries":            5,
+		},
+	}
+}
+
+func TestAwaitingRetryBuildEventData(t *testing.T) {
+	h := &WebhookSignalLifecycleHook{l: zap.NewNop()}
+	ctx := context.Background()
+
+	t.Run("successful carrier projects failed non-terminal step event", func(t *testing.T) {
+		event := awaitingRetryEvent()
+		outcome := &signal.SignalPhaseOutcome{Status: signal.SignalStatusSuccess}
+
+		data, ok := h.buildEventData(ctx, event, outcome)
+		require.True(t, ok)
+
+		assert.Equal(t, kindWorkflowStep, data.Kind)
+		assert.Equal(t, transitionAwaitingRetry, data.Transition)
+		assert.Equal(t, "org_1", data.OrgID)
+		assert.Equal(t, "wfl_1", data.Workflow.ID)
+		assert.Equal(t, "ins_1", data.Workflow.OwnerID)
+		assert.Equal(t, "installs", data.Workflow.OwnerType)
+
+		require.NotNil(t, data.Step)
+		assert.Equal(t, "iws_1", data.Step.ID)
+
+		require.NotNil(t, data.Outcome)
+		assert.Equal(t, statusFailed, data.Outcome.Status)
+		assert.Equal(t, "terraform apply failed", data.Outcome.Error)
+
+		require.NotNil(t, data.Metadata)
+		assert.Equal(t, true, data.Metadata["awaiting_retry"])
+		assert.Equal(t, true, data.Metadata["manual_action_required"])
+		assert.Equal(t, false, data.Metadata["terminal"])
+		assert.Equal(t, 2, data.Metadata["retry_index"])
+		assert.Equal(t, 5, data.Metadata["max_retries"])
+	})
+
+	t.Run("before-phase (nil outcome) produces no event", func(t *testing.T) {
+		_, ok := h.buildEventData(ctx, awaitingRetryEvent(), nil)
+		assert.False(t, ok)
+	})
+
+	t.Run("failed carrier produces no event", func(t *testing.T) {
+		_, ok := h.buildEventData(ctx, awaitingRetryEvent(), &signal.SignalPhaseOutcome{
+			Status:     signal.SignalStatusError,
+			ErrMessage: "notification carrier broke",
+		})
+		assert.False(t, ok)
+	})
+
+	t.Run("cancelled carrier produces no event", func(t *testing.T) {
+		_, ok := h.buildEventData(ctx, awaitingRetryEvent(), &signal.SignalPhaseOutcome{
+			Status: signal.SignalStatusCancelled,
+		})
+		assert.False(t, ok)
+	})
+
+	t.Run("missing error metadata keeps carrier error empty but status failed", func(t *testing.T) {
+		event := awaitingRetryEvent()
+		delete(event.Metadata, "error")
+
+		data, ok := h.buildEventData(ctx, event, &signal.SignalPhaseOutcome{Status: signal.SignalStatusSuccess})
+		require.True(t, ok)
+		require.NotNil(t, data.Outcome)
+		assert.Equal(t, statusFailed, data.Outcome.Status)
+		assert.Empty(t, data.Outcome.Error)
+	})
+}
+
+func TestAwaitingRetryStartedEventSuppression(t *testing.T) {
+	assert.True(t, suppressesStartedEvent(signalTypeWorkflowStepAwaitingRetry))
+	assert.False(t, isNotificationOnlySignalType(signalTypeWorkflowStepAwaitingRetry))
+}
+
+func TestAwaitingRetrySlackRendering(t *testing.T) {
+	event := awaitingRetryEvent()
+	data, ok := (&WebhookSignalLifecycleHook{l: zap.NewNop()}).
+		buildEventData(context.Background(), event, &signal.SignalPhaseOutcome{Status: signal.SignalStatusSuccess})
+	require.True(t, ok)
+
+	rendered := buildRenderEvent(data)
+	assert.Equal(t, slackrender.TransitionAwaitingRetry, rendered.event.Transition)
+	require.NotNil(t, rendered.event.Outcome)
+	assert.Equal(t, statusFailed, rendered.event.Outcome.Status)
+	assert.Equal(t, "terraform apply failed", rendered.event.Outcome.Error)
+}

--- a/services/ctl-api/internal/pkg/workflows/status/activities/activities.go
+++ b/services/ctl-api/internal/pkg/workflows/status/activities/activities.go
@@ -1,27 +1,42 @@
 package statusactivities
 
 import (
+	"context"
+
 	"go.uber.org/fx"
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/pkg/metrics"
 )
 
+// FlowStatusNotifier is an optional hook invoked after a flow status update
+// is persisted. Implemented outside this package (see
+// pkg/flow/signals/workflowstepawaitingretry) because the queue client can't
+// be imported here without an import cycle (queue/handler imports this
+// package). Implementations must be best-effort: they may not fail the
+// status update, so the method returns nothing.
+type FlowStatusNotifier interface {
+	FlowStatusUpdated(ctx context.Context, req UpdateStatusRequest)
+}
+
 type Params struct {
 	fx.In
 
-	DB *gorm.DB `name:"psql"`
-	MW metrics.Writer
+	DB       *gorm.DB `name:"psql"`
+	MW       metrics.Writer
+	Notifier FlowStatusNotifier `optional:"true"`
 }
 
 type Activities struct {
-	db *gorm.DB
-	mw metrics.Writer
+	db       *gorm.DB
+	mw       metrics.Writer
+	notifier FlowStatusNotifier
 }
 
 func New(params Params) *Activities {
 	return &Activities{
-		db: params.DB,
-		mw: params.MW,
+		db:       params.DB,
+		mw:       params.MW,
+		notifier: params.Notifier,
 	}
 }

--- a/services/ctl-api/internal/pkg/workflows/status/activities/update.go
+++ b/services/ctl-api/internal/pkg/workflows/status/activities/update.go
@@ -187,7 +187,14 @@ func (a *Activities) PkgStatusUpdateFlowStatus(ctx context.Context, req UpdateSt
 		return obj.Status, nil
 	}
 
-	return a.updateStatus(ctx, &obj, req.Status, getter)
+	if err := a.updateStatus(ctx, &obj, req.Status, getter); err != nil {
+		return err
+	}
+
+	if a.notifier != nil {
+		a.notifier.FlowStatusUpdated(ctx, req)
+	}
+	return nil
 }
 
 // @temporal-gen-v2 activity

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -4030,6 +4030,7 @@ export interface components {
       id?: string;
       namespace?: string;
       public_git_vcs_config?: components["schemas"]["app.PublicGitVCSConfig"];
+      skip_crds?: boolean;
       storage_driver?: string;
       /** @description Newer config fields that we don't need a column for */
       take_ownership?: boolean;
@@ -4043,6 +4044,7 @@ export interface components {
       chart_name?: string;
       helm_repo_config?: components["schemas"]["app.HelmRepoConfig"];
       namespace?: string;
+      skip_crds?: boolean;
       storage_driver?: string;
       /** @description Newer fields that we don't need to store as columns in the database */
       take_ownership?: boolean;
@@ -6469,6 +6471,7 @@ export interface components {
        */
       name?: string;
       namespace?: string;
+      skip_crds?: boolean;
       storage_driver?: string;
       take_ownership?: boolean;
       values?: components["schemas"]["plantypes.HelmValue"][];
@@ -7279,6 +7282,7 @@ export interface components {
       };
       public_git_vcs_config?: components["schemas"]["service.PublicGitVCSConfigRequest"];
       references?: string[];
+      skip_crds?: boolean;
       skip_noops?: boolean;
       storage_driver?: string;
       take_ownership?: boolean;


### PR DESCRIPTION
## Summary

Workflow steps now notify webhook and Slack subscribers when automatic retries are exhausted and the workflow pauses for manual action.

## What you can do after this PR

**Receive an action-required event when a step parks.** Webhooks receive a `workflow_step.awaiting_retry` event with the failed step, workflow, retry details, and error. Slack subscriptions receive a threaded “Awaiting manual retry” message.

**Use existing notification filters.** The event follows the step’s existing resource and operation, such as component deploy or sandbox provision, and matches the same subscriptions as other failed lifecycle events.

**Retry without duplicate notifications from ordinary activity retries.** Notifications are checked by step and retry index before enqueueing. A later manual retry can notify again if the step parks at a new retry index.

## What stays the same

Notification delivery is best-effort and cannot fail the workflow status update. No new subscription settings are required, and the parked workflow remains available for retry, skip, or cancellation.

## Mechanics worth flagging for review

The MVP dispatches after the status activity persists `failed-pending-retry`, avoiding Temporal workflow versioning for in-flight workflows. It does not backfill workflows that were already parked before rollout, and concurrent activity retries can still race around the database deduplication check.
