### PR TITLE
refactor(ui): app branches empty states & edit modals

### DIFF
--- a/services/dashboard-ui/DESIGN.md
+++ b/services/dashboard-ui/DESIGN.md
@@ -146,6 +146,11 @@ These are the specific inconsistencies that make the UI look "off". Treat each a
 6. **No layout-thrash animation / flicker.** See §7 (container queries) — labels must not flip
    between states on interaction.
 7. **No orphaned dark mode.** Every surface/border/text color must be correct in both themes.
+8. **Never two primary buttons on a page.** A page (or any single view/surface) has exactly one
+   `variant="primary"` action — the single most important thing the user is expected to do here.
+   Every other action, including the CTA in an empty state, is `secondary`/`ghost`. This holds even
+   when the page's primary button is disabled — a disabled primary still counts, so don't add a
+   second primary elsewhere to compensate. If two actions feel equally important, one of them isn't.
 
 ---
 
@@ -213,8 +218,8 @@ inside `labelProps`:
 - Variants: `primary | secondary | ghost | danger | tab | icon`.
 - `icon` = square, icon-only (`aspect-square rounded-md !p-0`, ghost-style hover/focus). Use for
   caret/arrow affordances next to a row instead of a bordered button.
-- One **primary** action per surface; everything else `secondary`/`ghost`. `danger` only for
-  destructive actions.
+- One **primary** action per surface — never two primary buttons on the same page (see §4.8);
+  everything else `secondary`/`ghost`. `danger` only for destructive actions.
 
 ### Tables
 Prefer the Stratus `Table`. If you must hand-roll (e.g. inside a modal), mirror its styling:

