### PR TITLE
fix: helm plan shows base64 parse error for every secret

### DIFF
--- a/bins/runner/internal/jobs/deploy/helm/diff.go
+++ b/bins/runner/internal/jobs/deploy/helm/diff.go
@@ -103,14 +103,26 @@ func (h *handler) getDiff(l *zap.Logger, kubeCfg *rest.Config, release, target *
 		newSpec = manifest.Parse(string(targetResources), target.Namespace, false)
 	}
 
-	diff, err := h.diff(currentSpecs, newSpec)
+	// helm-diff redacts Secret contents in place, so each pass gets its own
+	// copy — a second pass over redacted maps fails to re-parse them and
+	// replaces every Secret with "Error parsing new secret: illegal base64".
+	diff, err := h.diff(cloneSpecs(currentSpecs), cloneSpecs(newSpec))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to generate diff")
 	}
-	diffReport, err := h.diffReport(currentSpecs, newSpec)
+	diffReport, err := h.diffReport(cloneSpecs(currentSpecs), cloneSpecs(newSpec))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to generate diff report")
 	}
 
 	return diff, diffReport, nil
+}
+
+func cloneSpecs(specs map[string]*manifest.MappingResult) map[string]*manifest.MappingResult {
+	out := make(map[string]*manifest.MappingResult, len(specs))
+	for k, v := range specs {
+		cp := *v
+		out[k] = &cp
+	}
+	return out
 }


### PR DESCRIPTION
Chart-rendered Secrets in the dashboard's "Sync and plan" view show
`+ Error parsing new secret: error unmarshaling JSON: while decoding JSON: illegal base64 data at input byte 8`
instead of the redacted diff (seen on every helm component deploy in the lovable-enterprise azure install).

Cause: helm-diff's `redactSecrets` mutates the manifest maps in place — it rewrites each Secret's `data:` values to `REDACTED # (n bytes)` / `++++++++ # (n bytes)`. `getDiff` runs two passes (`diff`, then `diffReport`) over the same `map[string]*manifest.MappingResult`, so the second pass re-parses already-redacted content: both placeholders are 8 valid base64 chars followed by a space, hence the constant "byte 8" failure, and the fork replaces the whole Secret with the parse error. Upstream never hits this because the CLI does a single pass.

Fix: give each pass its own shallow copy of the maps.
