### PR TITLE
fix: confirm runner failures before alerting

### DIFF
--- a/services/ctl-api/internal/app/runner.go
+++ b/services/ctl-api/internal/app/runner.go
@@ -28,6 +28,8 @@ const (
 	RunnerStatusUnknown RunnerStatus = "unknown"
 )
 
+const RunnerHealthCheckConsecutiveFailuresMetadataKey = "runner_healthcheck_consecutive_failures"
+
 func (r RunnerStatus) String() string {
 	return string(r)
 }

--- a/services/ctl-api/internal/app/runners/signals/processinit/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/processinit/signal.go
@@ -55,6 +55,11 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to get runner process")
 	}
+	metadata := make(map[string]any)
+	switch process.Type {
+	case app.RunnerProcessTypeInstall, app.RunnerProcessTypeBuild, app.RunnerProcessTypeOrg:
+		metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey] = 0
+	}
 
 	// Only transition pending processes to active
 	if process.ProcessStatus() != app.RunnerProcessStatus(app.StatusPending) {
@@ -79,11 +84,14 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	}); err != nil {
 		return errors.Wrap(err, "unable to update runner status")
 	}
-	statusactivities.AwaitUpdateRunnerStatusV2(ctx, statusactivities.UpdateRunnerStatusV2Request{
+	if err := statusactivities.AwaitUpdateRunnerStatusV2(ctx, statusactivities.UpdateRunnerStatusV2Request{
 		RunnerID:          s.RunnerID,
 		Status:            app.RunnerStatusActive,
 		StatusDescription: "process initialized",
-	})
+		Metadata:          metadata,
+	}); err != nil {
+		l.Warn("unable to update runner status v2", "error", err)
+	}
 
 	l.Info("process initialized", "runner_id", s.RunnerID, "process_id", s.ProcessID)
 

--- a/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal.go
@@ -2,6 +2,7 @@ package runnerhealthcheck
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -119,17 +120,19 @@ func (s *Signal) checkOrgRunner(ctx workflow.Context, l *zap.Logger, tmw tmetric
 			)
 			tags["missing_build_process"] = "true"
 			tmw.Incr(ctx, "runner.health_check", metrics.ToTags(tags, metrics.ToTag("result", "unhealthy"))...)
+			status, metadata := runnerStatusAfterHealthCheck(runner, app.RunnerStatusOffline, nil)
 			ownerName := runner.Org.Name
-			if runner.Status == app.RunnerStatusActive {
+			if runner.Status == app.RunnerStatusActive && status == app.RunnerStatusOffline {
 				ownerName = s.emitOfflineEvent(ctx, runner, "no active build process")
 			}
-			return s.updateRunnerStatus(ctx, runner, app.RunnerStatusOffline, "no active build process", ownerName, nil)
+			return s.updateRunnerStatus(ctx, runner, status, "no active build process", ownerName, metadata)
 		}
 		return errors.Wrap(err, "unable to get current build process")
 	}
 
 	tmw.Incr(ctx, "runner.health_check", metrics.ToTags(tags, metrics.ToTag("result", "healthy"))...)
