### PR TITLE
test(ui): updated e2e navigation test

### DIFF
--- a/services/dashboard-ui/e2e/flows/navigation.flow.md
+++ b/services/dashboard-ui/e2e/flows/navigation.flow.md
@@ -1,11 +1,16 @@
 # Flow: Navigation
 
-Verifies the major org-level pages are reachable and render correctly. Each page sets a distinct browser tab title via `PageTitle`, used as the "rendered correctly" assertion.
+Verifies the major org-level pages in the main nav are reachable and render correctly. Each page sets a distinct browser tab title via `PageTitle`, used as the "rendered correctly" assertion. Pages correspond to the links in `client/components/navigation/main-nav-links.ts`.
 
 ## Setup
 - start: /:orgId
 
 ## Steps
+
+### Dashboard page
+- action: goto | /:orgId
+- action: wait | domcontentloaded
+- expect: title | /^Dashboard \|/
 
 ### Apps page
 - action: goto | /:orgId/apps
@@ -26,3 +31,18 @@ Verifies the major org-level pages are reachable and render correctly. Each page
 - action: goto | /:orgId/team
 - action: wait | domcontentloaded
 - expect: title | /^Team \|/
+
+### Webhooks page
+- action: goto | /:orgId/webhooks
+- action: wait | domcontentloaded
+- expect: title | /^Webhooks \|/
+
+### API tokens page
+- action: goto | /:orgId/api-tokens
+- action: wait | domcontentloaded
+- expect: title | /^API tokens \|/
+
+### Slack page
+- action: goto | /:orgId/slack
+- action: wait | domcontentloaded
+- expect: title | /^Slack \|/

--- a/services/dashboard-ui/e2e/global-setup.ts
+++ b/services/dashboard-ui/e2e/global-setup.ts
@@ -257,7 +257,7 @@ export default async function globalSetup(_config: FullConfig) {
 
   const page = await context.newPage();
   await page.goto(`${env.baseUrl}/${orgId}`);
-  await page.waitForLoadState("networkidle");
+  await page.waitForLoadState("domcontentloaded");
 
   await context.storageState({ path: AUTH_STATE_PATH });
   await browser.close();

--- a/services/dashboard-ui/e2e/specs/navigation.spec.ts
+++ b/services/dashboard-ui/e2e/specs/navigation.spec.ts
@@ -1,15 +1,19 @@
 import { test, expect } from "../fixtures";
 
 const pages = [
+  { path: "", title: /^Dashboard \|/, name: "dashboard" },
   { path: "apps", title: /^Apps \|/ },
   { path: "installs", title: /^Installs \|/ },
   { path: "runner", title: /^Builds \|/ },
   { path: "team", title: /^Team \|/ },
+  { path: "webhooks", title: /^Webhooks \|/ },
+  { path: "api-tokens", title: /^API tokens \|/ },
+  { path: "slack", title: /^Slack \|/ },
 ];
 
 test.describe("Navigation", () => {
-  for (const { path, title } of pages) {
-    test(`${path} page renders`, async ({ page, orgId }) => {
+  for (const { path, title, name } of pages) {
+    test(`${name ?? path} page renders`, async ({ page, orgId }) => {
       await page.goto(`/${orgId}/${path}`);
       await page.waitForLoadState("domcontentloaded");
       await expect(page).toHaveTitle(title, { timeout: 15000 });


### PR DESCRIPTION
- cover the rest of the dashboard top level page nav
- swap networkidle for domcontentloaded in setup