### PR TITLE
chore: task queue isolation followup

### DIFF
--- a/services/ctl-api/internal/app/installs/helpers/enqueue_install_signal.go
+++ b/services/ctl-api/internal/app/installs/helpers/enqueue_install_signal.go
@@ -1,0 +1,33 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+	queuesignal "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+// EnqueueInstallSignal enqueues a v2 signal onto the named queue for an install.
+func (h *Helpers) EnqueueInstallSignal(ctx context.Context, installID, queueName string, sig queuesignal.Signal) error {
+	var q app.Queue
+	if res := h.db.WithContext(ctx).
+		Where(app.Queue{OwnerID: installID, Name: queueName}).
+		First(&q); res.Error != nil {
+		return fmt.Errorf("unable to find %s queue for install %s: %w", queueName, installID, res.Error)
+	}
+
+	_, err := h.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+		QueueID: q.ID,
+		Signal:  sig,
+	})
+	return err
+}
+
+// EnqueueAppConfigUpdated re-enqueues appconfig-updated so drift/action cron
+// emitters get reconciled onto the namespace-correct dedicated cron queues.
+func (h *Helpers) EnqueueAppConfigUpdated(ctx context.Context, installID string) error {
+	return h.EnqueueInstallSignal(ctx, installID, InstallSignalsQueueName,
+		queuesignal.NewRaw("appconfig-updated", map[string]any{"install_id": installID}))
+}

--- a/services/ctl-api/internal/app/installs/helpers/enqueue_install_signal.go
+++ b/services/ctl-api/internal/app/installs/helpers/enqueue_install_signal.go
@@ -24,10 +24,3 @@ func (h *Helpers) EnqueueInstallSignal(ctx context.Context, installID, queueName
 	})
 	return err
 }
-
-// EnqueueAppConfigUpdated re-enqueues appconfig-updated so drift/action cron
-// emitters get reconciled onto the namespace-correct dedicated cron queues.
-func (h *Helpers) EnqueueAppConfigUpdated(ctx context.Context, installID string) error {
-	return h.EnqueueInstallSignal(ctx, installID, InstallSignalsQueueName,
-		queuesignal.NewRaw("appconfig-updated", map[string]any{"install_id": installID}))
-}

--- a/services/ctl-api/internal/app/installs/helpers/ensure_install_queues.go
+++ b/services/ctl-api/internal/app/installs/helpers/ensure_install_queues.go
@@ -81,7 +81,7 @@ func (s *Helpers) EnsureInstallQueues(ctx context.Context, installID string) err
 		}
 	}
 
