### PR TITLE
feat(ctl-api): ctl-api preflight 

### DIFF
--- a/services/ctl-api/cmd/preflight.go
+++ b/services/ctl-api/cmd/preflight.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/preflight"
+)
+
+func (c *cli) registerPreflight() {
+	cmd := &cobra.Command{
+		Use:   "preflight [checks...]",
+		Short: "validate configuration and service connectivity",
+		Long: `Run preflight checks to validate that required configuration is present
+and that external services (database, temporal, auth providers, etc.) are reachable.
+
+With no arguments, all checks are run. Pass check names to run a subset.
+Checks that do not apply to this deployment report as skipped.
+
+--json emits a machine-readable report on stdout, for both runs and --list.
+Secret values are never included: each field reports only whether it is set.
+
+Available checks: ` + strings.Join(preflight.Names(), ", "),
+		Run: runPreflight,
+	}
+	cmd.Flags().Bool("list", false, "list checks and the config they read, without connecting")
+	cmd.Flags().Bool("json", false, "emit JSON instead of a table")
+	rootCmd.AddCommand(cmd)
+}
+
+func runPreflight(cmd *cobra.Command, args []string) {
+	// Deliberately not internal.NewConfig: it validates the whole struct up
+	// front, so a single missing field would abort before any check could
+	// report which ones are actually wrong.
+	cfg, err := preflight.LoadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+
+	asJSON, _ := cmd.Flags().GetBool("json")
+
+	if list, _ := cmd.Flags().GetBool("list"); list {
+		described := preflight.Describe(cfg, args)
+		if asJSON {
+			if err := preflight.WriteJSONChecks(os.Stdout, described); err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				os.Exit(2)
+			}
+
+			return
+		}
+
+		preflight.PrintChecks(os.Stdout, described)
+
+		return
+	}
+
+	results := preflight.Run(context.Background(), cfg, args)
+	if asJSON {
+		os.Exit(preflight.WriteJSONResults(os.Stdout, results))
+	}
+
+	os.Exit(preflight.PrintResults(os.Stdout, results))
+}

--- a/services/ctl-api/cmd/root.go
+++ b/services/ctl-api/cmd/root.go
@@ -20,6 +20,7 @@ func Execute() {
 	c.registerWorker()
 	c.registerConsumer()
 	c.registerStartup()
+	c.registerPreflight()
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(2)

--- a/services/ctl-api/internal/pkg/db/psql/conn_config.go
+++ b/services/ctl-api/internal/pkg/db/psql/conn_config.go
@@ -1,0 +1,36 @@
+package psql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"moul.io/zapgorm2"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+// ConnConfig returns the connection config the service itself would use to
+// reach host, resolving an IAM auth token when db_use_iam is set.
+//
+// Exported for preflight: a caller that builds its own password DSN would
+// exercise a credential path the service may never take, so a passing check
+// would say nothing about whether the service can connect.
+func ConnConfig(ctx context.Context, cfg *internal.Config, host string) (*pgx.ConnConfig, error) {
+	d, err := newDatabase(cfg, zapgorm2.Logger{}, nil, nil, host)
+	if err != nil {
+		return nil, fmt.Errorf("unable to build database config: %w", err)
+	}
+	defer d.poolCtxCancel()
+
+	connCfg, err := d.connCfg()
+	if err != nil {
+		return nil, fmt.Errorf("unable to build connection config: %w", err)
+	}
+
+	if err := d.beforeConnect(ctx, connCfg); err != nil {
+		return nil, fmt.Errorf("unable to resolve database password: %w", err)
+	}
+
+	return connCfg, nil
+}

--- a/services/ctl-api/internal/preflight/check_aws.go
+++ b/services/ctl-api/internal/preflight/check_aws.go
@@ -1,0 +1,67 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/nuonco/nuon/pkg/aws/credentials"
+	internal "github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+var awsCheck = Check{
+	Name:        "aws",
+	Description: "management account role assumption",
+
+	// The management ARNs are validated per-cloud in internal.NewConfig, so on a
+	// GCP or Azure control plane they are legitimately empty.
+	Skip: func(cfg *internal.Config) (string, bool) {
+		if !cfg.IsAWS() {
+			return "cloud_provider=" + cfg.CloudProvider, true
+		}
+
+		return "", false
+	},
+
+	Fields: func(cfg *internal.Config) []Field {
+		return []Field{
+			{Name: "management_iam_role_arn", Value: cfg.ManagementIAMRoleARN, Required: true},
+			{Name: "management_account_id", Value: cfg.ManagementAccountID, Required: true},
+			{Name: "management_ecr_registry_id", Value: cfg.ManagementECRRegistryID, Required: true},
+			{Name: "management_ecr_registry_arn", Value: cfg.ManagementECRRegistryARN},
+			{Name: "blob_storage_region", Value: cfg.BlobStorageRegion},
+		}
+	},
+
+	Probe: func(ctx context.Context, cfg *internal.Config) (string, error) {
+		awsCfg, err := credentials.Fetch(ctx, &credentials.Config{
+			Region: cfg.BlobStorageRegion,
+			AssumeRole: &credentials.AssumeRoleConfig{
+				RoleARN:                cfg.ManagementIAMRoleARN,
+				SessionName:            "ctl-api-preflight",
+				SessionDurationSeconds: 15 * 60,
+			},
+		})
+		if err != nil {
+			return "", fmt.Errorf("unable to assume %s: %w", cfg.ManagementIAMRoleARN, err)
+		}
+
+		identity, err := sts.NewFromConfig(awsCfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+		if err != nil {
+			return "", fmt.Errorf("sts:GetCallerIdentity failed: %w", err)
+		}
+
+		// A valid role in the wrong account is the misconfiguration that a bare
+		// GetCallerIdentity would report as healthy.
+		account := aws.ToString(identity.Account)
+		if account != cfg.ManagementAccountID {
+			return "", fmt.Errorf("assumed role is in account %s, expected management_account_id=%s",
+				account, cfg.ManagementAccountID)
+		}
+
+		return fmt.Sprintf("assumed role %s", summary("account", account,
+			"arn", aws.ToString(identity.Arn))), nil
+	},
+}

--- a/services/ctl-api/internal/preflight/check_blobstore.go
+++ b/services/ctl-api/internal/preflight/check_blobstore.go
@@ -1,0 +1,57 @@
+package preflight
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"cloud.google.com/go/storage"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	internal "github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
+)
+
+// probeKey is never written. A not-found response still proves the bucket
+// resolves and the credentials carry read access, which is what we want to
+// verify without mutating the bucket.
+const probeKey = ".nuon-preflight-probe"
+
+var blobstoreCheck = Check{
+	Name:        "blobstore",
+	Description: "blob storage bucket access",
+
+	Fields: func(cfg *internal.Config) []Field {
+		return []Field{
+			{Name: "blob_storage_provider", Value: cfg.BlobStorageProvider, Required: true},
+			{Name: "blob_storage_bucket", Value: cfg.BlobStorageBucket, Required: true},
+			{Name: "blob_storage_region", Value: cfg.BlobStorageRegion, Required: true},
+		}
+	},
+
+	Probe: func(ctx context.Context, cfg *internal.Config) (string, error) {
+		svc, err := blobstore.NewService(cfg, nopMetrics())
+		if err != nil {
+			return "", fmt.Errorf("unable to build blob storage client: %w", err)
+		}
+
+		_, _, err = svc.GetMetadata(ctx, probeKey)
+		if err != nil && !isNotFound(err) {
+			return "", fmt.Errorf("bucket unreachable: %w", err)
+		}
+
+		return fmt.Sprintf("bucket reachable %s", summary(
+			"provider", cfg.BlobStorageProvider,
+			"bucket", cfg.BlobStorageBucket,
+			"region", cfg.BlobStorageRegion)), nil
+	},
+}
+
+func isNotFound(err error) bool {
+	var notFound *types.NotFound
+	var noSuchKey *types.NoSuchKey
+
+	return errors.As(err, &notFound) ||
+		errors.As(err, &noSuchKey) ||
+		errors.Is(err, storage.ErrObjectNotExist)
+}

