### PR TITLE
fix: surface azure custom stack outputs via phone home

### DIFF
--- a/pkg/config/app_stack.go
+++ b/pkg/config/app_stack.go
@@ -186,6 +186,14 @@ func (a *StackConfig) parse() error {
 			}
 		}
 	}
+	// The gcp-terraform renderer does not consume custom stacks; reject them
+	// instead of silently ignoring them.
+	if a.Type == "gcp-terraform" && len(a.CustomNestedStacks) > 0 {
+		return ErrConfig{
+			Description: "custom_nested_stacks are not supported when type is gcp-terraform",
+			Err:         fmt.Errorf("custom_nested_stacks are not supported when type is gcp-terraform"),
+		}
+	}
 	seenIndices := map[int]string{}
 	for i, stack := range a.CustomNestedStacks {
 		if stack.Name == "" {

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom.go
@@ -27,10 +27,18 @@ type customDeploymentIdentity struct {
 	DeploymentName string
 }
 
-func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any, map[string]ARMParameter, []customDeploymentIdentity, error) {
+// customDeploymentOutputs records a custom stack's deployment name and its
+// template's output keys so the phone-home script can report them.
+type customDeploymentOutputs struct {
+	StackName      string
+	DeploymentName string
+	OutputKeys     []string
+}
+
+func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any, map[string]ARMParameter, []customDeploymentIdentity, []customDeploymentOutputs, error) {
 	stacks := inp.AppCfg.StackConfig.CustomNestedStacks
 	if len(stacks) == 0 {
-		return nil, nil, nil, nil
+		return nil, nil, nil, nil, nil
 	}
 
 	// Sort by index
@@ -44,28 +52,29 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 	seenIndices := map[int]string{}
 	for _, stack := range sorted {
 		if prev, exists := seenIndices[stack.Index]; exists {
-			return nil, nil, nil, fmt.Errorf("custom_nested_stacks: duplicate index %d for stacks %q and %q", stack.Index, prev, stack.Name)
+			return nil, nil, nil, nil, fmt.Errorf("custom_nested_stacks: duplicate index %d for stacks %q and %q", stack.Index, prev, stack.Name)
 		}
 		seenIndices[stack.Index] = stack.Name
 	}
 
 	var resources []any
 	var identities []customDeploymentIdentity
+	var outputsMeta []customDeploymentOutputs
 	hoistedParams := map[string]ARMParameter{}
 	allParamNames := map[string]string{}
 	prevDeploymentName := ""
 
 	for i, stack := range sorted {
 		if stack.Name == "" {
-			return nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d]: name is required", i)
+			return nil, nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d]: name is required", i)
 		}
 		if stack.TemplateURL == "" {
-			return nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): template_url is required", i, stack.Name)
+			return nil, nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): template_url is required", i, stack.Name)
 		}
 
 		deploymentName := sanitizeDeploymentName(stack.Name)
 		if deploymentName == "" {
-			return nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): name produces invalid deployment name", i, stack.Name)
+			return nil, nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): name produces invalid deployment name", i, stack.Name)
 		}
 
 		// Resolve template URL (use uploaded S3 URL if contents were uploaded)
@@ -83,14 +92,25 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 		// Fetch template, validate structure, and extract parameters
 		armTmpl, err := fetchARMTemplate(templateURL)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): %w", i, stack.Name, err)
+			return nil, nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): %w", i, stack.Name, err)
 		}
 
 		if err := validateARMTemplate(armTmpl); err != nil {
-			return nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): %w", i, stack.Name, err)
+			return nil, nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): %w", i, stack.Name, err)
 		}
 
 		params, defaultParams := extractARMParameters(armTmpl, ReservedParamNames)
+
+		outputKeys := make([]string, 0, len(armTmpl.Outputs))
+		for key := range armTmpl.Outputs {
+			outputKeys = append(outputKeys, key)
+		}
+		sort.Strings(outputKeys)
+		outputsMeta = append(outputsMeta, customDeploymentOutputs{
+			StackName:      stack.Name,
+			DeploymentName: deploymentName,
+			OutputKeys:     outputKeys,
+		})
 
 		// Track custom nested stacks that declare managed identities so the
 		// parent template can create subscription-level role assignments.
@@ -103,7 +123,7 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 		// Check for parameter name conflicts
 		for paramName := range defaultParams {
 			if owner, exists := allParamNames[paramName]; exists {
-				return nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): parameter %q conflicts with stack %q", i, stack.Name, paramName, owner)
+				return nil, nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): parameter %q conflicts with stack %q", i, stack.Name, paramName, owner)
 			}
 			allParamNames[paramName] = stack.Name
 		}
