### PR TITLE
fix: retry failed migrations instead of skipping them

### DIFF
--- a/services/ctl-api/cmd/startup.go
+++ b/services/ctl-api/cmd/startup.go
@@ -28,6 +28,26 @@ func (c *cli) registerStartup() error {
 	return nil
 }
 
+// index builds on big tables can need more than this, hence the override
+const defaultMigrationsTimeout = time.Minute * 5
+
+func migrationsTimeout() time.Duration {
+	raw := os.Getenv("DB_MIGRATIONS_TIMEOUT")
+	if raw == "" {
+		return defaultMigrationsTimeout
+	}
+
+	timeout, err := time.ParseDuration(raw)
+	if err != nil || timeout <= 0 {
+		zap.L().Warn("invalid DB_MIGRATIONS_TIMEOUT, using default",
+			zap.String("value", raw),
+			zap.Duration("default", defaultMigrationsTimeout))
+		return defaultMigrationsTimeout
+	}
+
+	return timeout
+}
+
 func (c *cli) runStartup(cmd *cobra.Command, _ []string) {
 	start := time.Now()
 	l := zap.L()
@@ -40,7 +60,7 @@ func (c *cli) runStartup(cmd *cobra.Command, _ []string) {
 		fx.Provide(db.AsMigrator(ch.NewCHMigrator)),
 		fx.Invoke(db.DBMigratorParam(func(migs []*migrations.Migrator, shutdowner fx.Shutdowner) {
 			ctx := context.Background()
-			ctx, cancelFn := context.WithTimeout(ctx, time.Minute*5)
+			ctx, cancelFn := context.WithTimeout(ctx, migrationsTimeout())
 			defer cancelFn()
 
 			code := 0

--- a/services/ctl-api/internal/pkg/db/plugins/migrations/migrations.go
+++ b/services/ctl-api/internal/pkg/db/plugins/migrations/migrations.go
@@ -70,6 +70,9 @@ func (m *Migrator) applyMigration(ctx context.Context, obj any, idx Migration) e
 	return nil
 }
 
+// an in_progress migration older than this is assumed dead and gets reclaimed
+const abandonedMigrationTimeout = time.Hour
+
 func (a *Migrator) isMigrationApplied(ctx context.Context, name string) (bool, error) {
 	var migration MigrationModel
 	res := a.migrationDB.WithContext(ctx).
@@ -82,21 +85,47 @@ func (a *Migrator) isMigrationApplied(ctx context.Context, name string) (bool, e
 		return false, res.Error
 	}
 
-	return true, nil
+	// only applied counts. an error row used to read as applied and never retried.
+	return migration.Status == MigrationStatusApplied, nil
 }
 
-func (a *Migrator) createMigration(ctx context.Context, name string) error {
+// claimMigration marks a migration in progress and reports whether we won the claim.
+// errored and abandoned rows get reclaimed so they retry.
+func (a *Migrator) claimMigration(ctx context.Context, name string) (bool, error) {
+	now := time.Now()
+
+	res := a.migrationDB.WithContext(ctx).
+		Model(&MigrationModel{}).
+		Where("name = ?", name).
+		Where("status = ? OR (status = ? AND updated_at < ?)",
+			MigrationStatusError,
+			MigrationStatusInProgress, now.Add(-abandonedMigrationTimeout)).
+		Updates(map[string]any{
+			"status":     MigrationStatusInProgress,
+			"updated_at": now,
+		})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	if res.RowsAffected > 0 {
+		return true, nil
+	}
+
+	// nothing to reclaim, first attempt
 	migration := MigrationModel{
 		Name:   name,
 		Status: MigrationStatusInProgress,
 	}
-	res := a.migrationDB.WithContext(ctx).
-		Create(&migration)
-	if res.Error != nil {
-		return res.Error
+	if err := a.migrationDB.WithContext(ctx).Create(&migration).Error; err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			// another run got there first
+			return false, nil
+		}
+
+		return false, err
 	}
 
-	return nil
+	return true, nil
 }
 
 func (a *Migrator) updateMigrationStatus(ctx context.Context, name string, status MigrationStatus) error {
@@ -169,15 +198,15 @@ func (a *Migrator) execMigration(ctx context.Context, migration Migration) error
 		migration.Name = fmt.Sprintf("%s-%d", migration.Name, ts.Unix())
 	}
 
-	if err := a.createMigration(ctx, migration.Name); err != nil {
-		if errors.Is(err, gorm.ErrDuplicatedKey) {
-			a.l.Info("migration already in progress", zap.String("name", migration.Name))
-			statusDescription = "already_in_progress"
-			return nil
-		}
-
+	claimed, err := a.claimMigration(ctx, migration.Name)
+	if err != nil {
 		statusDescription = "db"
-		return fmt.Errorf("unable to create migration: %w", err)
+		return fmt.Errorf("unable to claim migration: %w", err)
+	}
+	if !claimed {
+		a.l.Info("migration already in progress", zap.String("name", migration.Name))
+		statusDescription = "already_in_progress"
+		return nil
 	}
 
 	if migration.Fn != nil {

--- a/services/ctl-api/internal/pkg/db/psql/migrations/113_backfill_runner_healthcheck_emitter.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/113_backfill_runner_healthcheck_emitter.go
@@ -4,21 +4,37 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
 
 func (m *Migrations) Migration113BackfillRunnerHealthcheckEmitter(ctx context.Context, db *gorm.DB) error {
+	ctx, err := m.systemCtx(ctx)
+	if err != nil {
+		return err
+	}
+
 	var runners []app.Runner
 	if res := db.WithContext(ctx).Find(&runners); res.Error != nil {
 		return fmt.Errorf("unable to list runners: %w", res.Error)
 	}
 
+	// one bad runner shouldn't leave every remaining runner without a healthcheck
+	var failed int
 	for _, runner := range runners {
 		if err := m.runnersHelpers.EnsureRunnerSignalsQueue(ctx, runner.ID); err != nil {
-			return fmt.Errorf("unable to ensure runner signals queue for runner %s: %w", runner.ID, err)
+			failed++
+			m.l.Warn("unable to ensure runner signals queue",
+				zap.String("runner_id", runner.ID),
+				zap.Error(err))
 		}
+	}
+	if failed > 0 {
+		m.l.Warn("finished backfilling runner healthcheck emitters with failures",
+			zap.Int("failed", failed),
+			zap.Int("total", len(runners)))
 	}
 
 	return nil

--- a/services/ctl-api/internal/pkg/db/psql/migrations/116_install_app_config_version_metadata_backfill.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/116_install_app_config_version_metadata_backfill.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nuonco/nuon/pkg/shortid/domains"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
 )
 
 func (m *Migrations) Migration116InstallAppConfigVersionMetadataBackfill(ctx context.Context, db *gorm.DB) error {
@@ -20,6 +21,14 @@ func (m *Migrations) Migration116InstallAppConfigVersionMetadataBackfill(ctx con
 		return fmt.Errorf("unable to create install_app_config_versions table: %w", err)
 	}
 
+	// installs whose creator is gone would fail the accounts FK, so fall back instead of
+	// skipping them
+	systemCtx, err := m.systemCtx(ctx)
+	if err != nil {
+		return err
+	}
+	fallbackCreatedByID := keys.CreatedByIDFromContext(systemCtx)
+
 	var installs []struct {
 		ID          string
 		OrgID       string
@@ -27,7 +36,9 @@ func (m *Migrations) Migration116InstallAppConfigVersionMetadataBackfill(ctx con
 		CreatedByID string
 	}
 	if err := db.WithContext(ctx).Raw(`
-		SELECT i.id, i.org_id, i.app_config_id, i.created_by_id
+		SELECT i.id, i.org_id, i.app_config_id,
+		       CASE WHEN EXISTS (SELECT 1 FROM accounts a WHERE a.id = i.created_by_id)
+		            THEN i.created_by_id ELSE '' END AS created_by_id
 		FROM installs i
 		WHERE i.app_config_id != ''
 		  AND i.deleted_at = 0
@@ -41,18 +52,24 @@ func (m *Migrations) Migration116InstallAppConfigVersionMetadataBackfill(ctx con
 
 	now := time.Now()
 	for _, inst := range installs {
+		createdByID := inst.CreatedByID
+		if createdByID == "" {
+			createdByID = fallbackCreatedByID
+		}
+
 		version := app.InstallAppConfigVersion{
 			ID:             domains.NewInstallAppConfigVersionID(),
 			OrgID:          inst.OrgID,
 			InstallID:      inst.ID,
 			NewAppConfigID: inst.AppConfigID,
-			CreatedByID:    inst.CreatedByID,
+			CreatedByID:    createdByID,
 			CreatedAt:      now,
 			UpdatedAt:      now,
 			Status:         app.CompositeStatus{Status: app.StatusSuccess},
 			Metadata:       map[string]string{"source": "backfill"},
 		}
-		if err := db.WithContext(ctx).Create(&version).Error; err != nil {
+		// backfilled rows have no previous config, and '' fails the app_configs FK
+		if err := db.WithContext(ctx).Omit("OldAppConfigID").Create(&version).Error; err != nil {
 			return fmt.Errorf("unable to backfill install %s: %w", inst.ID, err)
 		}
 	}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/migrations.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/migrations.go
@@ -1,9 +1,11 @@
 package migrations
 
 import (
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+
 	runnershelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
-	"go.uber.org/fx"
 )
 
 type Params struct {
@@ -11,16 +13,19 @@ type Params struct {
 
 	AcctClient     *account.Client
 	RunnersHelpers *runnershelpers.Helpers
+	L              *zap.Logger
 }
 
 type Migrations struct {
 	acctClient     *account.Client
 	runnersHelpers *runnershelpers.Helpers
+	l              *zap.Logger
 }
 
 func New(params Params) *Migrations {
 	return &Migrations{
 		acctClient:     params.AcctClient,
 		runnersHelpers: params.RunnersHelpers,
+		l:              params.L,
 	}
 }

--- a/services/ctl-api/internal/pkg/db/psql/migrations/system_context.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/system_context.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+// created by 01-create-internal-accounts, which runs before everything else
+const migrationServiceAccount = "nuonctl"
+
+// systemCtx attaches an acting account to ctx. BeforeCreate hooks pull created_by_id off
+// the context, which a migration has none of, and the empty value fails the accounts FK.
+func (m *Migrations) systemCtx(ctx context.Context) (context.Context, error) {
+	acct, err := m.acctClient.FindAccount(ctx, account.ServiceAccountEmail(migrationServiceAccount))
+	if err != nil {
+		return nil, fmt.Errorf("unable to find %s service account: %w", migrationServiceAccount, err)
+	}
+
+	return context.WithValue(ctx, keys.AccountIDCtxKey, acct.ID), nil
+}


### PR DESCRIPTION
Hit this upgrading a BYOC install. Two backfills failed and the deploy after them went green with neither applied.

isMigrationApplied only checked that a row existed, not its status, so an errored migration read as applied and got skipped for good. 113 errored, next run skipped it and died on 116, the run after that skipped 116 and exited 0. Only 'applied' counts now, and error or abandoned rows get reclaimed so they retry.

113 and 116 failed for the same reason: both create records through models, and BeforeCreate pulls created_by_id off the request context. Migrations run on context.Background() so it goes in as '' and hits the accounts FK. They only ever passed where the loop had no rows to iterate, which is why nothing caught them. Added systemCtx to attribute migration writes to the nuonctl service account. 116 also wrote old_app_config_id as '' which fails the app_configs FK, and 113 gave up on the whole backfill after one bad runner.

Once retries were live this surfaced 088, which had been sitting at status=error since 2025-08-05 and silently skipped ever since. It cleans up empty emails through a soft-delete scoped Find, but the NOT NULL and CHECK it adds cover soft deleted rows too, so any soft deleted account with an empty email fails the ALTER. Unscoped both queries.

Also fixed the error message. applyGlobalMigrations and applyMigrations both hardcoded Name: "indexes" in MigrationErr, so a failed global migration reported "error applying indexes migration to model global-migrations" and never named the migration that failed, which is why this took so long to track down. And applyMigration ignored its idx arg and re-ran every migration for each migration, dead path today since no model implements the interface.

Made the migration timeout overridable with DB_MIGRATIONS_TIMEOUT, a CREATE INDEX on queue_signals ran past the hardcoded 5m and nothing outside the image could raise it.

One thing to be aware of with retries: a migration that failed partway gets its successful prefix re-run, since nothing wraps the Fn in a transaction. All the current ones are guarded (NOT EXISTS subqueries, or filters that stop matching once a row is processed) so this is safe, but it is worth keeping in mind for new migrations.

Existing error rows need clearing to re-run: SELECT name, status FROM migrations WHERE status <> 'applied'. Older installs may have rows that have been silently skipped up to now.