### PR TITLE
refactor(ui): cache invalidation, error catchin & correct utils

### DIFF
--- a/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditorContainer.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditorContainer.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
@@ -46,6 +46,7 @@ export const DeploymentPlanEditorContainer = ({
   const { app, labelColors } = useApp()
   const { addToast } = useToast()
   const { removeModal } = useSurfaces()
+  const queryClient = useQueryClient()
 
   const { data: installsResult, isLoading: loadingInstalls } = useQuery({
     queryKey: ['app-installs', org.id, app.id],
@@ -114,6 +115,8 @@ export const DeploymentPlanEditorContainer = ({
       })
     },
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['app-branch', org.id, app.id, branch.id] })
+      queryClient.invalidateQueries({ queryKey: ['branch-configs', org.id, app.id, branch.id] })
       addToast(
         <Toast heading="Deployment plan saved" theme="success">
           <Text>A new config version has been created.</Text>

--- a/services/dashboard-ui/client/components/branches/EditBranchNameModal/EditBranchNameModalContainer.tsx
+++ b/services/dashboard-ui/client/components/branches/EditBranchNameModal/EditBranchNameModalContainer.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Badge } from '@/components/common/Badge'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
@@ -36,6 +36,7 @@ export const EditBranchNameModalContainer = ({
   const { org } = useOrg()
   const { addToast } = useToast()
   const { removeModal } = useSurfaces()
+  const queryClient = useQueryClient()
 
   const [validationError, setValidationError] = useState<string | null>(null)
 
@@ -150,6 +151,9 @@ export const EditBranchNameModalContainer = ({
       }
     },
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['app-branch', org.id, app.id, branch.id] })
+      queryClient.invalidateQueries({ queryKey: ['app-branches', org.id, app.id] })
+      queryClient.invalidateQueries({ queryKey: ['branch-configs', org.id, app.id, branch.id] })
       addToast(
         <Toast heading="Branch updated" theme="success">
           <Text>Updated branch <Badge variant="code" size="md">{branch.name}</Badge>.</Text>

--- a/services/dashboard-ui/client/components/install-components/InstallComponentsTable/InstallComponentsTableContainer.tsx
+++ b/services/dashboard-ui/client/components/install-components/InstallComponentsTable/InstallComponentsTableContainer.tsx
@@ -100,6 +100,9 @@ export const InstallComponentsTableContainer = ({
     }
   })
 
+  const orgId = org?.id
+  const appId = install?.app_id
+
   const removedRows = parseInstallComponentSummaryToTableData(
     removedComponents,
     [],
@@ -128,10 +131,12 @@ export const InstallComponentsTableContainer = ({
       filterActions={
         <div className="flex items-center gap-3">
           <SyncedFilterContainer />
-          <LabelFilterDropdown
-            queryKey={['component-label-keys', org.id, install?.app_id]}
-            queryFn={() => getComponentLabelKeys({ orgId: org.id, appId: install.app_id })}
-          />
+          {orgId && appId ? (
+            <LabelFilterDropdown
+              queryKey={['component-label-keys', orgId, appId]}
+              queryFn={() => getComponentLabelKeys({ orgId, appId })}
+            />
+          ) : null}
           <ComponentTypeFilterDropdown />
         </div>
       }

--- a/services/dashboard-ui/client/components/installs/forms/CreateInstallForm/CreateInstallForm.tsx
+++ b/services/dashboard-ui/client/components/installs/forms/CreateInstallForm/CreateInstallForm.tsx
@@ -122,9 +122,7 @@ export const CreateInstallForm = forwardRef<
           const result = await onSubmit(formData)
           onSuccess?.(result)
           clearDraft?.()
-        } catch (err) {
-          console.error('Form submission error:', err)
-        }
+        } catch {}
       }
     }
 

--- a/services/dashboard-ui/client/components/runbooks/RunRunbook/RunRunbook.tsx
+++ b/services/dashboard-ui/client/components/runbooks/RunRunbook/RunRunbook.tsx
@@ -17,6 +17,7 @@ import { useOrg } from '@/hooks/use-org'
 import { useSurfaces } from '@/hooks/use-surfaces'
 import { useToast } from '@/hooks/use-toast'
 import { runRunbook } from '@/lib'
