### PR TITLE
fix: Record helm kinds on plan runs

### DIFF
--- a/bins/runner/internal/jobs/deploy/helm/exec.go
+++ b/bins/runner/internal/jobs/deploy/helm/exec.go
@@ -19,6 +19,19 @@ import (
 	pkgop "github.com/nuonco/nuon/pkg/runner/op"
 )
 
+// renderedManifest is what the chart produced this run: the applied release when
+// there is one, otherwise the plan's template output. An uninstall renders the
+// objects being removed, so it is skipped rather than recorded as owned.
+func renderedManifest(rel *release.Release, plan HelmPlanContents) string {
+	if rel != nil {
+		return rel.Manifest
+	}
+	if plan.Op == "uninstall" {
+		return ""
+	}
+	return plan.TemplateOutput
+}
+
 // Use the common diff package for the plan contents
 type HelmPlanContents struct {
 	Diff           string              `json:"plan"`
@@ -203,10 +216,15 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 
 	// Hand the rendered kinds to the health engine: a chart shipping only custom
 	// resources is otherwise invisible, since nothing else knows to list them.
-	// This is the only place the manifest is readable — it lives in the release
-	// secret, which health's identity is deliberately denied.
-	if h.manifestKinds != nil && rel != nil {
-		h.manifestKinds.Set(h.state.plan.ComponentID, rel.Manifest)
+	// The release secret is the only other copy and health is denied secret
+	// reads, so the deploy is where this has to happen.
+	//
+	// Plan-only runs count too: a drift check renders the chart without applying
+	// it, which is how a component picks up its kinds without being redeployed.
+	if h.manifestKinds != nil {
+		if manifest := renderedManifest(rel, helmPlan); manifest != "" {
+			h.manifestKinds.Set(h.state.plan.ComponentID, manifest)
+		}
 	}
 
 	var apiRes *models.ServiceCreateRunnerJobExecutionResultRequest

--- a/bins/runner/internal/jobs/deploy/helm/rendered_manifest_test.go
+++ b/bins/runner/internal/jobs/deploy/helm/rendered_manifest_test.go
@@ -1,0 +1,36 @@
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	release "helm.sh/helm/v4/pkg/release/v1"
+)
+
+// A drift check renders the chart with PlanOnly, so the kinds are knowable
+// without applying — that is what lets a component pick up its custom resource
+// kinds without being redeployed.
+func TestRenderedManifestUsesPlanOutput(t *testing.T) {
+	const applied = "kind: NodePool\n"
+	const planned = "kind: EC2NodeClass\n"
+
+	t.Run("an applied release wins", func(t *testing.T) {
+		got := renderedManifest(&release.Release{Manifest: applied},
+			HelmPlanContents{Op: "upgrade", TemplateOutput: planned})
+		assert.Equal(t, applied, got)
+	})
+
+	t.Run("plan-only falls back to the template output", func(t *testing.T) {
+		got := renderedManifest(nil, HelmPlanContents{Op: "upgrade", TemplateOutput: planned})
+		assert.Equal(t, planned, got)
+	})
+
+	t.Run("an uninstall plan records nothing", func(t *testing.T) {
+		got := renderedManifest(nil, HelmPlanContents{Op: "uninstall", TemplateOutput: planned})
+		assert.Empty(t, got, "objects being removed are not owned kinds")
+	})
+
+	t.Run("no release and no output", func(t *testing.T) {
+		assert.Empty(t, renderedManifest(nil, HelmPlanContents{Op: "install"}))
+	})
+}


### PR DESCRIPTION
A component's custom resource kinds are only watchable once a deploy records them, so a chart shipping only CRs — a Karpenter NodePool, a ClickHouseInstallation — reports nothing until it is redeployed. That left ~140 prod installs waiting on a deploy they had no other reason to run.

A drift check already renders the chart with `PlanOnly: true`, which produces the same manifest an apply would. Recording from that closes the gap without applying anything: a scheduled drift scan is enough for a component to pick up its kinds, and keeps them current when a chart adds one later. `kubernetes_manifest` components already recorded on plan; this brings helm in line. An uninstall plan is skipped, since objects being removed are not owned kinds.

Terraform still needs an apply — a plan yields a diff, not state.