### PR TITLE
fix: (runner healthcheck) ignore stale active runner processes

### DIFF
--- a/services/ctl-api/internal/app/runners/signals/updatetag/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/updatetag/signal.go
@@ -99,14 +99,14 @@ func (s *Signal) handleInstallRunner(ctx workflow.Context, l log.Logger, runner 
 	// Fallback: update status to indicate restart needed
 	if err := activities.AwaitUpdateStatus(ctx, activities.UpdateStatusRequest{
 		RunnerID:          s.RunnerID,
-		Status:            app.RunnerStatusActive,
+		Status:            runner.Status,
 		StatusDescription: fmt.Sprintf("tag updated to %s, awaiting restart", s.Tag),
 	}); err != nil {
 		return errors.Wrap(err, "unable to update runner status")
 	}
 	statusactivities.AwaitUpdateRunnerStatusV2(ctx, statusactivities.UpdateRunnerStatusV2Request{
 		RunnerID:          s.RunnerID,
-		Status:            app.RunnerStatusActive,
+		Status:            runner.Status,
 		StatusDescription: fmt.Sprintf("tag updated to %s, awaiting restart", s.Tag),
 	})
 

--- a/services/ctl-api/internal/app/runners/worker/activities/get_current_runner_process.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_current_runner_process.go
@@ -3,6 +3,8 @@ package activities
 import (
 	"context"
 
+	"gorm.io/gorm"
+
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	dbgenerics "github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 )
@@ -17,12 +19,18 @@ type GetCurrentRunnerProcessRequest struct {
 func (a *Activities) GetCurrentRunnerProcess(ctx context.Context, req GetCurrentRunnerProcessRequest) (*app.RunnerProcess, error) {
 	var process app.RunnerProcess
 	res := a.db.WithContext(ctx).
-		Where("runner_id = ? AND type = ? AND composite_status->>'status' = ?", req.RunnerID, req.ProcessType, string(app.RunnerProcessStatusActive)).
+		Where(&app.RunnerProcess{
+			RunnerID: req.RunnerID,
+			Type:     app.RunnerProcessType(req.ProcessType),
+		}).
 		Preload("Shutdowns").
 		Order("created_at DESC").
 		First(&process)
 	if res.Error != nil {
 		return nil, dbgenerics.TemporalGormError(res.Error, "unable to get current runner process")
+	}
+	if process.ProcessStatus() != app.RunnerProcessStatusActive {
+		return nil, dbgenerics.TemporalGormError(gorm.ErrRecordNotFound, "no active current runner process")
 	}
 
 	return &process, nil


### PR DESCRIPTION
We had a small bug in the runner healthcheck related logic where we relied on the latest "active" runner process to determine health, instead of fetching the latest runner process and looking at it's status. This patch 

- Select the newest runner process before checking whether it is active so historical orphaned rows cannot keep an offline runner healthy.
- Preserve the runner's existing status when an update-tag operation cannot find a current active process, avoiding accidental reactivation.