### PR TITLE
chore: custom nested stacks: add support for templating

### DIFF
--- a/docs/guides/custom-nested-stacks.mdx
+++ b/docs/guides/custom-nested-stacks.mdx
@@ -76,7 +76,7 @@ ClusterName = "{{.nuon.install.inputs.cluster_name}}"
 | `name`         | `string`            | Yes      | Name of the nested stack. Used as the CloudFormation logical ID (converted to CamelCase) and parameter group label.                           |
 | `template_url` | `string`            | Yes      | S3 URL to the CloudFormation template YAML. Must be publicly accessible or accessible via the stack's execution role. Supports Go templating. |
 | `index`        | `int`               | Yes      | Execution order (ascending). Must be unique across all custom nested stacks.                                                                  |
-| `parameters`   | `map[string]string` | No       | Explicit parameter mappings from install inputs. See [Parameter Mapping](#parameter-mapping).                                                 |
+| `parameters`   | `map[string]string` | No       | Explicit parameter values. Supports Go templating. See [Parameter Mapping](#parameter-mapping).                                               |
 
 {/* prettier-ignore-start */}
 <Tip>
@@ -219,8 +219,8 @@ stacks define a parameter with the same name, `nuon apps sync` will fail with a 
 
 ## Parameter Mapping
 
-Use the `parameters` field to map a template parameter to an install input value. This is useful for passing
-customer-specific values from install inputs into your nested template without hoisting them to the CloudFormation UI.
+Use the `parameters` field to set a template parameter from your app config. This is useful for passing install-specific
+values into your nested template without hoisting them to the CloudFormation UI.
 
 ```toml
 [[custom_nested_stacks]]
@@ -232,12 +232,38 @@ index        = 0
 Namespaces = "{{.nuon.install.inputs.namespaces}}"
 ```
 
-Mapped parameters reference install inputs using the `{{.nuon.install.inputs.<name>}}` syntax. When a parameter is
-explicitly mapped:
+When a parameter is set explicitly:
 
-- Its value is resolved from the install's current inputs.
-- It is removed from the hoisted parameter set (not shown in the CloudFormation UI).
-- If the install input is not set, the parameter resolves to an empty string.
+- Its value is rendered when the install stack is generated.
+- It is removed from the hoisted parameter set (not shown in the CloudFormation UI). Because the value is resolved
+  before the customer applies the stack, it cannot be edited in the CloudFormation console.
+- If a referenced install input has no value, it resolves to that input's declared default (an empty string if it has
+  none).
+
+### Templating
+
+Parameter values are full Go templates with [sprig](https://masterminds.github.io/sprig/) functions available, so you
+can compose literals, branch on an optional input, or transform a value:
+
+```toml
+[custom_nested_stacks.parameters]
+# literal
+Environment = "production"
+# composed
+BucketName = "myapp-{{ .nuon.install.id }}-state"
+# conditional, with a derived fallback
+RootDomain = "{{ if .nuon.install.inputs.root_domain }}{{ .nuon.install.inputs.root_domain }}{{ else }}{{ .nuon.install.id | substr 0 15 }}.installs.example.com{{ end }}"
+```
+
+{/* prettier-ignore-start */}
+<Warning>
+Parameters are rendered **before** the customer applies the stack, so they can only reference state that exists at that
+point: `.nuon.install.inputs.*`, `.nuon.inputs.inputs.*`, `.nuon.install.id`, `.nuon.app.*` and `.nuon.org.*`.
+
+Sandbox outputs, component outputs, action outputs and install stack outputs are rejected when you sync your app config —
+they only exist after the stack has been applied. Reference those from component or sandbox vars instead.
+</Warning>
+{/* prettier-ignore-end */}
 
 ## Authoring Templates
 

--- a/pkg/config/app_stack.go
+++ b/pkg/config/app_stack.go
@@ -7,6 +7,10 @@ import (
 	"strings"
 
 	"github.com/invopop/jsonschema"
+
+	"github.com/nuonco/nuon/pkg/config/refs"
+	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/pkg/render"
 )
 
 // CustomNestedStackStatus describes whether a custom nested stack's template
@@ -48,9 +52,10 @@ func (a CustomNestedStack) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Long("Determines the execution order of custom nested stacks (ascending). Each stack must have a unique index. Lower indices execute first.").
 		Example("0").
 		Example("1").
-		Field("parameters").Short("parameter-to-input mappings").
-		Long("Map of CloudFormation parameter names to Nuon install input references. Values must use the template format {{.nuon.install.inputs.<input_name>}}. Only vendor-provided inputs are supported.").
-		Example("Namespaces = \"{{.nuon.install.inputs.namespaces}}\"")
+		Field("parameters").Short("parameter values").
+		Long("Map of nested stack parameter names to templated values. Values are rendered when the install stack is generated, so they may only reference state that exists at that point: " + availableStackParameterRefs + ". Sandbox, component, action and install stack outputs are not available.").
+		Example("Namespaces = \"{{.nuon.install.inputs.namespaces}}\"").
+		Example("RootDomain = \"{{ if .nuon.install.inputs.root_domain }}{{ .nuon.install.inputs.root_domain }}{{ else }}{{ .nuon.install.id }}.example.com{{ end }}\"")
 }
 
 // GCPCustomStackModuleMarker separates the repo address from the curated
@@ -155,12 +160,83 @@ func ValidateHTTPSURL(templateURL string, fieldName string) error {
 
 var installInputTemplatePattern = regexp.MustCompile(`^\{\{\s*\.nuon\.install\.inputs\.([a-zA-Z0-9_]+)\s*\}\}$`)
 
+// ParseInstallInputReference matches the single-install-input reference form,
+// {{.nuon.install.inputs.<input_name>}}, and returns the input name.
+//
+// Custom nested stack parameters are no longer limited to this form -- they are
+// rendered as full templates before the stack renderers see them (see
+// ValidateStackParameterTemplate). The stack renderers keep this as a fallback for
+// call paths that read config without rendering it first.
 func ParseInstallInputReference(value string) (string, error) {
 	matches := installInputTemplatePattern.FindStringSubmatch(value)
 	if matches == nil {
 		return "", fmt.Errorf("must be a template reference in the form {{.nuon.install.inputs.<input_name>}}, got %q", value)
 	}
 	return matches[1], nil
+}
+
+// RenderCustomNestedStackParameters renders each stack's parameter values in place.
+//
+// Parameters are rendered here rather than through the features:"template" tag on
+// the field because RenderStruct routes tagged fields through html/template, which
+// would escape "&" and quotes in a value that is bound for a cloud provider's API.
+func RenderCustomNestedStackParameters(stacks []CustomNestedStack, data map[string]any) error {
+	for i := range stacks {
+		if err := render.RenderTextStringMap(stacks[i].Parameters, data); err != nil {
+			return fmt.Errorf("custom_nested_stacks[%d] (%s): %w", i, stacks[i].Name, err)
+		}
+	}
+
+	return nil
+}
+
+// Custom nested stack parameters are rendered when the install stack is generated,
+// which happens before the customer applies the stack. References to anything that
+// only exists after that point cannot resolve, and because the renderer runs with
+// missingkey=error they do not render empty -- they fail the generate-install-stack
+// workflow at install create. Reject them at sync instead, where the vendor sees it.
+var disallowedStackParameterRefTypes = []refs.RefType{
+	refs.RefTypeSandbox,
+	refs.RefTypeComponents,
+	refs.RefTypeActions,
+	refs.RefTypeInstallStack,
+}
+
+// Legacy spellings of the same late-bound state. refs.ParseFieldRefs' patterns only
+// cover the flattened paths, so these are matched literally.
+var disallowedStackParameterPaths = []string{
+	"nuon.install.sandbox.",
+	"nuon.install.components.",
+	"nuon.install.actions.",
+}
+
+const availableStackParameterRefs = ".nuon.install.inputs.*, .nuon.inputs.inputs.*, .nuon.install.id, .nuon.app.*, .nuon.org.*"
+
+// ValidateStackParameterTemplate validates a custom nested stack parameter value: it
+// must be a parseable template that only references state which is populated when the
+// install stack is generated.
+func ValidateStackParameterTemplate(value string) error {
+	if value == "" {
+		return fmt.Errorf("must not be empty")
+	}
+
+	if err := render.ValidateTextTemplate(value); err != nil {
+		return fmt.Errorf("is not a valid template: %w", err)
+	}
+
+	for _, ref := range refs.ParseFieldRefs(value) {
+		if generics.SliceContains(ref.Type, disallowedStackParameterRefTypes) {
+			return fmt.Errorf("references %s, which is not populated when the install stack is generated; available: %s", ref.Input, availableStackParameterRefs)
+		}
+	}
+
+	for _, path := range disallowedStackParameterPaths {
+		if strings.Contains(value, path) {
+			return fmt.Errorf("references %s*, which is not populated when the install stack is generated; available: %s", path, availableStackParameterRefs)
+		}
+	}
+
+	return nil
 }
 
 var s3HostPattern = regexp.MustCompile(
@@ -245,7 +321,7 @@ func (a *StackConfig) parse() error {
 		}
 		seenIndices[stack.Index] = stack.Name
 		for paramName, paramValue := range stack.Parameters {
-			if _, err := ParseInstallInputReference(paramValue); err != nil {
+			if err := ValidateStackParameterTemplate(paramValue); err != nil {
 				return ErrConfig{
 					Description: fmt.Sprintf("custom_nested_stacks[%d] (%s): parameter %q: %s", i, stack.Name, paramName, err),
 					Err:         fmt.Errorf("custom_nested_stacks[%d] (%s): parameter %q: %w", i, stack.Name, paramName, err),

--- a/pkg/config/app_stack_test.go
+++ b/pkg/config/app_stack_test.go
@@ -195,6 +195,12 @@ func TestStackConfig_Parse_ValidParameters(t *testing.T) {
 				Parameters: map[string]string{
 					"Namespaces":  "{{.nuon.install.inputs.namespaces}}",
 					"ClusterName": "{{ .nuon.install.inputs.cluster_name }}",
+					// Parameter values are full templates: conditionals, sprig
+					// pipelines, composition with literals, and bare literals.
+					"RootDomain":  "{{ if .nuon.install.inputs.root_domain }}{{ .nuon.install.inputs.root_domain }}{{ else }}sandbox-{{ .nuon.install.id | substr 0 15 }}.installs.example.com{{ end }}",
+					"BucketName":  "vendor-{{ .nuon.install.id }}-service",
+					"Inputs":      "{{ .nuon.inputs.inputs.cluster_version }}",
+					"Environment": "production",
 				},
 			},
 		},
@@ -203,22 +209,40 @@ func TestStackConfig_Parse_ValidParameters(t *testing.T) {
 }
 
 func TestStackConfig_Parse_InvalidParameterValue(t *testing.T) {
-	cfg := &StackConfig{
-		CustomNestedStacks: []CustomNestedStack{
-			{
-				Name:        "my_stack",
-				TemplateURL: "https://s3.amazonaws.com/bucket/template.yaml",
-				Index:       0,
-				Parameters: map[string]string{
-					"Namespaces": "some-literal-value",
-				},
-			},
-		},
+	tests := []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{"unparseable template", "{{ if .nuon.install.inputs.foo }}no-end", "is not a valid template"},
+		{"unknown function", "{{ .nuon.install.inputs.foo | nope }}", "is not a valid template"},
+		{"empty value", "", "must not be empty"},
+		{"sandbox output", "{{ .nuon.sandbox.outputs.cluster }}", "is not populated when the install stack is generated"},
+		{"install stack output", "{{ .nuon.install_stack.outputs.region }}", "is not populated when the install stack is generated"},
+		{"component output", "{{ .nuon.components.nlb.outputs.dns_name }}", "is not populated when the install stack is generated"},
+		{"action output", "{{ .nuon.actions.setup.outputs.token }}", "is not populated when the install stack is generated"},
+		{"legacy sandbox output", "{{ .nuon.install.sandbox.outputs.nuon_dns.public_domain.zone_id }}", "is not populated when the install stack is generated"},
 	}
-	err := cfg.parse()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "parameter \"Namespaces\"")
-	assert.Contains(t, err.Error(), "must be a template reference")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &StackConfig{
+				CustomNestedStacks: []CustomNestedStack{
+					{
+						Name:        "my_stack",
+						TemplateURL: "https://s3.amazonaws.com/bucket/template.yaml",
+						Index:       0,
+						Parameters: map[string]string{
+							"Namespaces": tc.value,
+						},
+					},
+				},
+			}
+			err := cfg.parse()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "parameter \"Namespaces\"")
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
 }
 
 func TestStackConfig_Parse_EmptyParameters(t *testing.T) {

--- a/pkg/render/render_text.go
+++ b/pkg/render/render_text.go
@@ -1,0 +1,69 @@
+package render
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/Masterminds/sprig/v3"
+	"github.com/pkg/errors"
+)
+
+// RenderTextV2 does the same thing as RenderV2, but using "text/template" instead of "html/template", so special
+// characters are not escaped. Use it for values that end up in infrastructure APIs rather than in a browser: an input
+// value containing "&" or a quote renders as "&amp;" / "&#34;" through RenderV2, which silently corrupts things like
+// CloudFormation parameters.
+func RenderTextV2(inputVal string, data map[string]interface{}) (string, error) {
+	data = EnsurePrefix(data)
+
+	if !strings.Contains(inputVal, ".nuon") {
+		return inputVal, nil
+	}
+
+	temp, err := newTextTemplate(inputVal)
+	if err != nil {
+		return inputVal, err
+	}
+
+	buf := new(bytes.Buffer)
+	if err := temp.Execute(buf, data); err != nil {
+		return inputVal, fmt.Errorf("unable to execute template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// ValidateTextTemplate reports whether inputVal parses against the same function set RenderTextV2 executes with. Use it
+// to reject a bad template early (e.g. at config sync) instead of failing later at render time.
+func ValidateTextTemplate(inputVal string) error {
+	_, err := newTextTemplate(inputVal)
+	return err
+}
+
+func newTextTemplate(inputVal string) (*template.Template, error) {
+	funcMap := template.FuncMap{
+		"now": time.Now,
+	}
+
+	return template.New("input").
+		Funcs(funcMap).
+		Funcs(sprig.TxtFuncMap()).
+		Option("missingkey=error").
+		Parse(inputVal)
+}
+
+// RenderTextStringMap renders every value of m in place using RenderTextV2.
+func RenderTextStringMap(m map[string]string, data map[string]interface{}) error {
+	for key, val := range m {
+		rendered, err := RenderTextV2(val, data)
+		if err != nil {
+			return errors.Wrapf(err, "unable to render %q", key)
+		}
+
+		m[key] = rendered
+	}
+
+	return nil
+}

--- a/pkg/render/render_text_test.go
+++ b/pkg/render/render_text_test.go
@@ -1,0 +1,133 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// vendorRootDomain is the expression a vendor uses to derive a nested stack
+// parameter from an optional install input, falling back to a generated domain.
+const vendorRootDomain = `{{ if .nuon.install.inputs.root_domain }}{{ .nuon.install.inputs.root_domain }}{{ else }}sandbox-{{ .nuon.install.id | substr 0 15 }}.installs.vendor.app{{ end }}`
+
+func installData(inputs map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"install": map[string]interface{}{
+			"id":     "1a2b3c4d5e6f7g8h9i0j",
+			"inputs": inputs,
+		},
+	}
+}
+
+func TestRenderTextV2_ConditionalsAndPipelines(t *testing.T) {
+	t.Run("input set", func(t *testing.T) {
+		got, err := RenderTextV2(vendorRootDomain, installData(map[string]interface{}{
+			"root_domain": "lvbl.team.example.com",
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "lvbl.team.example.com", got)
+	})
+
+	t.Run("input empty falls back", func(t *testing.T) {
+		got, err := RenderTextV2(vendorRootDomain, installData(map[string]interface{}{
+			"root_domain": "",
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "sandbox-1a2b3c4d5e6f7g8.installs.vendor.app", got)
+	})
+
+	t.Run("substr is bounded by the string length", func(t *testing.T) {
+		data := map[string]interface{}{
+			"install": map[string]interface{}{
+				"id":     "short",
+				"inputs": map[string]interface{}{"root_domain": ""},
+			},
+		}
+		got, err := RenderTextV2(vendorRootDomain, data)
+		require.NoError(t, err)
+		assert.Equal(t, "sandbox-short.installs.vendor.app", got)
+	})
+}
+
+// The reason this renderer exists: RenderV2 uses html/template and escapes values
+// that are bound for infrastructure APIs, not browsers.
+func TestRenderTextV2_DoesNotEscape(t *testing.T) {
+	data := installData(map[string]interface{}{
+		"connection": `user=a&pass="b"<c>`,
+	})
+
+	got, err := RenderTextV2("{{ .nuon.install.inputs.connection }}", data)
+	require.NoError(t, err)
+	assert.Equal(t, `user=a&pass="b"<c>`, got)
+
+	escaped, err := RenderV2("{{ .nuon.install.inputs.connection }}", data)
+	require.NoError(t, err)
+	assert.NotEqual(t, got, escaped, "RenderV2 is expected to escape; if it stopped, this twin can go away")
+}
+
+func TestRenderTextV2_MissingKeyErrors(t *testing.T) {
+	_, err := RenderTextV2("{{ .nuon.install.inputs.nope }}", installData(map[string]interface{}{
+		"root_domain": "example.com",
+	}))
+	require.Error(t, err)
+}
+
+func TestRenderTextV2_PassesThroughWithoutNuonReference(t *testing.T) {
+	// Matches RenderV2's short-circuit: no ".nuon", no rendering.
+	got, err := RenderTextV2("{{ if true }}untouched{{ end }}", installData(nil))
+	require.NoError(t, err)
+	assert.Equal(t, "{{ if true }}untouched{{ end }}", got)
+}
+
+func TestValidateTextTemplate(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"conditional with pipeline", vendorRootDomain, false},
+		{"literal", "production", false},
+		{"unterminated if", "{{ if .nuon.install.inputs.foo }}no-end", true},
+		{"unknown function", "{{ .nuon.install.inputs.foo | nope }}", true},
+		{"sprig function", "{{ .nuon.install.id | trunc 8 }}", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTextTemplate(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRenderTextStringMap(t *testing.T) {
+	params := map[string]string{
+		"RootDomain":  vendorRootDomain,
+		"BucketName":  "vendor-{{ .nuon.install.id }}-service",
+		"Environment": "production",
+	}
+
+	require.NoError(t, RenderTextStringMap(params, installData(map[string]interface{}{
+		"root_domain": "",
+	})))
+
+	assert.Equal(t, map[string]string{
+		"RootDomain":  "sandbox-1a2b3c4d5e6f7g8.installs.vendor.app",
+		"BucketName":  "vendor-1a2b3c4d5e6f7g8h9i0j-service",
+		"Environment": "production",
+	}, params)
+}
+
+func TestRenderTextStringMap_ErrorNamesTheKey(t *testing.T) {
+	params := map[string]string{
+		"RootDomain": "{{ .nuon.install.inputs.nope }}",
+	}
+
+	err := RenderTextStringMap(params, installData(map[string]interface{}{}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RootDomain")
+}

--- a/services/ctl-api/internal/app/apps/service/create_app_stack_config.go
+++ b/services/ctl-api/internal/app/apps/service/create_app_stack_config.go
@@ -65,6 +65,13 @@ func (c *CreateAppStackConfigRequest) Validate(v *validator.Validate) error {
 		if stack.Contents == "" {
 			return fmt.Errorf("custom_nested_stacks[%d] (%s): contents is required when template_url is set", i, stack.Name)
 		}
+		// Also validated at config sync, but a bad parameter persisted here would
+		// fail stack generation for every install of the app.
+		for paramName, paramValue := range stack.Parameters {
+			if err := config.ValidateStackParameterTemplate(paramValue); err != nil {
+				return fmt.Errorf("custom_nested_stacks[%d] (%s): parameter %q: %w", i, stack.Name, paramName, err)
+			}
+		}
 	}
 	return nil
 }

--- a/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
+	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/pkg/render"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
@@ -133,6 +134,12 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 
 	if err := render.RenderStruct(&cfg.StackConfig, stateData); err != nil {
 		return errors.Wrap(err, "unable to render cloudformation stack config")
+	}
+
+	// Custom nested stack parameters are rendered separately so they do not go
+	// through html/template. The stack renderers below receive literal values.
+	if err := config.RenderCustomNestedStackParameters(cfg.StackConfig.CustomNestedStacks, stateData); err != nil {
+		return errors.Wrap(err, "unable to render custom nested stack parameters")
 	}
 
 	runner, err := activities.AwaitGetRunnerByID(ctx, install.RunnerID)

--- a/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
+++ b/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/pkg/render"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -96,6 +97,12 @@ func (w *Workflows) GenerateInstallStackVersion(ctx workflow.Context, sreq Gener
 
 	if err := render.RenderStruct(&cfg.StackConfig, stateData); err != nil {
 		return errors.Wrap(err, "unable to render cloudformation stack config")
+	}
+
+	// Custom nested stack parameters are rendered separately so they do not go
+	// through html/template. The stack renderers below receive literal values.
+	if err := config.RenderCustomNestedStackParameters(cfg.StackConfig.CustomNestedStacks, stateData); err != nil {
+		return errors.Wrap(err, "unable to render custom nested stack parameters")
 	}
 
 	runner, err := activities.AwaitGetRunnerByID(ctx, install.RunnerID)

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom.go
@@ -144,17 +144,19 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 			}
 		}
 
-		// Resolve explicit parameter mappings from install inputs
+		// Explicit parameter values. These arrive already rendered -- see
+		// config.RenderCustomNestedStackParameters, called when the install stack
+		// version is generated -- so they are used verbatim. The install-input
+		// reference form is still resolved here as a fallback for callers that read
+		// the config without rendering it first.
 		for cfnParamName, templateValue := range stack.Parameters {
-			inputName, err := config.ParseInstallInputReference(templateValue)
-			if err != nil {
-				return nil, nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): parameter %q: %w", i, stack.Name, cfnParamName, err)
-			}
-
-			resolved := ""
-			if inp.Install.CurrentInstallInputs != nil {
-				if val, ok := inp.Install.CurrentInstallInputs.Values[inputName]; ok && val != nil {
-					resolved = *val
+			resolved := templateValue
+			if inputName, err := config.ParseInstallInputReference(templateValue); err == nil {
+				resolved = ""
+				if inp.Install.CurrentInstallInputs != nil {
+					if val, ok := inp.Install.CurrentInstallInputs.Values[inputName]; ok && val != nil {
+						resolved = *val
+					}
 				}
 			}
 

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom_test.go
@@ -1,0 +1,123 @@
+package arm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/pkg/config"
+	"github.com/nuonco/nuon/pkg/types/state"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
+)
+
+const mockARMCustomTemplateJSON = `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "rootDomain": { "type": "string" }
+  },
+  "resources": [],
+  "outputs": {
+    "zoneName": { "type": "string", "value": "[parameters('rootDomain')]" }
+  }
+}`
+
+func armCustomStackInput(t *testing.T, serverURL string, parameters map[string]string) *stacks.TemplateInput {
+	t.Helper()
+
+	inp := minimalTemplateInput()
+	inp.AppCfg.StackConfig.CustomNestedStacks = []config.CustomNestedStack{
+		{
+			Name:        "route53_zones",
+			TemplateURL: serverURL + "/stack.json",
+			Index:       0,
+			Parameters:  parameters,
+		},
+	}
+
+	return inp
+}
+
+// ARM had no coverage for explicit parameter values. Both forms are exercised: a
+// pre-rendered literal (the current path) and the legacy install-input reference
+// (the fallback for callers that read config without rendering it).
+func TestGetCustomLinkedDeployments_ExplicitParameters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(mockARMCustomTemplateJSON))
+	}))
+	defer server.Close()
+
+	t.Run("rendered literal passes through", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armCustomStackInput(t, server.URL, map[string]string{
+			"rootDomain": "lvbl.team.example.com",
+		})
+
+		resources, hoisted, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+
+		assert.Equal(t, "lvbl.team.example.com", armDeploymentParamValue(t, resources[0], "rootDomain"))
+		assert.NotContains(t, hoisted, "rootDomain")
+	})
+
+	t.Run("legacy install input reference still resolves", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armCustomStackInput(t, server.URL, map[string]string{
+			"rootDomain": "{{.nuon.install.inputs.root_domain}}",
+		})
+		val := "legacy.example.com"
+		inp.Install.CurrentInstallInputs = &app.InstallInputs{
+			Values: pgtype.Hstore{"root_domain": &val},
+		}
+
+		resources, _, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+
+		assert.Equal(t, "legacy.example.com", armDeploymentParamValue(t, resources[0], "rootDomain"))
+	})
+
+	t.Run("templated value renders from install state", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armCustomStackInput(t, server.URL, map[string]string{
+			"rootDomain": `{{ if .nuon.install.inputs.root_domain }}{{ .nuon.install.inputs.root_domain }}{{ else }}{{ .nuon.install.id }}.example.com{{ end }}`,
+		})
+
+		st := state.New()
+		st.ID = inp.Install.ID
+		st.Inputs = &state.InputsState{Populated: true, Inputs: map[string]string{"root_domain": ""}}
+		st.Install = &state.InstallState{Populated: true, ID: st.ID, Inputs: st.Inputs.Inputs}
+		data, err := st.AsMap()
+		require.NoError(t, err)
+
+		require.NoError(t, config.RenderCustomNestedStackParameters(inp.AppCfg.StackConfig.CustomNestedStacks, data))
+
+		resources, _, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+
+		assert.Equal(t, inp.Install.ID+".example.com", armDeploymentParamValue(t, resources[0], "rootDomain"))
+	})
+}
+
+func armDeploymentParamValue(t *testing.T, resource any, name string) any {
+	t.Helper()
+
+	res, ok := resource.(map[string]any)
+	require.True(t, ok, "resource is not a map")
+	props, ok := res["properties"].(map[string]any)
+	require.True(t, ok, "properties is not a map")
+	params, ok := props["parameters"].(map[string]any)
+	require.True(t, ok, "parameters is not a map")
+	entry, ok := params[name].(map[string]any)
+	require.True(t, ok, "parameter %q not found in %v", name, params)
+
+	return entry["value"]
+}

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_custom.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_custom.go
@@ -217,17 +217,19 @@ func (tpl *Templates) buildCustomNestedStack(inp *stacks.TemplateInput, stack co
 		}
 	}
 
-	// Resolve explicit parameter mappings from install inputs
+	// Explicit parameter values. These arrive already rendered -- see
+	// config.RenderCustomNestedStackParameters, called when the install stack
+	// version is generated -- so they are used verbatim. The install-input
+	// reference form is still resolved here as a fallback for callers that read the
+	// config without rendering it first.
 	for cfnParamName, templateValue := range stack.Parameters {
-		inputName, err := config.ParseInstallInputReference(templateValue)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("parameter %q: %w", cfnParamName, err)
-		}
-
-		resolved := ""
-		if inp.Install.CurrentInstallInputs != nil {
-			if val, ok := inp.Install.CurrentInstallInputs.Values[inputName]; ok && val != nil {
-				resolved = *val
+		resolved := templateValue
+		if inputName, err := config.ParseInstallInputReference(templateValue); err == nil {
+			resolved = ""
+			if inp.Install.CurrentInstallInputs != nil {
+				if val, ok := inp.Install.CurrentInstallInputs.Values[inputName]; ok && val != nil {
+					resolved = *val
+				}
 			}
 		}
 

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_custom_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_custom_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nuonco/nuon/pkg/config"
+	"github.com/nuonco/nuon/pkg/types/state"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
@@ -1262,4 +1263,98 @@ func TestSanitizeLogicalID(t *testing.T) {
 			assert.Equal(t, tc.expected, sanitizeLogicalID(tc.input))
 		})
 	}
+}
+
+// installStateData builds the render context the way the install state does, mirroring
+// helpers.MapLegacyFields: .nuon.install.id and .nuon.install.inputs.* are the legacy
+// projections of the flattened state.
+func installStateData(t *testing.T, installID string, inputs map[string]string) map[string]any {
+	t.Helper()
+
+	st := state.New()
+	st.ID = installID
+	st.Inputs = &state.InputsState{Populated: true, Inputs: inputs}
+	st.Install = &state.InstallState{Populated: true, ID: st.ID, Inputs: st.Inputs.Inputs}
+
+	data, err := st.AsMap()
+	require.NoError(t, err)
+
+	return data
+}
+
+// The full chain a vendor sees: a templated parameter is rendered from install state
+// when the stack version is generated, then lands in the nested stack properties as a
+// literal. Both branches of the conditional are exercised.
+func TestGetCustomNestedStacks_ParameterRenderedFromInstallState(t *testing.T) {
+	const rootDomainParam = `{{ if .nuon.install.inputs.root_domain }}{{ .nuon.install.inputs.root_domain }}{{ else }}sandbox-{{ .nuon.install.id | substr 0 15 }}.example.com{{ end }}`
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"input set", "vendor.team.example.com", "vendor.team.example.com"},
+		{"input unset falls back", "", "sandbox-1a2b3c4d5e6f7g8.example.com"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(mockAdditionalTemplateNamespacesOnlyYAML))
+			}))
+			defer server.Close()
+
+			tpl := &Templates{cfg: &internal.Config{}}
+			inp := newTestInput(server.URL, []config.CustomNestedStack{
+				{
+					Name:        "route53_zones",
+					TemplateURL: server.URL + "/stack.yaml",
+					Index:       0,
+					Parameters: map[string]string{
+						"Namespaces": rootDomainParam,
+					},
+				},
+			})
+			inp.Install.ID = "1a2b3c4d5e6f7g8h9i0j"
+
+			data := installStateData(t, inp.Install.ID, map[string]string{"root_domain": tc.input})
+			require.NoError(t, config.RenderCustomNestedStackParameters(inp.AppCfg.StackConfig.CustomNestedStacks, data))
+
+			tb := tagBuilder{installID: inp.Install.ID}
+			result, err := tpl.getCustomNestedStacks(inp, tb, map[string]bool{"VPC": true, "RunnerAutoScalingGroup": true})
+			require.NoError(t, err)
+
+			stack := result.resources["Route53Zones"]
+			require.NotNil(t, stack)
+			assert.Equal(t, tc.want, stack.Parameters["Namespaces"])
+			assert.NotContains(t, result.params, "Namespaces")
+		})
+	}
+}
+
+// A value with no template actions is used verbatim, including characters that
+// html/template would have escaped.
+func TestGetCustomNestedStacks_LiteralParameterPassesThrough(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(mockAdditionalTemplateNamespacesOnlyYAML))
+	}))
+	defer server.Close()
+
+	tpl := &Templates{cfg: &internal.Config{}}
+	inp := newTestInput(server.URL, []config.CustomNestedStack{
+		{
+			Name:        "my_stack",
+			TemplateURL: server.URL + "/stack.yaml",
+			Index:       0,
+			Parameters: map[string]string{
+				"Namespaces": `user=a&pass="b"`,
+			},
+		},
+	})
+	tb := tagBuilder{installID: inp.Install.ID}
+
+	result, err := tpl.getCustomNestedStacks(inp, tb, map[string]bool{"VPC": true, "RunnerAutoScalingGroup": true})
+	require.NoError(t, err)
+
+	assert.Equal(t, `user=a&pass="b"`, result.resources["MyStack"].Parameters["Namespaces"])
 }

