### PR TITLE
fix: Mandatory push-based health checks

### DIFF
--- a/docs/config-ref/helm.mdx
+++ b/docs/config-ref/helm.mdx
@@ -86,6 +86,7 @@ title: 'Helm'
 | **`stabilization_window`**<br/>string | health stabilization window How long the component must hold healthy after a deploy applies before the deploy step is considered done. Duration string (e.g., "3m", "10m"). Default: 3m. Max: 1h | **Optional**<br/>Default: `"3m"` | `"3m"`, `"10m"` |
 | **`block_deploy`**<br/>boolean | fail the deploy when health does not stabilize When true, the deploy step fails if health does not stabilize inside the window. When false, the step still completes and only records what health did... | **Optional**<br/>Default: `"false"` | `"true"` |
 | **`probes`**<br/>array | synthetic health probes Probes the runner executes from inside the install to assert the component is actually serving. Each probe reports as its own health resource, and a failing probe makes the ... | **Optional** | - |
+| **`required_checks`**<br/>array | - | **Optional** | - |
 
 ### `value`
 

--- a/docs/config-ref/kubernetes-manifest.mdx
+++ b/docs/config-ref/kubernetes-manifest.mdx
@@ -73,4 +73,5 @@ title: 'Kubernetes Manifest'
 | **`stabilization_window`**<br/>string | health stabilization window How long the component must hold healthy after a deploy applies before the deploy step is considered done. Duration string (e.g., "3m", "10m"). Default: 3m. Max: 1h | **Optional**<br/>Default: `"3m"` | `"3m"`, `"10m"` |
 | **`block_deploy`**<br/>boolean | fail the deploy when health does not stabilize When true, the deploy step fails if health does not stabilize inside the window. When false, the step still completes and only records what health did... | **Optional**<br/>Default: `"false"` | `"true"` |
 | **`probes`**<br/>array | synthetic health probes Probes the runner executes from inside the install to assert the component is actually serving. Each probe reports as its own health resource, and a failing probe makes the ... | **Optional** | - |
+| **`required_checks`**<br/>array | - | **Optional** | - |
 

--- a/pkg/config/component_health.go
+++ b/pkg/config/component_health.go
@@ -20,6 +20,11 @@ type ComponentHealthConfig struct {
 	StabilizationWindow string                       `mapstructure:"stabilization_window,omitempty" toml:"stabilization_window,omitempty" features:"template" nuonhash:"omitempty"`
 	BlockDeploy         *bool                        `mapstructure:"block_deploy,omitempty" toml:"block_deploy,omitempty" nuonhash:"omitempty"`
 	Probes              []ComponentHealthProbeConfig `mapstructure:"probes,omitempty" toml:"probes,omitempty" nuonhash:"omitempty"`
+	// RequiredChecks are pushed check names a deploy waits for. Unlike probes the
+	// runner cannot produce these, so the gate holds until something external
+	// reports them healthy — the point being that a deploy can depend on a fact
+	// only the vendor's own system knows.
+	RequiredChecks []string `mapstructure:"required_checks,omitempty" toml:"required_checks,omitempty" nuonhash:"omitempty"`
 }
 
 // ComponentHealthProbeConfig is one synthetic health check the runner executes

