### PR TITLE
feat: add runner audit logs with customer OTLP export

### DIFF
--- a/bins/runner/internal/pkg/auditexport/auditexport.go
+++ b/bins/runner/internal/pkg/auditexport/auditexport.go
@@ -88,6 +88,20 @@ func (s *Supervisor) stop(ctx context.Context) error {
 	return nil
 }
 
+func (s *Supervisor) Available() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.child == nil {
+		return false
+	}
+	select {
+	case <-s.child.done:
+		return false
+	default:
+		return true
+	}
+}
+
 func (s *Supervisor) run(ctx context.Context) {
 	defer close(s.done)
 	if s.local || s.installID == "" {

--- a/bins/runner/internal/pkg/auditexport/auditexport_test.go
+++ b/bins/runner/internal/pkg/auditexport/auditexport_test.go
@@ -134,6 +134,24 @@ func TestEmptySecretDoesNotStartCollector(t *testing.T) {
 	}
 }
 
+func TestAvailableTracksCollectorProcess(t *testing.T) {
+	s := &Supervisor{}
+	if s.Available() {
+		t.Fatal("supervisor without a collector is available")
+	}
+
+	done := make(chan struct{})
+	s.child = &childProcess{done: done}
+	if !s.Available() {
+		t.Fatal("running collector is unavailable")
+	}
+
+	close(done)
+	if s.Available() {
+		t.Fatal("exited collector is available")
+	}
+}
+
 func TestReconcileLogsEnabledBackendAndDisabledTransition(t *testing.T) {
 	core, observed := observer.New(zap.InfoLevel)
 	logger := zap.New(core)

--- a/bins/runner/internal/pkg/jobloop/base_params.go
+++ b/bins/runner/internal/pkg/jobloop/base_params.go
@@ -5,6 +5,7 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/auditexport"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/drain"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/process"
 	"github.com/nuonco/nuon/pkg/metrics"
@@ -28,5 +29,6 @@ type BaseParams struct {
 	L *zap.Logger `name:"system"`
 
 	ProcessRegistrar *process.Registrar
+	AuditExport      *auditexport.Supervisor `optional:"true"`
 	Drainer          *drain.Drainer
 }

--- a/bins/runner/internal/pkg/jobloop/exec_job.go
+++ b/bins/runner/internal/pkg/jobloop/exec_job.go
@@ -33,10 +33,19 @@ type executeJobStep struct {
 }
 
 func (j *jobLoop) executeJob(ctx context.Context, job *models.AppRunnerJob) error {
+	job.RunnerProcessID = j.processRegistrar.ProcessID()
+
 	jl, err := slog.NewOTELProvider(j.cfg, j.settings, job.LogStreamID)
 	if err != nil {
 		return errors.Wrap(err, "unable to create otel provider")
 	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := jl.Shutdown(shutdownCtx); err != nil {
+			j.l.Error("unable to shut down job logger", zap.Error(err))
+		}
+	}()
 
 	l, err := log.NewOTELJobLogger(j.cfg, jl)
 	if err != nil {
@@ -46,15 +55,6 @@ func (j *jobLoop) executeJob(ctx context.Context, job *models.AppRunnerJob) erro
 	l = l.With(zap.String("runner_job.id", job.ID))
 	l = l.With(zap.String("runner_job.type", string(job.Type)))
 	l = l.With(zap.String("log_stream.id", job.LogStreamID))
-
-	defer func() {
-		if err := jl.ForceFlush(ctx); err != nil {
-			if errors.Is(err, context.Canceled) {
-				return
-			}
-			l.Error("unable to flush logger", zap.Error(err))
-		}
-	}()
 
 	// create an execution in the API
 	l.Info("creating job execution")

--- a/bins/runner/internal/pkg/jobloop/exec_job.go
+++ b/bins/runner/internal/pkg/jobloop/exec_job.go
@@ -81,25 +81,23 @@ func (j *jobLoop) executeJob(ctx context.Context, job *models.AppRunnerJob) erro
 	// so the entire job execution forms a single trace. Job metadata goes onto
 	// ctx so op.Start can stamp it on every descendant span without each
 	// callsite having to repeat itself.
-	ctx = pkgctx.SetJobMetadata(ctx, pkgctx.JobMetadata{
-		RunnerJobID:          job.ID,
-		RunnerJobExecutionID: execution.ID,
-	})
+	ctx = pkgctx.SetJobMetadata(ctx, jobs.AuditMetadata(job, execution.ID, ""))
 	// Stash the process-scoped TracerProvider into ctx so op.Start sees it
 	// and we don't get poisoned by transitive deps that overwrite the OTEL
 	// global (notably the docker distribution registry).
 	tp := j.processRegistrar.TracerProvider()
 	ctx = pkgctx.SetTracerProvider(ctx, tp)
 	tracer := tp.Tracer("github.com/nuonco/nuon/bins/runner/jobloop")
+	rootSpanAttrs := append([]attribute.KeyValue{
+		attribute.String("nuon.tool", "runner"),
+		attribute.String("nuon.job.type", string(job.Type)),
+		attribute.String("nuon.job.operation", string(job.Operation)),
+		attribute.String("runner_job.id", job.ID),
+		attribute.String("runner_job_execution.id", execution.ID),
+	}, jobs.AuditAttrs(job)...)
 	ctx, rootSpan := tracer.Start(ctx, "job."+string(job.Type),
 		trace.WithSpanKind(trace.SpanKindInternal),
-		trace.WithAttributes(
-			attribute.String("nuon.tool", "runner"),
-			attribute.String("nuon.job.type", string(job.Type)),
-			attribute.String("nuon.job.operation", string(job.Operation)),
-			attribute.String("runner_job.id", job.ID),
-			attribute.String("runner_job_execution.id", execution.ID),
-		),
+		trace.WithAttributes(rootSpanAttrs...),
 	)
 	// Re-wrap `l` with pkgctx.ContextField(ctx) so the otelzap bridge can
 	// extract the rootSpan on every emit. Without this, every "creating job
@@ -119,11 +117,18 @@ func (j *jobLoop) executeJob(ctx context.Context, job *models.AppRunnerJob) erro
 	ctx = errcapture.NewContext(ctx, capture)
 
 	ctx = pkgctx.SetLogger(ctx, l)
+
+	auditL := log.NewAudit(l, job)
+	log.AuditEvent(auditL, "job execution started", log.OutcomeStarted)
+
 	var jobErr error
 	defer func() {
 		if jobErr != nil {
+			log.AuditEvent(auditL, "job execution failed", log.OutcomeFailed, zap.Error(jobErr))
 			rootSpan.RecordError(jobErr)
 			rootSpan.SetStatus(codes.Error, jobErr.Error())
+		} else {
+			log.AuditEvent(auditL, "job execution finished", log.OutcomeSucceeded)
 		}
 		rootSpan.End()
 	}()
@@ -145,7 +150,8 @@ func (j *jobLoop) executeJob(ctx context.Context, job *models.AppRunnerJob) erro
 			j.errRecorder.Record("no handler found", updateErr)
 		}
 
-		return err
+		jobErr = err
+		return jobErr
 	}
 
 	// If sandbox mode, fetch config from API and replace handler
@@ -193,29 +199,34 @@ func (j *jobLoop) executeJob(ctx context.Context, job *models.AppRunnerJob) erro
 		// Stamp the step name onto JobMetadata so anything launched inside
 		// the step (op.Start callsites in deploy / sandbox handlers)
 		// inherits it.
-		stepCtx := pkgctx.SetJobMetadata(ctx, pkgctx.JobMetadata{
-			RunnerJobID:          job.ID,
-			RunnerJobExecutionID: execution.ID,
-			StepName:             step.name,
-		})
+		stepCtx := pkgctx.SetJobMetadata(ctx, jobs.AuditMetadata(job, execution.ID, step.name))
+		stepSpanAttrs := append([]attribute.KeyValue{
+			attribute.String("nuon.tool", "runner"),
+			attribute.String("runner_job_execution_step.name", step.name),
+			attribute.String("runner_job.id", job.ID),
+			attribute.String("runner_job_execution.id", execution.ID),
+		}, jobs.AuditAttrs(job)...)
 		stepCtx, stepSpan := tracer.Start(stepCtx, "step."+step.name,
 			trace.WithSpanKind(trace.SpanKindInternal),
-			trace.WithAttributes(
-				attribute.String("nuon.tool", "runner"),
-				attribute.String("runner_job_execution_step.name", step.name),
-				attribute.String("runner_job.id", job.ID),
-				attribute.String("runner_job_execution.id", execution.ID),
-			),
+			trace.WithAttributes(stepSpanAttrs...),
 		)
 		// Step-scope logger picks up the step span via ContextField so the
 		// "executing job step …" marker lands on the step span instead of
 		// the parent rootSpan.
 		stepL := l.With(pkgctx.ContextField(stepCtx))
 		stepL.Info("executing job step "+step.name, zap.String("step", step.name))
+
+		stepAuditL := log.NewAudit(stepL, job)
+		stepNameField := zap.String("runner_job_execution_step.name", step.name)
+		log.AuditEvent(stepAuditL, "job step started", log.OutcomeStarted, stepNameField)
+
 		stepErr := j.execJobStep(stepCtx, stepL, jl, step, job, execution)
 		if stepErr != nil {
+			log.AuditEvent(stepAuditL, "job step failed", log.OutcomeFailed, stepNameField, zap.Error(stepErr))
 			stepSpan.RecordError(stepErr)
 			stepSpan.SetStatus(codes.Error, stepErr.Error())
+		} else {
+			log.AuditEvent(stepAuditL, "job step finished", log.OutcomeSucceeded, stepNameField)
 		}
 		stepSpan.End()
 		if stepErr != nil {

--- a/bins/runner/internal/pkg/jobloop/exec_job.go
+++ b/bins/runner/internal/pkg/jobloop/exec_job.go
@@ -35,7 +35,11 @@ type executeJobStep struct {
 func (j *jobLoop) executeJob(ctx context.Context, job *models.AppRunnerJob) error {
 	job.RunnerProcessID = j.processRegistrar.ProcessID()
 
-	jl, err := slog.NewOTELProvider(j.cfg, j.settings, job.LogStreamID)
+	var auditExportAvailable func() bool
+	if j.auditExport != nil {
+		auditExportAvailable = j.auditExport.Available
+	}
+	jl, err := slog.NewOTELProvider(j.cfg, j.settings, job.LogStreamID, auditExportAvailable)
 	if err != nil {
 		return errors.Wrap(err, "unable to create otel provider")
 	}

--- a/bins/runner/internal/pkg/jobloop/jobloop.go
+++ b/bins/runner/internal/pkg/jobloop/jobloop.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/auditexport"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/drain"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/process"
 	"github.com/nuonco/nuon/pkg/metrics"
@@ -55,6 +56,7 @@ type jobLoop struct {
 	shutdowner fx.Shutdowner
 
 	processRegistrar *process.Registrar
+	auditExport      *auditexport.Supervisor
 
 	drainer   *drain.Drainer
 	jobDoneCh chan struct{}
@@ -96,6 +98,7 @@ func New(handlers []jobs.JobHandler, jobGroup models.AppRunnerJobGroup, params B
 		shutdowner: params.Shutdowner,
 
 		processRegistrar: params.ProcessRegistrar,
+		auditExport:      params.AuditExport,
 
 		drainer:    params.Drainer,
 		jobDoneCh:  jobDoneCh,

--- a/bins/runner/internal/pkg/process/process.go
+++ b/bins/runner/internal/pkg/process/process.go
@@ -87,7 +87,7 @@ func New(params Params) (Result, error) {
 	r.logStreamID = process.LogStreamID
 
 	if r.logStreamID != "" {
-		lp, err := slog.NewOTELProvider(r.cfg, r.settings, r.logStreamID)
+		lp, err := slog.NewOTELProvider(r.cfg, r.settings, r.logStreamID, nil)
 		if err == nil {
 			r.logProvider = lp
 		}

--- a/bins/runner/internal/pkg/slog/otel.go
+++ b/bins/runner/internal/pkg/slog/otel.go
@@ -21,14 +21,31 @@ const (
 )
 
 type auditProcessor struct {
-	next log.Processor
+	next      log.Processor
+	available func() bool
+}
+
+type availabilityExporter struct {
+	log.Exporter
+	available func() bool
+}
+
+func (e *availabilityExporter) Export(ctx context.Context, records []log.Record) error {
+	if !e.available() {
+		return nil
+	}
+	return e.Exporter.Export(ctx, records)
 }
 
 func (p *auditProcessor) Enabled(ctx context.Context, params log.EnabledParameters) bool {
-	return p.next.Enabled(ctx, params)
+	return p.available() && p.next.Enabled(ctx, params)
 }
 
 func (p *auditProcessor) OnEmit(ctx context.Context, record *log.Record) error {
+	if !p.available() {
+		return nil
+	}
+
 	isAudit := false
 	record.WalkAttributes(func(attr otellog.KeyValue) bool {
 		isAudit = attr.Key == runnerlog.AuditAttr &&
@@ -51,7 +68,7 @@ func (p *auditProcessor) ForceFlush(ctx context.Context) error {
 	return p.next.ForceFlush(ctx)
 }
 
-func NewOTELProvider(cfg *runnerconfig.Config, set *settings.Settings, logStreamID string) (*log.LoggerProvider, error) {
+func NewOTELProvider(cfg *runnerconfig.Config, set *settings.Settings, logStreamID string, auditExportAvailable func() bool) (*log.LoggerProvider, error) {
 	opts := []log.LoggerProviderOption{
 		log.WithResource(getResource(set, logStreamID)),
 	}
@@ -64,8 +81,8 @@ func NewOTELProvider(cfg *runnerconfig.Config, set *settings.Settings, logStream
 		opts = append(opts, log.WithProcessor(processor))
 	}
 
-	if cfg.OTELAuditExportEnabled {
-		processor, err := newAuditCollectorProcessor()
+	if auditExportAvailable != nil {
+		processor, err := newAuditCollectorProcessor(auditExportAvailable)
 		if err != nil {
 			return nil, err
 		}
@@ -90,15 +107,17 @@ func newAPIProcessor(cfg *runnerconfig.Config, logStreamID string) (log.Processo
 	return newBatchProcessor(exporter), nil
 }
 
-func newAuditCollectorProcessor() (log.Processor, error) {
+func newAuditCollectorProcessor(available func() bool) (log.Processor, error) {
 	exporter, err := otlploghttp.New(context.Background(),
 		otlploghttp.WithEndpointURL(auditCollectorEndpoint),
+		otlploghttp.WithRetry(otlploghttp.RetryConfig{Enabled: false}),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize audit collector log exporter: %w", err)
 	}
 
-	return &auditProcessor{next: newBatchProcessor(exporter)}, nil
+	availableExporter := &availabilityExporter{Exporter: exporter, available: available}
+	return &auditProcessor{next: newBatchProcessor(availableExporter), available: available}, nil
 }
 
 func newBatchProcessor(exporter log.Exporter) log.Processor {

--- a/bins/runner/internal/pkg/slog/otel.go
+++ b/bins/runner/internal/pkg/slog/otel.go
@@ -14,38 +14,69 @@ import (
 
 const (
 	defaultOTLPLogsEndpointTmpl string = "%s/v1/log-streams/%s/logs"
+
+	// auditCollectorEndpoint mirrors the receiver the bundled audit-export
+	// collector binds to. Both sides are fixed: the collector is supervised by
+	// this process and only ever listens on loopback.
+	auditCollectorEndpoint string = "http://127.0.0.1:4318/v1/logs"
 )
 
 func NewOTELProvider(cfg *runnerconfig.Config, set *settings.Settings, logStreamID string) (*log.LoggerProvider, error) {
-	if !set.EnableLogging {
-		return log.NewLoggerProvider(), nil
+	opts := []log.LoggerProviderOption{
+		log.WithResource(getResource(set, logStreamID)),
 	}
 
-	ctx := context.Background()
-	ctx, cancelFn := context.WithCancel(ctx)
+	if set.EnableLogging {
+		processor, err := newAPIProcessor(cfg, logStreamID)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, log.WithProcessor(processor))
+	}
 
+	if cfg.OTELAuditExportEnabled {
+		processor, err := newAuditCollectorProcessor()
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, log.WithProcessor(processor))
+	}
+
+	return log.NewLoggerProvider(opts...), nil
+}
+
+func newAPIProcessor(cfg *runnerconfig.Config, logStreamID string) (log.Processor, error) {
 	url := fmt.Sprintf(defaultOTLPLogsEndpointTmpl, cfg.RunnerAPIURL, logStreamID)
-	logExporter, err := otlploghttp.New(ctx,
+	exporter, err := otlploghttp.New(context.Background(),
 		otlploghttp.WithEndpointURL(url),
 		otlploghttp.WithHeaders(map[string]string{
 			"Authorization": "Bearer " + cfg.RunnerAPIToken,
 		}),
 	)
 	if err != nil {
-		cancelFn()
 		return nil, fmt.Errorf("unable to initialize otlp log exporter: %w", err)
 	}
 
-	rsrc := getResource(set)
-	// Create the logger provider
-	lp := log.NewLoggerProvider(
-		log.WithResource(rsrc),
-		log.WithProcessor(
-			log.NewBatchProcessor(logExporter,
-				log.WithExportMaxBatchSize(25),
-				log.WithExportInterval(time.Second*5)),
-		),
-	)
+	return newBatchProcessor(exporter), nil
+}
 
-	return lp, nil
+// newAuditCollectorProcessor ships to the audit-export collector bundled
+// alongside the runner. The collector filters to records tagged
+// nuon.audit="true" before forwarding to the customer's backend, so everything
+// else sent over this hop is dropped there.
+func newAuditCollectorProcessor() (log.Processor, error) {
+	exporter, err := otlploghttp.New(context.Background(),
+		otlploghttp.WithEndpointURL(auditCollectorEndpoint),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize audit collector log exporter: %w", err)
+	}
+
+	return newBatchProcessor(exporter), nil
+}
+
+func newBatchProcessor(exporter log.Exporter) log.Processor {
+	return log.NewBatchProcessor(exporter,
+		log.WithExportMaxBatchSize(25),
+		log.WithExportInterval(time.Second*5))
 }

--- a/bins/runner/internal/pkg/slog/otel.go
+++ b/bins/runner/internal/pkg/slog/otel.go
@@ -6,20 +6,50 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
+	otellog "go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/sdk/log"
 
 	runnerconfig "github.com/nuonco/nuon/pkg/runner/config"
+	runnerlog "github.com/nuonco/nuon/pkg/runner/log"
 	"github.com/nuonco/nuon/pkg/runner/settings"
 )
 
 const (
 	defaultOTLPLogsEndpointTmpl string = "%s/v1/log-streams/%s/logs"
 
-	// auditCollectorEndpoint mirrors the receiver the bundled audit-export
-	// collector binds to. Both sides are fixed: the collector is supervised by
-	// this process and only ever listens on loopback.
 	auditCollectorEndpoint string = "http://127.0.0.1:4318/v1/logs"
 )
+
+type auditProcessor struct {
+	next log.Processor
+}
+
+func (p *auditProcessor) Enabled(ctx context.Context, params log.EnabledParameters) bool {
+	return p.next.Enabled(ctx, params)
+}
+
+func (p *auditProcessor) OnEmit(ctx context.Context, record *log.Record) error {
+	isAudit := false
+	record.WalkAttributes(func(attr otellog.KeyValue) bool {
+		isAudit = attr.Key == runnerlog.AuditAttr &&
+			attr.Value.Kind() == otellog.KindString &&
+			attr.Value.AsString() == runnerlog.AuditAttrValue
+		return !isAudit
+	})
+	if !isAudit {
+		return nil
+	}
+
+	return p.next.OnEmit(ctx, record)
+}
+
+func (p *auditProcessor) Shutdown(ctx context.Context) error {
+	return p.next.Shutdown(ctx)
+}
+
+func (p *auditProcessor) ForceFlush(ctx context.Context) error {
+	return p.next.ForceFlush(ctx)
+}
 
 func NewOTELProvider(cfg *runnerconfig.Config, set *settings.Settings, logStreamID string) (*log.LoggerProvider, error) {
 	opts := []log.LoggerProviderOption{
@@ -60,10 +90,6 @@ func newAPIProcessor(cfg *runnerconfig.Config, logStreamID string) (log.Processo
 	return newBatchProcessor(exporter), nil
 }
 
-// newAuditCollectorProcessor ships to the audit-export collector bundled
-// alongside the runner. The collector filters to records tagged
-// nuon.audit="true" before forwarding to the customer's backend, so everything
-// else sent over this hop is dropped there.
 func newAuditCollectorProcessor() (log.Processor, error) {
 	exporter, err := otlploghttp.New(context.Background(),
 		otlploghttp.WithEndpointURL(auditCollectorEndpoint),
@@ -72,7 +98,7 @@ func newAuditCollectorProcessor() (log.Processor, error) {
 		return nil, fmt.Errorf("unable to initialize audit collector log exporter: %w", err)
 	}
 
-	return newBatchProcessor(exporter), nil
+	return &auditProcessor{next: newBatchProcessor(exporter)}, nil
 }
 
 func newBatchProcessor(exporter log.Exporter) log.Processor {

--- a/bins/runner/internal/pkg/slog/otel_test.go
+++ b/bins/runner/internal/pkg/slog/otel_test.go
@@ -3,6 +3,7 @@ package slog
 import (
 	"context"
 	"testing"
+	"time"
 
 	otellog "go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/sdk/log"
@@ -15,6 +16,18 @@ type recordingProcessor struct {
 	flushed int
 	stopped int
 }
+
+type recordingExporter struct {
+	exported int
+}
+
+func (e *recordingExporter) Export(_ context.Context, records []log.Record) error {
+	e.exported += len(records)
+	return nil
+}
+
+func (*recordingExporter) ForceFlush(context.Context) error { return nil }
+func (*recordingExporter) Shutdown(context.Context) error   { return nil }
 
 func (p *recordingProcessor) Enabled(context.Context, log.EnabledParameters) bool { return true }
 
@@ -35,7 +48,8 @@ func (p *recordingProcessor) Shutdown(context.Context) error {
 
 func TestAuditProcessor(t *testing.T) {
 	next := new(recordingProcessor)
-	processor := &auditProcessor{next: next}
+	available := true
+	processor := &auditProcessor{next: next, available: func() bool { return available }}
 	ctx := context.Background()
 	logger := log.NewLoggerProvider(log.WithProcessor(processor)).Logger("test")
 
@@ -49,6 +63,11 @@ func TestAuditProcessor(t *testing.T) {
 	if next.emitted != 1 {
 		t.Fatalf("forwarded %d records, want 1", next.emitted)
 	}
+	available = false
+	logger.Emit(ctx, records[2])
+	if next.emitted != 1 {
+		t.Fatalf("forwarded %d records while unavailable, want 1", next.emitted)
+	}
 	if err := processor.ForceFlush(ctx); err != nil {
 		t.Fatalf("ForceFlush() error = %v", err)
 	}
@@ -57,5 +76,29 @@ func TestAuditProcessor(t *testing.T) {
 	}
 	if next.flushed != 1 || next.stopped != 1 {
 		t.Fatalf("delegation counts = flush %d, shutdown %d; want 1 each", next.flushed, next.stopped)
+	}
+}
+
+func TestAvailabilityExporterDropsQueuedRecordsAfterCollectorStops(t *testing.T) {
+	available := true
+	exporter := new(recordingExporter)
+	gatedExporter := &availabilityExporter{Exporter: exporter, available: func() bool { return available }}
+	batch := log.NewBatchProcessor(gatedExporter, log.WithExportInterval(time.Hour))
+	processor := &auditProcessor{next: batch, available: func() bool { return available }}
+	provider := log.NewLoggerProvider(log.WithProcessor(processor))
+	logger := provider.Logger("test")
+
+	var record otellog.Record
+	record.AddAttributes(otellog.String(runnerlog.AuditAttr, runnerlog.AuditAttrValue))
+	logger.Emit(context.Background(), record)
+	available = false
+	if err := provider.ForceFlush(context.Background()); err != nil {
+		t.Fatalf("ForceFlush() error = %v", err)
+	}
+	if exporter.exported != 0 {
+		t.Fatalf("exported %d queued records after collector stopped, want 0", exporter.exported)
+	}
+	if err := provider.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
 	}
 }

--- a/bins/runner/internal/pkg/slog/otel_test.go
+++ b/bins/runner/internal/pkg/slog/otel_test.go
@@ -1,0 +1,61 @@
+package slog
+
+import (
+	"context"
+	"testing"
+
+	otellog "go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/sdk/log"
+
+	runnerlog "github.com/nuonco/nuon/pkg/runner/log"
+)
+
+type recordingProcessor struct {
+	emitted int
+	flushed int
+	stopped int
+}
+
+func (p *recordingProcessor) Enabled(context.Context, log.EnabledParameters) bool { return true }
+
+func (p *recordingProcessor) OnEmit(context.Context, *log.Record) error {
+	p.emitted++
+	return nil
+}
+
+func (p *recordingProcessor) ForceFlush(context.Context) error {
+	p.flushed++
+	return nil
+}
+
+func (p *recordingProcessor) Shutdown(context.Context) error {
+	p.stopped++
+	return nil
+}
+
+func TestAuditProcessor(t *testing.T) {
+	next := new(recordingProcessor)
+	processor := &auditProcessor{next: next}
+	ctx := context.Background()
+	logger := log.NewLoggerProvider(log.WithProcessor(processor)).Logger("test")
+
+	records := []otellog.Record{{}, {}, {}}
+	records[1].AddAttributes(otellog.String(runnerlog.AuditAttr, "false"))
+	records[2].AddAttributes(otellog.String(runnerlog.AuditAttr, runnerlog.AuditAttrValue))
+	for i := range records {
+		logger.Emit(ctx, records[i])
+	}
+
+	if next.emitted != 1 {
+		t.Fatalf("forwarded %d records, want 1", next.emitted)
+	}
+	if err := processor.ForceFlush(ctx); err != nil {
+		t.Fatalf("ForceFlush() error = %v", err)
+	}
+	if err := processor.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	if next.flushed != 1 || next.stopped != 1 {
+		t.Fatalf("delegation counts = flush %d, shutdown %d; want 1 each", next.flushed, next.stopped)
+	}
+}

--- a/bins/runner/internal/pkg/slog/resource.go
+++ b/bins/runner/internal/pkg/slog/resource.go
@@ -8,10 +8,13 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
-func getResource(set *settings.Settings) *resource.Resource {
+func getResource(set *settings.Settings, logStreamID string) *resource.Resource {
 	attrs := []attribute.KeyValue{}
 	builtInAttrs := map[string]string{
 		"service.name": "runner",
+	}
+	if logStreamID != "" {
+		builtInAttrs["log_stream.id"] = logStreamID
 	}
 
 	for k, v := range generics.MergeMap(set.Metadata, builtInAttrs) {

--- a/pkg/runner/config/config.go
+++ b/pkg/runner/config/config.go
@@ -35,6 +35,12 @@ type Config struct {
 	HostIP   string `config:"host_ip" validate:"required"`
 	LogLevel string `config:"log_level"`
 
+	// OTELAuditExportEnabled forwards audit-tagged records to the audit-export
+	// collector bundled alongside the runner. Off by default: the collector
+	// only ships with the AWS EKS stack today, and exporting to a loopback
+	// port nothing is listening on retries on every batch interval.
+	OTELAuditExportEnabled bool `config:"otel_audit_export_enabled"`
+
 	// some artifacts are bundled into the runner binary, to make loading them easier.
 	BundleDir    string `config:"bundle_dir" validate:"required"`
 	RegistryDir  string `config:"registry_dir" validate:"required"`

--- a/pkg/runner/config/config.go
+++ b/pkg/runner/config/config.go
@@ -35,12 +35,6 @@ type Config struct {
 	HostIP   string `config:"host_ip" validate:"required"`
 	LogLevel string `config:"log_level"`
 
-	// OTELAuditExportEnabled forwards audit-tagged records to the audit-export
-	// collector bundled alongside the runner. Off by default: the collector
-	// only ships with the AWS EKS stack today, and exporting to a loopback
-	// port nothing is listening on retries on every batch interval.
-	OTELAuditExportEnabled bool `config:"otel_audit_export_enabled"`
-
 	// some artifacts are bundled into the runner binary, to make loading them easier.
 	BundleDir    string `config:"bundle_dir" validate:"required"`
 	RegistryDir  string `config:"registry_dir" validate:"required"`

--- a/pkg/runner/controlplane/executor.go
+++ b/pkg/runner/controlplane/executor.go
@@ -28,6 +28,7 @@ import (
 	sandboxbuild "github.com/nuonco/nuon/pkg/runner/jobs/build/sandbox"
 	terraformbuild "github.com/nuonco/nuon/pkg/runner/jobs/build/terraform"
 	imagemetadatasync "github.com/nuonco/nuon/pkg/runner/jobs/sync/imagemetadata"
+	runnerlog "github.com/nuonco/nuon/pkg/runner/log"
 	ocicopy "github.com/nuonco/nuon/pkg/runner/oci/copy"
 	ociresolve "github.com/nuonco/nuon/pkg/runner/oci/resolve"
 	"github.com/nuonco/nuon/pkg/runner/settings"
@@ -175,23 +176,24 @@ func (e *Executor) Execute(ctx context.Context, job *models.AppRunnerJob, execut
 	go e.monitorJob(executionCtx, cancelExecution, monitorDone, job.ID, l, handler)
 	ctx = executionCtx
 
-	ctx = runnerctx.SetJobMetadata(ctx, runnerctx.JobMetadata{RunnerJobID: job.ID, RunnerJobExecutionID: execution.ID})
+	ctx = runnerctx.SetJobMetadata(ctx, jobs.AuditMetadata(job, execution.ID, ""))
 	var tracer trace.Tracer
 	var rootSpan trace.Span
 	var jobErr error
 	if traceProvider != nil {
 		ctx = runnerctx.SetTracerProvider(ctx, traceProvider)
 		tracer = traceProvider.Tracer("github.com/nuonco/nuon/pkg/runner/controlplane")
+		rootSpanAttrs := append([]attribute.KeyValue{
+			attribute.String("nuon.tool", "runner"),
+			attribute.String("nuon.job.type", string(job.Type)),
+			attribute.String("nuon.job.operation", string(job.Operation)),
+			attribute.String("runner_job.id", job.ID),
+			attribute.String("runner_job.executor", "control-plane"),
+			attribute.String("runner_job_execution.id", execution.ID),
+		}, jobs.AuditAttrs(job)...)
 		ctx, rootSpan = tracer.Start(ctx, "job."+string(job.Type),
 			trace.WithSpanKind(trace.SpanKindInternal),
-			trace.WithAttributes(
-				attribute.String("nuon.tool", "runner"),
-				attribute.String("nuon.job.type", string(job.Type)),
-				attribute.String("nuon.job.operation", string(job.Operation)),
-				attribute.String("runner_job.id", job.ID),
-				attribute.String("runner_job.executor", "control-plane"),
-				attribute.String("runner_job_execution.id", execution.ID),
-			),
+			trace.WithAttributes(rootSpanAttrs...),
 		)
 		l = l.With(runnerctx.ContextField(ctx))
 		defer func() {
@@ -203,6 +205,16 @@ func (e *Executor) Execute(ctx context.Context, job *models.AppRunnerJob, execut
 		}()
 	}
 	ctx = runnerctx.SetLogger(ctx, l)
+
+	auditL := runnerlog.NewAudit(l, job)
+	runnerlog.AuditEvent(auditL, "job execution started", runnerlog.OutcomeStarted)
+	defer func() {
+		if jobErr != nil {
+			runnerlog.AuditEvent(auditL, "job execution failed", runnerlog.OutcomeFailed, zap.Error(jobErr))
+			return
+		}
+		runnerlog.AuditEvent(auditL, "job execution finished", runnerlog.OutcomeSucceeded)
+	}()
 
 	if isSandboxableBuildHandler(handler) {
 		sandboxMode, err := e.getSandboxMode(ctx, job.ID)
@@ -274,25 +286,32 @@ func (e *Executor) Execute(ctx context.Context, job *models.AppRunnerJob, execut
 			jobErr = err
 			return jobErr
 		}
-		stepCtx := runnerctx.SetJobMetadata(ctx, runnerctx.JobMetadata{RunnerJobID: job.ID, RunnerJobExecutionID: execution.ID, StepName: step.name})
+		stepCtx := runnerctx.SetJobMetadata(ctx, jobs.AuditMetadata(job, execution.ID, step.name))
 		stepL := l.With(zap.String("runner_job_execution_step.name", step.name))
 		var stepSpan trace.Span
 		if tracer != nil {
+			stepSpanAttrs := append([]attribute.KeyValue{
+				attribute.String("nuon.tool", "runner"),
+				attribute.String("runner_job_execution_step.name", step.name),
+				attribute.String("runner_job.id", job.ID),
+				attribute.String("runner_job.executor", "control-plane"),
+				attribute.String("runner_job_execution.id", execution.ID),
+			}, jobs.AuditAttrs(job)...)
 			stepCtx, stepSpan = tracer.Start(stepCtx, "step."+step.name,
 				trace.WithSpanKind(trace.SpanKindInternal),
-				trace.WithAttributes(
-					attribute.String("nuon.tool", "runner"),
-					attribute.String("runner_job_execution_step.name", step.name),
-					attribute.String("runner_job.id", job.ID),
-					attribute.String("runner_job.executor", "control-plane"),
-					attribute.String("runner_job_execution.id", execution.ID),
-				),
+				trace.WithAttributes(stepSpanAttrs...),
 			)
 			stepL = stepL.With(runnerctx.ContextField(stepCtx))
 		}
 		stepCtx = runnerctx.SetLogger(stepCtx, stepL)
 		stepL.Info("executing job step "+step.name, zap.String("step", step.name))
+
+		stepAuditL := runnerlog.NewAudit(stepL, job)
+		stepNameField := zap.String("runner_job_execution_step.name", step.name)
+		runnerlog.AuditEvent(stepAuditL, "job step started", runnerlog.OutcomeStarted, stepNameField)
+
 		if err := step.fn(stepCtx); err != nil {
+			runnerlog.AuditEvent(stepAuditL, "job step failed", runnerlog.OutcomeFailed, stepNameField, zap.Error(err))
 			if cause := context.Cause(ctx); cause != nil {
 				err = fmt.Errorf("%w: %v", cause, err)
 			}
@@ -317,6 +336,7 @@ func (e *Executor) Execute(ctx context.Context, job *models.AppRunnerJob, execut
 			jobErr = fmt.Errorf("%s: %w", step.name, err)
 			return jobErr
 		}
+		runnerlog.AuditEvent(stepAuditL, "job step finished", runnerlog.OutcomeSucceeded, stepNameField)
 		if stepSpan != nil {
 			stepSpan.End()
 		}

--- a/pkg/runner/ctx/log.go
+++ b/pkg/runner/ctx/log.go
@@ -77,6 +77,15 @@ type JobMetadata struct {
 	RunnerJobID          string
 	RunnerJobExecutionID string
 	StepName             string
+
+	// Audit context. Only the dimensions worth querying spans by live here;
+	// the rest of the audit envelope rides on the job logger, which every
+	// descendant log inherits.
+	JobGroup     string
+	JobOperation string
+	Executor     string
+	OrgID        string
+	InstallID    string
 }
 
 type jobMetaCtxKey struct{}

--- a/pkg/runner/jobs/audit.go
+++ b/pkg/runner/jobs/audit.go
@@ -22,6 +22,8 @@ var auditMetadataAttrs = map[string]string{
 	"action_workflow_id":     "action_workflow.id",
 	"action_workflow_run_id": "action_workflow_run.id",
 	"deploy_id":              "deploy.id",
+	"install_component_id":   "install_component.id",
+	"notebook_cell_run_id":   "notebook_cell_run.id",
 	"sandbox_run_id":         "sandbox_run.id",
 	"sandbox_run_type":       "sandbox_run.type",
 }

--- a/pkg/runner/jobs/audit.go
+++ b/pkg/runner/jobs/audit.go
@@ -1,0 +1,101 @@
+package jobs
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.uber.org/zap"
+
+	pkgctx "github.com/nuonco/nuon/pkg/runner/ctx"
+	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
+)
+
+// auditMetadataAttrs maps runner job metadata keys, which ctl-api populates at
+// job creation and vary by job group, onto the attribute names we emit.
+var auditMetadataAttrs = map[string]string{
+	"install_id":             "install.id",
+	"flow_install_id":        "flow_install.id",
+	"flow_workflow_id":       "flow_workflow.id",
+	"app_id":                 "app.id",
+	"component_id":           "component.id",
+	"component_name":         "component.name",
+	"action_workflow_name":   "action_workflow.name",
+	"action_workflow_id":     "action_workflow.id",
+	"action_workflow_run_id": "action_workflow_run.id",
+	"deploy_id":              "deploy.id",
+	"sandbox_run_id":         "sandbox_run.id",
+	"sandbox_run_type":       "sandbox_run.type",
+}
+
+// auditPairs is the single source of truth for the audit envelope. Both the
+// zap field and OTEL attribute forms are derived from it so log records and
+// spans never drift apart.
+func auditPairs(job *models.AppRunnerJob) [][2]string {
+	if job == nil {
+		return nil
+	}
+
+	pairs := [][2]string{
+		{string(semconv.UserIDKey), job.CreatedByID},
+		{"runner_job.created_by_id", job.CreatedByID},
+		{"runner_job.group", string(job.Group)},
+		{"runner_job.operation", string(job.Operation)},
+		{"runner_job.executor", string(job.Executor)},
+		{"runner_job.owner_id", job.OwnerID},
+		{"runner_job.owner_type", job.OwnerType},
+		{"org.id", job.OrgID},
+		{"runner_process.id", job.RunnerProcessID},
+	}
+
+	for metaKey, attrKey := range auditMetadataAttrs {
+		if v, ok := job.Metadata[metaKey]; ok {
+			pairs = append(pairs, [2]string{attrKey, v})
+		}
+	}
+
+	out := make([][2]string, 0, len(pairs))
+	for _, p := range pairs {
+		if p[1] != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func AuditFields(job *models.AppRunnerJob) []zap.Field {
+	pairs := auditPairs(job)
+	fields := make([]zap.Field, 0, len(pairs))
+	for _, p := range pairs {
+		fields = append(fields, zap.String(p[0], p[1]))
+	}
+	return fields
+}
+
+// AuditMetadata builds the ctx-threaded job metadata that op.Start stamps onto
+// every descendant span. It carries only the dimensions worth querying spans
+// by; the full envelope rides on the job logger instead.
+func AuditMetadata(job *models.AppRunnerJob, executionID, stepName string) pkgctx.JobMetadata {
+	meta := pkgctx.JobMetadata{
+		RunnerJobExecutionID: executionID,
+		StepName:             stepName,
+	}
+	if job == nil {
+		return meta
+	}
+
+	meta.RunnerJobID = job.ID
+	meta.JobGroup = string(job.Group)
+	meta.JobOperation = string(job.Operation)
+	meta.Executor = string(job.Executor)
+	meta.OrgID = job.OrgID
+	meta.InstallID = job.Metadata["install_id"]
+	return meta
+}
+
+func AuditAttrs(job *models.AppRunnerJob) []attribute.KeyValue {
+	pairs := auditPairs(job)
+	attrs := make([]attribute.KeyValue, 0, len(pairs))
+	for _, p := range pairs {
+		attrs = append(attrs, attribute.String(p[0], p[1]))
+	}
+	return attrs
+}

--- a/pkg/runner/jobs/audit_test.go
+++ b/pkg/runner/jobs/audit_test.go
@@ -25,10 +25,12 @@ func TestAuditPairsPopulatedJob(t *testing.T) {
 		OrgID:           "org123",
 		RunnerProcessID: "proc123",
 		Metadata: map[string]string{
-			"install_id":       "inst123",
-			"component_name":   "api",
-			"deploy_id":        "dep123",
-			"flow_workflow_id": "wf123",
+			"install_id":           "inst123",
+			"component_name":       "api",
+			"deploy_id":            "dep123",
+			"flow_workflow_id":     "wf123",
+			"install_component_id": "instcmp123",
+			"notebook_cell_run_id": "cellrun123",
 		},
 	}
 
@@ -46,6 +48,8 @@ func TestAuditPairsPopulatedJob(t *testing.T) {
 		"component.name":           "api",
 		"deploy.id":                "dep123",
 		"flow_workflow.id":         "wf123",
+		"install_component.id":     "instcmp123",
+		"notebook_cell_run.id":     "cellrun123",
 	}
 
 	got := fieldMap(job)

--- a/pkg/runner/jobs/audit_test.go
+++ b/pkg/runner/jobs/audit_test.go
@@ -1,0 +1,96 @@
+package jobs
+
+import (
+	"testing"
+
+	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
+)
+
+func fieldMap(job *models.AppRunnerJob) map[string]string {
+	out := map[string]string{}
+	for _, p := range auditPairs(job) {
+		out[p[0]] = p[1]
+	}
+	return out
+}
+
+func TestAuditPairsPopulatedJob(t *testing.T) {
+	job := &models.AppRunnerJob{
+		CreatedByID:     "acct123",
+		Group:           models.AppRunnerJobGroupDeploy,
+		Operation:       models.AppRunnerJobOperationTypeApplyDashPlan,
+		Executor:        "org-runner",
+		OwnerID:         "dep123",
+		OwnerType:       "install_deploys",
+		OrgID:           "org123",
+		RunnerProcessID: "proc123",
+		Metadata: map[string]string{
+			"install_id":       "inst123",
+			"component_name":   "api",
+			"deploy_id":        "dep123",
+			"flow_workflow_id": "wf123",
+		},
+	}
+
+	want := map[string]string{
+		"user.id":                  "acct123",
+		"runner_job.created_by_id": "acct123",
+		"runner_job.group":         "deploy",
+		"runner_job.operation":     "apply-plan",
+		"runner_job.executor":      "org-runner",
+		"runner_job.owner_id":      "dep123",
+		"runner_job.owner_type":    "install_deploys",
+		"org.id":                   "org123",
+		"runner_process.id":        "proc123",
+		"install.id":               "inst123",
+		"component.name":           "api",
+		"deploy.id":                "dep123",
+		"flow_workflow.id":         "wf123",
+	}
+
+	got := fieldMap(job)
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("%s = %q, want %q", k, got[k], v)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %d attributes, want %d: %v", len(got), len(want), got)
+	}
+
+	if n := len(AuditFields(job)); n != len(want) {
+		t.Errorf("AuditFields returned %d fields, want %d", n, len(want))
+	}
+	if n := len(AuditAttrs(job)); n != len(want) {
+		t.Errorf("AuditAttrs returned %d attrs, want %d", n, len(want))
+	}
+}
+
+func TestAuditPairsSkipsEmptyValues(t *testing.T) {
+	job := &models.AppRunnerJob{
+		Group:    models.AppRunnerJobGroupDeploy,
+		Metadata: map[string]string{"install_id": "", "app_id": "app123"},
+	}
+
+	got := fieldMap(job)
+	for _, key := range []string{"user.id", "org.id", "install.id", "runner_job.owner_id"} {
+		if _, ok := got[key]; ok {
+			t.Errorf("%s present for an empty value", key)
+		}
+	}
+	if got["app.id"] != "app123" {
+		t.Errorf("app.id = %q, want %q", got["app.id"], "app123")
+	}
+}
+
+func TestAuditPairsEmptyJob(t *testing.T) {
+	if n := len(AuditFields(&models.AppRunnerJob{})); n != 0 {
+		t.Errorf("AuditFields on an empty job returned %d fields, want 0", n)
+	}
+	if n := len(AuditFields(nil)); n != 0 {
+		t.Errorf("AuditFields(nil) returned %d fields, want 0", n)
+	}
+	if n := len(AuditAttrs(nil)); n != 0 {
+		t.Errorf("AuditAttrs(nil) returned %d attrs, want 0", n)
+	}
+}

--- a/pkg/runner/log/audit.go
+++ b/pkg/runner/log/audit.go
@@ -1,0 +1,73 @@
+package log
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/pkg/runner/jobs"
+	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
+)
+
+// AuditAttr tags records the bundled collector forwards to the customer's
+// backend. Its filter drops anything where the log record attribute
+// nuon.audit != "true", so the value must be this exact string and must be a
+// record attribute rather than a resource attribute.
+const (
+	AuditAttr      = "nuon.audit"
+	AuditAttrValue = "true"
+
+	AuditEventAttr   = "nuon.audit.event"
+	AuditOutcomeAttr = "nuon.audit.outcome"
+)
+
+const (
+	OutcomeStarted   = "started"
+	OutcomeSucceeded = "succeeded"
+	OutcomeFailed    = "failed"
+)
+
+// auditEventTypes maps the runner job groups that produce customer-visible
+// changes onto the event types used by the install_audit_logs view, so the
+// streamed audit log stays consistent with the one customers download today.
+var auditEventTypes = map[models.AppRunnerJobGroup]string{
+	models.AppRunnerJobGroupDeploy:  "install_deploy",
+	models.AppRunnerJobGroupActions: "install_action_workflow_run",
+	models.AppRunnerJobGroupSandbox: "install_sandbox_run",
+}
+
+func AuditEventType(job *models.AppRunnerJob) string {
+	if job == nil {
+		return ""
+	}
+	return auditEventTypes[job.Group]
+}
+
+func IsAuditable(job *models.AppRunnerJob) bool {
+	return AuditEventType(job) != ""
+}
+
+// NewAudit derives an audit logger from a job logger. It returns nil for jobs
+// whose group is not auditable, so callers must nil-check before emitting;
+// tagging every job would send the runner's entire log volume to the customer.
+func NewAudit(l *zap.Logger, job *models.AppRunnerJob) *zap.Logger {
+	if l == nil || !IsAuditable(job) {
+		return nil
+	}
+
+	fields := []zap.Field{
+		zap.String(AuditAttr, AuditAttrValue),
+		zap.String(AuditEventAttr, AuditEventType(job)),
+	}
+	fields = append(fields, jobs.AuditFields(job)...)
+
+	return l.With(fields...)
+}
+
+// AuditEvent emits one audit record, and does nothing when l is nil so callers
+// can pass the result of NewAudit straight through without branching on
+// whether the job was auditable.
+func AuditEvent(l *zap.Logger, msg, outcome string, fields ...zap.Field) {
+	if l == nil {
+		return
+	}
+	l.Info(msg, append([]zap.Field{zap.String(AuditOutcomeAttr, outcome)}, fields...)...)
+}

--- a/pkg/runner/log/audit_test.go
+++ b/pkg/runner/log/audit_test.go
@@ -1,0 +1,109 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestAuditEventType(t *testing.T) {
+	tests := []struct {
+		group models.AppRunnerJobGroup
+		want  string
+	}{
+		{models.AppRunnerJobGroupDeploy, "install_deploy"},
+		{models.AppRunnerJobGroupActions, "install_action_workflow_run"},
+		{models.AppRunnerJobGroupSandbox, "install_sandbox_run"},
+		{models.AppRunnerJobGroupHealthDashChecks, ""},
+		{models.AppRunnerJobGroupSync, ""},
+		{models.AppRunnerJobGroupBuild, ""},
+		{models.AppRunnerJobGroupRunner, ""},
+		{models.AppRunnerJobGroupOperations, ""},
+		{models.AppRunnerJobGroupManagement, ""},
+		{models.AppRunnerJobGroupEmpty, ""},
+	}
+
+	for _, tt := range tests {
+		job := &models.AppRunnerJob{Group: tt.group}
+
+		if got := AuditEventType(job); got != tt.want {
+			t.Errorf("AuditEventType(%q) = %q, want %q", tt.group, got, tt.want)
+		}
+		if got, want := IsAuditable(job), tt.want != ""; got != want {
+			t.Errorf("IsAuditable(%q) = %v, want %v", tt.group, got, want)
+		}
+	}
+}
+
+func TestAuditEventTypeNilJob(t *testing.T) {
+	if got := AuditEventType(nil); got != "" {
+		t.Errorf("AuditEventType(nil) = %q, want empty", got)
+	}
+	if IsAuditable(nil) {
+		t.Error("IsAuditable(nil) = true, want false")
+	}
+}
+
+func TestNewAuditReturnsNilForNonAuditableJob(t *testing.T) {
+	core, _ := observer.New(zapcore.InfoLevel)
+	l := zap.New(core)
+	for _, group := range []models.AppRunnerJobGroup{
+		models.AppRunnerJobGroupBuild,
+		models.AppRunnerJobGroupOperations,
+		models.AppRunnerJobGroupEmpty,
+	} {
+		if got := NewAudit(l, &models.AppRunnerJob{Group: group}); got != nil {
+			t.Errorf("NewAudit(%q) returned a logger, want nil", group)
+		}
+	}
+}
+
+// The bundled collector drops records whose nuon.audit log-record attribute is
+// not exactly the string "true". A bool value, or moving the attribute to the
+// resource, silently discards every audit record, so pin both here.
+func TestAuditAttrMatchesCollectorFilter(t *testing.T) {
+	if AuditAttrValue != "true" {
+		t.Fatalf("AuditAttrValue = %q, want \"true\"", AuditAttrValue)
+	}
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	l := NewAudit(zap.New(core), &models.AppRunnerJob{
+		Group:       models.AppRunnerJobGroupDeploy,
+		CreatedByID: "acct123",
+		OrgID:       "org123",
+		Metadata:    map[string]string{"install_id": "inst123"},
+	})
+	if l == nil {
+		t.Fatal("NewAudit returned nil for a deploy job")
+	}
+	l.Info("deploy started")
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("got %d log entries, want 1", len(entries))
+	}
+
+	fields := entries[0].ContextMap()
+	got, ok := fields[AuditAttr]
+	if !ok {
+		t.Fatalf("%s not present on the record; fields: %v", AuditAttr, fields)
+	}
+	if s, isString := got.(string); !isString || s != "true" {
+		t.Errorf("%s = %#v, want the string \"true\" (a bool is dropped by the collector filter)", AuditAttr, got)
+	}
+
+	for key, want := range map[string]string{
+		AuditEventAttr:             "install_deploy",
+		"user.id":                  "acct123",
+		"runner_job.created_by_id": "acct123",
+		"org.id":                   "org123",
+		"install.id":               "inst123",
+	} {
+		if fields[key] != want {
+			t.Errorf("%s = %v, want %q", key, fields[key], want)
+		}
+	}
+}

--- a/pkg/runner/op/op.go
+++ b/pkg/runner/op/op.go
@@ -53,20 +53,25 @@ func Start(ctx context.Context, tool, operation string, attrs ...attribute.KeyVa
 	// the global, which transitive deps (e.g. docker distribution) overwrite.
 	tracer := pkgctx.TracerProvider(ctx).Tracer(tracerName)
 
-	spanAttrs := make([]attribute.KeyValue, 0, len(attrs)+5)
+	spanAttrs := make([]attribute.KeyValue, 0, len(attrs)+10)
 	spanAttrs = append(spanAttrs,
 		attribute.String("nuon.tool", tool),
 		attribute.String("nuon.op", operation),
 	)
 	if meta, ok := pkgctx.GetJobMetadata(ctx); ok {
-		if meta.RunnerJobID != "" {
-			spanAttrs = append(spanAttrs, attribute.String("runner_job.id", meta.RunnerJobID))
-		}
-		if meta.RunnerJobExecutionID != "" {
-			spanAttrs = append(spanAttrs, attribute.String("runner_job_execution.id", meta.RunnerJobExecutionID))
-		}
-		if meta.StepName != "" {
-			spanAttrs = append(spanAttrs, attribute.String("runner_job_execution_step.name", meta.StepName))
+		for key, value := range map[string]string{
+			"runner_job.id":                  meta.RunnerJobID,
+			"runner_job_execution.id":        meta.RunnerJobExecutionID,
+			"runner_job_execution_step.name": meta.StepName,
+			"runner_job.group":               meta.JobGroup,
+			"runner_job.operation":           meta.JobOperation,
+			"runner_job.executor":            meta.Executor,
+			"org.id":                         meta.OrgID,
+			"install.id":                     meta.InstallID,
+		} {
+			if value != "" {
+				spanAttrs = append(spanAttrs, attribute.String(key, value))
+			}
 		}
 	}
 	spanAttrs = append(spanAttrs, attrs...)

--- a/services/ctl-api/internal/app/actions/service/create_adhoc_action.go
+++ b/services/ctl-api/internal/app/actions/service/create_adhoc_action.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/audit"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	dbgenerics "github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	executeflow "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeflow"
@@ -230,6 +231,21 @@ func (s *service) createAdHocActionRun(
 	if err := s.db.WithContext(ctx).Create(&run).Error; err != nil {
 		return nil, err
 	}
+
+	s.audit.Emit(ctx, audit.Event{
+		Type:        audit.EventInstallActionWorkflowRun,
+		Message:     "adhoc action run created",
+		Outcome:     audit.OutcomeStarted,
+		InstallID:   install.ID,
+		SubjectID:   run.ID,
+		SubjectType: "install_action_workflow_runs",
+		Attrs: map[string]string{
+			"action_workflow_run.id": run.ID,
+			"trigger.type":           string(app.ActionWorkflowTriggerTypeAdHoc),
+			"triggered_by.id":        accountID,
+			"triggered_by.type":      "account",
+		},
+	})
 
 	return &run, nil
 }

--- a/services/ctl-api/internal/app/actions/service/service.go
+++ b/services/ctl-api/internal/app/actions/service/service.go
@@ -12,6 +12,7 @@ import (
 	installhelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	vcshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/vcs/helpers"
 	apiPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/audit"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
@@ -29,6 +30,7 @@ type Params struct {
 	EndpointAudit  *apiPkg.EndpointAudit
 	FeaturesClient *features.Features
 	QueueClient    *queueclient.Client
+	Audit          *audit.Emitter
 }
 
 type service struct {
@@ -42,6 +44,7 @@ type service struct {
 	installHelpers *installhelpers.Helpers
 	featuresClient *features.Features
 	queueClient    *queueclient.Client
+	audit          *audit.Emitter
 }
 
 var _ apiPkg.Service = (*service)(nil)
@@ -184,6 +187,7 @@ func New(params Params) *service {
 		installHelpers: params.InstallHelpers,
 		featuresClient: params.FeaturesClient,
 		queueClient:    params.QueueClient,
+		audit:          params.Audit,
 	}
 }
 

--- a/services/ctl-api/internal/app/installs/service/create_install_deploy.go
+++ b/services/ctl-api/internal/app/installs/service/create_install_deploy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/audit"
 	executeflow "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeflow"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
@@ -294,6 +295,22 @@ func (s *service) createInstallDeploy(ctx context.Context, installID string, req
 	if res.Error != nil {
 		return nil, fmt.Errorf("unable to create install deploy: %w", res.Error)
 	}
+
+	s.audit.Emit(ctx, audit.Event{
+		Type:        audit.EventInstallDeploy,
+		Message:     "install deploy created",
+		Outcome:     audit.OutcomeStarted,
+		InstallID:   installID,
+		ComponentID: build.ComponentConfigConnection.ComponentID,
+		SubjectID:   deploy.ID,
+		SubjectType: "install_deploys",
+		Attrs: map[string]string{
+			"deploy.id":            deploy.ID,
+			"deploy.type":          string(typ),
+			"component_build.id":   req.BuildID,
+			"install_component.id": installCmp.ID,
+		},
+	})
 
 	return &deploy, nil
 }

--- a/services/ctl-api/internal/app/installs/service/service.go
+++ b/services/ctl-api/internal/app/installs/service/service.go
@@ -12,6 +12,7 @@ import (
 	componenthelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/audit"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
 	flowclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/client"
@@ -42,6 +43,7 @@ type Params struct {
 	QueueClient      *queueclient.Client
 	FlowsClient      *flowclient.Client
 	BlobService      blobstore.Service
+	Audit            *audit.Emitter
 	EndpointAudit    *api.EndpointAudit
 }
 
@@ -63,6 +65,7 @@ type service struct {
 	queueClient      *queueclient.Client
 	flowsClient      *flowclient.Client
 	blobSvc          blobstore.Service
+	audit            *audit.Emitter
 }
 
 var _ api.Service = (*service)(nil)
@@ -391,6 +394,7 @@ func New(params Params) *service {
 		featuresClient:   params.FeaturesClient,
 		flowsClient:      params.FlowsClient,
 		blobSvc:          params.BlobService,
+		audit:            params.Audit,
 	}
 }
 

--- a/services/ctl-api/internal/app/installs/worker/activities/activities.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/activities.go
@@ -15,6 +15,7 @@ import (
 	runnershelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
 	vcshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/vcs/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/audit"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/authz"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
@@ -40,6 +41,7 @@ type Params struct {
 	BlobService       blobstore.Service
 	Features          *features.Features
 	L                 *zap.Logger
+	Audit             *audit.Emitter
 	AccountsHelpers   *account.Client
 	TClient           temporalclient.Client
 }
@@ -61,6 +63,7 @@ type Activities struct {
 	vcsHelpers        *vcshelpers.Helpers
 	features          *features.Features
 	l                 *zap.Logger
+	audit             *audit.Emitter
 	accountsHelpers   *account.Client
 	tClient           temporalclient.Client
 }
@@ -83,6 +86,7 @@ func New(params Params) *Activities {
 		componentsHelpers: params.ComponentsHelpers,
 		features:          params.Features,
 		l:                 params.L,
+		audit:             params.Audit,
 		accountsHelpers:   params.AccountsHelpers,
 		tClient:           params.TClient,
 	}

--- a/services/ctl-api/internal/app/installs/worker/activities/create_action_workflow_run.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/create_action_workflow_run.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/audit"
 )
 
 type CreateActionWorkflowRunRequest struct {
@@ -105,6 +106,24 @@ func (a *Activities) createActionWorkflowRun(ctx context.Context,
 	if res.Error != nil {
 		return nil, errors.Wrap(res.Error, "unable to create action workflow")
 	}
+
+	a.audit.Emit(ctx, audit.Event{
+		Type:        audit.EventInstallActionWorkflowRun,
+		Message:     "install action workflow run created",
+		Outcome:     audit.OutcomeStarted,
+		InstallID:   installID,
+		SubjectID:   newRun.ID,
+		SubjectType: "install_action_workflow_runs",
+		Attrs: map[string]string{
+			"action_workflow_run.id": newRun.ID,
+			"action_workflow.id":     installActionWorkflowID,
+			"action_workflow.config": cfg.ID,
+			"trigger.type":           string(triggerType),
+			"triggered_by.id":        triggeredByID,
+			"triggered_by.type":      string(triggeredByType),
+			"flow_workflow.id":       installWorkflowID,
+		},
+	})
 
 	return &newRun, nil
 }

--- a/services/ctl-api/internal/app/installs/worker/activities/create_action_workflow_run_job.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/create_action_workflow_run_job.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 )
 
 type CreateActionWorkflowRunRunnerJob struct {
@@ -28,6 +29,10 @@ func (a *Activities) CreateActionWorkflowRunRunnerJob(ctx context.Context, req *
 	if cfg.Timeout == 0 {
 		cfg.Timeout = run.Timeout
 	}
+	if run.InstallWorkflowID != nil {
+		ctx = cctx.SetFlowWorkflowIDContext(ctx, *run.InstallWorkflowID)
+	}
+	ctx = cctx.SetFlowInstallIDContext(ctx, run.InstallID)
 
 	job, err := a.runnersHelpers.CreateActionsWorkflowRunJob(ctx,
 		req.RunnerID,

--- a/services/ctl-api/internal/app/installs/worker/activities/create_sandbox_job.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/create_sandbox_job.go
@@ -26,8 +26,22 @@ func (a *Activities) CreateSandboxJob(ctx context.Context, req *CreateSandboxJob
 		jobType = app.RunnerJobTypeSandboxTerraform
 	}
 
-	// RunnerJob.BeforeCreate reads these from ctx into job metadata for telemetry.
-	ctx = cctx.SetFlowInstallIDContext(ctx, req.InstallID)
+	var run app.InstallSandboxRun
+	res := a.db.WithContext(ctx).
+		Select("install_id", "install_workflow_id").
+		Where(app.InstallSandboxRun{ID: req.OwnerID}).
+		First(&run)
+	if res.Error != nil {
+		return nil, fmt.Errorf("unable to get install sandbox run: %w", res.Error)
+	}
+	if run.InstallID != req.InstallID {
+		return nil, fmt.Errorf("sandbox run install %s does not match request install %s", run.InstallID, req.InstallID)
+	}
+
+	if run.InstallWorkflowID != nil {
+		ctx = cctx.SetFlowWorkflowIDContext(ctx, *run.InstallWorkflowID)
+	}
+	ctx = cctx.SetFlowInstallIDContext(ctx, run.InstallID)
 
 	job, err := a.runnersHelpers.CreateInstallSandboxJob(ctx,
 		req.RunnerID,

--- a/services/ctl-api/internal/app/installs/worker/activities/create_sandbox_run.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/create_sandbox_run.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/audit"
 )
 
 type CreateSandboxRunRequest struct {
@@ -55,6 +56,20 @@ func (a *Activities) CreateSandboxRun(ctx context.Context, req CreateSandboxRunR
 	if resCreateRun.Error != nil {
 		return nil, fmt.Errorf("unable to create install sandbox run: %w", resCreateRun.Error)
 	}
+
+	a.audit.Emit(ctx, audit.Event{
+		Type:        audit.EventInstallSandboxRun,
+		Message:     "install sandbox run created",
+		Outcome:     audit.OutcomeStarted,
+		InstallID:   req.InstallID,
+		SubjectID:   run.ID,
+		SubjectType: "install_sandbox_runs",
+		Attrs: map[string]string{
+			"sandbox_run.id":   run.ID,
+			"sandbox_run.type": string(req.RunType),
+			"flow_workflow.id": req.WorkflowID,
+		},
+	})
 
 	return &run, nil
 }

--- a/services/ctl-api/internal/app/installs/worker/activities/queue_component_deploy.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/queue_component_deploy.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/audit"
 )
 
 type CreateInstallDeployRequest struct {
@@ -54,6 +55,23 @@ func (a *Activities) CreateInstallDeploy(ctx context.Context, req CreateInstallD
 	if res.Error != nil {
 		return nil, fmt.Errorf("unable to create install deploy: %w", res.Error)
 	}
+
+	a.audit.Emit(ctx, audit.Event{
+		Type:        audit.EventInstallDeploy,
+		Message:     "install deploy created",
+		Outcome:     audit.OutcomeStarted,
+		InstallID:   req.InstallID,
+		ComponentID: req.ComponentID,
+		SubjectID:   installDeploy.ID,
+		SubjectType: "install_deploys",
+		Attrs: map[string]string{
+			"deploy.id":            installDeploy.ID,
+			"deploy.type":          string(installDeploy.Type),
+			"component_build.id":   req.BuildID,
+			"install_component.id": installCmp.ID,
+			"flow_workflow.id":     req.WorkflowID,
+		},
+	})
 
 	return &installDeploy, nil
 }

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -299,6 +299,12 @@ type Config struct {
 	WebhookURLs    []string      `config:"webhook_urls"`
 	WebhookTimeout time.Duration `config:"webhook_timeout"`
 
+	// Audit log export. Audit records are the only telemetry ctl-api ships over
+	// OTLP; everything else keeps going to stderr untouched. Leave the endpoint
+	// empty to disable, which is the default until the gateway collector exists.
+	AuditOTLPEndpoint string `config:"audit_otlp_endpoint"`
+	AuditOTLPToken    string `config:"audit_otlp_token"`
+
 	// configuration for runners
 	RunnerContainerImageURL      string `config:"runner_container_image_url" validate:"required"`
 	RunnerContainerImageURLGCP   string `config:"runner_container_image_url_gcp"`

--- a/services/ctl-api/internal/fxmodules/infrastructure.go
+++ b/services/ctl-api/internal/fxmodules/infrastructure.go
@@ -13,6 +13,7 @@ import (
 	notebookclient "github.com/nuonco/nuon/services/ctl-api/internal/app/notebooks/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/analytics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/audit"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/authz"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/propagator"
@@ -60,6 +61,7 @@ var InfrastructureModule = fx.Module("infrastructure",
 	fx.WithLogger(pkglog.NewFXLog),
 	fx.Provide(log.New),
 	fx.Provide(dblog.New),
+	fx.Provide(audit.New),
 
 	// Query collector (enabled by debug_enable_query_collector config)
 	fx.Provide(func(cfg *internal.Config) *querycollector.Collector {

--- a/services/ctl-api/internal/pkg/audit/audit.go
+++ b/services/ctl-api/internal/pkg/audit/audit.go
@@ -1,0 +1,95 @@
+package audit
+
+import (
+	"context"
+
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+// Attr tags records the gateway collector forwards to the customer's backend.
+// Collector filters compare the log record attribute against the string
+// "true", so the value must not be emitted as a bool.
+const (
+	Attr        = "nuon.audit"
+	AttrValue   = "true"
+	EventAttr   = "nuon.audit.event"
+	OutcomeAttr = "nuon.audit.outcome"
+)
+
+// EventType mirrors the type column of the install_audit_logs view so streamed
+// audit records stay consistent with the ones customers download today.
+type EventType string
+
+const (
+	EventInstallDeploy            EventType = "install_deploy"
+	EventInstallActionWorkflowRun EventType = "install_action_workflow_run"
+	EventInstallSandboxRun        EventType = "install_sandbox_run"
+	EventPolicyReport             EventType = "policy_report"
+)
+
+type Outcome string
+
+const (
+	OutcomeStarted   Outcome = "started"
+	OutcomeSucceeded Outcome = "succeeded"
+	OutcomeFailed    Outcome = "failed"
+)
+
+type Event struct {
+	Type        EventType
+	Message     string
+	Outcome     Outcome
+	InstallID   string
+	AppID       string
+	ComponentID string
+	SubjectID   string
+	SubjectType string
+	Attrs       map[string]string
+}
+
+type Emitter struct {
+	l *zap.Logger
+}
+
+func NewEmitter(l *zap.Logger) *Emitter {
+	return &Emitter{l: l}
+}
+
+// Emit writes one audit record. The actor and org come from the same context
+// that BeforeCreate uses to populate created_by_id, so an audit record can
+// never disagree with the row it describes about who caused it.
+func (e *Emitter) Emit(ctx context.Context, ev Event) {
+	if e == nil || e.l == nil {
+		return
+	}
+
+	fields := []zap.Field{
+		zap.String(Attr, AttrValue),
+		zap.String(EventAttr, string(ev.Type)),
+		zap.String(OutcomeAttr, string(ev.Outcome)),
+	}
+
+	for key, value := range map[string]string{
+		string(semconv.UserIDKey): keys.CreatedByIDFromContext(ctx),
+		"org.id":                  keys.OrgIDFromContext(ctx),
+		"install.id":              ev.InstallID,
+		"app.id":                  ev.AppID,
+		"component.id":            ev.ComponentID,
+		"nuon.audit.subject_id":   ev.SubjectID,
+		"nuon.audit.subject_type": ev.SubjectType,
+	} {
+		if value != "" {
+			fields = append(fields, zap.String(key, value))
+		}
+	}
+	for key, value := range ev.Attrs {
+		if value != "" {
+			fields = append(fields, zap.String(key, value))
+		}
+	}
+
+	e.l.Info(ev.Message, fields...)
+}

--- a/services/ctl-api/internal/pkg/audit/fx.go
+++ b/services/ctl-api/internal/pkg/audit/fx.go
@@ -1,0 +1,63 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/contrib/bridges/otelzap"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+type Params struct {
+	fx.In
+
+	Cfg *internal.Config
+	LC  fx.Lifecycle
+}
+
+// New builds the audit emitter. Its logger is deliberately standalone rather
+// than teed into the system logger: audit records must not reach stderr, so
+// ctl-api's normal log output stays byte-for-byte unchanged and the Datadog
+// monitors reading it are unaffected.
+func New(params Params) (*Emitter, error) {
+	if params.Cfg.AuditOTLPEndpoint == "" {
+		return &Emitter{}, nil
+	}
+
+	opts := []otlploghttp.Option{
+		otlploghttp.WithEndpointURL(params.Cfg.AuditOTLPEndpoint),
+	}
+	if params.Cfg.AuditOTLPToken != "" {
+		opts = append(opts, otlploghttp.WithHeaders(map[string]string{
+			"Authorization": "Bearer " + params.Cfg.AuditOTLPToken,
+		}))
+	}
+
+	exporter, err := otlploghttp.New(context.Background(), opts...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize audit log exporter: %w", err)
+	}
+
+	lp := sdklog.NewLoggerProvider(
+		sdklog.WithResource(resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName("ctl-api"),
+		)),
+		sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)),
+	)
+
+	params.LC.Append(fx.Hook{
+		OnStop: func(ctx context.Context) error {
+			return lp.Shutdown(ctx)
+		},
+	})
+
+	return NewEmitter(zap.New(otelzap.NewCore("audit", otelzap.WithLoggerProvider(lp)))), nil
+}

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/activities.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/activities.go
@@ -8,6 +8,7 @@ import (
 	temporalclient "github.com/nuonco/nuon/pkg/temporal/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	appshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/audit"
 )
 
 type Params struct {
@@ -18,7 +19,8 @@ type Params struct {
 	AppsHelpers *appshelpers.Helpers
 	TClient     temporalclient.Client
 	Cfg         *internal.Config
-	L           *zap.Logger `optional:"true"`
+	Audit       *audit.Emitter `optional:"true"`
+	L           *zap.Logger    `optional:"true"`
 }
 
 type Activities struct {
@@ -27,6 +29,7 @@ type Activities struct {
 	appsHelpers *appshelpers.Helpers
 	tClient     temporalclient.Client
 	cfg         *internal.Config
+	audit       *audit.Emitter
 	l           *zap.Logger
 }
 
@@ -41,6 +44,7 @@ func New(params Params) *Activities {
 		appsHelpers: params.AppsHelpers,
 		tClient:     params.TClient,
 		cfg:         params.Cfg,
+		audit:       params.Audit,
 		l:           l,
 	}
 }

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/persist_policy_report.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/persist_policy_report.go
@@ -2,6 +2,7 @@ package activities
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -11,6 +12,7 @@ import (
 	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/policy_reports/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/audit"
 )
 
 type PersistPolicyReportRequest struct {
@@ -131,6 +133,30 @@ func (a *Activities) PersistPolicyReport(ctx context.Context, req *PersistPolicy
 		zap.Int("warn_count", warnCount),
 		zap.Int("pass_count", passCount),
 	)
+
+	policyOutcome := audit.OutcomeSucceeded
+	if denyCount > 0 {
+		policyOutcome = audit.OutcomeFailed
+	}
+	a.audit.Emit(ctx, audit.Event{
+		Type:        audit.EventPolicyReport,
+		Message:     "policy report evaluated",
+		Outcome:     policyOutcome,
+		InstallID:   generics.FromPtrStr(req.InstallID),
+		AppID:       req.AppID,
+		ComponentID: generics.FromPtrStr(req.ComponentID),
+		SubjectID:   report.ID,
+		SubjectType: report.TableName(),
+		Attrs: map[string]string{
+			"policy_report.id":         report.ID,
+			"policy_report.deny":       strconv.Itoa(denyCount),
+			"policy_report.warn":       strconv.Itoa(warnCount),
+			"policy_report.pass":       strconv.Itoa(passCount),
+			"policy_report.owner_id":   req.OwnerID,
+			"policy_report.owner_type": req.OwnerType,
+			"runner_job.id":            generics.FromPtrStr(req.RunnerJobID),
+		},
+	})
 
 	// Write analytics events to ClickHouse (non-blocking — failures don't affect the activity)
 	a.persistPolicyAnalyticsEvents(ctx, l, report, policyResults)


### PR DESCRIPTION
## Summary

Adds structured audit logs for runner deploy, action, and sandbox jobs. Audit events include job, workflow, component, and runner-process attribution and are exported through the bundled OpenTelemetry Collector. This is all @ALPHAvibe's work, I have added some changes on top to integrate with the collector.

The customer audit-export secret is the single source of truth: when the secret is available, the Collector starts and the runner forwards audit events. Older stacks without the secret or IAM permissions continue working normally with audit export disabled.

## Details

- Emits job and step started, succeeded, and failed events.
- Exports only records tagged with `nuon.audit="true"`.
- Supports secret creation, removal, rotation, and Collector restarts without restarting the runner.
- Adds ctl-api audit events for relevant creation and policy-report operations.
- Flushes terminal audit events and cleans up per-job OTEL resources.
- Adds workflow, install component, notebook cell run, and runner process metadata.

## Validation

- Targeted runner and ctl-api tests
- Race tests for audit export and OTEL processing
