### PR TITLE
fix: make install resource states view filterable

### DIFF
--- a/services/ctl-api/internal/pkg/db/viewsql/install_component_resource_states_view_v1.sql
+++ b/services/ctl-api/internal/pkg/db/viewsql/install_component_resource_states_view_v1.sql
@@ -1,23 +1,31 @@
-WITH ranked_resource_states AS (
-    SELECT
-        s.*,
-        ROW_NUMBER() OVER (
-            PARTITION BY s.install_id,
-            s.install_component_id,
-            s.provider,
-            s.api_group,
-            s.kind,
-            s.namespace,
-            s.name
-            ORDER BY
-                s.observed_at DESC
-        ) AS row_num
-    FROM
-        install_component_resource_states AS s
-)
+-- argMax rather than ROW_NUMBER() OVER: ClickHouse cannot push a WHERE predicate through a
+-- window function, so a ranked view full-scans the whole table on every filtered read.
 SELECT
-    *
+    s.org_id AS org_id,
+    s.install_id AS install_id,
+    s.install_component_id AS install_component_id,
+    s.provider AS provider,
+    s.api_group AS api_group,
+    s.kind AS kind,
+    s.namespace AS namespace,
+    s.name AS name,
+    argMax(s.component_id, s.observed_at) AS component_id,
+    argMax(s.runner_id, s.observed_at) AS runner_id,
+    argMax(s.source, s.observed_at) AS source,
+    argMax(s.owner_name, s.observed_at) AS owner_name,
+    argMax(s.health, s.observed_at) AS health,
+    argMax(s.message, s.observed_at) AS message,
+    argMax(s.native_status, s.observed_at) AS native_status,
+    argMax(s.details, s.observed_at) AS details,
+    max(s.observed_at) AS observed_at
 FROM
-    ranked_resource_states
-WHERE
-    row_num = 1;
+    install_component_resource_states AS s
+GROUP BY
+    s.org_id,
+    s.install_id,
+    s.install_component_id,
+    s.provider,
+    s.api_group,
+    s.kind,
+    s.namespace,
+    s.name;


### PR DESCRIPTION
`GET /v1/installs/{install_id}/resources` was taking 3.3s in prod. The latest-state view ranked rows with `ROW_NUMBER() OVER (PARTITION BY ...)`, and ClickHouse can't push a WHERE predicate through a window function — so every request full-scanned the table (356k rows / 309 MiB / 378 MiB peak RAM) to return 69 rows, regardless of which install was asked for. The ingest path reads the same view on every runner report, so writes were slowing their own reads.

Rewritten as `argMax` + `GROUP BY`, which does accept pushdown. Measured in prod: 3.32s → 0.13s, peak RAM 378 MiB → 33 MiB, and byte-identical results (diffed all 17 columns against the old view, 0 rows differing). Verified the view creates via the migration template on stage and exposes the same column set; `AlwaysReapply` means it recreates on deploy.