### PR TITLE
fix: action trigger validation and complete trigger documentation

### DIFF
--- a/docs/concepts/actions.mdx
+++ b/docs/concepts/actions.mdx
@@ -112,9 +112,12 @@ nuon actions create-run -w <action-workflow-id> -i <install-id>
 
 ## Action Triggers
 
-Action triggers are now available for all workflows. You can now use the
-following set of triggers:
+Actions can run manually, on a cron schedule, or in response to install
+lifecycle events. The supported triggers that are not tied to a specific
+component are:
 
+- `manual`
+- `cron`
 - `pre-provision`
 - `post-provision`
 - `pre-reprovision`
@@ -140,6 +143,9 @@ Each workflow trigger is called at the beginning or end of the workflow. In some
 cases, such as `pre-provision` or `pre-reprovision` that include a stack-run,
 the trigger will be called right after the runner is healthy.
 
+`post-provision` runs after the complete install provision workflow, including
+sandbox provisioning and component deployment.
+
 ### Role change triggers
 
 The `role-enabled` and `role-disabled` triggers fire when a customer enables or
@@ -154,8 +160,15 @@ tied to a specific component:
 
 - `pre-deploy-component`
 - `post-deploy-component`
-- `post-teardown-component`
 - `pre-teardown-component`
+- `post-teardown-component`
+- `pre-enable-component`
+- `post-enable-component`
+- `pre-disable-component`
+- `post-disable-component`
+
+The enable and disable triggers run when an input update changes a toggleable
+component's enabled state.
 
 <Note>
 	`pre-component-deploy` and `post-component-deploy` have been renamed to

--- a/docs/config-ref/action.mdx
+++ b/docs/config-ref/action.mdx
@@ -29,7 +29,7 @@ title: 'Action'
 | **`type`**<br/>string | type of trigger Supported trigger types: manual, cron, pre-provision, post-provision, pre-reprovision, post-reprovision, pre-deprovision, post-deprovision, pre-deploy-all-components, post-deploy-al... | **✅ Required** | `"manual"`, `"cron"`, `"post-provision"` |
 | **`index`**<br/>integer | index for manual trigger Used to differentiate multiple manual triggers in the same action | **Optional** | `"0"`, `"1"` |
 | **`cron_schedule`**<br/>string | cron schedule expression for scheduled triggers Standard cron format (minute hour day month weekday). For example, '*/5 * * * *' runs every 5 minutes | **Optional** | `"*/5 * * * *"`, `"0 */4 * * *"` |
-| **`component_name`**<br/>string | component name for component-specific triggers Required for pre-deploy-component, post-deploy-component, pre-teardown-component, post-teardown-component triggers | **Optional** | `"database"`, `"api-server"` |
+| **`component_name`**<br/>string | component name for component-specific triggers Required for pre-deploy-component, post-deploy-component, pre-teardown-component, post-teardown-component, pre-enable-component, post-enable-component... | **Optional** | `"database"`, `"api-server"` |
 
 ### `steps`
 

--- a/docs/guides/actions.mdx
+++ b/docs/guides/actions.mdx
@@ -62,8 +62,10 @@ The example workflow will time out after 15 seconds, more than enough time to ma
 
 ### Action triggers
 
-Action triggers are available for all workflows. You can use the following set of triggers:
+Actions can run manually, on a cron schedule, or in response to install lifecycle events. The supported triggers that are not tied to a specific component are:
 
+- `manual`
+- `cron`
 - `pre-provision`
 - `post-provision`
 - `pre-reprovision`
@@ -86,6 +88,8 @@ Action triggers are available for all workflows. You can use the following set o
 - `role-disabled`
 
 Each workflow trigger is called at the beginning or end of the workflow. In some cases, such as `pre-provision` or `pre-reprovision` that include a stack-run, the trigger will be called right after the runner is healthy.
+
+`post-provision` runs after the complete install provision workflow, including sandbox provisioning and component deployment. There is no separate `post-provision-sandbox` trigger. Sandbox-specific triggers are available for reprovision and deprovision workflows.
 
 #### Role change triggers
 
