### PR TITLE
build: add Git to ctl-api runtime

### DIFF
--- a/images/go-base/Dockerfile-awsauth-cacert.runtime
+++ b/images/go-base/Dockerfile-awsauth-cacert.runtime
@@ -26,4 +26,4 @@ COPY --from=aws-iam-authenticator /bin/aws-iam-authenticator /usr/local/bin/aws-
 COPY --from=certs /global-bundle.pem /etc/ssl/cert.pem
 
 # Install basic runtime dependencies
-RUN apk add --update --no-cache ca-certificates
+RUN apk add --update --no-cache ca-certificates git


### PR DESCRIPTION
## Summary

Control-plane component builds can now invoke Git when Terraform modules or Kustomize remote resources require it.

## What stays the same

Initial repository checkout continues to use the existing Go Git implementation. This only adds the Git executable to the shared ctl-api runtime image.