+import type { TAPIError } from '@/types'
 import type { TRunbookInput } from '@/lib/ctl-api/apps/runbooks'
 import type {
   TInstallRunbook,
@@ -143,7 +144,7 @@ export const RunRunbookModal = ({
         navigate(`/${org!.id}/installs/${install!.id}/runbooks/${runbookId}`)
       }
     },
-    onError: (err: any) => {
+    onError: (err: TAPIError) => {
       addToast(
         <Toast heading="Runbook run failed" theme="error">
           <Text>{err?.error || `Unable to run ${runbookName}.`}</Text>

--- a/services/dashboard-ui/client/components/studio/OperationsStudio/RunbookNotebook.tsx
+++ b/services/dashboard-ui/client/components/studio/OperationsStudio/RunbookNotebook.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   DndContext,
   PointerSensor,
@@ -367,6 +367,8 @@ function VariablesPanel({
     template: string
     result: 'inserted' | 'copied'
   }>()
+  const feedbackTimer = useRef<number | undefined>(undefined)
+  useEffect(() => () => window.clearTimeout(feedbackTimer.current), [])
   const variables = useMemo(() => getStateVariables(state), [state])
   const filtered = variables.filter(
     (variable) =>
@@ -402,7 +404,8 @@ function VariablesPanel({
               onClick={() => {
                 const result = onInsert(variable.template)
                 setFeedback({ template: variable.template, result })
-                window.setTimeout(() => setFeedback(undefined), 1500)
+                window.clearTimeout(feedbackTimer.current)
+                feedbackTimer.current = window.setTimeout(() => setFeedback(undefined), 1500)
               }}
             >
               <code className="shrink-0 text-xs text-blue-700 dark:text-blue-400">
@@ -466,6 +469,8 @@ export function RunbookNotebook({
   const [importId, setImportId] = useState('')
   const [messages, setMessages] = useState<string[]>([])
   const [copied, setCopied] = useState<'toml' | 'markdown'>()
+  const copiedTimer = useRef<number | undefined>(undefined)
+  useEffect(() => () => window.clearTimeout(copiedTimer.current), [])
   const [previewTab, setPreviewTab] = useState<'preview' | 'toml' | 'template'>(
     'preview'
   )
@@ -559,7 +564,8 @@ export function RunbookNotebook({
   const copy = async (kind: 'toml' | 'markdown') => {
     await navigator.clipboard.writeText(kind === 'toml' ? toml : markdown)
     setCopied(kind)
-    window.setTimeout(() => setCopied(undefined), 1500)
+    window.clearTimeout(copiedTimer.current)
+    copiedTimer.current = window.setTimeout(() => setCopied(undefined), 1500)
   }
 
   const insertVariable = (template: string): 'inserted' | 'copied' => {

--- a/services/dashboard-ui/client/components/workflows/step-details/verify-health-details/VerifyHealthStepDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/verify-health-details/VerifyHealthStepDetails.tsx
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon'
 import { EmptyState } from '@/components/common/EmptyState'
 import { RemovedFromAppConfigBadge } from '@/components/installs/RemovedFromAppConfig/RemovedFromAppConfig'
 import { Badge } from '@/components/common/Badge'
@@ -205,7 +206,7 @@ export const VerifyHealthStepDetails = ({
                   <Time
                     variant="label"
                     className="shrink-0"
-                    time={new Date(entry.created_at_ts * 1000).toISOString()}
+                    time={DateTime.fromSeconds(entry.created_at_ts).toISO() ?? ''}
                     format="time-only"
                   />
                 ) : null}


### PR DESCRIPTION
- Added `queryClient.invalidateQueries` calls to the deployment plan save mutation in `DeploymentPlanEditorContainer.tsx` (invalidates `app-branch` and `branch-configs` caches)
- Added `queryClient.invalidateQueries` calls to the branch rename mutation in `EditBranchNameModalContainer.tsx` (invalidates `app-branch`, `app-branches`, and `branch-configs` caches)
- Guarded `LabelFilterDropdown` rendering in `InstallComponentsTableContainer.tsx` behind `orgId && appId` checks to prevent a crash when `install` is undefined on first render
- Removed the `console.error` from the swallowed submission error in `CreateInstallForm.tsx`, keeping a bare `catch {}` (callers already surface errors via their mutations' `onError` toasts)
- Replaced raw `new Date(ts * 1000).toISOString()` with Luxon's `DateTime.fromSeconds(ts).toISO()` in `VerifyHealthStepDetails.tsx`
- Typed the `onError` handler in `RunRunbook.tsx` as `TAPIError` instead of `any`
- Fixed the two un-cleared 1500ms feedback timers in `RunbookNotebook.tsx` (`setFeedback` and `setCopied`) to store ids in refs, clearing on re-trigger and unmount
- Rejected two review findings after inspection: the terminal-status set in `BranchRunSummaryContainer.tsx` is correct for the branch-run status vocabulary (`isTerminalStatusV2` doesn't fit), and `HealthTimelineContainer.tsx` already follows the `org!.id` queryFn convention