### PR TITLE
test(ui): more e2e test

### DIFF
--- a/services/dashboard-ui/e2e/flows/README.md
+++ b/services/dashboard-ui/e2e/flows/README.md
@@ -2,6 +2,29 @@
 
 Structured markdown format for describing E2E test flows. These serve as source-of-truth documentation — when flows change, update the markdown and ask Claude Code to regenerate the Playwright spec.
 
+## Flows
+
+Org-level:
+
+| Flow | Spec | Covers |
+|------|------|--------|
+| [smoke](./smoke.flow.md) | `specs/smoke.spec.ts` | Auth cookie injection and basic page render |
+| [navigation](./navigation.flow.md) | `specs/navigation.spec.ts` | Every org-level nav page is reachable and titled |
+| [webhooks-crud](./webhooks-crud.flow.md) | `specs/webhooks.spec.ts` | Create, edit, and delete a webhook |
+| [create-api-token](./create-api-token.flow.md) | `specs/api-tokens.spec.ts` | Create an API token, confirm the reveal modal, then delete it |
+
+Install-level:
+
+| Flow | Spec | Covers |
+|------|------|--------|
+| [create-install](./create-install.flow.md) | `specs/create-install.spec.ts` | Create an install from an app and redirect to its provision workflow |
+| [install-navigation](./install-navigation.flow.md) | `specs/install-navigation.spec.ts` | Every install sub-page renders without the error boundary |
+| [install-quick-management](./install-quick-management.flow.md) | `specs/install-quick-management.spec.ts` | Install row dropdown actions (edit inputs, current inputs, view state) |
+| [run-action](./run-action.flow.md) | `specs/run-action.spec.ts` | Trigger a manual action and redirect to its workflow |
+| [run-runbook](./run-runbook.flow.md) | `specs/run-runbook.spec.ts` | Run a runbook and redirect to its workflow |
+
+Some specs have no flow doc yet: `specs/apps.spec.ts` and `specs/install-labels.spec.ts`.
+
 ## Format
 
 ```markdown
@@ -30,7 +53,7 @@ Structured markdown format for describing E2E test flows. These serve as source-
 | `click` | `click \| button "Label"` | Click element by role + name |
 | `fill` | `fill \| input "Label" \| value` | Fill input by label |
 | `select` | `select \| select "Label" \| option` | Select dropdown option |
-| `wait` | `wait \| networkidle` | Wait for condition |
+| `wait` | `wait \| domcontentloaded` | Wait for condition (never `networkidle` — the SPA polls continuously, so the network never goes idle) |
 
 ## Assertion types
 

--- a/services/dashboard-ui/e2e/flows/create-api-token.flow.md
+++ b/services/dashboard-ui/e2e/flows/create-api-token.flow.md
@@ -1,0 +1,40 @@
+# Flow: Create and delete an API token
+
+Creates an org API token, verifies the one-time token reveal modal, confirms the token appears in the table, then deletes it. Pure API flow — no infra dependency, and self-cleaning.
+
+## Setup
+- env: E2E_ORG_ID (required)
+- start: /:orgId/api-tokens
+
+## Steps
+
+### Navigate to API tokens page
+- action: goto | /:orgId/api-tokens
+- action: wait | domcontentloaded
+- expect: title | /^API tokens \|/
+
+### Open create modal
+- action: click | button "Create token" first
+- expect: visible | heading "Create API token"
+
+### Fill token name (default role + expiry)
+- action: fill | input "e.g. ci-deploy" | e2e-token-{timestamp}
+
+### Submit and confirm the reveal modal
+- action: click | button "Create token" last
+- expect: visible | heading "API token created"
+- expect: visible | button "Done"
+
+### Dismiss the reveal modal
+- action: click | button "Done"
+
+### Token appears in the table
+- expect: visible | text "e2e-token-{timestamp}"
+
+### Open the row menu for the new token and delete
+- action: click | .locator | row menu trigger for the e2e-token-{timestamp} row
+- action: click | button "Delete token"
+- expect: visible | heading "Delete API token?"
+- action: click | button "Delete token"
+- expect: visible | text "Token deleted"
+- expect: not-visible | text "e2e-token-{timestamp}"

--- a/services/dashboard-ui/e2e/flows/create-install.flow.md
+++ b/services/dashboard-ui/e2e/flows/create-install.flow.md
@@ -10,7 +10,7 @@ Opens the create install modal, selects an app, fills out the form with auto-app
 
 ### Navigate to installs page
 - action: goto | /:orgId/installs
-- action: wait | networkidle
+- action: wait | domcontentloaded
 - expect: visible | heading "Installs"
 
 ### Open create modal
@@ -41,7 +41,7 @@ Opens the create install modal, selects an app, fills out the form with auto-app
 
 ### Submit the form
 - action: click | button "Create install" last
-- action: wait | networkidle
+- action: wait | domcontentloaded
 
 ### Redirected to provision workflow
 - expect: url | /workflows/

--- a/services/dashboard-ui/e2e/flows/run-action.flow.md
+++ b/services/dashboard-ui/e2e/flows/run-action.flow.md
@@ -1,0 +1,27 @@
+# Flow: Run an action
+
+From an install's actions list, opens the `healthcheck` action and triggers a manual run, verifying it kicks off an action workflow and redirects. Asserts up to workflow creation (like the create-install flow) — it does NOT wait for the run to complete, so it works in a sandbox-mode install without a live runner.
+
+## Setup
+- requires: at least one seed install (installIds[0]) — skip otherwise
+- start: /:orgId/installs/{installId}/actions
+
+## Steps
+
+### Navigate to the actions list
+- action: goto | /:orgId/installs/{installId}/actions
+- action: wait | domcontentloaded
+- expect: title | /^Actions \|/
+
+### Open the healthcheck action detail
+- action: click | link "healthcheck"
+- expect: visible | button "Run action"
+
+### Open the run modal
+- action: click | button "Run action" first
+- expect: visible | heading "Run action healthcheck"
+
+### Trigger the run
+- action: click | button "Run action" last
+- expect: url | /workflows/
+- expect: visible | text "Action workflow started"

--- a/services/dashboard-ui/e2e/flows/run-runbook.flow.md
+++ b/services/dashboard-ui/e2e/flows/run-runbook.flow.md
@@ -1,0 +1,26 @@
+# Flow: Run a runbook
+
+From an install's runbooks list, runs the `verify_status` runbook (which takes no inputs, so the run modal skips the input/steps wizard) via the row menu, verifying it kicks off a workflow and redirects. Asserts up to workflow creation — it does NOT wait for the run to complete, so it works in a sandbox-mode install without a live runner.
+
+## Setup
+- requires: at least one seed install (installIds[0]) — skip otherwise
+- start: /:orgId/installs/{installId}/runbooks
+
+## Steps
+
+### Navigate to the runbooks list
+- action: goto | /:orgId/installs/{installId}/runbooks
+- action: wait | domcontentloaded
+- expect: title | /^Runbooks \|/
+
+### Open the verify_status row menu and start a run
+- action: click | .locator | row menu trigger for the verify_status row
+- action: click | button "Run runbook"
+
+### Confirm in the run modal
+- expect: visible | text "Run verify_status"
+- action: click | button "Run runbook" last
+
+### Run kicks off and redirects
+- expect: url | /workflows/
+- expect: visible | text "Runbook run started"

--- a/services/dashboard-ui/e2e/flows/smoke.flow.md
+++ b/services/dashboard-ui/e2e/flows/smoke.flow.md
@@ -10,6 +10,6 @@ Validates the test infrastructure works: auth cookie injection, page rendering, 
 
 ### Dashboard loads
 - action: goto | /:orgId
-- action: wait | networkidle
+- action: wait | domcontentloaded
 - expect: visible | .logo-link
 - expect: visible | text "Nuon"

--- a/services/dashboard-ui/e2e/flows/webhooks-crud.flow.md
+++ b/services/dashboard-ui/e2e/flows/webhooks-crud.flow.md
@@ -1,0 +1,43 @@
+# Flow: Webhooks CRUD
+
+Creates a webhook with the default scope (everything in the org) and all events, verifies it appears in the table, edits it to set a signing secret, then deletes it. Pure API flow — no infra or Temporal dependency, and self-cleaning (the webhook it creates is deleted in the last step).
+
+## Setup
+- env: E2E_ORG_ID (required)
+- start: /:orgId/webhooks
+
+## Steps
+
+### Navigate to webhooks page
+- action: goto | /:orgId/webhooks
+- action: wait | domcontentloaded
+- expect: title | /^Webhooks \|/
+
+### Open create modal
+- action: click | button "Create webhook" first
+- expect: visible | heading "Create webhook"
+
+### Fill the webhook URL (default scope + all events)
+- action: fill | input "https://example.com/webhooks/nuon" | https://example.com/e2e-{timestamp}
+
+### Submit and confirm creation
+- action: click | button "Create webhook" last
+- expect: visible | text "Webhook created"
+- expect: visible | text "https://example.com/e2e-{timestamp}"
+
+### Open the edit modal for the new webhook
+- action: click | button "Edit" first
+- expect: visible | heading "Edit webhook"
+
+### Set a new signing secret and save
+- action: click | radio "Set a new secret"
+- action: fill | input "webhook-secret" | e2e-secret-value
+- action: click | button "Save changes"
+- expect: visible | text "Webhook updated"
+
+### Delete the webhook
+- action: click | button "Delete" first
+- expect: visible | heading "Delete webhook?"
+- action: click | button "Delete webhook"
+- expect: visible | text "Webhook deleted"
+- expect: not-visible | text "https://example.com/e2e-{timestamp}"

--- a/services/dashboard-ui/e2e/specs/api-tokens.spec.ts
+++ b/services/dashboard-ui/e2e/specs/api-tokens.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "../fixtures";
+
+test.describe("API tokens", () => {
+  test.setTimeout(60000);
+
+  test("create a token, confirm the reveal modal, then delete it", async ({
+    page,
+    orgId,
+  }) => {
+    const tokenName = `e2e-token-${Date.now()}`;
+
+    await page.goto(`/${orgId}/api-tokens`);
+    await page.waitForLoadState("domcontentloaded");
+    await expect(page).toHaveTitle(/^API tokens \|/, { timeout: 15000 });
+
+    // --- Create (default role + expiry) ---
+    await page.getByRole("button", { name: "Create token" }).first().click();
+    const createDialog = page.getByRole("dialog");
+    await expect(createDialog.getByText("Create API token")).toBeVisible();
+    await page.getByPlaceholder("e.g. ci-deploy").fill(tokenName);
+    await createDialog.getByRole("button", { name: "Create token" }).click();
+
+    // --- One-time reveal modal ---
+    const revealDialog = page.getByRole("dialog");
+    await expect(revealDialog.getByText("API token created")).toBeVisible({
+      timeout: 10000,
+    });
+    await revealDialog.getByRole("button", { name: "Done" }).click();
+
+    // --- Token appears in the table ---
+    const row = page.getByRole("row").filter({ hasText: tokenName });
+    await expect(row).toBeVisible({ timeout: 10000 });
+
+    // --- Delete via the row menu ---
+    await row.getByRole("button").last().click();
+    await page.getByRole("button", { name: "Delete token" }).click();
+    const deleteDialog = page.getByRole("dialog");
+    await expect(deleteDialog.getByText("Delete API token?")).toBeVisible();
+    await deleteDialog.getByRole("button", { name: "Delete token" }).click();
+    await expect(page.getByText("Token deleted")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(row).not.toBeVisible();
+  });
+});

--- a/services/dashboard-ui/e2e/specs/create-install.spec.ts
+++ b/services/dashboard-ui/e2e/specs/create-install.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "../fixtures";
 test.describe("Create install", () => {
   test("navigate to installs page", async ({ page, orgId }) => {
     await page.goto(`/${orgId}/installs`);
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
     await expect(page.getByRole("heading", { name: "Installs" })).toBeVisible();
   });
 
@@ -13,7 +13,7 @@ test.describe("Create install", () => {
   }) => {
     test.setTimeout(60000);
     await page.goto(`/${orgId}/installs`);
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Open create modal (first match is the page header button)
     await page.getByRole("button", { name: "Create install" }).first().click();
@@ -60,8 +60,8 @@ test.describe("Create install", () => {
 
     // Redirected to provision workflow
     await expect(page).toHaveURL(/\/workflows\//, { timeout: 30000 });
-    await expect(page.getByText("Install created successfully")).toBeVisible({
-      timeout: 10000,
-    });
+    await expect(
+      page.getByText("Install created", { exact: true })
+    ).toBeVisible({ timeout: 10000 });
   });
 });

--- a/services/dashboard-ui/e2e/specs/install-labels.spec.ts
+++ b/services/dashboard-ui/e2e/specs/install-labels.spec.ts
@@ -11,9 +11,15 @@ test.describe("Install labels", () => {
     const installId = installIds[0];
     test.skip(!installId, "No seed install available");
 
+    const labelBadge = (key: string, value: string) =>
+      page
+        .locator("span.inline-flex")
+        .filter({ hasText: key })
+        .filter({ hasText: value });
+
     // --- Step 1: Navigate to the install page ---
     await page.goto(`/${orgId}/installs/${installId}`);
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // --- Step 2: Open Manage → Edit labels, clear any existing labels ---
     await page.getByRole("button", { name: "Manage" }).click();
@@ -50,10 +56,10 @@ test.describe("Install labels", () => {
 
     // --- Step 4: Reload and verify all 3 labels ---
     await page.reload();
-    await page.waitForLoadState("networkidle");
-    await expect(page.getByText("env: staging")).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText("team: platform")).toBeVisible();
-    await expect(page.getByText("region: us-west-2")).toBeVisible();
+    await page.waitForLoadState("domcontentloaded");
+    await expect(labelBadge("env", "staging")).toBeVisible({ timeout: 10000 });
+    await expect(labelBadge("team", "platform")).toBeVisible();
+    await expect(labelBadge("region", "us-west-2")).toBeVisible();
 
     // --- Step 5: Open Edit labels to rename one and remove one ---
     await page.getByRole("button", { name: "Manage" }).click();
@@ -84,16 +90,16 @@ test.describe("Install labels", () => {
 
     // --- Step 6: Reload and verify updated labels ---
     await page.reload();
-    await page.waitForLoadState("networkidle");
-    await expect(page.getByText("environment: staging")).toBeVisible({
+    await page.waitForLoadState("domcontentloaded");
+    await expect(labelBadge("environment", "staging")).toBeVisible({
       timeout: 10000,
     });
-    await expect(page.getByText("region: us-west-2")).toBeVisible();
-    await expect(page.getByText("team: platform")).not.toBeVisible();
+    await expect(labelBadge("region", "us-west-2")).toBeVisible();
+    await expect(labelBadge("team", "platform")).not.toBeVisible();
 
     // --- Step 7: Navigate to installs list and test label filter ---
     await page.goto(`/${orgId}/installs`);
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     const labelsDropdown = page.getByRole("button", { name: /Labels/ });
     await expect(labelsDropdown).toBeVisible({ timeout: 10000 });

--- a/services/dashboard-ui/e2e/specs/run-action.spec.ts
+++ b/services/dashboard-ui/e2e/specs/run-action.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "../fixtures";
+
+test.describe("Run an action", () => {
+  test.setTimeout(60000);
+
+  test("trigger the healthcheck action and redirect to its workflow", async ({
+    page,
+    orgId,
+    installIds,
+  }) => {
+    const installId = installIds[0];
+    test.skip(!installId, "No seed install available");
+
+    await page.goto(`/${orgId}/installs/${installId}/actions`);
+    await page.waitForLoadState("domcontentloaded");
+    await expect(page).toHaveTitle(/^Actions \|/, { timeout: 15000 });
+
+    await page
+      .getByRole("link", { name: "healthcheck", exact: true })
+      .click();
+
+    const runButton = page.getByRole("button", { name: "Run action" }).first();
+    await expect(runButton).toBeVisible({ timeout: 15000 });
+    await runButton.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText("Run action healthcheck")).toBeVisible();
+    await dialog.getByRole("button", { name: "Run action" }).click();
+
+    await expect(page).toHaveURL(/\/workflows\//, { timeout: 30000 });
+    await expect(page.getByText("Action workflow started")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+});

--- a/services/dashboard-ui/e2e/specs/run-runbook.spec.ts
+++ b/services/dashboard-ui/e2e/specs/run-runbook.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "../fixtures";
+
+test.describe("Run a runbook", () => {
+  test.setTimeout(60000);
+
+  test("run the verify_status runbook and redirect to its workflow", async ({
+    page,
+    orgId,
+    installIds,
+  }) => {
+    const installId = installIds[0];
+    test.skip(!installId, "No seed install available");
+
+    await page.goto(`/${orgId}/installs/${installId}/runbooks`);
+    await page.waitForLoadState("domcontentloaded");
+    await expect(page).toHaveTitle(/^Runbooks \|/, { timeout: 15000 });
+
+    const row = page.getByRole("row").filter({ hasText: "verify_status" });
+    await expect(row).toBeVisible({ timeout: 15000 });
+    await row.getByRole("button").last().click();
+
+    await page.getByRole("button", { name: "Run runbook" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText("Run verify_status")).toBeVisible({
+      timeout: 10000,
+    });
+    await dialog.getByRole("button", { name: "Run runbook" }).click();
+
+    await expect(page).toHaveURL(/\/workflows\//, { timeout: 30000 });
+    await expect(page.getByText("Runbook run started")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+});

--- a/services/dashboard-ui/e2e/specs/smoke.spec.ts
+++ b/services/dashboard-ui/e2e/specs/smoke.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "../fixtures";
 
 test("dashboard loads and shows logo", async ({ page, orgId }) => {
   await page.goto(`/${orgId}`);
-  await page.waitForLoadState("networkidle");
+  await page.waitForLoadState("domcontentloaded");
 
   const logo = page.locator(".logo-link");
   await expect(logo).toBeVisible();

--- a/services/dashboard-ui/e2e/specs/webhooks.spec.ts
+++ b/services/dashboard-ui/e2e/specs/webhooks.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "../fixtures";
+
+test.describe("Webhooks CRUD", () => {
+  test.setTimeout(60000);
+
+  test("create, edit secret, then delete a webhook", async ({
+    page,
+    orgId,
+  }) => {
+    const url = `https://example.com/e2e-${Date.now()}`;
+
+    await page.goto(`/${orgId}/webhooks`);
+    await page.waitForLoadState("domcontentloaded");
+    await expect(page).toHaveTitle(/^Webhooks \|/, { timeout: 15000 });
+
+    // --- Create (default scope + all events, only the URL is required) ---
+    await page.getByRole("button", { name: "Create webhook" }).first().click();
+    const createDialog = page.getByRole("dialog");
+    const urlInput = page.getByPlaceholder("https://example.com/webhooks/nuon");
+    await expect(urlInput).toBeVisible();
+    await urlInput.fill(url);
+    await createDialog
+      .getByRole("button", { name: "Create webhook" })
+      .click();
+    await expect(page.getByText("Webhook created")).toBeVisible({
+      timeout: 10000,
+    });
+
+    const row = page.getByRole("row").filter({ hasText: url });
+    await expect(row).toBeVisible({ timeout: 10000 });
+
+    // --- Edit: set a new signing secret ---
+    await row.getByRole("button", { name: "Edit" }).click();
+    const editDialog = page.getByRole("dialog");
+    await expect(editDialog.getByText("Edit webhook")).toBeVisible();
+    await editDialog.getByRole("radio", { name: "Set a new secret" }).click();
+    await editDialog.locator("#webhook-secret").fill("e2e-secret-value");
+    await editDialog.getByRole("button", { name: "Save changes" }).click();
+    await expect(page.getByText("Webhook updated")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // --- Delete ---
+    await row.getByRole("button", { name: "Delete" }).click();
+    const deleteDialog = page.getByRole("dialog");
+    await expect(deleteDialog.getByText("Delete webhook?")).toBeVisible();
+    await deleteDialog
+      .getByRole("button", { name: "Delete webhook" })
+      .click();
+    await expect(page.getByText("Webhook deleted")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText(url)).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
- add webhook, api-token, action, and runbook flows
- fix stale create-install/install-labels assertions
- replace networkidle with domcontentloaded
- catalog flows in the README