--- a/services/dashboard-ui/client/components/branches/BranchDetailActions/BranchDetailActions.stories.tsx
+++ b/services/dashboard-ui/client/components/branches/BranchDetailActions/BranchDetailActions.stories.tsx
@@ -34,6 +34,19 @@ export const Default = () => (
     editButton={<MockEditButton />}
     deploymentPlanButton={<MockDeploymentPlanButton />}
     deleteButton={<MockDeleteButton />}
+    hasDeploymentPlan={true}
+    isTriggerPending={false}
+    onTriggerRun={noop}
+    onTriggerPreview={noop}
+  />
+)
+
+export const NoDeploymentPlan = () => (
+  <BranchDetailActions
+    editButton={<MockEditButton />}
+    deploymentPlanButton={<MockDeploymentPlanButton />}
+    deleteButton={<MockDeleteButton />}
+    hasDeploymentPlan={false}
     isTriggerPending={false}
     onTriggerRun={noop}
     onTriggerPreview={noop}
@@ -45,6 +58,7 @@ export const TriggerPending = () => (
     editButton={<MockEditButton />}
     deploymentPlanButton={<MockDeploymentPlanButton />}
     deleteButton={<MockDeleteButton />}
+    hasDeploymentPlan={true}
     isTriggerPending={true}
     onTriggerRun={noop}
     onTriggerPreview={noop}

--- a/services/dashboard-ui/client/components/branches/BranchDetailActions/BranchDetailActions.tsx
+++ b/services/dashboard-ui/client/components/branches/BranchDetailActions/BranchDetailActions.tsx
@@ -12,6 +12,7 @@ interface IBranchDetailActions {
   editButton: ReactNode
   deploymentPlanButton: ReactNode
   deleteButton: ReactNode
+  hasDeploymentPlan: boolean
   isTriggerPending: boolean
   showTriggerNudge?: boolean
   onTriggerRun: () => void
@@ -22,12 +23,14 @@ export const BranchDetailActions = ({
   editButton,
   deploymentPlanButton,
   deleteButton,
+  hasDeploymentPlan,
   isTriggerPending,
   showTriggerNudge = false,
   onTriggerRun,
   onTriggerPreview,
 }: IBranchDetailActions) => {
   const [nudgeOpen, setNudgeOpen] = useState(false)
+  const triggerDisabled = !hasDeploymentPlan || isTriggerPending
 
   useEffect(() => {
     if (!showTriggerNudge) {
@@ -62,16 +65,20 @@ export const BranchDetailActions = ({
 
       <div className="flex items-center">
         <Tooltip
-          isOpen={nudgeOpen}
-          disableHover
+          isOpen={hasDeploymentPlan ? nudgeOpen : undefined}
+          disableHover={hasDeploymentPlan}
           position="bottom"
           tipContent={
-            <Text variant="subtext">Trigger a run to deploy this branch</Text>
+            <Text variant="subtext">
+              {hasDeploymentPlan
+                ? 'Trigger a run to deploy this branch'
+                : 'Create a deployment plan to trigger a run'}
+            </Text>
           }
         >
           <Button
             variant="primary"
-            disabled={isTriggerPending}
+            disabled={triggerDisabled}
             onClick={() => {
               setNudgeOpen(false)
               onTriggerRun()
@@ -89,7 +96,7 @@ export const BranchDetailActions = ({
           variant="primary"
           alignment="right"
           hideIcon
-          disabled={isTriggerPending}
+          disabled={triggerDisabled}
           buttonClassName="!rounded-l-none !border-l !border-l-primary-700 !px-2"
           buttonText={<Icon variant="CaretDownIcon" size={14} />}
         >

--- a/services/dashboard-ui/client/components/branches/BranchDetailActions/BranchDetailActionsContainer.tsx
+++ b/services/dashboard-ui/client/components/branches/BranchDetailActions/BranchDetailActionsContainer.tsx
@@ -134,6 +134,7 @@ export const BranchDetailActionsContainer = ({
           <Icon variant="TrashIcon" size={16} />
         </Button>
       }
+      hasDeploymentPlan={(currentConfig?.install_groups?.length ?? 0) > 0}
       isTriggerPending={false}
       showTriggerNudge={showTriggerNudge}
       onTriggerRun={() => openTriggerModal(false)}

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditor.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditor.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Banner } from '@/components/common/Banner'
 import { Button } from '@/components/common/Button'
 import { EmptyState } from '@/components/common/EmptyState'
@@ -38,6 +38,14 @@ export const DeploymentPlanEditor = ({
 }: IDeploymentPlanEditor) => {
   const [groups, setGroups] = useState<IInstallGroup[]>(initialGroups)
   const [showValidation, setShowValidation] = useState(false)
+  const [scrollToId, setScrollToId] = useState<string | null>(null)
+  const newGroupRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!scrollToId) return
+    newGroupRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    setScrollToId(null)
+  }, [scrollToId])
 
   const installsById = useMemo(() => {
     const map: Record<string, TInstall> = {}
@@ -101,7 +109,9 @@ export const DeploymentPlanEditor = ({
   }
 
   const addGroup = () => {
-    setGroups((curr) => [...curr, newGroup(curr.length)])
+    const group = newGroup(groups.length)
+    setGroups((curr) => [...curr, group])
+    setScrollToId(group.id)
   }
 
   const deleteGroup = (id: string) => {
@@ -155,10 +165,21 @@ export const DeploymentPlanEditor = ({
     onSave(groups)
   }
 
+  const canAddGroup = !loadingInstalls && availableInstalls.length > 0
+
   return (
     <Modal
       heading="Deployment plan"
       size="xl"
+      className="!max-w-[1200px]"
+      footerActions={
+        canAddGroup ? (
+          <Button variant="secondary" onClick={addGroup} disabled={isDisabled}>
+            <Icon variant="PlusIcon" size={16} />
+            Add group
+          </Button>
+        ) : undefined
+      }
       primaryActionTrigger={{
         children: isSaving ? 'Saving...' : 'Save changes',
         onClick: handleSave,
@@ -190,20 +211,14 @@ export const DeploymentPlanEditor = ({
           </Text>
 
           {groups.length >= 2 && (
-            <DeploymentPlanGraph config={previewConfig} installsById={installsById} orgId={orgId} compact />
+            <DeploymentPlanGraph config={previewConfig} installsById={installsById} orgId={orgId} />
           )}
 
           {groups.length === 0 ? (
             <EmptyState
               variant="table"
               emptyTitle="No install groups yet"
-              emptyMessage="Add a group, then assign installs to it."
-              action={
-                <Button variant="primary" onClick={addGroup} disabled={isDisabled}>
-                  <Icon variant="PlusIcon" size={16} />
-                  Add group
-                </Button>
-              }
+              emptyMessage="Use Add group below to create your first group, then assign installs to it."
             />
           ) : (
             <>
@@ -215,40 +230,34 @@ export const DeploymentPlanEditor = ({
                 const contentError = showValidation ? groupContentError(group) : undefined
 
                 return (
-                  <GroupEditor
+                  <div
                     key={group.id}
-                    group={group}
-                    index={index}
-                    totalGroups={groups.length}
-                    availableInstalls={availableInstalls}
-                    unassignedInstalls={unassignedInstalls}
-                    labelColors={labelColors}
-                    disabled={isDisabled}
-                    nameError={nameError}
-                    contentError={contentError}
-                    onUpdate={(updates) => updateGroup(group.id, updates)}
-                    onAddInstalls={(installIds) =>
-                      addInstallsToGroup(group.id, installIds)
-                    }
-                    onRemoveInstall={(installId) =>
-                      removeInstallFromGroup(group.id, installId)
-                    }
-                    onMoveUp={() => moveGroup(group.id, -1)}
-                    onMoveDown={() => moveGroup(group.id, 1)}
-                    onDelete={() => deleteGroup(group.id)}
-                  />
+                    ref={group.id === scrollToId ? newGroupRef : null}
+                  >
+                    <GroupEditor
+                      group={group}
+                      index={index}
+                      totalGroups={groups.length}
+                      availableInstalls={availableInstalls}
+                      unassignedInstalls={unassignedInstalls}
+                      labelColors={labelColors}
+                      disabled={isDisabled}
+                      nameError={nameError}
+                      contentError={contentError}
+                      onUpdate={(updates) => updateGroup(group.id, updates)}
+                      onAddInstalls={(installIds) =>
+                        addInstallsToGroup(group.id, installIds)
+                      }
+                      onRemoveInstall={(installId) =>
+                        removeInstallFromGroup(group.id, installId)
+                      }
+                      onMoveUp={() => moveGroup(group.id, -1)}
+                      onMoveDown={() => moveGroup(group.id, 1)}
+                      onDelete={() => deleteGroup(group.id)}
+                    />
+                  </div>
                 )
               })}
-
-              <Button
-                variant="secondary"
-                onClick={addGroup}
-                disabled={isDisabled}
-                className="self-start"
-              >
-                <Icon variant="PlusIcon" size={16} />
-                Add group
-              </Button>
             </>
           )}
 

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditor.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditor.tsx
@@ -184,16 +184,19 @@ export const DeploymentPlanEditor = ({
         </Banner>
       ) : (
         <div className="flex flex-col gap-6">
-          {groups.length > 0 && (
-            <div className="max-w-[50%]">
-              <DeploymentPlanGraph config={previewConfig} installsById={installsById} orgId={orgId} compact />
-            </div>
+          <Text variant="subtext" theme="neutral">
+            Groups deploy top to bottom. Installs in a group deploy together, up
+            to its max parallel. Any install left unassigned is skipped.
+          </Text>
+
+          {groups.length >= 2 && (
+            <DeploymentPlanGraph config={previewConfig} installsById={installsById} orgId={orgId} compact />
           )}
 
           {groups.length === 0 ? (
             <EmptyState
               variant="table"
-              emptyTitle="No deployment groups"
+              emptyTitle="No install groups yet"
               emptyMessage="Add a group, then assign installs to it."
               action={
                 <Button variant="primary" onClick={addGroup} disabled={isDisabled}>
@@ -203,51 +206,53 @@ export const DeploymentPlanEditor = ({
               }
             />
           ) : (
-            groups.map((group, index) => {
-              const nameError =
-                showValidation && !group.name.trim()
-                  ? 'Group name is required'
-                  : undefined
-              const contentError = showValidation ? groupContentError(group) : undefined
+            <>
+              {groups.map((group, index) => {
+                const nameError =
+                  showValidation && !group.name.trim()
+                    ? 'Group name is required'
+                    : undefined
+                const contentError = showValidation ? groupContentError(group) : undefined
 
-              return (
-                <GroupEditor
-                  key={group.id}
-                  group={group}
-                  index={index}
-                  totalGroups={groups.length}
-                  availableInstalls={availableInstalls}
-                  unassignedInstalls={unassignedInstalls}
-                  labelColors={labelColors}
-                  disabled={isDisabled}
-                  nameError={nameError}
-                  contentError={contentError}
-                  onUpdate={(updates) => updateGroup(group.id, updates)}
-                  onAddInstalls={(installIds) =>
-                    addInstallsToGroup(group.id, installIds)
-                  }
-                  onRemoveInstall={(installId) =>
-                    removeInstallFromGroup(group.id, installId)
-                  }
-                  onMoveUp={() => moveGroup(group.id, -1)}
-                  onMoveDown={() => moveGroup(group.id, 1)}
-                  onDelete={() => deleteGroup(group.id)}
-                />
-              )
-            })
+                return (
+                  <GroupEditor
+                    key={group.id}
+                    group={group}
+                    index={index}
+                    totalGroups={groups.length}
+                    availableInstalls={availableInstalls}
+                    unassignedInstalls={unassignedInstalls}
+                    labelColors={labelColors}
+                    disabled={isDisabled}
+                    nameError={nameError}
+                    contentError={contentError}
+                    onUpdate={(updates) => updateGroup(group.id, updates)}
+                    onAddInstalls={(installIds) =>
+                      addInstallsToGroup(group.id, installIds)
+                    }
+                    onRemoveInstall={(installId) =>
+                      removeInstallFromGroup(group.id, installId)
+                    }
+                    onMoveUp={() => moveGroup(group.id, -1)}
+                    onMoveDown={() => moveGroup(group.id, 1)}
+                    onDelete={() => deleteGroup(group.id)}
+                  />
+                )
+              })}
+
+              <Button
+                variant="secondary"
+                onClick={addGroup}
+                disabled={isDisabled}
+                className="self-start"
+              >
+                <Icon variant="PlusIcon" size={16} />
+                Add group
+              </Button>
+            </>
           )}
 
-          <Button
-            variant="secondary"
-            onClick={addGroup}
-            disabled={isDisabled}
-            className="self-start"
-          >
-            <Icon variant="PlusIcon" size={16} />
-            Add group
-          </Button>
-
-          {unassignedInstalls.length > 0 && (
+          {groups.length > 0 && unassignedInstalls.length > 0 && (
             <div className="border-t pt-4">
               <div className="flex items-baseline gap-2 mb-2">
                 <Text variant="base" weight="strong">Unassigned</Text>

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditorContainer.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditorContainer.tsx
@@ -150,11 +150,13 @@ export const EditDeploymentPlanButton = ({
   branch,
   currentConfig,
   onSuccess,
+  label = 'Deployment plan',
   ...props
 }: {
   branch: TAppBranch
   currentConfig?: TAppBranchConfig
   onSuccess?: () => void
+  label?: string
 } & Omit<IButtonAsButton, 'children'>) => {
   const { addModal } = useSurfaces()
   const modal = (
@@ -171,7 +173,7 @@ export const EditDeploymentPlanButton = ({
       {...props}
     >
       {props?.isMenuButton ? null : <Icon variant="SlidersHorizontalIcon" size={16} />}
-      Deployment plan
+      {label}
       {props?.isMenuButton ? <Icon variant="SlidersHorizontalIcon" size={16} /> : null}
     </Button>
   )

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/GroupEditor.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/GroupEditor.tsx
@@ -9,7 +9,6 @@ import { Menu } from '@/components/common/Menu'
 import { Text } from '@/components/common/Text'
 import { ToggleButton } from '@/components/common/ToggleButton'
 import { Input } from '@/components/common/form/Input'
-import { CheckboxInput } from '@/components/common/form/CheckboxInput'
 import type { TInstall } from '@/types'
 import { cn } from '@/utils/classnames'
 import { matchesSelector } from '@/components/match/matches'
@@ -107,37 +106,13 @@ export const GroupEditor = ({
                 <Icon variant="ArrowDownIcon" />
               </Button>
               <hr />
-              <Button isMenuButton className="!text-red-800 dark:!text-red-500" onClick={onDelete}>
+              <Button isMenuButton variant="danger" onClick={onDelete}>
                 Delete group
                 <Icon variant="TrashIcon" />
               </Button>
             </Menu>
           </Dropdown>
         </div>
-      </div>
-
-      <div className="flex items-center gap-4 px-4 py-2 border-b text-xs">
-        <div className="flex items-center gap-2">
-          <Text variant="subtext" theme="neutral">Max parallel</Text>
-          <Input
-            id={`group-max-parallel-${group.id}`}
-            type="number"
-            min={1}
-            value={group.max_parallel ?? 1}
-            onChange={(e) => onUpdate({ max_parallel: parseInt(e.target.value) || 1 })}
-            disabled={disabled}
-            size="sm"
-            className="!w-14"
-          />
-        </div>
-
-        <CheckboxInput
-          id={`group-preview-${group.id}`}
-          checked={group.use_for_previews ?? false}
-          onChange={(e) => onUpdate({ use_for_previews: e.target.checked })}
-          disabled={disabled}
-          labelProps={{ labelText: 'Use for previews' }}
-        />
       </div>
 
       <div className="flex flex-col gap-3 p-4">

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanGraph/DeploymentPlanGraph.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanGraph/DeploymentPlanGraph.tsx
@@ -145,8 +145,9 @@ export const DeploymentPlanGraph = ({ config, installsById, compact = false }: I
       <div className="rounded-lg border p-6">
         <EmptyState
           variant="diagram"
-          emptyTitle="No install groups configured"
-          emptyMessage={`Use "Deployment plan" above to add deployment groups.`}
+          size={compact ? 'sm' : 'default'}
+          emptyTitle="No install groups"
+          emptyMessage="This deployment plan doesn't have any install groups yet."
         />
       </div>
     )

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanSection/DeploymentPlanSection.stories.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanSection/DeploymentPlanSection.stories.tsx
@@ -1,0 +1,90 @@
+import { Button } from '@/components/common/Button'
+import { Icon } from '@/components/common/Icon'
+import { DeploymentPlanSection } from './DeploymentPlanSection'
+
+export default {
+  title: 'Branches/DeploymentPlanSection',
+}
+
+const installsById: Record<string, any> = {
+  'inst-1': { id: 'inst-1', name: 'acme-prod', labels: { env: 'production', tier: 'primary' }, status_v2: { status: 'installed' } },
+  'inst-2': { id: 'inst-2', name: 'acme-eu', labels: { env: 'production', tier: 'secondary' }, status_v2: { status: 'installed' } },
+  'inst-3': { id: 'inst-3', name: 'acme-staging', labels: { env: 'staging' }, status_v2: { status: 'deploying' } },
+  'inst-4': { id: 'inst-4', name: 'demo-env', labels: {}, status_v2: { status: 'installed' } },
+}
+
+const CreateAction = () => (
+  <Button variant="secondary">
+    <Icon variant="SlidersHorizontalIcon" size={16} />
+    Create deployment plan
+  </Button>
+)
+
+const EditAction = () => (
+  <Button variant="ghost">
+    <Icon variant="SlidersHorizontalIcon" size={16} />
+    Edit plan
+  </Button>
+)
+
+export const Empty = () => (
+  <DeploymentPlanSection
+    installsById={{}}
+    orgId="org-1"
+    createAction={<CreateAction />}
+  />
+)
+
+export const SingleGroup = () => (
+  <DeploymentPlanSection
+    config={
+      {
+        config_number: 1,
+        install_groups: [
+          { id: 'group-1', name: 'All installs', order: 0, max_parallel: 1, install_ids: ['inst-1', 'inst-4'] },
+        ],
+      } as any
+    }
+    installsById={installsById}
+    orgId="org-1"
+    createAction={<CreateAction />}
+    editAction={<EditAction />}
+  />
+)
+
+export const MultipleGroups = () => (
+  <DeploymentPlanSection
+    config={
+      {
+        config_number: 3,
+        install_groups: [
+          { id: 'group-canary', name: 'Canary', order: 0, max_parallel: 1, install_ids: ['inst-4'] },
+          { id: 'group-staging', name: 'Staging', order: 1, max_parallel: 1, install_ids: ['inst-3'] },
+          { id: 'group-prod', name: 'Production', order: 2, max_parallel: 2, install_ids: ['inst-1', 'inst-2'] },
+        ],
+      } as any
+    }
+    installsById={installsById}
+    orgId="org-1"
+    createAction={<CreateAction />}
+    editAction={<EditAction />}
+  />
+)
+
+export const LabelBased = () => (
+  <DeploymentPlanSection
+    config={
+      {
+        config_number: 2,
+        install_groups: [
+          { id: 'group-staging', name: 'Staging', order: 0, max_parallel: 2, label_selector: { match_labels: { env: 'staging' } } },
+          { id: 'group-prod', name: 'Production', order: 1, max_parallel: 1, label_selector: { match_labels: { env: 'production' } } },
+        ],
+      } as any
+    }
+    installsById={installsById}
+    orgId="org-1"
+    createAction={<CreateAction />}
+    editAction={<EditAction />}
+  />
+)

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanSection/DeploymentPlanSection.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanSection/DeploymentPlanSection.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react'
+import { Badge } from '@/components/common/Badge'
+import { EmptyState } from '@/components/common/EmptyState'
+import { Text } from '@/components/common/Text'
+import { DeploymentPlanGraph } from '@/components/branches/DeploymentPlanGraph'
+import { InstallGroupsSection } from '@/components/branches/install-groups/InstallGroupsSection'
+import type { TAppBranchConfig, TInstall } from '@/types'
+
+interface IDeploymentPlanSection {
+  config?: TAppBranchConfig
+  installsById: Record<string, TInstall>
+  orgId: string
+  labelColors?: Record<string, string>
+  createAction: ReactNode
+  editAction?: ReactNode
+}
+
+export const DeploymentPlanSection = ({
+  config,
+  installsById,
+  orgId,
+  labelColors,
+  createAction,
+  editAction,
+}: IDeploymentPlanSection) => {
+  const hasDeploymentPlan = (config?.install_groups?.length ?? 0) > 0
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Text variant="base" weight="strong">
+            Deployment plan
+          </Text>
+          {hasDeploymentPlan && (
+            <Badge theme="info" size="sm">
+              v{config?.config_number}
+            </Badge>
+          )}
+        </div>
+        {hasDeploymentPlan && editAction}
+      </div>
+
+      {hasDeploymentPlan && config ? (
+        <div className="flex flex-col gap-6">
+          <DeploymentPlanGraph
+            config={config}
+            installsById={installsById}
+            orgId={orgId}
+          />
+          <div className="flex flex-col gap-3">
+            <Text variant="subtext" weight="strong" theme="neutral">
+              Install groups
+            </Text>
+            <InstallGroupsSection
+              config={config}
+              installsById={installsById}
+              orgId={orgId}
+              labelColors={labelColors}
+            />
+          </div>
+        </div>
+      ) : (
+        <div className="border rounded-lg p-6">
+          <EmptyState
+            variant="diagram"
+            emptyTitle="No deployment plan yet"
+            emptyMessage="Create a deployment plan to group installs and roll out branch changes in stages."
+            action={createAction}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanSection/index.ts
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanSection/index.ts
@@ -1,0 +1,1 @@
+export { DeploymentPlanSection } from './DeploymentPlanSection'

--- a/services/dashboard-ui/client/components/branches/EditBranchNameModal/EditBranchNameModalContainer.tsx
+++ b/services/dashboard-ui/client/components/branches/EditBranchNameModal/EditBranchNameModalContainer.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { Badge } from '@/components/common/Badge'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
@@ -42,9 +42,6 @@ export const EditBranchNameModalContainer = ({
   const vcsConnections = org?.vcs_connections || []
   const existingConnectionId =
     currentConfig?.connected_github_vcs_config?.vcs_connection_id || ''
-  const [vcsConnectionId, setVcsConnectionId] = useState(
-    existingConnectionId || vcsConnections[0]?.id || ''
-  )
 
   const existingRepo =
     currentConfig?.connected_github_vcs_config?.repo ||
@@ -55,6 +52,16 @@ export const EditBranchNameModalContainer = ({
     currentConfig?.public_git_vcs_config?.branch ||
     'main'
 
+  const repoOwner = existingRepo.split('/')[0] ?? ''
+  const [vcsConnectionId, setVcsConnectionId] = useState(
+    existingConnectionId ||
+      vcsConnections.find(
+        (c) => c.github_account_name?.toLowerCase() === repoOwner.toLowerCase()
+      )?.id ||
+      vcsConnections[0]?.id ||
+      ''
+  )
+
   const vcsBrowser = useVcsRepoBrowser({
     orgId: org.id,
     vcsConnectionId,
@@ -62,6 +69,17 @@ export const EditBranchNameModalContainer = ({
     initialRepo: existingRepo,
     initialBranch: existingBranch,
   })
+
+  const repos = useMemo(() => {
+    const list = vcsBrowser.repos ?? []
+    if (
+      vcsBrowser.selectedRepo &&
+      !list.some((r) => r.full_name === vcsBrowser.selectedRepo!.full_name)
+    ) {
+      return [vcsBrowser.selectedRepo, ...list]
+    }
+    return list
+  }, [vcsBrowser.repos, vcsBrowser.selectedRepo])
 
   const formatError = (err: TAPIError | Error): string => {
     if ('error' in err && typeof err.error === 'string') return err.error
@@ -157,7 +175,7 @@ export const EditBranchNameModalContainer = ({
       branch={branch}
       currentConfig={currentConfig}
       vcsConnections={vcsConnections}
-      repos={vcsBrowser.repos}
+      repos={repos}
       branches={vcsBrowser.branches}
       loadingRepos={vcsBrowser.loadingRepos}
       loadingBranches={vcsBrowser.loadingBranches}

--- a/services/dashboard-ui/client/components/branches/install-groups/InstallGroupsSection.tsx
+++ b/services/dashboard-ui/client/components/branches/install-groups/InstallGroupsSection.tsx
@@ -61,8 +61,8 @@ export const InstallGroupsSection = ({
       <div className="border rounded-lg p-6">
         <EmptyState
           variant="diagram"
-          emptyTitle="No install groups configured"
-          emptyMessage={`Use "Deployment plan" above to add deployment groups.`}
+          emptyTitle="No install groups"
+          emptyMessage="This deployment plan doesn't have any install groups yet."
         />
       </div>
     )

--- a/services/dashboard-ui/client/components/common/Menu.tsx
+++ b/services/dashboard-ui/client/components/common/Menu.tsx
@@ -15,41 +15,43 @@ export const Menu = ({ className, children, ...props }: IMenu) => {
       role="menu"
       {...props}
     >
-      {React.Children.map(children, (c) =>
-        React.isValidElement(c)
-          ? c.type === Button ||
-            c.type === Link ||
-            (c as any)?.props?.isMenuButton
-            ? React.cloneElement<IButtonAsButton | ILink>(c, {
-                variant: 'ghost',
-                className: cn(
-                  '!p-2 text-sm !leading-none h-8 w-full flex justify-between !rounded-md',
-                  c?.props.className,
-                  {
-                    '!text-red-600 dark:!text-red-400':
-                      c?.props?.variant === 'danger',
-                  }
-                ),
-              })
-            : c.type === Dropdown || (c as any).isMenuDropdown
-              ? React.cloneElement(c as React.ReactElement<IDropdown>, {
-                  variant: 'ghost',
-                  buttonClassName:
-                    '!p-2 text-sm !leading-none h-8 w-full flex justify-between !rounded-md',
-                })
-              : c.type === Text
-                ? React.cloneElement<IText>(c, {
-                    className: 'px-1.5 py-1',
-                    variant: 'label',
-                    theme: 'neutral',
-                  })
-                : c.type === 'hr'
-                  ? React.cloneElement<IText>(c, {
-                      className: 'my-1',
-                    })
-                  : c
-          : null
-      )}
+      {React.Children.map(children, (c) => {
+        if (!React.isValidElement(c)) return null
+
+        const childProps = (c as any).props ?? {}
+        const menuItemClass =
+          '!p-2 text-sm !leading-none h-8 w-full flex justify-between !rounded-md'
+
+        if (c.type === Button || c.type === Link || childProps.isMenuButton) {
+          const isDanger = childProps.variant === 'danger'
+          return React.cloneElement<IButtonAsButton | ILink>(c, {
+            variant: isDanger ? 'danger' : 'ghost',
+            isMenuButton: isDanger ? true : childProps.isMenuButton,
+            className: cn(menuItemClass, childProps.className),
+          })
+        }
+
+        if (c.type === Dropdown || childProps.isMenuDropdown) {
+          return React.cloneElement(c as React.ReactElement<IDropdown>, {
+            variant: 'ghost',
+            buttonClassName: menuItemClass,
+          })
+        }
+
+        if (c.type === Text) {
+          return React.cloneElement<IText>(c, {
+            className: 'px-1.5 py-1',
+            variant: 'label',
+            theme: 'neutral',
+          })
+        }
+
+        if (c.type === 'hr') {
+          return React.cloneElement(c, { className: 'my-1' })
+        }
+
+        return c
+      })}
     </div>
   )
 }

--- a/services/dashboard-ui/client/components/installs/CreateInstall/BranchConnectionStep/BranchConnectionStep.tsx
+++ b/services/dashboard-ui/client/components/installs/CreateInstall/BranchConnectionStep/BranchConnectionStep.tsx
@@ -203,7 +203,7 @@ export const BranchConnectionStep = ({
   return (
     <div className="flex flex-col gap-4">
       <Text variant="subtext" theme="neutral">
-        Add this install to a deployment group so app branch runs deploy to it. You can skip this and do it later.
+        Add this install to an install group so app branch runs deploy to it. You can skip this and do it later.
       </Text>
 
       <div className="flex flex-col gap-3">

--- a/services/dashboard-ui/client/components/installs/InstallBranches/InstallBranches.tsx
+++ b/services/dashboard-ui/client/components/installs/InstallBranches/InstallBranches.tsx
@@ -291,7 +291,7 @@ export const InstallBranches = ({ branches, orgId, appId, installId }: IInstallB
       <EmptyState
         variant="diagram"
         emptyTitle="No app branches connected"
-        emptyMessage="Add labels to this install to connect it to an app branch deployment group."
+        emptyMessage="Add labels to this install to connect it to an app branch install group."
       />
     )
   }

--- a/services/dashboard-ui/client/components/installs/forms/CreateInstallForm/CreateInstallForm.tsx
+++ b/services/dashboard-ui/client/components/installs/forms/CreateInstallForm/CreateInstallForm.tsx
@@ -43,7 +43,7 @@ const LabelsSection = () => {
     >
       <div className="flex flex-col gap-3 p-4 border-t">
         <Text variant="subtext" theme="neutral">
-          Labels connect this install to app branch deployment groups.
+          Labels connect this install to app branch install groups.
         </Text>
         {rows.map((row, idx) => (
           <div key={idx} className="flex items-center gap-2">

--- a/services/dashboard-ui/client/components/log-stream/SSELogs/SSELogs.tsx
+++ b/services/dashboard-ui/client/components/log-stream/SSELogs/SSELogs.tsx
@@ -194,7 +194,7 @@ const RawLogs = ({
       <pre
         className={cn(
           'mt-3 overflow-x-auto rounded-md border p-4',
-          'bg-dark-grey-900 text-cool-grey-300',
+          'bg-code',
           'font-mono text-xs leading-relaxed whitespace-pre-wrap break-all'
         )}
       >

--- a/services/dashboard-ui/client/views/app/branches/BranchDetail.tsx
+++ b/services/dashboard-ui/client/views/app/branches/BranchDetail.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { useParams, useSearchParams } from 'react-router'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { BackLink } from '@/components/common/BackLink'
-import { Badge } from '@/components/common/Badge'
 import { LabelBadge } from '@/components/common/LabelBadge'
 import { Card } from '@/components/common/Card'
 import { EmptyState } from '@/components/common/EmptyState'
@@ -19,7 +18,8 @@ import { useBranch } from '@/hooks/use-branch'
 import { BranchProvider } from '@/providers/branch-provider'
 
 import { BranchDetailActions } from '@/components/branches/BranchDetailActions'
-import { DeploymentPlanGraph } from '@/components/branches/DeploymentPlanGraph'
+import { DeploymentPlanSection } from '@/components/branches/DeploymentPlanSection'
+import { EditDeploymentPlanButton } from '@/components/branches/DeploymentPlanEditor'
 import { WorkflowTimelineComponent } from '@/components/workflows/WorkflowTimeline'
 import { getBranchWorkflowRuns, getAppInstalls } from '@/lib'
 import type { TInstall } from '@/types'
@@ -28,8 +28,8 @@ const LIMIT = 20
 
 const BranchDetailContent = () => {
   const { org } = useOrg()
-  const { app } = useApp()
-  const { branch } = useBranch()
+  const { app, labelColors } = useApp()
+  const { branch, refresh } = useBranch()
   const params = useParams()
   const [searchParams] = useSearchParams()
   const orgId = params.orgId as string
@@ -131,34 +131,30 @@ const BranchDetailContent = () => {
         />
       </div>
 
-      <div className="flex flex-col gap-4">
-        <div className="flex items-center justify-between">
-          <Text variant="base" weight="strong">
-            Install groups
-          </Text>
-          {currentConfig && (
-            <Badge theme="info" size="sm">
-              v{currentConfig.config_number}
-            </Badge>
-          )}
-        </div>
-
-        {!currentConfig ? (
-          <div className="border border-cool-grey-200 dark:border-dark-grey-700 rounded-lg p-6">
-            <EmptyState
-              variant="diagram"
-              emptyTitle="No install groups yet"
-              emptyMessage={`Use "Deployment plan" above to group installs for staged deployment.`}
-            />
-          </div>
-        ) : (
-          <DeploymentPlanGraph
-            config={currentConfig}
-            installsById={installsById}
-            orgId={orgId}
+      <DeploymentPlanSection
+        config={currentConfig}
+        installsById={installsById}
+        orgId={orgId}
+        labelColors={labelColors}
+        createAction={
+          <EditDeploymentPlanButton
+            branch={branch}
+            currentConfig={currentConfig}
+            variant="secondary"
+            label="Create deployment plan"
+            onSuccess={refresh}
           />
-        )}
-      </div>
+        }
+        editAction={
+          <EditDeploymentPlanButton
+            branch={branch}
+            currentConfig={currentConfig}
+            variant="ghost"
+            label="Edit plan"
+            onSuccess={refresh}
+          />
+        }
+      />
 
       <div className="flex flex-col gap-4">
         <Text variant="base" weight="strong">
@@ -172,7 +168,7 @@ const BranchDetailContent = () => {
             <EmptyState
               variant="history"
               emptyTitle="No workflow runs yet"
-              emptyMessage={`Use "Trigger run" above to start a deployment.`}
+              emptyMessage="Runs will appear here once you trigger a deployment of this branch."
             />
           </Card>
         ) : (

--- a/services/dashboard-ui/client/views/install/InstallLayout.tsx
+++ b/services/dashboard-ui/client/views/install/InstallLayout.tsx
@@ -1,4 +1,10 @@
-import { Outlet, useParams, useMatch, useSearchParams } from 'react-router'
+import {
+  Outlet,
+  useParams,
+  useMatch,
+  useSearchParams,
+  useLocation,
+} from 'react-router'
 import { LabelBadge } from '@/components/common/LabelBadge'
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { ID } from '@/components/common/ID'
@@ -7,6 +13,10 @@ import { LabeledValue } from '@/components/common/LabeledValue'
 import { Link } from '@/components/common/Link'
 import { Time } from '@/components/common/Time'
 import { Text } from '@/components/common/Text'
+import { Button } from '@/components/common/Button'
+import { EmptyState } from '@/components/common/EmptyState'
+import { ErrorBoundary } from '@/components/common/ErrorBoundary'
+import { PageSection } from '@/components/layout/PageSection'
 import { DeprovisionBanner } from '@/components/installs/DeprovisionBanner'
 import { DriftedSummary } from '@/components/installs/DriftedSummary'
 import { InstallStatusesContainer } from '@/components/installs/InstallStatuses'
@@ -15,7 +25,6 @@ import {
   useOpenInstallSettings,
   INSTALL_SETTINGS_PANEL_KEY,
 } from '@/components/installs/InstallSettingsPanel'
-import { InstallManagementDropdown } from '@/components/installs/management/InstallManagementDropdown'
 import { AdminDashboardLink } from '@/components/admin/AdminDashboardLink'
 import { PageLayout } from '@/components/layout/PageLayout'
 import { PageContent } from '@/components/layout/PageContent'
@@ -49,9 +58,25 @@ export const InstallLayout = () => {
   )
 }
 
+const InstallContentError = () => (
+  <PageSection>
+    <EmptyState
+      variant="404"
+      emptyTitle="Something went wrong"
+      emptyMessage="We couldn't load this page. Some of its data may be unavailable right now."
+      action={
+        <Button variant="secondary" onClick={() => window.location.reload()}>
+          Try again
+        </Button>
+      }
+    />
+  </PageSection>
+)
+
 const InstallTemplate = () => {
   const { org } = useOrg()
   const { install, labelColors } = useInstall()
+  const { pathname } = useLocation()
   const hasRunbooks = !!org?.features?.runbooks
   const hasNotebooks = !!org?.features?.notebooks
   const openSettings = useOpenInstallSettings()
@@ -185,7 +210,9 @@ const InstallTemplate = () => {
               links={navLinks}
             />
             <div className="flex flex-col flex-1 min-w-0">
-              <Outlet />
+              <ErrorBoundary key={pathname} fallback={<InstallContentError />}>
+                <Outlet />
+              </ErrorBoundary>
             </div>
           </PageContent>
         ) : (
@@ -251,7 +278,6 @@ const InstallTemplate = () => {
                     </Text>
                   </LabeledValue>
                   <InstallStatusesContainer collapsible />
-                  <InstallManagementDropdown />
                 </div>
               </div>
               {install?.drifted_objects?.length ? (
@@ -269,7 +295,9 @@ const InstallTemplate = () => {
                 links={navLinks}
               />
               <div className="flex flex-col flex-1 min-w-0">
-                <Outlet />
+                <ErrorBoundary key={pathname} fallback={<InstallContentError />}>
+                  <Outlet />
+                </ErrorBoundary>
               </div>
             </PageContent>
           </>


### PR DESCRIPTION
- Clean up empty states & copy
- Improved the deployment plan modal ux
- Fix issue with vcs connection not sticking in edit branch modal
- Light mode raw logs are back
- Removed extra manage settings dropdown from install layout
- Fix issue with danger buttons inside of dropdown menus