--- a/services/ctl-api/internal/pkg/stacks/gcp/render.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/render.go
@@ -157,14 +157,17 @@ func Render(inputs *stacks.TemplateInput) ([]byte, string, error) {
 		}
 		params := map[string]string{}
 		for paramName, templateValue := range stack.Parameters {
-			inputName, err := config.ParseInstallInputReference(templateValue)
-			if err != nil {
-				return nil, "", errors.Wrapf(err, "custom_nested_stacks (%s): parameter %q", stack.Name, paramName)
-			}
-			resolved := inputDefaults[inputName]
-			if inputs.Install.CurrentInstallInputs != nil {
-				if val, ok := inputs.Install.CurrentInstallInputs.Values[inputName]; ok && val != nil {
-					resolved = *val
+			// Already rendered -- see config.RenderCustomNestedStackParameters,
+			// called when the install stack version is generated. The
+			// install-input reference form is still resolved here as a fallback
+			// for callers that read the config without rendering it first.
+			resolved := templateValue
+			if inputName, err := config.ParseInstallInputReference(templateValue); err == nil {
+				resolved = inputDefaults[inputName]
+				if inputs.Install.CurrentInstallInputs != nil {
+					if val, ok := inputs.Install.CurrentInstallInputs.Values[inputName]; ok && val != nil {
+						resolved = *val
+					}
 				}
 			}
 			params[paramName] = resolved


### PR DESCRIPTION
### Description 

the inputs for the custom nested stacks had very limited support for
inputs. these were implemented in a naive way and only supported
single inputs. this PR fixes that by adding support for templating to
theses inputs.

these are still very limited. we can only really use the install id and
any inputs that are present when the install is created. however for our
purposes, these limitations are acceptable as they are used sparingly
and need only the most basic facts (at least for now).
