### PR TITLE
flow: gate lifecycle events and completion callbacks on workflow-row terminality

### DIFF
--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
@@ -100,12 +100,13 @@ type Signal struct {
 }
 
 var (
-	_ qsignal.Signal                     = (*Signal)(nil)
-	_ qsignal.SignalWithCancel           = (*Signal)(nil)
-	_ qsignal.SignalWithUpdateHandlers   = (*Signal)(nil)
-	_ qsignal.SignalWithLifecycleContext = (*Signal)(nil)
-	_ qsignal.SignalWithParams           = (*Signal)(nil)
-	_ qsignal.AutoExecuteOnTerminalStart = (*Signal)(nil)
+	_ qsignal.Signal                      = (*Signal)(nil)
+	_ qsignal.SignalWithCancel            = (*Signal)(nil)
+	_ qsignal.SignalWithUpdateHandlers    = (*Signal)(nil)
+	_ qsignal.SignalWithLifecycleContext  = (*Signal)(nil)
+	_ qsignal.SignalWithParams            = (*Signal)(nil)
+	_ qsignal.AutoExecuteOnTerminalStart  = (*Signal)(nil)
+	_ qsignal.CompletionCallbacksWorkflow = (*Signal)(nil)
 )
 
 func (s *Signal) WithParams(p *qsignal.Params) {
@@ -162,6 +163,13 @@ func (s *Signal) SleepAfter() time.Duration {
 // (re)started by update-with-start after it idled out and completed. See the
 // queue handler's re-warm path.
 func (s *Signal) AutoExecuteOnTerminalStart() bool { return s.Resident }
+
+func (s *Signal) CompletionCallbacksWorkflowID() string {
+	if !s.Resident {
+		return ""
+	}
+	return s.WorkflowID
+}
 
 // LifecycleContext exposes the workflow identity + owner so lifecycle hooks
 // can emit workflow.lifecycle.* webhook events without leaking inner-signal

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/signal_test.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/signal_test.go
@@ -1,0 +1,23 @@
+package executeflow
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletionCallbacksWorkflowID(t *testing.T) {
+	sig := &Signal{WorkflowID: "wfl_1"}
+	assert.Empty(t, sig.CompletionCallbacksWorkflowID())
+
+	sig.Resident = true
+	assert.Equal(t, "wfl_1", sig.CompletionCallbacksWorkflowID())
+}
+
+func TestLegacySignalDoesNotGateCompletionCallbacks(t *testing.T) {
+	var sig Signal
+	require.NoError(t, json.Unmarshal([]byte(`{"workflow_id":"wfl_1"}`), &sig))
+	assert.Empty(t, sig.CompletionCallbacksWorkflowID())
+}

--- a/services/ctl-api/internal/pkg/queue/activities/hold_completion_callbacks.go
+++ b/services/ctl-api/internal/pkg/queue/activities/hold_completion_callbacks.go
@@ -1,0 +1,34 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+type workflowStatusRow struct {
+	ID     string
+	Status app.CompositeStatus `gorm:"type:jsonb;serializer:json"`
+}
+
+func (workflowStatusRow) TableName() string {
+	return (&app.Workflow{}).TableName()
+}
+
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 1m
+// @as-wrapper
+// @by-field workflowID
+// @local
+func (a *Activities) holdCompletionCallbacks(ctx context.Context, workflowID string) (bool, error) {
+	var flw workflowStatusRow
+	if err := a.db.WithContext(ctx).
+		Select("status").
+		Where(workflowStatusRow{ID: workflowID}).
+		First(&flw).Error; err != nil {
+		return false, fmt.Errorf("unable to load workflow status for completion callbacks: %w", err)
+	}
+
+	return flw.Status.Status == app.StatusFailedPendingRetry, nil
+}

--- a/services/ctl-api/internal/pkg/queue/activities/hold_completion_callbacks_test.go
+++ b/services/ctl-api/internal/pkg/queue/activities/hold_completion_callbacks_test.go
@@ -1,0 +1,44 @@
+package activities
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+func TestHoldCompletionCallbacks(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&workflowStatusRow{}))
+
+	activities := &Activities{db: db}
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&workflowStatusRow{
+		ID: "wfl_1",
+		Status: app.CompositeStatus{
+			Status: app.StatusFailedPendingRetry,
+		},
+	}).Error)
+
+	hold, err := activities.holdCompletionCallbacks(ctx, "wfl_1")
+	require.NoError(t, err)
+	assert.True(t, hold)
+
+	require.NoError(t, db.Save(&workflowStatusRow{
+		ID: "wfl_1",
+		Status: app.CompositeStatus{
+			Status: app.StatusSuccess,
+		},
+	}).Error)
+
+	hold, err = activities.holdCompletionCallbacks(ctx, "wfl_1")
+	require.NoError(t, err)
+	assert.False(t, hold)
+}

