### PR TITLE
fix(components): show source failures in build history

### DIFF
--- a/services/ctl-api/internal/app/apps/signals/branches/activities/create_component_build.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/activities/create_component_build.go
@@ -36,7 +36,7 @@ func (a *Activities) CreateComponentBuild(ctx context.Context, req CreateCompone
 	ctx = cctx.SetOrgIDContext(ctx, cmp.OrgID)
 	ctx = cctx.SetAccountIDContext(ctx, cmp.CreatedByID)
 
-	build, err := a.componentHelpers.CreateComponentBuildWithID(ctx, req.BuildID, req.ComponentID, true, nil)
+	build, err := a.componentHelpers.CreateComponentBuildWithID(ctx, req.BuildID, req.ComponentID, false, nil)
 	if err != nil {
 		res := a.db.WithContext(ctx).Where(&app.ComponentBuild{ID: req.BuildID}).First(&existing)
 		if res.Error == nil {

--- a/services/ctl-api/internal/app/component_build.go
+++ b/services/ctl-api/internal/app/component_build.go
@@ -35,7 +35,8 @@ type ComponentBuild struct {
 	Org   Org    `json:"-" faker:"-" temporaljson:"org,omitzero,omitempty"`
 
 	// runner details
-	RunnerJob RunnerJob `json:"runner_job,omitzero" gorm:"polymorphic:Owner;" temporaljson:"runner_job,omitzero,omitempty"`
+	RunnerJob        RunnerJob `json:"runner_job,omitzero" gorm:"polymorphic:Owner;" temporaljson:"runner_job,omitzero,omitempty"`
+	BuildRunnerJobID *string   `json:"build_runner_job_id" gorm:"-" temporaljson:"-"`
 
 	LogStream LogStream `json:"log_stream,omitzero" gorm:"polymorphic:Owner;" temporaljson:"log_stream,omitzero,omitempty"`
 
@@ -125,6 +126,15 @@ func (c *ComponentBuild) Indexes(db *gorm.DB) []migrations.Index {
 			Name: indexes.Name(db, &ComponentBuild{}, "app_branch_run_id"),
 			Columns: []string{
 				"app_branch_run_id",
+			},
+		},
+		{
+			Name: indexes.Name(db, &ComponentBuild{}, "history"),
+			Columns: []string{
+				"org_id",
+				"deleted_at",
+				"created_at DESC",
+				"id DESC",
 			},
 		},
 	}

--- a/services/ctl-api/internal/app/components/helpers/component_build.go
+++ b/services/ctl-api/internal/app/components/helpers/component_build.go
@@ -2,12 +2,8 @@ package helpers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
-	"gorm.io/gorm"
-
-	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 )
@@ -29,7 +25,7 @@ func DockerBuildUnsupportedByFeature(feature app.OrgFeature) stderr.ErrUser {
 	}
 }
 
-func (s *Helpers) createComponentBuild(ctx context.Context, buildID, cmpID string, useLatest bool, gitRef *string) (*app.ComponentBuild, error) {
+func (s *Helpers) createComponentBuild(ctx context.Context, buildID, cmpID string, _ bool, gitRef *string) (*app.ComponentBuild, error) {
 	cmp, err := s.GetComponent(ctx, cmpID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get component: %w", err)
@@ -45,20 +41,9 @@ func (s *Helpers) createComponentBuild(ctx context.Context, buildID, cmpID strin
 		return nil, DockerBuildUnsupportedByFeature(app.OrgFeatureControlPlaneBuilds)
 	}
 
-	var vcsCommit *app.VCSConnectionCommit
 	switch cmp.LatestConfig.VCSConnectionType {
-	case app.VCSConnectionTypeConnectedRepo:
-		if useLatest {
-			var err error
-			vcsCommit, err = s.GetComponentCommit(ctx, cmpID)
-			if err != nil {
-				return nil, err
-			}
-
-			gitRef = generics.ToPtr(vcsCommit.SHA)
-		}
 	case app.VCSConnectionTypePublicRepo:
-		gitRef = generics.ToPtr(cmp.LatestConfig.PublicGitVCSConfig.Branch)
+		gitRef = &cmp.LatestConfig.PublicGitVCSConfig.Branch
 	}
 
 	bld := app.ComponentBuild{
@@ -68,10 +53,6 @@ func (s *Helpers) createComponentBuild(ctx context.Context, buildID, cmpID strin
 		GitRef:                      gitRef,
 		ComponentConfigConnectionID: cmp.LatestConfig.ID,
 	}
-	if vcsCommit != nil {
-		bld.VCSConnectionCommitID = generics.ToPtr(vcsCommit.ID)
-	}
-
 	res := s.db.WithContext(ctx).
 		Create(&bld)
 	if res.Error != nil {
@@ -85,38 +66,5 @@ func (s *Helpers) createComponentBuild(ctx context.Context, buildID, cmpID strin
 		return nil, fmt.Errorf("unable to set latest_build_id on config connection: %w", err)
 	}
 
-	// Check for duplicate builds (same commit SHA and config checksum).
-	// This is a warning only — the build still proceeds.
-	if vcsCommit != nil {
-		if dupBuild, err := s.findDuplicateBuild(ctx, bld.ID, cmpID, vcsCommit.SHA, cmp.LatestConfig.Checksum); err == nil && dupBuild != nil {
-			bld.StatusV2.Metadata = map[string]any{
-				"duplicate_build":       true,
-				"duplicate_of_build_id": dupBuild.ID,
-			}
-			s.db.WithContext(ctx).Model(&bld).Update("status_v2", bld.StatusV2)
-		}
-	}
-
 	return &bld, nil
-}
-
-func (s *Helpers) findDuplicateBuild(ctx context.Context, excludeBuildID string, componentID string, commitSHA string, checksum string) (*app.ComponentBuild, error) {
-	return nil, nil
-	var build app.ComponentBuild
-	res := s.db.WithContext(ctx).
-		Joins("JOIN vcs_connection_commits ON vcs_connection_commits.id = component_builds.vcs_connection_commit_id").
-		Joins("JOIN component_config_connections ON component_config_connections.id = component_builds.component_config_connection_id").
-		Where("component_builds.id != ?", excludeBuildID).
-		Where("component_config_connections.component_id = ?", componentID).
-		Where("vcs_connection_commits.sha = ?", commitSHA).
-		Where("component_config_connections.checksum = ?", checksum).
-		Order("component_builds.created_at DESC").
-		First(&build)
-	if res.Error != nil {
-		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
-		return nil, res.Error
-	}
-	return &build, nil
 }

--- a/services/ctl-api/internal/app/components/service/build_runner_jobs.go
+++ b/services/ctl-api/internal/app/components/service/build_runner_jobs.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm/clause"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
+)
+
+func (s *service) hydrateBuildRunnerJobs(ctx context.Context, builds ...*app.ComponentBuild) error {
+	if len(builds) == 0 {
+		return nil
+	}
+
+	buildIDs := make([]any, 0, len(builds))
+	buildsByID := make(map[string]*app.ComponentBuild, len(builds))
+	for _, build := range builds {
+		buildIDs = append(buildIDs, build.ID)
+		buildsByID[build.ID] = build
+	}
+
+	jobs := []app.RunnerJob{}
+	if err := s.db.WithContext(ctx).
+		Scopes(scopes.WithDisableViews).
+		Where(&app.RunnerJob{
+			OwnerType: "component_builds",
+			Group:     app.RunnerJobGroupBuild,
+			Operation: app.RunnerJobOperationTypeBuild,
+		}).
+		Where(clause.IN{Column: "owner_id", Values: buildIDs}).
+		Order(clause.OrderByColumn{Column: clause.Column{Name: "created_at"}, Desc: true}).
+		Order(clause.OrderByColumn{Column: clause.Column{Name: "id"}, Desc: true}).
+		Find(&jobs).Error; err != nil {
+		return fmt.Errorf("unable to load component build execution jobs: %w", err)
+	}
+
+	for i := range jobs {
+		build := buildsByID[jobs[i].OwnerID]
+		if build.BuildRunnerJobID != nil {
+			continue
+		}
+		build.RunnerJob = jobs[i]
+		build.BuildRunnerJobID = &jobs[i].ID
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/app/components/service/create_component_build_test.go
+++ b/services/ctl-api/internal/app/components/service/create_component_build_test.go
@@ -40,6 +40,8 @@ func (s *ComponentsServiceTestSuite) TestCreateAppComponentBuildSuccess() {
 		assert.NotEmpty(s.T(), response.ID)
 		assert.NotEmpty(s.T(), response.ComponentConfigConnectionID)
 		assert.Equal(s.T(), app.ComponentBuildStatus("queued"), response.Status)
+		require.NotNil(s.T(), response.GitRef)
+		assert.Equal(s.T(), "main", *response.GitRef)
 
 		// Verify persisted to DB
 		var dbBuild app.ComponentBuild
@@ -69,6 +71,12 @@ func (s *ComponentsServiceTestSuite) TestCreateAppComponentBuildUseLatest() {
 
 		assert.NotEmpty(s.T(), response.ID)
 		assert.Equal(s.T(), app.ComponentBuildStatus("queued"), response.Status)
+		assert.Nil(s.T(), response.GitRef)
+
+		var dbBuild app.ComponentBuild
+		require.NoError(s.T(), s.deps.DB.WithContext(s.ctx).First(&dbBuild, "id = ?", response.ID).Error)
+		assert.Nil(s.T(), dbBuild.GitRef)
+		assert.Nil(s.T(), dbBuild.VCSConnectionCommitID)
 	})
 }
 

--- a/services/ctl-api/internal/app/components/service/get_component_build.go
+++ b/services/ctl-api/internal/app/components/service/get_component_build.go
@@ -11,7 +11,6 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
 )
 
 // @ID						GetAppComponentBuild
@@ -98,14 +97,14 @@ func (s *service) getComponentBuild(ctx context.Context, cmpID, bldID string) (*
 			return db.Order(views.TableOrViewName(s.db, &app.ComponentConfigConnection{}, ".created_at DESC"))
 		}).
 		Preload("ComponentConfigConnection.Component").
-		Preload("RunnerJob", func(db *gorm.DB) *gorm.DB {
-			return db.Scopes(scopes.WithDisableViews)
-		}).
 		Preload("LogStream").
 		Preload("QueueSignal").
 		First(&bld, "id = ? AND org_id = ?", bldID, orgID)
 	if res.Error != nil {
 		return nil, fmt.Errorf("unable to get component build: %w", res.Error)
+	}
+	if err := s.hydrateBuildRunnerJobs(ctx, &bld); err != nil {
+		return nil, err
 	}
 
 	return &bld, nil

--- a/services/ctl-api/internal/app/components/service/list_org_component_builds.go
+++ b/services/ctl-api/internal/app/components/service/list_org_component_builds.go
@@ -1,0 +1,228 @@
+package service
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm/clause"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+)
+
+const (
+	componentBuildCursorOlder = "older"
+	componentBuildCursorNewer = "newer"
+)
+
+type componentBuildCursor struct {
+	CreatedAt time.Time `json:"created_at"`
+	ID        string    `json:"id"`
+	Direction string    `json:"direction"`
+}
+
+type OrgComponentBuildHistoryItem struct {
+	Build            app.ComponentBuild `json:"build"`
+	AppID            string             `json:"app_id"`
+	ComponentID      string             `json:"component_id"`
+	ComponentName    string             `json:"component_name"`
+	BuildRunnerJobID *string            `json:"build_runner_job_id"`
+}
+
+type OrgComponentBuildHistoryResponse struct {
+	Items          []OrgComponentBuildHistoryItem `json:"items"`
+	NextCursor     *string                        `json:"next_cursor"`
+	PreviousCursor *string                        `json:"previous_cursor"`
+}
+
+// @ID ListOrgComponentBuilds
+// @Summary list component build history for the current organization
+// @Tags components
+// @Produce json
+// @Security APIKey
+// @Security OrgID
+// @Param limit query int false "limit of builds to return" Default(10)
+// @Param cursor query string false "opaque component build history cursor"
+// @Success 200 {object} OrgComponentBuildHistoryResponse
+// @Failure 400 {object} stderr.ErrResponse
+// @Failure 500 {object} stderr.ErrResponse
+// @Router /v1/component-builds [get]
+func (s *service) ListOrgComponentBuilds(ctx *gin.Context) {
+	org, err := cctx.OrgFromContext(ctx)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	limit, err := strconv.Atoi(ctx.DefaultQuery("limit", "10"))
+	if err != nil || limit < 1 || limit > 100 {
+		ctx.Error(stderr.ErrUser{
+			Err:         fmt.Errorf("invalid limit %q", ctx.Query("limit")),
+			Description: "limit must be between 1 and 100",
+		})
+		return
+	}
+
+	cursor, err := decodeComponentBuildCursor(ctx.Query("cursor"))
+	if err != nil {
+		ctx.Error(stderr.ErrUser{Err: err, Description: "invalid component build history cursor"})
+		return
+	}
+
+	builds, hasMore, err := s.listOrgComponentBuilds(ctx, org.ID, cursor, limit)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	buildPtrs := make([]*app.ComponentBuild, len(builds))
+	for i := range builds {
+		buildPtrs[i] = &builds[i]
+	}
+	if err := s.hydrateBuildRunnerJobs(ctx, buildPtrs...); err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	response, err := buildOrgComponentBuildHistoryResponse(builds, cursor, hasMore)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+	ctx.JSON(http.StatusOK, response)
+}
+
+func (s *service) listOrgComponentBuilds(ctx *gin.Context, orgID string, cursor *componentBuildCursor, limit int) ([]app.ComponentBuild, bool, error) {
+	builds := []app.ComponentBuild{}
+	query := s.db.WithContext(ctx).
+		Preload("CreatedBy").
+		Preload("VCSConnectionCommit").
+		Preload("ComponentConfigConnection.Component").
+		Where(&app.ComponentBuild{OrgID: orgID})
+
+	newer := cursor != nil && cursor.Direction == componentBuildCursorNewer
+	if cursor != nil {
+		query = query.Where(componentBuildCursorClause(cursor))
+	}
+	if newer {
+		query = query.
+			Order(clause.OrderByColumn{Column: clause.Column{Name: "created_at"}}).
+			Order(clause.OrderByColumn{Column: clause.Column{Name: "id"}})
+	} else {
+		query = query.
+			Order(clause.OrderByColumn{Column: clause.Column{Name: "created_at"}, Desc: true}).
+			Order(clause.OrderByColumn{Column: clause.Column{Name: "id"}, Desc: true})
+	}
+
+	if err := query.Limit(limit + 1).Find(&builds).Error; err != nil {
+		return nil, false, fmt.Errorf("unable to list organization component builds: %w", err)
+	}
+
+	hasMore := len(builds) > limit
+	if hasMore {
+		builds = builds[:limit]
+	}
+	if newer {
+		reverseComponentBuilds(builds)
+	}
+	return builds, hasMore, nil
+}
+
+func componentBuildCursorClause(cursor *componentBuildCursor) clause.Expression {
+	createdAt := clause.Column{Name: "created_at"}
+	id := clause.Column{Name: "id"}
+	if cursor.Direction == componentBuildCursorNewer {
+		return clause.Or(
+			clause.Gt{Column: createdAt, Value: cursor.CreatedAt},
+			clause.And(
+				clause.Eq{Column: createdAt, Value: cursor.CreatedAt},
+				clause.Gt{Column: id, Value: cursor.ID},
+			),
+		)
+	}
+	return clause.Or(
+		clause.Lt{Column: createdAt, Value: cursor.CreatedAt},
+		clause.And(
+			clause.Eq{Column: createdAt, Value: cursor.CreatedAt},
+			clause.Lt{Column: id, Value: cursor.ID},
+		),
+	)
+}
+
+func buildOrgComponentBuildHistoryResponse(builds []app.ComponentBuild, cursor *componentBuildCursor, hasMore bool) (*OrgComponentBuildHistoryResponse, error) {
+	response := &OrgComponentBuildHistoryResponse{
+		Items: make([]OrgComponentBuildHistoryItem, 0, len(builds)),
+	}
+	for i := range builds {
+		build := builds[i]
+		response.Items = append(response.Items, OrgComponentBuildHistoryItem{
+			Build:            build,
+			AppID:            build.ComponentConfigConnection.Component.AppID,
+			ComponentID:      build.ComponentID,
+			ComponentName:    build.ComponentName,
+			BuildRunnerJobID: build.BuildRunnerJobID,
+		})
+	}
+	if len(builds) == 0 {
+		return response, nil
+	}
+
+	newer := cursor != nil && cursor.Direction == componentBuildCursorNewer
+	if ((cursor == nil || !newer) && hasMore) || newer {
+		next, err := encodeComponentBuildCursor(builds[len(builds)-1], componentBuildCursorOlder)
+		if err != nil {
+			return nil, err
+		}
+		response.NextCursor = &next
+	}
+	if cursor != nil && (!newer || hasMore) {
+		previous, err := encodeComponentBuildCursor(builds[0], componentBuildCursorNewer)
+		if err != nil {
+			return nil, err
+		}
+		response.PreviousCursor = &previous
+	}
+	return response, nil
+}
+
+func encodeComponentBuildCursor(build app.ComponentBuild, direction string) (string, error) {
+	data, err := json.Marshal(componentBuildCursor{
+		CreatedAt: build.CreatedAt,
+		ID:        build.ID,
+		Direction: direction,
+	})
+	if err != nil {
+		return "", fmt.Errorf("unable to encode component build cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func decodeComponentBuildCursor(value string) (*componentBuildCursor, error) {
+	if value == "" {
+		return nil, nil
+	}
+	data, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("decode cursor: %w", err)
+	}
+	var cursor componentBuildCursor
+	if err := json.Unmarshal(data, &cursor); err != nil {
+		return nil, fmt.Errorf("parse cursor: %w", err)
+	}
+	if cursor.CreatedAt.IsZero() || cursor.ID == "" || (cursor.Direction != componentBuildCursorOlder && cursor.Direction != componentBuildCursorNewer) {
+		return nil, fmt.Errorf("cursor is incomplete")
+	}
+	return &cursor, nil
+}
+
+func reverseComponentBuilds(builds []app.ComponentBuild) {
+	for left, right := 0, len(builds)-1; left < right; left, right = left+1, right-1 {
+		builds[left], builds[right] = builds[right], builds[left]
+	}
+}

--- a/services/ctl-api/internal/app/components/service/list_org_component_builds_test.go
+++ b/services/ctl-api/internal/app/components/service/list_org_component_builds_test.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+func (s *ComponentsServiceTestSuite) TestListOrgComponentBuilds() {
+	component := s.getSeededComponent(app.ComponentTypeHelmChart)
+	config := s.getSeededConfigConnection(component.ID)
+	oldest := s.deps.Seeder.CreateComponentBuild(s.ctx, s.T(), config.ID)
+	jobBacked := s.deps.Seeder.CreateComponentBuild(s.ctx, s.T(), config.ID)
+	newest := s.deps.Seeder.CreateComponentBuild(s.ctx, s.T(), config.ID)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	s.setComponentBuildCreatedAt(oldest, now.Add(-2*time.Minute))
+	s.setComponentBuildCreatedAt(jobBacked, now.Add(-time.Minute))
+	s.setComponentBuildCreatedAt(newest, now)
+
+	s.createComponentBuildJob(jobBacked.ID, app.RunnerJobGroupBuild, app.RunnerJobOperationTypeBuild, app.RunnerJobTypeHelmChartBuild)
+	executionJob := s.createComponentBuildJob(jobBacked.ID, app.RunnerJobGroupBuild, app.RunnerJobOperationTypeBuild, app.RunnerJobTypeHelmChartBuild)
+	require.NoError(s.T(), s.deps.DB.WithContext(s.ctx).Model(executionJob).UpdateColumn("created_at", now.Add(time.Minute)).Error)
+	s.createComponentBuildJob(jobBacked.ID, app.RunnerJobGroupSync, app.RunnerJobOperationTypeExec, app.RunnerJobTypeFetchImageMetadata)
+
+	rr := s.makeRequest(http.MethodGet, "/v1/component-builds?limit=2", nil)
+	require.Equal(s.T(), http.StatusOK, rr.Code, rr.Body.String())
+
+	var firstPage OrgComponentBuildHistoryResponse
+	require.NoError(s.T(), json.Unmarshal(rr.Body.Bytes(), &firstPage))
+	require.Len(s.T(), firstPage.Items, 2)
+	require.NotNil(s.T(), firstPage.NextCursor)
+	assert.Nil(s.T(), firstPage.PreviousCursor)
+	assert.Equal(s.T(), newest.ID, firstPage.Items[0].Build.ID)
+	assert.Nil(s.T(), firstPage.Items[0].BuildRunnerJobID)
+	assert.Equal(s.T(), jobBacked.ID, firstPage.Items[1].Build.ID)
+	require.NotNil(s.T(), firstPage.Items[1].BuildRunnerJobID)
+	assert.Equal(s.T(), executionJob.ID, *firstPage.Items[1].BuildRunnerJobID)
+	assert.Equal(s.T(), s.testApp.ID, firstPage.Items[0].AppID)
+	assert.Equal(s.T(), component.ID, firstPage.Items[0].ComponentID)
+
+	inserted := s.deps.Seeder.CreateComponentBuild(s.ctx, s.T(), config.ID)
+	s.setComponentBuildCreatedAt(inserted, now.Add(time.Minute))
+
+	rr = s.makeRequest(http.MethodGet, "/v1/component-builds?limit=2&cursor="+url.QueryEscape(*firstPage.NextCursor), nil)
+	require.Equal(s.T(), http.StatusOK, rr.Code, rr.Body.String())
+
+	var secondPage OrgComponentBuildHistoryResponse
+	require.NoError(s.T(), json.Unmarshal(rr.Body.Bytes(), &secondPage))
+	require.Len(s.T(), secondPage.Items, 1)
+	assert.Equal(s.T(), oldest.ID, secondPage.Items[0].Build.ID)
+	assert.NotEqual(s.T(), inserted.ID, secondPage.Items[0].Build.ID)
+	require.NotNil(s.T(), secondPage.PreviousCursor)
+	assert.Nil(s.T(), secondPage.NextCursor)
+
+	rr = s.makeRequest(http.MethodGet, "/v1/component-builds?limit=2&cursor="+url.QueryEscape(*secondPage.PreviousCursor), nil)
+	require.Equal(s.T(), http.StatusOK, rr.Code, rr.Body.String())
+
+	var previousPage OrgComponentBuildHistoryResponse
+	require.NoError(s.T(), json.Unmarshal(rr.Body.Bytes(), &previousPage))
+	require.Len(s.T(), previousPage.Items, 2)
+	assert.Equal(s.T(), newest.ID, previousPage.Items[0].Build.ID)
+	assert.Equal(s.T(), jobBacked.ID, previousPage.Items[1].Build.ID)
+}
+
+func (s *ComponentsServiceTestSuite) TestListOrgComponentBuildsRejectsInvalidCursor() {
+	rr := s.makeRequest(http.MethodGet, "/v1/component-builds?cursor=invalid", nil)
+	require.Equal(s.T(), http.StatusBadRequest, rr.Code, rr.Body.String())
+}
+
+func (s *ComponentsServiceTestSuite) createComponentBuildJob(buildID string, group app.RunnerJobGroup, operation app.RunnerJobOperationType, typ app.RunnerJobType) *app.RunnerJob {
+	job := &app.RunnerJob{
+		ID:                domains.NewRunnerJobID(),
+		OrgID:             s.testOrg.ID,
+		OwnerID:           buildID,
+		OwnerType:         "component_builds",
+		Status:            app.RunnerJobStatusAvailable,
+		StatusDescription: "test job",
+		Group:             group,
+		Operation:         operation,
+		Type:              typ,
+		Executor:          app.RunnerJobExecutorControlPlane,
+		QueueTimeout:      5 * time.Minute,
+		AvailableTimeout:  10 * time.Minute,
+		ExecutionTimeout:  30 * time.Minute,
+		OverallTimeout:    45 * time.Minute,
+		MaxExecutions:     1,
+	}
+	require.NoError(s.T(), s.deps.DB.WithContext(s.ctx).Create(job).Error)
+	return job
+}
+
+func (s *ComponentsServiceTestSuite) setComponentBuildCreatedAt(build *app.ComponentBuild, createdAt time.Time) {
+	require.NoError(s.T(), s.deps.DB.WithContext(s.ctx).Model(build).UpdateColumn("created_at", createdAt).Error)
+}

--- a/services/ctl-api/internal/app/components/service/service.go
+++ b/services/ctl-api/internal/app/components/service/service.go
@@ -55,6 +55,7 @@ var _ apiPkg.Service = (*service)(nil)
 func (s *service) RegisterPublicRoutes(api *gin.Engine) error {
 	// show all components for an org
 	api.GET("/v1/components", s.GetOrgComponents)
+	api.GET("/v1/component-builds", s.ListOrgComponentBuilds)
 
 	// components belong to an app
 	apps := api.Group("/v1/apps/:app_id")

--- a/services/ctl-api/internal/app/components/signals/build/signal.go
+++ b/services/ctl-api/internal/app/components/signals/build/signal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
@@ -73,6 +74,17 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	}
 
 	l.Info("executing build")
+	if workflow.GetVersion(ctx, "component-build-source-preflight", workflow.DefaultVersion, 1) != workflow.DefaultVersion {
+		preflightOptions := workflow.ActivityOptions{
+			RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1},
+		}
+		if _, err := activities.AwaitGetBuildGitSourceByBuildID(ctx, s.BuildID, &preflightOptions); err != nil {
+			l.Error(err.Error())
+			s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusError, err.Error())
+			return err
+		}
+	}
+
 	currentApp, err := activities.AwaitGetComponentAppByComponentID(ctx, s.ComponentID)
 	if err != nil {
 		s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusError, "unable to get component app")

--- a/services/ctl-api/internal/app/components/signals/build/signal.go
+++ b/services/ctl-api/internal/app/components/signals/build/signal.go
@@ -74,15 +74,13 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	}
 
 	l.Info("executing build")
-	if workflow.GetVersion(ctx, "component-build-source-preflight", workflow.DefaultVersion, 1) != workflow.DefaultVersion {
-		preflightOptions := workflow.ActivityOptions{
-			RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1},
-		}
-		if _, err := activities.AwaitGetBuildGitSourceByBuildID(ctx, s.BuildID, &preflightOptions); err != nil {
-			l.Error(err.Error())
-			s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusError, err.Error())
-			return err
-		}
+	preflightOptions := workflow.ActivityOptions{
+		RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1},
+	}
+	if _, err := activities.AwaitGetBuildGitSourceByBuildID(ctx, s.BuildID, &preflightOptions); err != nil {
+		l.Error(err.Error())
+		s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusError, err.Error())
+		return err
 	}
 
 	currentApp, err := activities.AwaitGetComponentAppByComponentID(ctx, s.ComponentID)

