### PR TITLE
fix: app branch list cli command

### DIFF
--- a/bins/cli/cmd/apps.go
+++ b/bins/cli/cmd/apps.go
@@ -363,8 +363,7 @@ func (c *cli) branchesCmd() *cobra.Command {
 			return svc.ListBranches(cmd.Context(), appID, PrintJSON)
 		}),
 	}
-	listCmd.Flags().StringVarP(&appID, "app-id", "a", "", "The ID or name of an app")
-	listCmd.MarkFlagRequired("app-id")
+	listCmd.Flags().StringVarP(&appID, "app-id", "a", "", "The ID or name of an app. Defaults to the selected app.")
 	branchesCmd.AddCommand(listCmd)
 
 	getCmd := &cobra.Command{
@@ -375,9 +374,8 @@ func (c *cli) branchesCmd() *cobra.Command {
 			return svc.GetBranch(cmd.Context(), appID, branchID, PrintJSON)
 		}),
 	}
-	getCmd.Flags().StringVarP(&appID, "app-id", "a", "", "The ID or name of an app")
-	getCmd.Flags().StringVarP(&branchID, "branch-id", "b", "", "The ID of the branch")
-	getCmd.MarkFlagRequired("app-id")
+	getCmd.Flags().StringVarP(&appID, "app-id", "a", "", "The ID or name of an app. Defaults to the selected app.")
+	getCmd.Flags().StringVarP(&branchID, "branch-id", "b", "", "The ID or name of the branch")
 	getCmd.MarkFlagRequired("branch-id")
 	branchesCmd.AddCommand(getCmd)
 

--- a/bins/cli/internal/services/apps/branches.go
+++ b/bins/cli/internal/services/apps/branches.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/nuonco/nuon/bins/cli/internal/lookup"
 	"github.com/nuonco/nuon/bins/cli/internal/ui"
 	"github.com/nuonco/nuon/bins/cli/internal/ui/bubbles"
 	"github.com/nuonco/nuon/bins/cli/internal/ui/v3/workflow"
@@ -13,6 +14,11 @@ import (
 func (s *Service) ListBranches(ctx context.Context, appID string, asJSON bool) error {
 	view := ui.NewListView()
 
+	appID, err := s.resolveAppID(ctx, appID)
+	if err != nil {
+		return view.Error(err)
+	}
+
 	branches, err := s.api.GetAppBranches(ctx, appID)
 	if err != nil {
 		return view.Error(err)
@@ -20,6 +26,11 @@ func (s *Service) ListBranches(ctx context.Context, appID string, asJSON bool) e
 
 	if asJSON {
 		ui.PrintJSON(branches)
+		return nil
+	}
+
+	if len(branches) == 0 {
+		view.Print(fmt.Sprintf("no branches found for app %s\n\ncreate one with: nuon apps branches create --app-id %s --name <name>", appID, appID))
 		return nil
 	}
 
@@ -38,6 +49,16 @@ func (s *Service) ListBranches(ctx context.Context, appID string, asJSON bool) e
 }
 
 func (s *Service) GetBranch(ctx context.Context, appID, branchID string, asJSON bool) error {
+	appID, err := s.resolveAppID(ctx, appID)
+	if err != nil {
+		return err
+	}
+
+	branchID, err = s.resolveAppBranchID(ctx, appID, branchID)
+	if err != nil {
+		return err
+	}
+
 	branch, err := s.api.GetAppBranch(ctx, appID, branchID)
 	if err != nil {
 		return err
@@ -53,6 +74,11 @@ func (s *Service) GetBranch(ctx context.Context, appID, branchID string, asJSON 
 }
 
 func (s *Service) CreateBranch(ctx context.Context, appID, name string, asJSON bool) error {
+	appID, err := s.resolveAppID(ctx, appID)
+	if err != nil {
+		return err
+	}
+
 	branch, err := s.api.CreateAppBranch(ctx, appID, &models.ServiceCreateAppBranchRequest{
 		Name: &name,
 	})
@@ -201,14 +227,9 @@ func (s *Service) selectBranchID(ctx context.Context, appID, branchID string) (s
 }
 
 func (s *Service) resolveAppID(ctx context.Context, appID string) (string, error) {
-	if appID != "" {
-		return appID, nil
+	if appID == "" {
+		appID = s.getAppID()
 	}
 
-	configured := s.getAppID()
-	if configured != "" {
-		return configured, nil
-	}
-
-	return "", fmt.Errorf("no app specified; use --app-id or select an app with: nuon config app")
+	return lookup.AppID(ctx, s.api, appID)
 }


### PR DESCRIPTION
Fixes `nuon apps branches` commands to work with the selected app and to accept
branch names, not just IDs.

- `--app-id` is no longer required on `branches list` / `branches get` — both now
  fall back to the selected app (`nuon apps select`), matching every other app
  subcommand.
- `resolveAppID` now routes through `lookup.AppID`, so a name resolves to an ID
  and a bad name returns `app "foo" not found` instead of a raw 404.
- `branches get` resolves `--branch-id` through `resolveAppBranchID`, so it takes
  a branch name or an ID (the flag help said ID-only).
- `branches list` prints a create hint instead of an empty table when an app has
  no branches.
- `CreateBranch` resolves the app the same way as the other commands.

## Why

`nuon apps branches list` errored out unless you passed `--app-id` explicitly,
even with an app already selected, and passing an app *name* hit the API raw and
404'd.