### PR TITLE
fix: show create instructions for all secrets on azure await install stack

### DIFF
--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.stories.tsx
@@ -17,6 +17,36 @@ const mockStep = {
   status: { status: 'active' },
 } as any
 
+const mockSecrets = [
+  {
+    name: 'optional_token',
+    display_name: 'Optional token',
+    description: 'Only needed when SSO is enabled.',
+  },
+  {
+    name: 'license_key',
+    display_name: 'License key',
+    description: 'The license key for your app.',
+    required: true,
+  },
+  {
+    name: 'smtp_password',
+    display_name: 'SMTP password',
+    default: 'change-me',
+  },
+  {
+    name: 'session_signing_key',
+    display_name: 'Session signing key',
+    auto_generate: true,
+  },
+  {
+    name: 'tls_cert',
+    display_name: 'TLS certificate',
+    required: true,
+    format: 'base64',
+  },
+] as any
+
 export const Default = () => (
   <div className="max-w-2xl p-4">
     <AwaitAzureDetails
@@ -24,6 +54,18 @@ export const Default = () => (
       step={mockStep}
       installId="install-1"
       azureLocation="eastus"
+    />
+  </div>
+)
+
+export const WithSecrets = () => (
+  <div className="max-w-2xl p-4">
+    <AwaitAzureDetails
+      stack={mockStack}
+      step={mockStep}
+      installId="install-1"
+      azureLocation="eastus"
+      secrets={mockSecrets}
     />
   </div>
 )

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.tsx
@@ -32,7 +32,7 @@ export const AwaitAzureDetails = ({ stack, installId, azureLocation, secrets }: 
 
   const secretHint = (secret: TAppSecretConfig) => {
     if (secret.auto_generate) {
-      return 'The command generates a random value for this secret.'
+      return 'The command generates a random value for test purposes. Replace it with your own value if needed.'
     }
     if (secret.default) {
       return 'The command pre-fills the app default. Replace the value to override it.'

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.tsx
@@ -2,7 +2,6 @@ import { Card } from '@/components/common/Card'
 import { ClickToCopyButton } from '@/components/common/ClickToCopy'
 import { Code } from '@/components/common/Code'
 import { Divider } from '@/components/common/Divider'
-import { Expand } from '@/components/common/Expand'
 import { Link } from '@/components/common/Link'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Text } from '@/components/common/Text'
@@ -17,13 +16,37 @@ interface IAwaitAzureDetails extends IStackDetails {
 
 export const AwaitAzureDetails = ({ stack, installId, azureLocation, secrets }: IAwaitAzureDetails) => {
   const vaultName = installId.slice(0, 24)
-  const customerSecrets = secrets?.filter((s) => !s.auto_generate)
-  const requiredSecrets = customerSecrets?.filter((s) => s.required || (!s.default && !s.required))
-  const overridableSecrets = customerSecrets?.filter((s) => !s.required && !!s.default)
+  // Azure stacks never create vault secrets — customers pre-create all of them, even auto-generated/defaulted ones
+  const allSecrets = [...(secrets ?? [])].sort(
+    (a, b) => Number(!!b.required) - Number(!!a.required)
+  )
+
+  const secretValue = (secret: TAppSecretConfig) => {
+    if (secret.auto_generate) {
+      return secret.format === 'base64'
+        ? '$(openssl rand -base64 48)'
+        : '$(openssl rand -hex 32)'
+    }
+    return secret.default || '<your-secret-value>'
+  }
+
+  const secretHint = (secret: TAppSecretConfig) => {
+    if (secret.auto_generate) {
+      return 'The command generates a random value for this secret.'
+    }
+    if (secret.default) {
+      return 'The command pre-fills the app default. Replace the value to override it.'
+    }
+    if (!secret.required) {
+      return 'Optional. Create it only if your app needs a value.'
+    }
+    return null
+  }
 
   const renderSecretCard = (secret: TAppSecretConfig) => {
-    const kvName = secret.name.replaceAll('_', '-')
-    const cmd = `az keyvault secret set --vault-name ${vaultName} --name ${kvName} --value "<your-secret-value>"`
+    const kvName = (secret.name ?? '').replaceAll('_', '-')
+    const cmd = `az keyvault secret set --vault-name ${vaultName} --name ${kvName} --value "${secretValue(secret)}"`
+    const hint = secretHint(secret)
     return (
       <Card key={secret.name}>
         <span className="flex justify-between items-center">
@@ -40,6 +63,10 @@ export const AwaitAzureDetails = ({ stack, installId, azureLocation, secrets }: 
         </span>
         {secret.description && (
           <Text variant="subtext">{secret.description}</Text>
+        )}
+        {hint && <Text variant="subtext">{hint}</Text>}
+        {secret.format === 'base64' && !secret.auto_generate && (
+          <Text variant="subtext">The value must be base64-encoded.</Text>
         )}
         <Code>{cmd}</Code>
       </Card>
@@ -100,14 +127,16 @@ export const AwaitAzureDetails = ({ stack, installId, azureLocation, secrets }: 
         </Card>
       </div>
 
-      {customerSecrets && customerSecrets.length > 0 && (
+      {allSecrets.length > 0 && (
         <div className="flex flex-col gap-4">
           <Text variant="base" weight="strong">
             Create secrets in the Key Vault
           </Text>
           <Text variant="subtext">
-            Before deploying the stack, create the following secrets in the Key
-             Vault. The secret names must match exactly.
+            Before deploying the stack, create every secret below in the Key
+            Vault. The stack does not create secrets — a skipped secret is never
+            synced, even when it has a default. The secret names must match
+            exactly.
           </Text>
 
           <Card>
@@ -125,25 +154,7 @@ export const AwaitAzureDetails = ({ stack, installId, azureLocation, secrets }: 
             `}</Code>
           </Card>
 
-            {requiredSecrets?.map(renderSecretCard)}
-              {overridableSecrets && overridableSecrets.length > 0 && (
-                <Expand
-                  id="overridable-secrets"
-                  heading={
-                    <Text variant="subtext">
-                      Optional overrides ({overridableSecrets.length})
-                    </Text>
-                  }
-                >
-                  <div className="flex flex-col gap-4 p-2">
-                    <Text variant="subtext">
-                      These secrets have default values. Set them only if you need
-                      to override the defaults.
-                    </Text>
-                    {overridableSecrets.map(renderSecretCard)}
-                  </div>
-                </Expand>
-              )}
+          {allSecrets.map(renderSecretCard)}
         </div>
       )}
 


### PR DESCRIPTION
On Azure the stack never creates Key Vault secrets, so the await-install-stack page now lists every secret (optional, defaulted, auto-generated) as a first-class create command instead of hiding non-required ones behind a skip-able "optional overrides" section.