-	return s.updateRunnerStatus(ctx, runner, app.RunnerStatusActive, "runner healthy", runner.Org.Name, nil)
+	status, metadata := runnerStatusAfterHealthCheck(runner, app.RunnerStatusActive, nil)
+	return s.updateRunnerStatus(ctx, runner, status, "runner healthy", runner.Org.Name, metadata)
 }
 
 func (s *Signal) checkInstallRunner(ctx workflow.Context, l *zap.Logger, tmw tmetrics.Writer, runner *app.Runner, tags map[string]string) error {
@@ -189,12 +192,51 @@ func (s *Signal) checkInstallRunner(ctx workflow.Context, l *zap.Logger, tmw tme
 		tmw.Incr(ctx, "runner.health_check", metrics.ToTags(tags, metrics.ToTag("result", "healthy"))...)
 	} else {
 		tmw.Incr(ctx, "runner.health_check", metrics.ToTags(tags, metrics.ToTag("result", "unhealthy"))...)
-		if runner.Status == app.RunnerStatusActive {
-			ownerName = s.emitOfflineEvent(ctx, runner, description)
-		}
+	}
+
+	status, metadata = runnerStatusAfterHealthCheck(runner, status, metadata)
+	if runner.Status == app.RunnerStatusActive && status == app.RunnerStatusOffline {
+		ownerName = s.emitOfflineEvent(ctx, runner, description)
 	}
 
 	return s.updateRunnerStatus(ctx, runner, status, description, ownerName, metadata)
+}
+
+func runnerStatusAfterHealthCheck(runner *app.Runner, status app.RunnerStatus, metadata map[string]any) (app.RunnerStatus, map[string]any) {
+	if metadata == nil {
+		metadata = make(map[string]any)
+	}
+
+	if status == app.RunnerStatusActive {
+		metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey] = 0
+		return status, metadata
+	}
+	if status != app.RunnerStatusOffline {
+		return status, metadata
+	}
+
+	failures := runnerHealthCheckFailures(runner.StatusV2.Metadata) + 1
+	if runner.Status == app.RunnerStatusOffline && failures < 2 {
+		failures = 2
+	}
+	if failures > 2 {
+		failures = 2
+	}
+	metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey] = failures
+
+	if runner.Status != app.RunnerStatusOffline && failures < 2 {
+		return runner.Status, metadata
+	}
+
+	return status, metadata
+}
+
+func runnerHealthCheckFailures(metadata map[string]any) int {
+	failures, err := strconv.Atoi(fmt.Sprint(metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey]))
+	if err != nil || failures < 0 {
+		return 0
+	}
+	return failures
 }
 
 func (s *Signal) emitOfflineEvent(ctx workflow.Context, runner *app.Runner, reason string) string {
@@ -284,12 +326,14 @@ func (s *Signal) updateRunnerStatus(ctx workflow.Context, runner *app.Runner, st
 		}
 	}
 
-	statusactivities.LocalAwaitUpdateRunnerStatusV2(ctx, statusactivities.UpdateRunnerStatusV2Request{
+	if err := statusactivities.LocalAwaitUpdateRunnerStatusV2(ctx, statusactivities.UpdateRunnerStatusV2Request{
 		RunnerID:          s.RunnerID,
 		Status:            status,
 		StatusDescription: description,
 		Metadata:          metadata,
-	})
+	}); err != nil {
+		return errors.Wrap(err, "unable to update runner status v2")
+	}
 
 	return nil
 }

