### PR TITLE
feat: suppress noisey runner logs

### DIFF
--- a/bins/runner/cmd/cli.go
+++ b/bins/runner/cmd/cli.go
@@ -32,6 +32,7 @@ func (c *cli) commonProviders() []fx.Option {
 		fx.Provide(slog.AsSystemProvider(slog.NewSystemProvider)),
 		fx.Provide(log.AsSystemLogger(log.NewSystem)),
 		fx.Provide(log.AsDevLogger(log.NewDev)),
+		fx.WithLogger(log.NewFXLog),
 		fx.Provide(errs.NewRecorder),
 		// auth: fetch token via IMDS (or use existing token from env)
 		fx.Provide(auth.New),

--- a/bins/runner/internal/registry/config.go
+++ b/bins/runner/internal/registry/config.go
@@ -16,8 +16,6 @@ func (r *Registry) getConfig(port int) *configuration.Configuration {
 
 	// basic parameters for listening/logging
 	cfg.Log.Level = "info"
-	// the registry is a localhost-only cache, so per-request access logs are pure noise
-	cfg.Log.AccessLog.Disabled = true
 	cfg.HTTP.Addr = fmt.Sprintf(":%d", port)
 	cfg.HTTP.Host = "localhost"
 

--- a/bins/runner/internal/registry/config.go
+++ b/bins/runner/internal/registry/config.go
@@ -16,6 +16,8 @@ func (r *Registry) getConfig(port int) *configuration.Configuration {
 
 	// basic parameters for listening/logging
 	cfg.Log.Level = "info"
+	// the registry is a localhost-only cache, so per-request access logs are pure noise
+	cfg.Log.AccessLog.Disabled = true
 	cfg.HTTP.Addr = fmt.Sprintf(":%d", port)
 	cfg.HTTP.Host = "localhost"
 

--- a/bins/runner/internal/registry/registry.go
+++ b/bins/runner/internal/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"os"
 
 	ociregistry "github.com/distribution/distribution/v3/registry"
 	"github.com/sourcegraph/conc"
@@ -37,6 +38,13 @@ func New(params Params) (*Registry, error) {
 		cfg:      params.Cfg,
 		ctx:      ctx,
 		cancelFn: cancelFn,
+	}
+
+	// distribution inits otel unconditionally inside NewRegistry with no config knob to disable it,
+	// and autoexport defaults to an OTLP exporter at localhost:4318 that logs a connection-refused
+	// error on every flush. We run no collector and never consume its spans, so turn it off.
+	if os.Getenv("OTEL_TRACES_EXPORTER") == "" {
+		os.Setenv("OTEL_TRACES_EXPORTER", "none")
 	}
 
 	cfg := reg.getConfig(params.Cfg.RegistryPort)

--- a/pkg/kube/cluster_info.go
+++ b/pkg/kube/cluster_info.go
@@ -71,6 +71,18 @@ func (c *ClusterInfo) WithGCPAuth(auth *gcpcredentials.Config) {
 	c.GCPAuth = auth
 }
 
+// client-go defaults to 5 QPS / 10 burst, which throttles helm and discovery fan-out.
+const (
+	restConfigQPS   = 50
+	restConfigBurst = 100
+)
+
+func withRateLimits(cfg *rest.Config) *rest.Config {
+	cfg.QPS = restConfigQPS
+	cfg.Burst = restConfigBurst
+	return cfg
+}
+
 func ConfigForCluster(ctx context.Context, cInfo *ClusterInfo) (*rest.Config, error) {
 	if cInfo.KubeConfig != "" {
 		config, err := clientcmd.RESTConfigFromKubeConfig([]byte(cInfo.KubeConfig))
@@ -78,7 +90,7 @@ func ConfigForCluster(ctx context.Context, cInfo *ClusterInfo) (*rest.Config, er
 			return nil, fmt.Errorf("unable to parse kube config: %w", err)
 		}
 
-		return config, nil
+		return withRateLimits(config), nil
 	}
 
 	if cInfo.AWSAuth == nil && cInfo.AzureAuth == nil && cInfo.GCPAuth == nil {
@@ -239,5 +251,5 @@ func ConfigForCluster(ctx context.Context, cInfo *ClusterInfo) (*rest.Config, er
 		}
 	}
 
-	return cfg, nil
+	return withRateLimits(cfg), nil
 }

--- a/pkg/runner/log/fx.go
+++ b/pkg/runner/log/fx.go
@@ -1,6 +1,25 @@
 package log
 
-import "go.uber.org/fx"
+import (
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type FXParams struct {
+	fx.In
+
+	L *zap.Logger `name:"dev"`
+}
+
+// Lifecycle events log at debug, keeping the dependency graph out of the default info-level logs
+// while leaving it available under LOG_LEVEL=debug. Errors keep fx's default error level.
+func NewFXLog(params FXParams) fxevent.Logger {
+	l := &fxevent.ZapLogger{Logger: params.L}
+	l.UseLogLevel(zapcore.DebugLevel)
+	return l
+}
 
 func AsSystemLogger(f any) any {
 	return fx.Annotate(


### PR DESCRIPTION
## Summary

Removes three sources of log noise from the runner. The runner container's stdout/stderr is the
customer's CloudWatch log group, and one customer's was ~1.2 GB of almost entirely agent-process
noise. No change to job execution or to what the runner reports to the control plane.

## Changes

1. **fx dependency graph re-dumped every boot** (runners reboot every 1–3 days) — the runner never
   called `fx.WithLogger`, so fx used its default console logger. Now an `fxevent.ZapLogger` with
   lifecycle events at debug, so the graph is out of the default info logs but still available via
   `LOG_LEVEL=debug`. fx errors stay at error level.

2. **Hourly `traces export: Post "https://localhost:4318/v1/traces": connection refused`** — not
   our exporter. `ociregistry.NewRegistry` unconditionally inits OTel via `autoexport`, which
   defaults to OTLP at localhost:4318 with no config knob to disable it. We run no collector and
   never consume its spans, so set `OTEL_TRACES_EXPORTER=none` (guarded on unset). Our own
   exporters use explicit endpoints and are unaffected.

3. **`Waited for … due to client-side throttling`** — `kube.ConfigForCluster` left `QPS`/`Burst`
   unset, so client-go applied its 5/10 default. Now 50/100.