--- a/pkg/config/sync/apisyncer/components_helm_chart.go
+++ b/pkg/config/sync/apisyncer/components_helm_chart.go
@@ -53,6 +53,7 @@ func (s *syncer) createHelmChartComponentConfig(ctx context.Context, resource, c
 		configRequest.HealthStabilizationWindow = obj.Health.StabilizationWindow
 		configRequest.HealthBlockDeploy = obj.Health.BlockDeploy
 		configRequest.HealthProbes = healthProbeRequests(obj.Health)
+		configRequest.HealthRequiredChecks = obj.Health.RequiredChecks
 	}
 
 	for _, ref := range comp.References {

--- a/pkg/config/sync/apisyncer/components_kubernetes_manifest.go
+++ b/pkg/config/sync/apisyncer/components_kubernetes_manifest.go
@@ -65,6 +65,7 @@ func (s *syncer) createKubernetesManifestComponentConfig(
 		configRequest.HealthStabilizationWindow = comp.KubernetesManifest.Health.StabilizationWindow
 		configRequest.HealthBlockDeploy = comp.KubernetesManifest.Health.BlockDeploy
 		configRequest.HealthProbes = healthProbeRequests(comp.KubernetesManifest.Health)
+		configRequest.HealthRequiredChecks = comp.KubernetesManifest.Health.RequiredChecks
 	}
 
 	for _, ref := range comp.References {

--- a/sdks/nuon-go/models/app_component_config_connection.go
+++ b/sdks/nuon-go/models/app_component_config_connection.go
@@ -74,6 +74,9 @@ type AppComponentConfigConnection struct {
 	// health probes
 	HealthProbes []*AppComponentHealthProbe `json:"health_probes"`
 
+	// health required checks
+	HealthRequiredChecks []string `json:"health_required_checks"`
+
 	// Duration string for how long health must hold after a deploy applies (e.g., "3m"). Max 1h.
 	HealthStabilizationWindow string `json:"health_stabilization_window,omitempty"`
 

--- a/sdks/nuon-go/models/service_create_helm_component_config_request.go
+++ b/sdks/nuon-go/models/service_create_helm_component_config_request.go
@@ -63,6 +63,9 @@ type ServiceCreateHelmComponentConfigRequest struct {
 	// health probes
 	HealthProbes []*ServiceHealthProbeRequest `json:"health_probes"`
 
+	// health required checks
+	HealthRequiredChecks []string `json:"health_required_checks"`
+
 	// Duration string for the health stabilization window (e.g., "3m")
 	HealthStabilizationWindow string `json:"health_stabilization_window,omitempty"`
 

--- a/sdks/nuon-go/models/service_create_kubernetes_manifest_component_config_request.go
+++ b/sdks/nuon-go/models/service_create_kubernetes_manifest_component_config_request.go
@@ -56,6 +56,9 @@ type ServiceCreateKubernetesManifestComponentConfigRequest struct {
 	// health probes
 	HealthProbes []*ServiceHealthProbeRequest `json:"health_probes"`
 
+	// health required checks
+	HealthRequiredChecks []string `json:"health_required_checks"`
+
 	// Duration string for the health stabilization window (e.g., "3m")
 	HealthStabilizationWindow string `json:"health_stabilization_window,omitempty"`
 

--- a/sdks/nuon-runner-go/models/app_component_config_connection.go
+++ b/sdks/nuon-runner-go/models/app_component_config_connection.go
@@ -74,6 +74,9 @@ type AppComponentConfigConnection struct {
 	// health probes
 	HealthProbes []*AppComponentHealthProbe `json:"health_probes"`
 
+	// health required checks
+	HealthRequiredChecks []string `json:"health_required_checks"`
+
 	// Duration string for how long health must hold after a deploy applies (e.g., "3m"). Max 1h.
 	HealthStabilizationWindow string `json:"health_stabilization_window,omitempty"`
 

--- a/services/ctl-api/internal/app/component_config_connection.go
+++ b/services/ctl-api/internal/app/component_config_connection.go
@@ -76,6 +76,7 @@ type ComponentConfigConnection struct {
 	HealthStabilizationWindow         string                             `json:"health_stabilization_window,omitempty" gorm:"default:null" temporaljson:"health_stabilization_window,omitzero,omitempty"` // Duration string for how long health must hold after a deploy applies (e.g., "3m"). Max 1h.
 	HealthBlockDeploy                 *bool                              `json:"health_block_deploy,omitempty" gorm:"default:null" temporaljson:"health_block_deploy,omitzero,omitempty" swaggertype:"boolean" extensions:"x-nullable"`
 	HealthProbes                      ComponentHealthProbes              `json:"health_probes,omitempty" gorm:"type:jsonb" temporaljson:"health_probes,omitzero,omitempty"`
+	HealthRequiredChecks              ComponentHealthRequiredChecks      `json:"health_required_checks,omitempty" gorm:"type:jsonb" temporaljson:"health_required_checks,omitzero,omitempty"`
 
 	// Operation roles map: operation type -> role name
 	OperationRoles pgtype.Hstore `json:"operation_roles,omitzero" gorm:"type:hstore" swaggertype:"object,string" temporaljson:"operation_roles,omitzero,omitempty"`
@@ -136,6 +137,39 @@ func (p ComponentHealthProbes) Value() (driver.Value, error) {
 }
 
 func (ComponentHealthProbes) GormDataType() string {
+	return "jsonb"
+}
+
+// ComponentHealthRequiredChecks are pushed check names a deploy gate waits for.
+type ComponentHealthRequiredChecks []string
+
+// Scan implements the database/sql.Scanner interface.
+func (c *ComponentHealthRequiredChecks) Scan(v interface{}) error {
+	switch v := v.(type) {
+	case nil:
+		*c = nil
+		return nil
+	case []byte:
+		if len(v) == 0 {
+			*c = nil
+			return nil
+		}
+		if err := json.Unmarshal(v, c); err != nil {
+			return errors.Wrap(err, "unable to scan component health required checks")
+		}
+	}
+	return nil
+}
+
+// Value implements the driver.Valuer interface.
+func (c ComponentHealthRequiredChecks) Value() (driver.Value, error) {
+	if c == nil {
+		return nil, nil
+	}
+	return json.Marshal(c)
+}
+
+func (ComponentHealthRequiredChecks) GormDataType() string {
 	return "jsonb"
 }
 

--- a/services/ctl-api/internal/app/components/service/create_helm_component_config.go
+++ b/services/ctl-api/internal/app/components/service/create_helm_component_config.go
@@ -39,7 +39,8 @@ type CreateHelmComponentConfigRequest struct {
 	HealthStabilizationWindow    string             `json:"health_stabilization_window,omitempty"` // Duration string for the health stabilization window (e.g., "3m")
 	HealthBlockDeploy            *bool              `json:"health_block_deploy,omitempty" swaggertype:"boolean" extensions:"x-nullable"`
 
-	HealthProbes []HealthProbeRequest `json:"health_probes,omitempty"`
+	HealthProbes         []HealthProbeRequest `json:"health_probes,omitempty"`
+	HealthRequiredChecks []string             `json:"health_required_checks,omitempty"`
 
 	AppConfigID string `json:"app_config_id"`
 
@@ -102,6 +103,9 @@ func (c *CreateHelmComponentConfigRequest) Validate(v *validator.Validate) error
 		}
 	}
 	if err := validateHealthProbes(c.HealthProbes); err != nil {
+		return err
+	}
+	if err := validateRequiredChecks(c.HealthRequiredChecks); err != nil {
 		return err
 	}
 
@@ -254,6 +258,7 @@ func (s *service) createHelmComponentConfig(ctx context.Context, cmpID string, r
 		HealthStabilizationWindow:    req.HealthStabilizationWindow,
 		HealthBlockDeploy:            req.HealthBlockDeploy,
 		HealthProbes:                 toAppHealthProbes(req.HealthProbes),
+		HealthRequiredChecks:         toAppRequiredChecks(req.HealthRequiredChecks),
 		OperationRoles:               operationRoles,
 		KubernetesContextName:        req.KubernetesContext,
 	}

--- a/services/ctl-api/internal/app/components/service/create_kubernetes_manifest_component_config.go
+++ b/services/ctl-api/internal/app/components/service/create_kubernetes_manifest_component_config.go
@@ -39,7 +39,8 @@ type CreateKubernetesManifestComponentConfigRequest struct {
 	HealthStabilizationWindow    string  `json:"health_stabilization_window,omitempty"` // Duration string for the health stabilization window (e.g., "3m")
 	HealthBlockDeploy            *bool   `json:"health_block_deploy,omitempty" swaggertype:"boolean" extensions:"x-nullable"`
 
-	HealthProbes []HealthProbeRequest `json:"health_probes,omitempty"`
+	HealthProbes         []HealthProbeRequest `json:"health_probes,omitempty"`
+	HealthRequiredChecks []string             `json:"health_required_checks,omitempty"`
 
 	// Kustomize configuration (mutually exclusive with Manifest)
 	Kustomize *KustomizeConfigRequest `json:"kustomize,omitempty"`
@@ -128,6 +129,9 @@ func (c *CreateKubernetesManifestComponentConfigRequest) Validate(v *validator.V
 		}
 	}
 	if err := validateHealthProbes(c.HealthProbes); err != nil {
+		return err
+	}
+	if err := validateRequiredChecks(c.HealthRequiredChecks); err != nil {
 		return err
 	}
 
@@ -277,6 +281,7 @@ func (s *service) createKubernetesManifestComponentConfig(
 		HealthStabilizationWindow:         req.HealthStabilizationWindow,
 		HealthBlockDeploy:                 req.HealthBlockDeploy,
 		HealthProbes:                      toAppHealthProbes(req.HealthProbes),
+		HealthRequiredChecks:              toAppRequiredChecks(req.HealthRequiredChecks),
 		OperationRoles:                    operationRoles,
 		KubernetesContextName:             req.KubernetesContext,
 	}

--- a/services/ctl-api/internal/app/components/service/required_checks_test.go
+++ b/services/ctl-api/internal/app/components/service/required_checks_test.go
@@ -1,0 +1,21 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A name the push endpoint would refuse can never be reported, so gating a
+// deploy on it would hang until timeout. Reject it at config time instead.
+func TestValidateRequiredChecks(t *testing.T) {
+	require.NoError(t, validateRequiredChecks(nil))
+	require.NoError(t, validateRequiredChecks([]string{"migrations-applied", "smoke.test_1"}))
+
+	for _, bad := range []string{"", "-leading", "trailing-", "has space", "has/slash"} {
+		assert.Error(t, validateRequiredChecks([]string{bad}), bad)
+	}
+
+	assert.ErrorContains(t, validateRequiredChecks([]string{"dup", "dup"}), "duplicate_required_check")
+}

--- a/services/ctl-api/internal/app/components/service/shared_validation.go
+++ b/services/ctl-api/internal/app/components/service/shared_validation.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/nuonco/nuon/pkg/config"
@@ -124,6 +125,40 @@ func validateHealthProbes(probes []HealthProbeRequest) error {
 		}
 	}
 	return nil
+}
+
+// validateRequiredChecks rejects names the push endpoint would refuse, so a
+// deploy cannot be gated on a check that can never be reported.
+func validateRequiredChecks(names []string) error {
+	seen := map[string]bool{}
+	for _, name := range names {
+		if !healthCheckNameRe.MatchString(name) {
+			return stderr.ErrUser{
+				Err:         errors.New("invalid_required_check"),
+				Code:        "invalid_required_check",
+				Description: fmt.Sprintf("required check name %q must be 1-100 characters of letters, digits, dots, dashes, or underscores, starting and ending with a letter or digit", name),
+			}
+		}
+		if seen[name] {
+			return stderr.ErrUser{
+				Err:         errors.New("duplicate_required_check"),
+				Code:        "duplicate_required_check",
+				Description: fmt.Sprintf("required check %q is listed more than once", name),
+			}
+		}
+		seen[name] = true
+	}
+	return nil
+}
+
+// healthCheckNameRe mirrors the push endpoint's name rule.
+var healthCheckNameRe = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9._-]{0,98}[a-zA-Z0-9])?$`)
+
+func toAppRequiredChecks(names []string) app.ComponentHealthRequiredChecks {
+	if len(names) == 0 {
+		return nil
+	}
+	return app.ComponentHealthRequiredChecks(names)
 }
 
 func toAppHealthProbes(probes []HealthProbeRequest) app.ComponentHealthProbes {

--- a/services/ctl-api/internal/app/installs/service/get_install_component_health_checks.go
+++ b/services/ctl-api/internal/app/installs/service/get_install_component_health_checks.go
@@ -2,10 +2,14 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
@@ -73,5 +77,82 @@ func (s *service) getInstallComponentHealthChecks(ctx context.Context, orgID, in
 		return nil, fmt.Errorf("unable to query custom health checks: %w", err)
 	}
 
-	return checks, nil
+	return s.withDeclaredChecks(ctx, orgID, installID, ic, checks)
+}
+
+// withDeclaredChecks lists declared checks that have never reported as unknown.
+// Without it a required check is invisible until a deploy fails on it.
+func (s *service) withDeclaredChecks(
+	ctx context.Context,
+	orgID, installID string,
+	ic *app.InstallComponent,
+	observed []app.InstallComponentResourceState,
+) ([]app.InstallComponentResourceState, error) {
+	ccc, err := s.currentComponentConfig(ctx, installID, ic.ComponentID)
+	if err != nil {
+		// Config is context for the list, never a reason to fail the read.
+		s.l.Warn("unable to load component config for declared health checks",
+			zap.String("install_id", installID), zap.Error(err))
+		return observed, nil
+	}
+	if ccc == nil {
+		return observed, nil
+	}
+
+	declared := make([]string, 0, len(ccc.HealthRequiredChecks)+len(ccc.HealthProbes))
+	declared = append(declared, ccc.HealthRequiredChecks...)
+	for _, probe := range ccc.HealthProbes {
+		declared = append(declared, probe.Name)
+	}
+
+	seen := make(map[string]bool, len(observed))
+	for _, c := range observed {
+		seen[c.Name] = true
+	}
+
+	for _, name := range declared {
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		observed = append(observed, app.InstallComponentResourceState{
+			OrgID:              orgID,
+			InstallID:          installID,
+			InstallComponentID: ic.ID,
+			ComponentID:        ic.ComponentID,
+			Provider:           customCheckProvider,
+			Kind:               "CustomCheck",
+			Name:               name,
+			Health:             string(app.InstallComponentHealthStatusUnknown),
+			Message:            "declared but not reported yet",
+		})
+	}
+
+	sort.Slice(observed, func(i, j int) bool { return observed[i].Name < observed[j].Name })
+	return observed, nil
+}
+
+func (s *service) currentComponentConfig(ctx context.Context, installID, componentID string) (*app.ComponentConfigConnection, error) {
+	var appConfigID string
+	if err := s.db.WithContext(ctx).
+		Model(&app.Install{}).
+		Select("app_config_id").
+		Where("id = ?", installID).
+		Scan(&appConfigID).Error; err != nil {
+		return nil, err
+	}
+	if appConfigID == "" {
+		return nil, nil
+	}
+
+	var ccc app.ComponentConfigConnection
+	if err := s.db.WithContext(ctx).
+		Where(app.ComponentConfigConnection{AppConfigID: appConfigID, ComponentID: componentID}).
+		First(&ccc).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &ccc, nil
 }

--- a/services/ctl-api/internal/app/installs/signals/awaitcomponenthealthy/judge.go
+++ b/services/ctl-api/internal/app/installs/signals/awaitcomponenthealthy/judge.go
@@ -1,6 +1,8 @@
 package awaitcomponenthealthy
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -97,6 +99,37 @@ func missingProbes(declared []string, checks []activities.ComponentHealthCheckRo
 	return missing
 }
 
+// withAwaitedChecks scopes the snapshot to in-window evidence: a verdict from
+// before the apply says nothing about this deploy, so every check starts unknown
+// and the first in-window report sets it.
+func withAwaitedChecks(checks []activities.ComponentHealthCheckRow, declared []string, gateStartedAt time.Time) []activities.ComponentHealthCheckRow {
+	present := map[string]bool{}
+	out := make([]activities.ComponentHealthCheckRow, 0, len(checks)+len(declared))
+
+	for _, c := range checks {
+		present[c.Name] = true
+		if c.ObservedAtTS <= 0 || time.Unix(c.ObservedAtTS, 0).Before(gateStartedAt) {
+			c.Health = "unknown"
+			c.Message = "no report since the deploy applied"
+		}
+		out = append(out, c)
+	}
+
+	for _, name := range declared {
+		if present[name] {
+			continue
+		}
+		out = append(out, activities.ComponentHealthCheckRow{
+			Kind:    "CustomCheck",
+			Name:    name,
+			Health:  "unknown",
+			Message: "waiting for a report",
+		})
+	}
+
+	return out
+}
+
 // markRemovedCheckRows labels probe rows that are no longer declared in the
 // component's current config, computed fresh each poll so a re-added probe
 // loses the label immediately.
@@ -114,4 +147,63 @@ func markRemovedCheckRows(checks []activities.ComponentHealthCheckRow, declared 
 
 func isProbeKind(kind string) bool {
 	return strings.HasSuffix(kind, "Probe")
+}
+
+// failedChecks returns declared checks whose in-window report is failing.
+// Presence alone is not enough: a required check exists so the deploy can be
+// gated on its verdict, so one reporting degraded or unhealthy must fail the
+// window rather than satisfy it.
+func failedChecks(declared []string, checks []activities.ComponentHealthCheckRow, gateStartedAt time.Time) []string {
+	want := map[string]bool{}
+	for _, name := range declared {
+		if name != "" {
+			want[name] = true
+		}
+	}
+
+	var failed []string
+	for _, c := range checks {
+		if !want[c.Name] {
+			continue
+		}
+		if c.ObservedAtTS <= 0 || time.Unix(c.ObservedAtTS, 0).Before(gateStartedAt) {
+			continue
+		}
+		if isBadReportHealth(c.Health) {
+			failed = append(failed, c.Name+" is "+c.Health)
+		}
+	}
+	sort.Strings(failed)
+	return failed
+}
+
+// checkTransitions describes only what moved since the last poll, so a quiet
+// window writes nothing to the timeline.
+func checkTransitions(prev map[string]string, checks []activities.ComponentHealthCheckRow) string {
+	var moved []string
+	for _, c := range checks {
+		was, seen := prev[c.Name]
+		if !seen {
+			// First sight of a check is only worth reporting once it says
+			// something; unknown is the state everything starts in.
+			if c.Health != "" && c.Health != "unknown" {
+				moved = append(moved, fmt.Sprintf("%s unknown → %s", c.Name, c.Health))
+			}
+			continue
+		}
+		if was != c.Health {
+			moved = append(moved, fmt.Sprintf("%s %s → %s", c.Name, was, c.Health))
+		}
+	}
+	if len(moved) == 0 {
+		return ""
+	}
+	sort.Strings(moved)
+	return strings.Join(moved, ", ")
+}
+
+func rememberCheckHealth(prev map[string]string, checks []activities.ComponentHealthCheckRow) {
+	for _, c := range checks {
+		prev[c.Name] = c.Health
+	}
 }

--- a/services/ctl-api/internal/app/installs/signals/awaitcomponenthealthy/judge_test.go
+++ b/services/ctl-api/internal/app/installs/signals/awaitcomponenthealthy/judge_test.go
@@ -102,17 +102,18 @@ func TestWindowNarration(t *testing.T) {
 	window := time.Minute
 	healthy := report(gateAt.Add(7*time.Second), "healthy", "Deployment", "whoami", "")
 
-	got := windowNarration(windowWait, &healthy, gateAt, gateAt.Add(25*time.Second), window)
+	got := windowNarration(windowWait, &healthy, gateAt, gateAt.Add(25*time.Second), window, nil)
 	assert.Equal(t, "healthy so far — 35s of the 1m0s window left — healthy (Deployment whoami)", got)
 
-	got = windowNarration(windowWait, nil, gateAt, gateAt.Add(10*time.Second), window)
+	got = windowNarration(windowWait, nil, gateAt, gateAt.Add(10*time.Second), window, nil)
 	assert.Contains(t, got, "waiting for the first health report")
 
-	got = windowNarration(windowPass, &healthy, gateAt, gateAt.Add(window), window)
+	got = windowNarration(windowPass, &healthy, gateAt, gateAt.Add(window), window,
+		[]activities.ComponentHealthCheckRow{{Name: "cert", Health: "healthy"}})
 	assert.Contains(t, got, "held healthy for 1m0s")
 
 	bad := report(gateAt.Add(30*time.Second), "unhealthy", "ExecProbe", "gate-test-always-fails", "exit code 1")
-	got = windowNarration(windowFailBad, &bad, gateAt, gateAt.Add(31*time.Second), window)
+	got = windowNarration(windowFailBad, &bad, gateAt, gateAt.Add(31*time.Second), window, nil)
 	assert.Equal(t, "component is unhealthy: ExecProbe gate-test-always-fails: exit code 1", got)
 }
 

--- a/services/ctl-api/internal/app/installs/signals/awaitcomponenthealthy/required_checks_test.go
+++ b/services/ctl-api/internal/app/installs/signals/awaitcomponenthealthy/required_checks_test.go
@@ -1,0 +1,196 @@
+package awaitcomponenthealthy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
+)
+
+// A required check is one the runner cannot produce, so the gate has to hold
+// until something external pushes it — that is the whole point of declaring it.
+func TestRequiredCheckBlocksUntilPushed(t *testing.T) {
+	gateStart := time.Now().Add(-2 * time.Minute)
+	declared := []string{"migrations-applied", "public-endpoint"}
+
+	t.Run("nothing pushed yet", func(t *testing.T) {
+		assert.ElementsMatch(t, declared, missingProbes(declared, nil, gateStart))
+	})
+
+	t.Run("pushed before the gate opened does not count", func(t *testing.T) {
+		stale := []activities.ComponentHealthCheckRow{
+			{Name: "migrations-applied", ObservedAtTS: gateStart.Add(-time.Minute).Unix()},
+		}
+		assert.ElementsMatch(t, declared, missingProbes(declared, stale, gateStart),
+			"a report from a previous deploy must not satisfy this one")
+	})
+
+	t.Run("one pushed, one still missing", func(t *testing.T) {
+		rows := []activities.ComponentHealthCheckRow{
+			{Name: "migrations-applied", ObservedAtTS: gateStart.Add(time.Minute).Unix()},
+		}
+		assert.Equal(t, []string{"public-endpoint"}, missingProbes(declared, rows, gateStart))
+	})
+
+	t.Run("all pushed since the gate opened", func(t *testing.T) {
+		rows := []activities.ComponentHealthCheckRow{
+			{Name: "migrations-applied", ObservedAtTS: gateStart.Add(time.Minute).Unix()},
+			{Name: "public-endpoint", ObservedAtTS: gateStart.Add(time.Minute).Unix()},
+		}
+		assert.Empty(t, missingProbes(declared, rows, gateStart))
+	})
+}
+
+// The snapshot must show what the gate is waiting on. Showing only resource
+// verdicts made a blocked gate read as fully healthy.
+func TestWithAwaitedChecksShowsUnknown(t *testing.T) {
+	gateStart := time.Now().Add(-2 * time.Minute)
+	declared := []string{"migrations-applied"}
+
+	t.Run("never reported appears as unknown", func(t *testing.T) {
+		rows := []activities.ComponentHealthCheckRow{
+			{Kind: "Certificate", Name: "cert", Health: "healthy", ObservedAtTS: gateStart.Add(time.Minute).Unix()},
+		}
+		out := withAwaitedChecks(rows, declared, gateStart)
+		require.Len(t, out, 2)
+		assert.Equal(t, "healthy", out[0].Health, "an in-window resource report stands")
+		assert.Equal(t, "migrations-applied", out[1].Name)
+		assert.Equal(t, "unknown", out[1].Health)
+	})
+
+	// The window judges this deploy, so a resource verdict from before the apply
+	// is not evidence about it — the same rule as for pushed checks.
+	t.Run("a resource row from before the gate is unknown too", func(t *testing.T) {
+		rows := []activities.ComponentHealthCheckRow{
+			{Kind: "Certificate", Name: "cert", Health: "healthy", ObservedAtTS: gateStart.Add(-time.Hour).Unix()},
+			{Kind: "Issuer", Name: "iss", Health: "healthy"},
+		}
+		out := withAwaitedChecks(rows, nil, gateStart)
+		require.Len(t, out, 2)
+		assert.Equal(t, "unknown", out[0].Health)
+		assert.Equal(t, "unknown", out[1].Health, "a row with no timestamp is not in-window evidence")
+	})
+
+	t.Run("a pre-apply report is also unknown", func(t *testing.T) {
+		rows := []activities.ComponentHealthCheckRow{
+			{Kind: "CustomCheck", Name: "migrations-applied", Health: "healthy",
+				ObservedAtTS: gateStart.Add(-time.Minute).Unix()},
+		}
+		out := withAwaitedChecks(rows, declared, gateStart)
+		require.Len(t, out, 1, "the existing row is relabelled, not duplicated")
+		assert.Equal(t, "unknown", out[0].Health)
+		assert.Contains(t, out[0].Message, "since the deploy applied")
+	})
+
+	t.Run("reported since the gate opened is left alone", func(t *testing.T) {
+		rows := []activities.ComponentHealthCheckRow{
+			{Kind: "CustomCheck", Name: "migrations-applied", Health: "healthy",
+				ObservedAtTS: gateStart.Add(time.Minute).Unix()},
+		}
+		out := withAwaitedChecks(rows, declared, gateStart)
+		require.Len(t, out, 1)
+		assert.Equal(t, "healthy", out[0].Health)
+	})
+}
+
+// The countdown must not defeat the dedupe: two polls that differ only by the
+// clock are the same state and should post one timeline entry, not one per tick.
+func TestStripRemainingCollapsesCountdown(t *testing.T) {
+	a := "healthy so far — 39s of the 1m0s window left — healthy (Certificate cert)"
+	b := "healthy so far — 13s of the 1m0s window left — healthy (Certificate cert)"
+	assert.Equal(t, stripRemaining(a), stripRemaining(b))
+
+	// A real state change still reads as different.
+	c := "waiting for the first health report since the apply — 50s of the window left"
+	assert.NotEqual(t, stripRemaining(a), stripRemaining(c))
+
+	// And a changed verdict is a different state even at the same remaining time.
+	d := "healthy so far — 39s of the 1m0s window left — degraded (Certificate cert)"
+	assert.NotEqual(t, stripRemaining(a), stripRemaining(d))
+}
+
+// The timeline should read as a record of what moved, not one line per poll.
+func TestCheckTransitions(t *testing.T) {
+	prev := map[string]string{}
+	rows := func(h ...string) []activities.ComponentHealthCheckRow {
+		return []activities.ComponentHealthCheckRow{
+			{Name: "cert", Health: h[0]},
+			{Name: "migrations-applied", Health: h[1]},
+		}
+	}
+
+	// Everything starts unknown, so the first poll says nothing.
+	first := rows("unknown", "unknown")
+	assert.Empty(t, checkTransitions(prev, first))
+	rememberCheckHealth(prev, first)
+
+	// A quiet poll stays quiet.
+	assert.Empty(t, checkTransitions(prev, rows("unknown", "unknown")))
+
+	// Only what moved is reported, and it names both ends.
+	moved := rows("healthy", "unknown")
+	assert.Equal(t, "cert unknown → healthy", checkTransitions(prev, moved))
+	rememberCheckHealth(prev, moved)
+
+	both := rows("degraded", "healthy")
+	assert.Equal(t, "cert healthy → degraded, migrations-applied unknown → healthy",
+		checkTransitions(prev, both))
+}
+
+// A pass line naming one resource reads as though that was all it looked at.
+func TestDescribeChecksSummarisesTheSet(t *testing.T) {
+	checks := []activities.ComponentHealthCheckRow{
+		{Kind: "Certificate", Name: "cert", Health: "healthy"},
+		{Kind: "Issuer", Name: "iss", Health: "healthy"},
+		{Kind: "ConfigMap", Name: "cm", Health: "not-applicable"},
+		{Kind: "CustomCheck", Name: "migrations-applied", Health: "healthy"},
+	}
+	assert.Equal(t, "4 checks: 3 healthy, 1 not-applicable", describeChecks(checks))
+	assert.Equal(t, "no checks reported", describeChecks(nil))
+}
+
+// The bug this pins: missingProbes only tests presence, so a required check that
+// reported failing satisfied the gate and the deploy passed with an unhealthy
+// check on screen. Reporting is not passing.
+func TestFailedChecksFailTheWindow(t *testing.T) {
+	gateStart := time.Now().Add(-2 * time.Minute)
+	declared := []string{"migrations-applied", "smoke-tests"}
+	inWindow := gateStart.Add(time.Minute).Unix()
+
+	rows := []activities.ComponentHealthCheckRow{
+		{Kind: "CustomCheck", Name: "migrations-applied", Health: "degraded", ObservedAtTS: inWindow},
+		{Kind: "CustomCheck", Name: "smoke-tests", Health: "unhealthy", ObservedAtTS: inWindow},
+	}
+
+	// Both reported, so nothing is "missing" — which is exactly why presence
+	// alone was not enough.
+	assert.Empty(t, missingProbes(declared, rows, gateStart))
+	assert.Equal(t,
+		[]string{"migrations-applied is degraded", "smoke-tests is unhealthy"},
+		failedChecks(declared, rows, gateStart))
+
+	t.Run("healthy and not-applicable do not fail", func(t *testing.T) {
+		ok := []activities.ComponentHealthCheckRow{
+			{Name: "migrations-applied", Health: "healthy", ObservedAtTS: inWindow},
+			{Name: "smoke-tests", Health: "not-applicable", ObservedAtTS: inWindow},
+		}
+		assert.Empty(t, failedChecks(declared, ok, gateStart))
+	})
+
+	t.Run("a failing report from before the gate is not this deploy's evidence", func(t *testing.T) {
+		stale := []activities.ComponentHealthCheckRow{
+			{Name: "smoke-tests", Health: "unhealthy", ObservedAtTS: gateStart.Add(-time.Hour).Unix()},
+		}
+		assert.Empty(t, failedChecks(declared, stale, gateStart))
+	})
+
+	t.Run("undeclared failing checks are not the gate's business", func(t *testing.T) {
+		other := []activities.ComponentHealthCheckRow{
+			{Name: "some-other-check", Health: "unhealthy", ObservedAtTS: inWindow},
+		}
+		assert.Empty(t, failedChecks(declared, other, gateStart))
+	})
+}

--- a/services/ctl-api/internal/app/installs/signals/awaitcomponenthealthy/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/awaitcomponenthealthy/signal.go
@@ -6,6 +6,8 @@ package awaitcomponenthealthy
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -129,7 +131,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return nil
 	}
 
-	declaredProbes := make([]string, 0, len(ccc.HealthProbes))
+	// Required checks wait exactly like probes, except the runner cannot produce
+	// them — something external must push before the deploy proceeds.
+	declaredProbes := make([]string, 0, len(ccc.HealthProbes)+len(ccc.HealthRequiredChecks))
+	declaredProbes = append(declaredProbes, ccc.HealthRequiredChecks...)
 	for _, probe := range ccc.HealthProbes {
 		if probe.Name != "" {
 			declaredProbes = append(declaredProbes, probe.Name)
@@ -145,6 +150,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	var lastReport *activities.GateHealthReport
 	var sawData bool
 	var lastNarration string
+	lastCheckHealth := map[string]string{}
 	var failMsg string
 	var awaitingProbes []string
 	pollErr := poll.Poll(ctx, s.v, poll.PollOpts{
@@ -179,22 +185,43 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 				checks = nil
 			}
 			markRemovedCheckRows(checks, declaredProbes)
+			checks = withAwaitedChecks(checks, declaredProbes, gateStartedAt)
 
-			// The runner picks probes up a cycle late after a first deploy, so
-			// without this an all-healthy window could verify a deploy whose
-			// declared checks never ran once.
+			// An all-healthy window must not verify a deploy whose declared
+			// checks never ran. This is terminal at the window boundary rather
+			// than a retry: the stabilization window is the wait, so anyone
+			// needing longer for a pusher to arrive lengthens the window.
 			awaitingProbes = nil
 			if outcome == windowPass && len(declaredProbes) > 0 {
 				if missing := missingProbes(declaredProbes, checks, gateStartedAt); len(missing) > 0 {
 					awaitingProbes = missing
-					s.narrate(ctx, &lastNarration, fmt.Sprintf(
-						"window elapsed all-healthy — waiting for declared probes to report (%d of %d): missing %s",
-						len(declaredProbes)-len(missing), len(declaredProbes), strings.Join(missing, ", ")), checks)
-					return errors.Errorf("declared probes have not reported yet")
+					failMsg = missingChecksMessage(missing, window)
+					s.narrate(ctx, &lastNarration, failMsg, checks)
+					return errors.Wrap(poll.NonRetryableError, failMsg)
+				}
+				// Reporting is not passing: a declared check that reports failing
+				// has to fail the window, or gating on it means nothing.
+				if failed := failedChecks(declaredProbes, checks, gateStartedAt); len(failed) > 0 {
+					failMsg = "declared checks reported failing: " + strings.Join(failed, ", ")
+					s.narrate(ctx, &lastNarration, failMsg, checks)
+					return errors.Wrap(poll.NonRetryableError, failMsg)
 				}
 			}
 
-			s.narrate(ctx, &lastNarration, windowNarration(outcome, report, gateStartedAt, now, window), checks)
+			// The step's status already shows every check's current state, so the
+			// timeline carries transitions only — a readable record of what moved
+			// during the window instead of a line per poll.
+			// Narrate every poll so the detail view always carries the current
+			// state of every check, including the ones still unknown. The dedupe
+			// keys on state rather than the countdown, so a quiet poll adds no
+			// timeline entry; when a check moves, the line says what moved.
+			// One line per poll, carrying the snapshot either way, deduped on
+			// state — so the first poll still writes it while all checks are unknown.
+			if moved := checkTransitions(lastCheckHealth, checks); moved != "" {
+				s.narrate(ctx, &lastNarration, moved, checks)
+			}
+			s.narrate(ctx, &lastNarration, windowNarration(outcome, report, gateStartedAt, now, window, checks), checks)
+			rememberCheckHealth(lastCheckHealth, checks)
 
 			switch outcome {
 			case windowPass:
@@ -226,8 +253,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 				window+noObservationExtension, window, noObservationExtension)
 		}
 		if len(awaitingProbes) > 0 {
-			return fmt.Errorf("declared health probes never reported after the apply: %s — a passing window must include every configured check",
-				strings.Join(awaitingProbes, ", "))
+			return errors.New(missingChecksMessage(awaitingProbes, window))
 		}
 		return fmt.Errorf("component did not hold healthy for %s: window ended %s", window, describeReport(lastReport))
 	}
@@ -268,6 +294,37 @@ func badReportMessage(r *activities.GateHealthReport) string {
 	return msg
 }
 
+// missingChecksMessage names the checks that never reported inside the window.
+// Lengthening stabilization_window is the way to wait longer, so the message
+// says so rather than leaving the reader to guess.
+func missingChecksMessage(missing []string, window time.Duration) string {
+	return fmt.Sprintf("no report inside the %s window for: %s — push these before the window closes, or lengthen stabilization_window",
+		window, strings.Join(missing, ", "))
+}
+
+// describeChecks summarises the whole set, so a pass does not read as though a
+// single resource was all that was looked at.
+func describeChecks(checks []activities.ComponentHealthCheckRow) string {
+	if len(checks) == 0 {
+		return "no checks reported"
+	}
+	byHealth := map[string]int{}
+	order := make([]string, 0, 4)
+	for _, c := range checks {
+		if _, seen := byHealth[c.Health]; !seen {
+			order = append(order, c.Health)
+		}
+		byHealth[c.Health]++
+	}
+	sort.Strings(order)
+
+	parts := make([]string, 0, len(order))
+	for _, h := range order {
+		parts = append(parts, fmt.Sprintf("%d %s", byHealth[h], h))
+	}
+	return fmt.Sprintf("%d checks: %s", len(checks), strings.Join(parts, ", "))
+}
+
 func describeReport(r *activities.GateHealthReport) string {
 	if r == nil {
 		return "with no health observations"
@@ -285,11 +342,24 @@ func describeReport(r *activities.GateHealthReport) string {
 
 // narrate writes the gate's progress onto its workflow step, so it isn't a silent
 // step that eventually flips. Best-effort — a failure here must not fail the gate.
+// remainingRe matches the "— 39s of the 1m0s window left" fragment so two polls
+// that differ only by the clock dedupe to one entry.
+var remainingRe = regexp.MustCompile(`— [0-9hms.]+ of (the )?[0-9hms.]* ?window left`)
+
+func stripRemaining(narration string) string {
+	return remainingRe.ReplaceAllString(narration, "— window running")
+}
+
+// narrate writes the gate's progress and its check snapshot onto the workflow
+// step. Deduped on state, not on the countdown, so the detail view stays current
+// without the timeline growing a line per poll.
 func (s *Signal) narrate(ctx workflow.Context, lastNarration *string, narration string, checks []activities.ComponentHealthCheckRow) {
 	if s.WorkflowStepID == "" || narration == "" {
 		return
 	}
-	key := narration
+	// Keying on the raw narration would defeat the dedupe, since the countdown
+	// changes every poll — 46 lines on a 10m window.
+	key := stripRemaining(narration)
 	for _, c := range checks {
 		key += "|" + c.Kind + "/" + c.Name + "=" + c.Health
 	}
@@ -333,10 +403,10 @@ func (s *Signal) narrate(ctx workflow.Context, lastNarration *string, narration 
 
 // windowNarration renders one poll reading as a human sentence with the real
 // remaining budget.
-func windowNarration(outcome windowOutcome, report *activities.GateHealthReport, gateStartedAt, now time.Time, window time.Duration) string {
+func windowNarration(outcome windowOutcome, report *activities.GateHealthReport, gateStartedAt, now time.Time, window time.Duration, checks []activities.ComponentHealthCheckRow) string {
 	switch outcome {
 	case windowPass:
-		return fmt.Sprintf("held healthy for %s — %s", window, describeReport(report))
+		return fmt.Sprintf("held healthy for %s — %s", window, describeChecks(checks))
 	case windowFailBad:
 		// Written just before the step's error lands, so the failing snapshot
 		// is locked in the step history with the checks that caused it.

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -4033,6 +4033,7 @@ export interface components {
       health_block_deploy?: boolean | null;
       health_enabled?: boolean | null;
       health_probes?: components["schemas"]["app.ComponentHealthProbe"][];
+      health_required_checks?: string[];
       /** @description Duration string for how long health must hold after a deploy applies (e.g., "3m"). Max 1h. */
       health_stabilization_window?: string;
       helm?: components["schemas"]["app.HelmComponentConfig"];
@@ -7743,6 +7744,7 @@ export interface components {
       health_block_deploy?: boolean | null;
       health_enabled?: boolean | null;
       health_probes?: components["schemas"]["service.HealthProbeRequest"][];
+      health_required_checks?: string[];
       /** @description Duration string for the health stabilization window (e.g., "3m") */
       health_stabilization_window?: string;
       helm_repo_config?: components["schemas"]["service.HelmRepoConfigRequest"];
@@ -7879,6 +7881,7 @@ export interface components {
       health_block_deploy?: boolean | null;
       health_enabled?: boolean | null;
       health_probes?: components["schemas"]["service.HealthProbeRequest"][];
+      health_required_checks?: string[];
       /** @description Duration string for the health stabilization window (e.g., "3m") */
       health_stabilization_window?: string;
       kubernetes_context?: string;


### PR DESCRIPTION
Lets a component declare check names a deploy must wait for, so a deploy can be gated on a fact only an external system knows — a migration having run, a smoke suite passing, a webhook confirming.

`required_checks` on a component's `[health]` block. The gate already waits for declared probes and holds until each has reported since the gate opened; required checks join that same path, the difference being the runner cannot produce them, so something has to push before the deploy proceeds. Names are validated at config time against the push endpoint's rule, since gating on an unpushable name would just hang until timeout. Declared checks are also listed on the checks endpoint as unknown until they report, so you can see what a deploy will wait for without having to make one fail first.

The gate's snapshot is scoped to the window: every check starts unknown and only in-window reports count, since a verdict from before the apply says nothing about this deploy. The timeline records check transitions rather than a line per poll.

Verified live on a stage install: gate blocks with all resources healthy and the required checks missing, releases within one poll of both being pushed, and declared-but-unpushed checks list as unknown.