### PR TITLE
flow: unwind await-retry onto the resident host instead of parking in-place

### DIFF
--- a/services/ctl-api/internal/app/installs/service/cancel_workflow_step.go
+++ b/services/ctl-api/internal/app/installs/service/cancel_workflow_step.go
@@ -64,6 +64,7 @@ func (s *service) CancelWorkflowStep(ctx *gin.Context) {
 	cancelableStatuses := []app.Status{
 		app.StatusInProgress,
 		app.StatusPending,
+		app.StatusError,
 		app.AwaitingApproval,
 		app.Status("awaiting-approval"),
 		app.StatusFailedPendingRetry,

--- a/services/ctl-api/internal/pkg/flow/directive/directive.go
+++ b/services/ctl-api/internal/pkg/flow/directive/directive.go
@@ -107,6 +107,9 @@ const (
 
 	// GroupAwaitApproval means the group is awaiting approval.
 	GroupAwaitApproval Group = "await-approval"
+
+	// GroupAwaitRetry means the group is awaiting a manual retry or skip.
+	GroupAwaitRetry Group = "await-retry"
 )
 
 // MetadataKey is the key used to store the directive in status metadata.

--- a/services/ctl-api/internal/pkg/flow/errors.go
+++ b/services/ctl-api/internal/pkg/flow/errors.go
@@ -31,6 +31,12 @@ func NewApprovalPauseErr(stepID string) *ApprovalPauseErr {
 	return &ApprovalPauseErr{StepID: stepID}
 }
 
+type AwaitRetryPauseErr struct{}
+
+func (e *AwaitRetryPauseErr) Error() string {
+	return "workflow paused awaiting retry"
+}
+
 // FlowStoppedErr is returned when a workflow is stopped due to a denial or
 // skip-dependents response. Unlike ErrNotApproved, this carries context about
 // why the flow stopped and signals to the execute-flow signal that it should

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
@@ -27,10 +27,6 @@ const residentIdleTimeout = 15 * time.Minute
 // Each execution segment (initial, retry, skip, resume) is tracked as a WorkflowRun.
 // The flow pauses at approval points and errors, waiting for update handlers to resume.
 func (s *Signal) executeFlow(ctx workflow.Context) (retErr error) {
-	// Mark the conductor as started so a retry-step update that lands during a
-	// re-warm (before the loop reaches its parked state) is still cloned+queued.
-	s.executeStarted = true
-
 	// Initialize temporal metrics writer if the underlying metrics writer was injected.
 	if s.mw != nil && s.v != nil {
 		tmw, err := tmetrics.New(s.v, tmetrics.WithMetricsWriter(s.mw))
@@ -69,6 +65,8 @@ func (s *Signal) executeFlow(ctx workflow.Context) (retErr error) {
 			initialStartIdx = s.resumeStartIdx
 			initialStepID = s.resumeStepID
 			s.resumeRequested = false
+			s.resumeRunType = ""
+			s.resumeStepID = ""
 		} else if pos, ok := s.firstPendingGroupPosition(ctx); ok {
 			initialStartIdx = pos
 		}
@@ -80,26 +78,32 @@ func (s *Signal) executeFlow(ctx workflow.Context) (retErr error) {
 
 	for {
 		runErr := s.executeRun(ctx, run)
+		_, awaitingRetry := runErr.(*flow.AwaitRetryPauseErr)
+		if awaitingRetry {
+			runErr = nil
+		}
 
 		// Only a resume requested while parked below is valid; drop stale ones.
 		s.resumeRequested = false
 
 		if runErr == nil {
 			if s.cancelRequested {
+				if s.Resident {
+					s.updateRunStatus(ctx, run.ID, app.StatusCancelled)
+					if err := s.awaitResidentUpdates(ctx); err != nil {
+						return err
+					}
+				}
 				return nil
 			}
 
-			// Run completed without error. Check if workflow is fully done
-			// or if we paused at an approval/directive point.
-			if s.isWorkflowComplete(ctx) {
+			if awaitingRetry {
+				s.updateRunStatus(ctx, run.ID, app.StatusFailedPendingRetry)
+			} else if s.isWorkflowComplete(ctx) {
 				s.updateRunStatus(ctx, run.ID, app.StatusSuccess)
-				if !s.Resident {
+				if !s.Resident || (s.updatesInFlight == 0 && !s.appendRequested && !s.resumeRequested) {
 					return nil
 				}
-				// Resident: stay alive to accept the next step (e.g. a
-				// appended step) instead of completing. Fall through to the
-				// shared park below, which honors appendRequested and an idle
-				// timeout in resident mode.
 			} else if !s.Resident {
 				// Paused at approval - update run status and wait for resume.
 				// Resident hosts skip this: a non-complete state just means a
@@ -108,6 +112,12 @@ func (s *Signal) executeFlow(ctx workflow.Context) (retErr error) {
 			}
 		} else {
 			if s.cancelRequested {
+				if s.Resident {
+					s.updateRunStatus(ctx, run.ID, app.StatusCancelled)
+					if err := s.awaitResidentUpdates(ctx); err != nil {
+						return err
+					}
+				}
 				return nil
 			}
 
@@ -172,6 +182,9 @@ func (s *Signal) executeFlow(ctx workflow.Context) (retErr error) {
 			}
 			if s.cancelRequested {
 				s.updateRunStatus(ctx, run.ID, app.StatusCancelled)
+				if err := s.awaitResidentUpdates(ctx); err != nil {
+					return err
+				}
 				return runErr
 			}
 			if !parked {
@@ -179,7 +192,14 @@ func (s *Signal) executeFlow(ctx workflow.Context) (retErr error) {
 				return nil
 			}
 			// parkResident set resumeStartIdx to the first pending group.
-			run, err = s.createRun(ctx, app.WorkflowRunTypeResume, "", s.resumeStartIdx)
+			resumeRunType := s.resumeRunType
+			if resumeRunType == "" {
+				resumeRunType = app.WorkflowRunTypeResume
+			}
+			resumeStepID := s.resumeStepID
+			s.resumeRunType = ""
+			s.resumeStepID = ""
+			run, err = s.createRun(ctx, resumeRunType, resumeStepID, s.resumeStartIdx)
 			if err != nil {
 				return err
 			}
@@ -441,6 +461,10 @@ func (s *Signal) handle(ctx workflow.Context, startFromGroupIdx int) error {
 
 		group := &groups[gi]
 
+		if s.Resident && group.Status.Status == app.StatusFailedPendingRetry && !residentPending[group.GroupIdx] {
+			return &flow.AwaitRetryPauseErr{}
+		}
+
 		if s.Resident && !residentPending[group.GroupIdx] {
 			continue
 		}
@@ -517,6 +541,11 @@ func (s *Signal) handle(ctx workflow.Context, startFromGroupIdx int) error {
 
 		case flowdirective.GroupAwaitApproval:
 			return flow.NewApprovalPauseErr("")
+
+		case flowdirective.GroupAwaitRetry:
+			if s.Resident {
+				return &flow.AwaitRetryPauseErr{}
+			}
 
 		case flowdirective.GroupRetryGroup:
 			// Clone the group and re-dispatch the same group position.
@@ -728,6 +757,9 @@ func (s *Signal) firstPendingGroupPosition(ctx workflow.Context) (int, bool) {
 		if pending[g.GroupIdx] {
 			return pos, true
 		}
+		if g.Status.Status == app.StatusFailedPendingRetry {
+			return 0, false
+		}
 	}
 	return 0, false
 }
@@ -750,7 +782,7 @@ func (s *Signal) parkResident(ctx workflow.Context) (bool, error) {
 		}
 
 		s.awaitingResume = true
-		woke, err := workflow.AwaitWithTimeout(ctx, residentIdleTimeout, func() bool {
+		woke, err := workflow.AwaitWithTimeout(ctx, s.residentIdleTimeout(), func() bool {
 			return s.resumeRequested || s.appendRequested || s.cancelRequested
 		})
 		s.awaitingResume = false
@@ -784,6 +816,17 @@ func (s *Signal) parkResident(ctx workflow.Context) (bool, error) {
 		}
 		// Woke — loop back to re-scan for a pending group.
 	}
+}
+
+func (s *Signal) residentIdleTimeout() time.Duration {
+	if s.ResidentIdleTimeout > 0 {
+		return s.ResidentIdleTimeout
+	}
+	return residentIdleTimeout
+}
+
+func (s *Signal) awaitResidentUpdates(ctx workflow.Context) error {
+	return workflow.Await(ctx, func() bool { return s.updatesInFlight == 0 })
 }
 
 // markRemainingGroupStepsDiscarded marks all remaining groups and their

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/execute_group.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/execute_group.go
@@ -32,6 +32,7 @@ func (s *Signal) executeGroup(ctx workflow.Context, group *app.WorkflowStepGroup
 		TargetQueueName: cfg.TargetQueueName,
 		Parallel:        group.Parallel,
 		DerivedTimeout:  group.Timeout,
+		ResidentFlow:    s.Resident,
 		// Forward stamped names so the step signal can expose them via
 		// LifecycleContext for workflow_step lifecycle webhooks.
 		OrgID:     s.OrgID,

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/signal.go
@@ -50,6 +50,8 @@ type Signal struct {
 	// the loop returns cleanly and the workflow re-warms on the next dispatch.
 	Resident bool `json:"resident,omitempty"`
 
+	ResidentIdleTimeout time.Duration `json:"resident_idle_timeout,omitempty"`
+
 	// Resume state — set by update handlers (approve/retry/skip) to wake the
 	// main execute loop when it is waiting after an approval pause or error.
 	resumeRequested bool
@@ -61,13 +63,14 @@ type Signal struct {
 	// parked resident workflow and run a freshly-added step.
 	appendRequested bool
 
-	// updatesInFlight counts append-step and retry-step update handlers that
+	// updatesInFlight counts resident update handlers that
 	// are currently executing. Those handlers persist their step rows before
 	// they set appendRequested/resumeRequested, so a resident host that idles
 	// out on its timer alone could close while a step is still being written
 	// and orphan it until the next dispatch re-warms the host. parkResident
 	// will not idle out while this counter is non-zero.
 	updatesInFlight int
+	retryInFlight   map[string]bool
 
 	// Cancel state — set by cancel update handlers.
 	cancelRequested bool
@@ -82,12 +85,6 @@ type Signal struct {
 
 	// awaitingResume: true while the main loop is parked awaiting resume/cancel.
 	awaitingResume bool
-
-	// executeStarted: true once executeFlow() has begun running. A retry-step
-	// update that lands on a freshly re-warmed resident host (before the loop
-	// reaches its parked state) must still clone+queue the retry, so the retry
-	// handler treats "not started yet" like the parked case.
-	executeStarted bool
 
 	// Pause state — set by "pause-workflow" update handler. When true, the
 	// flow will pause after the current group completes.

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/update_cancel_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/update_cancel_step.go
@@ -1,10 +1,15 @@
 package executeflow
 
 import (
+	"fmt"
+
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/directive"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 	workflowactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow/activities"
 )
 
@@ -19,9 +24,12 @@ type CancelStepResponse struct {
 }
 
 // cancelStepHandler sets cancelRequested immediately and propagates the
-// cancellation to the group asynchronously. Unlike retry, cancellation does
-// not need to wait for a response — it is fire-and-forget.
+// cancellation to a live group. Resident flows also persist the equivalent
+// cancellation directly so the same update works after descendants unwind.
 func (s *Signal) cancelStepHandler(ctx workflow.Context, req CancelStepRequest) (*CancelStepResponse, error) {
+	s.updatesInFlight++
+	defer func() { s.updatesInFlight-- }()
+
 	s.cancelRequested = true
 
 	l, _ := log.WorkflowLogger(ctx)
@@ -35,7 +43,6 @@ func (s *Signal) cancelStepHandler(ctx workflow.Context, req CancelStepRequest) 
 		}
 		return &CancelStepResponse{WorkflowID: s.WorkflowID}, nil
 	}
-
 	if _, err := workflowactivities.AwaitForwardCancelStepToGroup(ctx, workflowactivities.ForwardCancelStepToGroupRequest{
 		StepID:      req.StepID,
 		StepGroupID: step.WorkflowStepGroupID,
@@ -47,5 +54,134 @@ func (s *Signal) cancelStepHandler(ctx workflow.Context, req CancelStepRequest) 
 		}
 	}
 
+	if s.Resident {
+		if err := s.cancelResidentStep(ctx, step); err != nil {
+			return nil, err
+		}
+		if err := s.finishResidentCancellation(ctx); err != nil {
+			return nil, err
+		}
+	}
+
 	return &CancelStepResponse{WorkflowID: s.WorkflowID}, nil
+}
+
+func (s *Signal) cancelResidentStep(ctx workflow.Context, step *app.WorkflowStep) error {
+	if err := workflowactivities.AwaitPkgWorkflowsFlowUpdateFlowStepResultDirective(ctx, workflowactivities.UpdateFlowStepResultDirectiveRequest{
+		StepID:    step.ID,
+		Directive: string(directive.StepStop),
+	}); err != nil {
+		return fmt.Errorf("unable to write cancel directive for step %s: %w", step.ID, err)
+	}
+	if err := statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
+		ID: step.ID,
+		Status: app.CompositeStatus{
+			Status:                 app.StatusCancelled,
+			StatusHumanDescription: "Step was cancelled by the user.",
+		},
+	}); err != nil {
+		return fmt.Errorf("unable to mark step %s cancelled: %w", step.ID, err)
+	}
+
+	if err := workflowactivities.AwaitPkgWorkflowsFlowUpdateFlowStepTargetStatus(ctx, workflowactivities.UpdateFlowStepTargetStatusRequest{
+		StepID:            step.ID,
+		Status:            app.StatusCancelled,
+		StatusDescription: "Cancelled",
+	}); err != nil {
+		return fmt.Errorf("unable to mark target for step %s cancelled: %w", step.ID, err)
+	}
+
+	steps, err := workflowactivities.AwaitPkgWorkflowsFlowGetFlowSteps(ctx, workflowactivities.GetFlowStepsRequest{
+		FlowID: s.WorkflowID,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to load steps during resident cancellation: %w", err)
+	}
+	for _, candidate := range steps {
+		if candidate.ID == step.ID || isStepTerminal(candidate.Status.Status) {
+			continue
+		}
+
+		status := app.StatusNotAttempted
+		description := "Step was not attempted because the workflow was cancelled."
+		sameGroup := candidate.GroupIdx == step.GroupIdx
+		if step.WorkflowStepGroupID != "" {
+			sameGroup = candidate.WorkflowStepGroupID == step.WorkflowStepGroupID
+		}
+		if sameGroup {
+			status = app.StatusCancelled
+			description = "Step was cancelled with its group."
+		} else if candidate.GroupIdx < step.GroupIdx {
+			continue
+		}
+
+		if err := statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
+			ID: candidate.ID,
+			Status: app.CompositeStatus{
+				Status:                 status,
+				StatusHumanDescription: description,
+			},
+		}); err != nil {
+			return fmt.Errorf("unable to update step %s during resident cancellation: %w", candidate.ID, err)
+		}
+	}
+
+	groups, err := workflowactivities.AwaitPkgWorkflowsFlowGetFlowStepGroups(ctx, s.WorkflowID)
+	if err != nil {
+		return fmt.Errorf("unable to load groups during resident cancellation: %w", err)
+	}
+	for _, group := range groups {
+		if group.GroupIdx < step.GroupIdx {
+			continue
+		}
+
+		targetGroup := group.ID == step.WorkflowStepGroupID || (step.WorkflowStepGroupID == "" && group.GroupIdx == step.GroupIdx)
+		if !targetGroup && isStepTerminal(group.Status.Status) {
+			continue
+		}
+
+		groupStatus := app.StatusDiscarded
+		groupDirective := directive.GroupStop
+		description := "group discarded because the workflow was cancelled"
+		if targetGroup {
+			groupStatus = app.StatusCancelled
+			description = "group cancelled"
+		}
+		if err := workflowactivities.AwaitPkgWorkflowsFlowUpdateFlowStepGroupResultDirective(ctx, workflowactivities.UpdateFlowStepGroupResultDirectiveRequest{
+			StepGroupID: group.ID,
+			Directive:   string(groupDirective),
+		}); err != nil {
+			return fmt.Errorf("unable to update group %s cancel directive: %w", group.ID, err)
+		}
+		if err := statusactivities.AwaitPkgStatusUpdateFlowStepGroupStatus(ctx, statusactivities.UpdateStatusRequest{
+			ID: group.ID,
+			Status: app.CompositeStatus{
+				Status:                 groupStatus,
+				StatusHumanDescription: description,
+			},
+		}); err != nil {
+			return fmt.Errorf("unable to update group %s during resident cancellation: %w", group.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *Signal) finishResidentCancellation(ctx workflow.Context) error {
+	if err := workflowactivities.AwaitPkgWorkflowsFlowUpdateFlowFinishedAtByID(ctx, s.WorkflowID); err != nil {
+		return fmt.Errorf("unable to mark resident workflow finished: %w", err)
+	}
+	if err := statusactivities.AwaitPkgStatusUpdateFlowStatus(ctx, statusactivities.UpdateStatusRequest{
+		ID: s.WorkflowID,
+		Status: app.CompositeStatus{
+			Status:                 app.StatusCancelled,
+			StatusHumanDescription: "workflow cancelled",
+			Metadata: map[string]any{
+				"cancel_requested_at": workflow.Now(ctx).Unix(),
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("unable to mark resident workflow cancelled: %w", err)
+	}
+	return nil
 }

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/update_cancel_workflow.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/update_cancel_workflow.go
@@ -1,9 +1,14 @@
 package executeflow
 
 import (
+	"fmt"
+
 	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/directive"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 	workflowactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow/activities"
@@ -18,22 +23,67 @@ type CancelWorkflowResponse struct {
 // currently running group signal (which cascades to steps and calls Cancel()
 // callbacks), then marks the workflow as cancelled.
 func (s *Signal) cancelWorkflowHandler(ctx workflow.Context) (*CancelWorkflowResponse, error) {
+	s.updatesInFlight++
+	defer func() { s.updatesInFlight-- }()
+
 	s.cancelRequested = true
 
-	// Persist cancel_requested_at in metadata so downstream signals (groups,
-	// steps) can detect cancellation even if the in-memory flag hasn't
-	// propagated yet. This survives ContinueAsNew and is the durable
-	// source of truth for cancellation.
-	_ = statusactivities.AwaitPkgStatusUpdateFlowStatus(ctx, statusactivities.UpdateStatusRequest{
-		ID: s.WorkflowID,
-		Status: app.CompositeStatus{
-			Status:                 app.StatusCancelled,
-			StatusHumanDescription: "workflow cancelled",
-			Metadata: map[string]any{
-				"cancel_requested_at": workflow.Now(ctx).Unix(),
+	if s.Resident {
+		steps, err := workflowactivities.AwaitPkgWorkflowsFlowGetFlowSteps(ctx, workflowactivities.GetFlowStepsRequest{
+			FlowID: s.WorkflowID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("unable to load steps for resident workflow cancellation: %w", err)
+		}
+		var residentStep *app.WorkflowStep
+		for i := range steps {
+			if directive.Step(steps[i].ResultDirective) == directive.StepAwaitRetry {
+				residentStep = &steps[i]
+				break
+			}
+		}
+		if residentStep == nil {
+			for i := range steps {
+				if !isStepTerminal(steps[i].Status.Status) {
+					residentStep = &steps[i]
+					break
+				}
+			}
+		}
+		if residentStep != nil {
+			if _, err := workflowactivities.AwaitForwardCancelStepToGroup(ctx, workflowactivities.ForwardCancelStepToGroupRequest{
+				StepID:      residentStep.ID,
+				StepGroupID: residentStep.WorkflowStepGroupID,
+			}); err != nil {
+				if l, _ := log.WorkflowLogger(ctx); l != nil {
+					l.Warn("cancel-workflow: unable to forward cancel to resident group",
+						zap.String("step_id", residentStep.ID),
+						zap.Error(err))
+				}
+			}
+			if err := s.cancelResidentStep(ctx, residentStep); err != nil {
+				return nil, err
+			}
+		}
+		if err := s.finishResidentCancellation(ctx); err != nil {
+			return nil, err
+		}
+	} else {
+		// Persist cancel_requested_at in metadata so downstream signals (groups,
+		// steps) can detect cancellation even if the in-memory flag hasn't
+		// propagated yet. This survives ContinueAsNew and is the durable
+		// source of truth for cancellation.
+		_ = statusactivities.AwaitPkgStatusUpdateFlowStatus(ctx, statusactivities.UpdateStatusRequest{
+			ID: s.WorkflowID,
+			Status: app.CompositeStatus{
+				Status:                 app.StatusCancelled,
+				StatusHumanDescription: "workflow cancelled",
+				Metadata: map[string]any{
+					"cancel_requested_at": workflow.Now(ctx).Unix(),
+				},
 			},
-		},
-	})
+		})
+	}
 
 	// Cancel the active group signal. This triggers the group's Cancel()
 	// method which propagates to step signals and their inner signals.
@@ -41,7 +91,9 @@ func (s *Signal) cancelWorkflowHandler(ctx workflow.Context) (*CancelWorkflowRes
 		client.AwaitCancelSignal(ctx, s.activeGroupQueueSignalID)
 	}
 
-	_ = workflowactivities.AwaitPkgWorkflowsFlowUpdateFlowFinishedAtByID(ctx, s.WorkflowID)
+	if !s.Resident {
+		_ = workflowactivities.AwaitPkgWorkflowsFlowUpdateFlowFinishedAtByID(ctx, s.WorkflowID)
+	}
 
 	return &CancelWorkflowResponse{WorkflowID: s.WorkflowID}, nil
 }

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/update_retry_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/update_retry_step.go
@@ -30,14 +30,16 @@ type RetryStepResponse struct {
 func (s *Signal) retryStepHandler(ctx workflow.Context, req RetryStepRequest) (*RetryStepResponse, error) {
 	s.updatesInFlight++
 	defer func() { s.updatesInFlight-- }()
-	if s.retryInFlight == nil {
-		s.retryInFlight = make(map[string]bool)
+	if s.Resident {
+		if s.retryInFlight == nil {
+			s.retryInFlight = make(map[string]bool)
+		}
+		if s.retryInFlight[req.StepID] {
+			return &RetryStepResponse{WorkflowID: s.WorkflowID, Retryable: true}, nil
+		}
+		s.retryInFlight[req.StepID] = true
+		defer delete(s.retryInFlight, req.StepID)
 	}
-	if s.retryInFlight[req.StepID] {
-		return &RetryStepResponse{WorkflowID: s.WorkflowID, Retryable: true}, nil
-	}
-	s.retryInFlight[req.StepID] = true
-	defer delete(s.retryInFlight, req.StepID)
 
 	step, err := workflowactivities.AwaitPkgWorkflowsFlowGetFlowsStepByFlowStepID(ctx, req.StepID)
 	if err != nil {

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/update_retry_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/update_retry_step.go
@@ -22,15 +22,22 @@ type RetryStepResponse struct {
 	Retryable  bool   `json:"retryable"`
 }
 
-// retryStepHandler forwards the retry request to the group, which forwards to
-// the step. The step's createStepRetryHandler writes the terminal directive and
-// unblocks Execute(). The queue signal completes, the group reads the directive,
-// and the group's sequential loop handles cloning.
+// retryStepHandler forwards the retry request through the group to the step.
+// Legacy groups clone the retry themselves; resident flows clone here after
+// descendants unwind so warm and cold updates share one durable owner.
 //
-// Flow: API → flow (here) → group → step → directive → group clones
+// Flow: API → flow (here) → group → step → directive → clone owner
 func (s *Signal) retryStepHandler(ctx workflow.Context, req RetryStepRequest) (*RetryStepResponse, error) {
 	s.updatesInFlight++
 	defer func() { s.updatesInFlight-- }()
+	if s.retryInFlight == nil {
+		s.retryInFlight = make(map[string]bool)
+	}
+	if s.retryInFlight[req.StepID] {
+		return &RetryStepResponse{WorkflowID: s.WorkflowID, Retryable: true}, nil
+	}
+	s.retryInFlight[req.StepID] = true
+	defer delete(s.retryInFlight, req.StepID)
 
 	step, err := workflowactivities.AwaitPkgWorkflowsFlowGetFlowsStepByFlowStepID(ctx, req.StepID)
 	if err != nil {
@@ -40,6 +47,12 @@ func (s *Signal) retryStepHandler(ctx workflow.Context, req RetryStepRequest) (*
 	if step.WorkflowStepGroupID == "" {
 		return nil, fmt.Errorf("step %s has no group ID, cannot forward retry", req.StepID)
 	}
+	stepDirective := directive.Step(step.ResultDirective)
+	residentManualRetry := s.Resident && (stepDirective == directive.StepAwaitRetry || stepDirective == directive.StepAwaitApproval)
+	if s.Resident && !residentManualRetry {
+		return &RetryStepResponse{WorkflowID: s.WorkflowID, Retryable: false}, nil
+	}
+	wasRetried := step.Retried
 
 	_, err = workflowactivities.AwaitForwardRetryStepToGroup(ctx, workflowactivities.ForwardRetryStepToGroupRequest{
 		StepID:      req.StepID,
@@ -49,29 +62,28 @@ func (s *Signal) retryStepHandler(ctx workflow.Context, req RetryStepRequest) (*
 		return nil, fmt.Errorf("unable to forward retry to group: %w", err)
 	}
 
-	// Parked flow (or a resident host re-warming before the conductor has
-	// started): the group isn't live to clone, so clone here and wake/seed the
-	// loop. !executeStarted covers the re-warm race where this update lands
-	// before executeFlow() runs; executeFlow's initial run then honors the
-	// seeded resume request.
-	if s.awaitingResume || (s.Resident && !s.executeStarted) {
+	// Resident flows own manual retry cloning after the child stack unwinds.
+	// Legacy parked flows retain their existing cold clone path.
+	if residentManualRetry || s.awaitingResume {
 		updated, err := workflowactivities.AwaitPkgWorkflowsFlowGetFlowsStepByFlowStepID(ctx, req.StepID)
 		if err != nil {
 			return nil, fmt.Errorf("unable to re-read step %s: %w", req.StepID, err)
 		}
 
-		if directive.Step(updated.ResultDirective) == directive.StepRetryGroup {
-			if err := s.cloneGroupForRetry(ctx, updated.GroupIdx); err != nil {
-				return nil, fmt.Errorf("unable to clone group for retry: %w", err)
+		if !residentManualRetry || !wasRetried {
+			if directive.Step(updated.ResultDirective) == directive.StepRetryGroup {
+				if err := s.cloneGroupForRetry(ctx, updated.GroupIdx); err != nil {
+					return nil, fmt.Errorf("unable to clone group for retry: %w", err)
+				}
+			} else if err := executeworkflowstepgroup.CloneStepForRetry(ctx, req.StepID, s.WorkflowID); err != nil {
+				return nil, fmt.Errorf("unable to clone step for retry: %w", err)
 			}
-		} else if err := executeworkflowstepgroup.CloneStepForRetry(ctx, req.StepID, s.WorkflowID); err != nil {
-			return nil, fmt.Errorf("unable to clone step for retry: %w", err)
 		}
 
-		s.resumeRequested = true
 		s.resumeRunType = app.WorkflowRunTypeRetry
 		s.resumeStepID = req.StepID
 		s.resumeStartIdx = s.findGroupPositionForStep(ctx, req.StepID)
+		s.resumeRequested = true
 	}
 
 	return &RetryStepResponse{WorkflowID: s.WorkflowID, Retryable: true}, nil

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/update_skip_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/update_skip_step.go
@@ -4,7 +4,13 @@ import (
 	"fmt"
 
 	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
 
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/directive"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 	workflowactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow/activities"
 )
 
@@ -20,24 +26,146 @@ type SkipStepResponse struct {
 }
 
 func (s *Signal) skipStepHandler(ctx workflow.Context, req SkipStepRequest) (*SkipStepResponse, error) {
-	// Look up the step to get its group ID for direct group lookup.
+	s.updatesInFlight++
+	defer func() { s.updatesInFlight-- }()
+
 	step, err := workflowactivities.AwaitPkgWorkflowsFlowGetFlowsStepByFlowStepID(ctx, req.StepID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get step %s: %w", req.StepID, err)
 	}
+	if !step.Skippable {
+		return &SkipStepResponse{WorkflowID: s.WorkflowID, Skippable: false}, nil
+	}
 
-	// Forward to the group handler which will mark the step as skipped and
-	// resume its step loop.
+	residentAwaitRetry := s.Resident && directive.Step(step.ResultDirective) == directive.StepAwaitRetry
+
 	resp, err := workflowactivities.AwaitForwardSkipStepToGroup(ctx, workflowactivities.ForwardSkipStepToGroupRequest{
 		StepID:      req.StepID,
 		StepGroupID: step.WorkflowStepGroupID,
 	})
-	if err != nil {
+	if err != nil && !residentAwaitRetry {
 		return nil, fmt.Errorf("unable to forward skip-step to group: %w", err)
+	}
+	if err != nil {
+		if l, _ := log.WorkflowLogger(ctx); l != nil {
+			l.Warn("skip-step: unable to forward skip to unwound group",
+				zap.String("step_id", req.StepID),
+				zap.Error(err))
+		}
+	}
+
+	if residentAwaitRetry {
+		skipDirective := residentSkipDirective(step)
+		if resp != nil && resp.Directive != "" {
+			skipDirective = directive.Step(resp.Directive)
+		}
+
+		if err := statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
+			ID: step.ID,
+			Status: app.CompositeStatus{
+				Status:                 app.StatusUserSkipped,
+				StatusHumanDescription: "Step was skipped by the user.",
+				Metadata: map[string]any{
+					"skipped": true,
+				},
+			},
+		}); err != nil {
+			return nil, fmt.Errorf("unable to mark step %s as skipped: %w", step.ID, err)
+		}
+		if err := workflowactivities.AwaitPkgWorkflowsFlowUpdateFlowStepResultDirective(ctx, workflowactivities.UpdateFlowStepResultDirectiveRequest{
+			StepID:    step.ID,
+			Directive: string(skipDirective),
+		}); err != nil {
+			return nil, fmt.Errorf("unable to write skip directive: %w", err)
+		}
+		if err := s.repairResidentSkippedGroup(ctx, step, skipDirective); err != nil {
+			return nil, err
+		}
+
+		s.resumeRunType = app.WorkflowRunTypeSkip
+		s.resumeStepID = req.StepID
+		s.resumeStartIdx = s.findGroupPositionForStep(ctx, req.StepID)
+		s.resumeRequested = true
 	}
 
 	return &SkipStepResponse{
 		WorkflowID: s.WorkflowID,
-		Skippable:  resp.Skippable,
+		Skippable:  true,
 	}, nil
+}
+
+func residentSkipDirective(step *app.WorkflowStep) directive.Step {
+	if step.QueueSignal != nil && step.QueueSignal.Signal != nil {
+		if skipGroup, ok := step.QueueSignal.Signal.(signal.SignalWithSkipGroup); ok && skipGroup.SkipGroup() {
+			return directive.StepSkipGroup
+		}
+	}
+	return directive.StepContinue
+}
+
+func (s *Signal) repairResidentSkippedGroup(ctx workflow.Context, step *app.WorkflowStep, skipDirective directive.Step) error {
+	steps, err := workflowactivities.AwaitPkgWorkflowsFlowGetFlowSteps(ctx, workflowactivities.GetFlowStepsRequest{
+		FlowID: s.WorkflowID,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to load group steps after skip: %w", err)
+	}
+
+	hasPending := false
+	for _, candidate := range steps {
+		sameGroup := candidate.GroupIdx == step.GroupIdx
+		if step.WorkflowStepGroupID != "" {
+			sameGroup = candidate.WorkflowStepGroupID == step.WorkflowStepGroupID
+		}
+		if !sameGroup || candidate.ID == step.ID || isStepTerminal(candidate.Status.Status) {
+			continue
+		}
+
+		if skipDirective == directive.StepSkipGroup && candidate.Idx > step.Idx {
+			if err := statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
+				ID: candidate.ID,
+				Status: app.CompositeStatus{
+					Status:                 app.StatusDiscarded,
+					StatusHumanDescription: "Step was discarded after the group was skipped.",
+				},
+			}); err != nil {
+				return fmt.Errorf("unable to discard skipped group step %s: %w", candidate.ID, err)
+			}
+			continue
+		}
+		hasPending = true
+	}
+
+	if step.WorkflowStepGroupID == "" {
+		return nil
+	}
+
+	groupDirective := directive.GroupContinue
+	if skipDirective == directive.StepSkipGroup {
+		groupDirective = directive.GroupSkipGroup
+	}
+	if err := workflowactivities.AwaitPkgWorkflowsFlowUpdateFlowStepGroupResultDirective(ctx, workflowactivities.UpdateFlowStepGroupResultDirectiveRequest{
+		StepGroupID: step.WorkflowStepGroupID,
+		Directive:   string(groupDirective),
+	}); err != nil {
+		return fmt.Errorf("unable to update skipped group directive: %w", err)
+	}
+
+	groupStatus := app.StatusSuccess
+	groupDescription := "group completed after step was skipped"
+	if hasPending {
+		groupStatus = app.StatusPending
+		groupDescription = "group pending after step was skipped"
+	}
+	if err := statusactivities.AwaitPkgStatusUpdateFlowStepGroupStatus(ctx, statusactivities.UpdateStatusRequest{
+		ID: step.WorkflowStepGroupID,
+		Status: app.CompositeStatus{
+			Status:                 groupStatus,
+			StatusHumanDescription: groupDescription,
+		},
+	}); err != nil {
+		return fmt.Errorf("unable to update skipped group status: %w", err)
+	}
+
+	return nil
 }

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/update_skip_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/update_skip_step.go
@@ -33,7 +33,7 @@ func (s *Signal) skipStepHandler(ctx workflow.Context, req SkipStepRequest) (*Sk
 	if err != nil {
 		return nil, fmt.Errorf("unable to get step %s: %w", req.StepID, err)
 	}
-	if !step.Skippable {
+	if s.Resident && !step.Skippable {
 		return &SkipStepResponse{WorkflowID: s.WorkflowID, Skippable: false}, nil
 	}
 
@@ -88,9 +88,13 @@ func (s *Signal) skipStepHandler(ctx workflow.Context, req SkipStepRequest) (*Sk
 		s.resumeRequested = true
 	}
 
+	skippable := true
+	if resp != nil {
+		skippable = resp.Skippable
+	}
 	return &SkipStepResponse{
 		WorkflowID: s.WorkflowID,
-		Skippable:  true,
+		Skippable:  skippable,
 	}, nil
 }
 

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
@@ -135,7 +135,7 @@ func (s *Signal) handleStepError(ctx workflow.Context, l *zap.Logger, step *app.
 		}
 
 		// Mark step as errored and write the await-retry directive.
-		// Execute() blocks here until the user retries or cancels.
+		// Legacy Execute() blocks here until the user retries or cancels.
 		_ = s.markStepFailed(ctx, step, stepErr, map[string]any{
 			"auto_retries_exhausted": nextRetryIndex > maxAutoRetries,
 			"skip_auto_retry":        skipAutoRetry,
@@ -158,6 +158,10 @@ func (s *Signal) handleStepError(ctx workflow.Context, l *zap.Logger, step *app.
 				},
 			},
 		})
+
+		if s.ResidentFlow {
+			return nil
+		}
 
 		// Block until user retries or cancels. The group's AwaitQueueSignal
 		// stays blocked naturally. When the retry update arrives (flow → group → step),

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/signal.go
@@ -70,6 +70,8 @@ type Signal struct {
 	// When non-zero, Timeout() returns this instead of the hardcoded fallback.
 	DerivedTimeout time.Duration `json:"derived_timeout,omitempty"`
 
+	ResidentFlow bool `json:"resident_flow,omitempty"`
+
 	// innerQueueSignalID tracks the currently executing inner signal so that
 	// Cancel() can propagate cancellation to it. Set during executeInnerSignal,
 	// read during Cancel. Safe because Temporal workflows are single-threaded.

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/execute.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/execute.go
@@ -70,6 +70,11 @@ func (s *Signal) Execute(ctx workflow.Context) (err error) {
 				},
 			})
 		}
+	} else if s.lastDirective == string(directive.GroupAwaitRetry) {
+		s.updateGroupStatus(ctx, app.CompositeStatus{
+			Status:                 app.StatusFailedPendingRetry,
+			StatusHumanDescription: "group failed, awaiting retry or skip",
+		})
 	} else if s.lastDirective == string(directive.GroupStop) {
 		s.updateGroupStatus(ctx, app.CompositeStatus{
 			Status:                 app.StatusError,
@@ -129,6 +134,7 @@ func (s *Signal) executeParallel(ctx workflow.Context, l *zap.Logger) error {
 	var firstErr error
 	hasStop := false
 	hasRetryGroup := false
+	hasAwaitRetry := false
 
 	for range steps {
 		var result StepResult
@@ -140,7 +146,15 @@ func (s *Signal) executeParallel(ctx workflow.Context, l *zap.Logger) error {
 			hasStop = true
 		}
 		if result.Result.Directive == directive.StepRetryGroup {
-			hasRetryGroup = true
+			if s.ResidentFlow && result.ManualRetry {
+				hasAwaitRetry = true
+			} else {
+				hasRetryGroup = true
+			}
+		}
+		if s.ResidentFlow && (result.Result.Directive == directive.StepAwaitRetry ||
+			(result.Result.Directive == directive.StepRetry && result.ManualRetry)) {
+			hasAwaitRetry = true
 		}
 	}
 
@@ -159,6 +173,10 @@ func (s *Signal) executeParallel(ctx workflow.Context, l *zap.Logger) error {
 		return s.writeStepGroupDirective(ctx, directive.GroupRetryGroup)
 	}
 
+	if hasAwaitRetry {
+		return s.writeStepGroupDirective(ctx, directive.GroupAwaitRetry)
+	}
+
 	return s.writeStepGroupDirective(ctx, directive.GroupContinue)
 }
 
@@ -174,6 +192,7 @@ func (s *Signal) dispatchStep(ctx workflow.Context, step *app.WorkflowStep, cb c
 		TargetQueueName: s.TargetQueueName,
 		TargetQueueID:   step.TargetQueueID,
 		DerivedTimeout:  step.Timeout,
+		ResidentFlow:    s.ResidentFlow,
 		// Forward stamped names so workflow_step lifecycle webhook events
 		// carry human-readable identifiers without a per-event DB lookup.
 		OrgID:     s.OrgID,

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/execute_sequential.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/execute_sequential.go
@@ -42,6 +42,9 @@ func (s *Signal) executeSequential(ctx workflow.Context, l *zap.Logger) error {
 			continue
 
 		case directive.StepRetry:
+			if s.ResidentFlow && result.ManualRetry {
+				return s.writeStepGroupDirective(ctx, directive.GroupAwaitRetry)
+			}
 			// Clone the step for individual retry. The next iteration
 			// picks up the pending clone.
 			if err := CloneStepForRetry(ctx, step.ID, s.WorkflowID); err != nil {
@@ -59,6 +62,9 @@ func (s *Signal) executeSequential(ctx workflow.Context, l *zap.Logger) error {
 			return s.writeStepGroupDirective(ctx, directive.GroupStop)
 
 		case directive.StepRetryGroup:
+			if s.ResidentFlow && result.ManualRetry {
+				return s.writeStepGroupDirective(ctx, directive.GroupAwaitRetry)
+			}
 			s.cancelRemainingSteps(ctx, l, steps, step.ID, app.StatusDiscarded)
 			return s.writeStepGroupDirective(ctx, directive.GroupRetryGroup)
 
@@ -72,6 +78,12 @@ func (s *Signal) executeSequential(ctx workflow.Context, l *zap.Logger) error {
 
 		case directive.StepAwaitApproval:
 			return s.writeStepGroupDirective(ctx, directive.GroupAwaitApproval)
+
+		case directive.StepAwaitRetry:
+			if s.ResidentFlow {
+				return s.writeStepGroupDirective(ctx, directive.GroupAwaitRetry)
+			}
+			continue
 
 		default:
 			continue

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/execute_single_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/execute_single_step.go
@@ -15,15 +15,16 @@ type StepResult struct {
 	// Result carries the directive and status metadata from the step.
 	Result directive.StepResult
 
+	ManualRetry bool
+
 	// Error is set when the step failed unexpectedly (not handled by the
 	// directive system). The caller should propagate this as a group error.
 	Error error
 }
 
 // executeSingleStep dispatches a step, awaits its queue signal completion, and
-// reads the step's directive from the database. Execute() stays alive until the
-// directive is terminal (blocking for approval or retry), so AwaitQueueSignal
-// naturally blocks for the full step lifecycle.
+// reads the step's directive from the database. Resident await-retry outcomes
+// return to the flow host; legacy inputs continue waiting in place.
 func (s *Signal) executeSingleStep(ctx workflow.Context, l *zap.Logger, step *app.WorkflowStep) StepResult {
 	l.Debug("dispatching step",
 		zap.String("step_id", step.ID),
@@ -75,9 +76,9 @@ func (s *Signal) executeSingleStep(ctx workflow.Context, l *zap.Logger, step *ap
 
 		d = directive.Step(updatedStep.ResultDirective)
 
-		// await-retry is non-terminal: the wait may have just timed out; keep
-		// waiting so the step stays retryable instead of stopping.
-		if d == directive.StepAwaitRetry {
+		// await-retry remains non-terminal for legacy inputs. Resident flows
+		// unwind it to the parent host instead.
+		if d == directive.StepAwaitRetry && !s.ResidentFlow {
 			continue
 		}
 		break
@@ -98,11 +99,15 @@ func (s *Signal) executeSingleStep(ctx workflow.Context, l *zap.Logger, step *ap
 
 	// Build the result with the step's status metadata for reason/status info.
 	result := directive.NewStepResult(d)
+	manualRetry := false
 	if updatedStep.Status.StatusHumanDescription != "" {
 		result.Reason = updatedStep.Status.StatusHumanDescription
 	}
 	// Read optional status overrides from step metadata.
 	if meta := updatedStep.Status.Metadata; meta != nil {
+		if retryType, ok := meta["retry_type"].(string); ok && retryType == "manual" {
+			manualRetry = true
+		}
 		if v, ok := meta["sibling_status"].(string); ok && v != "" {
 			result.SiblingStatus = app.Status(v)
 		}
@@ -111,5 +116,5 @@ func (s *Signal) executeSingleStep(ctx workflow.Context, l *zap.Logger, step *ap
 		}
 	}
 
-	return StepResult{Result: result}
+	return StepResult{Result: result, ManualRetry: manualRetry}
 }

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/signal.go
@@ -27,6 +27,7 @@ const (
 	DirectiveRetryGroup    = directive.StepRetryGroup
 	DirectiveSkipGroup     = directive.StepSkipGroup
 	DirectiveAwaitApproval = directive.StepAwaitApproval
+	DirectiveAwaitRetry    = directive.StepAwaitRetry
 )
 
 // Signal encapsulates the lifecycle of executing all steps within a single
@@ -69,6 +70,8 @@ type Signal struct {
 	// DerivedTimeout is set at dispatch time from the group's TimeoutSeconds.
 	// When non-zero, Timeout() returns this instead of the hardcoded fallback.
 	DerivedTimeout time.Duration `json:"derived_timeout,omitempty"`
+
+	ResidentFlow bool `json:"resident_flow,omitempty"`
 
 	// stepSignalIDs tracks in-flight step signal IDs for cancellation propagation.
 	stepSignalIDs []string

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/update_skip_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/update_skip_step.go
@@ -68,5 +68,9 @@ func (s *Signal) skipStepHandler(ctx workflow.Context, req SkipStepRequest) (*Sk
 		StepID: req.StepID,
 	})
 
-	return &SkipStepResponse{Skippable: true, Directive: string(skipDirective)}, nil
+	resp := &SkipStepResponse{Skippable: true}
+	if s.ResidentFlow {
+		resp.Directive = string(skipDirective)
+	}
+	return resp, nil
 }

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/update_skip_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup/update_skip_step.go
@@ -19,7 +19,8 @@ type SkipStepRequest struct {
 
 // SkipStepResponse is the response from the "skip-step" group update handler.
 type SkipStepResponse struct {
-	Skippable bool `json:"skippable"`
+	Skippable bool   `json:"skippable"`
+	Directive string `json:"directive,omitempty"`
 }
 
 // skipStepHandler marks the step as user-skipped, writes a continue directive,
@@ -67,5 +68,5 @@ func (s *Signal) skipStepHandler(ctx workflow.Context, req SkipStepRequest) (*Sk
 		StepID: req.StepID,
 	})
 
-	return &SkipStepResponse{Skippable: true}, nil
+	return &SkipStepResponse{Skippable: true, Directive: string(skipDirective)}, nil
 }

--- a/services/ctl-api/internal/pkg/flow/testworker/flow_resident_retry_test.go
+++ b/services/ctl-api/internal/pkg/flow/testworker/flow_resident_retry_test.go
@@ -1,0 +1,371 @@
+package testworker
+
+import (
+	"context"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	flowclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/client"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/directive"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeflow"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeworkflowstepgroup"
+	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
+)
+
+func residentRetrySteps(skippable bool) []app.WorkflowStep {
+	return []app.WorkflowStep{
+		{
+			Name:          "await-manual-retry",
+			Idx:           100,
+			GroupIdx:      1,
+			ExecutionType: app.WorkflowStepExecutionTypeSystem,
+			Retryable:     true,
+			Skippable:     skippable,
+			QueueSignal:   &signaldb.SignalData{Signal: &ManualRetrySignal{}},
+		},
+		{
+			Name:          "after-manual-action",
+			Idx:           200,
+			GroupIdx:      2,
+			ExecutionType: app.WorkflowStepExecutionTypeSystem,
+			QueueSignal:   &signaldb.SignalData{Signal: &SuccessSignal{}},
+		},
+	}
+}
+
+func (e *FlowTestSuite) waitForResidentAwaitRetry(ctx context.Context, flw *app.Workflow, stepName string) *app.WorkflowStep {
+	e.waitForWorkflowStatus(ctx, flw.ID, app.StatusFailedPendingRetry)
+
+	var failedStep *app.WorkflowStep
+	require.Eventually(e.T(), func() bool {
+		steps := e.getStepsByWorkflow(ctx, flw.ID)
+		for i := range steps {
+			if steps[i].Name == stepName &&
+				steps[i].Status.Status == app.StatusError &&
+				directive.Step(steps[i].ResultDirective) == directive.StepAwaitRetry {
+				failedStep = &steps[i]
+				return true
+			}
+		}
+		return false
+	}, pollTimeout, pollInterval)
+
+	e.waitForQueueSignalStatus(ctx, failedStep.ID, "install_workflow_steps", executeworkflowstep.SignalType, app.StatusSuccess)
+	e.waitForQueueSignalStatus(ctx, failedStep.WorkflowStepGroupID, "workflow_step_groups", executeworkflowstepgroup.SignalType, app.StatusSuccess)
+	require.Equal(e.T(), app.StatusFailedPendingRetry, e.getStepGroup(ctx, failedStep.WorkflowStepGroupID).Status.Status)
+	require.Eventually(e.T(), func() bool {
+		runs := e.getWorkflowRuns(ctx, flw.ID)
+		return len(runs) > 0 && runs[len(runs)-1].Status.Status == app.StatusFailedPendingRetry
+	}, pollTimeout, pollInterval)
+
+	return failedStep
+}
+
+func (e *FlowTestSuite) assertSingleSuccessfulRetry(ctx context.Context, flw *app.Workflow, originalStepID string) {
+	e.waitForWorkflowStatus(ctx, flw.ID, app.StatusSuccess)
+
+	steps := e.getStepsByWorkflow(ctx, flw.ID)
+	retryCount := 0
+	for i := range steps {
+		step := &steps[i]
+		if step.GroupIdx != 1 || step.ID == originalStepID {
+			continue
+		}
+		retryCount++
+		require.Equal(e.T(), 1, step.RetryIndex)
+		require.Equal(e.T(), app.StatusSuccess, step.Status.Status)
+	}
+	require.Equal(e.T(), 1, retryCount, "manual retry should create and execute exactly one clone")
+
+	for _, step := range steps {
+		if step.Name == "after-manual-action" {
+			require.Equal(e.T(), app.StatusSuccess, step.Status.Status)
+		}
+	}
+}
+
+func (e *FlowTestSuite) TestResidentAwaitRetryUnwindsAndExpires() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+	ownerID, ownerType := newTestOwner()
+	flw, queueID := e.setupGroupedFlowTest(ctx, ownerID, ownerType, residentRetrySteps(true))
+
+	e.enqueueResidentFlow(ctx, queueID, flw, ownerID, ownerType, 2*time.Second)
+	failedStep := e.waitForResidentAwaitRetry(ctx, flw, "await-manual-retry")
+	e.waitForQueueSignalStatus(ctx, flw.ID, "install_workflows", executeflow.SignalType, app.StatusSuccess)
+
+	failedStep = e.getStep(ctx, failedStep.ID)
+	require.Equal(e.T(), app.StatusError, failedStep.Status.Status)
+	require.Equal(e.T(), directive.StepAwaitRetry, directive.Step(failedStep.ResultDirective))
+	steps := e.getStepsByWorkflow(ctx, flw.ID)
+	for _, step := range steps {
+		if step.Name == "after-manual-action" {
+			require.Equal(e.T(), app.StatusPending, step.Status.Status)
+		}
+	}
+}
+
+func (e *FlowTestSuite) TestResidentWarmRetryResumes() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+	ownerID, ownerType := newTestOwner()
+	flw, queueID := e.setupGroupedFlowTest(ctx, ownerID, ownerType, residentRetrySteps(true))
+
+	e.enqueueResidentFlow(ctx, queueID, flw, ownerID, ownerType, 30*time.Second)
+	failedStep := e.waitForResidentAwaitRetry(ctx, flw, "await-manual-retry")
+	flowSignal := e.getLatestQueueSignal(ctx, flw.ID, "install_workflows", executeflow.SignalType)
+	require.NotEqual(e.T(), app.StatusSuccess, flowSignal.Status.Status)
+
+	_, err := e.service.FlowClient.RetryStep(ctx, &flowclient.RetryStepRequest{
+		InstallWorkflowID: flw.ID,
+		StepID:            failedStep.ID,
+	})
+	require.NoError(e.T(), err)
+	e.assertSingleSuccessfulRetry(ctx, flw, failedStep.ID)
+}
+
+func (e *FlowTestSuite) TestResidentColdRetryRewarms() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+	ownerID, ownerType := newTestOwner()
+	flw, queueID := e.setupGroupedFlowTest(ctx, ownerID, ownerType, residentRetrySteps(true))
+
+	e.enqueueResidentFlow(ctx, queueID, flw, ownerID, ownerType, 2*time.Second)
+	failedStep := e.waitForResidentAwaitRetry(ctx, flw, "await-manual-retry")
+	e.waitForQueueSignalStatus(ctx, flw.ID, "install_workflows", executeflow.SignalType, app.StatusSuccess)
+
+	_, err := e.service.FlowClient.RetryStep(ctx, &flowclient.RetryStepRequest{
+		InstallWorkflowID: flw.ID,
+		StepID:            failedStep.ID,
+	})
+	require.NoError(e.T(), err)
+	e.assertSingleSuccessfulRetry(ctx, flw, failedStep.ID)
+}
+
+func (e *FlowTestSuite) TestResidentRetryIsIdempotentAcrossConcurrentUpdates() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+	ownerID, ownerType := newTestOwner()
+	flw, queueID := e.setupGroupedFlowTest(ctx, ownerID, ownerType, residentRetrySteps(true))
+
+	e.enqueueResidentFlow(ctx, queueID, flw, ownerID, ownerType, 30*time.Second)
+	failedStep := e.waitForResidentAwaitRetry(ctx, flw, "await-manual-retry")
+
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := e.service.FlowClient.RetryStep(ctx, &flowclient.RetryStepRequest{
+				InstallWorkflowID: flw.ID,
+				StepID:            failedStep.ID,
+			})
+			errs <- err
+		}()
+	}
+	for range 2 {
+		require.NoError(e.T(), <-errs)
+	}
+
+	e.assertSingleSuccessfulRetry(ctx, flw, failedStep.ID)
+}
+
+func (e *FlowTestSuite) TestResidentRetriesDistinctStepsInTheSameGroup() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+	ownerID, ownerType := newTestOwner()
+	flw, queueID := e.setupGroupedFlowTest(ctx, ownerID, ownerType, []app.WorkflowStep{
+		{
+			Name:          "first-manual-retry",
+			Idx:           100,
+			GroupIdx:      1,
+			ExecutionType: app.WorkflowStepExecutionTypeSystem,
+			Retryable:     true,
+			QueueSignal:   &signaldb.SignalData{Signal: &ManualRetrySignal{}},
+		},
+		{
+			Name:          "second-manual-retry",
+			Idx:           200,
+			GroupIdx:      1,
+			ExecutionType: app.WorkflowStepExecutionTypeSystem,
+			Retryable:     true,
+			QueueSignal:   &signaldb.SignalData{Signal: &ManualRetrySignal{}},
+		},
+		{
+			Name:          "after-two-retries",
+			Idx:           300,
+			GroupIdx:      2,
+			ExecutionType: app.WorkflowStepExecutionTypeSystem,
+			QueueSignal:   &signaldb.SignalData{Signal: &SuccessSignal{}},
+		},
+	})
+
+	e.enqueueResidentFlow(ctx, queueID, flw, ownerID, ownerType, 30*time.Second)
+	firstStep := e.waitForResidentAwaitRetry(ctx, flw, "first-manual-retry")
+	_, err := e.service.FlowClient.RetryStep(ctx, &flowclient.RetryStepRequest{
+		InstallWorkflowID: flw.ID,
+		StepID:            firstStep.ID,
+	})
+	require.NoError(e.T(), err)
+
+	secondStep := e.waitForResidentAwaitRetry(ctx, flw, "second-manual-retry")
+	_, err = e.service.FlowClient.RetryStep(ctx, &flowclient.RetryStepRequest{
+		InstallWorkflowID: flw.ID,
+		StepID:            secondStep.ID,
+	})
+	require.NoError(e.T(), err)
+	e.waitForWorkflowStatus(ctx, flw.ID, app.StatusSuccess)
+
+	steps := e.getStepsByWorkflow(ctx, flw.ID)
+	retries := map[string]int{}
+	for _, step := range steps {
+		if step.RetryIndex > 0 {
+			retries[step.Name]++
+			require.Equal(e.T(), app.StatusSuccess, step.Status.Status)
+		}
+	}
+	require.Equal(e.T(), 1, retries["first-manual-retry"])
+	require.Equal(e.T(), 1, retries["second-manual-retry"])
+}
+
+func (e *FlowTestSuite) TestResidentWarmSkipResumes() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+	ownerID, ownerType := newTestOwner()
+	flw, queueID := e.setupGroupedFlowTest(ctx, ownerID, ownerType, residentRetrySteps(true))
+
+	e.enqueueResidentFlow(ctx, queueID, flw, ownerID, ownerType, 30*time.Second)
+	failedStep := e.waitForResidentAwaitRetry(ctx, flw, "await-manual-retry")
+	flowSignal := e.getLatestQueueSignal(ctx, flw.ID, "install_workflows", executeflow.SignalType)
+	require.NotEqual(e.T(), app.StatusSuccess, flowSignal.Status.Status)
+	resp, err := e.service.FlowClient.SkipStep(ctx, &flowclient.SkipStepRequest{
+		InstallWorkflowID: flw.ID,
+		StepID:            failedStep.ID,
+	})
+	require.NoError(e.T(), err)
+	require.True(e.T(), resp.Skippable)
+
+	e.waitForWorkflowStatus(ctx, flw.ID, app.StatusSuccess)
+	require.Equal(e.T(), app.StatusUserSkipped, e.getStep(ctx, failedStep.ID).Status.Status)
+}
+
+func (e *FlowTestSuite) TestResidentColdSkipRewarms() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+	ownerID, ownerType := newTestOwner()
+	flw, queueID := e.setupGroupedFlowTest(ctx, ownerID, ownerType, residentRetrySteps(true))
+
+	e.enqueueResidentFlow(ctx, queueID, flw, ownerID, ownerType, 2*time.Second)
+	failedStep := e.waitForResidentAwaitRetry(ctx, flw, "await-manual-retry")
+	e.waitForQueueSignalStatus(ctx, flw.ID, "install_workflows", executeflow.SignalType, app.StatusSuccess)
+	resp, err := e.service.FlowClient.SkipStep(ctx, &flowclient.SkipStepRequest{
+		InstallWorkflowID: flw.ID,
+		StepID:            failedStep.ID,
+	})
+	require.NoError(e.T(), err)
+	require.True(e.T(), resp.Skippable)
+
+	e.waitForWorkflowStatus(ctx, flw.ID, app.StatusSuccess)
+	require.Equal(e.T(), app.StatusUserSkipped, e.getStep(ctx, failedStep.ID).Status.Status)
+}
+
+func (e *FlowTestSuite) TestResidentWarmCancelStops() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+	ownerID, ownerType := newTestOwner()
+	flw, queueID := e.setupGroupedFlowTest(ctx, ownerID, ownerType, residentRetrySteps(true))
+
+	e.enqueueResidentFlow(ctx, queueID, flw, ownerID, ownerType, 30*time.Second)
+	failedStep := e.waitForResidentAwaitRetry(ctx, flw, "await-manual-retry")
+	flowSignal := e.getLatestQueueSignal(ctx, flw.ID, "install_workflows", executeflow.SignalType)
+	require.NotEqual(e.T(), app.StatusSuccess, flowSignal.Status.Status)
+	_, err := e.service.FlowClient.CancelStep(ctx, &flowclient.CancelStepRequest{
+		InstallWorkflowID: flw.ID,
+		StepID:            failedStep.ID,
+	})
+	require.NoError(e.T(), err)
+
+	e.waitForWorkflowStatus(ctx, flw.ID, app.StatusCancelled)
+	require.Equal(e.T(), app.StatusCancelled, e.getStep(ctx, failedStep.ID).Status.Status)
+	require.Equal(e.T(), app.StatusCancelled, e.getStepGroup(ctx, failedStep.WorkflowStepGroupID).Status.Status)
+}
+
+func (e *FlowTestSuite) TestResidentColdCancelRewarms() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+	ownerID, ownerType := newTestOwner()
+	flw, queueID := e.setupGroupedFlowTest(ctx, ownerID, ownerType, residentRetrySteps(true))
+
+	e.enqueueResidentFlow(ctx, queueID, flw, ownerID, ownerType, 2*time.Second)
+	failedStep := e.waitForResidentAwaitRetry(ctx, flw, "await-manual-retry")
+	e.waitForQueueSignalStatus(ctx, flw.ID, "install_workflows", executeflow.SignalType, app.StatusSuccess)
+	_, err := e.service.FlowClient.CancelStep(ctx, &flowclient.CancelStepRequest{
+		InstallWorkflowID: flw.ID,
+		StepID:            failedStep.ID,
+	})
+	require.NoError(e.T(), err)
+
+	e.waitForWorkflowStatus(ctx, flw.ID, app.StatusCancelled)
+	require.Equal(e.T(), app.StatusCancelled, e.getStep(ctx, failedStep.ID).Status.Status)
+}
+
+func (e *FlowTestSuite) TestResidentColdCancelWorkflowRepairsAwaitRetryStep() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+	ownerID, ownerType := newTestOwner()
+	flw, queueID := e.setupGroupedFlowTest(ctx, ownerID, ownerType, residentRetrySteps(true))
+
+	e.enqueueResidentFlow(ctx, queueID, flw, ownerID, ownerType, 2*time.Second)
+	failedStep := e.waitForResidentAwaitRetry(ctx, flw, "await-manual-retry")
+	e.waitForQueueSignalStatus(ctx, flw.ID, "install_workflows", executeflow.SignalType, app.StatusSuccess)
+	_, err := e.service.FlowClient.CancelWorkflow(ctx, &flowclient.CancelWorkflowRequest{
+		InstallWorkflowID: flw.ID,
+	})
+	require.NoError(e.T(), err)
+
+	e.waitForWorkflowStatus(ctx, flw.ID, app.StatusCancelled)
+	e.waitForStepStatus(ctx, failedStep.ID, app.StatusCancelled)
+}
+
+func (e *FlowTestSuite) TestLegacyAwaitRetryRemainsParkedInPlace() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+	ownerID, ownerType := newTestOwner()
+	flw, queueID := e.setupGroupedFlowTest(ctx, ownerID, ownerType, residentRetrySteps(true))
+
+	e.enqueueGroupedLegacyFlow(ctx, queueID, flw, ownerID, ownerType)
+	e.waitForWorkflowStatus(ctx, flw.ID, app.StatusFailedPendingRetry)
+	steps := e.getStepsByWorkflow(ctx, flw.ID)
+	failedStep := &steps[0]
+	time.Sleep(2 * time.Second)
+
+	stepSignal := e.getLatestQueueSignal(ctx, failedStep.ID, "install_workflow_steps", executeworkflowstep.SignalType)
+	groupSignal := e.getLatestQueueSignal(ctx, failedStep.WorkflowStepGroupID, "workflow_step_groups", executeworkflowstepgroup.SignalType)
+	flowSignal := e.getLatestQueueSignal(ctx, flw.ID, "install_workflows", executeflow.SignalType)
+	require.NotEqual(e.T(), app.StatusSuccess, stepSignal.Status.Status)
+	require.NotEqual(e.T(), app.StatusSuccess, groupSignal.Status.Status)
+	require.NotEqual(e.T(), app.StatusSuccess, flowSignal.Status.Status)
+}
+
+func (e *FlowTestSuite) TestResidentCleanSuccessFastExits() {
+	ctx := e.service.Seed.EnsureAccount(e.T().Context(), e.T())
+	ctx = e.service.Seed.EnsureOrg(ctx, e.T())
+	ownerID, ownerType := newTestOwner()
+	flw, queueID := e.setupGroupedFlowTest(ctx, ownerID, ownerType, []app.WorkflowStep{
+		{
+			Name:          "resident-success",
+			Idx:           100,
+			GroupIdx:      1,
+			ExecutionType: app.WorkflowStepExecutionTypeSystem,
+			QueueSignal:   &signaldb.SignalData{Signal: &SuccessSignal{}},
+		},
+	})
+
+	e.enqueueResidentFlow(ctx, queueID, flw, ownerID, ownerType, 30*time.Second)
+	e.waitForWorkflowStatus(ctx, flw.ID, app.StatusSuccess)
+	require.Eventually(e.T(), func() bool {
+		queueSignal := e.getLatestQueueSignal(ctx, flw.ID, "install_workflows", executeflow.SignalType)
+		return queueSignal.Status.Status == app.StatusSuccess
+	}, 10*time.Second, pollInterval, "resident success should not wait for the idle timeout")
+}

--- a/services/ctl-api/internal/pkg/flow/testworker/flow_success_test.go
+++ b/services/ctl-api/internal/pkg/flow/testworker/flow_success_test.go
@@ -2,6 +2,7 @@ package testworker
 
 import (
 	"context"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -31,6 +32,42 @@ func (e *FlowTestSuite) setupFlowTest(ctx context.Context, ownerID, ownerType st
 	return &flw, stepQueue.ID
 }
 
+func (e *FlowTestSuite) setupGroupedFlowTest(ctx context.Context, ownerID, ownerType string, steps []app.WorkflowStep) (*app.Workflow, string) {
+	stepQueue := e.createTestQueue(ctx, ownerID, ownerType, "install-workflow-steps")
+	e.createTestQueue(ctx, ownerID, ownerType, "install-workflow-step-groups")
+	e.createTestQueue(ctx, ownerID, ownerType, "install-signals")
+
+	flw := app.Workflow{
+		OwnerID:   ownerID,
+		OwnerType: ownerType,
+		Type:      "test_flow",
+		Status:    app.NewCompositeStatus(ctx, app.StatusPending),
+	}
+	res := e.service.DB.WithContext(ctx).Create(&flw)
+	require.Nil(e.T(), res.Error)
+
+	groups := make(map[int]string)
+	for i := range steps {
+		groupID, ok := groups[steps[i].GroupIdx]
+		if !ok {
+			group := app.WorkflowStepGroup{
+				WorkflowID: flw.ID,
+				GroupIdx:   steps[i].GroupIdx,
+				Parallel:   steps[i].GroupParallel,
+				Status:     app.NewCompositeStatus(ctx, app.StatusPending),
+			}
+			res := e.service.DB.WithContext(ctx).Create(&group)
+			require.Nil(e.T(), res.Error)
+			groupID = group.ID
+			groups[steps[i].GroupIdx] = groupID
+		}
+		steps[i].WorkflowStepGroupID = groupID
+	}
+
+	e.createTestSteps(ctx, &flw, steps)
+	return &flw, stepQueue.ID
+}
+
 // enqueueFlow dispatches the execute-flow signal to start the workflow.
 func (e *FlowTestSuite) enqueueFlow(ctx context.Context, queueID string, flw *app.Workflow, ownerID, ownerType string) {
 	resp, err := e.service.QueueClient.EnqueueSignal(ctx, &client.EnqueueSignalRequest{
@@ -44,6 +81,44 @@ func (e *FlowTestSuite) enqueueFlow(ctx context.Context, queueID string, flw *ap
 		},
 		// Set owner so the flow client can find this queue signal via
 		// findQueueSignalByOwner(workflowID, "install_workflows", ...).
+		OwnerID:   flw.ID,
+		OwnerType: "install_workflows",
+	})
+	require.Nil(e.T(), err)
+	require.NotNil(e.T(), resp)
+}
+
+func (e *FlowTestSuite) enqueueResidentFlow(ctx context.Context, queueID string, flw *app.Workflow, ownerID, ownerType string, idleTimeout time.Duration) {
+	resp, err := e.service.QueueClient.EnqueueSignal(ctx, &client.EnqueueSignalRequest{
+		QueueID: queueID,
+		Signal: &executeflow.Signal{
+			WorkflowID:          flw.ID,
+			StepGroupQueueName:  "install-workflow-step-groups",
+			StepQueueName:       "install-workflow-steps",
+			StepTargetQueueName: "install-signals",
+			OwnerID:             ownerID,
+			OwnerType:           ownerType,
+			Resident:            true,
+			ResidentIdleTimeout: idleTimeout,
+		},
+		OwnerID:   flw.ID,
+		OwnerType: "install_workflows",
+	})
+	require.Nil(e.T(), err)
+	require.NotNil(e.T(), resp)
+}
+
+func (e *FlowTestSuite) enqueueGroupedLegacyFlow(ctx context.Context, queueID string, flw *app.Workflow, ownerID, ownerType string) {
+	resp, err := e.service.QueueClient.EnqueueSignal(ctx, &client.EnqueueSignalRequest{
+		QueueID: queueID,
+		Signal: &executeflow.Signal{
+			WorkflowID:          flw.ID,
+			StepGroupQueueName:  "install-workflow-step-groups",
+			StepQueueName:       "install-workflow-steps",
+			StepTargetQueueName: "install-signals",
+			OwnerID:             ownerID,
+			OwnerType:           ownerType,
+		},
 		OwnerID:   flw.ID,
 		OwnerType: "install_workflows",
 	})

--- a/services/ctl-api/internal/pkg/flow/testworker/helpers_test.go
+++ b/services/ctl-api/internal/pkg/flow/testworker/helpers_test.go
@@ -86,6 +86,44 @@ func (e *FlowTestSuite) getStep(ctx context.Context, id string) *app.WorkflowSte
 	return &step
 }
 
+func (e *FlowTestSuite) getStepGroup(ctx context.Context, id string) *app.WorkflowStepGroup {
+	var group app.WorkflowStepGroup
+	res := e.service.DB.WithContext(ctx).Where(app.WorkflowStepGroup{ID: id}).First(&group)
+	require.Nil(e.T(), res.Error)
+	return &group
+}
+
+func (e *FlowTestSuite) getLatestQueueSignal(ctx context.Context, ownerID, ownerType string, signalType signal.SignalType) *app.QueueSignal {
+	var queueSignal app.QueueSignal
+	res := e.service.DB.WithContext(ctx).
+		Where(app.QueueSignal{
+			OwnerID:   ownerID,
+			OwnerType: ownerType,
+			Type:      signalType,
+		}).
+		Order("created_at DESC").
+		First(&queueSignal)
+	require.Nil(e.T(), res.Error)
+	return &queueSignal
+}
+
+func (e *FlowTestSuite) waitForQueueSignalStatus(ctx context.Context, ownerID, ownerType string, signalType signal.SignalType, expected app.Status) {
+	require.Eventually(e.T(), func() bool {
+		queueSignal := e.getLatestQueueSignal(ctx, ownerID, ownerType, signalType)
+		return queueSignal.Status.Status == expected
+	}, pollTimeout, pollInterval, "queue signal %s for %s did not reach %s", signalType, ownerID, expected)
+}
+
+func (e *FlowTestSuite) getWorkflowRuns(ctx context.Context, workflowID string) []app.WorkflowRun {
+	var runs []app.WorkflowRun
+	res := e.service.DB.WithContext(ctx).
+		Where(app.WorkflowRun{WorkflowID: workflowID}).
+		Order("created_at ASC").
+		Find(&runs)
+	require.Nil(e.T(), res.Error)
+	return runs
+}
+
 // getStepsByWorkflow fetches all steps for a workflow ordered by Idx.
 func (e *FlowTestSuite) getStepsByWorkflow(ctx context.Context, workflowID string) []app.WorkflowStep {
 	var steps []app.WorkflowStep

--- a/services/ctl-api/internal/pkg/flow/testworker/testsignals.go
+++ b/services/ctl-api/internal/pkg/flow/testworker/testsignals.go
@@ -16,6 +16,7 @@ func init() {
 	catalog.Register(FailSignalType, func() signal.Signal { return &FailSignal{} })
 	catalog.Register(SlowSignalType, func() signal.Signal { return &SlowSignal{} })
 	catalog.Register(AutoRetrySignalType, func() signal.Signal { return &AutoRetrySignal{} })
+	catalog.Register(ManualRetrySignalType, func() signal.Signal { return &ManualRetrySignal{} })
 	catalog.Register(RetryGroupSignalType, func() signal.Signal { return &RetryGroupSignal{} })
 	catalog.Register(CountdownSignalType, func() signal.Signal { return &CountdownSignal{} })
 	catalog.Register(CountdownGroupSignalType, func() signal.Signal { return &CountdownGroupSignal{} })
@@ -81,6 +82,41 @@ func (s *AutoRetrySignal) SleepAfter() time.Duration { return time.Second }
 
 var _ signal.SignalWithAutoRetry = (*AutoRetrySignal)(nil)
 var _ signal.SignalWithMaxRetries = (*AutoRetrySignal)(nil)
+
+const ManualRetrySignalType signal.SignalType = "test-flow-manual-retry"
+
+type ManualRetrySignal struct {
+	StepID string `json:"step_id,omitempty"`
+	FlowID string `json:"flow_id,omitempty"`
+}
+
+func (s *ManualRetrySignal) Type() signal.SignalType         { return ManualRetrySignalType }
+func (s *ManualRetrySignal) Validate(workflow.Context) error { return nil }
+func (s *ManualRetrySignal) AutoRetry() bool                 { return true }
+func (s *ManualRetrySignal) MaxRetries() int                 { return 2 }
+func (s *ManualRetrySignal) MaxAutoRetries(workflow.Context) int {
+	return 0
+}
+func (s *ManualRetrySignal) SetStepContext(stepID, flowID string) {
+	s.StepID = stepID
+	s.FlowID = flowID
+}
+func (s *ManualRetrySignal) Execute(ctx workflow.Context) error {
+	step, err := activities.AwaitPkgWorkflowsFlowGetFlowsStepByFlowStepID(ctx, s.StepID)
+	if err != nil {
+		return fmt.Errorf("manual retry signal: unable to get step: %w", err)
+	}
+	if step.RetryIndex > 0 {
+		return nil
+	}
+	return fmt.Errorf("manual retry signal: waiting for manual retry")
+}
+func (s *ManualRetrySignal) SleepAfter() time.Duration { return time.Second }
+
+var _ signal.SignalWithAutoRetry = (*ManualRetrySignal)(nil)
+var _ signal.SignalWithMaxRetries = (*ManualRetrySignal)(nil)
+var _ signal.SignalWithMaxAutoRetries = (*ManualRetrySignal)(nil)
+var _ signal.SignalWithStepContext = (*ManualRetrySignal)(nil)
 
 // --- RetryGroupSignal: fails and requests group retry ---
 

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_to_group.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/forward_to_group.go
@@ -152,7 +152,8 @@ type ForwardSkipStepToGroupRequest struct {
 
 // ForwardSkipStepToGroupResponse wraps the group's skip-step response.
 type ForwardSkipStepToGroupResponse struct {
-	Skippable bool `json:"skippable"`
+	Skippable bool   `json:"skippable"`
+	Directive string `json:"directive,omitempty"`
 }
 
 // @temporal-gen-v2 activity


### PR DESCRIPTION
## Summary

- carry the resident-flow behavior switch from `executeflow.Signal.Resident` into serialized group and step inputs
- unwind exhausted `await-retry` steps and groups back to the resident flow host instead of retaining the full child stack
- preserve the failed-pending-retry barrier, park the host for a bounded idle window, and fast-exit clean resident successes
- make retry, skip, step cancel, and workflow cancel work both against a warm parked host and after cold update-with-start re-warm
- keep manual retry cloning flow-host-owned and idempotent, including concurrent duplicate updates and multiple retried steps in one group

## Cancel / skip parity

Resident skip persists the same user-skipped status and continue/skip-group directive as the live child path, repairs the group to pending or terminal as appropriate, then seeds the correct resume position.

Resident cancellation first forwards to live descendants when present, then durably writes stop/cancel state for the selected step, sibling/future steps and groups, the workflow status, `cancel_requested_at`, and `finished_at`. The flow waits for in-flight update handlers before closing so warm cancellation cannot abandon its persistence work. The public cancel-step endpoint now accepts the errored status used by an await-retry step.

## Replay safety and rollout

- the switch is input-carried: `Resident` is copied to `ResidentFlow` on group and step inputs
- every new workflow branch and update-result change is gated by `Resident` / `ResidentFlow`; legacy unset inputs retain the parked-in-place await and polling paths
- the test idle-timeout override is also serialized on the flow input
- no production enqueue site sets resident mode in this PR; activation remains PR 3
- no `workflow.GetVersion`, feature flag, or mutable global is used
- the repository has no `WorkflowReplayer` / `ReplayWorkflowHistory` harness, so no history-replay test was added

## Tests

Added integration coverage for:

- resident unwind, bounded park, and clean host exit with DB-only pending-retry state
- warm and cold manual retry
- warm and cold skip
- warm and cold step cancel, plus cold workflow cancel
- concurrent duplicate retry idempotence
- distinct retries for two steps in the same group
- legacy unset-input behavior remaining parked in place
- clean resident success fast-exit

Validation run with constrained parallelism:

- `GOMAXPROCS=2 go test -p 1 -ldflags='-s -w' ./services/ctl-api/internal/pkg/flow/... ./services/ctl-api/internal/pkg/queue/...` ✅ (integration-gated suites compile and skip without `INTEGRATION=true`)
- `GOMAXPROCS=2 go test -c -p 1 -ldflags='-s -w' -o /tmp/testworker.test ./services/ctl-api/internal/pkg/flow/testworker/` ✅
- `GOMAXPROCS=2 go build -p 1` for the changed flow, workflow-activity, and installs-service packages ✅

The integration cases were **not executed**: this orb has PostgreSQL but no Temporal, ClickHouse, Docker, or Temporal CLI. The test binary was compiled successfully.

The requested broad `go build -p 1 ./services/ctl-api/...` was attempted but cannot start from this clean checkout because generated Swagger Go packages under `services/ctl-api/docs/{admin,public,runner}` are absent. I did not run Swagger generation because the task explicitly warns that it OOMs the ~2 GB orb. The installs-service test package is likewise blocked by the checkout's absent generated `temporalclient.NewMockClient`; its production package builds.

## Review notes / residual risk

- warm/cold behavior is covered in the harness but not runtime-executed in this environment
- the idle-timeout close path retains the existing in-flight update and final DB re-scan checks; there is no deterministic test landing an update at the exact timer boundary
- parallel-group and manual retry-group resident variants are implemented through the same directive path but do not have dedicated new integration cases in this PR