### PR TITLE
fix: dont skip inputs state update

### DIFF
--- a/services/ctl-api/internal/app/installs/workflows/v2/component_toggle.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/component_toggle.go
@@ -37,7 +37,14 @@ func stateInputsRefreshStep(ctx workflow.Context, sg *stepGroup, install *app.In
 		stateSignal = &generatestate.Signal{InstallID: install.ID}
 	}
 
-	return sg.installSignalStep(ctx, install.ID, "update install state inputs", pgtype.Hstore{}, stateSignal, planOnly, WithSkippable(false))
+	return sg.installSignalStep(
+		ctx,
+		install.ID,
+		"update install state inputs",
+		pgtype.Hstore{},
+		stateSignal, planOnly,
+		WithSkippable(false),
+	)
 }
 
 // ComponentEnabledSteps and ComponentDisabledSteps back the dedicated

--- a/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/update_input.go
@@ -25,7 +25,7 @@ func InputUpdate(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRes
 	sg := newStepGroup(flw)
 	steps := make([]*app.WorkflowStep, 0)
 
-	sg.nextGroup() // refresh inputs partial in state
+	sg.nextGroupEager() // refresh inputs partial in state
 	step, err := stateInputsRefreshStep(ctx, sg, install, flw.PlanOnly)
 	if err != nil {
 		return nil, err

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
@@ -430,6 +430,8 @@ func (s *Signal) handle(ctx workflow.Context, startFromGroupIdx int) error {
 		}
 	}
 
+	var eagerExecuted map[int]bool
+
 	for gi := startFromGroupIdx; gi < len(groups); gi++ {
 		if s.cancelRequested {
 			s.markRemainingGroupStepsDiscarded(ctx, l, groups, gi-1)
@@ -440,6 +442,10 @@ func (s *Signal) handle(ctx workflow.Context, startFromGroupIdx int) error {
 		group := &groups[gi]
 
 		if s.Resident && !residentPending[group.GroupIdx] {
+			continue
+		}
+
+		if eagerExecuted[group.GroupIdx] {
 			continue
 		}
 
@@ -562,6 +568,11 @@ func (s *Signal) handle(ctx workflow.Context, startFromGroupIdx int) error {
 			}
 			flw = completedFlw
 
+			eagerExecuted = make(map[int]bool, gi+1)
+			for i := 0; i <= gi && i < len(groups); i++ {
+				eagerExecuted[groups[i].GroupIdx] = true
+			}
+
 			// Check for cancellation before overwriting status. The cancel
 			// handler may have set StatusCancelled while we were waiting for
 			// step generation to complete.
@@ -596,6 +607,16 @@ func (s *Signal) handle(ctx workflow.Context, startFromGroupIdx int) error {
 					})
 				}
 			}
+
+			// Eager groups can sit mid-list in group_idx order; rewind so groups ordered before them are not skipped.
+			next := len(groups)
+			for i := range groups {
+				if !eagerExecuted[groups[i].GroupIdx] {
+					next = i
+					break
+				}
+			}
+			gi = next - 1
 		}
 
 		// ContinueAsNew every 5 groups to bound workflow history


### PR DESCRIPTION
when a input affects sandbox, we add input state hint at the start, but the sandbox eager steps due to it being eager causes workflow to start from group 1 and skip out on state update entirely. 

This pr fixes that issue and runs input state hint along with eager steps.