### PR TITLE
feat: general metrics table sizes

### DIFF
--- a/services/ctl-api/internal/app/general/worker/activities/ensure_cron_workflows.go
+++ b/services/ctl-api/internal/app/general/worker/activities/ensure_cron_workflows.go
@@ -50,7 +50,7 @@ func (a *Activities) EnsureCronWorkflows(ctx context.Context, _ EnsureCronWorkfl
 	metricsOpts := tclient.StartWorkflowOptions{
 		ID:                    "general-metrics-cron",
 		TaskQueue:             workflows.APITaskQueue,
-		CronSchedule:          "*/1 * * * *",
+		CronSchedule:          "*/15 * * * *",
 		WorkflowIDReusePolicy: enumsv1.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 0,

--- a/services/ctl-api/internal/app/general/worker/activities/psql_table_metrics.go
+++ b/services/ctl-api/internal/app/general/worker/activities/psql_table_metrics.go
@@ -20,8 +20,7 @@ func (a *Activities) GetPSQLTableMetrics(ctx context.Context, req GetPSQLTableMe
 func (a *Activities) getTableSizes(ctx context.Context, db *gorm.DB) ([]app.PSQLTableSize, error) {
 	var tables []app.PSQLTableSize
 
-	// ForceReplica is required rather than WithReplica: the view isn't on the
-	// table ACL allow-list, so an opt-in would be routed back to primary.
+	// ForceReplica bypasses the table ACL, which would block a WithReplica opt-in.
 	res := db.WithContext(ctx).
 		Scopes(scopes.ForceReplica).
 		Find(&tables)

--- a/services/ctl-api/internal/app/general/worker/activities/psql_table_metrics.go
+++ b/services/ctl-api/internal/app/general/worker/activities/psql_table_metrics.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
 )
 
 type GetPSQLTableMetricsRequest struct{}
@@ -19,7 +20,10 @@ func (a *Activities) GetPSQLTableMetrics(ctx context.Context, req GetPSQLTableMe
 func (a *Activities) getTableSizes(ctx context.Context, db *gorm.DB) ([]app.PSQLTableSize, error) {
 	var tables []app.PSQLTableSize
 
+	// ForceReplica is required rather than WithReplica: the view isn't on the
+	// table ACL allow-list, so an opt-in would be routed back to primary.
 	res := db.WithContext(ctx).
+		Scopes(scopes.ForceReplica).
 		Find(&tables)
 
 	if res.Error != nil {

--- a/services/ctl-api/internal/app/general/worker/metrics_workflow.go
+++ b/services/ctl-api/internal/app/general/worker/metrics_workflow.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	metricsWorkflowCronTab string = "*/1 * * * *"
+	metricsWorkflowCronTab string = "*/15 * * * *"
 	metricsWorkflowName    string = "general-metrics-cron"
 )
 


### PR DESCRIPTION
`SELECT * FROM psql_table_sizes_view_v1` calls `pg_total_relation_size()` twice per
row over every relation *and view* in `public` — ~500ms, running once a minute
(1,440/day, confirmed flat in DD).

**Changes:**
1. `general-metrics-cron`: `*/1` → `*/15` (1,440 → 96 runs/day)
2. `scopes.ForceReplica` on the read so it's off the primary entirely
   (`ForceReplica` not `WithReplica` — the view isn't on the table ACL allow-list, so
   the opt-in would route back to primary; same pattern as
   `get_queue_signal_enqueue_metrics.go`)

this slows other general metrics checks as well. We were ok to bump to 1hr cadence but I never made the change. Keeping it at 15min cadence for now.