### PR TITLE
fix: delay alerts until runners stay offline

### DIFF
--- a/services/ctl-api/AGENTS.md
+++ b/services/ctl-api/AGENTS.md
@@ -988,6 +988,17 @@ The admin dashboard is a React 18 SPA backed by a JSON BFF at `internal/app/admi
 
 **Full documentation**: See [`internal/app/admin-dashboard/AGENTS.md`](internal/app/admin-dashboard/AGENTS.md) for tech stack, handler patterns, and step-by-step recipes for adding pages.
 
+## Composite Status Metadata Updates
+
+Update `CompositeStatus.Metadata` independently from status transitions. Do not add metadata fields to or pass metadata
+through `Update*StatusV2Request` types. Full status updates read and rewrite the composite status, so using them for
+metadata can overwrite concurrent changes.
+
+Runner workflows must use `UpdateRunnerStatusV2Metadata` through its generated Temporal wrapper. At the database layer,
+use `generics.MergeJSONBMetadata` rather than updating the JSONB column directly. The helper atomically merges metadata;
+a `nil` value removes that key. Clear temporary metadata through this helper instead of rebuilding the metadata map or
+storing JSON `null`.
+
 ## Workflow Status Descriptions
 
 **Never use `step.Idx` in user-facing strings.** This includes `StatusHumanDescription`, `StatusDescription`, and error

--- a/services/ctl-api/internal/app/runner.go
+++ b/services/ctl-api/internal/app/runner.go
@@ -28,7 +28,7 @@ const (
 	RunnerStatusUnknown RunnerStatus = "unknown"
 )
 
-const RunnerHealthCheckConsecutiveFailuresMetadataKey = "runner_healthcheck_consecutive_failures"
+const RunnerOfflineTSMetadataKey = "offline_ts"
 
 func (r RunnerStatus) String() string {
 	return string(r)

--- a/services/ctl-api/internal/app/runners/signals/processinit/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/processinit/signal.go
@@ -55,15 +55,26 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to get runner process")
 	}
-	metadata := make(map[string]any)
+	resetRunnerHealth := false
 	switch process.Type {
 	case app.RunnerProcessTypeInstall, app.RunnerProcessTypeBuild, app.RunnerProcessTypeOrg:
-		metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey] = 0
+		resetRunnerHealth = true
+	}
+	processStatus := process.ProcessStatus()
+	if resetRunnerHealth && (processStatus == app.RunnerProcessStatus(app.StatusPending) || processStatus == app.RunnerProcessStatusActive) {
+		if err := statusactivities.AwaitUpdateRunnerStatusV2Metadata(ctx, statusactivities.UpdateRunnerStatusV2MetadataRequest{
+			RunnerID: s.RunnerID,
+			Metadata: map[string]any{
+				app.RunnerOfflineTSMetadataKey: nil,
+			},
+		}); err != nil {
+			return errors.Wrap(err, "unable to clear runner offline metadata")
+		}
 	}
 
 	// Only transition pending processes to active
-	if process.ProcessStatus() != app.RunnerProcessStatus(app.StatusPending) {
-		l.Info("process not pending, skipping", "process_id", s.ProcessID, "status", string(process.ProcessStatus()))
+	if processStatus != app.RunnerProcessStatus(app.StatusPending) {
+		l.Info("process not pending, skipping", "process_id", s.ProcessID, "status", string(processStatus))
 		return nil
 	}
 
@@ -88,7 +99,6 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		RunnerID:          s.RunnerID,
 		Status:            app.RunnerStatusActive,
 		StatusDescription: "process initialized",
-		Metadata:          metadata,
 	}); err != nil {
 		l.Warn("unable to update runner status v2", "error", err)
 	}

--- a/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal.go
@@ -2,7 +2,6 @@ package runnerhealthcheck
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -23,7 +22,10 @@ import (
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
-const SignalType signal.SignalType = "runner_healthcheck"
+const (
+	SignalType                signal.SignalType = "runner_healthcheck"
+	runnerUnhealthyAlertDelay                   = 15 * time.Minute
+)
 
 type Signal struct {
 	RunnerID string `json:"runner_id"`
@@ -120,19 +122,13 @@ func (s *Signal) checkOrgRunner(ctx workflow.Context, l *zap.Logger, tmw tmetric
 			)
 			tags["missing_build_process"] = "true"
 			tmw.Incr(ctx, "runner.health_check", metrics.ToTags(tags, metrics.ToTag("result", "unhealthy"))...)
-			status, metadata := runnerStatusAfterHealthCheck(runner, app.RunnerStatusOffline, nil)
-			ownerName := runner.Org.Name
-			if runner.Status == app.RunnerStatusActive && status == app.RunnerStatusOffline {
-				ownerName = s.emitOfflineEvent(ctx, runner, "no active build process")
-			}
-			return s.updateRunnerStatus(ctx, runner, status, "no active build process", ownerName, metadata)
+			return s.handleRunnerOffline(ctx, tmw, runner, "no active build process")
 		}
 		return errors.Wrap(err, "unable to get current build process")
 	}
 
 	tmw.Incr(ctx, "runner.health_check", metrics.ToTags(tags, metrics.ToTag("result", "healthy"))...)
-	status, metadata := runnerStatusAfterHealthCheck(runner, app.RunnerStatusActive, nil)
-	return s.updateRunnerStatus(ctx, runner, status, "runner healthy", runner.Org.Name, metadata)
+	return s.handleRunnerActive(ctx, runner)
 }
 
 func (s *Signal) checkInstallRunner(ctx workflow.Context, l *zap.Logger, tmw tmetrics.Writer, runner *app.Runner, tags map[string]string) error {
@@ -163,7 +159,8 @@ func (s *Signal) checkInstallRunner(ctx workflow.Context, l *zap.Logger, tmw tme
 		description = "runner healthy"
 	}
 
-	var metadata map[string]any
+	missingMngProcess := false
+	mngProcessChecked := false
 	_, mngErr := activities.LocalAwaitGetCurrentRunnerProcess(ctx, activities.GetCurrentRunnerProcessRequest{
 		RunnerID:    s.RunnerID,
 		ProcessType: string(app.RunnerProcessTypeMng),
@@ -172,11 +169,12 @@ func (s *Signal) checkInstallRunner(ctx workflow.Context, l *zap.Logger, tmw tme
 	tags["missing_mng_process"] = "false"
 	if mngErr != nil {
 		if isNotFound(mngErr) {
+			mngProcessChecked = true
+			missingMngProcess = true
 			l.Warn("install runner missing management process",
 				zap.String("runner_id", s.RunnerID),
 			)
 			tags["missing_mng_process"] = "true"
-			metadata = map[string]any{"missing_mng_process": true}
 		} else {
 			l.Warn("unable to check management process",
 				zap.String("runner_id", s.RunnerID),
@@ -184,62 +182,75 @@ func (s *Signal) checkInstallRunner(ctx workflow.Context, l *zap.Logger, tmw tme
 			)
 		}
 	} else {
-		metadata = map[string]any{"missing_mng_process": false}
+		mngProcessChecked = true
 	}
 
-	ownerName := runner.Org.Name
+	currentMissingMngProcess, hasMissingMngProcess := runner.StatusV2.Metadata["missing_mng_process"].(bool)
+	if mngProcessChecked && (!hasMissingMngProcess || currentMissingMngProcess != missingMngProcess) {
+		if err := statusactivities.LocalAwaitUpdateRunnerStatusV2Metadata(ctx, statusactivities.UpdateRunnerStatusV2MetadataRequest{
+			RunnerID: s.RunnerID,
+			Metadata: map[string]any{"missing_mng_process": missingMngProcess},
+		}); err != nil {
+			return errors.Wrap(err, "unable to update management process status metadata")
+		}
+	}
+
 	if status == app.RunnerStatusActive {
 		tmw.Incr(ctx, "runner.health_check", metrics.ToTags(tags, metrics.ToTag("result", "healthy"))...)
-	} else {
-		tmw.Incr(ctx, "runner.health_check", metrics.ToTags(tags, metrics.ToTag("result", "unhealthy"))...)
+		return s.handleRunnerActive(ctx, runner)
 	}
 
-	status, metadata = runnerStatusAfterHealthCheck(runner, status, metadata)
-	if runner.Status == app.RunnerStatusActive && status == app.RunnerStatusOffline {
-		ownerName = s.emitOfflineEvent(ctx, runner, description)
-	}
-
-	return s.updateRunnerStatus(ctx, runner, status, description, ownerName, metadata)
+	tmw.Incr(ctx, "runner.health_check", metrics.ToTags(tags, metrics.ToTag("result", "unhealthy"))...)
+	return s.handleRunnerOffline(ctx, tmw, runner, description)
 }
 
-func runnerStatusAfterHealthCheck(runner *app.Runner, status app.RunnerStatus, metadata map[string]any) (app.RunnerStatus, map[string]any) {
-	if metadata == nil {
-		metadata = make(map[string]any)
+func (s *Signal) handleRunnerActive(ctx workflow.Context, runner *app.Runner) error {
+	if _, ok := runner.StatusV2.Metadata[app.RunnerOfflineTSMetadataKey]; ok {
+		if err := statusactivities.LocalAwaitUpdateRunnerStatusV2Metadata(ctx, statusactivities.UpdateRunnerStatusV2MetadataRequest{
+			RunnerID: s.RunnerID,
+			Metadata: map[string]any{
+				app.RunnerOfflineTSMetadataKey: nil,
+			},
+		}); err != nil {
+			return errors.Wrap(err, "unable to clear runner offline metadata")
+		}
 	}
 
-	if status == app.RunnerStatusActive {
-		metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey] = 0
-		return status, metadata
-	}
-	if status != app.RunnerStatusOffline {
-		return status, metadata
-	}
-
-	failures := runnerHealthCheckFailures(runner.StatusV2.Metadata) + 1
-	if runner.Status == app.RunnerStatusOffline && failures < 2 {
-		failures = 2
-	}
-	if failures > 2 {
-		failures = 2
-	}
-	metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey] = failures
-
-	if runner.Status != app.RunnerStatusOffline && failures < 2 {
-		return runner.Status, metadata
-	}
-
-	return status, metadata
+	return s.updateRunnerStatus(ctx, runner, app.RunnerStatusActive, "runner healthy")
 }
 
-func runnerHealthCheckFailures(metadata map[string]any) int {
-	failures, err := strconv.Atoi(fmt.Sprint(metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey]))
-	if err != nil || failures < 0 {
-		return 0
+func (s *Signal) handleRunnerOffline(ctx workflow.Context, tmw tmetrics.Writer, runner *app.Runner, reason string) error {
+	now := workflow.Now(ctx)
+	offlineAt, hasOfflineTS := runner.StatusV2.MetadataUnixTime(app.RunnerOfflineTSMetadataKey)
+
+	if !hasOfflineTS {
+		if err := statusactivities.LocalAwaitUpdateRunnerStatusV2Metadata(ctx, statusactivities.UpdateRunnerStatusV2MetadataRequest{
+			RunnerID: s.RunnerID,
+			Metadata: map[string]any{
+				app.RunnerOfflineTSMetadataKey: now.Unix(),
+			},
+		}); err != nil {
+			return errors.Wrap(err, "unable to set runner offline metadata")
+		}
+		offlineAt = now
 	}
-	return failures
+
+	if runner.Status != app.RunnerStatusOffline || runner.StatusV2.Status != app.Status(app.RunnerStatusOffline) {
+		return s.updateRunnerStatus(ctx, runner, app.RunnerStatusOffline, reason)
+	}
+
+	if now.Sub(offlineAt) < runnerUnhealthyAlertDelay {
+		return nil
+	}
+
+	if err := s.notifyRunnerUnhealthy(ctx, tmw, runner, reason, offlineAt); err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func (s *Signal) emitOfflineEvent(ctx workflow.Context, runner *app.Runner, reason string) string {
+func (s *Signal) runnerOfflineEvent(ctx workflow.Context, runner *app.Runner, reason string) (*statsd.Event, string) {
 	eventTags := []string{
 		metrics.ToTag("runner_id", s.RunnerID),
 		metrics.ToTag("runner_type", string(runner.RunnerGroup.Type)),
@@ -277,7 +288,7 @@ func (s *Signal) emitOfflineEvent(ctx workflow.Context, runner *app.Runner, reas
 		}
 	}
 
-	s.mw.Event(&statsd.Event{
+	return &statsd.Event{
 		Title:          title,
 		Text:           text,
 		Tags:           eventTags,
@@ -285,11 +296,43 @@ func (s *Signal) emitOfflineEvent(ctx workflow.Context, runner *app.Runner, reas
 		Priority:       statsd.Normal,
 		AlertType:      statsd.Error,
 		AggregationKey: "runner-health-check",
-	})
-	return ownerName
+	}, ownerName
 }
 
-func (s *Signal) updateRunnerStatus(ctx workflow.Context, runner *app.Runner, status app.RunnerStatus, description, ownerName string, metadata map[string]any) error {
+func (s *Signal) notifyRunnerUnhealthy(ctx workflow.Context, tmw tmetrics.Writer, runner *app.Runner, reason string, offlineAt time.Time) error {
+	event, ownerName := s.runnerOfflineEvent(ctx, runner, reason)
+	resp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
+		OwnerID:         runner.OrgID,
+		OwnerType:       "orgs",
+		QueueName:       "org-signals",
+		SignalOwnerID:   runner.ID,
+		SignalOwnerType: "runners",
+		IdempotencyKey:  fmt.Sprintf("runner-unhealthy:%s:%d", runner.ID, offlineAt.Unix()),
+		Signal: &runnerunhealthy.Signal{
+			RunnerID:             runner.ID,
+			RunnerName:           runner.DisplayName,
+			OrgID:                runner.OrgID,
+			OrgName:              runner.Org.Name,
+			FromStatus:           app.RunnerStatusActive,
+			ToStatus:             app.RunnerStatusOffline,
+			Reason:               reason,
+			RunnerGroupID:        runner.RunnerGroupID,
+			RunnerGroupType:      runner.RunnerGroup.Type,
+			RunnerGroupOwnerID:   runner.RunnerGroup.OwnerID,
+			RunnerGroupOwnerType: runner.RunnerGroup.OwnerType,
+			RunnerGroupOwnerName: ownerName,
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "unable to enqueue runner unhealthy signal")
+	}
+	if !resp.Deduplicated {
+		tmw.Event(ctx, event)
+	}
+	return nil
+}
+
+func (s *Signal) updateRunnerStatus(ctx workflow.Context, runner *app.Runner, status app.RunnerStatus, description string) error {
 	if runner.Status != status {
 		if err := activities.LocalAwaitUpdateStatus(ctx, activities.UpdateStatusRequest{
 			RunnerID:          s.RunnerID,
@@ -298,39 +341,15 @@ func (s *Signal) updateRunnerStatus(ctx workflow.Context, runner *app.Runner, st
 		}); err != nil {
 			return errors.Wrap(err, "unable to update runner status")
 		}
-
-		if runner.Status == app.RunnerStatusActive && status == app.RunnerStatusOffline {
-			if _, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
-				OwnerID:         runner.OrgID,
-				OwnerType:       "orgs",
-				QueueName:       "org-signals",
-				SignalOwnerID:   runner.ID,
-				SignalOwnerType: "runners",
-				Signal: &runnerunhealthy.Signal{
-					RunnerID:             runner.ID,
-					RunnerName:           runner.DisplayName,
-					OrgID:                runner.OrgID,
-					OrgName:              runner.Org.Name,
-					FromStatus:           runner.Status,
-					ToStatus:             status,
-					Reason:               description,
-					RunnerGroupID:        runner.RunnerGroupID,
-					RunnerGroupType:      runner.RunnerGroup.Type,
-					RunnerGroupOwnerID:   runner.RunnerGroup.OwnerID,
-					RunnerGroupOwnerType: runner.RunnerGroup.OwnerType,
-					RunnerGroupOwnerName: ownerName,
-				},
-			}); err != nil {
-				return errors.Wrap(err, "unable to enqueue runner unhealthy signal")
-			}
-		}
+	}
+	if runner.StatusV2.Status == app.Status(status) {
+		return nil
 	}
 
 	if err := statusactivities.LocalAwaitUpdateRunnerStatusV2(ctx, statusactivities.UpdateRunnerStatusV2Request{
 		RunnerID:          s.RunnerID,
 		Status:            status,
 		StatusDescription: description,
-		Metadata:          metadata,
 	}); err != nil {
 		return errors.Wrap(err, "unable to update runner status v2")
 	}

--- a/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal_test.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal_test.go
@@ -1,37 +1,43 @@
 package runnerhealthcheck
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 
+	basemetrics "github.com/nuonco/nuon/pkg/metrics"
+	tmetrics "github.com/nuonco/nuon/pkg/temporal/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	runneractivities "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/worker/activities"
+	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
 	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
-func TestSecondFailedHealthCheckEnqueuesUnhealthyAfterOfflineTransition(t *testing.T) {
+func TestFirstFailedHealthCheckMarksRunnerOfflineWithoutAlerting(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
+	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	env.SetStartTime(now)
 
-	runner := runnerWithHealthCheckFailures(app.RunnerStatusActive, float64(1))
+	runner := testRunner(app.RunnerStatusActive)
 	sig := &Signal{RunnerID: runner.ID}
 	var calls []string
 
+	env.OnActivity((*statusactivities.Activities).UpdateRunnerStatusV2Metadata, mock.MatchedBy(func(req statusactivities.UpdateRunnerStatusV2MetadataRequest) bool {
+		return len(req.Metadata) == 1 && req.Metadata[app.RunnerOfflineTSMetadataKey] == now.Unix()
+	})).Run(func(mock.Arguments) { calls = append(calls, "offline-ts") }).Return(nil).Once()
 	env.OnActivity((*runneractivities.Activities).UpdateStatus, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(mock.Arguments) { calls = append(calls, "status") }).
 		Return(nil).
-		Once()
-	env.OnActivity((*sharedactivities.Activities).EnqueueSignalToOwner, mock.Anything, mock.Anything, mock.Anything).
-		Run(func(mock.Arguments) {
-			calls = append(calls, "notification")
-		}).
-		Return(&sharedactivities.EnqueueSignalToOwnerResponse{}, nil).
 		Once()
 	env.OnActivity((*statusactivities.Activities).UpdateRunnerStatusV2, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(mock.Arguments) { calls = append(calls, "status-v2") }).
@@ -39,30 +45,108 @@ func TestSecondFailedHealthCheckEnqueuesUnhealthyAfterOfflineTransition(t *testi
 		Once()
 
 	env.ExecuteWorkflow(func(ctx workflow.Context) error {
-		status, metadata := runnerStatusAfterHealthCheck(runner, app.RunnerStatusOffline, nil)
-		return sig.updateRunnerStatus(ctx, runner, status, "no active build process", runner.Org.Name, metadata)
+		return sig.handleRunnerOffline(ctx, nil, runner, "no active install process")
 	})
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
-	require.Equal(t, []string{"status", "notification", "status-v2"}, calls)
+	require.Equal(t, []string{"offline-ts", "status", "status-v2"}, calls)
 	env.AssertExpectations(t)
 }
 
-func TestFirstFailedHealthCheckDoesNotMarkRunnerOffline(t *testing.T) {
+func TestOfflineRunnerDoesNotAlertBeforeDelay(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
+	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	env.SetStartTime(now)
 
-	runner := testRunner(app.RunnerStatusActive)
+	runner := runnerWithOfflineMetadata(app.RunnerStatusOffline, now.Add(-runnerUnhealthyAlertDelay+time.Second))
 	sig := &Signal{RunnerID: runner.ID}
 
-	env.OnActivity((*statusactivities.Activities).UpdateRunnerStatusV2, mock.MatchedBy(func(req statusactivities.UpdateRunnerStatusV2Request) bool {
-		return req.Status == app.RunnerStatusActive && req.Metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey] == 1
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		return sig.handleRunnerOffline(ctx, nil, runner, "no active install process")
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	env.AssertExpectations(t)
+}
+
+func TestOfflineRunnerEnqueuesIdempotentAlertAfterDelay(t *testing.T) {
+	var workflowSuite testsuite.WorkflowTestSuite
+	env := workflowSuite.NewTestWorkflowEnvironment()
+	env.SetDataConverter(signalDataConverter())
+	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	env.SetStartTime(now)
+
+	offlineAt := now.Add(-runnerUnhealthyAlertDelay)
+	runner := runnerWithOfflineMetadata(app.RunnerStatusOffline, offlineAt)
+	runner.RunnerGroup.Type = app.RunnerGroupTypeOrg
+	runner.RunnerGroup.OwnerID = runner.OrgID
+	runner.RunnerGroup.OwnerType = "orgs"
+	sig := &Signal{RunnerID: runner.ID}
+	tmw := testTemporalMetricsWriter(t)
+	var calls []string
+
+	env.OnActivity(new(sharedactivities.Activities).EnqueueSignalToOwner, mock.Anything, mock.MatchedBy(func(req *sharedactivities.EnqueueSignalToOwnerRequest) bool {
+		return req.IdempotencyKey == fmt.Sprintf("runner-unhealthy:%s:%d", runner.ID, offlineAt.Unix())
+	})).
+		Run(func(mock.Arguments) { calls = append(calls, "notification") }).
+		Return(&sharedactivities.EnqueueSignalToOwnerResponse{Deduplicated: false}, nil).
+		Once()
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		return sig.handleRunnerOffline(ctx, tmw, runner, "no active build process")
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, []string{"notification"}, calls)
+	env.AssertExpectations(t)
+}
+
+func TestOfflineRunnerReusesAlertIdempotencyKey(t *testing.T) {
+	var workflowSuite testsuite.WorkflowTestSuite
+	env := workflowSuite.NewTestWorkflowEnvironment()
+	env.SetDataConverter(signalDataConverter())
+	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	env.SetStartTime(now)
+
+	offlineAt := now.Add(-time.Hour)
+	runner := runnerWithOfflineMetadata(app.RunnerStatusOffline, offlineAt)
+	runner.RunnerGroup.Type = app.RunnerGroupTypeOrg
+	runner.RunnerGroup.OwnerID = runner.OrgID
+	runner.RunnerGroup.OwnerType = "orgs"
+	sig := &Signal{RunnerID: runner.ID}
+
+	env.OnActivity(new(sharedactivities.Activities).EnqueueSignalToOwner, mock.Anything, mock.MatchedBy(func(req *sharedactivities.EnqueueSignalToOwnerRequest) bool {
+		return req.IdempotencyKey == fmt.Sprintf("runner-unhealthy:%s:%d", runner.ID, offlineAt.Unix())
+	})).Return(&sharedactivities.EnqueueSignalToOwnerResponse{Deduplicated: true}, nil).Once()
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		return sig.handleRunnerOffline(ctx, nil, runner, "no active install process")
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	env.AssertExpectations(t)
+}
+
+func TestOfflineRunnerWithoutTimestampArmsAlert(t *testing.T) {
+	var workflowSuite testsuite.WorkflowTestSuite
+	env := workflowSuite.NewTestWorkflowEnvironment()
+	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	env.SetStartTime(now)
+
+	runner := testRunner(app.RunnerStatusOffline)
+	sig := &Signal{RunnerID: runner.ID}
+
+	env.OnActivity((*statusactivities.Activities).UpdateRunnerStatusV2Metadata, mock.MatchedBy(func(req statusactivities.UpdateRunnerStatusV2MetadataRequest) bool {
+		return req.Metadata[app.RunnerOfflineTSMetadataKey] == now.Unix()
 	})).Return(nil).Once()
 
 	env.ExecuteWorkflow(func(ctx workflow.Context) error {
-		status, metadata := runnerStatusAfterHealthCheck(runner, app.RunnerStatusOffline, nil)
-		return sig.updateRunnerStatus(ctx, runner, status, "no active install process", runner.Org.Name, metadata)
+		return sig.handleRunnerOffline(ctx, nil, runner, "no active install process")
 	})
 
 	require.True(t, env.IsWorkflowCompleted())
@@ -70,11 +154,39 @@ func TestFirstFailedHealthCheckDoesNotMarkRunnerOffline(t *testing.T) {
 	env.AssertExpectations(t)
 }
 
-func TestUpdateRunnerStatusDoesNotRepeatUnhealthyWhileOffline(t *testing.T) {
+func TestActiveRunnerWithOfflineTimestampDoesNotResetDelay(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
+	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	env.SetStartTime(now)
 
-	runner := testRunner(app.RunnerStatusOffline)
+	runner := runnerWithOfflineMetadata(app.RunnerStatusActive, now.Add(-time.Minute))
+	sig := &Signal{RunnerID: runner.ID}
+
+	env.OnActivity((*runneractivities.Activities).UpdateStatus, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).
+		Once()
+	env.OnActivity((*statusactivities.Activities).UpdateRunnerStatusV2, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).
+		Once()
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		return sig.handleRunnerOffline(ctx, nil, runner, "no active install process")
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	env.AssertExpectations(t)
+}
+
+func TestOfflineCheckRepairsStaleStatusV2(t *testing.T) {
+	var workflowSuite testsuite.WorkflowTestSuite
+	env := workflowSuite.NewTestWorkflowEnvironment()
+	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	env.SetStartTime(now)
+
+	runner := runnerWithOfflineMetadata(app.RunnerStatusOffline, now.Add(-time.Minute))
+	runner.StatusV2.Status = app.Status(app.RunnerStatusActive)
 	sig := &Signal{RunnerID: runner.ID}
 
 	env.OnActivity((*statusactivities.Activities).UpdateRunnerStatusV2, mock.Anything, mock.Anything, mock.Anything).
@@ -82,7 +194,7 @@ func TestUpdateRunnerStatusDoesNotRepeatUnhealthyWhileOffline(t *testing.T) {
 		Once()
 
 	env.ExecuteWorkflow(func(ctx workflow.Context) error {
-		return sig.updateRunnerStatus(ctx, runner, app.RunnerStatusOffline, "no active build process", runner.Org.Name, nil)
+		return sig.handleRunnerOffline(ctx, nil, runner, "no active install process")
 	})
 
 	require.True(t, env.IsWorkflowCompleted())
@@ -90,7 +202,37 @@ func TestUpdateRunnerStatusDoesNotRepeatUnhealthyWhileOffline(t *testing.T) {
 	env.AssertExpectations(t)
 }
 
-func TestUpdateRunnerStatusDoesNotEnqueueWhenOfflineUpdateFails(t *testing.T) {
+func TestHealthyCheckClearsOfflineMetadataAndRestoresActive(t *testing.T) {
+	var workflowSuite testsuite.WorkflowTestSuite
+	env := workflowSuite.NewTestWorkflowEnvironment()
+
+	runner := runnerWithOfflineMetadata(app.RunnerStatusOffline, time.Now().Add(-time.Minute))
+	sig := &Signal{RunnerID: runner.ID}
+	var calls []string
+
+	env.OnActivity((*statusactivities.Activities).UpdateRunnerStatusV2Metadata, mock.MatchedBy(func(req statusactivities.UpdateRunnerStatusV2MetadataRequest) bool {
+		return len(req.Metadata) == 1 && req.Metadata[app.RunnerOfflineTSMetadataKey] == nil
+	})).Run(func(mock.Arguments) { calls = append(calls, "clear") }).Return(nil).Once()
+	env.OnActivity((*runneractivities.Activities).UpdateStatus, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(mock.Arguments) { calls = append(calls, "status") }).
+		Return(nil).
+		Once()
+	env.OnActivity((*statusactivities.Activities).UpdateRunnerStatusV2, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(mock.Arguments) { calls = append(calls, "status-v2") }).
+		Return(nil).
+		Once()
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		return sig.handleRunnerActive(ctx, runner)
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, []string{"clear", "status", "status-v2"}, calls)
+	env.AssertExpectations(t)
+}
+
+func TestUpdateRunnerStatusStopsWhenLegacyUpdateFails(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
 
@@ -102,79 +244,12 @@ func TestUpdateRunnerStatusDoesNotEnqueueWhenOfflineUpdateFails(t *testing.T) {
 		Once()
 
 	env.ExecuteWorkflow(func(ctx workflow.Context) error {
-		return sig.updateRunnerStatus(ctx, runner, app.RunnerStatusOffline, "no active build process", runner.Org.Name, nil)
+		return sig.updateRunnerStatus(ctx, runner, app.RunnerStatusOffline, "no active install process")
 	})
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.Error(t, env.GetWorkflowError())
 	env.AssertExpectations(t)
-}
-
-func TestRunnerStatusAfterHealthCheck(t *testing.T) {
-	tests := map[string]struct {
-		runner         *app.Runner
-		status         app.RunnerStatus
-		metadata       map[string]any
-		expectedStatus app.RunnerStatus
-		expectedCount  int
-	}{
-		"first failed check keeps active runner active": {
-			runner:         testRunner(app.RunnerStatusActive),
-			status:         app.RunnerStatusOffline,
-			expectedStatus: app.RunnerStatusActive,
-			expectedCount:  1,
-		},
-		"second consecutive failed check marks runner offline": {
-			runner:         runnerWithHealthCheckFailures(app.RunnerStatusActive, float64(1)),
-			status:         app.RunnerStatusOffline,
-			expectedStatus: app.RunnerStatusOffline,
-			expectedCount:  2,
-		},
-		"healthy check resets the failure count": {
-			runner:         runnerWithHealthCheckFailures(app.RunnerStatusActive, int64(1)),
-			status:         app.RunnerStatusActive,
-			expectedStatus: app.RunnerStatusActive,
-			expectedCount:  0,
-		},
-		"offline runner remains offline without exceeding threshold": {
-			runner:         testRunner(app.RunnerStatusOffline),
-			status:         app.RunnerStatusOffline,
-			expectedStatus: app.RunnerStatusOffline,
-			expectedCount:  2,
-		},
-		"existing metadata is preserved": {
-			runner:         testRunner(app.RunnerStatusActive),
-			status:         app.RunnerStatusActive,
-			metadata:       map[string]any{"missing_mng_process": true},
-			expectedStatus: app.RunnerStatusActive,
-			expectedCount:  0,
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			status, metadata := runnerStatusAfterHealthCheck(tt.runner, tt.status, tt.metadata)
-
-			require.Equal(t, tt.expectedStatus, status)
-			require.Equal(t, tt.expectedCount, metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey])
-			if tt.metadata != nil {
-				require.Equal(t, true, metadata["missing_mng_process"])
-			}
-		})
-	}
-}
-
-func TestHealthyCheckBreaksFailureStreak(t *testing.T) {
-	runner := runnerWithHealthCheckFailures(app.RunnerStatusActive, float64(1))
-
-	status, metadata := runnerStatusAfterHealthCheck(runner, app.RunnerStatusActive, nil)
-	require.Equal(t, app.RunnerStatusActive, status)
-	require.Equal(t, 0, metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey])
-
-	runner.StatusV2.Metadata = metadata
-	status, metadata = runnerStatusAfterHealthCheck(runner, app.RunnerStatusOffline, nil)
-	require.Equal(t, app.RunnerStatusActive, status)
-	require.Equal(t, 1, metadata[app.RunnerHealthCheckConsecutiveFailuresMetadataKey])
 }
 
 func testRunner(status app.RunnerStatus) *app.Runner {
@@ -192,13 +267,34 @@ func testRunner(status app.RunnerStatus) *app.Runner {
 			OwnerID:   "ins_1",
 			OwnerType: "installs",
 		},
+		StatusV2: app.CompositeStatus{
+			Status: app.Status(status),
+		},
 	}
 }
 
-func runnerWithHealthCheckFailures(status app.RunnerStatus, failures any) *app.Runner {
+func runnerWithOfflineMetadata(status app.RunnerStatus, offlineAt time.Time) *app.Runner {
 	runner := testRunner(status)
 	runner.StatusV2.Metadata = map[string]any{
-		app.RunnerHealthCheckConsecutiveFailuresMetadataKey: failures,
+		app.RunnerOfflineTSMetadataKey: float64(offlineAt.Unix()),
 	}
 	return runner
+}
+
+func testTemporalMetricsWriter(t *testing.T) tmetrics.Writer {
+	v := validator.New()
+	mw, err := basemetrics.New(v, basemetrics.WithDisable(true))
+	require.NoError(t, err)
+	tmw, err := tmetrics.New(v, tmetrics.WithMetricsWriter(mw))
+	require.NoError(t, err)
+	return tmw
+}
+
+func signalDataConverter() converter.DataConverter {
+	return converter.NewCompositeDataConverter(
+		signaldb.NewPayloadConverter(),
+		converter.NewNilPayloadConverter(),
+		converter.NewByteSlicePayloadConverter(),
+		converter.NewJSONPayloadConverter(),
+	)
 }

--- a/services/ctl-api/internal/app/status.go
+++ b/services/ctl-api/internal/app/status.go
@@ -129,6 +129,32 @@ type CompositeStatus struct {
 	History []CompositeStatus `json:"history,omitzero,omitempty" temporaljson:"history,omitzero,omitempty"`
 }
 
+// MetadataUnixTime returns a Unix timestamp from metadata regardless of whether
+// it came directly from Go or through a JSON round trip.
+func (c CompositeStatus) MetadataUnixTime(key string) (time.Time, bool) {
+	var ts int64
+	switch value := c.Metadata[key].(type) {
+	case int:
+		ts = int64(value)
+	case int64:
+		ts = value
+	case float64:
+		ts = int64(value)
+	case json.Number:
+		parsed, err := value.Int64()
+		if err != nil {
+			return time.Time{}, false
+		}
+		ts = parsed
+	default:
+		return time.Time{}, false
+	}
+	if ts <= 0 {
+		return time.Time{}, false
+	}
+	return time.Unix(ts, 0), true
+}
+
 // Scan implements the database/sql.Scanner interface.
 func (c *CompositeStatus) Scan(v interface{}) (err error) {
 	switch v := v.(type) {

--- a/services/ctl-api/internal/pkg/db/generics/json.go
+++ b/services/ctl-api/internal/pkg/db/generics/json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/lib/pq"
 	"gorm.io/gorm"
 )
 
@@ -66,8 +67,8 @@ func (jq *JSONBQuerier) WhereJSONPath(field string, path []string, operator stri
 }
 
 // MergeJSONBMetadata reads a JSONB column's "metadata" key, merges the provided
-// key-value pairs, and writes the column back. The model must be a pointer to a
-// GORM model (e.g. &app.QueueSignal{}).
+// key-value pairs, and writes the column back. Nil values remove their keys. The
+// model must be a pointer to a GORM model (e.g. &app.QueueSignal{}).
 func MergeJSONBMetadata(db *gorm.DB, model any, id string, field string, metadata map[string]any) error {
 	// Build a jsonb_set chain that merges each key into the metadata sub-object.
 	// First ensure the metadata key exists as an object, then set each key.
@@ -78,6 +79,12 @@ func MergeJSONBMetadata(db *gorm.DB, model any, id string, field string, metadat
 
 	args := make([]any, 0, len(metadata))
 	for k, v := range metadata {
+		if v == nil {
+			expr = fmt.Sprintf("(%s #- ?::text[])", expr)
+			args = append(args, pq.Array([]string{"metadata", k}))
+			continue
+		}
+
 		valJSON, err := json.Marshal(v)
 		if err != nil {
 			return fmt.Errorf("unable to marshal metadata value for key %s: %w", k, err)

--- a/services/ctl-api/internal/pkg/queue/client/enqueue_signal.go
+++ b/services/ctl-api/internal/pkg/queue/client/enqueue_signal.go
@@ -3,10 +3,13 @@ package client
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
+	"gorm.io/gorm/clause"
 
 	"github.com/nuonco/nuon/pkg/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -24,6 +27,9 @@ type EnqueueSignalRequest struct {
 	OwnerType string
 	ExpiresAt *time.Time
 	EmitterID *string
+
+	// IdempotencyKey deduplicates repeated requests for the same signal type and queue.
+	IdempotencyKey string `validate:"omitempty,max=255"`
 
 	// Callback describes where the handler should send a Temporal signal on completion.
 	// Deprecated: use Callbacks for new code.
@@ -89,8 +95,33 @@ func (c *Client) EnqueueSignal(ctx context.Context, req *EnqueueSignalRequest) (
 		Callbacks: callbacks,
 	}
 
-	if res := c.db.WithContext(ctx).Create(&queueSignal); res.Error != nil {
+	db := c.db.WithContext(ctx)
+	if req.IdempotencyKey != "" {
+		queueSignal.ID = idempotentQueueSignalID(req.QueueID, req.Signal.Type(), req.IdempotencyKey)
+		queueSignal.Workflow.ID = fmt.Sprintf(queueSignal.Workflow.IDTemplate, queueSignal.ID)
+		db = db.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "id"}},
+			DoNothing: true,
+		})
+	}
+
+	res := db.Create(&queueSignal)
+	if res.Error != nil {
 		return nil, errors.Wrap(res.Error, "unable to create queue signal")
+	}
+	if res.RowsAffected == 0 {
+		var existing app.QueueSignal
+		if res := c.db.WithContext(ctx).
+			Unscoped().
+			Where(app.QueueSignal{ID: queueSignal.ID}).
+			First(&existing); res.Error != nil {
+			return nil, errors.Wrap(res.Error, "unable to get idempotent queue signal")
+		}
+		return &queue.EnqueueResponse{
+			ID:           existing.ID,
+			WorkflowID:   existing.Workflow.ID,
+			Deduplicated: true,
+		}, nil
 	}
 
 	if c.enqueuer != nil {
@@ -103,7 +134,13 @@ func (c *Client) EnqueueSignal(ctx context.Context, req *EnqueueSignalRequest) (
 	}))
 
 	return &queue.EnqueueResponse{
-		ID:         queueSignal.ID,
-		WorkflowID: queueSignal.Workflow.ID,
+		ID:           queueSignal.ID,
+		WorkflowID:   queueSignal.Workflow.ID,
+		Deduplicated: false,
 	}, nil
+}
+
+func idempotentQueueSignalID(queueID string, signalType signal.SignalType, idempotencyKey string) string {
+	sum := sha256.Sum256([]byte(queueID + "\x00" + string(signalType) + "\x00" + idempotencyKey))
+	return "qsi" + hex.EncodeToString(sum[:])[:23]
 }

--- a/services/ctl-api/internal/pkg/queue/enqueue.go
+++ b/services/ctl-api/internal/pkg/queue/enqueue.go
@@ -14,8 +14,9 @@ const EnqueueUpdateName string = "enqueue"
 const enqueuUpdateType = handlerTypeUpdate
 
 type EnqueueResponse struct {
-	ID         string
-	WorkflowID string
+	ID           string
+	WorkflowID   string
+	Deduplicated bool
 }
 
 // EnqueueHandlerInput is the input to the enqueue update handler.

--- a/services/ctl-api/internal/pkg/queue/testworker/enqueue_test.go
+++ b/services/ctl-api/internal/pkg/queue/testworker/enqueue_test.go
@@ -69,6 +69,68 @@ func (e *EnqueueTestSuite) TestEnqueueAndProcessNSignals() {
 	}
 }
 
+func (e *EnqueueTestSuite) TestEnqueueSignalIdempotency() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+
+	queue, err := e.service.Client.Create(ctx, &client.CreateQueueRequest{
+		OwnerID:     generics.GetFakeObj[string](),
+		OwnerType:   generics.GetFakeObj[string](),
+		Namespace:   defaultNamespace,
+		MaxInFlight: 5,
+		MaxDepth:    100,
+	})
+	require.NoError(e.T(), err)
+	require.NoError(e.T(), e.service.Client.QueueReady(ctx, queue.ID))
+
+	key := "same-logical-event"
+	first, err := e.service.Client.EnqueueSignal(ctx, &client.EnqueueSignalRequest{
+		QueueID: queue.ID,
+		Signal: &example.ExampleSignal{
+			Arg1: generics.GetFakeObj[string](),
+			Arg2: generics.GetFakeObj[string](),
+		},
+		IdempotencyKey: key,
+	})
+	require.NoError(e.T(), err)
+	require.False(e.T(), first.Deduplicated)
+	timeout := 5 * time.Second
+	status, err := e.service.Client.PollSignal(ctx, first.ID, &client.PollSignalOptions{
+		Timeout:      &timeout,
+		PollInterval: 500 * time.Millisecond,
+	})
+	require.NoError(e.T(), err)
+	require.True(e.T(), status.Finished)
+
+	second, err := e.service.Client.EnqueueSignal(ctx, &client.EnqueueSignalRequest{
+		QueueID: queue.ID,
+		Signal: &example.ExampleSignal{
+			Arg1: generics.GetFakeObj[string](),
+			Arg2: generics.GetFakeObj[string](),
+		},
+		IdempotencyKey: key,
+	})
+	require.NoError(e.T(), err)
+	require.True(e.T(), second.Deduplicated)
+	require.Equal(e.T(), first.ID, second.ID)
+	require.Equal(e.T(), first.WorkflowID, second.WorkflowID)
+	var queueSignal app.QueueSignal
+	require.NoError(e.T(), e.service.DB.WithContext(ctx).Where(app.QueueSignal{ID: first.ID}).First(&queueSignal).Error)
+	require.Equal(e.T(), 1, queueSignal.ExecutionCount)
+
+	third, err := e.service.Client.EnqueueSignal(ctx, &client.EnqueueSignalRequest{
+		QueueID: queue.ID,
+		Signal: &example.ExampleSignal{
+			Arg1: generics.GetFakeObj[string](),
+			Arg2: generics.GetFakeObj[string](),
+		},
+		IdempotencyKey: "different-logical-event",
+	})
+	require.NoError(e.T(), err)
+	require.False(e.T(), third.Deduplicated)
+	require.NotEqual(e.T(), first.ID, third.ID)
+}
+
 func (e *EnqueueTestSuite) TestPanickingSignalUpdatesDBStatus() {
 	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
 	ctx = e.service.Seed.EnsureOrg(ctx, e.T())

--- a/services/ctl-api/internal/pkg/workflows/activities/enqueue_signal.go
+++ b/services/ctl-api/internal/pkg/workflows/activities/enqueue_signal.go
@@ -25,6 +25,7 @@ type EnqueueSignalToOwnerRequest struct {
 	// which entity (e.g. workflow step) triggered this signal execution.
 	SignalOwnerID   string `json:"signal_owner_id,omitempty"`
 	SignalOwnerType string `json:"signal_owner_type,omitempty"`
+	IdempotencyKey  string `json:"idempotency_key,omitempty" validate:"omitempty,max=255"`
 
 	// Callback describes where the handler should send a Temporal signal on completion.
 	// Deprecated: use Callbacks for new code.
@@ -37,6 +38,7 @@ type EnqueueSignalToOwnerRequest struct {
 type EnqueueSignalToOwnerResponse struct {
 	QueueSignalID string `json:"queue_signal_id"`
 	WorkflowID    string `json:"workflow_id"`
+	Deduplicated  bool   `json:"deduplicated"`
 }
 
 // EnqueueSignalToOwner sends a signal to a queue owned by a specific entity (e.g., runner, install).
@@ -66,12 +68,13 @@ func (a *Activities) EnqueueSignalToOwner(ctx context.Context, req *EnqueueSigna
 
 	// Enqueue the signal
 	enqueueResp, err := a.queueClient.EnqueueSignal(ctx, &client.EnqueueSignalRequest{
-		QueueID:   queueID,
-		Signal:    req.Signal,
-		OwnerID:   req.SignalOwnerID,
-		OwnerType: req.SignalOwnerType,
-		Callback:  req.Callback,
-		Callbacks: req.Callbacks,
+		QueueID:        queueID,
+		Signal:         req.Signal,
+		OwnerID:        req.SignalOwnerID,
+		OwnerType:      req.SignalOwnerType,
+		IdempotencyKey: req.IdempotencyKey,
+		Callback:       req.Callback,
+		Callbacks:      req.Callbacks,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to enqueue signal")
@@ -80,5 +83,6 @@ func (a *Activities) EnqueueSignalToOwner(ctx context.Context, req *EnqueueSigna
 	return &EnqueueSignalToOwnerResponse{
 		QueueSignalID: enqueueResp.ID,
 		WorkflowID:    enqueueResp.WorkflowID,
+		Deduplicated:  enqueueResp.Deduplicated,
 	}, nil
 }

--- a/services/ctl-api/internal/pkg/workflows/status/activities/update.go
+++ b/services/ctl-api/internal/pkg/workflows/status/activities/update.go
@@ -456,7 +456,6 @@ type UpdateRunnerStatusV2Request struct {
 	RunnerID          string           `validate:"required"`
 	Status            app.RunnerStatus `validate:"required"`
 	StatusDescription string           `validate:"required"`
-	Metadata          map[string]any
 }
 
 // @temporal-gen-v2 activity
@@ -474,10 +473,21 @@ func (a *Activities) UpdateRunnerStatusV2(ctx context.Context, req UpdateRunnerS
 
 	status := app.NewCompositeStatus(ctx, app.Status(req.Status))
 	status.StatusHumanDescription = req.StatusDescription
-	for k, v := range req.Metadata {
-		status.Metadata[k] = v
-	}
 	return a.updateStatusV2(ctx, &obj, status, getter)
+}
+
+type UpdateRunnerStatusV2MetadataRequest struct {
+	RunnerID string `validate:"required"`
+	Metadata map[string]any
+}
+
+// @temporal-gen-v2 activity
+// @local
+func (a *Activities) UpdateRunnerStatusV2Metadata(ctx context.Context, req UpdateRunnerStatusV2MetadataRequest) error {
+	if err := generics.MergeJSONBMetadata(a.db.WithContext(ctx), &app.Runner{}, req.RunnerID, "status_v2", req.Metadata); err != nil {
+		return errors.Wrap(err, "unable to update runner status metadata")
+	}
+	return nil
 }
 
 type UpdateActionWorkflowStatusV2Request struct {


### PR DESCRIPTION
## Summary

Runner health checks now mark a runner offline immediately when its required process disappears, but wait for at least 15 minutes of continuous downtime before sending `runners.unhealthy` to Slack, webhooks, and Datadog. A recovered process cancels the pending alert.

## What you can do after this PR

**Avoid alerts for transient runner restarts.** The first failed check records when the outage began. A later check sends the notification only if the required process has remained missing for at least 15 minutes.

**See offline state immediately.** Runner status changes to offline on the first failed check, independently of the notification delay.

**Receive one alert per outage.** Repeated health checks reuse the same queue signal for the outage, so they do not send duplicate Slack, webhook, or Datadog notifications. Recovery clears the outage timestamp, allowing a later outage to send a new alert.

## What stays the same

Missing management processes remain warning-only. Install runners continue to check their install process, while existing org runners retain their build-process check. Existing rows need no migration; legacy health metadata is ignored.

## Mechanics worth flagging for review

Runner metadata contains only `offline_ts`. The alert identity combines the runner and that outage timestamp. Repeated enqueue requests return the existing durable queue signal without dispatching it again.

## Docs

Contributor guidance now records the shared status metadata update and deletion convention.