@@ -114,8 +118,14 @@ The following triggers require a `component_name` field to be set, as they are t
 
 - `pre-deploy-component`
 - `post-deploy-component`
-- `post-teardown-component`
 - `pre-teardown-component`
+- `post-teardown-component`
+- `pre-enable-component`
+- `post-enable-component`
+- `pre-disable-component`
+- `post-disable-component`
+
+The enable and disable triggers run when an input update changes a toggleable component's enabled state.
 
 Actions can be triggered manually, on a cron, or by install events. You can define multiple triggers for an action.
 

--- a/docs/guides/app-init.mdx
+++ b/docs/guides/app-init.mdx
@@ -233,7 +233,8 @@ Common trigger types:
 - `manual` - Triggered manually from dashboard or CLI
 - `cron` - Scheduled using cron expression
 - `post-provision` - Runs after installation provisioning
-- `post-deploy` - Runs after component deployment
+- `post-deploy-component` - Runs after deployment of the component specified by `component_name`
+- `post-deploy-all-components` - Runs after an all-components deployment
 
 ## Common Workflows
 

--- a/pkg/config/action_config.go
+++ b/pkg/config/action_config.go
@@ -92,7 +92,7 @@ func (a ActionConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 func (a ActionTriggerConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 	NewSchemaBuilder(schema).
 		Field("type").Short("type of trigger").Required().
-		Long("Supported trigger types: manual, cron, pre-provision, post-provision, pre-reprovision, post-reprovision, pre-deprovision, post-deprovision, pre-deploy-all-components, post-deploy-all-components, pre-teardown-all-components, post-teardown-all-components, pre-deploy-component, post-deploy-component, pre-teardown-component, post-teardown-component, pre-deprovision-sandbox, post-deprovision-sandbox, pre-reprovision-sandbox, post-reprovision-sandbox, pre-update-inputs, post-update-inputs, pre-secrets-sync, post-secrets-sync").
+		Long("Supported trigger types: manual, cron, pre-provision, post-provision, pre-reprovision, post-reprovision, pre-deprovision, post-deprovision, pre-deploy-all-components, post-deploy-all-components, pre-teardown-all-components, post-teardown-all-components, pre-deploy-component, post-deploy-component, pre-teardown-component, post-teardown-component, pre-enable-component, post-enable-component, pre-disable-component, post-disable-component, pre-deprovision-sandbox, post-deprovision-sandbox, pre-reprovision-sandbox, post-reprovision-sandbox, pre-update-inputs, post-update-inputs, pre-secrets-sync, post-secrets-sync, role-enabled, role-disabled").
 		Example("manual").
 		Example("cron").
 		Example("post-provision").
@@ -101,7 +101,7 @@ func (a ActionTriggerConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Example("*/5 * * * *").
 		Example("0 */4 * * *").
 		Field("component_name").Short("component name for component-specific triggers").
-		Long("Required for pre-deploy-component, post-deploy-component, pre-teardown-component, post-teardown-component triggers").
+		Long("Required for pre-deploy-component, post-deploy-component, pre-teardown-component, post-teardown-component, pre-enable-component, post-enable-component, pre-disable-component, and post-disable-component triggers").
 		Example("database").
 		Example("api-server").
 		Field("index").Short("index for manual trigger").

--- a/services/ctl-api/internal/app/action_workflow_trigger_config.go
+++ b/services/ctl-api/internal/app/action_workflow_trigger_config.go
@@ -83,7 +83,7 @@ var AllActionWorkflowComponentTriggerTypes = []ActionWorkflowTriggerType{
 	ActionWorkflowTriggerTypePostDisableComponent,
 }
 
-// All component types
+// All trigger types
 var AllActionWorkflowTriggerTypes = []ActionWorkflowTriggerType{
 	ActionWorkflowTriggerTypeManual,
 	ActionWorkflowTriggerTypeCron,
@@ -92,6 +92,8 @@ var AllActionWorkflowTriggerTypes = []ActionWorkflowTriggerType{
 	ActionWorkflowTriggerTypePostDeployComponent,
 	ActionWorkflowTriggerTypePreTeardownComponent,
 	ActionWorkflowTriggerTypePostTeardownComponent,
+	ActionWorkflowTriggerTypePreSecretsSync,
+	ActionWorkflowTriggerTypePostSecretsSync,
 	ActionWorkflowTriggerTypePreProvision,
 	ActionWorkflowTriggerTypePostProvision,
 	ActionWorkflowTriggerTypePreReprovision,

--- a/services/ctl-api/internal/app/actions/service/create_action_workflow_config_test.go
+++ b/services/ctl-api/internal/app/actions/service/create_action_workflow_config_test.go
@@ -209,6 +209,35 @@ func (s *CreateAppActionConfigTestSuite) TestCreateActionConfigSuccess() {
 			},
 		},
 		{
+			name: "secrets sync triggers",
+			setupFunc: func() (string, string, string) {
+				action := s.createActionWorkflow(s.testApp.ID, "secrets-sync-action")
+				appConfig := s.createAppConfig(s.testApp.ID)
+				return action.ID, appConfig.ID, ""
+			},
+			requestFunc: func(actionID, appConfigID, componentID string) CreateActionWorkflowConfigRequest {
+				return CreateActionWorkflowConfigRequest{
+					AppConfigID: appConfigID,
+					Triggers: []CreateActionWorkflowConfigTriggerRequest{
+						{Type: app.ActionWorkflowTriggerTypePreSecretsSync},
+						{Type: app.ActionWorkflowTriggerTypePostSecretsSync},
+					},
+					Steps: []CreateActionWorkflowConfigStepRequest{
+						{
+							Name:           "secrets-sync-step",
+							InlineContents: "echo 'secrets synced'",
+						},
+					},
+				}
+			},
+			expectedCode: http.StatusCreated,
+			validateFunc: func(config *app.ActionWorkflowConfig) {
+				assert.Len(s.T(), config.Triggers, 2)
+				assert.Equal(s.T(), app.ActionWorkflowTriggerTypePreSecretsSync, config.Triggers[0].Type)
+				assert.Equal(s.T(), app.ActionWorkflowTriggerTypePostSecretsSync, config.Triggers[1].Type)
+			},
+		},
+		{
 			name: "component lifecycle trigger",
 			setupFunc: func() (string, string, string) {
 				action := s.createActionWorkflow(s.testApp.ID, "component-action")
@@ -435,6 +464,21 @@ func (s *CreateAppActionConfigTestSuite) TestCreateActionConfigValidation() {
 					AppConfigID: appConfig.ID,
 					Triggers: []CreateActionWorkflowConfigTriggerRequest{
 						{Type: app.ActionWorkflowTriggerTypePostDeployComponent},
+					},
+					Steps: []CreateActionWorkflowConfigStepRequest{
+						{Name: "test", InlineContents: "echo 'test'"},
+					},
+				}
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "unknown trigger type",
+			requestFunc: func() CreateActionWorkflowConfigRequest {
+				return CreateActionWorkflowConfigRequest{
+					AppConfigID: appConfig.ID,
+					Triggers: []CreateActionWorkflowConfigTriggerRequest{
+						{Type: app.ActionWorkflowTriggerType("unknown")},
 					},
 					Steps: []CreateActionWorkflowConfigStepRequest{
 						{Name: "test", InlineContents: "echo 'test'"},


### PR DESCRIPTION
### Summary

Align action trigger validation and documentation with the triggers implemented by install workflows.

### Changes

- Allow `pre-secrets-sync` and `post-secrets-sync` through action config API validation.
- Document all component-scoped enable and disable triggers:
  - `pre-enable-component`
  - `post-enable-component`
  - `pre-disable-component`
  - `post-disable-component`
- Document that component-scoped triggers require `component_name`.
- Clarify that `post-provision` runs after the complete install provision workflow, including sandbox provisioning and component deployment.
- Replace the invalid documented post-deploy trigger with:
  - `post-deploy-component`
  - `post-deploy-all-components`
- Update the action config schema description and regenerate its reference documentation.