--- a/services/ctl-api/internal/preflight/check_clickhouse.go
+++ b/services/ctl-api/internal/preflight/check_clickhouse.go
@@ -1,0 +1,68 @@
+package preflight
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"strconv"
+
+	clickhousecore "github.com/ClickHouse/clickhouse-go/v2"
+
+	internal "github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+var clickhouseCheck = Check{
+	Name:        "clickhouse",
+	Description: "clickhouse connectivity",
+
+	Fields: func(cfg *internal.Config) []Field {
+		return []Field{
+			{Name: "clickhouse_db_host", Value: cfg.ClickhouseDBHost, Required: true},
+			{Name: "clickhouse_db_port", Value: cfg.ClickhouseDBPort, Required: true},
+			{Name: "clickhouse_db_name", Value: cfg.ClickhouseDBName, Required: true},
+			{Name: "clickhouse_db_user", Value: cfg.ClickhouseDBUser, Required: true},
+			{Name: "clickhouse_db_password", Value: cfg.ClickhouseDBPassword, Required: true, Secret: true},
+			{Name: "clickhouse_db_use_tls", Value: strconv.FormatBool(cfg.ClickhouseDBUseTLS)},
+			{Name: "clickhouse_db_dial_timeout", Value: cfg.ClickhouseDBDialTimeout.String()},
+			{Name: "clickhouse_db_read_timeout", Value: cfg.ClickhouseDBReadTimeout.String()},
+			{Name: "clickhouse_db_write_timeout", Value: cfg.ClickhouseDBWriteTimeout.String()},
+		}
+	},
+
+	Probe: func(ctx context.Context, cfg *internal.Config) (string, error) {
+		var tlsCfg *tls.Config
+		if cfg.ClickhouseDBUseTLS {
+			tlsCfg = &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // matches internal/pkg/db/ch
+			}
+		}
+
+		conn, err := clickhousecore.Open(&clickhousecore.Options{
+			Addr: []string{fmt.Sprintf("%s:%s", cfg.ClickhouseDBHost, cfg.ClickhouseDBPort)},
+			Auth: clickhousecore.Auth{
+				Database: cfg.ClickhouseDBName,
+				Username: cfg.ClickhouseDBUser,
+				Password: cfg.ClickhouseDBPassword,
+			},
+			TLS:         tlsCfg,
+			DialTimeout: cfg.ClickhouseDBDialTimeout,
+			ReadTimeout: cfg.ClickhouseDBReadTimeout,
+		})
+		if err != nil {
+			return "", fmt.Errorf("open failed: %w", err)
+		}
+		defer conn.Close()
+
+		if err := conn.Ping(ctx); err != nil {
+			return "", fmt.Errorf("ping failed: %w", err)
+		}
+
+		var version string
+		if err := conn.QueryRow(ctx, "SELECT version()").Scan(&version); err != nil {
+			return "", fmt.Errorf("query failed: %w", err)
+		}
+
+		return fmt.Sprintf("ClickHouse %s %s", version,
+			summary("host", cfg.ClickhouseDBHost+":"+cfg.ClickhouseDBPort)), nil
+	},
+}

--- a/services/ctl-api/internal/preflight/check_github.go
+++ b/services/ctl-api/internal/preflight/check_github.go
@@ -1,0 +1,37 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-playground/validator/v10"
+
+	internal "github.com/nuonco/nuon/services/ctl-api/internal"
+	ctlgithub "github.com/nuonco/nuon/services/ctl-api/internal/pkg/github"
+)
+
+var githubCheck = Check{
+	Name:        "github",
+	Description: "github app credentials",
+
+	Fields: func(cfg *internal.Config) []Field {
+		return []Field{
+			{Name: "github_app_id", Value: cfg.GithubAppID, Required: true},
+			{Name: "github_app_key", Value: cfg.GithubAppKey, Required: true, Secret: true},
+			{Name: "github_app_key_secret_name", Value: cfg.GithubAppKeySecretName},
+			{Name: "integration_github_install_id", Value: cfg.IntegrationGithubInstallID},
+		}
+	},
+
+	// Offline: building the client parses and validates the PEM key, which is
+	// the failure this catches. A live API call would need an installation
+	// token, which is per-repo rather than config.
+	Probe: func(_ context.Context, cfg *internal.Config) (string, error) {
+		if _, err := ctlgithub.New(validator.New(), cfg); err != nil {
+			return "", fmt.Errorf("invalid github app credentials: %w", err)
+		}
+
+		return fmt.Sprintf("app key valid %s",
+			summary("app_id", cfg.GithubAppID)), nil
+	},
+}

--- a/services/ctl-api/internal/preflight/check_kafka.go
+++ b/services/ctl-api/internal/preflight/check_kafka.go
@@ -1,0 +1,68 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	pkgkafka "github.com/nuonco/nuon/pkg/kafka"
+	internal "github.com/nuonco/nuon/services/ctl-api/internal"
+	ctlkafka "github.com/nuonco/nuon/services/ctl-api/internal/pkg/kafka"
+)
+
+const kafkaSSLProtocol = "SSL"
+
+var kafkaCheck = Check{
+	Name:        "kafka",
+	Description: "kafka broker connectivity",
+
+	Skip: func(cfg *internal.Config) (string, bool) {
+		if !cfg.KafkaEnabled {
+			return "kafka_enabled=false", true
+		}
+
+		return "", false
+	},
+
+	Fields: func(cfg *internal.Config) []Field {
+		usesTLS := strings.EqualFold(cfg.KafkaSecurityProtocol, kafkaSSLProtocol)
+
+		return []Field{
+			{Name: "kafka_brokers", Value: cfg.KafkaBrokers, Required: true},
+			{Name: "kafka_security_protocol", Value: cfg.KafkaSecurityProtocol, Required: true},
+			{Name: "kafka_client_id", Value: ctlkafka.ClientID(cfg)},
+			{Name: "kafka_tls_ca_path", Value: cfg.KafkaTLSCAPath, Required: usesTLS},
+			{Name: "kafka_tls_cert_path", Value: cfg.KafkaTLSCertPath, Required: usesTLS},
+			{Name: "kafka_tls_key_path", Value: cfg.KafkaTLSKeyPath, Required: usesTLS},
+			{Name: "kafka_consumer_group_prefix", Value: cfg.KafkaConsumerGroupPrefix},
+		}
+	},
+
+	Probe: func(ctx context.Context, cfg *internal.Config) (string, error) {
+		if strings.EqualFold(cfg.KafkaSecurityProtocol, kafkaSSLProtocol) {
+			// Checked before dialling: a missing mount surfaces as an opaque
+			// handshake error otherwise.
+			for _, path := range []string{cfg.KafkaTLSCAPath, cfg.KafkaTLSCertPath, cfg.KafkaTLSKeyPath} {
+				if _, err := os.Stat(path); err != nil {
+					return "", fmt.Errorf("TLS material unreadable: %w", err)
+				}
+			}
+		}
+
+		producer, err := pkgkafka.NewProducer(ctlkafka.ClientConfig(cfg), nopLogger(), nopMetrics())
+		if err != nil {
+			return "", fmt.Errorf("unable to build producer: %w", err)
+		}
+		defer producer.Close()
+
+		if err := producer.Ping(ctx); err != nil {
+			return "", fmt.Errorf("ping failed: %w", err)
+		}
+
+		return fmt.Sprintf("brokers reachable %s", summary(
+			"brokers", cfg.KafkaBrokers,
+			"protocol", cfg.KafkaSecurityProtocol,
+			"client_id", ctlkafka.ClientID(cfg))), nil
+	},
+}

