### PR TITLE
refactor(ui): clean up toast & error messages

### DIFF
--- a/services/dashboard-ui/client/components/branches/EditBranchNameModal/EditBranchNameModalContainer.tsx
+++ b/services/dashboard-ui/client/components/branches/EditBranchNameModal/EditBranchNameModalContainer.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { Badge } from '@/components/common/Badge'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
@@ -150,13 +149,13 @@ export const EditBranchNameModalContainer = ({
         }
       }
     },
-    onSuccess: () => {
+    onSuccess: (_result, data) => {
       queryClient.invalidateQueries({ queryKey: ['app-branch', org.id, app.id, branch.id] })
       queryClient.invalidateQueries({ queryKey: ['app-branches', org.id, app.id] })
       queryClient.invalidateQueries({ queryKey: ['branch-configs', org.id, app.id, branch.id] })
       addToast(
         <Toast heading="Branch updated" theme="success">
-          <Text>Updated branch <Badge variant="code" size="md">{branch.name}</Badge>.</Text>
+          <Text>Updated branch {data.branchName}.</Text>
         </Toast>
       )
       setValidationError(null)

--- a/services/dashboard-ui/client/components/branches/WorkflowStepsPipeline/WorkflowStepsPipeline.tsx
+++ b/services/dashboard-ui/client/components/branches/WorkflowStepsPipeline/WorkflowStepsPipeline.tsx
@@ -223,7 +223,7 @@ export const WorkflowStepsPipeline = ({
 
                   <div className="flex items-center gap-2">
                     <Badge size="sm" variant="code">
-                      GROUP {step.group_idx ?? idx + 1}
+                      Group {step.group_idx ?? idx + 1}
                     </Badge>
                     {step.execution_time ? (
                       <Duration

--- a/services/dashboard-ui/client/components/installs/CreateInstall/CreateInstallFromAppContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/CreateInstall/CreateInstallFromAppContainer.tsx
@@ -158,7 +158,7 @@ export const CreateInstallFromAppContainer = ({
     onSuccess: (result) => {
       addToast(
         <Toast heading="Install created" theme="success">
-          <Text>Install created.</Text>
+          <Text>Created {result.data?.name ?? 'install'}. Provisioning may take a few minutes.</Text>
         </Toast>
       )
       queryClient.invalidateQueries({ queryKey: ['workflow-approvals'] })

--- a/services/dashboard-ui/client/components/runbooks/InstallRunbooksTable/InstallRunbooksTable.tsx
+++ b/services/dashboard-ui/client/components/runbooks/InstallRunbooksTable/InstallRunbooksTable.tsx
@@ -230,7 +230,7 @@ export const InstallRunbooksTable = ({
         variant: 'actions',
         emptyTitle: 'No runbooks yet',
         emptyMessage:
-          'Runbooks let you run operational procedures on this install.',
+          'Runbooks let you run operational procedures on this install. They will appear here once the app config includes runbooks.',
       }}
       pagination={pagination}
       searchPlaceholder="Search by name or ID..."

--- a/services/dashboard-ui/client/components/runbooks/RunRunbook/RunRunbook.tsx
+++ b/services/dashboard-ui/client/components/runbooks/RunRunbook/RunRunbook.tsx
@@ -125,14 +125,8 @@ export const RunRunbookModal = ({
       }),
     onSuccess: (result) => {
       addToast(
-        <Toast heading="Runbook run started" theme="info">
-          <Text>
-            Running{' '}
-            <Badge variant="code" size="md">
-              {runbookName}
-            </Badge>
-            .
-          </Text>
+        <Toast heading="Running runbook" theme="info">
+          <Text>Running {runbookName} on {install?.name}.</Text>
         </Toast>
       )
       removeModal(props.modalId)

--- a/services/dashboard-ui/client/components/runbooks/RunbooksTable/RunbooksTable.tsx
+++ b/services/dashboard-ui/client/components/runbooks/RunbooksTable/RunbooksTable.tsx
@@ -135,7 +135,7 @@ export const RunbooksTable = ({
         variant: 'actions',
         emptyTitle: 'No runbooks yet',
         emptyMessage:
-          'Runbooks let you define operational procedures for your installs.',
+          'Runbooks let you define operational procedures for your installs. Add runbooks to your app config and sync to see them here.',
       }}
       pagination={pagination}
       searchPlaceholder="Search by name or ID..."

--- a/services/dashboard-ui/client/components/triggers/TriggerRuleDetails/TriggerRuleDetailsContainer.tsx
+++ b/services/dashboard-ui/client/components/triggers/TriggerRuleDetails/TriggerRuleDetailsContainer.tsx
@@ -1,4 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
+import { Button } from '@/components/common/Button'
+import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
 import { useOrg } from '@/hooks/use-org'
 import { getTriggerRule } from '@/lib'
@@ -19,6 +21,14 @@ export const TriggerRuleDetailsContainer = ({
   })
   if (query.isLoading) return <Text theme="neutral">Loading rule...</Text>
   if (query.error || !query.data)
-    return <Text theme="error">Rule loading failed.</Text>
+    return (
+      <div className="flex flex-col items-start gap-3">
+        <Text theme="error">Rule loading failed.</Text>
+        <Button variant="secondary" onClick={() => void query.refetch()}>
+          <Icon variant="ArrowClockwiseIcon" />
+          Retry loading rule
+        </Button>
+      </div>
+    )
   return <TriggerRuleDetails orgId={org?.id ?? ''} rule={query.data} />
 }

--- a/services/dashboard-ui/client/components/triggers/TriggerRules/TriggerRules.tsx
+++ b/services/dashboard-ui/client/components/triggers/TriggerRules/TriggerRules.tsx
@@ -123,7 +123,7 @@ export const TriggerRules = ({
   if (hasError) {
     return (
       <div className="flex flex-col items-start gap-3">
-        <Text theme="error">Unable to load rules.</Text>
+        <Text theme="error">Rules loading failed.</Text>
         <Button variant="secondary" onClick={onRetry}>
           <Icon variant="ArrowClockwiseIcon" />
           Retry loading rules

--- a/services/dashboard-ui/client/components/triggers/event-ledger/EventDetails/EventDetails.tsx
+++ b/services/dashboard-ui/client/components/triggers/event-ledger/EventDetails/EventDetails.tsx
@@ -346,7 +346,7 @@ export const EventDetails = ({
   if (!event) {
     return (
       <div className="flex flex-col items-start gap-3">
-        <Text theme="error">Unable to load this event.</Text>
+        <Text theme="error">Event loading failed.</Text>
         <Button variant="secondary" disabled={isRetrying} onClick={onRetry}>
           <Icon variant={isRetrying ? 'Loading' : 'ArrowClockwiseIcon'} />
           {isRetrying ? 'Retrying event' : 'Retry loading event'}
@@ -674,7 +674,7 @@ export const EventDetails = ({
               </CodeBlock>
             ) : hasRawError ? (
               <div className="flex flex-col items-start gap-3">
-                <Text theme="error">Unable to load the raw request.</Text>
+                <Text theme="error">Raw request loading failed.</Text>
                 <Button size="sm" variant="secondary" onClick={onRevealRaw}>
                   <Icon variant="ArrowClockwiseIcon" />
                   Retry loading raw request

--- a/services/dashboard-ui/client/components/triggers/event-ledger/EventsTable/EventsTable.tsx
+++ b/services/dashboard-ui/client/components/triggers/event-ledger/EventsTable/EventsTable.tsx
@@ -158,7 +158,7 @@ export const EventsTable = ({
   if (hasError && !hasLoadedData) {
     return (
       <div className="flex flex-col items-start gap-3">
-        <Text theme="error">Unable to load events.</Text>
+        <Text theme="error">Events loading failed.</Text>
         <Button variant="secondary" disabled={isRetrying} onClick={onRetry}>
           <Icon variant={isRetrying ? 'Loading' : 'ArrowClockwiseIcon'} />
           {isRetrying ? 'Retrying events' : 'Retry loading events'}

--- a/services/dashboard-ui/client/views/install/InstallConfigs.tsx
+++ b/services/dashboard-ui/client/views/install/InstallConfigs.tsx
@@ -56,7 +56,7 @@ export const InstallConfigs = () => {
         queryKey: ['install-config-versions', org?.id, install?.id],
       })
       addToast(
-        <Toast heading="Config sync triggered" theme="info">
+        <Toast heading="Syncing config" theme="info">
           <Text>Syncing configs for {install?.name}.</Text>
         </Toast>
       )

--- a/services/dashboard-ui/client/views/org/TriggerLayout.tsx
+++ b/services/dashboard-ui/client/views/org/TriggerLayout.tsx
@@ -1,5 +1,7 @@
 import { Outlet, useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
+import { Button } from '@/components/common/Button'
+import { Icon } from '@/components/common/Icon'
 import { ID } from '@/components/common/ID'
 import { Status } from '@/components/common/Status'
 import { Text } from '@/components/common/Text'
@@ -64,7 +66,13 @@ export const TriggerLayout = () => {
           {query.isLoading ? (
             <Text theme="neutral">Loading trigger...</Text>
           ) : query.error || !trigger ? (
-            <Text theme="error">Trigger loading failed.</Text>
+            <div className="flex flex-col items-start gap-3">
+              <Text theme="error">Trigger loading failed.</Text>
+              <Button variant="secondary" onClick={() => void query.refetch()}>
+                <Icon variant="ArrowClockwiseIcon" />
+                Retry loading trigger
+              </Button>
+            </div>
           ) : (
             <Outlet context={{ trigger }} />
           )}


### PR DESCRIPTION
- Removed the `<Badge>` from the branch-updated toast in `EditBranchNameModalContainer.tsx`; description is now plain text using the submitted name from mutation variables (the old toast showed the stale pre-rename `branch.name`), and the unused `Badge` import was dropped
- Changed the run-runbook toast in `RunRunbook.tsx` to heading "Running runbook" (was "Runbook run started") with a plain-text description: `Running {runbookName} on {install?.name}.`
- Changed the config sync toast heading in `InstallConfigs.tsx` from "Config sync triggered" to "Syncing config"
- Changed the install-created toast description in `CreateInstallFromAppContainer.tsx` from repeating the heading to `Created {name}. Provisioning may take a few minutes.`
- Reworded "Unable to load this event." to "Event loading failed." and "Unable to load the raw request." to "Raw request loading failed." in `EventDetails.tsx`
- Reworded "Unable to load rules." to "Rules loading failed." in `TriggerRules.tsx`
- Reworded "Unable to load events." to "Events loading failed." in `EventsTable.tsx`
- Added a "Retry loading rule" button (`query.refetch`) to the error state in `TriggerRuleDetailsContainer.tsx`
- Added a "Retry loading trigger" button (`query.refetch`) to the error state in `TriggerLayout.tsx`
- Appended "Add runbooks to your app config and sync to see them here." to the empty state in `RunbooksTable.tsx`
- Appended "They will appear here once the app config includes runbooks." to the empty state in `InstallRunbooksTable.tsx`
- Changed the all-caps "GROUP {n}" badge to "Group {n}" in `WorkflowStepsPipeline.tsx`