### PR TITLE
fix: attach azure per-op identities to custom runner templates

### DIFF
--- a/pkg/config/validate/validate.go
+++ b/pkg/config/validate/validate.go
@@ -60,6 +60,9 @@ func Validate(ctx context.Context, v *validator.Validate, a *config.AppConfig) e
 		func() error {
 			return ValidateCustomNestedStackOutputs(a)
 		},
+		func() error {
+			return ValidateAzureRunnerIdentities(a)
+		},
 		//
 		func() error {
 			if err := a.OperationRoles.Validate(); err != nil {

--- a/pkg/config/validate/validate_azure_runner_identities.go
+++ b/pkg/config/validate/validate_azure_runner_identities.go
@@ -1,0 +1,83 @@
+package validate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/nuonco/nuon/pkg/config"
+)
+
+type armParametersShape struct {
+	Parameters map[string]json.RawMessage `yaml:"parameters" json:"parameters"`
+}
+
+// ValidateAzureRunnerIdentities guards the one combination that otherwise fails
+// with an opaque IMDS "Identity not found" at runtime: an azure-bicep app that
+// defines per-operation identities (any azure permission role) AND pins a custom
+// runner_nested_template_url whose template does not accept a
+// "userAssignedIdentities" parameter. Only the built-in runner (empty URL) or a
+// template that declares that parameter can attach the identities to the VMSS.
+func ValidateAzureRunnerIdentities(a *config.AppConfig) error {
+	if a.Stack == nil || a.Stack.Type != "azure-bicep" || a.Stack.RunnerNestedTemplateURL == "" {
+		return nil
+	}
+	if a.Permissions == nil || !hasAzurePermissionRole(a.Permissions) {
+		return nil
+	}
+
+	params, err := fetchTemplateParameters(a.Stack.RunnerNestedTemplateURL)
+	if err != nil {
+		// Don't fail validation on a transient fetch error; the render-time
+		// check in ctl-api still enforces this.
+		return nil
+	}
+	if _, ok := params["userAssignedIdentities"]; !ok {
+		return fmt.Errorf(
+			"custom runner_nested_template_url %q must declare a 'userAssignedIdentities' parameter to attach this app's per-operation Azure managed identities; omit runner_nested_template_url to use the built-in runner",
+			a.Stack.RunnerNestedTemplateURL,
+		)
+	}
+	return nil
+}
+
+func hasAzurePermissionRole(p *config.PermissionsConfig) bool {
+	roles := []*config.AppAWSIAMRole{p.ProvisionRole, p.DeprovisionRole, p.MaintenanceRole}
+	roles = append(roles, p.CustomRoles...)
+	roles = append(roles, p.Roles...)
+	for _, r := range roles {
+		if r != nil && r.CloudPlatform == "azure" {
+			return true
+		}
+	}
+	return false
+}
+
+func fetchTemplateParameters(templateURL string) (map[string]json.RawMessage, error) {
+	resp, err := templateOutputsClient.Get(templateURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, templateURL)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var tmpl armParametersShape
+	if strings.HasSuffix(templateURL, ".json") {
+		err = json.Unmarshal(body, &tmpl)
+	} else {
+		err = yaml.Unmarshal(body, &tmpl)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template parameters: %w", err)
+	}
+	return tmpl.Parameters, nil
+}

--- a/pkg/config/validate/validate_azure_runner_identities_test.go
+++ b/pkg/config/validate/validate_azure_runner_identities_test.go
@@ -1,0 +1,55 @@
+package validate
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/pkg/config"
+)
+
+func azureRunnerTestServer(t *testing.T, body string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL + "/runner.json"
+}
+
+func azureAppCfg(url string) *config.AppConfig {
+	return &config.AppConfig{
+		Stack: &config.StackConfig{Type: "azure-bicep", RunnerNestedTemplateURL: url},
+		Permissions: &config.PermissionsConfig{
+			ProvisionRole: &config.AppAWSIAMRole{CloudPlatform: "azure"},
+		},
+	}
+}
+
+func TestValidateAzureRunnerIdentities_MissingParam(t *testing.T) {
+	url := azureRunnerTestServer(t, `{"parameters":{"nuonInstallID":{"type":"string"}},"resources":[]}`)
+	err := ValidateAzureRunnerIdentities(azureAppCfg(url))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "userAssignedIdentities")
+}
+
+func TestValidateAzureRunnerIdentities_ParamPresent(t *testing.T) {
+	url := azureRunnerTestServer(t, `{"parameters":{"userAssignedIdentities":{"type":"object"}},"resources":[]}`)
+	require.NoError(t, ValidateAzureRunnerIdentities(azureAppCfg(url)))
+}
+
+func TestValidateAzureRunnerIdentities_BuiltInRunnerSkips(t *testing.T) {
+	cfg := azureAppCfg("")
+	cfg.Stack.RunnerNestedTemplateURL = ""
+	require.NoError(t, ValidateAzureRunnerIdentities(cfg))
+}
+
+func TestValidateAzureRunnerIdentities_NonAzureRoleSkips(t *testing.T) {
+	url := azureRunnerTestServer(t, `{"parameters":{},"resources":[]}`)
+	cfg := azureAppCfg(url)
+	cfg.Permissions.ProvisionRole.CloudPlatform = "aws"
+	require.NoError(t, ValidateAzureRunnerIdentities(cfg))
+}

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_runner.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_runner.go
@@ -12,9 +12,6 @@ func (t *Templates) getRunnerLinkedDeployment(inp *stacks.TemplateInput, operati
 		return t.getDefaultRunnerDeployment(inp, operationIDs), nil, nil
 	}
 