--- a/services/ctl-api/internal/preflight/check_nuon_auth.go
+++ b/services/ctl-api/internal/preflight/check_nuon_auth.go
@@ -1,0 +1,111 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	internal "github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/auth/providers"
+)
+
+// The three provider types the auth service accepts. Kept in step with
+// getDefaultIdentityProvider in internal/app/auth/service/identity_providers.go,
+// which is what actually refuses to start on an unknown type.
+const (
+	providerTypeOIDC   = "oidc"
+	providerTypeGoogle = "google"
+	providerTypeGitHub = "github"
+)
+
+var nuonAuthCheck = Check{
+	Name:        "nuon-auth",
+	Description: "nuon auth identity provider",
+
+	// nuon_auth_provider_type is documented as becoming required once auth is
+	// GA; until then an entirely unset block means the feature is off, not
+	// misconfigured.
+	Skip: func(cfg *internal.Config) (string, bool) {
+		if cfg.NuonAuthIssuerURL == "" && cfg.NuonAuthProviderType == "" {
+			return "nuon auth not configured", true
+		}
+
+		return "", false
+	},
+
+	Fields: func(cfg *internal.Config) []Field {
+		return []Field{
+			{Name: "nuon_auth_provider_type", Value: cfg.NuonAuthProviderType, Required: true},
+			// Google and GitHub have fixed OAuth endpoints baked into their
+			// providers, so only a generic OIDC provider needs an issuer to
+			// discover from.
+			{
+				Name:     "nuon_auth_issuer_url",
+				Value:    cfg.NuonAuthIssuerURL,
+				Required: needsIssuerURL(cfg.NuonAuthProviderType),
+			},
+			{Name: "nuon_auth_client_id", Value: cfg.NuonAuthClientID, Required: true},
+			{Name: "nuon_auth_client_secret", Value: cfg.NuonAuthClientSecret, Required: true, Secret: true},
+			{Name: "nuon_auth_redirect_url", Value: cfg.NuonAuthRedirectURL, Required: true},
+			{Name: "nuon_auth_session_key", Value: cfg.NuonAuthSessionKey, Required: true, Secret: true},
+		}
+	},
+
+	Probe: func(_ context.Context, cfg *internal.Config) (string, error) {
+		providerCfg := &providers.ProviderConfig{
+			ClientID:     cfg.NuonAuthClientID,
+			ClientSecret: cfg.NuonAuthClientSecret,
+			RedirectURL:  cfg.NuonAuthRedirectURL,
+			IssuerURL:    cfg.NuonAuthIssuerURL,
+			Logger:       nopLogger(),
+		}
+
+		switch cfg.NuonAuthProviderType {
+		case providerTypeGoogle:
+			if err := providers.NewGoogleProvider().Configure(providerCfg); err != nil {
+				return "", fmt.Errorf("google provider config invalid: %w", err)
+			}
+
+			return "", warnf("google credentials present but unverified: fixed endpoints, nothing to discover %s",
+				summary("client_id", cfg.NuonAuthClientID))
+
+		case providerTypeGitHub:
+			if err := providers.NewGitHubProvider().Configure(providerCfg); err != nil {
+				return "", fmt.Errorf("github provider config invalid: %w", err)
+			}
+
+			return "", warnf("github credentials present but unverified: fixed endpoints, nothing to discover %s",
+				summary("client_id", cfg.NuonAuthClientID))
+
+		case providerTypeOIDC:
+			// Configure runs discovery against the issuer, so this is the one
+			// provider type preflight can genuinely confirm.
+			provider := providers.NewOpenIDProvider()
+			if err := provider.Configure(providerCfg); err != nil {
+				return "", fmt.Errorf("OIDC discovery failed: %w", err)
+			}
+
+			discovery := provider.GetDiscoveryConfig()
+			if discovery == nil {
+				return "", fmt.Errorf("OIDC discovery returned no configuration")
+			}
+
+			return fmt.Sprintf("OIDC discovery OK %s", summary("issuer", discovery.Issuer)), nil
+
+		default:
+			return "", fmt.Errorf("invalid nuon_auth_provider_type: %q (must be %s, %s, or %s)",
+				cfg.NuonAuthProviderType, providerTypeOIDC, providerTypeGoogle, providerTypeGitHub)
+		}
+	},
+}
+
+// needsIssuerURL reports whether the provider type discovers its endpoints.
+// An unset type is treated as OIDC so a half-configured generic provider still
+// reports the missing issuer rather than an opaque type error.
+func needsIssuerURL(providerType string) bool {
+	switch providerType {
+	case providerTypeGoogle, providerTypeGitHub:
+		return false
+	default:
+		return true
+	}
+}

--- a/services/ctl-api/internal/preflight/check_rds.go
+++ b/services/ctl-api/internal/preflight/check_rds.go
@@ -1,0 +1,59 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/jackc/pgx/v5"
+
+	internal "github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/psql"
+)
+
+var rdsCheck = Check{
+	Name:        "rds",
+	Description: "postgres connectivity",
+
+	Fields: func(cfg *internal.Config) []Field {
+		return []Field{
+			{Name: "db_host", Value: cfg.DBHost, Required: true},
+			{Name: "db_port", Value: cfg.DBPort, Required: true},
+			{Name: "db_name", Value: cfg.DBName, Required: true},
+			{Name: "db_user", Value: cfg.DBUser, Required: true},
+			{Name: "db_ssl_mode", Value: cfg.DBSSLMode, Required: true},
+			{Name: "db_use_iam", Value: strconv.FormatBool(cfg.DBUseIAM)},
+			// Exactly one credential path applies: an IAM token is minted per
+			// connection, otherwise the static password is used.
+			{Name: "db_password", Value: cfg.DBPassword, Required: !cfg.DBUseIAM, Secret: true},
+			{Name: "db_region", Value: cfg.DBRegion, Required: cfg.DBUseIAM},
+			{Name: "cloud_provider", Value: cfg.CloudProvider},
+		}
+	},
+
+	Probe: func(ctx context.Context, cfg *internal.Config) (string, error) {
+		connCfg, err := psql.ConnConfig(ctx, cfg, cfg.DBHost)
+		if err != nil {
+			return "", err
+		}
+
+		conn, err := pgx.ConnectConfig(ctx, connCfg)
+		if err != nil {
+			return "", fmt.Errorf("connection failed: %w", err)
+		}
+		defer conn.Close(ctx)
+
+		var version string
+		if err := conn.QueryRow(ctx, "SELECT version()").Scan(&version); err != nil {
+			return "", fmt.Errorf("query failed: %w", err)
+		}
+
+		auth := "password"
+		if cfg.DBUseIAM {
+			auth = "iam"
+		}
+
+		return fmt.Sprintf("%s %s", truncate(version, 40),
+			summary("host", cfg.DBHost+":"+cfg.DBPort, "auth", auth)), nil
+	},
+}