@@ -128,7 +148,7 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 		for cfnParamName, templateValue := range stack.Parameters {
 			inputName, err := config.ParseInstallInputReference(templateValue)
 			if err != nil {
-				return nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): parameter %q: %w", i, stack.Name, cfnParamName, err)
+				return nil, nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): parameter %q: %w", i, stack.Name, cfnParamName, err)
 			}
 
 			resolved := ""
@@ -205,5 +225,5 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 		prevDeploymentName = deploymentName
 	}
 
-	return resources, hoistedParams, identities, nil
+	return resources, hoistedParams, identities, outputsMeta, nil
 }

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home.go
@@ -2,12 +2,19 @@ package arm
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
 )
 
-func (t *Templates) getPhoneHomeResource(inp *stacks.TemplateInput) map[string]any {
+var envNameRegexp = regexp.MustCompile(`[^A-Za-z0-9]`)
+
+func envToken(s string) string {
+	return strings.ToUpper(envNameRegexp.ReplaceAllString(s, "_"))
+}
+
+func (t *Templates) getPhoneHomeResource(inp *stacks.TemplateInput, customOutputs []customDeploymentOutputs) map[string]any {
 	phoneHomeURL := inp.CloudFormationStackVersion.PhoneHomeURL
 
 	// Build per-secret env vars and payload fields dynamically.
@@ -43,6 +50,28 @@ func (t *Templates) getPhoneHomeResource(inp *stacks.TemplateInput) map[string]a
 		`  "subscription_tenant_id": "$SUBSCRIPTION_TENANT_ID"`,
 	}
 	payloadFields = append(payloadFields, secretPayloadFields...)
+
+	// Custom nested stack outputs, mirroring the AWS phone-home shape:
+	// custom_nested_stacks.<name>.outputs.<key>. Non-string ARM outputs are
+	// serialized with string().
+	var customEnvVars []map[string]any
+	if len(customOutputs) > 0 {
+		var stackFields []string
+		for _, co := range customOutputs {
+			var outFields []string
+			for _, key := range co.OutputKeys {
+				envName := fmt.Sprintf("CUSTOM_%s_%s", envToken(co.StackName), envToken(key))
+				customEnvVars = append(customEnvVars, map[string]any{
+					"name":  envName,
+					"value": fmt.Sprintf("[string(reference('%s').outputs.%s.value)]", co.DeploymentName, key),
+				})
+				outFields = append(outFields, fmt.Sprintf(`      "%s": "$%s"`, key, envName))
+			}
+			stackFields = append(stackFields, fmt.Sprintf("    \"%s\": {\n      \"outputs\": {\n  %s\n      }\n    }", co.StackName, strings.Join(outFields, ",\n  ")))
+		}
+		payloadFields = append(payloadFields, "  \"custom_nested_stacks\": {\n"+strings.Join(stackFields, ",\n")+"\n  }")
+	}
+
 	payloadJSON := "{\n" + strings.Join(payloadFields, ",\n") + "\n}"
 
 	scriptContent := `#!/bin/bash
@@ -97,6 +126,12 @@ fi
 		{"name": "PRIVATE_SUBNET_NAMES_CSV", "value": "[reference('vnetDeployment').outputs.privateSubnetNames.value]"},
 	}
 	envVars = append(envVars, secretEnvVars...)
+	envVars = append(envVars, customEnvVars...)
+
+	dependsOn := []string{"vnetDeployment"}
+	for _, co := range customOutputs {
+		dependsOn = append(dependsOn, co.DeploymentName)
+	}
 
 	return map[string]any{
 		"type":       "Microsoft.Resources/deploymentScripts",
@@ -105,7 +140,7 @@ fi
 		"location":   "[parameters('location')]",
 		"tags":       "[variables('commonTags')]",
 		"kind":       "AzureCLI",
-		"dependsOn":  []string{"vnetDeployment"},
+		"dependsOn":  dependsOn,
 		"properties": map[string]any{
 			"forceUpdateTag":       "[parameters('deployTimestamp')]",
 			"azCliVersion":         "2.40.0",

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_test.go
@@ -1,0 +1,55 @@
+package arm
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+func TestGetPhoneHomeResource_CustomStackOutputs(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+	inp := minimalTemplateInput()
+
+	res := tmpl.getPhoneHomeResource(inp, []customDeploymentOutputs{
+		{StackName: "preview_bucket", DeploymentName: "PreviewBucket", OutputKeys: []string{"bucketName", "bucketUrl"}},
+	})
+
+	props := res["properties"].(map[string]any)
+	script := props["scriptContent"].(string)
+	for _, want := range []string{
+		`"custom_nested_stacks"`,
+		`"preview_bucket"`,
+		`"bucketName": "$CUSTOM_PREVIEW_BUCKET_BUCKETNAME"`,
+		`"bucketUrl": "$CUSTOM_PREVIEW_BUCKET_BUCKETURL"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("script missing %s", want)
+		}
+	}
+
+	found := false
+	for _, env := range props["environmentVariables"].([]map[string]any) {
+		if env["name"] == "CUSTOM_PREVIEW_BUCKET_BUCKETNAME" {
+			found = true
+			if env["value"] != "[string(reference('PreviewBucket').outputs.bucketName.value)]" {
+				t.Errorf("unexpected env value: %v", env["value"])
+			}
+		}
+	}
+	if !found {
+		t.Error("CUSTOM_PREVIEW_BUCKET_BUCKETNAME env var not found")
+	}
+
+	deps := res["dependsOn"].([]string)
+	if !strings.Contains(strings.Join(deps, ","), "PreviewBucket") {
+		t.Errorf("dependsOn missing PreviewBucket: %v", deps)
+	}
+
+	resBytes, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	assertNoNestedBrackets(t, resBytes)
+}