--- a/services/ctl-api/internal/app/components/signals/inlinebuild/signal.go
+++ b/services/ctl-api/internal/app/components/signals/inlinebuild/signal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
@@ -104,6 +105,17 @@ func (s *Signal) execBuild(ctx workflow.Context, buildID string) error {
 	}
 
 	l.Info("executing inline build")
+	if workflow.GetVersion(ctx, "inline-component-build-source-preflight", workflow.DefaultVersion, 1) != workflow.DefaultVersion {
+		preflightOptions := workflow.ActivityOptions{
+			RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1},
+		}
+		if _, err := activities.AwaitGetBuildGitSourceByBuildID(ctx, buildID, &preflightOptions); err != nil {
+			l.Error(err.Error())
+			s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, err.Error())
+			return err
+		}
+	}
+
 	currentApp, err := activities.AwaitGetComponentAppByComponentID(ctx, s.ComponentID)
 	if err != nil {
 		s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to get component app")

--- a/services/ctl-api/internal/app/components/signals/inlinebuild/signal.go
+++ b/services/ctl-api/internal/app/components/signals/inlinebuild/signal.go
@@ -105,15 +105,13 @@ func (s *Signal) execBuild(ctx workflow.Context, buildID string) error {
 	}
 
 	l.Info("executing inline build")
-	if workflow.GetVersion(ctx, "inline-component-build-source-preflight", workflow.DefaultVersion, 1) != workflow.DefaultVersion {
-		preflightOptions := workflow.ActivityOptions{
-			RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1},
-		}
-		if _, err := activities.AwaitGetBuildGitSourceByBuildID(ctx, buildID, &preflightOptions); err != nil {
-			l.Error(err.Error())
-			s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, err.Error())
-			return err
-		}
+	preflightOptions := workflow.ActivityOptions{
+		RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1},
+	}
+	if _, err := activities.AwaitGetBuildGitSourceByBuildID(ctx, buildID, &preflightOptions); err != nil {
+		l.Error(err.Error())
+		s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, err.Error())
+		return err
 	}
 
 	currentApp, err := activities.AwaitGetComponentAppByComponentID(ctx, s.ComponentID)

