### PR TITLE
fix: backfill workflow names and add missing workflow titles

### DIFF
--- a/services/ctl-api/internal/app/workflow.go
+++ b/services/ctl-api/internal/app/workflow.go
@@ -74,10 +74,14 @@ func (i WorkflowType) PastTenseName() string {
 		return "Reprovisioned sandbox"
 	case WorkflowTypeDeprovision:
 		return "Deprovisioned install"
+	case WorkflowTypeDeprovisionSandbox:
+		return "Deprovisioned sandbox"
 	case WorkflowTypeManualDeploy, WorkflowTypeDriftRun:
 		return "Deployed to install"
 	case WorkflowTypeInputUpdate:
 		return "Updated Input"
+	case WorkflowTypeTeardownComponent:
+		return "Tore down component"
 	case WorkflowTypeTeardownComponents:
 		return "Tore down all components"
 	case WorkflowTypeDeployComponents:
@@ -94,6 +98,12 @@ func (i WorkflowType) PastTenseName() string {
 		return "Enabled component"
 	case WorkflowTypeComponentDisabled:
 		return "Disabled component"
+	case WorkflowTypeAppBranchesConfigRepoUpdate:
+		return "Config repo updated"
+	case WorkflowTypeAppBranchesComponentRepoUpdate:
+		return "Component repo updated"
+	case WorkflowTypeAppBranchConfigUpdate:
+		return "Branch config updated"
 	default:
 	}
 
@@ -108,10 +118,14 @@ func (i WorkflowType) Name() string {
 		return "Reprovisioning install"
 	case WorkflowTypeDeprovision:
 		return "Deprovisioning install"
+	case WorkflowTypeDeprovisionSandbox:
+		return "Deprovisioning sandbox"
 	case WorkflowTypeManualDeploy, WorkflowTypeDriftRun:
 		return "Deploying to install"
 	case WorkflowTypeInputUpdate:
 		return "Input Update"
+	case WorkflowTypeTeardownComponent:
+		return "Tearing down component"
 	case WorkflowTypeTeardownComponents:
 		return "Tearing down all components"
 	case WorkflowTypeDeployComponents:
@@ -130,6 +144,12 @@ func (i WorkflowType) Name() string {
 		return "Enabling component"
 	case WorkflowTypeComponentDisabled:
 		return "Disabling component"
+	case WorkflowTypeAppBranchesConfigRepoUpdate:
+		return "Config repo update"
+	case WorkflowTypeAppBranchesComponentRepoUpdate:
+		return "Component repo update"
+	case WorkflowTypeAppBranchConfigUpdate:
+		return "Branch config update"
 	default:
 	}
 

--- a/services/ctl-api/internal/app/workflow_name.go
+++ b/services/ctl-api/internal/app/workflow_name.go
@@ -10,6 +10,12 @@ import (
 // dashboard, CLI, and search index. It is the single source of truth — the
 // install_workflows.name column is populated by Workflow.BeforeSave so the
 // stored value stays in sync with this logic.
+// ComputeName lets backfills recompute the title without a full Save, which
+// would try to upsert every association on the struct.
+func (w *Workflow) ComputeName() string {
+	return computeWorkflowName(w)
+}
+
 func computeWorkflowName(w *Workflow) string {
 	suffix := workflowNameSuffix(w)
 

--- a/services/ctl-api/internal/app/workflow_name_test.go
+++ b/services/ctl-api/internal/app/workflow_name_test.go
@@ -1,0 +1,57 @@
+package app
+
+import "testing"
+
+// every type declared in workflow.go — add new ones here so the titles below
+// stay mandatory rather than silently falling back to the lowercased type
+var allWorkflowTypes = []WorkflowType{
+	WorkflowTypeProvision,
+	WorkflowTypeDeprovision,
+	WorkflowTypeDeprovisionSandbox,
+	WorkflowTypeManualDeploy,
+	WorkflowTypeInputUpdate,
+	WorkflowTypeDeployComponents,
+	WorkflowTypeTeardownComponent,
+	WorkflowTypeTeardownComponents,
+	WorkflowTypeReprovisionSandbox,
+	WorkflowTypeDriftRunReprovisionSandbox,
+	WorkflowTypeActionWorkflowRun,
+	WorkflowTypeSyncSecrets,
+	WorkflowTypeDriftRun,
+	WorkflowTypeAppBranchesRun,
+	WorkflowTypeAppBranchesConfigRepoUpdate,
+	WorkflowTypeAppBranchesComponentRepoUpdate,
+	WorkflowTypeAppBranchConfigUpdate,
+	WorkflowTypeReprovision,
+	WorkflowTypeAppConfigBuild,
+	WorkflowTypeRunbookRun,
+	WorkflowTypeComponentEnabled,
+	WorkflowTypeComponentDisabled,
+}
+
+func TestWorkflowTypeTitlesAreExhaustive(t *testing.T) {
+	for _, wt := range allWorkflowTypes {
+		// app_branches_manual_update is titled from its metadata instead
+		if wt == WorkflowTypeAppBranchesRun {
+			continue
+		}
+		if wt.Name() == "" {
+			t.Errorf("%s has no Name()", wt)
+		}
+		if wt.PastTenseName() == "" {
+			t.Errorf("%s has no PastTenseName()", wt)
+		}
+	}
+}
+
+func TestComputeNameNeverFallsBackToRawType(t *testing.T) {
+	for _, wt := range allWorkflowTypes {
+		name := (&Workflow{Type: wt}).ComputeName()
+		if name == "" {
+			t.Errorf("%s computed an empty name", wt)
+		}
+		if name == string(wt) {
+			t.Errorf("%s computed the raw type as its name", wt)
+		}
+	}
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/119_backfill_workflow_names.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/119_backfill_workflow_names.go
@@ -1,0 +1,85 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+const workflowNameBatchSize = 500
+
+// these types hit neither title switch until now, so any name they already have
+// is the lowercased type fallback and needs recomputing
+var workflowTypesMissingTitles = []app.WorkflowType{
+	app.WorkflowTypeDeprovisionSandbox,
+	app.WorkflowTypeTeardownComponent,
+	app.WorkflowTypeAppBranchesConfigRepoUpdate,
+	app.WorkflowTypeAppBranchesComponentRepoUpdate,
+	app.WorkflowTypeAppBranchConfigUpdate,
+}
+
+// Migration119BackfillWorkflowNames redoes the 108 backfill, which left name
+// NULL, and recomputes the types that had no title. Unlike 108 the expression
+// is not restated in SQL — names come from Workflow.ComputeName so Go stays the
+// only source of truth.
+func (m *Migrations) Migration119BackfillWorkflowNames(ctx context.Context, db *gorm.DB) error {
+	if err := db.WithContext(ctx).Exec(
+		`ALTER TABLE install_workflows ADD COLUMN IF NOT EXISTS name TEXT`,
+	).Error; err != nil {
+		return fmt.Errorf("unable to ensure install_workflows.name: %w", err)
+	}
+
+	var batch []app.Workflow
+	res := db.WithContext(ctx).
+		Model(&app.Workflow{}).
+		Unscoped().
+		Select("id", "type", "metadata", "finished_at").
+		Where("name IS NULL OR name = '' OR type IN ?", workflowTypesMissingTitles).
+		FindInBatches(&batch, workflowNameBatchSize, func(_ *gorm.DB, _ int) error {
+			// a fresh handle, not the batch tx — Exec appends to the
+			// statement's existing Vars and the batch query's own binds
+			// would still be there
+			return setWorkflowNames(db.WithContext(ctx), batch)
+		})
+	if res.Error != nil {
+		return fmt.Errorf("unable to backfill workflow names: %w", res.Error)
+	}
+
+	m.l.Info("backfilled workflow names", zap.Int64("rows", res.RowsAffected))
+
+	if err := db.WithContext(ctx).Exec(
+		`CREATE INDEX IF NOT EXISTS idx_install_workflows_name ON install_workflows (name)`,
+	).Error; err != nil {
+		return fmt.Errorf("unable to create idx_install_workflows_name: %w", err)
+	}
+
+	return nil
+}
+
+// one statement per batch, and never through Save/Updates — the hook would
+// recompute from the partially selected struct and updated_at would move on
+// every workflow in the table
+func setWorkflowNames(tx *gorm.DB, batch []app.Workflow) error {
+	tuples := make([]string, 0, len(batch))
+	args := make([]any, 0, len(batch)*2)
+	for i := range batch {
+		tuples = append(tuples, "(?::text, ?::text)")
+		args = append(args, batch[i].ID, batch[i].ComputeName())
+	}
+
+	sql := `UPDATE install_workflows AS w
+		SET name = v.name
+		FROM (VALUES ` + strings.Join(tuples, ", ") + `) AS v(id, name)
+		WHERE w.id = v.id`
+
+	if err := tx.Exec(sql, args...).Error; err != nil {
+		return fmt.Errorf("unable to set names for %d workflows: %w", len(batch), err)
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/all.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/all.go
@@ -148,5 +148,9 @@ func (m *Migrations) All() []migrations.Migration {
 			Name: "118-backfill-read-only-role",
 			Fn:   m.Migration118BackfillReadOnlyRole,
 		},
+		{
+			Name: "119-backfill-workflow-names",
+			Fn:   m.Migration119BackfillWorkflowNames,
+		},
 	}
 }


### PR DESCRIPTION
Migration 108's backfill left `install_workflows.name` NULL, and `deprovision_sandbox`, `teardown_component` and the `app_branches_*` types hit neither `Name()` nor `PastTenseName()`, so they fell back to the lowercased type string.

Adds migration 119 to recompute names for unnamed rows plus those types, reusing `Workflow.ComputeName()` instead of restating the title expression in SQL. Test asserts every declared workflow type has both titles.