### PR TITLE
feat: add post-provision-sandbox action trigger

### DIFF
--- a/docs/concepts/actions.mdx
+++ b/docs/concepts/actions.mdx
@@ -120,6 +120,7 @@ component are:
 - `cron`
 - `pre-provision`
 - `post-provision`
+- `post-provision-sandbox`
 - `pre-reprovision`
 - `post-reprovision`
 - `pre-deprovision`
@@ -143,8 +144,10 @@ Each workflow trigger is called at the beginning or end of the workflow. In some
 cases, such as `pre-provision` or `pre-reprovision` that include a stack-run,
 the trigger will be called right after the runner is healthy.
 
+`post-provision-sandbox` runs immediately after the initial sandbox apply
+succeeds, before secrets sync, DNS provisioning, and component deployment.
 `post-provision` runs after the complete install provision workflow, including
-sandbox provisioning and component deployment.
+component deployment.
 
 ### Role change triggers
 

--- a/docs/config-ref/action.mdx
+++ b/docs/config-ref/action.mdx
@@ -26,7 +26,7 @@ title: 'Action'
 
 | Property | Description | Values | Example |
 |----------|----------|----------|----------|
-| **`type`**<br/>string | type of trigger Supported trigger types: manual, cron, pre-provision, post-provision, pre-reprovision, post-reprovision, pre-deprovision, post-deprovision, pre-deploy-all-components, post-deploy-al... | **✅ Required** | `"manual"`, `"cron"`, `"post-provision"` |
+| **`type`**<br/>string | type of trigger Supported trigger types: manual, cron, pre-provision, post-provision, post-provision-sandbox, pre-reprovision, post-reprovision, pre-deprovision, post-deprovision, pre-deploy-all-co... | **✅ Required** | `"manual"`, `"cron"`, `"post-provision"` |
 | **`index`**<br/>integer | index for manual trigger Used to differentiate multiple manual triggers in the same action | **Optional** | `"0"`, `"1"` |
 | **`cron_schedule`**<br/>string | cron schedule expression for scheduled triggers Standard cron format (minute hour day month weekday). For example, '*/5 * * * *' runs every 5 minutes | **Optional** | `"*/5 * * * *"`, `"0 */4 * * *"` |
 | **`component_name`**<br/>string | component name for component-specific triggers Required for pre-deploy-component, post-deploy-component, pre-teardown-component, post-teardown-component, pre-enable-component, post-enable-component... | **Optional** | `"database"`, `"api-server"` |

--- a/docs/guides/actions.mdx
+++ b/docs/guides/actions.mdx
@@ -68,6 +68,7 @@ Actions can run manually, on a cron schedule, or in response to install lifecycl
 - `cron`
 - `pre-provision`
 - `post-provision`
+- `post-provision-sandbox`
 - `pre-reprovision`
 - `post-reprovision`
 - `pre-deprovision`
@@ -89,7 +90,7 @@ Actions can run manually, on a cron schedule, or in response to install lifecycl
 
 Each workflow trigger is called at the beginning or end of the workflow. In some cases, such as `pre-provision` or `pre-reprovision` that include a stack-run, the trigger will be called right after the runner is healthy.
 
-`post-provision` runs after the complete install provision workflow, including sandbox provisioning and component deployment. There is no separate `post-provision-sandbox` trigger. Sandbox-specific triggers are available for reprovision and deprovision workflows.
+`post-provision-sandbox` runs immediately after the initial sandbox apply succeeds, before secrets sync, DNS provisioning, and component deployment. `post-provision` runs after the complete install provision workflow, including component deployment.
 
 #### Role change triggers
 

--- a/docs/guides/app-init.mdx
+++ b/docs/guides/app-init.mdx
@@ -232,6 +232,7 @@ nuon apps init action \
 Common trigger types:
 - `manual` - Triggered manually from dashboard or CLI
 - `cron` - Scheduled using cron expression
+- `post-provision-sandbox` - Runs after initial sandbox provisioning and before component deployment
 - `post-provision` - Runs after installation provisioning
 - `post-deploy-component` - Runs after deployment of the component specified by `component_name`
 - `post-deploy-all-components` - Runs after an all-components deployment