--- a/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal_test.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal_test.go
@@ -15,11 +15,11 @@ import (
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
-func TestUpdateRunnerStatusEnqueuesUnhealthyAfterOfflineTransition(t *testing.T) {
+func TestSecondFailedHealthCheckEnqueuesUnhealthyAfterOfflineTransition(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
 
-	runner := testRunner(app.RunnerStatusActive)
+	runner := runnerWithHealthCheckFailures(app.RunnerStatusActive, float64(1))
 	sig := &Signal{RunnerID: runner.ID}
 	var calls []string
 
@@ -39,12 +39,34 @@ func TestUpdateRunnerStatusEnqueuesUnhealthyAfterOfflineTransition(t *testing.T)
 		Once()
 
 	env.ExecuteWorkflow(func(ctx workflow.Context) error {
-		return sig.updateRunnerStatus(ctx, runner, app.RunnerStatusOffline, "no active build process", runner.Org.Name, nil)
+		status, metadata := runnerStatusAfterHealthCheck(runner, app.RunnerStatusOffline, nil)
+		return sig.updateRunnerStatus(ctx, runner, status, "no active build process", runner.Org.Name, metadata)
 	})
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
 	require.Equal(t, []string{"status", "notification", "status-v2"}, calls)
+	env.AssertExpectations(t)
+}
+
+func TestFirstFailedHealthCheckDoesNotMarkRunnerOffline(t *testing.T) {
+	var workflowSuite testsuite.WorkflowTestSuite
+	env := workflowSuite.NewTestWorkflowEnvironment()
+
+	runner := testRunner(app.RunnerStatusActive)
+	sig := &Signal{RunnerID: runner.ID}
+
+	env.OnActivity((*statusactivities.Activities).UpdateRunnerStatusV2, mock.MatchedBy(func(req statusactivities.UpdateRunnerStatusV2Request) bool {
+		return req.Status == app.RunnerStatusActive && req.Metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey] == 1
+	})).Return(nil).Once()
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		status, metadata := runnerStatusAfterHealthCheck(runner, app.RunnerStatusOffline, nil)
+		return sig.updateRunnerStatus(ctx, runner, status, "no active install process", runner.Org.Name, metadata)
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
 	env.AssertExpectations(t)
 }
 
@@ -88,6 +110,73 @@ func TestUpdateRunnerStatusDoesNotEnqueueWhenOfflineUpdateFails(t *testing.T) {
 	env.AssertExpectations(t)
 }
 
+func TestRunnerStatusAfterHealthCheck(t *testing.T) {
+	tests := map[string]struct {
+		runner         *app.Runner
+		status         app.RunnerStatus
+		metadata       map[string]any
+		expectedStatus app.RunnerStatus
+		expectedCount  int
+	}{
+		"first failed check keeps active runner active": {
+			runner:         testRunner(app.RunnerStatusActive),
+			status:         app.RunnerStatusOffline,
+			expectedStatus: app.RunnerStatusActive,
+			expectedCount:  1,
+		},
+		"second consecutive failed check marks runner offline": {
+			runner:         runnerWithHealthCheckFailures(app.RunnerStatusActive, float64(1)),
+			status:         app.RunnerStatusOffline,
+			expectedStatus: app.RunnerStatusOffline,
+			expectedCount:  2,
+		},
+		"healthy check resets the failure count": {
+			runner:         runnerWithHealthCheckFailures(app.RunnerStatusActive, int64(1)),
+			status:         app.RunnerStatusActive,
+			expectedStatus: app.RunnerStatusActive,
+			expectedCount:  0,
+		},
+		"offline runner remains offline without exceeding threshold": {
+			runner:         testRunner(app.RunnerStatusOffline),
+			status:         app.RunnerStatusOffline,
+			expectedStatus: app.RunnerStatusOffline,
+			expectedCount:  2,
+		},
+		"existing metadata is preserved": {
+			runner:         testRunner(app.RunnerStatusActive),
+			status:         app.RunnerStatusActive,
+			metadata:       map[string]any{"missing_mng_process": true},
+			expectedStatus: app.RunnerStatusActive,
+			expectedCount:  0,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			status, metadata := runnerStatusAfterHealthCheck(tt.runner, tt.status, tt.metadata)
+
+			require.Equal(t, tt.expectedStatus, status)
+			require.Equal(t, tt.expectedCount, metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey])
+			if tt.metadata != nil {
+				require.Equal(t, true, metadata["missing_mng_process"])
+			}
+		})
+	}
+}
+
+func TestHealthyCheckBreaksFailureStreak(t *testing.T) {
+	runner := runnerWithHealthCheckFailures(app.RunnerStatusActive, float64(1))
+
+	status, metadata := runnerStatusAfterHealthCheck(runner, app.RunnerStatusActive, nil)
+	require.Equal(t, app.RunnerStatusActive, status)
+	require.Equal(t, 0, metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey])
+
+	runner.StatusV2.Metadata = metadata
+	status, metadata = runnerStatusAfterHealthCheck(runner, app.RunnerStatusOffline, nil)
+	require.Equal(t, app.RunnerStatusActive, status)
+	require.Equal(t, 1, metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey])
+}
+
 func testRunner(status app.RunnerStatus) *app.Runner {
 	return &app.Runner{
 		ID:          "rnr_1",
@@ -104,4 +193,12 @@ func testRunner(status app.RunnerStatus) *app.Runner {
 			OwnerType: "installs",
 		},
 	}
+}
+
+func runnerWithHealthCheckFailures(status app.RunnerStatus, failures any) *app.Runner {
+	runner := testRunner(status)
+	runner.StatusV2.Metadata = map[string]any{
+		app.RunnerHealthCheckConsecutiveFailuresMetadataKey: failures,
+	}
+	return runner
 }


### PR DESCRIPTION
## Summary

Runner health alerts now require two consecutive failed checks of the required process. A successful check or required-process initialization clears the pending failure.

## What you can do after this PR

**Avoid alerts during routine runner restarts.** The first missed check keeps the runner active and records the failure. A second consecutive miss transitions the runner offline and sends the existing Datadog event, Slack notification, and webhook.