--- a/services/ctl-api/internal/pkg/stacks/arm/template.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/template.go
@@ -100,9 +100,6 @@ func (t *Templates) getAzureTemplate(inp *stacks.TemplateInput) (*ARMTemplate, e
 		}
 	}
 
-	// Phone home deployment script
-	tmpl.Resources = append(tmpl.Resources, t.getPhoneHomeResource(inp))
-
 	// VMSS role assignments at resource-group scope (depends on runner VMSS)
 	if !t.cfg.UseLocalRunners {
 		tmpl.Resources = append(tmpl.Resources, t.getVMSSRoleAssignments()...)
@@ -115,12 +112,14 @@ func (t *Templates) getAzureTemplate(inp *stacks.TemplateInput) (*ARMTemplate, e
 		tmpl.Resources = append(tmpl.Resources, t.getCustomRoleDeployment(inp))
 	}
 
-	// Custom linked deployments
+	// Custom linked deployments (before phone home, which reports their outputs)
+	var customOutputs []customDeploymentOutputs
 	if len(inp.AppCfg.StackConfig.CustomNestedStacks) > 0 {
-		customResources, customParams, customIdentities, err := t.getCustomLinkedDeployments(inp)
+		customResources, customParams, customIdentities, customOutputsMeta, err := t.getCustomLinkedDeployments(inp)
 		if err != nil {
 			return nil, err
 		}
+		customOutputs = customOutputsMeta
 		tmpl.Resources = append(tmpl.Resources, customResources...)
 		for k, v := range customParams {
 			tmpl.Parameters[k] = v
@@ -134,6 +133,9 @@ func (t *Templates) getAzureTemplate(inp *stacks.TemplateInput) (*ARMTemplate, e
 			tmpl.Resources = append(tmpl.Resources, t.getCustomDeploymentRoleAssignment(id))
 		}
 	}
+
+	// Phone home deployment script
+	tmpl.Resources = append(tmpl.Resources, t.getPhoneHomeResource(inp, customOutputs))
 
 	// Add standard outputs (VNet, subnets, key vault)
 	t.addStandardOutputs(tmpl)


### PR DESCRIPTION
azure-bicep already deploys `custom_nested_stacks` (`arm/linked_deployment_custom.go`), but their outputs never reach the phone-home payload — so `{{ .nuon.install_stack.outputs.custom_nested_stacks.* }}` resolves on aws and silently never populates on azure.

- collect each custom deployment's template output keys during composition
- add them to the phone-home script as env vars (`[string(reference('<deployment>').outputs.<key>.value)]`) and a `custom_nested_stacks` payload field mirroring the aws lambda shape, with dependsOn on each custom deployment
- reorder template composition so the phone-home resource is built after custom deployments
- reject `custom_nested_stacks` on `gcp-terraform` at config parse — the gcp renderer ignores them, so today they validate, upload, and then silently do nothing

Non-string ARM outputs are serialized with `string()`.
