### PR TITLE
fix(api): qualify orgs.name in org search to resolve ambiguous column

### DIFF
--- a/services/ctl-api/internal/app/orgs/service/get_orgs.go
+++ b/services/ctl-api/internal/app/orgs/service/get_orgs.go
@@ -57,7 +57,7 @@ func (s *service) getOrgs(ctx *gin.Context, orgIDs []string, q string) ([]app.Or
 		Order(fmt.Sprintf("CASE WHEN accounts.account_type = '%s' THEN 1 ELSE 0 END, orgs.id", app.AccountTypeCanary))
 
 	if q != "" {
-		tx = tx.Where("name ILIKE ? OR orgs.id = ?", "%"+q+"%", q)
+		tx = tx.Where("orgs.name ILIKE ? OR orgs.id = ?", "%"+q+"%", q)
 	}
 
 	res := tx.


### PR DESCRIPTION
Use `org.name` for orgs endpoint query