--- a/services/ctl-api/internal/preflight/check_slack.go
+++ b/services/ctl-api/internal/preflight/check_slack.go
@@ -1,0 +1,94 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	svcconfig "github.com/nuonco/nuon/pkg/services/config"
+	internal "github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+// Dev-only defaults registered in internal/config.go so the slack fx module can
+// build without SLACK_* set. Reaching a deployed environment with either still
+// in place means signed-webhook verification is trivially forgeable.
+const (
+	devSlackSigningSecret  = "insecure-slack-signing-secret-for-dev-only"
+	devSlackStateJWTSecret = "insecure-slack-state-jwt-secret-for-dev-only"
+)
+
+func devPlaceholders(cfg *internal.Config) []string {
+	var found []string
+	if cfg.SlackSigningSecret == devSlackSigningSecret {
+		found = append(found, "slack_signing_secret")
+	}
+	if cfg.SlackStateJWTSecret == devSlackStateJWTSecret {
+		found = append(found, "slack_state_jwt_secret")
+	}
+
+	return found
+}
+
+var slackCheck = Check{
+	Name:        "slack",
+	Description: "slack app configuration",
+
+	// The whole integration is optional: no client id means no slack app, which
+	// is a supported deployment rather than a misconfiguration.
+	Skip: func(cfg *internal.Config) (string, bool) {
+		if cfg.SlackClientID == "" {
+			return "slack app not configured", true
+		}
+
+		return "", false
+	},
+
+	// Only the two values with no registered default can actually be missing;
+	// the signing and state secrets always hold at least their dev default, so
+	// the placeholder comparison in Probe is what covers them.
+	Fields: func(cfg *internal.Config) []Field {
+		return []Field{
+			{Name: "slack_client_id", Value: cfg.SlackClientID},
+			{Name: "slack_client_secret", Value: cfg.SlackClientSecret, Required: true, Secret: true},
+			{Name: "slack_signing_secret", Value: cfg.SlackSigningSecret, Secret: true},
+			{Name: "slack_state_jwt_secret", Value: cfg.SlackStateJWTSecret, Secret: true},
+			{Name: "slack_oauth_redirect_url", Value: cfg.SlackOAuthRedirectURL, Required: true},
+			{Name: "slack_http_port", Value: cfg.SlackHTTPPort},
+		}
+	},
+
+	// No live Slack call: every Slack API method needs a per-workspace token
+	// held in the database, not in config. What config alone can be wrong about
+	// is placeholder secrets and a malformed redirect URL.
+	Probe: func(_ context.Context, cfg *internal.Config) (string, error) {
+		redirect, err := url.Parse(cfg.SlackOAuthRedirectURL)
+		if err != nil {
+			return "", fmt.Errorf("slack_oauth_redirect_url is not a valid URL: %w", err)
+		}
+		if redirect.Scheme != "https" || redirect.Host == "" {
+			return "", fmt.Errorf("slack_oauth_redirect_url must be an absolute https URL, got %q",
+				cfg.SlackOAuthRedirectURL)
+		}
+
+		// Production supplies these explicitly, so a value still equal to the
+		// registered dev default there means webhook signature verification is
+		// forgeable. Everywhere else the default is the intended value, and a
+		// laptop reports whatever env its configmap carries — so warn rather
+		// than fail outside production.
+		if placeholders := devPlaceholders(cfg); len(placeholders) > 0 {
+			joined := strings.Join(placeholders, ", ")
+			if cfg.Env == svcconfig.Production {
+				return "", fmt.Errorf("insecure dev default in production for %s", joined)
+			}
+
+			return "", warnf("insecure dev default still in place for %s %s",
+				joined, summary("env", cfg.Env.String()))
+		}
+
+		// Same shape as the google/github auth providers: everything config can
+		// be wrong about is checked, but nothing confirms Slack accepts it.
+		return "", warnf("config valid but unverified: no live API call without a workspace token %s",
+			summary("client_id", cfg.SlackClientID, "redirect", redirect.Host))
+	},
+}

--- a/services/ctl-api/internal/preflight/check_temporal.go
+++ b/services/ctl-api/internal/preflight/check_temporal.go
@@ -1,0 +1,45 @@
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-playground/validator/v10"
+	tclient "go.temporal.io/sdk/client"
+
+	temporalclient "github.com/nuonco/nuon/pkg/temporal/client"
+	internal "github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+var temporalCheck = Check{
+	Name:        "temporal",
+	Description: "temporal server health",
+
+	Fields: func(cfg *internal.Config) []Field {
+		return []Field{
+			{Name: "temporal_host", Value: cfg.TemporalHost, Required: true},
+			{Name: "temporal_namespace", Value: cfg.TemporalNamespace},
+		}
+	},
+
+	// Dials and calls CheckHealth rather than opening a TCP socket: a listening
+	// port proves nothing about whether the frontend service is actually serving.
+	Probe: func(ctx context.Context, cfg *internal.Config) (string, error) {
+		client, err := temporalclient.New(validator.New(),
+			temporalclient.WithAddr(cfg.TemporalHost),
+			temporalclient.WithNamespace(cfg.TemporalNamespace),
+			temporalclient.WithLogger(nopLogger()),
+		)
+		if err != nil {
+			return "", fmt.Errorf("dial failed: %w", err)
+		}
+		defer client.Close()
+
+		if _, err := client.CheckHealth(ctx, &tclient.CheckHealthRequest{}); err != nil {
+			return "", fmt.Errorf("health check failed: %w", err)
+		}
+
+		return fmt.Sprintf("healthy %s",
+			summary("host", cfg.TemporalHost, "namespace", cfg.TemporalNamespace)), nil
+	},
+}

--- a/services/ctl-api/internal/preflight/deps.go
+++ b/services/ctl-api/internal/preflight/deps.go
@@ -1,0 +1,35 @@
+package preflight
+
+import (
+	"time"
+
+	"github.com/go-playground/validator/v10"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/pkg/metrics"
+)
+
+// probeTimeout bounds a single check so one unreachable dependency cannot stall
+// the whole run.
+const probeTimeout = 10 * time.Second
+
+// Preflight runs outside the fx graph — it has to work when config is broken
+// enough that fx boot would fail — so the shared constructors it reuses get
+// throwaway no-op dependencies instead of the real logger and metrics writer.
+
+func nopLogger() *zap.Logger { return zap.NewNop() }
+
+// WithLogger is not optional here: metrics.New otherwise builds its own
+// development logger, whose debug lines would interleave with the results table.
+func nopMetrics() metrics.Writer {
+	mw, err := metrics.New(validator.New(),
+		metrics.WithDisable(true),
+		metrics.WithLogger(nopLogger()),
+	)
+	if err != nil {
+		// Neither option can fail validation, so this is unreachable.
+		return nil
+	}
+
+	return mw
+}

--- a/services/ctl-api/internal/preflight/json.go
+++ b/services/ctl-api/internal/preflight/json.go
@@ -1,0 +1,121 @@
+package preflight
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// The JSON shape is a deliberate DTO rather than tags on Result and Field.
+// Field.Value holds raw config, secrets included, so marshalling it directly
+// would make a leak one forgotten tag away. Here a secret has nowhere to go.
+type jsonReport struct {
+	Checks  []jsonCheck  `json:"checks"`
+	Summary *jsonSummary `json:"summary,omitempty"`
+}
+
+type jsonCheck struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	// Absent for --list, which resolves fields without running anything.
+	Status Status      `json:"status,omitempty"`
+	Detail string      `json:"detail,omitempty"`
+	Fields []jsonField `json:"fields"`
+}
+
+type jsonField struct {
+	Name     string `json:"name"`
+	Required bool   `json:"required"`
+	Secret   bool   `json:"secret"`
+	// Set separates "configured" from "empty" without publishing the value,
+	// which is the only thing callers need for a secret.
+	Set   bool   `json:"set"`
+	Value string `json:"value,omitempty"`
+}
+
+type jsonSummary struct {
+	Passed  int `json:"passed"`
+	Warned  int `json:"warned"`
+	Failed  int `json:"failed"`
+	Skipped int `json:"skipped"`
+}
+
+// WriteJSONResults emits a run as JSON and returns the process exit code, using
+// the same rule as the table: only a failure is non-zero.
+func WriteJSONResults(w io.Writer, results []Result) int {
+	summary := summarize(results)
+	if err := writeJSON(w, jsonReport{Checks: toJSONChecks(results), Summary: &summary}); err != nil {
+		fmt.Fprintf(w, "unable to encode results: %v\n", err)
+
+		return 2
+	}
+
+	if summary.Failed > 0 {
+		return 1
+	}
+
+	return 0
+}
+
+// WriteJSONChecks emits the check catalogue as JSON. No summary: nothing ran.
+func WriteJSONChecks(w io.Writer, results []Result) error {
+	return writeJSON(w, jsonReport{Checks: toJSONChecks(results)})
+}
+
+func writeJSON(w io.Writer, report jsonReport) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	return enc.Encode(report)
+}
+
+func toJSONChecks(results []Result) []jsonCheck {
+	checks := make([]jsonCheck, 0, len(results))
+	for _, r := range results {
+		checks = append(checks, jsonCheck{
+			Name:        r.Name,
+			Description: r.Description,
+			Status:      r.Status,
+			Detail:      r.Detail,
+			Fields:      toJSONFields(r.Fields),
+		})
+	}
+
+	return checks
+}
+
+func toJSONFields(fields []Field) []jsonField {
+	out := make([]jsonField, 0, len(fields))
+	for _, f := range fields {
+		jf := jsonField{
+			Name:     f.Name,
+			Required: f.Required,
+			Secret:   f.Secret,
+			Set:      f.Value != "",
+		}
+		if !f.Secret {
+			jf.Value = f.Value
+		}
+		out = append(out, jf)
+	}
+
+	return out
+}
+
+func summarize(results []Result) jsonSummary {
+	var s jsonSummary
+	for _, r := range results {
+		switch r.Status {
+		case StatusPass:
+			s.Passed++
+		case StatusWarn:
+			s.Warned++
+		case StatusFail:
+			s.Failed++
+		case StatusSkipped:
+			s.Skipped++
+		}
+	}
+
+	return s
+}