--- a/services/ctl-api/internal/app/components/worker/activities/create_component_build_record.go
+++ b/services/ctl-api/internal/app/components/worker/activities/create_component_build_record.go
@@ -27,8 +27,7 @@ type CreateComponentBuildRecordRequest struct {
 func (a *Activities) CreateComponentBuildRecord(ctx context.Context, req CreateComponentBuildRecordRequest) (*app.ComponentBuild, error) {
 	ctx = cctx.SetOrgIDContext(ctx, req.OrgID)
 
-	useLatest := req.GitRef == nil
-	build, err := a.helpers.CreateComponentBuild(ctx, req.ComponentID, useLatest, req.GitRef)
+	build, err := a.helpers.CreateComponentBuild(ctx, req.ComponentID, false, req.GitRef)
 	if err != nil {
 		return nil, fmt.Errorf("create component build: %w", err)
 	}

--- a/services/ctl-api/internal/app/components/worker/activities/get_build_git_source.go
+++ b/services/ctl-api/internal/app/components/worker/activities/get_build_git_source.go
@@ -2,11 +2,15 @@ package activities
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins"
 )
 
 type GetBuildGitSource struct {
@@ -23,7 +27,56 @@ func (a *Activities) GetBuildGitSource(ctx context.Context, req GetBuildGitSourc
 
 	switch build.ComponentConfigConnection.VCSConnectionType {
 	case app.VCSConnectionTypeConnectedRepo:
-		return a.vcsHelpers.GetGitSource(ctx, build.ComponentConfigConnection.ConnectedGithubVCSConfig)
+		gitRef := build.GitRef
+		if gitRef == nil {
+			cfg := build.ComponentConfigConnection.ConnectedGithubVCSConfig
+			commit, err := a.vcsHelpers.GetConnectedGithubVCSConfigLatestCommit(ctx, cfg)
+			if err != nil {
+				return nil, err
+			}
+
+			vcsCommit := a.vcsHelpers.GithubCommitToVCSConnectionCommit(
+				commit,
+				cfg.ID,
+				plugins.TableName(a.db, &app.ConnectedGithubVCSConfig{}),
+				cfg.VCSConnectionID,
+			)
+			if vcsCommit == nil {
+				return nil, fmt.Errorf("invalid commit data from GitHub")
+			}
+
+			resolvedRef := vcsCommit.SHA
+			if err := a.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+				var current app.ComponentBuild
+				if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+					Where(app.ComponentBuild{ID: build.ID}).
+					First(&current).Error; err != nil {
+					return fmt.Errorf("unable to lock component build: %w", err)
+				}
+				if current.GitRef != nil {
+					resolvedRef = *current.GitRef
+					return nil
+				}
+
+				if err := tx.Create(vcsCommit).Error; err != nil {
+					return fmt.Errorf("unable to create vcs commit: %w", err)
+				}
+				if err := tx.Model(&app.ComponentBuild{}).
+					Where(app.ComponentBuild{ID: build.ID}).
+					Updates(map[string]any{
+						"git_ref":                  vcsCommit.SHA,
+						"vcs_connection_commit_id": vcsCommit.ID,
+					}).Error; err != nil {
+					return fmt.Errorf("unable to update component build git source: %w", err)
+				}
+				return nil
+			}); err != nil {
+				return nil, err
+			}
+			gitRef = &resolvedRef
+		}
+
+		return a.vcsHelpers.GetGitSourceAtCommit(ctx, build.ComponentConfigConnection.ConnectedGithubVCSConfig, *gitRef)
 	case app.VCSConnectionTypePublicRepo:
 		return a.vcsHelpers.GetPubliGitSource(ctx, build.ComponentConfigConnection.PublicGitVCSConfig)
 	default:

--- a/services/dashboard-ui/client/components/builds/BuildHeader/BuildHeader.tsx
+++ b/services/dashboard-ui/client/components/builds/BuildHeader/BuildHeader.tsx
@@ -35,6 +35,7 @@ export const BuildHeader = ({ component, build, app }: IBuildHeader) => {
   const { org } = useOrg()
   const { addToast } = useToast()
   const [hasBeenCanceled, setHasBeenCanceled] = useState(false)
+  const executionJobId = build?.build_runner_job_id ?? build?.runner_job?.id
 
   const { mutate: cancelBuild, isPending: isCanceling } = useMutation<
     unknown,
@@ -171,11 +172,19 @@ export const BuildHeader = ({ component, build, app }: IBuildHeader) => {
                 label="View signal"
               />
             ) : null}
-            {build?.runner_job ? (
-              <RunnerJobPlanButton
-                buttonText="Build plan"
-                runnerJobId={build?.runner_job?.id}
-              />
+            {executionJobId ? (
+              <>
+                <RunnerJobPlanButton
+                  buttonText="Build plan"
+                  runnerJobId={executionJobId}
+                />
+                <Button
+                  href={`/${org?.id}/runner/jobs/${executionJobId}`}
+                  variant="secondary"
+                >
+                  View execution
+                </Button>
+              </>
             ) : null}
           </div>
         </div>

--- a/services/dashboard-ui/client/components/common/Timeline.tsx
+++ b/services/dashboard-ui/client/components/common/Timeline.tsx
@@ -16,6 +16,7 @@ export interface ITimeline<T extends IHasCreatedAt>
   events: Array<T>
   eventCount?: number
   groupByDate?: boolean
+  getEventKey?: (event: T, idx: number) => React.Key
   pagination: Omit<IPagination, 'position'>
   renderEvent?: (event: T, idx: number) => React.ReactNode
 }
@@ -25,6 +26,7 @@ const TimelineBase = <T extends IHasCreatedAt>({
   events,
   eventCount = 10,
   groupByDate = true,
+  getEventKey,
   pagination,
   renderEvent,
   ...props
@@ -49,7 +51,7 @@ const TimelineBase = <T extends IHasCreatedAt>({
             <Text className="timeline-date">{formatToRelativeDay(date)}</Text>
             <div className="timeline-events">
               {groupedEvents[date].map((event, idx) => (
-                <React.Fragment key={event.created_at}>
+                <React.Fragment key={getEventKey?.(event, idx) ?? event.created_at}>
                   {renderEvent ? renderEvent?.(event, idx) : null}
                 </React.Fragment>
               ))}
@@ -59,7 +61,7 @@ const TimelineBase = <T extends IHasCreatedAt>({
       ) : (
         <div className="timeline-events">
           {events.map((event, idx) => (
-            <React.Fragment key={event.created_at}>
+            <React.Fragment key={getEventKey?.(event, idx) ?? event.created_at}>
               {renderEvent ? renderEvent?.(event, idx) : null}
             </React.Fragment>
           ))}

--- a/services/dashboard-ui/client/components/runners/ControlPlaneRecentActivity/ControlPlaneRecentActivity.stories.tsx
+++ b/services/dashboard-ui/client/components/runners/ControlPlaneRecentActivity/ControlPlaneRecentActivity.stories.tsx
@@ -2,21 +2,61 @@ export default {
   title: 'Runners/ControlPlaneRecentActivity',
 }
 
-import { RunnerRecentActivityComponent } from '../RunnerRecentActivity'
+import { ControlPlaneRecentActivity } from './ControlPlaneRecentActivity'
 
-const mockJobs = [
-  { id: 'job-1', type: 'build', status: 'succeeded', created_at: '2024-01-15T10:00:00Z', group: 'build' },
-  { id: 'job-2', type: 'sandbox-build', status: 'running', created_at: '2024-01-15T09:00:00Z', group: 'build' },
+const mockActivity = [
+  {
+    app_id: 'app-1',
+    component_id: 'component-1',
+    component_name: 'API',
+    build_runner_job_id: 'job-1',
+    build: {
+      id: 'build-1',
+      created_at: '2024-01-15T10:00:00Z',
+      status: 'active',
+    },
+  },
+  {
+    app_id: 'app-1',
+    component_id: 'component-2',
+    component_name: 'Worker',
+    build_runner_job_id: null,
+    build: {
+      id: 'build-2',
+      created_at: '2024-01-14T09:00:00Z',
+      status: 'error',
+      status_description: 'branch not found',
+    },
+  },
 ] as any[]
 
 export const Default = () => (
-  <RunnerRecentActivityComponent jobs={mockJobs} isLoading={false} hasNext={false} offset={0} />
+  <ControlPlaneRecentActivity
+    activity={mockActivity}
+    orgId="org-1"
+    isLoading={false}
+    nextCursor="older"
+    previousCursor={null}
+    onCursorChange={() => {}}
+  />
 )
 
 export const Loading = () => (
-  <RunnerRecentActivityComponent jobs={[]} isLoading={true} hasNext={false} offset={0} />
+  <ControlPlaneRecentActivity
+    activity={[]}
+    isLoading={true}
+    nextCursor={null}
+    previousCursor={null}
+    onCursorChange={() => {}}
+  />
 )
 
 export const Empty = () => (
-  <RunnerRecentActivityComponent jobs={[]} isLoading={false} hasNext={false} offset={0} />
+  <ControlPlaneRecentActivity
+    activity={[]}
+    isLoading={false}
+    nextCursor={null}
+    previousCursor={null}
+    onCursorChange={() => {}}
+  />
 )

--- a/services/dashboard-ui/client/components/runners/ControlPlaneRecentActivity/ControlPlaneRecentActivity.tsx
+++ b/services/dashboard-ui/client/components/runners/ControlPlaneRecentActivity/ControlPlaneRecentActivity.tsx
@@ -1,0 +1,109 @@
+import { Button } from '@/components/common/Button'
+import { Icon } from '@/components/common/Icon'
+import { ID } from '@/components/common/ID'
+import { Link } from '@/components/common/Link'
+import { Skeleton } from '@/components/common/Skeleton'
+import { Timeline, type ITimeline } from '@/components/common/Timeline'
+import { TimelineEvent } from '@/components/common/TimelineEvent'
+import { TimelineSkeleton } from '@/components/common/TimelineSkeleton'
+import { Text } from '@/components/common/Text'
+import type { TOrgComponentBuildHistoryItem } from '@/lib'
+
+type TComponentBuildHistoryEvent = TOrgComponentBuildHistoryItem & {
+  created_at: string
+}
+
+interface IControlPlaneRecentActivity
+  extends Omit<
+    ITimeline<TComponentBuildHistoryEvent>,
+    'events' | 'renderEvent' | 'pagination'
+  > {
+  activity: TOrgComponentBuildHistoryItem[]
+  orgId?: string
+  isLoading: boolean
+  isFetching?: boolean
+  nextCursor: string | null
+  previousCursor: string | null
+  onCursorChange: (cursor: string | null) => void
+}
+
+export const ControlPlaneRecentActivity = ({
+  activity,
+  orgId,
+  isLoading,
+  isFetching = false,
+  nextCursor,
+  previousCursor,
+  onCursorChange,
+  ...props
+}: IControlPlaneRecentActivity) => {
+  if (isLoading) {
+    return (
+      <>
+        <Skeleton height="24px" width="110px" />
+        <TimelineSkeleton eventCount={10} />
+      </>
+    )
+  }
+
+  const events = activity.map((item) => ({
+    ...item,
+    created_at: item?.build?.created_at ?? '',
+  }))
+
+  return (
+    <div className="flex flex-col">
+      {events.length === 0 ? (
+        <Text theme="neutral">No component builds yet.</Text>
+      ) : null}
+      <Timeline<TComponentBuildHistoryEvent>
+        events={events}
+        getEventKey={(item) => item?.build?.id}
+        pagination={{ hasNext: false, offset: 0 }}
+        renderEvent={(item) => {
+          const build = item?.build
+          const href = `/${orgId ?? ''}/apps/${item?.app_id ?? ''}/components/${item?.component_id ?? ''}/builds/${build?.id ?? ''}`
+          return (
+            <TimelineEvent
+              key={build?.id}
+              caption={<ID>{build?.id}</ID>}
+              createdAt={item?.created_at}
+              status={build?.status_v2?.status ?? build?.status}
+              title={
+                <Link href={href}>
+                  {item?.component_name ?? 'Component'} build
+                </Link>
+              }
+              underline={
+                build?.status_description ? (
+                  <Text variant="label" theme="neutral">
+                    {build.status_description}
+                  </Text>
+                ) : null
+              }
+            />
+          )
+        }}
+        {...props}
+      />
+      {previousCursor || nextCursor ? (
+        <div className="flex items-center gap-3 self-center">
+          <Button
+            disabled={!previousCursor || isFetching}
+            onClick={() => onCursorChange(previousCursor)}
+          >
+            <Icon variant="ArrowLeftIcon" />
+            Newer
+          </Button>
+          <Button
+            disabled={!nextCursor || isFetching}
+            onClick={() => onCursorChange(nextCursor)}
+          >
+            Older
+            <Icon variant="ArrowRightIcon" />
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/services/dashboard-ui/client/components/runners/ControlPlaneRecentActivity/ControlPlaneRecentActivityContainer.tsx
+++ b/services/dashboard-ui/client/components/runners/ControlPlaneRecentActivity/ControlPlaneRecentActivityContainer.tsx
@@ -2,57 +2,68 @@ import { useQuery } from '@tanstack/react-query'
 import { useSearchParams } from 'react-router'
 import type { ITimeline } from '@/components/common/Timeline'
 import { useOrg } from '@/hooks/use-org'
-import { getOrgRunnerJobs } from '@/lib'
-import type { TRunnerJob } from '@/types'
 import {
-  RunnerRecentActivityComponent,
-  RECENT_ACTIVITY_SEARCH_PARAM,
-  RECENT_ACTIVITY_LIMIT,
-} from '../RunnerRecentActivity'
+  getOrgComponentBuildHistory,
+  type TOrgComponentBuildHistoryItem,
+} from '@/lib'
+import { ControlPlaneRecentActivity } from './ControlPlaneRecentActivity'
 
-const HIDDEN_JOB_TYPES = ['fetch-image-metadata']
+const BUILD_HISTORY_CURSOR_PARAM = 'build_cursor'
+const BUILD_HISTORY_LIMIT = 10
 
 interface IControlPlaneRecentActivityContainer
-  extends Omit<ITimeline<TRunnerJob>, 'events' | 'renderEvent' | 'pagination'> {
+  extends Omit<
+    ITimeline<TOrgComponentBuildHistoryItem & { created_at: string }>,
+    'events' | 'renderEvent' | 'pagination'
+  > {
   shouldPoll?: boolean
   pollInterval?: number
-  jobDetailBasePath?: string
 }
 
 export const ControlPlaneRecentActivityContainer = ({
   shouldPoll = false,
   pollInterval = 20000,
-  jobDetailBasePath,
   ...props
 }: IControlPlaneRecentActivityContainer) => {
   const { org } = useOrg()
-  const [searchParams] = useSearchParams()
-  const offset = Number(searchParams.get(RECENT_ACTIVITY_SEARCH_PARAM) ?? 0)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const cursor = searchParams.get(BUILD_HISTORY_CURSOR_PARAM) ?? undefined
 
-  const { data: result, isLoading } = useQuery({
-    queryKey: ['control-plane-runner-jobs', org?.id, offset],
+  const {
+    data: result,
+    isFetching,
+    isLoading,
+  } = useQuery({
+    queryKey: ['org-component-build-history', org?.id, cursor],
     queryFn: () =>
-      getOrgRunnerJobs({
+      getOrgComponentBuildHistory({
         orgId: org!.id,
-        executor: 'control-plane',
-        limit: RECENT_ACTIVITY_LIMIT,
-        offset,
+        limit: BUILD_HISTORY_LIMIT,
+        cursor,
       }),
-    refetchInterval: shouldPoll ? pollInterval : false,
+    refetchInterval: shouldPoll && !cursor ? pollInterval : false,
     enabled: !!org?.id,
   })
 
-  const visibleJobs = (result?.data ?? []).filter(
-    (job) => !HIDDEN_JOB_TYPES.includes(job.type)
-  )
+  const setCursor = (nextCursor: string | null) => {
+    const params = new URLSearchParams(searchParams)
+    if (nextCursor) {
+      params.set(BUILD_HISTORY_CURSOR_PARAM, nextCursor)
+    } else {
+      params.delete(BUILD_HISTORY_CURSOR_PARAM)
+    }
+    setSearchParams(params)
+  }
 
   return (
-    <RunnerRecentActivityComponent
-      jobs={visibleJobs}
+    <ControlPlaneRecentActivity
+      activity={result?.items ?? []}
+      orgId={org?.id}
+      isFetching={isFetching}
       isLoading={isLoading}
-      hasNext={result?.pagination?.hasNext ?? false}
-      offset={offset}
-      jobDetailBasePath={jobDetailBasePath}
+      nextCursor={result?.next_cursor ?? null}
+      previousCursor={result?.previous_cursor ?? null}
+      onCursorChange={setCursor}
       {...props}
     />
   )

--- a/services/dashboard-ui/client/components/runners/ControlPlaneRecentActivity/index.ts
+++ b/services/dashboard-ui/client/components/runners/ControlPlaneRecentActivity/index.ts
@@ -1,1 +1,2 @@
 export { ControlPlaneRecentActivityContainer as ControlPlaneRecentActivity } from './ControlPlaneRecentActivityContainer'
+export { ControlPlaneRecentActivity as ControlPlaneRecentActivityComponent } from './ControlPlaneRecentActivity'

--- a/services/dashboard-ui/client/lib/ctl-api/apps/components/builds/get-org-component-build-history.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/components/builds/get-org-component-build-history.ts
@@ -1,0 +1,31 @@
+import { api } from '@/lib/api'
+import type { TBuild } from '@/types'
+import { buildQueryParams } from '@/utils/build-query-params'
+
+export type TOrgComponentBuildHistoryItem = {
+  build: TBuild
+  app_id: string
+  component_id: string
+  component_name: string
+  build_runner_job_id: string | null
+}
+
+export type TOrgComponentBuildHistoryResponse = {
+  items: TOrgComponentBuildHistoryItem[]
+  next_cursor: string | null
+  previous_cursor: string | null
+}
+
+export const getOrgComponentBuildHistory = ({
+  cursor,
+  limit = 10,
+  orgId,
+}: {
+  cursor?: string
+  limit?: number
+  orgId: string
+}) =>
+  api<TOrgComponentBuildHistoryResponse>({
+    path: `component-builds${buildQueryParams({ cursor, limit })}`,
+    orgId,
+  })

--- a/services/dashboard-ui/client/lib/ctl-api/apps/components/builds/index.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/components/builds/index.ts
@@ -1,3 +1,4 @@
 export * from './cancel-component-build'
 export * from './get-component-build'
 export * from './get-component-builds'
+export * from './get-org-component-build-history'

--- a/services/dashboard-ui/client/types/ctl-api.types.ts
+++ b/services/dashboard-ui/client/types/ctl-api.types.ts
@@ -104,7 +104,10 @@ export type TComponentType = components['schemas']['app.ComponentType']
 
 // build
 export type TComponentBuild = components['schemas']['app.ComponentBuild']
-export type TBuild = TComponentBuild & { org_id: string }
+export type TBuild = TComponentBuild & {
+  org_id: string
+  build_runner_job_id?: string | null
+}
 
 // org
 export type TOrg = components['schemas']['app.Org']

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -959,6 +959,10 @@ export interface paths {
      */
     get: operations["GetComponentBuilds"];
   };
+  "/v1/component-builds": {
+    /** list component build history for the current organization */
+    get: operations["ListOrgComponentBuilds"];
+  };
   "/v1/components": {
     /**
      * get all components for an org
@@ -3758,6 +3762,7 @@ export interface components {
     };
     "app.ComponentBuild": {
       app_branch_run_id?: string;
+      build_runner_job_id?: string;
       /** @description checksum of our intermediate component config */
       checksum?: string;
       component_config_connection?: components["schemas"]["app.ComponentConfigConnection"];
@@ -7820,6 +7825,18 @@ export interface components {
       operation: components["schemas"]["app.OperationType"];
       principal: string;
       role: string;
+    };
+    "service.OrgComponentBuildHistoryItem": {
+      app_id?: string;
+      build?: components["schemas"]["app.ComponentBuild"];
+      build_runner_job_id?: string;
+      component_id?: string;
+      component_name?: string;
+    };
+    "service.OrgComponentBuildHistoryResponse": {
+      items?: components["schemas"]["service.OrgComponentBuildHistoryItem"][];
+      next_cursor?: string;
+      previous_cursor?: string;
     };
     "service.PatchInstallConfigParams": {
       approval_option?: components["schemas"]["app.InstallApprovalOption"];
@@ -16284,6 +16301,37 @@ export interface operations {
       };
       /** @description Not Found */
       404: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+    };
+  };
+  /** list component build history for the current organization */
+  ListOrgComponentBuilds: {
+    parameters: {
+      query?: {
+        /** @description limit of builds to return */
+        limit?: number;
+        /** @description opaque component build history cursor */
+        cursor?: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["service.OrgComponentBuildHistoryResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
         content: {
           "application/json": components["schemas"]["stderr.ErrResponse"];
         };

--- a/services/dashboard-ui/client/views/app/BuildDetail.tsx
+++ b/services/dashboard-ui/client/views/app/BuildDetail.tsx
@@ -65,7 +65,7 @@ const BuildDetailInner = ({ component }: { component: TComponent | undefined }) 
               Waiting on log stream
             </Text>
             <Text variant="body" theme="neutral">
-              Logs will appear here once the build runner starts.
+              Logs will appear when build processing starts.
             </Text>
             <Button
               variant="ghost"

--- a/services/dashboard-ui/client/views/org/BuildRunner.tsx
+++ b/services/dashboard-ui/client/views/org/BuildRunner.tsx
@@ -101,15 +101,12 @@ export const BuildRunner = () => {
         <PageHeader>
           <PageHeadingGroup
             title="Builds"
-            subtitle="Component and sandbox builds run on Nuon's control plane."
+            subtitle="Component builds run on Nuon's control plane."
           />
         </PageHeader>
         <PageContent>
           <PageSection>
-            <ControlPlaneRecentActivity
-              shouldPoll
-              jobDetailBasePath={`/${org?.id}/runner`}
-            />
+            <ControlPlaneRecentActivity shouldPoll />
           </PageSection>
         </PageContent>
       </PageLayout>


### PR DESCRIPTION
## Summary

Component builds now exist before Nuon checks their connected repository source. Invalid branches and other source lookup failures appear as failed builds with logs instead of leaving app sync waiting for a build record that never arrives.

## What you can do after this PR

**See source lookup failures in component build history.** Nuon creates the build and its log stream before resolving the configured branch. A failed lookup marks the build as failed and stops before creating a runner job.

**Retry against a stable commit.** Successful source resolution records the commit SHA on the build. Planning and retries reuse that SHA instead of resolving the branch again.

**Get consistent behavior from app sync and app builds.** Both queued sync builds and app-level build workflows use the same preflight ordering.

## What stays the same

Manual component builds retain their existing eager source validation. Public repositories, non-Git components, and explicit branch-run commit pins behave as before.