--- a/services/ctl-api/internal/pkg/queue/handler/completion.go
+++ b/services/ctl-api/internal/pkg/queue/handler/completion.go
@@ -2,10 +2,12 @@ package handler
 
 import (
 	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/callback"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 )
 
 // sendCompletionCallbacks sends Temporal signals to all registered parent
@@ -15,6 +17,17 @@ import (
 // added after initializeState (e.g. by EnsureSignal) are picked up.
 func (h *handler) sendCompletionCallbacks(ctx workflow.Context) {
 	l, _ := log.WorkflowLogger(ctx)
+
+	if workflowID := completionCallbacksWorkflowID(h.sig); workflowID != "" {
+		hold, err := activities.LocalAwaitHoldCompletionCallbacksByWorkflowID(ctx, workflowID)
+		if err != nil {
+			l.Error("unable to reload workflow before sending completion callbacks",
+				zap.String("workflow_id", workflowID),
+				zap.Error(err))
+		} else if hold {
+			return
+		}
+	}
 
 	// Reload from DB to pick up callbacks added after init (e.g. by EnsureSignal).
 	qs, err := activities.LocalAwaitGetQueueSignalByQueueSignalID(ctx, h.queueSignalID)
@@ -46,6 +59,14 @@ func (h *handler) sendCompletionCallbacks(ctx workflow.Context) {
 	for _, cb := range h.callbacks {
 		callback.Send(ctx, l, cb, result)
 	}
+}
+
+func completionCallbacksWorkflowID(sig signal.Signal) string {
+	residentFlow, ok := sig.(signal.CompletionCallbacksWorkflow)
+	if !ok {
+		return ""
+	}
+	return residentFlow.CompletionCallbacksWorkflowID()
 }
 
 // hasCallbacks returns true if at least one completion callback is configured.

--- a/services/ctl-api/internal/pkg/queue/handler/completion_test.go
+++ b/services/ctl-api/internal/pkg/queue/handler/completion_test.go
@@ -1,0 +1,115 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/callback"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+type callbackGateSignal struct {
+	workflowID string
+}
+
+func (s *callbackGateSignal) Type() signal.SignalType               { return "callback-gate-test" }
+func (s *callbackGateSignal) Validate(workflow.Context) error       { return nil }
+func (s *callbackGateSignal) Execute(workflow.Context) error        { return nil }
+func (s *callbackGateSignal) CompletionCallbacksWorkflowID() string { return s.workflowID }
+
+type ordinaryCallbackSignal struct{}
+
+func (s *ordinaryCallbackSignal) Type() signal.SignalType         { return "ordinary-callback-test" }
+func (s *ordinaryCallbackSignal) Validate(workflow.Context) error { return nil }
+func (s *ordinaryCallbackSignal) Execute(workflow.Context) error  { return nil }
+
+func TestCompletionCallbacksWorkflowID(t *testing.T) {
+	assert.Equal(t, "wfl_1", completionCallbacksWorkflowID(&callbackGateSignal{workflowID: "wfl_1"}))
+	assert.Empty(t, completionCallbacksWorkflowID(&callbackGateSignal{}))
+	assert.Empty(t, completionCallbacksWorkflowID(&ordinaryCallbackSignal{}))
+}
+
+func TestSendCompletionCallbacksGate(t *testing.T) {
+	tests := map[string]struct {
+		sig       signal.Signal
+		hold      bool
+		gateErr   error
+		wantCalls []string
+	}{
+		"resident parked workflow holds callback": {
+			sig:       &callbackGateSignal{workflowID: "wfl_1"},
+			hold:      true,
+			wantCalls: []string{"gate"},
+		},
+		"resident terminal workflow sends callback": {
+			sig:       &callbackGateSignal{workflowID: "wfl_1"},
+			wantCalls: []string{"gate", "reload", "send"},
+		},
+		"gate lookup failure preserves callback delivery": {
+			sig:       &callbackGateSignal{workflowID: "wfl_1"},
+			gateErr:   errors.New("database unavailable"),
+			wantCalls: []string{"gate", "reload", "send"},
+		},
+		"ordinary signal does not use gate": {
+			sig:       &ordinaryCallbackSignal{},
+			wantCalls: []string{"reload", "send"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var suite testsuite.WorkflowTestSuite
+			env := suite.NewTestWorkflowEnvironment()
+			env.RegisterActivityWithOptions(func(context.Context, any) error { return nil }, activity.RegisterOptions{Name: "SendSignal"})
+			calls := make([]string, 0, len(tt.wantCalls))
+
+			if completionCallbacksWorkflowID(tt.sig) != "" {
+				env.OnActivity((*activities.Activities).HoldCompletionCallbacks, mock.Anything, mock.Anything).
+					Run(func(mock.Arguments) { calls = append(calls, "gate") }).
+					Return(tt.hold, tt.gateErr).
+					Once()
+			}
+
+			if !tt.hold {
+				env.OnActivity((*activities.Activities).QueueInternalGetQueueSignal, mock.Anything, mock.Anything).
+					Run(func(mock.Arguments) { calls = append(calls, "reload") }).
+					Return(&app.QueueSignal{
+						Callbacks: callback.Refs{{
+							WorkflowID: "parent-workflow",
+							SignalName: "complete",
+						}},
+					}, nil).
+					Once()
+				env.OnActivity("SendSignal", mock.Anything, mock.Anything).
+					Run(func(mock.Arguments) { calls = append(calls, "send") }).
+					Return(nil).
+					Once()
+			}
+
+			env.ExecuteWorkflow(func(ctx workflow.Context) error {
+				h := &handler{
+					queueSignalID:  "queue-signal",
+					sig:            tt.sig,
+					finishedStatus: app.StatusSuccess,
+				}
+				h.sendCompletionCallbacks(ctx)
+				return nil
+			})
+
+			require.True(t, env.IsWorkflowCompleted())
+			require.NoError(t, env.GetWorkflowError())
+			assert.Equal(t, tt.wantCalls, calls)
+			env.AssertExpectations(t)
+		})
+	}
+}

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/flow_completion_test.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/flow_completion_test.go
@@ -1,0 +1,103 @@
+package hooks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+	slackclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/slack/client"
+)
+
+func TestSuppressParkedFlowCompletion(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&workflowStatusRow{}))
+
+	ctx := context.Background()
+	event := signal.SignalPhaseEvent{
+		SignalType: signalTypeExecuteWorkflow,
+		Phase:      signal.SignalPhaseExecute,
+		WorkflowID: "wfl_1",
+		OwnerType:  "installs",
+	}
+	outcome := signal.SignalPhaseOutcome{Status: signal.SignalStatusSuccess}
+
+	require.NoError(t, db.Create(&workflowStatusRow{
+		ID:        "wfl_1",
+		OwnerType: "installs",
+		Status: app.CompositeStatus{
+			Status: app.StatusFailedPendingRetry,
+		},
+	}).Error)
+
+	suppressed, err := suppressParkedFlowCompletion(ctx, db, event, outcome)
+	require.NoError(t, err)
+	assert.True(t, suppressed)
+
+	require.NoError(t, db.Save(&workflowStatusRow{
+		ID:        event.WorkflowID,
+		OwnerType: "installs",
+		Status: app.CompositeStatus{
+			Status: app.StatusSuccess,
+		},
+	}).Error)
+
+	suppressed, err = suppressParkedFlowCompletion(ctx, db, event, outcome)
+	require.NoError(t, err)
+	assert.False(t, suppressed)
+
+	require.NoError(t, db.Save(&workflowStatusRow{
+		ID:        event.WorkflowID,
+		OwnerType: "apps",
+		Status: app.CompositeStatus{
+			Status: app.StatusFailedPendingRetry,
+		},
+	}).Error)
+
+	suppressed, err = suppressParkedFlowCompletion(ctx, db, event, outcome)
+	require.NoError(t, err)
+	assert.False(t, suppressed)
+
+	event.SignalType = signalTypeExecuteWorkflowStep
+	suppressed, err = suppressParkedFlowCompletion(ctx, db, event, outcome)
+	require.NoError(t, err)
+	assert.False(t, suppressed)
+
+	event.SignalType = signalTypeExecuteWorkflow
+	event.WorkflowID = "missing"
+	outcome.Status = signal.SignalStatusError
+	suppressed, err = suppressParkedFlowCompletion(ctx, db, event, outcome)
+	require.NoError(t, err)
+	assert.False(t, suppressed)
+}
+
+func TestFlowCompletionStatusLookupFailureDoesNotSuppressHooks(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&workflowStatusRow{}))
+
+	event := signal.SignalPhaseEvent{
+		SignalType: signalTypeExecuteWorkflow,
+		Phase:      signal.SignalPhaseExecute,
+		WorkflowID: "missing",
+	}
+	outcome := signal.SignalPhaseOutcome{Status: signal.SignalStatusSuccess}
+
+	webhookHook := &WebhookSignalLifecycleHook{l: zap.NewNop(), db: db}
+	require.NoError(t, webhookHook.AfterPhase(context.Background(), event, outcome))
+
+	slackHook := &SlackSignalLifecycleHook{
+		l:           zap.NewNop(),
+		db:          db,
+		slackClient: &slackclient.Client{},
+		enricher:    webhookHook,
+	}
+	require.NoError(t, slackHook.AfterPhase(context.Background(), event, outcome))
+}

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/slack.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/slack.go
@@ -196,6 +196,13 @@ func (h *SlackSignalLifecycleHook) AfterPhase(ctx context.Context, event signal.
 		return nil
 	}
 