--- a/services/ctl-api/internal/preflight/json_test.go
+++ b/services/ctl-api/internal/preflight/json_test.go
@@ -1,0 +1,142 @@
+package preflight
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	internal "github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+// The whole point of the DTO: no path through the encoder can publish a secret.
+// Runs over every real check so a new one cannot opt out by accident.
+func TestJSONNeverEmitsSecretValues(t *testing.T) {
+	const sentinel = "SUPER-SECRET-SENTINEL"
+
+	cfg := &internal.Config{
+		DBPassword:            sentinel,
+		ClickhouseDBPassword:  sentinel,
+		GithubAppKey:          sentinel,
+		NuonAuthClientSecret:  sentinel,
+		NuonAuthSessionKey:    sentinel,
+		NuonAuthProviderType:  "google",
+		NuonAuthClientID:      "client-id",
+		NuonAuthRedirectURL:   "https://example.com/cb",
+		SlackClientID:         "client-id",
+		SlackClientSecret:     sentinel,
+		SlackSigningSecret:    sentinel,
+		SlackStateJWTSecret:   sentinel,
+		SlackOAuthRedirectURL: "https://example.com/slack",
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteJSONChecks(&buf, Describe(cfg, nil)))
+
+	assert.NotContains(t, buf.String(), sentinel)
+
+	// ...and the secrets really were present, so the assertion above means
+	// something.
+	var report jsonReport
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &report))
+
+	var secretsSeen int
+	for _, c := range report.Checks {
+		for _, f := range c.Fields {
+			if f.Secret {
+				secretsSeen++
+				assert.Empty(t, f.Value, "%s.%s published a value", c.Name, f.Name)
+			}
+		}
+	}
+	assert.Positive(t, secretsSeen, "no secret fields exercised")
+}
+
+// set distinguishes configured-but-hidden from absent, which is all a caller
+// can learn about a secret.
+func TestJSONSetFlagTracksPresenceForSecrets(t *testing.T) {
+	fields := toJSONFields([]Field{
+		{Name: "with_value", Value: "v", Secret: true},
+		{Name: "without_value", Secret: true},
+		{Name: "plain", Value: "visible"},
+	})
+
+	assert.True(t, fields[0].Set)
+	assert.Empty(t, fields[0].Value)
+
+	assert.False(t, fields[1].Set)
+	assert.Empty(t, fields[1].Value)
+
+	assert.True(t, fields[2].Set)
+	assert.Equal(t, "visible", fields[2].Value)
+}
+
+// --list did not run anything, so it must not claim a status or a tally.
+func TestJSONChecksOmitStatusAndSummary(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, WriteJSONChecks(&buf, Describe(&internal.Config{}, []string{"rds"})))
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &raw))
+
+	assert.NotContains(t, raw, "summary")
+
+	checks := raw["checks"].([]any)
+	require.Len(t, checks, 1)
+	assert.NotContains(t, checks[0].(map[string]any), "status")
+}
+
+func TestJSONResultsCarrySummaryAndExitCode(t *testing.T) {
+	var buf bytes.Buffer
+
+	code := WriteJSONResults(&buf, []Result{
+		{Name: "a", Status: StatusPass},
+		{Name: "b", Status: StatusWarn},
+		{Name: "c", Status: StatusSkipped},
+	})
+	assert.Equal(t, 0, code, "only a failure is non-zero")
+
+	var report jsonReport
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &report))
+	require.NotNil(t, report.Summary)
+	assert.Equal(t, jsonSummary{Passed: 1, Warned: 1, Failed: 0, Skipped: 1}, *report.Summary)
+
+	buf.Reset()
+	assert.Equal(t, 1, WriteJSONResults(&buf, []Result{{Name: "a", Status: StatusFail}}))
+}
+
+// A run and a listing must describe a check identically, so docs generated from
+// either agree.
+func TestJSONSkippedCheckStillCarriesFields(t *testing.T) {
+	cfg := &internal.Config{}
+
+	ran := run(t.Context(), cfg, mustLookup(t, "kafka"))
+	listed := Describe(cfg, []string{"kafka"})[0]
+
+	assert.Equal(t, StatusSkipped, ran.Status)
+	assert.NotEmpty(t, ran.Fields)
+	assert.Equal(t, listed.Fields, ran.Fields)
+}
+
+func TestJSONIsStableAcrossRuns(t *testing.T) {
+	cfg := &internal.Config{}
+
+	var first, second bytes.Buffer
+	require.NoError(t, WriteJSONChecks(&first, Describe(cfg, nil)))
+	require.NoError(t, WriteJSONChecks(&second, Describe(cfg, nil)))
+
+	assert.Equal(t, first.String(), second.String())
+	assert.True(t, strings.HasSuffix(second.String(), "\n"))
+}
+
+func mustLookup(t *testing.T, name string) Check {
+	t.Helper()
+
+	check, ok := Lookup(name)
+	require.True(t, ok, "check %q not registered", name)
+
+	return check
+}