-	if err := s.ensureComponentHealthQueue(ctx, installID, ownerType); err != nil {
+	if err := s.ensureComponentHealthQueue(ctx, installID, ownerType, cronsNamespace); err != nil {
 		return err
 	}
 
@@ -92,17 +92,23 @@ func (s *Helpers) EnsureInstallQueues(ctx context.Context, installID string) err
 // emitter. The evaluator itself no-ops for orgs without the component-health
 // feature, so the emitter is created unconditionally and enabling the feature
 // needs no backfill.
-func (s *Helpers) ensureComponentHealthQueue(ctx context.Context, installID, ownerType string) error {
+func (s *Helpers) ensureComponentHealthQueue(ctx context.Context, installID, ownerType, namespace string) error {
 	q, err := s.queueClient.Create(ctx, &queueclient.CreateQueueRequest{
 		OwnerID:     installID,
 		OwnerType:   ownerType,
-		Namespace:   "installs",
+		Namespace:   namespace,
 		Name:        InstallComponentHealthQueueName,
 		MaxInFlight: 1,
 		MaxDepth:    10,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to ensure %s queue: %w", InstallComponentHealthQueueName, err)
+	}
+
+	// Create migrates the queue workflow when its namespace changed; move the
+	// emitter to match (no-op if unchanged).
+	if err := s.emitterClient.MigrateQueueEmitters(ctx, q.ID, namespace); err != nil {
+		return fmt.Errorf("unable to migrate %s queue emitters: %w", InstallComponentHealthQueueName, err)
 	}
 
 	emitters, err := s.emitterClient.GetEmittersByQueueID(ctx, q.ID)

--- a/services/ctl-api/internal/app/orgs/service/migrate_crons_namespaces.go
+++ b/services/ctl-api/internal/app/orgs/service/migrate_crons_namespaces.go
@@ -72,7 +72,7 @@ func (s *service) MigrateCronsNamespaces(ctx *gin.Context) {
 	// now migrate cron queues to the namespace dictated by the feature flag.
 	if _, err := s.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
 		QueueID: queue.ID,
-		Signal:  &queuemigration.Signal{OrgID: org.ID},
+		Signal:  &queuemigration.Signal{OrgID: org.ID, ReconcileCronEmitters: true},
 	}); err != nil {
 		s.l.Error("unable to enqueue migration signal", zap.String("org_id", org.ID), zap.Error(err))
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "unable to enqueue migration signal: " + err.Error()})

--- a/services/ctl-api/internal/app/orgs/signals/queue_migration/signal.go
+++ b/services/ctl-api/internal/app/orgs/signals/queue_migration/signal.go
@@ -15,6 +15,10 @@ const SignalType signal.SignalType = "org-queue-migration"
 
 type Signal struct {
 	OrgID string `json:"org_id"`
+	// ReconcileCronEmitters, when true, re-enqueues appconfig-updated per install so
+	// drift/action cron emitters move onto the namespace-correct dedicated cron queues.
+	// Only the cron-migrate endpoint sets this; defaults false (no-op) for other callers.
+	ReconcileCronEmitters bool `json:"reconcile_cron_emitters"`
 }
 
 var _ signal.Signal = (*Signal)(nil)
@@ -95,6 +99,13 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		l.Info("ensuring install queues", zap.String("install_id", install.ID))
 		if err := activities.AwaitEnsureInstallQueuesByInstallID(ctx, install.ID); err != nil {
 			l.Warn("unable to ensure install queues", zap.String("install_id", install.ID), zap.Error(err))
+		}
+
+		if s.ReconcileCronEmitters {
+			if err := activities.AwaitEnqueueAppConfigUpdatedByInstallID(ctx, install.ID); err != nil {
+				l.Warn("unable to enqueue appconfig-updated for emitter reconcile",
+					zap.String("install_id", install.ID), zap.Error(err))
+			}
 		}
 
 		// Ensure install-level runner queues

--- a/services/ctl-api/internal/app/orgs/worker/activities/queue_migration.go
+++ b/services/ctl-api/internal/app/orgs/worker/activities/queue_migration.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	appconfigupdated "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/appconfigupdated"
 )
 
 type EnsureOrgQueueRequest struct {
@@ -34,7 +36,8 @@ type EnqueueAppConfigUpdatedRequest struct {
 // @temporal-gen-v2 activity
 // @by-field InstallID
 func (a *Activities) EnqueueAppConfigUpdated(ctx context.Context, req EnqueueAppConfigUpdatedRequest) error {
-	return a.installsHelpers.EnqueueAppConfigUpdated(ctx, req.InstallID)
+	return a.installsHelpers.EnqueueInstallSignal(ctx, req.InstallID, installshelpers.InstallSignalsQueueName,
+		&appconfigupdated.Signal{InstallID: req.InstallID})
 }
 
 type EnsureAppQueueRequest struct {

--- a/services/ctl-api/internal/app/orgs/worker/activities/queue_migration.go
+++ b/services/ctl-api/internal/app/orgs/worker/activities/queue_migration.go
@@ -27,6 +27,16 @@ func (a *Activities) EnsureInstallQueues(ctx context.Context, req EnsureInstallQ
 	return a.installsHelpers.EnsureInstallQueues(ctx, req.InstallID)
 }
 
+type EnqueueAppConfigUpdatedRequest struct {
+	InstallID string `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+// @by-field InstallID
+func (a *Activities) EnqueueAppConfigUpdated(ctx context.Context, req EnqueueAppConfigUpdatedRequest) error {
+	return a.installsHelpers.EnqueueAppConfigUpdated(ctx, req.InstallID)
+}
+
 type EnsureAppQueueRequest struct {
 	AppID string `validate:"required"`
 }


### PR DESCRIPTION
This change adds few migration requirements for task queue isolation
changes. Primarily it calls appconfigupdated signal in migration path
which allows to migrate drift checks and action crons to newer config in
db.
