### PR TITLE
feat: containerize actions (wip)

### DIFF
--- a/bins/runner/cmd/cli.go
+++ b/bins/runner/cmd/cli.go
@@ -20,7 +20,12 @@ import (
 	"github.com/nuonco/nuon/pkg/runner/settings"
 )
 
-type cli struct{}
+type cli struct {
+	// extraProviders are appended to the install-mode providers. Used by
+	// run-local (dev) to also register the image-actions loop in-process so
+	// image-backed actions can be exercised without a separate mng process.
+	extraProviders []fx.Option
+}
 
 func (c *cli) commonProviders() []fx.Option {
 	// providers for both runner modes: mng and (org |install)

--- a/bins/runner/cmd/install.go
+++ b/bins/runner/cmd/install.go
@@ -48,6 +48,10 @@ func (c *cli) runInstall(cmd *cobra.Command, _ []string) {
 	providers = append(providers, deploy.GetJobs()...)
 	providers = append(providers, actions.GetJobs()...)
 
+	// dev-only: run-local appends the image-actions loop so image-backed
+	// actions can be exercised locally without a separate mng process.
+	providers = append(providers, c.extraProviders...)
+
 	// heartbeat, registry, job loop execution
 	providers = append(
 		providers,

--- a/bins/runner/cmd/mng.go
+++ b/bins/runner/cmd/mng.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/nuonco/nuon/bins/runner/internal/jobs/actions"
 	"github.com/nuonco/nuon/bins/runner/internal/jobs/management"
 	fetchtoken "github.com/nuonco/nuon/bins/runner/internal/jobs/management/fetch_token"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/health"
@@ -46,6 +47,9 @@ func (c *cli) runMng(cmd *cobra.Command, _ []string) {
 	providers := []fx.Option{fx.Provide(log.NewSystem)}
 	providers = append(c.commonProviders(), providers...)
 	providers = append(providers, management.GetJobs()...)
+	// image-backed actions run on the mng host (which has docker); registering
+	// this loop only here is what gates image-backed actions to VM runners.
+	providers = append(providers, actions.GetImageActionJobs()...)
 	providers = append(providers, fx.Provide(shutdownbeacon.New))
 	// add mng and heartbeater to the mng process
 	providers = append(providers,

--- a/bins/runner/cmd/root.go
+++ b/bins/runner/cmd/root.go
@@ -16,6 +16,7 @@ func Execute() {
 	c.registerRun()
 	c.registerVersion()
 	c.registerRunLocal()
+	c.registerSupervisor()
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(2)

--- a/bins/runner/cmd/run_local.go
+++ b/bins/runner/cmd/run_local.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/nuonco/nuon/bins/runner/internal/jobs/actions"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/dev"
 )
 
@@ -69,6 +70,9 @@ func (c *cli) runLocalRun(cmd *cobra.Command, args []string) {
 	case "org", "build":
 		c.runBuild(cmd, nil)
 	case "install":
+		// register the image-actions loop in-process so image-backed actions
+		// can be exercised locally (they normally run only in the mng process).
+		c.extraProviders = actions.GetImageActionJobs()
 		c.runInstall(cmd, nil)
 	default:
 		log.Fatalf("we know naught of this arg: %s", arg)

--- a/bins/runner/cmd/supervisor.go
+++ b/bins/runner/cmd/supervisor.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nuonco/nuon/pkg/actions/supervisor"
+)
+
+func (c *cli) registerSupervisor() error {
+	cmd := &cobra.Command{
+		Use:    "actions-supervisor",
+		Long:   "run an image-backed action step inside its container (mounted by the mng runner as the container entrypoint)",
+		Hidden: true,
+		Run:    c.runSupervisor,
+	}
+	cmd.Flags().String("script", "", "path to the rendered action step script")
+	cmd.Flags().String("workdir", "", "working directory to execute the script in")
+	rootCmd.AddCommand(cmd)
+	return nil
+}
+
+func (c *cli) runSupervisor(cmd *cobra.Command, _ []string) {
+	script, _ := cmd.Flags().GetString("script")
+	workdir, _ := cmd.Flags().GetString("workdir")
+
+	if script == "" {
+		fmt.Fprintln(os.Stderr, "actions-supervisor: --script is required")
+		os.Exit(1)
+	}
+	if workdir == "" {
+		workdir = "."
+	}
+
+	exitCode, err := supervisor.Run(cmd.Context(), script, workdir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "actions-supervisor: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(exitCode)
+}

--- a/bins/runner/internal/jobs/actions/image_actions.go
+++ b/bins/runner/internal/jobs/actions/image_actions.go
@@ -1,0 +1,37 @@
+package actions
+
+import (
+	"go.uber.org/fx"
+
+	workflow "github.com/nuonco/nuon/bins/runner/internal/jobs/actions/workflow"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/jobloop"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/launcher"
+	"github.com/nuonco/nuon/pkg/runner/jobs"
+	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
+)
+
+const (
+	imageActionsJobGroup models.AppRunnerJobGroup = models.AppRunnerJobGroupImageDashActions
+)
+
+type ImageActionJobLoopParams struct {
+	jobloop.BaseParams
+
+	Handlers []jobs.JobHandler `group:"image-actions"`
+}
+
+func NewImageActionJobLoop(params ImageActionJobLoopParams) jobloop.JobLoop {
+	return jobloop.New(params.Handlers, imageActionsJobGroup, params.BaseParams)
+}
+
+// GetImageActionJobs wires the image-actions job loop and its docker launcher.
+// It is registered ONLY by the mng process (which runs natively on the VM host
+// with docker access) — that registration is what gates image-backed actions
+// to VM runners.
+func GetImageActionJobs() []fx.Option {
+	return []fx.Option{
+		fx.Provide(fx.Annotate(launcher.NewDockerLauncher, fx.As(new(launcher.Launcher)))),
+		fx.Provide(jobloop.AsJobLoop(NewImageActionJobLoop)),
+		fx.Provide(jobs.AsJobHandler("image-actions", workflow.New)),
+	}
+}

--- a/bins/runner/internal/jobs/actions/workflow/env.go
+++ b/bins/runner/internal/jobs/actions/workflow/env.go
@@ -37,6 +37,46 @@ func (h *handler) getBuiltInEnv(ctx context.Context, cfg *models.AppActionWorkfl
 		env[hasKubeConfigEnvVar] = "false"
 	}
 
+	cloudEnv, err := h.cloudCredentialEnv(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return generics.MergeMap(env, cloudEnv), nil
+}
+
+// getContainerBuiltInEnv is the image-backed-action variant of getBuiltInEnv:
+// it maps every host path (outputs file, workspace root, kubeconfig) through
+// mapPath so the values resolve inside the container's workspace mount.
+func (h *handler) getContainerBuiltInEnv(ctx context.Context, cfg *models.AppActionWorkflowStepConfig, mapPath func(string) string) (map[string]string, error) {
+	env := map[string]string{
+		outputsEnvVar: mapPath(h.outputsFP(cfg)),
+		rootEnvVar:    mapPath(h.state.workspace.Root()),
+	}
+
+	if h.state.plan.ClusterInfo != nil {
+		path := h.state.workspace.AbsPath(config.DefaultKubeConfigFilename)
+		if err := config.WriteConfig(ctx, h.state.plan.ClusterInfo, path); err != nil {
+			return nil, errors.Wrap(err, "unable to write kube config")
+		}
+
+		env[config.DefaultKubeConfigEnvVar] = mapPath(path)
+		env[hasKubeConfigEnvVar] = "true"
+	} else {
+		env[hasKubeConfigEnvVar] = "false"
+	}
+
+	cloudEnv, err := h.cloudCredentialEnv(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return generics.MergeMap(env, cloudEnv), nil
+}
+
+func (h *handler) cloudCredentialEnv(ctx context.Context) (map[string]string, error) {
+	env := map[string]string{}
+
 	if h.state.auth.AWSAuth != nil {
 		awsEnv, err := credentials.FetchEnv(ctx, h.state.auth.AWSAuth)
 		if err != nil {

--- a/bins/runner/internal/jobs/actions/workflow/exec_command.go
+++ b/bins/runner/internal/jobs/actions/workflow/exec_command.go
@@ -18,6 +18,10 @@ import (
 )
 
 func (h *handler) execCommand(ctx context.Context, l *zap.Logger, cfg *models.AppActionWorkflowStepConfig, src *plantypes.GitSource, envVars map[string]string) error {
+	if h.state.plan.SourceImage != "" {
+		return h.execCommandInContainer(ctx, l, cfg, envVars)
+	}
+
 	defaultEnvVars := map[string]string{
 		"COLUMNS": "500",
 	}

--- a/bins/runner/internal/jobs/actions/workflow/exec_image.go
+++ b/bins/runner/internal/jobs/actions/workflow/exec_image.go
@@ -1,0 +1,154 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/launcher"
+	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/pkg/runner/op"
+	"github.com/nuonco/nuon/pkg/zapwriter"
+
+	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
+)
+
+const (
+	containerWorkspaceMount = "/nuon/work"
+	containerSupervisorPath = "/nuon/bin/runner"
+)
+
+// execCommandInContainer runs an image-backed action step inside its container.
+// The workspace is bind-mounted so the supervisor writes outputs to a file the
+// runner reads back on the host after the container exits.
+func (h *handler) execCommandInContainer(ctx context.Context, l *zap.Logger, cfg *models.AppActionWorkflowStepConfig, envVars map[string]string) error {
+	if h.launcher == nil {
+		return errors.New("image-backed action received by a runner without a container launcher")
+	}
+
+	supervisorPath, err := h.supervisorBinaryPath()
+	if err != nil {
+		return errors.Wrap(err, "unable to resolve supervisor binary path")
+	}
+
+	scriptHostPath, err := h.prepareInlineContentsCommand(ctx, l, cfg)
+	if err != nil {
+		return errors.Wrap(err, "unable to prepare inline command")
+	}
+
+	root := h.state.workspace.Root()
+	mapPath := func(hostPath string) string {
+		rel, relErr := filepath.Rel(root, hostPath)
+		if relErr != nil {
+			return hostPath
+		}
+		return filepath.Join(containerWorkspaceMount, rel)
+	}
+
+	builtInEnv, err := h.getContainerBuiltInEnv(ctx, cfg, mapPath)
+	if err != nil {
+		return errors.Wrap(err, "unable to get container env")
+	}
+
+	// same env layering as the host path, minus any inherited host environment.
+	env := map[string]string{"COLUMNS": "500"}
+	env = generics.MergeMap(env, h.state.plan.BuiltinEnvVars)
+	env = generics.MergeMap(env, builtInEnv)
+	env = generics.MergeMap(env, h.state.run.RunEnvVars)
+	env = generics.MergeMap(env, envVars)
+	env = generics.MergeMap(env, h.state.plan.OverrideEnvVars)
+
+	image, username, password := h.actionImageRef()
+
+	outL := l.With(zap.String("nuon.command_output", "true"))
+	lOut := zapwriter.New(outL, zapcore.InfoLevel, "")
+	lErr := zapwriter.New(outL, zapcore.ErrorLevel, "")
+
+	spec := launcher.RunSpec{
+		Image:         image,
+		PullUsername:  username,
+		PullPassword:  password,
+		ContainerName: fmt.Sprintf("nuon-action-%s-%d", h.state.run.ID, cfg.Idx),
+		Mounts: []launcher.Mount{
+			{HostPath: supervisorPath, ContainerPath: containerSupervisorPath, ReadOnly: true},
+			{HostPath: root, ContainerPath: containerWorkspaceMount},
+		},
+		Command: []string{
+			containerSupervisorPath, "actions-supervisor",
+			"--script", mapPath(scriptHostPath),
+			"--workdir", containerWorkspaceMount,
+		},
+		Env: env,
+		Labels: map[string]string{
+			"nuon.install_id": h.state.plan.InstallID,
+			"nuon.run_id":     h.state.run.ID,
+		},
+		Memory:    "2g",
+		CPUs:      "1",
+		PidsLimit: 512,
+		Stdout:    lOut,
+		Stderr:    lErr,
+	}
+
+	opCtx, end := op.Tool(ctx, "action", "image-command")
+	if err := h.launcher.Run(opCtx, spec); err != nil {
+		end(err)
+		return fmt.Errorf("unable to run action container: %w", err)
+	}
+	end(nil)
+
+	return nil
+}
+
+// actionImageRef resolves the image ref and pull credentials for the launcher.
+// Prod pulls the install-registry mirror; the dev real-docker path pulls the
+// source image directly (no mirror, no creds).
+func (h *handler) actionImageRef() (image, username, password string) {
+	plan := h.state.plan
+
+	if h.pullSourceImageDirectly() {
+		return plan.SourceImage, "", ""
+	}
+
+	if plan.ImageRegistry != nil && plan.ImageTag != "" {
+		image = fmt.Sprintf("%s/%s:%s",
+			strings.TrimSuffix(plan.ImageRegistry.LoginServer, "/"),
+			plan.ImageRegistry.Repository,
+			plan.ImageTag,
+		)
+		if plan.ImageRegistry.OCIAuth != nil {
+			username = plan.ImageRegistry.OCIAuth.Username
+			password = plan.ImageRegistry.OCIAuth.Password
+		}
+		return image, username, password
+	}
+
+	return plan.SourceImage, "", ""
+}
+
+// supervisorBinaryPath returns the host path to the supervisor binary to mount
+// into the container. In the dev real-docker path this must be an explicit
+// linux cross-build (the darwin host binary can't run in a linux container).
+func (h *handler) supervisorBinaryPath() (string, error) {
+	if h.pullSourceImageDirectly() {
+		if p := os.Getenv("NUON_DEV_SUPERVISOR_BIN"); p != "" {
+			return p, nil
+		}
+	}
+	return os.Executable()
+}
+
+// pullSourceImageDirectly reports whether the dev-only real-docker path is
+// active, in which case the launcher pulls the app-authored source image
+// directly (ctl-api can't know a local registry address) instead of the
+// install-registry mirror.
+func (h *handler) pullSourceImageDirectly() bool {
+	return os.Getenv("NUON_DEV_REAL_IMAGE_ACTIONS") == "true" &&
+		strings.EqualFold(os.Getenv("ENV"), "development")
+}

--- a/bins/runner/internal/jobs/actions/workflow/exec_image.go
+++ b/bins/runner/internal/jobs/actions/workflow/exec_image.go
@@ -69,6 +69,8 @@ func (h *handler) execCommandInContainer(ctx context.Context, l *zap.Logger, cfg
 	outL := l.With(zap.String("nuon.command_output", "true"))
 	lOut := zapwriter.New(outL, zapcore.InfoLevel, "")
 	lErr := zapwriter.New(outL, zapcore.ErrorLevel, "")
+	// pull progress: INFO, untagged (not the action's command output)
+	lPull := zapwriter.New(l, zapcore.InfoLevel, "")
 
 	spec := launcher.RunSpec{
 		Image:         image,
@@ -94,6 +96,7 @@ func (h *handler) execCommandInContainer(ctx context.Context, l *zap.Logger, cfg
 		PidsLimit: 512,
 		Stdout:    lOut,
 		Stderr:    lErr,
+		PullLog:   lPull,
 	}
 
 	opCtx, end := op.Tool(ctx, "action", "image-command")

--- a/bins/runner/internal/jobs/actions/workflow/handler.go
+++ b/bins/runner/internal/jobs/actions/workflow/handler.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/launcher"
 	"github.com/nuonco/nuon/pkg/runner/jobs"
 	"github.com/nuonco/nuon/pkg/runner/settings"
 )
@@ -17,6 +18,10 @@ type handler struct {
 	v         *validator.Validate
 	apiClient nuonrunner.Client
 	settings  *settings.Settings
+
+	// launcher is only set for the image-actions handler registered by the mng
+	// process; it is nil for the in-process actions handler.
+	launcher launcher.Launcher
 
 	// state is reused between function calls, but can _not_ be reused with different jobs.
 	//
@@ -33,6 +38,7 @@ type HandlerParams struct {
 	V         *validator.Validate
 	APIClient nuonrunner.Client
 	Settings  *settings.Settings
+	Launcher  launcher.Launcher `optional:"true"`
 }
 
 func New(params HandlerParams) *handler {
@@ -40,6 +46,7 @@ func New(params HandlerParams) *handler {
 		apiClient: params.APIClient,
 		v:         params.V,
 		settings:  params.Settings,
+		launcher:  params.Launcher,
 	}
 }
 

--- a/bins/runner/internal/jobs/actions/workflow/outputs.go
+++ b/bins/runner/internal/jobs/actions/workflow/outputs.go
@@ -1,77 +1,26 @@
 package workflow
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
-	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 
+	"github.com/nuonco/nuon/pkg/actions/outputs"
 	"github.com/nuonco/nuon/pkg/generics"
 	pkgctx "github.com/nuonco/nuon/pkg/runner/ctx"
 )
 
-const (
-	kvDelimiter     string = "="
-	jsonObjStart    string = "{"
-	jsonArrayStart  string = "["
-	outputsFilename string = "%d.nuon-outputs.json"
-)
-
 func (h *handler) outputsFP(cfg *models.AppActionWorkflowStepConfig) string {
-	fn := fmt.Sprintf(outputsFilename, cfg.Idx)
-	return filepath.Join(h.state.workspace.Root(), fn)
-}
-
-func (h *handler) parseOutputLine(ctx context.Context, str string) (map[string]interface{}, error) {
-	l, err := pkgctx.Logger(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// look to parse the string as a json map
-	if strings.HasPrefix(str, jsonObjStart) {
-		var out map[string]interface{}
-		if err := json.Unmarshal([]byte(str), &out); err != nil {
-			return nil, errors.Wrap(err, "unable to parse as json")
-		}
-
-		return out, nil
-	}
-
-	// check to make sure it is not a json array
-	if strings.HasPrefix(str, jsonArrayStart) {
-		l.Error("outputs with top level json arrays are not yet supported")
-		return nil, errors.New("outputs with top level json arrays are not supported yet")
-	}
-
-	// check to see if it is a key value
-	pieces := strings.SplitN(str, kvDelimiter, 2)
-	if len(pieces) == 2 {
-		return map[string]interface{}{
-			pieces[0]: pieces[1],
-		}, nil
-	}
-
-	l.Error("output format not supported, must be one a json object or k=v string", zap.String("output", str))
-	return nil, errors.New("unsupported outputs format")
+	return filepath.Join(h.state.workspace.Root(), outputs.Filename(cfg.Idx))
 }
 
 func (h *handler) parseOutputs(ctx context.Context) (map[string]interface{}, error) {
-	l, err := pkgctx.Logger(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	steps := make(map[string]any, 0)
-	outputs := make(map[string]interface{}, 0)
+	merged := make(map[string]interface{}, 0)
 
 	// build the list of step configs to read outputs from
 	var stepCfgs []*models.AppActionWorkflowStepConfig
@@ -90,40 +39,21 @@ func (h *handler) parseOutputs(ctx context.Context) (map[string]interface{}, err
 	}
 
 	if len(stepCfgs) == 0 {
-		return outputs, nil
+		return merged, nil
 	}
 
 	for _, stepCfg := range stepCfgs {
-		fh, err := os.Open(h.outputsFP(stepCfg))
+		stepOutputs, err := outputs.ParseFile(h.outputsFP(stepCfg))
 		if err != nil {
-			l.Error("error opening outputs file", zap.Error(err))
-			return nil, errors.Wrap(err, "unable to get outputs file")
-		}
-		defer fh.Close()
-
-		stepOutputs := make(map[string]interface{}, 0)
-
-		scanner := bufio.NewScanner(fh)
-		for scanner.Scan() {
-			line := scanner.Text()
-			lineOutputs, err := h.parseOutputLine(ctx, line)
-			if err != nil {
-				l.Error("error parsing outputs line", zap.Error(err))
-				return nil, errors.Wrap(err, "error parsing outputs")
-			}
-
-			stepOutputs = generics.MergeMap(stepOutputs, lineOutputs)
-		}
-		if err := scanner.Err(); err != nil {
-			return nil, errors.Wrap(err, "unable to scan outputs file")
+			return nil, errors.Wrapf(err, "unable to parse outputs for step %s", stepCfg.Name)
 		}
 
-		outputs = generics.MergeMap(outputs, stepOutputs)
+		merged = generics.MergeMap(merged, stepOutputs)
 		steps[stepCfg.Name] = stepOutputs
 	}
 
-	outputs["steps"] = steps
-	return outputs, nil
+	merged["steps"] = steps
+	return merged, nil
 }
 
 func (h *handler) Outputs(ctx context.Context) (map[string]interface{}, error) {

--- a/bins/runner/internal/pkg/jobloop/sandbox.go
+++ b/bins/runner/internal/pkg/jobloop/sandbox.go
@@ -1,6 +1,9 @@
 package jobloop
 
 import (
+	"os"
+	"strings"
+
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 )
 
@@ -9,5 +12,16 @@ func (j *jobLoop) isSandbox(job *models.AppRunnerJob) bool {
 		return false
 	}
 
+	// dev-only: let image-backed actions run their real container locally so
+	// the supervisor + launcher contract can be validated without cloud.
+	if job.Group == models.AppRunnerJobGroupImageDashActions && devRealImageActions() {
+		return false
+	}
+
 	return j.settings.SandboxMode
+}
+
+func devRealImageActions() bool {
+	return os.Getenv("NUON_DEV_REAL_IMAGE_ACTIONS") == "true" &&
+		strings.EqualFold(os.Getenv("ENV"), "development")
 }

--- a/bins/runner/internal/pkg/launcher/docker.go
+++ b/bins/runner/internal/pkg/launcher/docker.go
@@ -59,8 +59,15 @@ func (d *DockerLauncher) pull(ctx context.Context, spec RunSpec, dockerConfigDir
 	args := []string{"pull", spec.Image}
 	cmd := exec.CommandContext(ctx, d.dockerPath, args...)
 	cmd.Env = dockerEnv(dockerConfigDir)
-	cmd.Stdout = spec.Stderr // pull progress is noise; keep it off the action stdout
-	cmd.Stderr = spec.Stderr
+
+	// Pull progress goes to the dedicated pull log (INFO), not the action's
+	// stdout/stderr — docker writes it to stderr but it isn't an error.
+	pullLog := spec.PullLog
+	if pullLog == nil {
+		pullLog = spec.Stdout
+	}
+	cmd.Stdout = pullLog
+	cmd.Stderr = pullLog
 	return cmd.Run()
 }
 

--- a/bins/runner/internal/pkg/launcher/docker.go
+++ b/bins/runner/internal/pkg/launcher/docker.go
@@ -1,0 +1,175 @@
+package launcher
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// DockerLauncher runs action containers via the host docker CLI. It mirrors the
+// mechanism mng already uses to launch the install container (shelling docker),
+// rather than adding a docker Go SDK dependency.
+type DockerLauncher struct {
+	dockerPath string
+}
+
+var _ Launcher = (*DockerLauncher)(nil)
+
+func NewDockerLauncher() *DockerLauncher {
+	path := "docker"
+	if p, err := exec.LookPath("docker"); err == nil {
+		path = p
+	}
+	return &DockerLauncher{dockerPath: path}
+}
+
+func (d *DockerLauncher) Run(ctx context.Context, spec RunSpec) error {
+	// Pull credentials, when present, are written to a throwaway DOCKER_CONFIG
+	// so they never touch argv or the shared docker login state.
+	var dockerConfigDir string
+	if spec.PullUsername != "" || spec.PullPassword != "" {
+		var err error
+		dockerConfigDir, err = writeDockerConfig(spec.Image, spec.PullUsername, spec.PullPassword)
+		if err != nil {
+			return errors.Wrap(err, "unable to write docker auth config")
+		}
+		defer os.RemoveAll(dockerConfigDir)
+	}
+
+	if err := d.pull(ctx, spec, dockerConfigDir); err != nil {
+		return errors.Wrap(err, "unable to pull action image")
+	}
+
+	// Best-effort remove of any stale container with the same name, plus a
+	// guaranteed cleanup after the run (--rm covers the normal path).
+	d.remove(context.WithoutCancel(ctx), spec.ContainerName)
+	defer d.remove(context.WithoutCancel(ctx), spec.ContainerName)
+
+	return d.run(ctx, spec, dockerConfigDir)
+}
+
+func (d *DockerLauncher) pull(ctx context.Context, spec RunSpec, dockerConfigDir string) error {
+	args := []string{"pull", spec.Image}
+	cmd := exec.CommandContext(ctx, d.dockerPath, args...)
+	cmd.Env = dockerEnv(dockerConfigDir)
+	cmd.Stdout = spec.Stderr // pull progress is noise; keep it off the action stdout
+	cmd.Stderr = spec.Stderr
+	return cmd.Run()
+}
+
+func (d *DockerLauncher) run(ctx context.Context, spec RunSpec, dockerConfigDir string) error {
+	args := []string{
+		"run", "--rm",
+		"--name", spec.ContainerName,
+		// Isolation: default bridge network (outbound only, so kubectl/cloud
+		// APIs still work) — never --network host. No added privileges.
+		"--security-opt", "no-new-privileges",
+	}
+
+	if spec.Memory != "" {
+		args = append(args, "--memory", spec.Memory)
+	}
+	if spec.CPUs != "" {
+		args = append(args, "--cpus", spec.CPUs)
+	}
+	if spec.PidsLimit > 0 {
+		args = append(args, "--pids-limit", fmt.Sprintf("%d", spec.PidsLimit))
+	}
+
+	for _, m := range spec.Mounts {
+		vol := fmt.Sprintf("%s:%s", m.HostPath, m.ContainerPath)
+		if m.ReadOnly {
+			vol += ":ro"
+		}
+		args = append(args, "--volume", vol)
+	}
+
+	// Explicit env only — never --env-file of the host environment.
+	for k, v := range spec.Env {
+		args = append(args, "--env", fmt.Sprintf("%s=%s", k, v))
+	}
+	for k, v := range spec.Labels {
+		args = append(args, "--label", fmt.Sprintf("%s=%s", k, v))
+	}
+
+	if len(spec.Command) > 0 {
+		args = append(args, "--entrypoint", spec.Command[0])
+	}
+
+	args = append(args, spec.Image)
+
+	if len(spec.Command) > 1 {
+		args = append(args, spec.Command[1:]...)
+	}
+
+	cmd := exec.CommandContext(ctx, d.dockerPath, args...)
+	cmd.Env = dockerEnv(dockerConfigDir)
+	cmd.Stdout = spec.Stdout
+	cmd.Stderr = spec.Stderr
+	return cmd.Run()
+}
+
+func (d *DockerLauncher) remove(ctx context.Context, name string) {
+	if name == "" {
+		return
+	}
+	cmd := exec.CommandContext(ctx, d.dockerPath, "rm", "-f", name)
+	_ = cmd.Run()
+}
+
+// dockerEnv returns the host environment for the docker CLI itself (so it can
+// find the daemon and its config), optionally overriding DOCKER_CONFIG to the
+// throwaway auth dir. This is the docker process env, NOT the container env.
+func dockerEnv(dockerConfigDir string) []string {
+	env := os.Environ()
+	if dockerConfigDir != "" {
+		env = append(env, fmt.Sprintf("DOCKER_CONFIG=%s", dockerConfigDir))
+	}
+	return env
+}
+
+func writeDockerConfig(image, username, password string) (string, error) {
+	registry := registryHost(image)
+	auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+
+	cfg := map[string]any{
+		"auths": map[string]any{
+			registry: map[string]string{"auth": auth},
+		},
+	}
+
+	dir, err := os.MkdirTemp("", "nuon-action-docker-cfg-")
+	if err != nil {
+		return "", err
+	}
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		os.RemoveAll(dir)
+		return "", err
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0o600); err != nil {
+		os.RemoveAll(dir)
+		return "", err
+	}
+
+	return dir, nil
+}
+
+// registryHost extracts the registry host from an image ref for the docker
+// config auths key (everything before the first "/" when it looks like a host).
+func registryHost(image string) string {
+	parts := strings.SplitN(image, "/", 2)
+	if len(parts) == 2 && (strings.ContainsAny(parts[0], ".:") || parts[0] == "localhost") {
+		return parts[0]
+	}
+	return "https://index.docker.io/v1/"
+}

--- a/bins/runner/internal/pkg/launcher/launcher.go
+++ b/bins/runner/internal/pkg/launcher/launcher.go
@@ -39,6 +39,11 @@ type RunSpec struct {
 
 	Stdout io.Writer
 	Stderr io.Writer
+
+	// PullLog receives image-pull progress (docker writes it to stderr, but it
+	// is not an error and not the action's output — keep it separate so it logs
+	// at INFO and isn't tagged as command output).
+	PullLog io.Writer
 }
 
 // Launcher pulls and runs an image-backed action container.

--- a/bins/runner/internal/pkg/launcher/launcher.go
+++ b/bins/runner/internal/pkg/launcher/launcher.go
@@ -1,0 +1,47 @@
+// Package launcher runs an image-backed action's container. Only a docker
+// backend exists today (used by the mng process on VM runners), but the
+// Launcher interface is the seam a future Kubernetes Pod/Job backend would
+// implement.
+package launcher
+
+import (
+	"context"
+	"io"
+)
+
+// Mount is a host-path to container-path bind mount.
+type Mount struct {
+	HostPath      string
+	ContainerPath string
+	ReadOnly      bool
+}
+
+// RunSpec fully describes an image-backed action container invocation. Env is
+// the ONLY environment the container receives — the host/runner environment is
+// never inherited (an RFC security requirement).
+type RunSpec struct {
+	Image         string
+	PullUsername  string
+	PullPassword  string
+	ContainerName string
+
+	Mounts []Mount
+
+	// Command is the container entrypoint + args (the mounted supervisor).
+	Command []string
+
+	Env    map[string]string
+	Labels map[string]string
+
+	Memory    string
+	CPUs      string
+	PidsLimit int
+
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Launcher pulls and runs an image-backed action container.
+type Launcher interface {
+	Run(ctx context.Context, spec RunSpec) error
+}

--- a/docs/config-ref/action.mdx
+++ b/docs/config-ref/action.mdx
@@ -20,6 +20,7 @@ title: 'Action'
 | **`break_glass_role`**<br/>string | IAM role for break-glass access to this action When set, allows the action to use a break glass role for elevated permissions during critical operations. Break glass roles are defined in CloudForma... | **Optional** | `"bucket-operations-break-glass"`, `"database-migration-break-glass"` |
 | **`role`**<br/>string | IAM role name for action execution Name of the IAM role to use when executing this action. The role must be defined in the CloudFormation stack deployed to the customer's AWS account. If not specif... | **Optional** | `"{{.nuon.install.id}}-maintenance"` |
 | **`enable_kube_config`**<br/>boolean | whether to fetch and inject kubeconfig for this action When set to false, the action runner will not fetch the install's kubeconfig or set the KUBECONFIG env var. Defaults to true. Set to false for... | **Optional** | `"true"`, `"false"` |
+| **`image`**<br/>string | container image the action's steps run inside Optional container image (e.g. ghcr.io/acme/kubernetes-tools:v1) supplying the tools the action needs. When set, Nuon mirrors the image into the instal... | **Optional** | `"ghcr.io/acme/kubernetes-tools:v1"` |
 | **`kubernetes_context`**<br/>string | kubernetes context this action targets Name of a top-level kubernetes_context binding to target when this action runs. When set, the action's runner receives the cluster connection details from tha... | **Optional** | `"compute"`, `"data-cluster"` |
 
 ### `triggers`

--- a/pkg/actions/outputs/outputs.go
+++ b/pkg/actions/outputs/outputs.go
@@ -1,0 +1,91 @@
+// Package outputs implements the action-output file grammar shared by the
+// runner's action handler and the actions-supervisor. Both ends must agree on
+// how a step's outputs file is written and parsed, so the grammar lives here
+// rather than in either binary.
+package outputs
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/pkg/generics"
+)
+
+const (
+	kvDelimiter    string = "="
+	jsonObjStart   string = "{"
+	jsonArrayStart string = "["
+
+	// FilenameFormat is the per-step outputs filename, indexed by step index.
+	FilenameFormat string = "%d.nuon-outputs.json"
+)
+
+// Filename returns the outputs filename for a given step index.
+func Filename(idx int64) string {
+	return fmt.Sprintf(FilenameFormat, idx)
+}
+
+// ParseLine parses a single outputs line. A line beginning with "{" is a JSON
+// object; a top-level JSON array is unsupported; otherwise the line is a
+// "key=value" pair.
+func ParseLine(str string) (map[string]interface{}, error) {
+	if strings.HasPrefix(str, jsonObjStart) {
+		var out map[string]interface{}
+		if err := json.Unmarshal([]byte(str), &out); err != nil {
+			return nil, errors.Wrap(err, "unable to parse as json")
+		}
+		return out, nil
+	}
+
+	if strings.HasPrefix(str, jsonArrayStart) {
+		return nil, errors.New("outputs with top level json arrays are not supported yet")
+	}
+
+	pieces := strings.SplitN(str, kvDelimiter, 2)
+	if len(pieces) == 2 {
+		return map[string]interface{}{
+			pieces[0]: pieces[1],
+		}, nil
+	}
+
+	return nil, errors.New("unsupported outputs format, must be a json object or k=v string")
+}
+
+// ParseFile reads an outputs file and merges every line into a single map.
+// A missing file is treated as empty output.
+func ParseFile(path string) (map[string]interface{}, error) {
+	out := make(map[string]interface{}, 0)
+
+	fh, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return out, nil
+		}
+		return nil, errors.Wrap(err, "unable to open outputs file")
+	}
+	defer fh.Close()
+
+	scanner := bufio.NewScanner(fh)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		lineOutputs, err := ParseLine(line)
+		if err != nil {
+			return nil, errors.Wrap(err, "error parsing outputs")
+		}
+		out = generics.MergeMap(out, lineOutputs)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, errors.Wrap(err, "unable to scan outputs file")
+	}
+
+	return out, nil
+}

--- a/pkg/actions/outputs/outputs_test.go
+++ b/pkg/actions/outputs/outputs_test.go
@@ -1,0 +1,80 @@
+package outputs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseLine(t *testing.T) {
+	t.Run("key value", func(t *testing.T) {
+		out, err := ParseLine("pod_count=3")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out["pod_count"] != "3" {
+			t.Fatalf("expected pod_count=3, got %v", out["pod_count"])
+		}
+	})
+
+	t.Run("json object", func(t *testing.T) {
+		out, err := ParseLine(`{"pod_count": 3, "region": "us-west-2"}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out["region"] != "us-west-2" {
+			t.Fatalf("expected region us-west-2, got %v", out["region"])
+		}
+	})
+
+	t.Run("json array rejected", func(t *testing.T) {
+		if _, err := ParseLine(`["a", "b"]`); err == nil {
+			t.Fatal("expected error for top-level json array")
+		}
+	})
+
+	t.Run("unsupported", func(t *testing.T) {
+		if _, err := ParseLine("not-a-pair"); err == nil {
+			t.Fatal("expected error for unsupported format")
+		}
+	})
+}
+
+func TestParseFile(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("missing file is empty", func(t *testing.T) {
+		out, err := ParseFile(filepath.Join(dir, "does-not-exist.json"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(out) != 0 {
+			t.Fatalf("expected empty map, got %v", out)
+		}
+	})
+
+	t.Run("merges lines", func(t *testing.T) {
+		path := filepath.Join(dir, Filename(0))
+		contents := "pod_count=3\n\n{\"region\": \"us-west-2\"}\n"
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		out, err := ParseFile(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out["pod_count"] != "3" {
+			t.Fatalf("expected pod_count=3, got %v", out["pod_count"])
+		}
+		if out["region"] != "us-west-2" {
+			t.Fatalf("expected region us-west-2, got %v", out["region"])
+		}
+	})
+}
+
+func TestFilename(t *testing.T) {
+	if got := Filename(2); got != "2.nuon-outputs.json" {
+		t.Fatalf("expected 2.nuon-outputs.json, got %s", got)
+	}
+}

--- a/pkg/actions/supervisor/supervisor.go
+++ b/pkg/actions/supervisor/supervisor.go
@@ -1,0 +1,112 @@
+// Package supervisor is the entrypoint Nuon mounts into an image-backed
+// action's container. It provisions the nuon_output helper, executes the
+// rendered step script inside the image, and propagates the script's exit
+// status. Outputs are left in NUON_ACTIONS_OUTPUT_FILEPATH for the runner to
+// read from the shared workspace mount after the container exits.
+package supervisor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// OutputFilepathEnvVar names the file the nuon_output helper appends to.
+	OutputFilepathEnvVar = "NUON_ACTIONS_OUTPUT_FILEPATH"
+	// RootEnvVar names the workspace root inside the container.
+	RootEnvVar = "NUON_ACTIONS_ROOT"
+
+	nuonOutputShim = `#!/bin/sh
+printf '%s=%s\n' "$1" "$2" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+`
+)
+
+// Run provisions the nuon_output helper, ensures the script is executable, and
+// executes it in workdir, streaming stdout/stderr through. It returns the
+// script's exit code (0 on success) alongside any execution error.
+func Run(ctx context.Context, scriptPath, workdir string) (int, error) {
+	root := os.Getenv(RootEnvVar)
+	if root == "" {
+		root = workdir
+	}
+
+	binDir := filepath.Join(root, ".nuon", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return 1, errors.Wrap(err, "unable to create nuon bin directory")
+	}
+
+	shimPath := filepath.Join(binDir, "nuon_output")
+	if err := os.WriteFile(shimPath, []byte(nuonOutputShim), 0o755); err != nil {
+		return 1, errors.Wrap(err, "unable to write nuon_output helper")
+	}
+
+	if err := ensureExecutableScript(scriptPath); err != nil {
+		return 1, err
+	}
+
+	env := envWithPathPrefix(os.Environ(), binDir)
+
+	cmd := exec.CommandContext(ctx, scriptPath)
+	cmd.Dir = workdir
+	cmd.Env = env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode(), nil
+		}
+		return 1, errors.Wrap(err, "unable to execute action script")
+	}
+
+	return 0, nil
+}
+
+// ensureExecutableScript adds a POSIX shebang when the script lacks one and
+// makes it executable, so any base image with /bin/sh can run it.
+func ensureExecutableScript(scriptPath string) error {
+	contents, err := os.ReadFile(scriptPath)
+	if err != nil {
+		return errors.Wrap(err, "unable to read action script")
+	}
+
+	if !strings.HasPrefix(string(contents), "#!") {
+		contents = append([]byte("#!/bin/sh\n"), contents...)
+		if err := os.WriteFile(scriptPath, contents, 0o755); err != nil {
+			return errors.Wrap(err, "unable to rewrite action script with shebang")
+		}
+	}
+
+	// os.WriteFile does not change the mode of an existing file, so chmod
+	// explicitly to ensure the script is executable in any base image.
+	if err := os.Chmod(scriptPath, 0o755); err != nil {
+		return errors.Wrap(err, "unable to make action script executable")
+	}
+	return nil
+}
+
+// envWithPathPrefix returns env with binDir prepended to PATH.
+func envWithPathPrefix(env []string, binDir string) []string {
+	out := make([]string, 0, len(env))
+	found := false
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") {
+			out = append(out, fmt.Sprintf("PATH=%s%c%s", binDir, os.PathListSeparator, strings.TrimPrefix(kv, "PATH=")))
+			found = true
+			continue
+		}
+		out = append(out, kv)
+	}
+	if !found {
+		out = append(out, fmt.Sprintf("PATH=%s%c/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", binDir, os.PathListSeparator))
+	}
+	return out
+}

--- a/pkg/actions/supervisor/supervisor_test.go
+++ b/pkg/actions/supervisor/supervisor_test.go
@@ -1,0 +1,83 @@
+package supervisor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/nuonco/nuon/pkg/actions/outputs"
+)
+
+func TestRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("supervisor uses POSIX shell scripts")
+	}
+
+	workdir := t.TempDir()
+	outputFile := filepath.Join(workdir, outputs.Filename(0))
+
+	t.Setenv(RootEnvVar, workdir)
+	t.Setenv(OutputFilepathEnvVar, outputFile)
+
+	t.Run("runs script and collects nuon_output", func(t *testing.T) {
+		script := filepath.Join(workdir, "step.sh")
+		contents := "#!/bin/sh\nnuon_output hello world\necho done\n"
+		if err := os.WriteFile(script, []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		code, err := Run(context.Background(), script, workdir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+
+		out, err := outputs.ParseFile(outputFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out["hello"] != "world" {
+			t.Fatalf("expected hello=world, got %v", out["hello"])
+		}
+	})
+
+	t.Run("adds shebang when missing", func(t *testing.T) {
+		script := filepath.Join(workdir, "no-shebang.sh")
+		if err := os.WriteFile(script, []byte("echo hi\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		code, err := Run(context.Background(), script, workdir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+
+		contents, _ := os.ReadFile(script)
+		if !strings.HasPrefix(string(contents), "#!") {
+			t.Fatalf("expected shebang to be added, got %q", string(contents))
+		}
+	})
+
+	t.Run("propagates non-zero exit", func(t *testing.T) {
+		script := filepath.Join(workdir, "fail.sh")
+		if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 7\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		code, err := Run(context.Background(), script, workdir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if code != 7 {
+			t.Fatalf("expected exit 7, got %d", code)
+		}
+	})
+}

--- a/pkg/config/action_config.go
+++ b/pkg/config/action_config.go
@@ -25,6 +25,11 @@ type ActionConfig struct {
 
 	EnableKubeConfig *bool `mapstructure:"enable_kube_config,omitempty" toml:"enable_kube_config,omitempty"`
 
+	// Image is an optional container image the action's steps run inside. When
+	// set, Nuon mounts the actions-supervisor into the image and executes each
+	// step's inline_contents there. Steps must use inline_contents.
+	Image string `mapstructure:"image,omitempty" toml:"image,omitempty" features:"template"`
+
 	// KubernetesContext is the name of a kubernetes_context this action
 	// targets. Empty means fall back to the implicit sandbox default (when
 	// the sandbox emits cluster outputs). See pkg/config/kubernetes_context.go.
@@ -83,6 +88,9 @@ func (a ActionConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Long("When set to false, the action runner will not fetch the install's kubeconfig or set the KUBECONFIG env var. Defaults to true. Set to false for actions that do not need Kubernetes access to avoid the overhead of fetching cluster credentials").
 		Example("true").
 		Example("false").
+		Field("image").Short("container image the action's steps run inside").
+		Long("Optional container image (e.g. ghcr.io/acme/kubernetes-tools:v1) supplying the tools the action needs. When set, Nuon mirrors the image into the install registry and runs each step's inline_contents inside the image via the mounted actions-supervisor. All steps must use inline_contents when an image is set. Only supported on VM-based runners").
+		Example("ghcr.io/acme/kubernetes-tools:v1").
 		Field("kubernetes_context").Short("kubernetes context this action targets").
 		Long("Name of a top-level kubernetes_context binding to target when this action runs. When set, the action's runner receives the cluster connection details from that context's source component. Empty falls back to the implicit sandbox default. Only takes effect when enable_kube_config is true").
 		Example("compute").
@@ -142,6 +150,16 @@ func (a *ActionConfig) parse() error {
 			return ErrConfig{
 				Description: fmt.Sprintf("unable to parse timeout %s", a.Timeout),
 				Err:         err,
+			}
+		}
+	}
+
+	if a.Image != "" {
+		for _, step := range a.Steps {
+			if step.InlineContents == "" {
+				return ErrConfig{
+					Description: fmt.Sprintf("action %s sets an image, so step %s must use inline_contents (command and repo steps are not supported with image-backed actions)", a.Name, step.Name),
+				}
 			}
 		}
 	}

--- a/pkg/config/sync/apisyncer/actions_sync.go
+++ b/pkg/config/sync/apisyncer/actions_sync.go
@@ -75,6 +75,7 @@ func (s *syncer) syncAction(ctx context.Context, resource string, action *config
 		Role:              action.Role,
 		EnableKubeConfig:  &enableKubeConfig,
 		KubernetesContext: action.KubernetesContext,
+		Image:             action.Image,
 	}
 
 	for _, ref := range action.References {

--- a/pkg/plans/types/action_workflow_run.go
+++ b/pkg/plans/types/action_workflow_run.go
@@ -7,6 +7,7 @@ import (
 	azurecredentials "github.com/nuonco/nuon/pkg/azure/credentials"
 	gcpcredentials "github.com/nuonco/nuon/pkg/gcp/credentials"
 	"github.com/nuonco/nuon/pkg/kube"
+	"github.com/nuonco/nuon/pkg/plugins/configs"
 )
 
 type ActionWorkflowRunPlan struct {
@@ -31,6 +32,13 @@ type ActionWorkflowRunPlan struct {
 	AWSAuth     *awscredentials.Config   `json:"aws_auth,omitempty"`
 	AzureAuth   *azurecredentials.Config `json:"azure_auth,omitempty"`
 	GCPAuth     *gcpcredentials.Config   `json:"gcp_auth,omitempty"`
+
+	// Image-backed actions: SourceImage is the rendered app-authored ref
+	// (e.g. ghcr.io/acme/tools:v1); ImageRegistry/ImageTag point at the
+	// install-registry mirror the runner pulls from.
+	SourceImage   string                         `json:"source_image,omitempty"`
+	ImageRegistry *configs.OCIRegistryRepository `json:"image_registry,omitempty"`
+	ImageTag      string                         `json:"image_tag,omitempty"`
 
 	MinSandboxMode
 }

--- a/sdks/nuon-go/models/app_action_workflow_config.go
+++ b/sdks/nuon-go/models/app_action_workflow_config.go
@@ -47,6 +47,9 @@ type AppActionWorkflowConfig struct {
 	// id
 	ID string `json:"id,omitempty"`
 
+	// Image is an optional container image the action's steps run inside.
+	Image string `json:"image,omitempty"`
+
 	// KubernetesContextName is the name of an AppKubernetesContextConfig on
 	// the same AppConfig. Empty means fall back to the implicit sandbox
 	// default. Stored as a name (not an FK) so it remains stable across

--- a/sdks/nuon-go/models/app_runner_job_group.go
+++ b/sdks/nuon-go/models/app_runner_job_group.go
@@ -57,6 +57,9 @@ const (
 	// AppRunnerJobGroupActions captures enum value "actions"
 	AppRunnerJobGroupActions AppRunnerJobGroup = "actions"
 
+	// AppRunnerJobGroupImageDashActions captures enum value "image-actions"
+	AppRunnerJobGroupImageDashActions AppRunnerJobGroup = "image-actions"
+
 	// AppRunnerJobGroupEmpty captures enum value ""
 	AppRunnerJobGroupEmpty AppRunnerJobGroup = ""
 
@@ -69,7 +72,7 @@ var appRunnerJobGroupEnum []any
 
 func init() {
 	var res []AppRunnerJobGroup
-	if err := json.Unmarshal([]byte(`["health-checks","sync","build","deploy","sandbox","runner","operations","management","actions","","any"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["health-checks","sync","build","deploy","sandbox","runner","operations","management","actions","image-actions","","any"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/sdks/nuon-go/models/plantypes_action_workflow_run_plan.go
+++ b/sdks/nuon-go/models/plantypes_action_workflow_run_plan.go
@@ -41,6 +41,12 @@ type PlantypesActionWorkflowRunPlan struct {
 	// id
 	ID string `json:"id,omitempty"`
 
+	// image registry
+	ImageRegistry *ConfigsOCIRegistryRepository `json:"image_registry,omitempty"`
+
+	// image tag
+	ImageTag string `json:"image_tag,omitempty"`
+
 	// install id
 	InstallID string `json:"install_id,omitempty"`
 
@@ -49,6 +55,11 @@ type PlantypesActionWorkflowRunPlan struct {
 
 	// sandbox mode
 	SandboxMode *PlantypesSandboxMode `json:"sandbox_mode,omitempty"`
+
+	// Image-backed actions: SourceImage is the rendered app-authored ref
+	// (e.g. ghcr.io/acme/tools:v1); ImageRegistry/ImageTag point at the
+	// install-registry mirror the runner pulls from.
+	SourceImage string `json:"source_image,omitempty"`
 
 	// steps
 	Steps []*PlantypesActionWorkflowRunStepPlan `json:"steps"`
@@ -74,6 +85,10 @@ func (m *PlantypesActionWorkflowRunPlan) Validate(formats strfmt.Registry) error
 	}
 
 	if err := m.validateGcpAuth(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateImageRegistry(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -183,6 +198,29 @@ func (m *PlantypesActionWorkflowRunPlan) validateGcpAuth(formats strfmt.Registry
 	return nil
 }
 
+func (m *PlantypesActionWorkflowRunPlan) validateImageRegistry(formats strfmt.Registry) error {
+	if swag.IsZero(m.ImageRegistry) { // not required
+		return nil
+	}
+
+	if m.ImageRegistry != nil {
+		if err := m.ImageRegistry.Validate(formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("image_registry")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("image_registry")
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *PlantypesActionWorkflowRunPlan) validateSandboxMode(formats strfmt.Registry) error {
 	if swag.IsZero(m.SandboxMode) { // not required
 		return nil
@@ -253,6 +291,10 @@ func (m *PlantypesActionWorkflowRunPlan) ContextValidate(ctx context.Context, fo
 	}
 
 	if err := m.contextValidateGcpAuth(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateImageRegistry(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -361,6 +403,31 @@ func (m *PlantypesActionWorkflowRunPlan) contextValidateGcpAuth(ctx context.Cont
 			ce := new(errors.CompositeError)
 			if stderrors.As(err, &ce) {
 				return ce.ValidateName("gcp_auth")
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *PlantypesActionWorkflowRunPlan) contextValidateImageRegistry(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ImageRegistry != nil {
+
+		if swag.IsZero(m.ImageRegistry) { // not required
+			return nil
+		}
+
+		if err := m.ImageRegistry.ContextValidate(ctx, formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("image_registry")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("image_registry")
 			}
 
 			return err

--- a/sdks/nuon-go/models/service_create_action_workflow_config_request.go
+++ b/sdks/nuon-go/models/service_create_action_workflow_config_request.go
@@ -34,6 +34,9 @@ type ServiceCreateActionWorkflowConfigRequest struct {
 	// enable kube config
 	EnableKubeConfig *bool `json:"enable_kube_config,omitempty"`
 
+	// image
+	Image string `json:"image,omitempty"`
+
 	// kubernetes context
 	KubernetesContext string `json:"kubernetes_context,omitempty"`
 

--- a/sdks/nuon-runner-go/client/nuon_runner_api_client.go
+++ b/sdks/nuon-runner-go/client/nuon_runner_api_client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/client/operations"
 )
 

--- a/sdks/nuon-runner-go/models/app_action_workflow_config.go
+++ b/sdks/nuon-runner-go/models/app_action_workflow_config.go
@@ -47,6 +47,9 @@ type AppActionWorkflowConfig struct {
 	// id
 	ID string `json:"id,omitempty"`
 
+	// Image is an optional container image the action's steps run inside.
+	Image string `json:"image,omitempty"`
+
 	// KubernetesContextName is the name of an AppKubernetesContextConfig on
 	// the same AppConfig. Empty means fall back to the implicit sandbox
 	// default. Stored as a name (not an FK) so it remains stable across

--- a/sdks/nuon-runner-go/models/app_runner_job_group.go
+++ b/sdks/nuon-runner-go/models/app_runner_job_group.go
@@ -57,6 +57,9 @@ const (
 	// AppRunnerJobGroupActions captures enum value "actions"
 	AppRunnerJobGroupActions AppRunnerJobGroup = "actions"
 
+	// AppRunnerJobGroupImageDashActions captures enum value "image-actions"
+	AppRunnerJobGroupImageDashActions AppRunnerJobGroup = "image-actions"
+
 	// AppRunnerJobGroupEmpty captures enum value ""
 	AppRunnerJobGroupEmpty AppRunnerJobGroup = ""
 
@@ -69,7 +72,7 @@ var appRunnerJobGroupEnum []any
 
 func init() {
 	var res []AppRunnerJobGroup
-	if err := json.Unmarshal([]byte(`["health-checks","sync","build","deploy","sandbox","runner","operations","management","actions","","any"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["health-checks","sync","build","deploy","sandbox","runner","operations","management","actions","image-actions","","any"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/sdks/nuon-runner-go/models/plantypes_action_workflow_run_plan.go
+++ b/sdks/nuon-runner-go/models/plantypes_action_workflow_run_plan.go
@@ -41,6 +41,12 @@ type PlantypesActionWorkflowRunPlan struct {
 	// id
 	ID string `json:"id,omitempty"`
 
+	// image registry
+	ImageRegistry *ConfigsOCIRegistryRepository `json:"image_registry,omitempty"`
+
+	// image tag
+	ImageTag string `json:"image_tag,omitempty"`
+
 	// install id
 	InstallID string `json:"install_id,omitempty"`
 
@@ -49,6 +55,11 @@ type PlantypesActionWorkflowRunPlan struct {
 
 	// sandbox mode
 	SandboxMode *PlantypesSandboxMode `json:"sandbox_mode,omitempty"`
+
+	// Image-backed actions: SourceImage is the rendered app-authored ref
+	// (e.g. ghcr.io/acme/tools:v1); ImageRegistry/ImageTag point at the
+	// install-registry mirror the runner pulls from.
+	SourceImage string `json:"source_image,omitempty"`
 
 	// steps
 	Steps []*PlantypesActionWorkflowRunStepPlan `json:"steps"`
@@ -74,6 +85,10 @@ func (m *PlantypesActionWorkflowRunPlan) Validate(formats strfmt.Registry) error
 	}
 
 	if err := m.validateGcpAuth(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateImageRegistry(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -183,6 +198,29 @@ func (m *PlantypesActionWorkflowRunPlan) validateGcpAuth(formats strfmt.Registry
 	return nil
 }
 
+func (m *PlantypesActionWorkflowRunPlan) validateImageRegistry(formats strfmt.Registry) error {
+	if swag.IsZero(m.ImageRegistry) { // not required
+		return nil
+	}
+
+	if m.ImageRegistry != nil {
+		if err := m.ImageRegistry.Validate(formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("image_registry")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("image_registry")
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *PlantypesActionWorkflowRunPlan) validateSandboxMode(formats strfmt.Registry) error {
 	if swag.IsZero(m.SandboxMode) { // not required
 		return nil
@@ -253,6 +291,10 @@ func (m *PlantypesActionWorkflowRunPlan) ContextValidate(ctx context.Context, fo
 	}
 
 	if err := m.contextValidateGcpAuth(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateImageRegistry(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -361,6 +403,31 @@ func (m *PlantypesActionWorkflowRunPlan) contextValidateGcpAuth(ctx context.Cont
 			ce := new(errors.CompositeError)
 			if stderrors.As(err, &ce) {
 				return ce.ValidateName("gcp_auth")
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *PlantypesActionWorkflowRunPlan) contextValidateImageRegistry(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ImageRegistry != nil {
+
+		if swag.IsZero(m.ImageRegistry) { // not required
+			return nil
+		}
+
+		if err := m.ImageRegistry.ContextValidate(ctx, formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("image_registry")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("image_registry")
 			}
 
 			return err

--- a/services/ctl-api/internal/app/action_workflow_config.go
+++ b/services/ctl-api/internal/app/action_workflow_config.go
@@ -60,6 +60,9 @@ type ActionWorkflowConfig struct {
 
 	EnableKubeConfig sql.NullBool `json:"enable_kube_config" gorm:"default:true" temporaljson:"enable_kube_config"`
 
+	// Image is an optional container image the action's steps run inside.
+	Image string `json:"image,omitzero" gorm:"default:null" temporaljson:"image,omitzero,omitempty"`
+
 	// KubernetesContextName is the name of an AppKubernetesContextConfig on
 	// the same AppConfig. Empty means fall back to the implicit sandbox
 	// default. Stored as a name (not an FK) so it remains stable across

--- a/services/ctl-api/internal/app/actions/service/create_action_workflow_config.go
+++ b/services/ctl-api/internal/app/actions/service/create_action_workflow_config.go
@@ -92,6 +92,8 @@ type CreateActionWorkflowConfigRequest struct {
 	EnableKubeConfig *bool `json:"enable_kube_config" swaggertype:"boolean" extensions:"x-nullable"`
 
 	KubernetesContext string `json:"kubernetes_context,omitempty"`
+
+	Image string `json:"image,omitempty"`
 }
 
 type CreateActionWorkflowConfigTriggerRequest struct {
@@ -167,6 +169,18 @@ func (c *CreateActionWorkflowConfigRequest) Validate(v *validator.Validate) erro
 				Err: errors.New(fmt.Sprintf("component_name not supported for %s trigger", trigger.Type)),
 				Description: fmt.Sprintf("component_name only available for (%s) triggers",
 					strings.Join(generics.ToStringSlice(app.AllActionWorkflowComponentTriggerTypes), ", ")),
+			}
+		}
+	}
+
+	// image-backed actions require every step to use inline_contents
+	if c.Image != "" {
+		for _, step := range c.Steps {
+			if step.InlineContents == "" {
+				return stderr.ErrUser{
+					Err:         errors.New("image-backed actions require inline_contents on every step"),
+					Description: fmt.Sprintf("step %s must use inline_contents because the action sets an image (command and repo steps are not supported with image-backed actions)", step.Name),
+				}
 			}
 		}
 	}
@@ -270,6 +284,19 @@ func (s *service) CreateActionWorkflowConfig(ctx *gin.Context) {
 }
 
 func (s *service) createActionWorkflowConfig(ctx context.Context, parentApp *app.App, orgID string, awID string, req *CreateActionWorkflowConfigRequest) (*app.ActionWorkflowConfig, error) {
+	if req.Image != "" {
+		enabled, err := s.featuresClient.OrgHasFeature(ctx, orgID, app.OrgFeatureImageBackedActions)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to check image-backed-actions feature")
+		}
+		if !enabled {
+			return nil, stderr.ErrUser{
+				Err:         errors.New("image-backed actions are not enabled for this org"),
+				Description: "image-backed actions are not enabled for this organization; contact Nuon to enable the image-backed-actions feature",
+			}
+		}
+	}
+
 	timeout := req.Timeout
 	if timeout == 0 {
 		timeout = defaultTimeout
@@ -298,6 +325,7 @@ func (s *service) createActionWorkflowConfig(ctx context.Context, parentApp *app
 		Role:                   req.Role,
 		EnableKubeConfig:       enableKubeConfig,
 		KubernetesContextName:  req.KubernetesContext,
+		Image:                  req.Image,
 	}
 
 	res := s.db.WithContext(ctx).

--- a/services/ctl-api/internal/app/actions/service/create_action_workflow_config_test.go
+++ b/services/ctl-api/internal/app/actions/service/create_action_workflow_config_test.go
@@ -349,6 +349,133 @@ func (s *CreateAppActionConfigTestSuite) TestCreateActionConfigSuccess() {
 	}
 }
 
+func (s *CreateAppActionConfigTestSuite) TestCreateActionConfigImageBackedActions() {
+	testCases := []struct {
+		name          string
+		actionName    string
+		enableFeature bool
+		requestFunc   func(appConfigID string) CreateActionWorkflowConfigRequest
+		expectedCode  int
+		validateFunc  func(*app.ActionWorkflowConfig)
+	}{
+		{
+			name:          "image set with inline_contents steps and feature enabled succeeds",
+			actionName:    "image-action-enabled",
+			enableFeature: true,
+			requestFunc: func(appConfigID string) CreateActionWorkflowConfigRequest {
+				return CreateActionWorkflowConfigRequest{
+					AppConfigID: appConfigID,
+					Image:       "ghcr.io/nuonco/actions-runner:latest",
+					Triggers: []CreateActionWorkflowConfigTriggerRequest{
+						{Type: app.ActionWorkflowTriggerTypeManual},
+					},
+					Steps: []CreateActionWorkflowConfigStepRequest{
+						{Name: "step1", InlineContents: "echo 'one'"},
+						{Name: "step2", InlineContents: "echo 'two'"},
+					},
+				}
+			},
+			expectedCode: http.StatusCreated,
+			validateFunc: func(config *app.ActionWorkflowConfig) {
+				assert.Equal(s.T(), "ghcr.io/nuonco/actions-runner:latest", config.Image)
+				assert.Len(s.T(), config.Steps, 2)
+			},
+		},
+		{
+			name:          "image set but org feature disabled is rejected",
+			actionName:    "image-action-disabled",
+			enableFeature: false,
+			requestFunc: func(appConfigID string) CreateActionWorkflowConfigRequest {
+				return CreateActionWorkflowConfigRequest{
+					AppConfigID: appConfigID,
+					Image:       "ghcr.io/nuonco/actions-runner:latest",
+					Triggers: []CreateActionWorkflowConfigTriggerRequest{
+						{Type: app.ActionWorkflowTriggerTypeManual},
+					},
+					Steps: []CreateActionWorkflowConfigStepRequest{
+						{Name: "step1", InlineContents: "echo 'one'"},
+					},
+				}
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:          "no image set succeeds regardless of feature flag",
+			actionName:    "image-action-no-image",
+			enableFeature: false,
+			requestFunc: func(appConfigID string) CreateActionWorkflowConfigRequest {
+				return CreateActionWorkflowConfigRequest{
+					AppConfigID: appConfigID,
+					Triggers: []CreateActionWorkflowConfigTriggerRequest{
+						{Type: app.ActionWorkflowTriggerTypeManual},
+					},
+					Steps: []CreateActionWorkflowConfigStepRequest{
+						{Name: "step1", InlineContents: "echo 'one'"},
+					},
+				}
+			},
+			expectedCode: http.StatusCreated,
+			validateFunc: func(config *app.ActionWorkflowConfig) {
+				assert.Empty(s.T(), config.Image)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			if tc.enableFeature {
+				s.enableOrgFeature(app.OrgFeatureImageBackedActions)
+			} else {
+				s.disableOrgFeature(app.OrgFeatureImageBackedActions)
+			}
+
+			action := s.createActionWorkflow(s.testApp.ID, tc.actionName)
+			appConfig := s.createAppConfig(s.testApp.ID)
+
+			req := tc.requestFunc(appConfig.ID)
+			path := fmt.Sprintf("/v1/apps/%s/actions/%s/configs", s.testApp.ID, action.ID)
+			rr := s.makeRequest(http.MethodPost, path, req)
+
+			if rr.Code != tc.expectedCode {
+				s.T().Logf("Status: %d, Body: %s", rr.Code, rr.Body.String())
+			}
+			require.Equal(s.T(), tc.expectedCode, rr.Code)
+
+			if tc.expectedCode != http.StatusCreated {
+				// verify no config was persisted for the rejected request
+				var count int64
+				res := s.service.DB.WithContext(s.ctx).
+					Model(&app.ActionWorkflowConfig{}).
+					Where("action_workflow_id = ?", action.ID).
+					Count(&count)
+				require.NoError(s.T(), res.Error)
+				assert.Equal(s.T(), int64(0), count)
+				return
+			}
+
+			var config app.ActionWorkflowConfig
+			err := json.Unmarshal(rr.Body.Bytes(), &config)
+			require.NoError(s.T(), err)
+
+			// Verify database state
+			var dbConfig app.ActionWorkflowConfig
+			res := s.service.DB.WithContext(s.ctx).
+				Preload("Triggers").
+				Preload("Steps").
+				First(&dbConfig, "id = ?", config.ID)
+			require.NoError(s.T(), res.Error)
+
+			if tc.validateFunc != nil {
+				tc.validateFunc(&dbConfig)
+			}
+
+			s.T().Cleanup(func() {
+				s.service.DB.Unscoped().Where("id = ?", config.ID).Delete(&app.ActionWorkflowConfig{})
+			})
+		})
+	}
+}
+
 func (s *CreateAppActionConfigTestSuite) TestCreateActionConfigValidation() {
 	action := s.createActionWorkflow(s.testApp.ID, "validation-action")
 	appConfig := s.createAppConfig(s.testApp.ID)
@@ -477,6 +604,23 @@ func (s *CreateAppActionConfigTestSuite) TestCreateActionConfigValidation() {
 			},
 			expectedCode: http.StatusBadRequest,
 		},
+		{
+			name: "image set with a step missing inline_contents",
+			requestFunc: func() CreateActionWorkflowConfigRequest {
+				return CreateActionWorkflowConfigRequest{
+					AppConfigID: appConfig.ID,
+					Image:       "ghcr.io/nuonco/actions-runner:latest",
+					Triggers: []CreateActionWorkflowConfigTriggerRequest{
+						{Type: app.ActionWorkflowTriggerTypeManual},
+					},
+					Steps: []CreateActionWorkflowConfigStepRequest{
+						{Name: "inline-step", InlineContents: "echo 'ok'"},
+						{Name: "command-step", Command: "echo 'not allowed with image'"},
+					},
+				}
+			},
+			expectedCode: http.StatusBadRequest,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -572,6 +716,26 @@ func (s *CreateAppActionConfigTestSuite) TestCreateActionConfigCrossOrgIsolation
 }
 
 // Helper methods
+
+func (s *CreateAppActionConfigTestSuite) enableOrgFeature(feature app.OrgFeature) {
+	s.setOrgFeature(feature, true)
+}
+
+func (s *CreateAppActionConfigTestSuite) disableOrgFeature(feature app.OrgFeature) {
+	s.setOrgFeature(feature, false)
+}
+
+func (s *CreateAppActionConfigTestSuite) setOrgFeature(feature app.OrgFeature, enabled bool) {
+	features := s.testOrg.Features
+	if features == nil {
+		features = make(map[string]bool)
+	}
+	features[string(feature)] = enabled
+	require.NoError(s.T(), s.service.DB.WithContext(s.ctx).
+		Model(&app.Org{ID: s.testOrg.ID}).
+		Update("features", features).Error)
+	s.testOrg.Features = features
+}
 
 func (s *CreateAppActionConfigTestSuite) createActionWorkflow(appID, name string) *app.ActionWorkflow {
 	action := &app.ActionWorkflow{

--- a/services/ctl-api/internal/app/installs/signals/actionworkflowrun/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/actionworkflowrun/signal.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/distribution/reference"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
+	"github.com/nuonco/nuon/pkg/plugins/configs"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
@@ -284,6 +286,15 @@ func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, installID string
 		return errors.Wrap(err, "unable to create plan")
 	}
 
+	// image-backed actions: mirror the app image into the install registry
+	// and verify the runner can host the container before dispatching.
+	if planResponse.Plan.SourceImage != "" {
+		if err := s.mirrorActionImage(ctx, run, ls.ID, planResponse.Plan); err != nil {
+			s.updateActionRunStatus(ctx, run.ID, app.InstallActionRunStatusError, err.Error())
+			return errors.Wrap(err, "unable to prepare image-backed action")
+		}
+	}
+
 	// execute job
 	l.Info("creating runner job to execute action")
 	runnerJob, err := activities.AwaitCreateActionWorkflowRunRunnerJob(ctx, &activities.CreateActionWorkflowRunRunnerJob{
@@ -364,6 +375,117 @@ func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, installID string
 	}
 
 	return nil
+}
+
+// mirrorActionImage mirrors an image-backed action's app-authored image into
+// the install registry via an oci-sync job, after confirming the org has the
+// feature enabled and the install's runner is a VM (only VM runners run the
+// mng process that launches action containers).
+func (s *Signal) mirrorActionImage(ctx workflow.Context, run *app.InstallActionWorkflowRun, logStreamID string, awPlan *plantypes.ActionWorkflowRunPlan) error {
+	l := workflow.GetLogger(ctx)
+
+	enabled, err := activities.AwaitHasFeatureByFeature(ctx, string(app.OrgFeatureImageBackedActions))
+	if err != nil {
+		return errors.Wrap(err, "unable to check image-backed-actions feature")
+	}
+	if !enabled {
+		return errors.New("image-backed actions are not enabled for this organization")
+	}
+
+	platform := run.Install.RunnerGroup.Platform
+	if !isVMRunnerPlatform(platform) {
+		return fmt.Errorf("image-backed actions require a VM-based runner; runner platform %q is not supported", platform)
+	}
+
+	src, srcTag, err := parseActionImageSource(awPlan.SourceImage)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse action image reference")
+	}
+
+	l.Info("mirroring image-backed action image into install registry",
+		zap.String("source_image", awPlan.SourceImage))
+
+	syncJob, err := activities.AwaitCreateActionImageSyncJob(ctx, &activities.CreateActionImageSyncJobRequest{
+		ActionWorkflowRunID: run.ID,
+		RunnerID:            run.Install.RunnerID,
+		LogStreamID:         logStreamID,
+		Metadata: map[string]string{
+			"install_id":             run.InstallID,
+			"action_workflow_run_id": run.ID,
+			"source_image":           awPlan.SourceImage,
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "unable to create image sync job")
+	}
+
+	syncPlan := &plantypes.SyncOCIPlan{
+		Src:    src,
+		SrcTag: srcTag,
+		Dst:    awPlan.ImageRegistry,
+		DstTag: awPlan.ImageTag,
+	}
+	if awPlan.SandboxMode != nil {
+		syncPlan.SandboxMode = &plantypes.SandboxMode{Enabled: true}
+	}
+
+	syncPlanJSON, err := json.Marshal(syncPlan)
+	if err != nil {
+		return errors.Wrap(err, "unable to marshal sync plan")
+	}
+
+	if err := activities.AwaitSaveRunnerJobPlan(ctx, &activities.SaveRunnerJobPlanRequest{
+		JobID:         syncJob.ID,
+		PlanJSON:      string(syncPlanJSON),
+		CompositePlan: plantypes.CompositePlan{SyncOCIPlan: syncPlan},
+	}); err != nil {
+		return errors.Wrap(err, "unable to save sync job plan")
+	}
+
+	if _, err := job.AwaitExecuteJob(ctx, &job.ExecuteJobRequest{
+		RunnerID:   run.Install.RunnerID,
+		JobID:      syncJob.ID,
+		WorkflowID: "action-image-sync-exec-job-" + run.ID,
+	}); err != nil {
+		return errors.Wrap(err, "image sync job failed")
+	}
+
+	return nil
+}
+
+func isVMRunnerPlatform(p app.AppRunnerType) bool {
+	switch p {
+	case app.AppRunnerTypeAWS, app.AppRunnerTypeAzure, app.AppRunnerTypeGCP, app.AppRunnerTypeLocal:
+		return true
+	default:
+		return false
+	}
+}
+
+// parseActionImageSource splits an app-authored image ref (e.g.
+// ghcr.io/acme/tools:v1) into the source registry descriptor and tag the
+// oci-sync copier pulls from.
+func parseActionImageSource(sourceImage string) (*configs.OCIRegistryRepository, string, error) {
+	named, err := reference.ParseDockerRef(sourceImage)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid image reference %q: %w", sourceImage, err)
+	}
+
+	tag := "latest"
+	if tagged, ok := named.(reference.Tagged); ok {
+		tag = tagged.Tag()
+	}
+
+	loginServer := ""
+	if reference.Domain(named) == "docker.io" {
+		loginServer = "docker.io"
+	}
+
+	return &configs.OCIRegistryRepository{
+		RegistryType: configs.OCIRegistryTypePublicOCI,
+		Repository:   named.Name(),
+		LoginServer:  loginServer,
+	}, tag, nil
 }
 
 func (s *Signal) updateActionRunStatus(ctx workflow.Context, runID string, status app.InstallActionWorkflowRunStatus, msg string) {

--- a/services/ctl-api/internal/app/installs/worker/activities/create_action_image_sync_job.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/create_action_image_sync_job.go
@@ -6,9 +6,10 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 )
 
-type CreateActionWorkflowRunRunnerJob struct {
+type CreateActionImageSyncJobRequest struct {
 	ActionWorkflowRunID string            `validate:"required"`
 	RunnerID            string            `validate:"required"`
 	LogStreamID         string            `validate:"required"`
@@ -17,35 +18,23 @@ type CreateActionWorkflowRunRunnerJob struct {
 
 // @temporal-gen-v2 activity
 // @by-field ActionWorkflowRunID
-func (a *Activities) CreateActionWorkflowRunRunnerJob(ctx context.Context, req *CreateActionWorkflowRunRunnerJob) (*app.RunnerJob, error) {
+func (a *Activities) CreateActionImageSyncJob(ctx context.Context, req *CreateActionImageSyncJobRequest) (*app.RunnerJob, error) {
 	run, err := a.getInstallActionWorkflowRun(ctx, req.ActionWorkflowRunID)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get action workflow run")
 	}
 
-	// adhoc runs have no ActionWorkflowConfig; their timeout lives on the run
-	cfg := run.ActionWorkflowConfig
-	if cfg.Timeout == 0 {
-		cfg.Timeout = run.Timeout
-	}
+	ctx = cctx.SetAccountIDContext(ctx, run.CreatedByID)
+	ctx = cctx.SetOrgIDContext(ctx, run.OrgID)
 
-	// image-backed actions are launched by the mng process on VM runners, which
-	// polls the dedicated image-actions group.
-	group := app.RunnerJobGroupActions
-	if cfg.Image != "" {
-		group = app.RunnerJobGroupImageActions
-	}
-
-	job, err := a.runnersHelpers.CreateActionsWorkflowRunJob(ctx,
+	job, err := a.runnersHelpers.CreateActionImageSyncJob(ctx,
 		req.RunnerID,
 		req.ActionWorkflowRunID,
 		req.LogStreamID,
-		&cfg,
-		group,
 		req.Metadata,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create runner job")
+		return nil, errors.Wrap(err, "unable to create action image sync job")
 	}
 
 	return job, nil

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
@@ -1,6 +1,8 @@
 package plan
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -132,6 +134,22 @@ func (p *Planner) createActionWorkflowRunPlan(ctx workflow.Context, runID string
 		plan.Steps = append(plan.Steps, stepPlan)
 	}
 
+	if !run.ActionWorkflowConfigID.Empty() && run.ActionWorkflowConfig.Image != "" {
+		sourceImage, err := RenderText(run.ActionWorkflowConfig.Image, stateMap)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "unable to render action image")
+		}
+
+		imageRegistry, err := p.getOrgRegistryRepositoryConfig(ctx, run.InstallID, runID)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "unable to get registry for action image")
+		}
+
+		plan.SourceImage = sourceImage
+		plan.ImageRegistry = imageRegistry
+		plan.ImageTag = actionImageTag(sourceImage)
+	}
+
 	if slimInstall.SandboxMode.Bool {
 		targetRefs := helpers.GetActionReferences(appCfg, run.ActionWorkflowConfig.ActionWorkflow.Name)
 
@@ -143,6 +161,14 @@ func (p *Planner) createActionWorkflowRunPlan(ctx workflow.Context, runID string
 
 	l.Info("successfully created plan")
 	return plan, roleSelection, nil
+}
+
+// actionImageTag derives a stable, digest-like tag for the mirrored action
+// image from its rendered source ref, so re-runs of an unchanged image reuse
+// the same mirror and registries dedupe the underlying layers.
+func actionImageTag(sourceImage string) string {
+	sum := sha256.Sum256([]byte(sourceImage))
+	return fmt.Sprintf("action-%s", hex.EncodeToString(sum[:])[:16])
 }
 
 // TODO(ja): make this a method on the run struct?

--- a/services/ctl-api/internal/app/org.go
+++ b/services/ctl-api/internal/app/org.go
@@ -97,6 +97,11 @@ const (
 	// provider's stack_config data source) and use the slimmed-down tfvars
 	// instead of the full generated set.
 	OrgFeatureStackTFProvider OrgFeature = "stack-tf-provider"
+	// OrgFeatureImageBackedActions lets actions declare a container image
+	// their steps run inside. Nuon mirrors the image into the install
+	// registry and the mng process runs each step's inline_contents in the
+	// image via the mounted actions-supervisor. VM-based runners only.
+	OrgFeatureImageBackedActions OrgFeature = "image-backed-actions"
 )
 
 type Org struct {
@@ -220,6 +225,7 @@ func (o *Org) BeforeCreate(tx *gorm.DB) error {
 		OrgFeatureNotebooks:               false,
 		OrgFeatureSpaceliftInstallStacks:  false,
 		OrgFeatureStackTFProvider:         false,
+		OrgFeatureImageBackedActions:      false,
 		OrgFeatureOrgRunner:               false,
 
 		// Enabled by default
@@ -294,6 +300,7 @@ func GetFeatures() []OrgFeature {
 		OrgFeatureSpaceliftInstallStacks,
 		OrgFeatureControlPlaneBuilds,
 		OrgFeatureStackTFProvider,
+		OrgFeatureImageBackedActions,
 	}
 }
 
@@ -332,6 +339,7 @@ func GetFeatureDescriptions() map[OrgFeature]string {
 		OrgFeatureSpaceliftInstallStacks:  "Surface the Spacelift options (blueprint and administrative stack) on the install stack await step, so customers can provision the Terraform install stack through Spacelift instead of running Terraform locally.",
 		OrgFeatureControlPlaneBuilds:      "Run component and sandbox builds on Temporal-backed control-plane workers instead of the org runner, so build-only work does not require a live org runner.",
 		OrgFeatureStackTFProvider:         "Use the Terraform-provider install stack flow: the await step's directions clone the ja/stack-sdk branch of install-stacks (which reads config from the API via the stack provider) and use the slimmed-down tfvars.",
+		OrgFeatureImageBackedActions:      "Allow actions to declare a container image their steps run inside. Nuon mirrors the image into the install registry and the mng process runs each step's inline_contents in the image via the mounted actions-supervisor. VM-based runners only.",
 	}
 }
 

--- a/services/ctl-api/internal/app/runner_job.go
+++ b/services/ctl-api/internal/app/runner_job.go
@@ -83,6 +83,10 @@ const (
 	// actions workflows
 	RunnerJobGroupActions RunnerJobGroup = "actions"
 
+	// image-backed action workflows, polled only by the mng process on VM
+	// runners (which has host docker access to launch the action container).
+	RunnerJobGroupImageActions RunnerJobGroup = "image-actions"
+
 	RunnerJobGroupUnknown RunnerJobGroup = ""
 	RunnerJobGroupAny     RunnerJobGroup = "any"
 )

--- a/services/ctl-api/internal/app/runners/helpers/create_runner_queues.go
+++ b/services/ctl-api/internal/app/runners/helpers/create_runner_queues.go
@@ -18,6 +18,7 @@ var allRunnerJobGroups = []app.RunnerJobGroup{
 	app.RunnerJobGroupOperations,
 	app.RunnerJobGroupManagement,
 	app.RunnerJobGroupActions,
+	app.RunnerJobGroupImageActions,
 }
 
 // CreateRunnerQueues creates one queue per job group for the given runner.

--- a/services/ctl-api/internal/app/runners/helpers/jobs_action_image_sync.go
+++ b/services/ctl-api/internal/app/runners/helpers/jobs_action_image_sync.go
@@ -3,34 +3,32 @@ package helpers
 import (
 	"context"
 	"fmt"
-	"time"
 
 	pkggenerics "github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 )
 
-func (h *Helpers) CreateActionsWorkflowRunJob(ctx context.Context,
+// CreateActionImageSyncJob creates an oci-sync job that mirrors an
+// image-backed action's app-authored image into the install registry before
+// the action runs. It is owned by the action run so it is cancelled/cleaned up
+// alongside it.
+func (h *Helpers) CreateActionImageSyncJob(ctx context.Context,
 	runnerID string,
-	runID string, logStreamID string,
-	cfg *app.ActionWorkflowConfig,
-	group app.RunnerJobGroup,
+	runID string,
+	logStreamID string,
 	metadata map[string]string,
 ) (*app.RunnerJob, error) {
 	job := &app.RunnerJob{
-		RunnerID:     runnerID,
-		QueueTimeout: DefaultQueueTimeout,
-		// NOTE(jm): we create a buffer to allow the runner to finish cleaning up, when a job times out. If this
-		// is set to the exact timeout, the workflow can not actually cleanup. Thus, this is an arbitrary buffer
-		// that should never be hit because the runner job would timeout mid-job and mark itself as timed out
-		// first.
-		ExecutionTimeout:  cfg.Timeout + time.Minute,
+		RunnerID:          runnerID,
+		QueueTimeout:      DefaultQueueTimeout,
+		ExecutionTimeout:  h.getDefaultExecutionTimeout(app.RunnerJobTypeOCISync),
 		AvailableTimeout:  DefaultAvailableTimeout,
 		MaxExecutions:     DefaultMaxExecutions,
 		Status:            app.RunnerJobStatusQueued,
 		StatusDescription: string(app.RunnerJobStatusQueued),
-		Type:              app.RunnerJobTypeActionsWorkflowRun,
-		Group:             group,
+		Type:              app.RunnerJobTypeOCISync,
+		Group:             app.RunnerJobGroupSync,
 		Operation:         app.RunnerJobOperationTypeExec,
 		OwnerType:         "install_action_workflow_runs",
 		OwnerID:           runID,
@@ -39,7 +37,7 @@ func (h *Helpers) CreateActionsWorkflowRunJob(ctx context.Context,
 	}
 
 	if res := h.db.WithContext(ctx).Create(&job); res.Error != nil {
-		return nil, fmt.Errorf("unable to create job: %w", res.Error)
+		return nil, fmt.Errorf("unable to create action image sync job: %w", res.Error)
 	}
 
 	return job, nil

--- a/services/ctl-api/internal/pkg/config/syncer/actions.go
+++ b/services/ctl-api/internal/pkg/config/syncer/actions.go
@@ -60,6 +60,22 @@ func (s *syncer) syncAction(ctx context.Context, action *config.ActionConfig) er
 		}
 	}
 
+	if action.Image != "" {
+		enabled, err := s.orgHasFeature(ctx, app.OrgFeatureImageBackedActions)
+		if err != nil {
+			return sync.SyncInternalErr{
+				Description: "unable to check image-backed-actions feature",
+				Err:         err,
+			}
+		}
+		if !enabled {
+			return sync.SyncErr{
+				Resource:    fmt.Sprintf("action-%s", action.Name),
+				Description: "image-backed actions are not enabled for this organization; contact Nuon to enable the image-backed-actions feature",
+			}
+		}
+	}
+
 	// Sync labels
 	labelRes := s.db.WithContext(ctx).
 		Model(&actionWorkflow).
@@ -219,6 +235,7 @@ func (s *syncer) syncAction(ctx context.Context, action *config.ActionConfig) er
 		References:             pq.StringArray(actionReferences),
 		BreakGlassRoleARN:      generics.NewNullString(action.BreakGlassRole),
 		KubernetesContextName:  action.KubernetesContext,
+		Image:                  action.Image,
 		Triggers:               triggers,
 		Steps:                  steps,
 	}
@@ -247,6 +264,19 @@ func (s *syncer) syncAction(ctx context.Context, action *config.ActionConfig) er
 	})
 
 	return nil
+}
+
+func (s *syncer) orgHasFeature(ctx context.Context, feature app.OrgFeature) (bool, error) {
+	var org app.Org
+	res := s.db.WithContext(ctx).
+		Select("id", "features").
+		Where(&app.Org{ID: s.orgID}).
+		First(&org)
+	if res.Error != nil {
+		return false, res.Error
+	}
+
+	return org.Features[string(feature)], nil
 }
 
 // getAction finds an action workflow by name.

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -40,6 +40,27 @@ export interface paths {
      */
     get: operations["GetCurrentAccount"];
   };
+  "/v1/account/static-token": {
+    /**
+     * create a static API token for your org's service account
+     * @description Creates a long-lived static API token scoped to your current org. The token is issued for the org's service account, which is created automatically if it does not already exist. The token only grants access to the current org.
+     */
+    post: operations["CreateStaticToken"];
+  };
+  "/v1/account/static-tokens": {
+    /**
+     * list your org's static API tokens
+     * @description Lists the static API tokens for your current org's service account. Token secrets are never returned.
+     */
+    get: operations["ListStaticTokens"];
+  };
+  "/v1/account/static-tokens/{token_id}": {
+    /**
+     * delete a static API token
+     * @description Deletes a static API token belonging to your current org's service account. Once deleted, the token can no longer be used to access the API.
+     */
+    delete: operations["DeleteStaticToken"];
+  };
   "/v1/account/user-journeys": {
     /**
      * Get user journeys
@@ -3053,6 +3074,8 @@ export interface components {
       created_by_id?: string;
       enable_kube_config?: components["schemas"]["sql.NullBool"];
       id?: string;
+      /** @description Image is an optional container image the action's steps run inside. */
+      image?: string;
       /**
        * @description KubernetesContextName is the name of an AppKubernetesContextConfig on
        * the same AppConfig. Empty means fall back to the implicit sandbox
@@ -3166,6 +3189,8 @@ export interface components {
     "app.AppAWSIAMPolicyConfig": {
       app_aws_iam_role_config_id?: string;
       app_config_id?: string;
+      azure_actions?: string[];
+      azure_built_in_roles?: string[];
       cloudformation_stack_name?: string;
       contents?: string;
       created_at?: string;
@@ -3670,12 +3695,24 @@ export interface components {
       updated_at?: string;
     };
     "app.AzureStackOutputs": {
+      break_glass_identity_client_ids?: {
+        [key: string]: string;
+      };
+      custom_identity_client_ids?: {
+        [key: string]: string;
+      };
+      deprovision_identity_client_id?: string;
+      install_inputs?: {
+        [key: string]: string;
+      };
       key_vault_id?: string;
       key_vault_name?: string;
+      maintenance_identity_client_id?: string;
       network_id?: string;
       network_name?: string;
       private_subnet_ids?: string[];
       private_subnet_names?: string[];
+      provision_identity_client_id?: string;
       public_subnet_ids?: string[];
       public_subnet_names?: string[];
       resource_group_id?: string;
@@ -4218,7 +4255,6 @@ export interface components {
       updated_at?: string;
     };
     "app.InstallAppConfigVersion": {
-      app_branch_run?: components["schemas"]["app.AppBranchRun"];
       app_branch_run_id?: string;
       created_at?: string;
       created_by_id?: string;
@@ -5430,7 +5466,7 @@ export interface components {
     /** @enum {string} */
     "app.RunnerJobExecutionStatus": "pending" | "initializing" | "in-progress" | "cleaning-up" | "finished" | "failed" | "timed-out" | "not-attempted" | "cancelled" | "unknown";
     /** @enum {string} */
-    "app.RunnerJobGroup": "health-checks" | "sync" | "build" | "deploy" | "sandbox" | "runner" | "operations" | "management" | "actions" | "" | "any";
+    "app.RunnerJobGroup": "health-checks" | "sync" | "build" | "deploy" | "sandbox" | "runner" | "operations" | "management" | "actions" | "image-actions" | "" | "any";
     /** @enum {string} */
     "app.RunnerJobOperationType": "exec" | "build" | "create-apply-plan" | "create-teardown-plan" | "apply-plan" | "unknown";
     "app.RunnerJobPlan": {
@@ -5673,6 +5709,21 @@ export interface components {
       /** @description Foreign key to TerraformWorkspace with unique constraint to prevent conflicting states for a workspace */
       workspace_id?: string;
     };
+    "app.Token": {
+      account_id?: string;
+      created_at?: string;
+      created_by_id?: string;
+      /** @description claim data */
+      expires_at?: string;
+      id?: string;
+      issued_at?: string;
+      issuer?: string;
+      name?: string;
+      token_type?: components["schemas"]["app.TokenType"];
+      updated_at?: string;
+    };
+    /** @enum {string} */
+    "app.TokenType": "auth" | "auth0" | "admin" | "static" | "integration" | "canary" | "nuon";
     "app.UserJourney": {
       name?: string;
       steps?: components["schemas"]["app.UserJourneyStep"][];
@@ -6199,6 +6250,11 @@ export interface components {
       use_default?: boolean;
     };
     "github_com_nuonco_nuon_pkg_azure_credentials.Config": {
+      /**
+       * @description ManagedIdentityClientID runs the operation as a specific user-assigned
+       * managed identity instead of the VM's system identity.
+       */
+      managed_identity_client_id?: string;
       service_principal?: components["schemas"]["credentials.ServicePrincipalCredentials"];
       use_default?: boolean;
     };
@@ -6237,6 +6293,10 @@ export interface components {
       secrets?: components["schemas"]["state.SecretsState"];
       /** @description loaded from the database but not part of the state itself */
       stale_at?: string;
+    };
+    "github_com_nuonco_nuon_services_ctl-api_internal_app_accounts_service.StaticTokenResponse": {
+      api_token?: string;
+      id?: string;
     };
     "helpers.ConnectedGithubVCSConfigRequest": {
       branch?: string;
@@ -6329,11 +6389,19 @@ export interface components {
       cluster_info?: components["schemas"]["kube.ClusterInfo"];
       gcp_auth?: components["schemas"]["github_com_nuonco_nuon_pkg_gcp_credentials.Config"];
       id?: string;
+      image_registry?: components["schemas"]["configs.OCIRegistryRepository"];
+      image_tag?: string;
       install_id?: string;
       override_env_vars?: {
         [key: string]: string;
       };
       sandbox_mode?: components["schemas"]["plantypes.SandboxMode"];
+      /**
+       * @description Image-backed actions: SourceImage is the rendered app-authored ref
+       * (e.g. ghcr.io/acme/tools:v1); ImageRegistry/ImageTag point at the
+       * install-registry mirror the runner pulls from.
+       */
+      source_image?: string;
       steps?: components["schemas"]["plantypes.ActionWorkflowRunStepPlan"][];
       timeout?: number;
     };
@@ -6781,6 +6849,8 @@ export interface components {
       };
     };
     "service.AppAWSIAMPolicyConfig": {
+      azure_actions?: string[];
+      azure_built_in_roles?: string[];
       contents?: string;
       gcp_permissions?: string[];
       gcp_predefined_role?: string;
@@ -6984,6 +7054,7 @@ export interface components {
       break_glass_role_arn?: string;
       dependencies?: string[];
       enable_kube_config?: boolean | null;
+      image?: string;
       kubernetes_context?: string;
       references?: string[];
       role?: string;
@@ -7533,6 +7604,15 @@ export interface components {
     "service.CreateRunnerBootstrapTokenResponse": {
       expires_at?: string;
       token?: string;
+    };
+    "service.CreateStaticTokenRequest": {
+      /**
+       * @description defaults to one year
+       * @default 8760h
+       */
+      duration?: string;
+      /** @description human-friendly name to identify the token later */
+      name: string;
     };
     "service.CreateTerraformModuleComponentConfigRequest": {
       app_config_id?: string;
@@ -8359,6 +8439,58 @@ export interface operations {
         content: {
           "application/json": components["schemas"]["stderr.ErrResponse"];
         };
+      };
+    };
+  };
+  /**
+   * create a static API token for your org's service account
+   * @description Creates a long-lived static API token scoped to your current org. The token is issued for the org's service account, which is created automatically if it does not already exist. The token only grants access to the current org.
+   */
+  CreateStaticToken: {
+    /** @description Input */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["service.CreateStaticTokenRequest"];
+      };
+    };
+    responses: {
+      /** @description Created */
+      201: {
+        content: {
+          "application/json": components["schemas"]["github_com_nuonco_nuon_services_ctl-api_internal_app_accounts_service.StaticTokenResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * list your org's static API tokens
+   * @description Lists the static API tokens for your current org's service account. Token secrets are never returned.
+   */
+  ListStaticTokens: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["app.Token"][];
+        };
+      };
+    };
+  };
+  /**
+   * delete a static API token
+   * @description Deletes a static API token belonging to your current org's service account. Once deleted, the token can no longer be used to access the API.
+   */
+  DeleteStaticToken: {
+    parameters: {
+      path: {
+        /** @description token ID */
+        token_id: string;
+      };
+    };
+    responses: {
+      /** @description No Content */
+      204: {
+        content: never;
       };
     };
   };


### PR DESCRIPTION
Image-Backed Actions (wip)

Lets app authors run action steps inside a container image they choose (e.g. curlimages/curl, kubectl tooling), instead of relying on whatever the runner image happens to have. Nuon mounts an actions-supervisor into the image, runs the step's inline_contents inside it, and collects outputs.

Usage

```
[[actions]]
name  = "healthcheck"
image = "ghcr.io/acme/kubernetes-tools:v1"   # new: optional

  [[actions.steps]]
  name = "check"
  inline_contents = "#!/bin/sh\nkubectl get pods\nnuon_output pod_count 3"
```

Steps in an image-backed action must use inline_contents.

How it works

- ctl-api mirrors the app image into the install registry, then runs the step inside it on the runner via docker run, with the actions-supervisor (a runner subcommand) mounted as the entrypoint.
- Executes on the mng process (VM host with docker access) — the image-actions job loop is registered only in mng, which also gates it to VM runners. K8s runners fail fast with a clear error.
- nuon_output <key> <value> is available on PATH inside the container and writes to NUON_ACTIONS_OUTPUT_FILEPATH; the runner reads outputs back from the shared workspace mount.

Gating

- Org feature flag image-backed-actions (default off).
- New image-actions runner job group.

Sandbox / local

- Sandbox orgs simulate the action (no real container) — validates the full control-plane path with no infra.
- Dev-only real-Docker path (ENV=development + NUON_DEV_REAL_IMAGE_ACTIONS=true + a linux NUON_DEV_SUPERVISOR_BIN) actually pulls the image and runs it locally.