### PR TITLE
refactor(ui): clean up runbook studio code

### DIFF
--- a/services/dashboard-ui/client/components/branches/AppConfigDiff/AppConfigDiffContainer.tsx
+++ b/services/dashboard-ui/client/components/branches/AppConfigDiff/AppConfigDiffContainer.tsx
@@ -74,7 +74,7 @@ export const AppConfigDiffContainer = ({ appConfigId, className, focus }: IAppCo
         id="config-changes"
         isOpen={cardOpen}
         className={cn(
-          'border border-cool-grey-200 dark:border-dark-grey-700 rounded-xl bg-white dark:bg-dark-grey-900 shadow-sm overflow-hidden',
+          'border rounded-xl bg-white dark:bg-dark-grey-900 shadow-sm overflow-hidden',
           className
         )}
         headerClassName="px-5 py-4"
@@ -99,7 +99,7 @@ export const AppConfigDiffContainer = ({ appConfigId, className, focus }: IAppCo
           </div>
         }
       >
-        <div className="p-5 border-t border-cool-grey-100 dark:border-dark-grey-800 max-h-[70vh] overflow-y-auto">
+        <div className="p-5 border-t max-h-[70vh] overflow-y-auto">
           <AppConfigDiff
             sections={sections}
             summary={null}

--- a/services/dashboard-ui/client/components/branches/WorkflowStepsPipeline/WorkflowStepsPipeline.tsx
+++ b/services/dashboard-ui/client/components/branches/WorkflowStepsPipeline/WorkflowStepsPipeline.tsx
@@ -40,7 +40,7 @@ const StatusIcon = ({ category }: { category: TStepStatusCategory }) => {
     return (
       <div className="w-[26px] h-[26px] rounded-full bg-blue-500 flex items-center justify-center shrink-0">
         <svg className="animate-spin" width="16" height="16" viewBox="0 0 16 16" fill="none">
-          <circle cx="8" cy="8" r="6" stroke="rgba(255,255,255,0.3)" strokeWidth="2" />
+          <circle cx="8" cy="8" r="6" stroke="white" strokeOpacity="0.3" strokeWidth="2" />
           <path d="M8 2 A6 6 0 0 1 14 8" stroke="white" strokeWidth="2" strokeLinecap="round" />
         </svg>
       </div>
@@ -59,10 +59,7 @@ const StatusIcon = ({ category }: { category: TStepStatusCategory }) => {
   }
 
   return (
-    <div
-      className="w-[26px] h-[26px] rounded-full flex items-center justify-center shrink-0"
-      style={{ boxShadow: 'inset 0 0 0 1.5px rgba(150,150,170,0.35)' }}
-    >
+    <div className="w-[26px] h-[26px] rounded-full flex items-center justify-center shrink-0 ring-1 ring-inset ring-cool-grey-400/40 dark:ring-dark-grey-500/40">
       <div className="w-[5px] h-[5px] rounded-full bg-cool-grey-400 dark:bg-dark-grey-500" />
     </div>
   )
@@ -181,18 +178,18 @@ export const WorkflowStepsPipeline = ({
 
             let cardBorder = ''
             let cardBg = 'bg-cool-grey-50 dark:bg-dark-grey-800'
-            let cardShadow = ''
+            let cardRing = ''
 
             if (isSelected) {
               cardBorder = 'border-primary-500 dark:border-primary-400'
-              cardBg = 'bg-primary-50 dark:bg-[#1B1026]'
-              cardShadow = '0 0 0 3px rgba(124,58,237,0.18)'
+              cardBg = 'bg-primary-50 dark:bg-primary-500/15'
+              cardRing = 'ring-2 ring-primary-500/20'
             } else if (category === 'active') {
               cardBorder = 'border-blue-400/50 dark:border-blue-500/50'
-              cardBg = 'bg-blue-50/40 dark:bg-[#0d1b2e]'
+              cardBg = 'bg-blue-50/40 dark:bg-blue-500/10'
             } else if (category === 'awaiting') {
               cardBorder = 'border-amber-400/50 dark:border-amber-500/50'
-              cardBg = 'bg-amber-50/40 dark:bg-[#2a1f06]'
+              cardBg = 'bg-amber-50/40 dark:bg-amber-500/10'
             } else if (category === 'success') {
               cardBorder = 'border-green-400/50 dark:border-green-500/40'
               cardBg = 'bg-green-50/30 dark:bg-dark-grey-800'
@@ -207,8 +204,7 @@ export const WorkflowStepsPipeline = ({
 
                 <div
                   ref={isSelected ? selectedCardRef : undefined}
-                  className={`snap-start scroll-mx-12 flex flex-col flex-1 min-w-[168px] items-center justify-center gap-2 px-4 py-4 rounded-[10px] cursor-pointer border transition-all ${cardBorder} ${cardBg} hover:brightness-105`}
-                  style={cardShadow ? { boxShadow: cardShadow } : undefined}
+                  className={`snap-start scroll-mx-12 flex flex-col flex-1 min-w-[168px] items-center justify-center gap-2 px-4 py-4 rounded-[10px] cursor-pointer border transition-all ${cardBorder} ${cardBg} ${cardRing} hover:brightness-105`}
                   onClick={() => onSelectStep(step)}
                 >
                   <StatusIcon category={category} />

--- a/services/dashboard-ui/client/components/branches/graph/GraphCanvas.tsx
+++ b/services/dashboard-ui/client/components/branches/graph/GraphCanvas.tsx
@@ -24,13 +24,13 @@ const GraphControls = () => {
       role="toolbar"
       aria-label="Graph controls"
     >
-      <Button size="xs" variant="ghost" onClick={() => zoomIn()} aria-label="Zoom in">
+      <Button variant="icon" onClick={() => zoomIn()} aria-label="Zoom in">
         <Icon variant="PlusIcon" size={14} />
       </Button>
-      <Button size="xs" variant="ghost" onClick={() => zoomOut()} aria-label="Zoom out">
+      <Button variant="icon" onClick={() => zoomOut()} aria-label="Zoom out">
         <Icon variant="MinusIcon" size={14} />
       </Button>
-      <Button size="xs" variant="ghost" onClick={() => fitView({ padding: 0.2 })} aria-label="Fit to view">
+      <Button variant="icon" onClick={() => fitView({ padding: 0.2 })} aria-label="Fit to view">
         <Icon variant="CornersOutIcon" size={14} />
       </Button>
     </div>

--- a/services/dashboard-ui/client/components/installs/InstallBranches/InstallBranches.tsx
+++ b/services/dashboard-ui/client/components/installs/InstallBranches/InstallBranches.tsx
@@ -224,7 +224,7 @@ const BranchCard = ({
       </div>
 
       {latestRun ? (
-        <div className="flex flex-col gap-3 border-t border-cool-grey-100 dark:border-dark-grey-700 pt-3">
+        <div className="flex flex-col gap-3 border-t pt-3">
           <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-2">
               <Text variant="subtext" weight="strong" theme="neutral">
@@ -268,7 +268,7 @@ const BranchCard = ({
           )}
         </div>
       ) : (
-        <div className="border-t border-cool-grey-100 dark:border-dark-grey-700 pt-3">
+        <div className="border-t pt-3">
           <Text variant="subtext" theme="neutral">
             No runs yet
           </Text>

--- a/services/dashboard-ui/client/components/installs/forms/CreateInstallForm/CreateInstallForm.tsx
+++ b/services/dashboard-ui/client/components/installs/forms/CreateInstallForm/CreateInstallForm.tsx
@@ -62,8 +62,7 @@ const LabelsSection = () => {
               className="flex-1"
             />
             <Button
-              variant="ghost"
-              size="xs"
+              variant="icon"
               onClick={() => removeRow(idx)}
               type="button"
             >
@@ -71,7 +70,7 @@ const LabelsSection = () => {
             </Button>
           </div>
         ))}
-        <Button variant="secondary" size="sm" onClick={addRow} type="button" className="w-fit">
+        <Button variant="secondary" onClick={addRow} type="button" className="w-fit">
           <Icon variant="PlusIcon" size={14} />
           Add label
         </Button>

--- a/services/dashboard-ui/client/components/runbooks/InstallRunbooksTable/InstallRunbooksTable.stories.tsx
+++ b/services/dashboard-ui/client/components/runbooks/InstallRunbooksTable/InstallRunbooksTable.stories.tsx
@@ -2,6 +2,7 @@ export default {
   title: 'Runbooks/InstallRunbooksTable',
 }
 
+import { Text } from '@/components/common/Text'
 import {
   InstallRunbooksTable,
   InstallRunbooksTableSkeleton,
@@ -12,13 +13,13 @@ const mockRows: TInstallRunbookRow[] = Array.from({ length: 3 }, (_, i) => ({
   runbookId: `runbook-${i + 1}`,
   runbookName: `rotate-secrets-${i + 1}`,
   description: (
-    <span className="text-sm text-gray-500">
+    <Text variant="subtext" theme="neutral">
       Rotates API keys and credentials.
-    </span>
+    </Text>
   ),
-  labels: <span className="text-sm text-gray-500">production</span>,
-  lastUpdated: <span className="text-sm text-gray-500">3 days ago</span>,
-  lastRun: <span className="text-sm text-gray-500">2 hours ago</span>,
+  labels: <Text variant="subtext" theme="neutral">production</Text>,
+  lastUpdated: <Text variant="subtext" theme="neutral">3 days ago</Text>,
+  lastRun: <Text variant="subtext" theme="neutral">2 hours ago</Text>,
   href: `/org-1/installs/install-1/runbooks/runbook-${i + 1}`,
   latestRunHref: `/org-1/installs/install-1/workflows/wf-${i + 1}`,
   installRunbook: { id: `ir-${i + 1}`, runbook_id: `runbook-${i + 1}` } as any,

--- a/services/dashboard-ui/client/components/runbooks/RunRunbookCard/RunRunbookCard.tsx
+++ b/services/dashboard-ui/client/components/runbooks/RunRunbookCard/RunRunbookCard.tsx
@@ -32,8 +32,8 @@ export const RunRunbookCard = ({
 
   if (error) {
     return (
-      <div className="flex w-fit items-center gap-3 rounded-lg border border-red-300 dark:border-red-700 px-3 py-2.5">
-        <Text variant="subtext" className="text-red-600 dark:text-red-400">
+      <div className="flex w-fit items-center gap-3 rounded-lg border px-3 py-2.5">
+        <Text variant="subtext" theme="error">
           {error}
         </Text>
       </div>

--- a/services/dashboard-ui/client/components/runbooks/RunbooksTable/RunbooksTable.stories.tsx
+++ b/services/dashboard-ui/client/components/runbooks/RunbooksTable/RunbooksTable.stories.tsx
@@ -2,6 +2,7 @@ export default {
   title: 'Runbooks/RunbooksTable',
 }
 
+import { Text } from '@/components/common/Text'
 import {
   RunbooksTable,
   RunbooksTableSkeleton,
@@ -12,12 +13,12 @@ const mockRows: TRunbookRow[] = Array.from({ length: 3 }, (_, i) => ({
   runbookId: `runbook-${i + 1}`,
   runbookName: `rotate-secrets-${i + 1}`,
   description: (
-    <span className="text-sm text-gray-500">
+    <Text variant="subtext" theme="neutral">
       Rotates API keys and secrets for the install.
-    </span>
+    </Text>
   ),
-  labels: <span className="text-sm text-gray-500">production</span>,
-  lastUpdated: <span className="text-sm text-gray-500">3 days ago</span>,
+  labels: <Text variant="subtext" theme="neutral">production</Text>,
+  lastUpdated: <Text variant="subtext" theme="neutral">3 days ago</Text>,
   href: `/org-1/apps/app-1/runbooks/runbook-${i + 1}`,
 }))
 

--- a/services/dashboard-ui/client/components/studio/OperationsStudio/RunbookNotebook.tsx
+++ b/services/dashboard-ui/client/components/studio/OperationsStudio/RunbookNotebook.tsx
@@ -256,7 +256,7 @@ function SortableCell({
               >
                 <Icon variant="TrashIcon" size="14" />
               </Button>
-              <Button variant="secondary" size="xs" onClick={onDone}>
+              <Button variant="secondary" onClick={onDone}>
                 Done
               </Button>
             </div>
@@ -377,7 +377,7 @@ function VariablesPanel({
   )
 
   return (
-    <Card className="!p-4 !gap-3">
+    <Card className="!p-4 !gap-4">
       <div className="flex items-center gap-2">
         <Icon variant="BracketsCurlyIcon" size="14" />
         <Text weight="strong">Install state variables</Text>
@@ -610,102 +610,104 @@ export function RunbookNotebook({
 
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-4 items-start">
         <div className="flex flex-col gap-3">
-          <Card className="!py-6 !pl-11 !pr-6 !gap-0">
-            <input
-              className="w-full bg-transparent text-2xl font-semibold outline-none placeholder:text-cool-grey-400 dark:placeholder:text-cool-grey-600"
-              placeholder="Untitled runbook"
-              aria-label="Runbook name"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-            />
-            <input
-              className="w-full bg-transparent text-sm outline-none mt-1 mb-4 text-cool-grey-700 dark:text-cool-grey-300 placeholder:text-cool-grey-400 dark:placeholder:text-cool-grey-600"
-              placeholder="Add a description"
-              aria-label="Runbook description"
-              value={description}
-              onChange={(event) => setDescription(event.target.value)}
-            />
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={onDragEnd}
-            >
-              <SortableContext
-                items={cells.map((cell) => cell.key)}
-                strategy={verticalListSortingStrategy}
+          <Card>
+            <div className="flex flex-col pl-5">
+              <input
+                className="w-full bg-transparent text-2xl font-semibold outline-none placeholder:text-cool-grey-400 dark:placeholder:text-cool-grey-600"
+                placeholder="Untitled runbook"
+                aria-label="Runbook name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
+              <input
+                className="w-full bg-transparent text-sm outline-none mt-1 mb-4 text-cool-grey-700 dark:text-cool-grey-300 placeholder:text-cool-grey-400 dark:placeholder:text-cool-grey-600"
+                placeholder="Add a description"
+                aria-label="Runbook description"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+              />
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={onDragEnd}
               >
-                {cells.map((cell, index) => (
-                  <div key={cell.key} className="flex flex-col">
-                    <InsertZone
-                      id={`insert-${cell.key}`}
-                      onAddMarkdown={() => insertAt(index, newMarkdownCell())}
-                      onAddStep={(operation) =>
-                        insertAt(index, newStepCell(operation))
-                      }
-                    />
-                    <SortableCell
-                      cell={cell}
-                      stepNumber={stepNumbers.get(cell.key)}
-                      active={activeKey === cell.key}
-                      issues={validation.byCell[cell.key] ?? []}
-                      onActivate={() => setActiveKey(cell.key)}
-                      onDone={() => setActiveKey(null)}
-                      onRemove={() => removeCell(cell.key)}
-                    >
-                      {cell.kind === 'markdown' ? (
-                        <Textarea
-                          id={`markdown-${cell.key}`}
-                          aria-label="Markdown content"
-                          placeholder="Explain what happens next, add checklists, warnings, or links."
-                          value={cell.content}
-                          autoResize
-                          minRows={3}
-                          onChange={(event) =>
-                            setCells((current) =>
-                              current.map((item) =>
-                                item.key === cell.key &&
-                                item.kind === 'markdown'
-                                  ? { ...item, content: event.target.value }
-                                  : item
+                <SortableContext
+                  items={cells.map((cell) => cell.key)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {cells.map((cell, index) => (
+                    <div key={cell.key} className="flex flex-col">
+                      <InsertZone
+                        id={`insert-${cell.key}`}
+                        onAddMarkdown={() => insertAt(index, newMarkdownCell())}
+                        onAddStep={(operation) =>
+                          insertAt(index, newStepCell(operation))
+                        }
+                      />
+                      <SortableCell
+                        cell={cell}
+                        stepNumber={stepNumbers.get(cell.key)}
+                        active={activeKey === cell.key}
+                        issues={validation.byCell[cell.key] ?? []}
+                        onActivate={() => setActiveKey(cell.key)}
+                        onDone={() => setActiveKey(null)}
+                        onRemove={() => removeCell(cell.key)}
+                      >
+                        {cell.kind === 'markdown' ? (
+                          <Textarea
+                            id={`markdown-${cell.key}`}
+                            aria-label="Markdown content"
+                            placeholder="Explain what happens next, add checklists, warnings, or links."
+                            value={cell.content}
+                            autoResize
+                            minRows={3}
+                            onChange={(event) =>
+                              setCells((current) =>
+                                current.map((item) =>
+                                  item.key === cell.key &&
+                                  item.kind === 'markdown'
+                                    ? { ...item, content: event.target.value }
+                                    : item
+                                )
                               )
-                            )
-                          }
-                        />
-                      ) : (
-                        <StepEditor
-                          step={cell.step}
-                          components={components}
-                          actions={actions}
-                          onChange={(patch) => updateStep(cell.key, patch)}
-                        />
-                      )}
-                    </SortableCell>
-                  </div>
-                ))}
-              </SortableContext>
-            </DndContext>
-            <div className="mt-3 -ml-2">
-              <Dropdown
-                id="add-cell-end"
-                variant="ghost"
-                size="xs"
-                hideIcon
-                buttonText={
-                  <span className="flex items-center gap-1.5 text-cool-grey-500 dark:text-cool-grey-400">
-                    <Icon variant="PlusIcon" size="14" />
-                    Add content or step
-                  </span>
-                }
-              >
-                <CellMenuItems
-                  onAddMarkdown={() =>
-                    insertAt(cells.length, newMarkdownCell())
+                            }
+                          />
+                        ) : (
+                          <StepEditor
+                            step={cell.step}
+                            components={components}
+                            actions={actions}
+                            onChange={(patch) => updateStep(cell.key, patch)}
+                          />
+                        )}
+                      </SortableCell>
+                    </div>
+                  ))}
+                </SortableContext>
+              </DndContext>
+              <div className="mt-3 -ml-2">
+                <Dropdown
+                  id="add-cell-end"
+                  variant="ghost"
+                  size="xs"
+                  hideIcon
+                  buttonText={
+                    <span className="flex items-center gap-1.5 text-cool-grey-500 dark:text-cool-grey-400">
+                      <Icon variant="PlusIcon" size="14" />
+                      Add content or step
+                    </span>
                   }
-                  onAddStep={(operation) =>
-                    insertAt(cells.length, newStepCell(operation))
-                  }
-                />
-              </Dropdown>
+                >
+                  <CellMenuItems
+                    onAddMarkdown={() =>
+                      insertAt(cells.length, newMarkdownCell())
+                    }
+                    onAddStep={(operation) =>
+                      insertAt(cells.length, newStepCell(operation))
+                    }
+                  />
+                </Dropdown>
+              </div>
             </div>
           </Card>
 
@@ -806,7 +808,7 @@ export function RunbookNotebook({
                     <Icon
                       variant="WarningIcon"
                       size="14"
-                      className="text-orange-500"
+                      className="text-orange-500 dark:text-orange-400"
                     />
                     <Text variant="subtext" theme="warn">
                       {validation.errors.length}{' '}
@@ -818,7 +820,7 @@ export function RunbookNotebook({
                     <Icon
                       variant="CheckIcon"
                       size="14"
-                      className="text-green-600"
+                      className="text-green-600 dark:text-green-400"
                     />
                     <Text variant="subtext" theme="success">
                       Ready

--- a/services/dashboard-ui/client/components/triggers/TriggerOverview/TriggerOverview.tsx
+++ b/services/dashboard-ui/client/components/triggers/TriggerOverview/TriggerOverview.tsx
@@ -131,7 +131,6 @@ export const TriggerOverview = ({
             <div className="flex items-center gap-2">
               {onRevealSecret ? (
                 <Button
-                  size="sm"
                   disabled={pending}
                   onClick={() =>
                     revealed
@@ -147,7 +146,6 @@ export const TriggerOverview = ({
                 </Button>
               ) : null}
               <Button
-                size="sm"
                 variant="danger"
                 onClick={() => onRevokeSecret?.(secret.id!)}
               >
@@ -187,7 +185,6 @@ export const TriggerOverview = ({
               </Text>
               {onRevealSecret && activeSecret?.id ? (
                 <Button
-                  size="sm"
                   disabled={revealPendingSecretId === activeSecret.id}
                   onClick={() => onRevealSecret(activeSecret.id!)}
                 >
@@ -222,7 +219,7 @@ export const TriggerOverview = ({
               Send an HTTP request to this trigger to test its routing rules.
             </Text>
           </div>
-          <Button size="sm" onClick={onRotateIngressURL}>
+          <Button onClick={onRotateIngressURL}>
             {ingressUrl ? 'Replace ingress URL' : 'Generate ingress URL'}
           </Button>
         </div>
@@ -304,7 +301,7 @@ export const TriggerOverview = ({
               </Text>
             </div>
             {canRotateSecret(trigger?.preset) ? (
-              <Button size="sm" onClick={onRotateSecret}>
+              <Button onClick={onRotateSecret}>
                 Rotate secret
               </Button>
             ) : null}

--- a/services/dashboard-ui/client/components/triggers/event-ledger/EventDetails/EventDetails.tsx
+++ b/services/dashboard-ui/client/components/triggers/event-ledger/EventDetails/EventDetails.tsx
@@ -390,7 +390,6 @@ export const EventDetails = ({
               </Text>
             </div>
             <Button
-              size="sm"
               variant="secondary"
               disabled={isRetrying}
               onClick={onRetry}
@@ -564,7 +563,6 @@ export const EventDetails = ({
                 </Status>
                 {dispatch?.status === 'dead_lettered' && dispatch?.id ? (
                   <Button
-                    size="sm"
                     variant="secondary"
                     disabled={retryingDispatchId === dispatch.id}
                     onClick={() => {
@@ -675,7 +673,7 @@ export const EventDetails = ({
             ) : hasRawError ? (
               <div className="flex flex-col items-start gap-3">
                 <Text theme="error">Raw request loading failed.</Text>
-                <Button size="sm" variant="secondary" onClick={onRevealRaw}>
+                <Button variant="secondary" onClick={onRevealRaw}>
                   <Icon variant="ArrowClockwiseIcon" />
                   Retry loading raw request
                 </Button>

--- a/services/dashboard-ui/client/components/triggers/event-ledger/EventsTable/EventsTable.tsx
+++ b/services/dashboard-ui/client/components/triggers/event-ledger/EventsTable/EventsTable.tsx
@@ -113,11 +113,9 @@ export const EventsTable = ({
         header:
           receivedOrder && onReceivedOrderChange
             ? () => (
-                <Button
+                <button
                   type="button"
-                  variant="ghost"
-                  size="xs"
-                  className="h-auto p-1"
+                  className="flex cursor-pointer items-center gap-1"
                   aria-label={`Received, ${receivedOrder === 'desc' ? 'newest first' : 'oldest first'}. Sort ${receivedOrder === 'desc' ? 'oldest first' : 'newest first'}`}
                   onClick={() =>
                     onReceivedOrderChange(
@@ -131,7 +129,7 @@ export const EventsTable = ({
                       receivedOrder === 'desc' ? 'ArrowDownIcon' : 'ArrowUpIcon'
                     }
                   />
-                </Button>
+                </button>
               )
             : 'Received',
         accessorKey: 'received_at',
@@ -179,7 +177,6 @@ export const EventsTable = ({
               </Text>
             </div>
             <Button
-              size="sm"
               variant="secondary"
               disabled={isRetrying}
               onClick={onRetry}

--- a/services/dashboard-ui/client/views/app/branches/BranchRunDetail.tsx
+++ b/services/dashboard-ui/client/views/app/branches/BranchRunDetail.tsx
@@ -7,6 +7,7 @@ import { Card } from '@/components/common/Card'
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Icon } from '@/components/common/Icon'
 import { ID } from '@/components/common/ID'
+import { Link } from '@/components/common/Link'
 import { Status } from '@/components/common/Status'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
@@ -145,16 +146,11 @@ const BranchRunDetailContent = () => {
                     <Text variant="base" weight="strong">Source</Text>
                   </div>
                   {githubUrl && (
-                    <a
-                      href={githubUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-1.5 text-xs text-primary-500 hover:text-primary-600 dark:text-primary-400 dark:hover:text-primary-300"
-                    >
+                    <Link href={githubUrl} isExternal className="text-xs">
                       <Icon variant="GithubLogoIcon" size={14} />
                       View in GitHub
                       <Icon variant="ArrowSquareOutIcon" size={12} />
-                    </a>
+                    </Link>
                   )}
                 </div>
 

--- a/services/dashboard-ui/client/views/install/InstallConfigs.tsx
+++ b/services/dashboard-ui/client/views/install/InstallConfigs.tsx
@@ -100,7 +100,6 @@ export const InstallConfigs = () => {
           <div className="shrink-0">
             <Button
               variant="secondary"
-              size="sm"
               disabled={isSyncing}
               onClick={() => syncNow()}
             >
@@ -168,7 +167,7 @@ const ConfigVersionRow = ({ version }: { version: TInstallConfigVersion }) => {
   return (
     <Expand
       id={`config-version-${version.id}`}
-      className="border border-cool-grey-200 dark:border-dark-grey-700 rounded-xl bg-white dark:bg-dark-grey-900 shadow-sm overflow-hidden"
+      className="border rounded-xl bg-white dark:bg-dark-grey-900 shadow-sm overflow-hidden"
       headerClassName="px-5 py-4"
       heading={
         <div className="flex items-center gap-3 w-full">
@@ -210,7 +209,7 @@ const ConfigVersionRow = ({ version }: { version: TInstallConfigVersion }) => {
         </div>
       }
     >
-      <div className="p-5 border-t border-cool-grey-100 dark:border-dark-grey-800 flex flex-col gap-4">
+      <div className="p-5 border-t flex flex-col gap-4">
         {commit && <CommitCard commit={commit} />}
 
         {isDiffLoading && !diff ? (

--- a/services/dashboard-ui/client/views/install/Versions.tsx
+++ b/services/dashboard-ui/client/views/install/Versions.tsx
@@ -220,7 +220,7 @@ const VersionCard = ({ version }: { version: TInstallAppConfigVersion }) => {
   return (
     <Expand
       id={`version-${version.id}`}
-      className="border border-cool-grey-200 dark:border-dark-grey-700 rounded-xl bg-white dark:bg-dark-grey-900 shadow-sm overflow-hidden"
+      className="border rounded-xl bg-white dark:bg-dark-grey-900 shadow-sm overflow-hidden"
       headerClassName="px-5 py-4"
       heading={
         <div className="flex items-center gap-3 w-full">
@@ -247,7 +247,7 @@ const VersionCard = ({ version }: { version: TInstallAppConfigVersion }) => {
         </div>
       }
     >
-      <div className="p-5 border-t border-cool-grey-100 dark:border-dark-grey-800">
+      <div className="p-5 border-t">
         <div className="grid grid-cols-2 gap-3 mb-4">
           <LabeledValue label="Old config">
             {version.old_app_config_id ? (


### PR DESCRIPTION
- Replaced hardcoded hex dark backgrounds in `WorkflowStepsPipeline.tsx` with token + opacity: `dark:bg-[#1B1026]` → `dark:bg-primary-500/15`, `dark:bg-[#0d1b2e]` → `dark:bg-blue-500/10`, `dark:bg-[#2a1f06]` → `dark:bg-amber-500/10`
- Removed the three inline rgba values in `WorkflowStepsPipeline.tsx`: spinner stroke now uses `strokeOpacity`, the pending-status glyph's inline `boxShadow` is now `ring-1 ring-inset` with tokenized color, and the selected-card glow is now a `ring-2 ring-primary-500/20` class (was off-palette violet)
- Replaced the hand-rolled red error box in `RunRunbookCard.tsx` with bare `border` + `Text theme="error"` (kept the compact card shape instead of a `Banner` to match the sibling loading/default states)
- Added missing dark-mode pairs to the warning/check icons in `RunbookNotebook.tsx` (`dark:text-orange-400`, `dark:text-green-400`)
- Replaced raw `text-gray-500` spans with `<Text variant="subtext" theme="neutral">` in `RunbooksTable.stories.tsx` and `InstallRunbooksTable.stories.tsx`
- Removed all eight explicit `border-cool-grey-* dark:border-dark-grey-*` pairs in favor of bare `border`/`border-t` across `InstallConfigs.tsx`, `Versions.tsx`, `InstallBranches.tsx`, and `AppConfigDiffContainer.tsx`
- Removed `size="sm"` from thirteen action buttons: five in `TriggerOverview.tsx` (reveal/hide/revoke/rotate secret, ingress URL), three in `EventDetails.tsx` (refresh, retry dispatch, retry raw request), the refresh button in `EventsTable.tsx`, "Add label" in `CreateInstallForm.tsx`, "Sync now" in `InstallConfigs.tsx`, and "Done" in `RunbookNotebook.tsx`
- Converted icon-only `size="xs"` ghost buttons to `variant="icon"`: the three graph zoom/fit controls in `GraphCanvas.tsx` and the remove-label button in `CreateInstallForm.tsx`
- Rebuilt the "Received" sort toggle in `EventsTable.tsx` as an unstyled `<button>` with text + arrow icon, mirroring the common Table's native sortable-header pattern (a Button variant didn't fit a text-labeled header control)
- Replaced the native GitHub `<a target="_blank">` in `BranchRunDetail.tsx` with the common `Link` component using `isExternal`, dropping the hand-rolled color classes
- Fixed the VariablesPanel Card rhythm in `RunbookNotebook.tsx`: `!p-4 !gap-3` → `!p-4 !gap-4`
- Restructured the notebook Card in `RunbookNotebook.tsx`: replaced the asymmetric `!py-6 !pl-11 !pr-6 !gap-0` override with a default-padding Card containing a `flex flex-col pl-5` wrapper (same 44px drag-handle gutter, identical visuals)
- Verified the studio page with live light/dark screenshots against the local stack (enabled the `runbook-studio` feature flag on the seed org to do so)
- Flagged but did not change (design call): ~8 more xs/sm buttons in `RunbookNotebook.tsx` toolbars and the sm primary "Run" button in `RunRunbookCard.tsx`