### PR TITLE
fix: use non-auth client for public image components

### DIFF
--- a/pkg/runner/oci/repo.go
+++ b/pkg/runner/oci/repo.go
@@ -57,19 +57,29 @@ func GetRepo(ctx context.Context, cfg *configs.OCIRegistryRepository) (registry.
 		return nil, fmt.Errorf("unable to get repository: %w", err)
 	}
 
-	// Only configure static credentials if we actually have them.
-	// For anonymous pulls (empty credentials), rely on oras-go's default
-	// anonymous bearer token flow which handles the 401 challenge properly.
-	if accessInfo.Auth != nil && accessInfo.Auth.Username != "" {
-		repo.Client = &auth.Client{
-			Client: retry.DefaultClient,
-			Cache:  auth.NewCache(),
-			Credential: auth.StaticCredential(strings.TrimPrefix(accessInfo.Auth.ServerAddress, "https://"), auth.Credential{
-				Username: accessInfo.Auth.Username,
-				Password: accessInfo.Auth.Password,
-			}),
-		}
+	// Always give every repository its own isolated auth client and cache.
+	// Leaving repo.Client nil makes oras-go fall back to the process-global
+	// auth.DefaultClient/auth.DefaultCache, which is shared across every job in
+	// a long-lived worker process. That lets a token cached for a host by one
+	// job leak into another job's request to the same host — e.g. an
+	// authenticated pull caching a credential under "public.ecr.aws" (the
+	// runner image and vendor public images share that host), which is then
+	// attached to a later anonymous public pull and rejected with a 400
+	// "Your Authorization Token is invalid". A per-repo cache keeps each pull
+	// isolated. Credentials are attached only when we actually have them; for
+	// anonymous pulls the nil Credential drives oras-go's anonymous bearer
+	// token flow with a clean cache.
+	authClient := &auth.Client{
+		Client: retry.DefaultClient,
+		Cache:  auth.NewCache(),
 	}
+	if accessInfo.Auth != nil && accessInfo.Auth.Username != "" {
+		authClient.Credential = auth.StaticCredential(strings.TrimPrefix(accessInfo.Auth.ServerAddress, "https://"), auth.Credential{
+			Username: accessInfo.Auth.Username,
+			Password: accessInfo.Auth.Password,
+		})
+	}
+	repo.Client = authClient
 
 	return repo, nil
 }

--- a/pkg/runner/oci/repo_test.go
+++ b/pkg/runner/oci/repo_test.go
@@ -62,3 +62,27 @@ func TestGetRepoDoesNotShareAuthCache(t *testing.T) {
 	secondRepo := getRepo("second")
 	require.NoError(t, secondRepo.Tags(context.Background(), "", func(tags []string) error { return nil }))
 }
+
+// TestGetRepoAnonymousDoesNotUseSharedGlobalClient guards the fix for
+// anonymous/public pulls leaking credentials through oras-go's process-global
+// auth.DefaultClient/auth.DefaultCache. GetRepo must always install an isolated
+// per-repo auth client with its own cache — never leave repo.Client nil (which
+// falls back to the shared global) and never reuse auth.DefaultCache.
+func TestGetRepoAnonymousDoesNotUseSharedGlobalClient(t *testing.T) {
+	repo, err := GetRepo(context.Background(), &configs.OCIRegistryRepository{
+		RegistryType: configs.OCIRegistryTypePublicOCI,
+		Repository:   "public.ecr.aws/p7e3r5y0/kitchen-sink-ui",
+		OCIAuth:      &configs.OCIRegistryAuth{},
+	})
+	require.NoError(t, err)
+
+	remoteRepo := repo.(*remote.Repository)
+	require.NotNil(t, remoteRepo.Client, "anonymous repo must get an isolated client, not fall back to auth.DefaultClient")
+
+	authClient, ok := remoteRepo.Client.(*auth.Client)
+	require.True(t, ok)
+	require.NotSame(t, auth.DefaultClient, authClient, "must not reuse the process-global default client")
+	require.NotNil(t, authClient.Cache, "anonymous repo must have its own cache")
+	require.NotSame(t, auth.DefaultCache, authClient.Cache, "must not reuse the process-global default cache")
+	require.Nil(t, authClient.Credential, "anonymous repo must not attach static credentials")
+}


### PR DESCRIPTION
## Summary

Building a public image component with a valid config was failing. It looks like auth credentials from building private images are being cached, causing the public build to fail.