+	suppress, err := suppressParkedFlowCompletion(ctx, h.db, event, outcome)
+	if err != nil {
+		h.l.Warn("unable to verify workflow status before lifecycle completion", zap.Error(err))
+	} else if suppress {
+		return nil
+	}
+
 	h.l.Debug("workflow lifecycle slack after-phase",
 		zap.String("queue_signal_id", event.QueueSignalID),
 		zap.String("phase", string(event.Phase)),

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/webhook.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/webhook.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
+	"gorm.io/plugin/soft_delete"
 
 	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/pkg/metrics"
@@ -328,6 +329,13 @@ func (h *WebhookSignalLifecycleHook) AfterPhase(ctx context.Context, event signa
 		return nil
 	}
 
+	suppress, err := suppressParkedFlowCompletion(ctx, h.db, event, outcome)
+	if err != nil {
+		h.l.Warn("unable to verify workflow status before lifecycle completion", zap.Error(err))
+	} else if suppress {
+		return nil
+	}
+
 	h.l.Debug("workflow lifecycle webhook after-phase",
 		zap.String("queue_signal_id", event.QueueSignalID),
 		zap.String("phase", string(event.Phase)),
@@ -336,6 +344,37 @@ func (h *WebhookSignalLifecycleHook) AfterPhase(ctx context.Context, event signa
 	)
 
 	return h.publish(ctx, event, &outcome)
+}
+
+type workflowStatusRow struct {
+	ID        string
+	DeletedAt soft_delete.DeletedAt
+	OwnerType string
+	Status    app.CompositeStatus `gorm:"type:jsonb;serializer:json"`
+}
+
+func (workflowStatusRow) TableName() string {
+	return (&app.Workflow{}).TableName()
+}
+
+func suppressParkedFlowCompletion(ctx context.Context, db *gorm.DB, event signal.SignalPhaseEvent, outcome signal.SignalPhaseOutcome) (bool, error) {
+	if db == nil ||
+		event.SignalType != signalTypeExecuteWorkflow ||
+		event.Phase != signal.SignalPhaseExecute ||
+		event.WorkflowID == "" ||
+		outcome.Status != signal.SignalStatusSuccess {
+		return false, nil
+	}
+
+	var flw workflowStatusRow
+	if err := db.WithContext(ctx).
+		Select("owner_type", "status").
+		Where(workflowStatusRow{ID: event.WorkflowID}).
+		First(&flw).Error; err != nil {
+		return false, fmt.Errorf("unable to load workflow status for lifecycle completion: %w", err)
+	}
+
+	return flw.OwnerType == "installs" && flw.Status.Status == app.StatusFailedPendingRetry, nil
 }
 
 // CloudEvents v1.0 envelope.

--- a/services/ctl-api/internal/pkg/queue/signal/signal.go
+++ b/services/ctl-api/internal/pkg/queue/signal/signal.go
@@ -41,6 +41,13 @@ type AutoExecuteOnTerminalStart interface {
 	AutoExecuteOnTerminalStart() bool
 }
 
+// CompletionCallbacksWorkflow identifies resident flow signals whose parent
+// callbacks must reflect the persisted workflow outcome instead of the queue
+// signal's transport outcome. An empty ID preserves the default behavior.
+type CompletionCallbacksWorkflow interface {
+	CompletionCallbacksWorkflowID() string
+}
+
 const DefaultSleepAfter = 1 * time.Minute
 
 // Raw is a signal envelope for enqueueing without importing the concrete signal


### PR DESCRIPTION
## Summary
- suppress successful Webhook and Slack flow lifecycle completions when the persisted install workflow is `failed-pending-retry`
- gate parent completion callbacks for resident flow signals using an activity-side workflow-row status read
- fail open on status lookup errors so existing lifecycle and callback delivery is not silently lost

These branches are inert for today's retry-park behavior because parked step workflows do not complete their queue signal. They become active only when the later resident unwind allows the host signal to exit cleanly.

## Tests
- `go test ./services/ctl-api/internal/pkg/queue/... ./services/ctl-api/internal/pkg/flow/...`
- added lifecycle suppression matrix, callback workflow-environment coverage, persisted-status activity tests, and legacy non-resident serialization coverage