-	// Custom runner templates manage their own VMSS identity; per-operation
-	// identities are only auto-attached on the default runner.
-
 	// Custom runner template — fetch and inspect declared parameters.
 	// Unlike the generic custom-nested-stack path we do NOT hoist arbitrary
 	// params. The runner template is Nuon-owned plumbing; every parameter
@@ -22,6 +19,23 @@ func (t *Templates) getRunnerLinkedDeployment(inp *stacks.TemplateInput, operati
 	armTmpl, err := fetchARMTemplate(templateURL)
 	if err != nil {
 		return nil, nil, fmt.Errorf("runner linked deployment: %w", err)
+	}
+
+	// Per-operation user-assigned identities must be attached to the runner
+	// VMSS to be usable via IMDS (Azure has no assume-role). The default runner
+	// attaches them automatically; a custom template must opt in by declaring a
+	// "userAssignedIdentities" object parameter, into which we inject the
+	// attachment map. Without it the identities would exist but never reach the
+	// instance, and the runner would fail with an opaque IMDS "Identity not
+	// found" at deploy time — so we reject that combination up front.
+	userAssigned, uamiDependsOn := operationIdentityAttachment(operationIDs)
+	if len(userAssigned) > 0 {
+		if _, ok := armTmpl.Parameters["userAssignedIdentities"]; !ok {
+			return nil, nil, fmt.Errorf(
+				"runner linked deployment: custom runner template %q must declare a 'userAssignedIdentities' object parameter to receive the per-operation managed identities this app's permissions define; omit runner_nested_template_url to use the built-in runner instead",
+				templateURL,
+			)
+		}
 	}
 
 	// All values Nuon can supply. Only injected if the template declares
@@ -39,6 +53,10 @@ func (t *Templates) getRunnerLinkedDeployment(inp *stacks.TemplateInput, operati
 		"commonTags":          "[variables('commonTags')]",
 	}
 
+	if len(userAssigned) > 0 {
+		managedParams["userAssignedIdentities"] = userAssigned
+	}
+
 	deploymentParams := map[string]any{}
 	for paramName := range armTmpl.Parameters {
 		if val, ok := managedParams[paramName]; ok {
@@ -49,11 +67,13 @@ func (t *Templates) getRunnerLinkedDeployment(inp *stacks.TemplateInput, operati
 		// know about, ARM will surface a clear deployment error.
 	}
 
+	dependsOn := append([]string{"vnetDeployment"}, uamiDependsOn...)
+
 	deployment := map[string]any{
 		"type":       "Microsoft.Resources/deployments",
 		"apiVersion": "2022-09-01",
 		"name":       "runnerDeployment",
-		"dependsOn":  []string{"vnetDeployment"},
+		"dependsOn":  dependsOn,
 		"properties": map[string]any{
 			"mode": "Incremental",
 			"templateLink": map[string]any{

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_runner_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_runner_test.go
@@ -1,0 +1,51 @@
+package arm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+func runnerTemplateServer(t *testing.T, body string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL + "/runner.json"
+}
+
+func TestGetRunnerLinkedDeployment_CustomTemplateMissingIdentityParam(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+	inp := minimalTemplateInput()
+	inp.RunnerNestedStackTemplateURL = runnerTemplateServer(t, `{"parameters":{"nuonInstallID":{"type":"string"}},"resources":[]}`)
+
+	ids := []azureOperationIdentity{{roleName: "prov", suffix: "provision", kind: "provision"}}
+	_, _, err := tmpl.getRunnerLinkedDeployment(inp, ids)
+	if err == nil {
+		t.Fatal("expected error for custom template without userAssignedIdentities param")
+	}
+}
+
+func TestGetRunnerLinkedDeployment_CustomTemplateAttachesIdentities(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+	inp := minimalTemplateInput()
+	inp.RunnerNestedStackTemplateURL = runnerTemplateServer(t, `{"parameters":{"nuonInstallID":{"type":"string"},"userAssignedIdentities":{"type":"object"}},"resources":[]}`)
+
+	ids := []azureOperationIdentity{{roleName: "prov", suffix: "provision", kind: "provision"}}
+	dep, _, err := tmpl.getRunnerLinkedDeployment(inp, ids)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	params := dep["properties"].(map[string]any)["parameters"].(map[string]any)
+	if _, ok := params["userAssignedIdentities"]; !ok {
+		t.Error("expected userAssignedIdentities injected into deployment params")
+	}
+	deps := dep["dependsOn"].([]string)
+	if len(deps) < 2 {
+		t.Errorf("expected identity dependsOn appended, got %v", deps)
+	}
+}


### PR DESCRIPTION
Fixes the Azure per-operation identity footgun for custom runner templates, once and for all.

Today: if an azure-bicep app defines per-operation identities (any azure permission role) AND pins a custom `runner_nested_template_url`, ctl-api creates the user-assigned identities but never attaches them to the runner VMSS — only the built-in runner attaches them. The runner then can't get an IMDS token for the per-op identity and provisioning fails with an opaque "Identity not found".

- `getRunnerLinkedDeployment`: when a custom runner template declares a `userAssignedIdentities` object parameter, inject the per-op identity attachment map + the dependsOn on the identity resources. Backward compatible — templates without the param are unaffected.
- hard error at render if per-op identities exist but the custom template can't accept them (points to the fix or the built-in runner).
- sync-time validation (`ValidateAzureRunnerIdentities`): the same check at `nuon apps validate`, so vendors catch it before any install exists instead of at sandbox runtime.

Pairs with install-stacks: the shared azure/runner.json now declares the param.