--- a/pkg/config/action_config.go
+++ b/pkg/config/action_config.go
@@ -92,7 +92,7 @@ func (a ActionConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 func (a ActionTriggerConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 	NewSchemaBuilder(schema).
 		Field("type").Short("type of trigger").Required().
-		Long("Supported trigger types: manual, cron, pre-provision, post-provision, pre-reprovision, post-reprovision, pre-deprovision, post-deprovision, pre-deploy-all-components, post-deploy-all-components, pre-teardown-all-components, post-teardown-all-components, pre-deploy-component, post-deploy-component, pre-teardown-component, post-teardown-component, pre-enable-component, post-enable-component, pre-disable-component, post-disable-component, pre-deprovision-sandbox, post-deprovision-sandbox, pre-reprovision-sandbox, post-reprovision-sandbox, pre-update-inputs, post-update-inputs, pre-secrets-sync, post-secrets-sync, role-enabled, role-disabled").
+		Long("Supported trigger types: manual, cron, pre-provision, post-provision, post-provision-sandbox, pre-reprovision, post-reprovision, pre-deprovision, post-deprovision, pre-deploy-all-components, post-deploy-all-components, pre-teardown-all-components, post-teardown-all-components, pre-deploy-component, post-deploy-component, pre-teardown-component, post-teardown-component, pre-enable-component, post-enable-component, pre-disable-component, post-disable-component, pre-deprovision-sandbox, post-deprovision-sandbox, pre-reprovision-sandbox, post-reprovision-sandbox, pre-update-inputs, post-update-inputs, pre-secrets-sync, post-secrets-sync, role-enabled, role-disabled").
 		Example("manual").
 		Example("cron").
 		Example("post-provision").

--- a/sdks/nuon-go/models/app_action_workflow_trigger_type.go
+++ b/sdks/nuon-go/models/app_action_workflow_trigger_type.go
@@ -63,6 +63,9 @@ const (
 	// AppActionWorkflowTriggerTypePostDashProvision captures enum value "post-provision"
 	AppActionWorkflowTriggerTypePostDashProvision AppActionWorkflowTriggerType = "post-provision"
 
+	// AppActionWorkflowTriggerTypePostDashProvisionDashSandbox captures enum value "post-provision-sandbox"
+	AppActionWorkflowTriggerTypePostDashProvisionDashSandbox AppActionWorkflowTriggerType = "post-provision-sandbox"
+
 	// AppActionWorkflowTriggerTypePreDashReprovision captures enum value "pre-reprovision"
 	AppActionWorkflowTriggerTypePreDashReprovision AppActionWorkflowTriggerType = "pre-reprovision"
 
@@ -129,7 +132,7 @@ var appActionWorkflowTriggerTypeEnum []any
 
 func init() {
 	var res []AppActionWorkflowTriggerType
-	if err := json.Unmarshal([]byte(`["manual","cron","adhoc","pre-deploy-component","post-deploy-component","pre-teardown-component","post-teardown-component","pre-secrets-sync","post-secrets-sync","pre-provision","post-provision","pre-reprovision","post-reprovision","pre-deprovision","post-deprovision","pre-deploy-all-components","post-deploy-all-components","pre-teardown-all-components","post-teardown-all-components","pre-deprovision-sandbox","post-deprovision-sandbox","pre-reprovision-sandbox","post-reprovision-sandbox","pre-update-inputs","post-update-inputs","role-enabled","role-disabled","pre-enable-component","post-enable-component","pre-disable-component","post-disable-component"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["manual","cron","adhoc","pre-deploy-component","post-deploy-component","pre-teardown-component","post-teardown-component","pre-secrets-sync","post-secrets-sync","pre-provision","post-provision","post-provision-sandbox","pre-reprovision","post-reprovision","pre-deprovision","post-deprovision","pre-deploy-all-components","post-deploy-all-components","pre-teardown-all-components","post-teardown-all-components","pre-deprovision-sandbox","post-deprovision-sandbox","pre-reprovision-sandbox","post-reprovision-sandbox","pre-update-inputs","post-update-inputs","role-enabled","role-disabled","pre-enable-component","post-enable-component","pre-disable-component","post-disable-component"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/sdks/nuon-runner-go/models/app_action_workflow_trigger_type.go
+++ b/sdks/nuon-runner-go/models/app_action_workflow_trigger_type.go
@@ -63,6 +63,9 @@ const (
 	// AppActionWorkflowTriggerTypePostDashProvision captures enum value "post-provision"
 	AppActionWorkflowTriggerTypePostDashProvision AppActionWorkflowTriggerType = "post-provision"
 
+	// AppActionWorkflowTriggerTypePostDashProvisionDashSandbox captures enum value "post-provision-sandbox"
+	AppActionWorkflowTriggerTypePostDashProvisionDashSandbox AppActionWorkflowTriggerType = "post-provision-sandbox"
+
 	// AppActionWorkflowTriggerTypePreDashReprovision captures enum value "pre-reprovision"
 	AppActionWorkflowTriggerTypePreDashReprovision AppActionWorkflowTriggerType = "pre-reprovision"
 
@@ -129,7 +132,7 @@ var appActionWorkflowTriggerTypeEnum []any
 
 func init() {
 	var res []AppActionWorkflowTriggerType
-	if err := json.Unmarshal([]byte(`["manual","cron","adhoc","pre-deploy-component","post-deploy-component","pre-teardown-component","post-teardown-component","pre-secrets-sync","post-secrets-sync","pre-provision","post-provision","pre-reprovision","post-reprovision","pre-deprovision","post-deprovision","pre-deploy-all-components","post-deploy-all-components","pre-teardown-all-components","post-teardown-all-components","pre-deprovision-sandbox","post-deprovision-sandbox","pre-reprovision-sandbox","post-reprovision-sandbox","pre-update-inputs","post-update-inputs","role-enabled","role-disabled","pre-enable-component","post-enable-component","pre-disable-component","post-disable-component"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["manual","cron","adhoc","pre-deploy-component","post-deploy-component","pre-teardown-component","post-teardown-component","pre-secrets-sync","post-secrets-sync","pre-provision","post-provision","post-provision-sandbox","pre-reprovision","post-reprovision","pre-deprovision","post-deprovision","pre-deploy-all-components","post-deploy-all-components","pre-teardown-all-components","post-teardown-all-components","pre-deprovision-sandbox","post-deprovision-sandbox","pre-reprovision-sandbox","post-reprovision-sandbox","pre-update-inputs","post-update-inputs","role-enabled","role-disabled","pre-enable-component","post-enable-component","pre-disable-component","post-disable-component"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/services/ctl-api/internal/app/action_workflow_trigger_config.go
+++ b/services/ctl-api/internal/app/action_workflow_trigger_config.go
@@ -36,8 +36,9 @@ const (
 	ActionWorkflowTriggerTypePostSecretsSync ActionWorkflowTriggerType = "post-secrets-sync"
 
 	// workflow triggers
-	ActionWorkflowTriggerTypePreProvision  ActionWorkflowTriggerType = "pre-provision"
-	ActionWorkflowTriggerTypePostProvision ActionWorkflowTriggerType = "post-provision"
+	ActionWorkflowTriggerTypePreProvision         ActionWorkflowTriggerType = "pre-provision"
+	ActionWorkflowTriggerTypePostProvision        ActionWorkflowTriggerType = "post-provision"
+	ActionWorkflowTriggerTypePostProvisionSandbox ActionWorkflowTriggerType = "post-provision-sandbox"
 
 	ActionWorkflowTriggerTypePreReprovision  ActionWorkflowTriggerType = "pre-reprovision"
 	ActionWorkflowTriggerTypePostReprovision ActionWorkflowTriggerType = "post-reprovision"
@@ -96,6 +97,7 @@ var AllActionWorkflowTriggerTypes = []ActionWorkflowTriggerType{
 	ActionWorkflowTriggerTypePostSecretsSync,
 	ActionWorkflowTriggerTypePreProvision,
 	ActionWorkflowTriggerTypePostProvision,
+	ActionWorkflowTriggerTypePostProvisionSandbox,
 	ActionWorkflowTriggerTypePreReprovision,
 	ActionWorkflowTriggerTypePostReprovision,
 	ActionWorkflowTriggerTypePreDeprovision,

--- a/services/ctl-api/internal/app/actions/service/create_action_workflow_config_test.go
+++ b/services/ctl-api/internal/app/actions/service/create_action_workflow_config_test.go
@@ -238,6 +238,33 @@ func (s *CreateAppActionConfigTestSuite) TestCreateActionConfigSuccess() {
 			},
 		},
 		{
+			name: "post provision sandbox trigger",
+			setupFunc: func() (string, string, string) {
+				action := s.createActionWorkflow(s.testApp.ID, "post-provision-sandbox-action")
+				appConfig := s.createAppConfig(s.testApp.ID)
+				return action.ID, appConfig.ID, ""
+			},
+			requestFunc: func(actionID, appConfigID, componentID string) CreateActionWorkflowConfigRequest {
+				return CreateActionWorkflowConfigRequest{
+					AppConfigID: appConfigID,
+					Triggers: []CreateActionWorkflowConfigTriggerRequest{
+						{Type: app.ActionWorkflowTriggerTypePostProvisionSandbox},
+					},
+					Steps: []CreateActionWorkflowConfigStepRequest{
+						{
+							Name:           "post-provision-sandbox-step",
+							InlineContents: "echo 'sandbox provisioned'",
+						},
+					},
+				}
+			},
+			expectedCode: http.StatusCreated,
+			validateFunc: func(config *app.ActionWorkflowConfig) {
+				assert.Len(s.T(), config.Triggers, 1)
+				assert.Equal(s.T(), app.ActionWorkflowTriggerTypePostProvisionSandbox, config.Triggers[0].Type)
+			},
+		},
+		{
 			name: "component lifecycle trigger",
 			setupFunc: func() (string, string, string) {
 				action := s.createActionWorkflow(s.testApp.ID, "component-action")

--- a/services/ctl-api/internal/app/installs/workflows/v2/provision.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/provision.go
@@ -149,6 +149,12 @@ func Provision(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResul
 		}
 		steps = append(steps, step)
 
+		lifecycleSteps, err = getLifecycleActionsSteps(ctx, dg, app.ActionWorkflowTriggerTypePostProvisionSandbox)
+		if err != nil {
+			return nil, err
+		}
+		steps = append(steps, lifecycleSteps...)
+
 		lifecycleSteps, err = getLifecycleActionsSteps(ctx, dg, app.ActionWorkflowTriggerTypePreSecretsSync)
 		if err != nil {
 			return nil, err

--- a/services/dashboard-ui/client/components/actions/TriggeredByFilter/TriggeredByFilter.tsx
+++ b/services/dashboard-ui/client/components/actions/TriggeredByFilter/TriggeredByFilter.tsx
@@ -17,6 +17,7 @@ const TRIGGER_OPTIONS = [
   'post-secrets-sync',
   'pre-provision',
   'post-provision',
+  'post-provision-sandbox',
   'pre-reprovision',
   'post-reprovision',
   'pre-deprovision',

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -3108,7 +3108,7 @@ export interface components {
       updated_at?: string;
     };
     /** @enum {string} */
-    "app.ActionWorkflowTriggerType": "manual" | "cron" | "adhoc" | "pre-deploy-component" | "post-deploy-component" | "pre-teardown-component" | "post-teardown-component" | "pre-secrets-sync" | "post-secrets-sync" | "pre-provision" | "post-provision" | "pre-reprovision" | "post-reprovision" | "pre-deprovision" | "post-deprovision" | "pre-deploy-all-components" | "post-deploy-all-components" | "pre-teardown-all-components" | "post-teardown-all-components" | "pre-deprovision-sandbox" | "post-deprovision-sandbox" | "pre-reprovision-sandbox" | "post-reprovision-sandbox" | "pre-update-inputs" | "post-update-inputs" | "role-enabled" | "role-disabled" | "pre-enable-component" | "post-enable-component" | "pre-disable-component" | "post-disable-component";
+    "app.ActionWorkflowTriggerType": "manual" | "cron" | "adhoc" | "pre-deploy-component" | "post-deploy-component" | "pre-teardown-component" | "post-teardown-component" | "pre-secrets-sync" | "post-secrets-sync" | "pre-provision" | "post-provision" | "post-provision-sandbox" | "pre-reprovision" | "post-reprovision" | "pre-deprovision" | "post-deprovision" | "pre-deploy-all-components" | "post-deploy-all-components" | "pre-teardown-all-components" | "post-teardown-all-components" | "pre-deprovision-sandbox" | "post-deprovision-sandbox" | "pre-reprovision-sandbox" | "post-reprovision-sandbox" | "pre-update-inputs" | "post-update-inputs" | "role-enabled" | "role-disabled" | "pre-enable-component" | "post-enable-component" | "pre-disable-component" | "post-disable-component";
     "app.AdHocStepConfig": {
       action_workflow_config_id?: string;
       /** @description this belongs to an app config id */


### PR DESCRIPTION
Adds a component-independent action trigger that runs after the initial sandbox apply and before secrets sync, DNS provisioning, and component deployment. Updates validation, workflow scheduling, SDK and dashboard types, config references, documentation, and API coverage.