--- a/services/ctl-api/internal/preflight/load.go
+++ b/services/ctl-api/internal/preflight/load.go
@@ -1,0 +1,22 @@
+package preflight
+
+import (
+	"fmt"
+
+	svcconfig "github.com/nuonco/nuon/pkg/services/config"
+	internal "github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+// LoadConfig loads configuration without running struct validation.
+//
+// internal.NewConfig would reject a partial config before any check could run,
+// which is the opposite of what preflight is for: each check validates only the
+// fields it needs and reports them by name.
+func LoadConfig() (*internal.Config, error) {
+	var cfg internal.Config
+	if err := svcconfig.LoadInto(nil, &cfg); err != nil {
+		return nil, fmt.Errorf("unable to load config: %w", err)
+	}
+
+	return &cfg, nil
+}

--- a/services/ctl-api/internal/preflight/preflight.go
+++ b/services/ctl-api/internal/preflight/preflight.go
@@ -1,0 +1,234 @@
+package preflight
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	internal "github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+type Status string
+
+const (
+	StatusPass    Status = "pass"
+	StatusWarn    Status = "warn"
+	StatusFail    Status = "fail"
+	StatusSkipped Status = "skipped"
+)
+
+// warning is returned by a probe that validated everything the config allows
+// but could not confirm it against the live service — a provider with fixed
+// endpoints and nothing to discover, say. Reported distinctly from a pass so
+// the gap is visible, but not counted as a failure.
+type warning struct{ msg string }
+
+func (w *warning) Error() string { return w.msg }
+
+func warnf(format string, args ...any) error {
+	return &warning{msg: fmt.Sprintf(format, args...)}
+}
+
+func isWarning(err error) bool {
+	var w *warning
+
+	return errors.As(err, &w)
+}
+
+// Field is one config value a check depends on. Value is pre-rendered by the
+// check so typed fields (bool, time.Duration) format themselves.
+type Field struct {
+	Name     string
+	Value    string
+	Required bool
+	Secret   bool
+}
+
+// Display renders a field value for output, masking secrets.
+func (f Field) Display() string {
+	switch {
+	case f.Value == "":
+		return "(unset)"
+	case f.Secret:
+		return "******"
+	default:
+		return f.Value
+	}
+}
+
+// Check declares an external dependency, the config it reads, and how to probe it.
+type Check struct {
+	Name        string
+	Description string
+
+	// Skip reports why the check does not apply to this config, e.g. a
+	// cloud_provider or feature flag that turns the dependency off.
+	Skip func(cfg *internal.Config) (string, bool)
+
+	// Fields is a func rather than a static list so required-ness can depend on
+	// other config: db_password is only required when db_use_iam is off.
+	Fields func(cfg *internal.Config) []Field
+
+	Probe func(ctx context.Context, cfg *internal.Config) (string, error)
+}
+
+type Result struct {
+	Name        string
+	Description string
+	Status      Status
+	Detail      string
+	Fields      []Field
+}
+
+func (r Result) Failed() bool { return r.Status == StatusFail }
+
+// Run executes the named checks, or every check in registry order when names is
+// empty. A check is skipped, then field-validated, then probed.
+func Run(ctx context.Context, cfg *internal.Config, names []string) []Result {
+	checks, unknown := resolve(names)
+
+	results := make([]Result, 0, len(checks)+len(unknown))
+	for _, name := range unknown {
+		results = append(results, Result{
+			Name:   name,
+			Status: StatusFail,
+			Detail: "unknown check",
+		})
+	}
+
+	for _, check := range checks {
+		results = append(results, run(ctx, cfg, check))
+	}
+
+	return results
+}
+
+// Describe evaluates skip state and field values for the named checks without
+// probing anything, backing `preflight --list`.
+func Describe(cfg *internal.Config, names []string) []Result {
+	checks, unknown := resolve(names)
+
+	results := make([]Result, 0, len(checks)+len(unknown))
+	for _, name := range unknown {
+		results = append(results, Result{Name: name, Status: StatusFail, Detail: "unknown check"})
+	}
+
+	for _, check := range checks {
+		// No Status: nothing was run, and a listing that claimed otherwise
+		// would be misleading.
+		result := Result{
+			Name:        check.Name,
+			Description: check.Description,
+			Fields:      check.Fields(cfg),
+		}
+		if check.Skip != nil {
+			if reason, skip := check.Skip(cfg); skip {
+				result.Status = StatusSkipped
+				result.Detail = reason
+			}
+		}
+		results = append(results, result)
+	}
+
+	return results
+}
+
+func run(ctx context.Context, cfg *internal.Config, check Check) Result {
+	// Fields are resolved even when the check is skipped, so a run and a --list
+	// describe a check identically. Consumers generating docs from the JSON get
+	// the same field set either way.
+	result := Result{
+		Name:        check.Name,
+		Description: check.Description,
+		Fields:      check.Fields(cfg),
+	}
+
+	if check.Skip != nil {
+		if reason, skip := check.Skip(cfg); skip {
+			result.Status = StatusSkipped
+			result.Detail = reason
+
+			return result
+		}
+	}
+
+	if missing := missingFields(result.Fields); len(missing) > 0 {
+		result.Status = StatusFail
+		result.Detail = "missing required config: " + strings.Join(missing, ", ")
+
+		return result
+	}
+
+	// Bounded per check so one black-holed host cannot stall the whole run.
+	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+
+	detail, err := check.Probe(ctx, cfg)
+	switch {
+	case err == nil:
+		result.Status = StatusPass
+		result.Detail = detail
+	case isWarning(err):
+		result.Status = StatusWarn
+		result.Detail = err.Error()
+	default:
+		result.Status = StatusFail
+		result.Detail = err.Error()
+	}
+
+	return result
+}
+
+func missingFields(fields []Field) []string {
+	var missing []string
+	for _, f := range fields {
+		if f.Required && f.Value == "" {
+			missing = append(missing, f.Name)
+		}
+	}
+
+	return missing
+}
+
+// resolve maps requested names onto registry entries, preserving registry order
+// so output is stable, and reports any name with no matching check.
+func resolve(names []string) ([]Check, []string) {
+	if len(names) == 0 {
+		return All(), nil
+	}
+
+	wanted := make(map[string]bool, len(names))
+	var unknown []string
+	for _, name := range names {
+		if _, ok := Lookup(name); !ok {
+			unknown = append(unknown, name)
+			continue
+		}
+		wanted[name] = true
+	}
+
+	var checks []Check
+	for _, check := range All() {
+		if wanted[check.Name] {
+			checks = append(checks, check)
+		}
+	}
+
+	return checks, unknown
+}
+
+// summary renders a short "(key=value, ...)" tail for a probe detail line.
+func summary(pairs ...string) string {
+	var parts []string
+	for i := 0; i+1 < len(pairs); i += 2 {
+		if pairs[i+1] != "" {
+			parts = append(parts, fmt.Sprintf("%s=%s", pairs[i], pairs[i+1]))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return "(" + strings.Join(parts, ", ") + ")"
+}

--- a/services/ctl-api/internal/preflight/preflight_test.go
+++ b/services/ctl-api/internal/preflight/preflight_test.go
@@ -1,0 +1,404 @@
+package preflight
+
+import (
+	"bytes"
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	svcconfig "github.com/nuonco/nuon/pkg/services/config"
+	internal "github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+// TestFieldNamesExistInConfig is the guard that replaces the `preflight:"..."`
+// struct tag this package used to rely on. The tag kept check membership next
+// to the field, but silently survived a rename and vanished entirely in a bad
+// merge. Here a stale or misspelled key fails the build instead.
+func TestFieldNamesExistInConfig(t *testing.T) {
+	known := configKeys(reflect.TypeOf(internal.Config{}))
+	require.NotEmpty(t, known, "no config keys discovered — reflection walk is broken")
+
+	cfg := &internal.Config{}
+	for _, check := range All() {
+		for _, field := range check.Fields(cfg) {
+			assert.Contains(t, known, field.Name,
+				"check %q reads %q, which is not a config key on internal.Config",
+				check.Name, field.Name)
+		}
+	}
+}
+
+// configKeys collects every `config:"..."` key on the struct, following
+// embedded structs so squashed config (worker.Config) is included.
+func configKeys(t reflect.Type) map[string]bool {
+	keys := map[string]bool{}
+
+	for i := range t.NumField() {
+		field := t.Field(i)
+
+		if field.Anonymous && field.Type.Kind() == reflect.Struct {
+			for k := range configKeys(field.Type) {
+				keys[k] = true
+			}
+			continue
+		}
+
+		name, _, _ := strings.Cut(field.Tag.Get("config"), ",")
+		if name == "" {
+			name = strings.ToLower(field.Name)
+		}
+		keys[name] = true
+	}
+
+	return keys
+}
+
+func TestRegistryIsWellFormed(t *testing.T) {
+	seen := map[string]bool{}
+
+	for _, check := range All() {
+		assert.NotEmpty(t, check.Name)
+		assert.NotEmpty(t, check.Description, "check %q has no description", check.Name)
+		assert.NotNil(t, check.Fields, "check %q has no Fields", check.Name)
+		assert.NotNil(t, check.Probe, "check %q has no Probe", check.Name)
+
+		assert.False(t, seen[check.Name], "duplicate check %q", check.Name)
+		seen[check.Name] = true
+
+		found, ok := Lookup(check.Name)
+		require.True(t, ok, "check %q is not resolvable by name", check.Name)
+		assert.Equal(t, check.Name, found.Name)
+	}
+}
+
+func TestSkipPredicates(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		check  string
+		cfg    *internal.Config
+		skip   bool
+		reason string
+	}{
+		{
+			name:   "aws skips on gcp",
+			check:  "aws",
+			cfg:    &internal.Config{CloudProvider: "gcp"},
+			skip:   true,
+			reason: "cloud_provider=gcp",
+		},
+		{
+			name:   "aws skips on azure",
+			check:  "aws",
+			cfg:    &internal.Config{CloudProvider: "azure"},
+			skip:   true,
+			reason: "cloud_provider=azure",
+		},
+		{
+			// IsAWS treats an unset provider as AWS, matching NewConfig.
+			name:  "aws runs when provider is unset",
+			check: "aws",
+			cfg:   &internal.Config{},
+			skip:  false,
+		},
+		{
+			name:   "kafka skips when disabled",
+			check:  "kafka",
+			cfg:    &internal.Config{},
+			skip:   true,
+			reason: "kafka_enabled=false",
+		},
+		{
+			name:  "kafka runs when enabled",
+			check: "kafka",
+			cfg:   &internal.Config{KafkaEnabled: true},
+			skip:  false,
+		},
+		{
+			name:   "slack skips without a client id",
+			check:  "slack",
+			cfg:    &internal.Config{},
+			skip:   true,
+			reason: "slack app not configured",
+		},
+		{
+			name:  "slack runs with a client id",
+			check: "slack",
+			cfg:   &internal.Config{SlackClientID: "abc"},
+			skip:  false,
+		},
+		{
+			name:   "nuon-auth skips when unconfigured",
+			check:  "nuon-auth",
+			cfg:    &internal.Config{},
+			skip:   true,
+			reason: "nuon auth not configured",
+		},
+		{
+			name:  "nuon-auth runs with an issuer",
+			check: "nuon-auth",
+			cfg:   &internal.Config{NuonAuthIssuerURL: "https://example.com"},
+			skip:  false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			check, ok := Lookup(tt.check)
+			require.True(t, ok)
+			require.NotNil(t, check.Skip)
+
+			reason, skip := check.Skip(tt.cfg)
+			assert.Equal(t, tt.skip, skip)
+			if tt.skip {
+				assert.Equal(t, tt.reason, reason)
+			}
+		})
+	}
+}
+
+// Requirements that vary with other config are the thing struct tags could not
+// express, so they get explicit coverage.
+func TestConditionalRequirements(t *testing.T) {
+	required := func(fields []Field, name string) bool {
+		for _, f := range fields {
+			if f.Name == name {
+				return f.Required
+			}
+		}
+		t.Fatalf("field %q not found", name)
+		return false
+	}
+
+	rds, _ := Lookup("rds")
+	assert.True(t, required(rds.Fields(&internal.Config{}), "db_password"),
+		"db_password is required without IAM auth")
+	assert.False(t, required(rds.Fields(&internal.Config{DBUseIAM: true}), "db_password"),
+		"db_password is not required when the token is minted per connection")
+	assert.True(t, required(rds.Fields(&internal.Config{DBUseIAM: true}), "db_region"),
+		"db_region is required to mint an IAM token")
+
+	kafka, _ := Lookup("kafka")
+	plaintext := kafka.Fields(&internal.Config{KafkaSecurityProtocol: "PLAINTEXT"})
+	assert.False(t, required(plaintext, "kafka_tls_cert_path"))
+	ssl := kafka.Fields(&internal.Config{KafkaSecurityProtocol: "SSL"})
+	assert.True(t, required(ssl, "kafka_tls_cert_path"))
+}
+
+// Google and GitHub carry fixed OAuth endpoints, so nuon_auth_issuer_url being
+// empty is correct for them rather than a missing-config failure. Mirrors
+// getDefaultIdentityProvider in app/auth/service/identity_providers.go.
+func TestNuonAuthIssuerRequiredOnlyForOIDC(t *testing.T) {
+	check, ok := Lookup("nuon-auth")
+	require.True(t, ok)
+
+	issuerRequired := func(providerType string) bool {
+		fields := check.Fields(&internal.Config{NuonAuthProviderType: providerType})
+		for _, f := range fields {
+			if f.Name == "nuon_auth_issuer_url" {
+				return f.Required
+			}
+		}
+		t.Fatal("nuon_auth_issuer_url not found")
+		return false
+	}
+
+	assert.False(t, issuerRequired("google"))
+	assert.False(t, issuerRequired("github"))
+	assert.True(t, issuerRequired("oidc"))
+	assert.True(t, issuerRequired(""), "an unset type falls back to the generic OIDC requirement")
+}
+
+// A provider that cannot be confirmed over the network warns rather than fails,
+// so an otherwise healthy google deployment still exits 0.
+func TestNuonAuthGoogleWarnsWithoutIssuer(t *testing.T) {
+	check, ok := Lookup("nuon-auth")
+	require.True(t, ok)
+
+	cfg := &internal.Config{
+		NuonAuthProviderType: "google",
+		NuonAuthClientID:     "client-id",
+		NuonAuthClientSecret: "client-secret",
+		NuonAuthRedirectURL:  "https://example.com/callback",
+		NuonAuthSessionKey:   "session-key",
+	}
+
+	result := run(t.Context(), cfg, check)
+
+	assert.Equal(t, StatusWarn, result.Status)
+	assert.Contains(t, result.Detail, "google credentials present but unverified")
+}
+
+func TestNuonAuthRejectsUnknownProviderType(t *testing.T) {
+	check, ok := Lookup("nuon-auth")
+	require.True(t, ok)
+
+	cfg := &internal.Config{
+		NuonAuthProviderType: "okta",
+		NuonAuthIssuerURL:    "https://example.com",
+		NuonAuthClientID:     "client-id",
+		NuonAuthClientSecret: "client-secret",
+		NuonAuthRedirectURL:  "https://example.com/callback",
+		NuonAuthSessionKey:   "session-key",
+	}
+
+	result := run(t.Context(), cfg, check)
+
+	assert.Equal(t, StatusFail, result.Status)
+	assert.Contains(t, result.Detail, "invalid nuon_auth_provider_type")
+}
+
+// Production overrides the registered slack defaults, so a value still equal to
+// one there means signature verification is forgeable. Elsewhere the default is
+// the intended value.
+func TestSlackDevDefaultsFailOnlyInProduction(t *testing.T) {
+	check, ok := Lookup("slack")
+	require.True(t, ok)
+
+	withEnv := func(env svcconfig.Env) *internal.Config {
+		cfg := &internal.Config{
+			SlackClientID:         "client-id",
+			SlackClientSecret:     "client-secret",
+			SlackOAuthRedirectURL: "https://example.com/slack/oauth/callback",
+			SlackSigningSecret:    devSlackSigningSecret,
+			SlackStateJWTSecret:   "real-state-secret",
+		}
+		cfg.Env = env
+
+		return cfg
+	}
+
+	prod := run(t.Context(), withEnv(svcconfig.Production), check)
+	assert.Equal(t, StatusFail, prod.Status)
+	assert.Contains(t, prod.Detail, "insecure dev default in production for slack_signing_secret")
+
+	for _, env := range []svcconfig.Env{svcconfig.Development, svcconfig.Stage} {
+		result := run(t.Context(), withEnv(env), check)
+		assert.Equal(t, StatusWarn, result.Status, "env %s", env)
+		assert.Contains(t, result.Detail, "slack_signing_secret")
+	}
+}
+
+// Slack is an optional integration: an absent app must never fail a run.
+func TestSlackSkipsWhenUnconfigured(t *testing.T) {
+	check, ok := Lookup("slack")
+	require.True(t, ok)
+
+	result := run(t.Context(), &internal.Config{}, check)
+
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Equal(t, "slack app not configured", result.Detail)
+}
+
+func TestWarnIsNotAFailure(t *testing.T) {
+	var buf bytes.Buffer
+
+	code := PrintResults(&buf, []Result{
+		{Name: "a", Status: StatusPass},
+		{Name: "b", Status: StatusWarn, Detail: "unverified"},
+	})
+
+	assert.Equal(t, 0, code)
+	assert.Contains(t, buf.String(), "1 passed, 1 warned, 0 failed, 0 skipped")
+}
+
+func TestFieldDisplayRedactsSecrets(t *testing.T) {
+	assert.Equal(t, "******", Field{Name: "k", Value: "hunter2", Secret: true}.Display())
+	assert.Equal(t, "(unset)", Field{Name: "k", Secret: true}.Display())
+	assert.Equal(t, "plain", Field{Name: "k", Value: "plain"}.Display())
+}
+
+func TestResolveUnknownCheck(t *testing.T) {
+	checks, unknown := resolve([]string{"rds", "nope"})
+
+	require.Len(t, checks, 1)
+	assert.Equal(t, "rds", checks[0].Name)
+	assert.Equal(t, []string{"nope"}, unknown)
+}
+
+// resolve follows registry order so the table does not reshuffle between runs.
+func TestResolvePreservesRegistryOrder(t *testing.T) {
+	checks, _ := resolve([]string{"slack", "rds", "temporal"})
+
+	names := make([]string, 0, len(checks))
+	for _, c := range checks {
+		names = append(names, c.Name)
+	}
+	assert.Equal(t, []string{"rds", "temporal", "slack"}, names)
+}
+
+// A missing required field short-circuits before the probe, so an unset host
+// reports the config key rather than a connection-refused error.
+func TestRunSkipsProbeWhenRequiredConfigIsMissing(t *testing.T) {
+	probed := false
+	check := Check{
+		Name:        "example",
+		Description: "example",
+		Fields: func(*internal.Config) []Field {
+			return []Field{
+				{Name: "present_key", Value: "set", Required: true},
+				{Name: "missing_key", Required: true},
+			}
+		},
+		Probe: func(context.Context, *internal.Config) (string, error) {
+			probed = true
+			return "", nil
+		},
+	}
+
+	result := run(t.Context(), &internal.Config{}, check)
+
+	assert.False(t, probed, "probe ran despite missing config")
+	assert.Equal(t, StatusFail, result.Status)
+	assert.Equal(t, "missing required config: missing_key", result.Detail)
+	assert.Len(t, result.Fields, 2, "fields are attached so the printer can expand them")
+}
+
+func TestRunSkipsBeforeValidatingFields(t *testing.T) {
+	check := Check{
+		Name:        "example",
+		Description: "example",
+		Skip:        func(*internal.Config) (string, bool) { return "not applicable", true },
+		Fields: func(*internal.Config) []Field {
+			return []Field{{Name: "missing_key", Required: true}}
+		},
+		Probe: func(context.Context, *internal.Config) (string, error) {
+			t.Fatal("probe ran for a skipped check")
+			return "", nil
+		},
+	}
+
+	result := run(t.Context(), &internal.Config{}, check)
+
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Equal(t, "not applicable", result.Detail)
+}
+
+func TestPrintResultsExitCode(t *testing.T) {
+	var buf bytes.Buffer
+
+	assert.Equal(t, 0, PrintResults(&buf, []Result{
+		{Name: "a", Status: StatusPass},
+		{Name: "b", Status: StatusSkipped},
+	}), "a skipped check is not a failure")
+
+	assert.Equal(t, 1, PrintResults(&buf, []Result{
+		{Name: "a", Status: StatusPass},
+		{Name: "b", Status: StatusFail},
+	}))
+}
+
+func TestPrintResultsRedactsSecretsInExpandedFields(t *testing.T) {
+	var buf bytes.Buffer
+
+	PrintResults(&buf, []Result{{
+		Name:   "example",
+		Status: StatusFail,
+		Detail: "boom",
+		Fields: []Field{{Name: "some_secret", Value: "hunter2", Secret: true}},
+	}})
+
+	assert.Contains(t, buf.String(), "some_secret")
+	assert.NotContains(t, buf.String(), "hunter2")
+}

--- a/services/ctl-api/internal/preflight/print.go
+++ b/services/ctl-api/internal/preflight/print.go
@@ -1,0 +1,136 @@
+package preflight
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+type palette struct {
+	pass, warn, fail, skip, dim, reset string
+}
+
+func paletteFor(w io.Writer) palette {
+	if os.Getenv("NO_COLOR") != "" {
+		return palette{}
+	}
+
+	f, ok := w.(*os.File)
+	if !ok || !term.IsTerminal(int(f.Fd())) {
+		return palette{}
+	}
+
+	return palette{
+		pass:  "\033[32m",
+		warn:  "\033[33m",
+		fail:  "\033[31m",
+		skip:  "\033[90m",
+		dim:   "\033[90m",
+		reset: "\033[0m",
+	}
+}
+
+func (p palette) status(s Status) string {
+	switch s {
+	case StatusPass:
+		return p.pass + "✓ pass" + p.reset
+	case StatusWarn:
+		return p.warn + "! warn" + p.reset
+	case StatusFail:
+		return p.fail + "✗ fail" + p.reset
+	default:
+		return p.skip + "- skip" + p.reset
+	}
+}
+
+// PrintResults renders the results table and returns the process exit code. A
+// skipped check is not a failure.
+func PrintResults(w io.Writer, results []Result) int {
+	p := paletteFor(w)
+	s := summarize(results)
+	width := nameWidth(results)
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  %-*s  %-6s  %s\n", width, "CHECK", "STATUS", "DETAIL")
+	for _, r := range results {
+		// Details are not truncated: on a failure the message is the whole
+		// point, and a clipped driver error sends people back to the logs.
+		fmt.Fprintf(w, "  %-*s  %s  %s\n", width, r.Name, p.status(r.Status), r.Detail)
+
+		// Only failures get their config expanded — on a pass the values are
+		// noise, and `--list` covers deliberate inspection.
+		if r.Failed() {
+			for _, f := range r.Fields {
+				fmt.Fprintf(w, "  %-*s  %s%s%s\n", width, "", p.dim, fieldLine(f), p.reset)
+			}
+		}
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  %d passed, %d warned, %d failed, %d skipped\n",
+		s.Passed, s.Warned, s.Failed, s.Skipped)
+
+	if s.Failed > 0 {
+		return 1
+	}
+
+	return 0
+}
+
+// PrintChecks renders every check, its skip state, and the config it reads.
+// Pair it with Describe to list checks without touching the network.
+func PrintChecks(w io.Writer, results []Result) {
+	p := paletteFor(w)
+
+	for i, r := range results {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+
+		if _, ok := Lookup(r.Name); !ok {
+			fmt.Fprintf(w, "  %s%s%s%s — %s%s\n", p.dim, r.Name, p.reset, p.fail, r.Detail, p.reset)
+			continue
+		}
+
+		fmt.Fprintf(w, "  %s%s%s — %s\n", p.dim, r.Name, p.reset, r.Description)
+		if r.Status == StatusSkipped {
+			fmt.Fprintf(w, "    %sskipped: %s%s\n", p.skip, r.Detail, p.reset)
+		}
+
+		for _, f := range r.Fields {
+			fmt.Fprintf(w, "    %s\n", fieldLine(f))
+		}
+	}
+}
+
+func fieldLine(f Field) string {
+	req := "optional"
+	if f.Required {
+		req = "required"
+	}
+
+	return fmt.Sprintf("%-32s %-8s %s", f.Name, req, f.Display())
+}
+
+func nameWidth(results []Result) int {
+	width := len("CHECK")
+	for _, r := range results {
+		if len(r.Name) > width {
+			width = len(r.Name)
+		}
+	}
+
+	return width
+}
+
+func truncate(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= max {
+		return s
+	}
+
+	return s[:max-3] + "..."
+}

--- a/services/ctl-api/internal/preflight/registry.go
+++ b/services/ctl-api/internal/preflight/registry.go
@@ -1,0 +1,38 @@
+package preflight
+
+// registry is an ordered slice rather than a map so the results table and
+// --list output keep a stable order between runs.
+var registry = []Check{
+	rdsCheck,
+	clickhouseCheck,
+	temporalCheck,
+	nuonAuthCheck,
+	githubCheck,
+	awsCheck,
+	kafkaCheck,
+	blobstoreCheck,
+	slackCheck,
+}
+
+func All() []Check {
+	return registry
+}
+
+func Lookup(name string) (Check, bool) {
+	for _, check := range registry {
+		if check.Name == name {
+			return check, true
+		}
+	}
+
+	return Check{}, false
+}
+
+func Names() []string {
+	names := make([]string, 0, len(registry))
+	for _, check := range registry {
+		names = append(names, check.Name)
+	}
+
+	return names
+}


### PR DESCRIPTION
### Description

Introduces a new command to `ctl-api`:

```sh
/bins/ctl-api preflight

Run preflight checks to validate that required configuration is present
and that external services (database, temporal, auth providers, etc.) are reachable.

With no arguments, all checks are run. Pass check names to run a subset.
Checks that do not apply to this deployment report as skipped.

--json emits a machine-readable report on stdout, for both runs and --list.
Secret values are never included: each field reports only whether it is set.

Available checks: rds, clickhouse, temporal, nuon-auth, github, aws, kafka, blobstore, slack

Usage:
   preflight [checks...] [flags]

Flags:
  -h, --help   help for preflight
      --json   emit JSON instead of a table
      --list   list checks and the config they read, without connecting

Global Flags:
  -n, --namespace string   namespace defines the namespace whose workers to run. e.g. all, general, orgs, apps, components, installs, releases. (default "all")
      --skip string        comma-separated list of namespaces to skip (e.g. 'installs,releases')
```

includes preflight checks for the following:

- rds
- clickhouse
- temporal
- nuon-auth
- github
- aws
- kafka
- blobstore
- slack