### PR TITLE
fix: restore `nuon orgs api-token` functionality

### DIFF
--- a/bins/cli/cmd/orgs.go
+++ b/bins/cli/cmd/orgs.go
@@ -57,11 +57,14 @@ func (c *cli) orgsCmd() *cobra.Command {
 
 	deprecatedAPITokenCmd := &cobra.Command{
 		Use:    "api-token",
-		Short:  "Manage API tokens (deprecated)",
+		Short:  "Get api token (deprecated)",
+		Long:   "Get api token that is active for current org",
 		Hidden: true,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			printDeprecatedCommandWarning(cmd, "Use `nuon orgs api-tokens` instead")
-			return cmd.Help()
+
+			svc := orgs.New(c.apiClient, c.cfg)
+			return svc.APIToken(cmd.Context(), PrintJSON)
 		}),
 	}
 	orgsCmd.AddCommand(deprecatedAPITokenCmd)

--- a/bins/cli/cmd/readonly.go
+++ b/bins/cli/cmd/readonly.go
@@ -35,6 +35,7 @@ var readOnlyCommands = map[string]struct{}{
 	"deploys":              {},
 	"sandbox":              {},
 	"plan":                 {},
+	"api-token":            {},
 	"logs":                 {},
 	"deploy-logs":          {},
 	"sandbox-run-logs":     {},

--- a/bins/cli/cmd/readonly_test.go
+++ b/bins/cli/cmd/readonly_test.go
@@ -14,6 +14,7 @@ func TestReadOnlyAllowsConfigViewers(t *testing.T) {
 		"input-config",
 		"runner-config",
 		"plan",
+		"api-token",
 		"runs",
 	}
 

--- a/bins/cli/internal/services/orgs/api_token.go
+++ b/bins/cli/internal/services/orgs/api_token.go
@@ -1,0 +1,21 @@
+package orgs
+
+import (
+	"context"
+
+	"github.com/nuonco/nuon/bins/cli/internal/ui"
+)
+
+func (s *Service) APIToken(ctx context.Context, asJSON bool) error {
+	view := ui.NewGetView()
+
+	if asJSON {
+		ui.PrintJSON(s.cfg.APIToken)
+		return nil
+	}
+
+	view.Render([][]string{
+		{"api-token", s.cfg.APIToken},
+	})
+	return nil
+}


### PR DESCRIPTION
## Summary

This command was deprecated, but was intended to continue working to maintain backwards compatibility. A recent change accidentally broke it. This PR restores it, while maintaining the deprecation warning.