### PR TITLE
feat: manage Github actions OIDC from VCS connection settings

### DIFF
--- a/docs/guides/github-actions.mdx
+++ b/docs/guides/github-actions.mdx
@@ -58,7 +58,7 @@ If you do not yet have an org setup, please follow the [quickstart guide](/get-s
 
 GitHub Actions is one OIDC issuer; see [OIDC federation](/concepts/oidc-federation) for the general model and other providers. With a trust policy in place, workflows authenticate using the OIDC token GitHub issues to each job — nothing is stored in your repository.
 
-First, create a trust policy for your repository once (from the Dashboard under **Settings → OIDC federation**, or with the CLI):
+First, create a trust policy for your repository once. The quickest path is from your GitHub connection page in the Dashboard (**Connections → your GitHub connection**), where each repository has a **Manage OIDC** button that prefills the issuer, audience, and `sub` for you. You can also create one under **Settings → OIDC federation**, or with the CLI:
 
 ```sh
 nuon orgs oidc-trust-policies create \

--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.stories.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.stories.tsx
@@ -9,7 +9,11 @@ const noop = () => {}
 
 export const Default = () => (
   <ModalStory>
-    <CreateOIDCTrustPolicyModal isPending={false} error={null} onSubmit={noop} />
+    <CreateOIDCTrustPolicyModal
+      isPending={false}
+      error={null}
+      onSubmit={noop}
+    />
   </ModalStory>
 )
 

--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
@@ -35,28 +35,40 @@ export const CreateOIDCTrustPolicyModal = ({
   isPending,
   error,
   onSubmit,
+  initialValues,
+  lockIssuer,
+  reservedNames,
   ...props
 }: {
   isPending: boolean
   error: TAPIError | null
   onSubmit: (input: OIDCTrustPolicyFormInput) => void
+  initialValues?: Partial<OIDCTrustPolicyFormInput>
+  lockIssuer?: boolean
+  reservedNames?: string[]
 } & Omit<IModal, 'onSubmit'>) => {
-  const [name, setName] = useState('')
-  const [issuerUrl, setIssuerUrl] = useState('')
-  const [audience, setAudience] = useState('')
-  const [role, setRole] = useState('org_read_only')
-  const [tokenDurationSeconds, setTokenDurationSeconds] = useState('')
-  const [claimConditions, setClaimConditions] = useState<ClaimCondition[]>([
-    { key: 'sub', value: '' },
-  ])
+  const [name, setName] = useState(initialValues?.name ?? '')
+  const [issuerUrl, setIssuerUrl] = useState(initialValues?.issuerUrl ?? '')
+  const [audience, setAudience] = useState(initialValues?.audience ?? '')
+  const [role, setRole] = useState(initialValues?.role ?? 'org_read_only')
+  const [tokenDurationSeconds, setTokenDurationSeconds] = useState(
+    initialValues?.tokenDurationSeconds ?? ''
+  )
+  const [claimConditions, setClaimConditions] = useState<ClaimCondition[]>(
+    initialValues?.claimConditions ?? [{ key: 'sub', value: '' }]
+  )
 
   const trimmedName = name.trim()
   const trimmedIssuerUrl = issuerUrl.trim()
   const trimmedAudience = audience.trim()
   const isValidIssuerUrl = /^https?:\/\/.+/i.test(trimmedIssuerUrl)
+  const isNameTaken = !!reservedNames?.some(
+    (reserved) => reserved.trim().toLowerCase() === trimmedName.toLowerCase()
+  )
   const canSubmit =
     !isPending &&
     !!trimmedName &&
+    !isNameTaken &&
     isValidIssuerUrl &&
     !!trimmedAudience &&
     hasSubCondition(claimConditions)
@@ -133,6 +145,12 @@ export const CreateOIDCTrustPolicyModal = ({
             onChange={(e) => setName(e.target.value)}
             required
           />
+          {isNameTaken ? (
+            <Text variant="subtext" theme="error">
+              A trust policy named {trimmedName} already exists. Choose a
+              different name.
+            </Text>
+          ) : null}
         </div>
 
         <div className="flex flex-col gap-2">
@@ -144,6 +162,8 @@ export const CreateOIDCTrustPolicyModal = ({
             value={issuerUrl}
             onChange={(e) => setIssuerUrl(e.target.value)}
             required
+            readOnly={lockIssuer}
+            disabled={lockIssuer}
           />
           <Text variant="subtext" theme="neutral">
             Must be an absolute http or https URL.
@@ -193,8 +213,8 @@ export const CreateOIDCTrustPolicyModal = ({
         <div className="flex flex-col gap-2">
           <Label>Claim conditions</Label>
           <Text variant="subtext" theme="neutral">
-            All conditions must match the presented token. A `sub` condition
-            is required.
+            All conditions must match the presented token. A `sub` condition is
+            required.
           </Text>
           <div className="flex flex-col gap-2">
             {claimConditions.map((condition, index) => (

--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicyContainer.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicyContainer.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
@@ -47,7 +48,9 @@ const CreateOIDCTrustPolicyModalContainer = (props: Record<string, any>) => {
       })
       addToast(
         <Toast heading="Trust policy created" theme="success">
-          <Text>{policy.name} can now exchange OIDC tokens for org access.</Text>
+          <Text>
+            {policy.name} can now exchange OIDC tokens for org access.
+          </Text>
         </Toast>
       )
       removeModal(props.modalId)
@@ -72,15 +75,35 @@ const CreateOIDCTrustPolicyModalContainer = (props: Record<string, any>) => {
 }
 
 export const CreateOIDCTrustPolicyButton = ({
+  initialValues,
+  lockIssuer,
+  reservedNames,
+  children,
+  variant = 'primary',
   ...props
-}: Omit<IButtonAsButton, 'children'>) => {
+}: Omit<IButtonAsButton, 'children'> & {
+  initialValues?: Partial<OIDCTrustPolicyFormInput>
+  lockIssuer?: boolean
+  reservedNames?: string[]
+  children?: ReactNode
+}) => {
   const { addModal } = useSurfaces()
-  const modal = <CreateOIDCTrustPolicyModalContainer />
+  const modal = (
+    <CreateOIDCTrustPolicyModalContainer
+      initialValues={initialValues}
+      lockIssuer={lockIssuer}
+      reservedNames={reservedNames}
+    />
+  )
 
   return (
-    <Button variant="primary" onClick={() => addModal(modal)} {...props}>
-      <Icon variant="PlusIcon" />
-      Create trust policy
+    <Button variant={variant} onClick={() => addModal(modal)} {...props}>
+      {children ?? (
+        <>
+          <Icon variant="PlusIcon" />
+          Create trust policy
+        </>
+      )}
     </Button>
   )
 }

--- a/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/ConnectionDetail.stories.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/ConnectionDetail.stories.tsx
@@ -62,7 +62,9 @@ export const LoadingRepos = () => (
 export const ReposError = () => (
   <ConnectionDetail
     vcs_connection={mockConnection}
-    reposError={{ error: 'Failed to load repositories. Check your GitHub connection.' }}
+    reposError={{
+      error: 'Failed to load repositories. Check your GitHub connection.',
+    }}
   />
 )
 

--- a/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/ConnectionDetail.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/ConnectionDetail.tsx
@@ -1,4 +1,8 @@
-import type { TVCSConnection, TVCSConnectionReposResponse, TVCSWebhookSubscription } from '@/types'
+import type {
+  TVCSConnection,
+  TVCSConnectionReposResponse,
+  TVCSWebhookSubscription,
+} from '@/types'
 import { GitHubAccountSection } from './GitHubAccountSection'
 import { RepositoriesSection } from './RepositoriesSection'
 import { WebhookSubscriptionSection } from './WebhookSubscriptionSection'
@@ -12,6 +16,7 @@ interface IConnectionDetail {
   subscriptionQueried?: boolean
   onCreateSubscription?: () => void
   isCreatingSubscription?: boolean
+  oidcEnabled?: boolean
 }
 
 export const ConnectionDetail = ({
@@ -23,6 +28,7 @@ export const ConnectionDetail = ({
   subscriptionQueried = false,
   onCreateSubscription,
   isCreatingSubscription,
+  oidcEnabled = false,
 }: IConnectionDetail) => (
   <>
     <GitHubAccountSection vcs_connection={vcs_connection} />
@@ -33,6 +39,11 @@ export const ConnectionDetail = ({
         isCreating={isCreatingSubscription}
       />
     )}
-    <RepositoriesSection repos={repos} error={reposError} isLoading={isLoadingRepos} />
+    <RepositoriesSection
+      repos={repos}
+      error={reposError}
+      isLoading={isLoadingRepos}
+      oidcEnabled={oidcEnabled}
+    />
   </>
 )

--- a/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/ConnectionDetailContainer.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/ConnectionDetailContainer.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'react-router'
 import { Text } from '@/components/common/Text'
 import { Toast } from '@/components/surfaces/Toast'
+import { useCLIConfig } from '@/hooks/use-cli-config'
 import { useOrg } from '@/hooks/use-org'
 import { useToast } from '@/hooks/use-toast'
 import {
@@ -16,11 +17,14 @@ interface IConnectionDetailContainer {
   vcs_connection: TVCSConnection
 }
 
-export const ConnectionDetailContainer = ({ vcs_connection }: IConnectionDetailContainer) => {
+export const ConnectionDetailContainer = ({
+  vcs_connection,
+}: IConnectionDetailContainer) => {
   const { connectionId } = useParams<{ connectionId: string }>()
   const { org } = useOrg()
   const { addToast } = useToast()
   const queryClient = useQueryClient()
+  const { data: cliConfig } = useCLIConfig()
 
   const {
     data: repos,
@@ -28,7 +32,8 @@ export const ConnectionDetailContainer = ({ vcs_connection }: IConnectionDetailC
     isLoading: isLoadingRepos,
   } = useQuery({
     queryKey: ['vcs-connection-repos', org?.id, connectionId],
-    queryFn: () => getVCSConnectionRepos({ orgId: org!.id, connectionId: connectionId! }),
+    queryFn: () =>
+      getVCSConnectionRepos({ orgId: org!.id, connectionId: connectionId! }),
     enabled: !!org?.id && !!connectionId,
   })
 
@@ -38,32 +43,50 @@ export const ConnectionDetailContainer = ({ vcs_connection }: IConnectionDetailC
     error: subscriptionError,
   } = useQuery({
     queryKey: ['vcs-connection-webhook-subscription', org?.id, connectionId],
-    queryFn: () => getVCSConnectionWebhookSubscription({ orgId: org!.id, connectionId: connectionId! }),
+    queryFn: () =>
+      getVCSConnectionWebhookSubscription({
+        orgId: org!.id,
+        connectionId: connectionId!,
+      }),
     enabled: !!org?.id && !!connectionId,
     retry: false,
   })
 
   const subscriptionQueried = !isLoadingSubscription
 
-  const { mutate: createSubscription, isPending: isCreatingSubscription } = useMutation({
-    mutationFn: () =>
-      createVCSConnectionWebhookSubscription({ orgId: org!.id, connectionId: connectionId! }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['vcs-connection-webhook-subscription', org?.id, connectionId] })
-      addToast(
-        <Toast heading="Creating webhook subscription" theme="info">
-          <Text>Webhook subscription is being created. This may take a moment.</Text>
-        </Toast>
-      )
-    },
-    onError: (err: TAPIError) => {
-      addToast(
-        <Toast heading="Webhook subscription failed" theme="error">
-          <Text>{err?.error || 'Unable to create webhook subscription.'}</Text>
-        </Toast>
-      )
-    },
-  })
+  const { mutate: createSubscription, isPending: isCreatingSubscription } =
+    useMutation({
+      mutationFn: () =>
+        createVCSConnectionWebhookSubscription({
+          orgId: org!.id,
+          connectionId: connectionId!,
+        }),
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: [
+            'vcs-connection-webhook-subscription',
+            org?.id,
+            connectionId,
+          ],
+        })
+        addToast(
+          <Toast heading="Creating webhook subscription" theme="info">
+            <Text>
+              Webhook subscription is being created. This may take a moment.
+            </Text>
+          </Toast>
+        )
+      },
+      onError: (err: TAPIError) => {
+        addToast(
+          <Toast heading="Webhook subscription failed" theme="error">
+            <Text>
+              {err?.error || 'Unable to create webhook subscription.'}
+            </Text>
+          </Toast>
+        )
+      },
+    })
 
   return (
     <ConnectionDetail
@@ -75,6 +98,7 @@ export const ConnectionDetailContainer = ({ vcs_connection }: IConnectionDetailC
       subscriptionQueried={subscriptionQueried}
       onCreateSubscription={() => createSubscription()}
       isCreatingSubscription={isCreatingSubscription}
+      oidcEnabled={!!cliConfig?.oidc_federation_enabled}
     />
   )
 }

--- a/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/GitHubAccountSection.stories.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/GitHubAccountSection.stories.tsx
@@ -15,7 +15,9 @@ const mockConnection: TVCSConnection = {
   vcs_connection_commit: [],
 } as TVCSConnection
 
-export const Default = () => <GitHubAccountSection vcs_connection={mockConnection} />
+export const Default = () => (
+  <GitHubAccountSection vcs_connection={mockConnection} />
+)
 
 export const WithCommits = () => (
   <GitHubAccountSection

--- a/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/GitHubAccountSection.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/GitHubAccountSection.tsx
@@ -37,7 +37,11 @@ export const GitHubAccountSection = ({
               className="inline-flex items-center gap-1.5 hover:underline"
             >
               <ID theme="default">{vcs_connection.github_install_id}</ID>
-              <Icon variant="ArrowSquareOutIcon" size={12} className="text-cool-grey-400" />
+              <Icon
+                variant="ArrowSquareOutIcon"
+                size={12}
+                className="text-cool-grey-400"
+              />
             </a>
           ) : (
             <ID theme="default">—</ID>

--- a/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/RepoTypeFilter.stories.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/RepoTypeFilter.stories.tsx
@@ -3,10 +3,15 @@ export default {
 }
 
 import { useState } from 'react'
-import { RepoTypeFilter, REPO_FILTER_OPTIONS, type TRepoFilterType } from './RepoTypeFilter'
+import {
+  RepoTypeFilter,
+  REPO_FILTER_OPTIONS,
+  type TRepoFilterType,
+} from './RepoTypeFilter'
 
 export const Default = () => {
-  const [selected, setSelected] = useState<TRepoFilterType[]>(REPO_FILTER_OPTIONS)
+  const [selected, setSelected] =
+    useState<TRepoFilterType[]>(REPO_FILTER_OPTIONS)
   return <RepoTypeFilter selected={selected} onChange={setSelected} />
 }
 
@@ -16,6 +21,9 @@ export const OneSelected = () => {
 }
 
 export const TwoSelected = () => {
-  const [selected, setSelected] = useState<TRepoFilterType[]>(['public', 'fork'])
+  const [selected, setSelected] = useState<TRepoFilterType[]>([
+    'public',
+    'fork',
+  ])
   return <RepoTypeFilter selected={selected} onChange={setSelected} />
 }

--- a/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/RepoTypeFilter.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/RepoTypeFilter.tsx
@@ -7,12 +7,28 @@ import { CheckboxInputWithButton } from '@/components/common/form/CheckboxInput'
 
 export type TRepoFilterType = 'public' | 'private' | 'fork'
 
-export const REPO_FILTER_OPTIONS: TRepoFilterType[] = ['public', 'private', 'fork']
+export const REPO_FILTER_OPTIONS: TRepoFilterType[] = [
+  'public',
+  'private',
+  'fork',
+]
 
 const FILTER_LABELS: Record<TRepoFilterType, React.ReactNode> = {
-  public: <><Icon variant="GlobeIcon" size={12} /> public</>,
-  private: <><Icon variant="LockIcon" size={12} /> private</>,
-  fork: <><Icon variant="GitForkIcon" size={12} /> fork</>,
+  public: (
+    <>
+      <Icon variant="GlobeIcon" size={12} /> public
+    </>
+  ),
+  private: (
+    <>
+      <Icon variant="LockIcon" size={12} /> private
+    </>
+  ),
+  fork: (
+    <>
+      <Icon variant="GitForkIcon" size={12} /> fork
+    </>
+  ),
 }
 
 interface IRepoTypeFilter {
@@ -33,7 +49,11 @@ export const RepoTypeFilter = ({ selected, onChange }: IRepoTypeFilter) => {
 
   const handleOnly = (e: React.MouseEvent<HTMLButtonElement>) => {
     const value = e.currentTarget.value as TRepoFilterType
-    onChange(selected.length === 1 && selected[0] === value ? REPO_FILTER_OPTIONS : [value])
+    onChange(
+      selected.length === 1 && selected[0] === value
+        ? REPO_FILTER_OPTIONS
+        : [value]
+    )
   }
 
   const handleReset = () => onChange(REPO_FILTER_OPTIONS)
@@ -47,7 +67,8 @@ export const RepoTypeFilter = ({ selected, onChange }: IRepoTypeFilter) => {
       buttonClassName="!p-1"
       buttonText={
         <>
-          <Icon variant="FunnelIcon" size="14" /> Filter{!allSelected && ` (${selected.length})`}
+          <Icon variant="FunnelIcon" size="14" /> Filter
+          {!allSelected && ` (${selected.length})`}
         </>
       }
     >
@@ -56,14 +77,17 @@ export const RepoTypeFilter = ({ selected, onChange }: IRepoTypeFilter) => {
           <div className="flex items-center" key={opt}>
             <CheckboxInputWithButton
               buttonProps={{
-                className: '!p-1 flex items-center justify-between group w-full',
+                className:
+                  '!p-1 flex items-center justify-between group w-full',
                 children: (
                   <>
                     <span className="flex items-center gap-1 text-xs font-semibold">
                       {FILTER_LABELS[opt]}
                     </span>
                     <span className="ml-2 text-xs opacity-0 group-hover:opacity-100 w-[40px]">
-                      {selected.length === 1 && selected[0] === opt ? 'Reset' : 'Only'}
+                      {selected.length === 1 && selected[0] === opt
+                        ? 'Reset'
+                        : 'Only'}
                     </span>
                   </>
                 ),

--- a/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/RepositoriesSection.stories.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/RepositoriesSection.stories.tsx
@@ -87,16 +87,20 @@ export const Empty = () => (
 export const Error = () => (
   <RepositoriesSection
     isLoading={false}
-    error={{ error: 'Failed to load repositories. Check your GitHub connection.' }}
+    error={{
+      error: 'Failed to load repositories. Check your GitHub connection.',
+    }}
   />
 )
 
 export const SingleRepo = () => (
   <RepositoriesSection
-    repos={{
-      total_count: 1,
-      repositories: [mockRepos.repositories![0]],
-    } as TVCSConnectionReposResponse}
+    repos={
+      {
+        total_count: 1,
+        repositories: [mockRepos.repositories![0]],
+      } as TVCSConnectionReposResponse
+    }
     isLoading={false}
   />
 )

--- a/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/RepositoriesSection.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/RepositoriesSection.tsx
@@ -8,6 +8,7 @@ import { SearchInput } from '@/components/common/SearchInput'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
+import { ManageRepoOIDCButton } from '@/components/vcs-connections/ManageRepoOIDC'
 import type { TVCSConnectionReposResponse } from '@/types'
 import {
   REPO_FILTER_OPTIONS,
@@ -19,12 +20,14 @@ interface IRepositoriesSection {
   repos?: TVCSConnectionReposResponse
   error?: any
   isLoading: boolean
+  oidcEnabled?: boolean
 }
 
 export const RepositoriesSection = ({
   repos,
   error,
   isLoading,
+  oidcEnabled = false,
 }: IRepositoriesSection) => {
   const [search, setSearch] = useState('')
   const [typeFilter, setTypeFilter] =
@@ -153,6 +156,13 @@ export const RepositoriesSection = ({
                       {repo.description}
                     </Text>
                   )}
+                  {oidcEnabled && (
+                    <ManageRepoOIDCButton
+                      repoFullName={repo.full_name}
+                      size="sm"
+                      className="w-fit"
+                    />
+                  )}
                 </div>
               ))
             ) : (
@@ -160,7 +170,11 @@ export const RepositoriesSection = ({
                 variant="search"
                 size="sm"
                 emptyTitle={isFiltering ? 'No results' : 'No repositories'}
-                emptyMessage={isFiltering ? 'Try adjusting your search or filters.' : 'No repositories found for this connection.'}
+                emptyMessage={
+                  isFiltering
+                    ? 'Try adjusting your search or filters.'
+                    : 'No repositories found for this connection.'
+                }
               />
             )}
           </div>

--- a/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/ManageRepoOIDC.stories.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/ManageRepoOIDC.stories.tsx
@@ -1,0 +1,69 @@
+import { Button } from '@/components/common/Button'
+import { Icon } from '@/components/common/Icon'
+import { ModalStory } from '@/components/__stories__/helpers'
+import type { TOIDCTrustPolicy } from '@/types'
+import { ManageRepoOIDCModal } from './ManageRepoOIDC'
+
+export default {
+  title: 'VCS Connections/ManageRepoOIDC',
+}
+
+const createSlot = (
+  <Button variant="secondary" size="sm" className="w-fit">
+    <Icon variant="PlusIcon" size={14} />
+    Create trust policy
+  </Button>
+)
+
+const renderDelete = () => (
+  <Button variant="ghost" size="sm">
+    <Icon variant="TrashIcon" size={14} />
+    Delete
+  </Button>
+)
+
+const policies: TOIDCTrustPolicy[] = [
+  {
+    id: 'oidcpolicy1',
+    name: 'github-app',
+    role: 'org_read_only',
+    enabled: true,
+    claim_conditions: { sub: 'repo:acme/app:ref:refs/heads/*' },
+  },
+]
+
+export const WithPolicy = () => (
+  <ModalStory>
+    <ManageRepoOIDCModal
+      policies={policies}
+      isLoading={false}
+      onToggle={() => {}}
+      createSlot={createSlot}
+      renderDelete={renderDelete}
+    />
+  </ModalStory>
+)
+
+export const Empty = () => (
+  <ModalStory>
+    <ManageRepoOIDCModal
+      policies={[]}
+      isLoading={false}
+      onToggle={() => {}}
+      createSlot={createSlot}
+      renderDelete={renderDelete}
+    />
+  </ModalStory>
+)
+
+export const Loading = () => (
+  <ModalStory>
+    <ManageRepoOIDCModal
+      policies={[]}
+      isLoading
+      onToggle={() => {}}
+      createSlot={createSlot}
+      renderDelete={renderDelete}
+    />
+  </ModalStory>
+)

--- a/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/ManageRepoOIDC.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/ManageRepoOIDC.tsx
@@ -1,0 +1,100 @@
+import type { ReactNode } from 'react'
+import { Badge } from '@/components/common/Badge'
+import { Banner } from '@/components/common/Banner'
+import { EmptyState } from '@/components/common/EmptyState'
+import { Icon } from '@/components/common/Icon'
+import { Skeleton } from '@/components/common/Skeleton'
+import { Text } from '@/components/common/Text'
+import { Toggle } from '@/components/common/form/Toggle'
+import { Modal, type IModal } from '@/components/surfaces/Modal'
+import type { TAPIError, TOIDCTrustPolicy } from '@/types'
+
+export const ManageRepoOIDCModal = ({
+  policies,
+  isLoading,
+  error,
+  togglingId,
+  onToggle,
+  createSlot,
+  renderDelete,
+  ...props
+}: {
+  policies: TOIDCTrustPolicy[]
+  isLoading: boolean
+  error?: TAPIError | null
+  togglingId?: string
+  onToggle: (policy: TOIDCTrustPolicy, next: boolean) => void
+  createSlot: ReactNode
+  renderDelete: (policy: TOIDCTrustPolicy) => ReactNode
+} & Omit<IModal, 'onSubmit'>) => (
+  <Modal
+    heading={
+      <Text flex className="gap-4" variant="h3" weight="strong">
+        <Icon variant="ShieldCheckIcon" size="24" />
+        Manage OIDC
+      </Text>
+    }
+    showFooter={false}
+    {...props}
+  >
+    <div className="flex flex-col gap-6">
+      {error ? (
+        <Banner theme="error">
+          {error?.error || 'Unable to load trust policies'}
+        </Banner>
+      ) : null}
+
+      {isLoading ? (
+        <div className="flex flex-col gap-2">
+          {Array.from({ length: 2 }).map((_, idx) => (
+            <Skeleton key={idx} height="56px" />
+          ))}
+        </div>
+      ) : policies.length ? (
+        <div className="flex flex-col gap-2">
+          {policies.map((policy) => (
+            <div
+              key={policy.id}
+              className="flex items-center justify-between gap-4 py-2 px-4 border rounded-md"
+            >
+              <div className="flex flex-col gap-1">
+                <Text variant="subtext" weight="strong">
+                  {policy.name}
+                </Text>
+                <Text
+                  flex
+                  className="gap-2 flex-wrap"
+                  variant="subtext"
+                  theme="neutral"
+                >
+                  <Badge size="sm" variant="code">
+                    {policy.role}
+                  </Badge>
+                  {policy.claim_conditions?.sub}
+                </Text>
+              </div>
+              <div className="flex items-center gap-3">
+                <Toggle
+                  checked={!!policy.enabled}
+                  disabled={togglingId === policy.id}
+                  label={policy.enabled ? 'Enabled' : 'Disabled'}
+                  onChange={(next) => onToggle(policy, next)}
+                />
+                {renderDelete(policy)}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <EmptyState
+          variant="search"
+          size="sm"
+          emptyTitle="No trust policy yet"
+          emptyMessage="Create one to let this repository authenticate without a stored token."
+        />
+      )}
+
+      <div>{createSlot}</div>
+    </div>
+  </Modal>
+)

--- a/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/ManageRepoOIDCContainer.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/ManageRepoOIDCContainer.tsx
@@ -1,0 +1,143 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Button, type IButtonAsButton } from '@/components/common/Button'
+import { Icon } from '@/components/common/Icon'
+import { Text } from '@/components/common/Text'
+import { CreateOIDCTrustPolicyButton } from '@/components/oidc-trust-policies/CreateOIDCTrustPolicy'
+import { DeleteOIDCTrustPolicyButton } from '@/components/oidc-trust-policies/DeleteOIDCTrustPolicy'
+import { Toast } from '@/components/surfaces/Toast'
+import { useConfig } from '@/hooks/use-config'
+import { useOrg } from '@/hooks/use-org'
+import { useSurfaces } from '@/hooks/use-surfaces'
+import { useToast } from '@/hooks/use-toast'
+import {
+  getCurrentOrgOIDCTrustPolicies,
+  updateCurrentOrgOIDCTrustPolicy,
+} from '@/lib'
+import type { TAPIError, TOIDCTrustPolicy } from '@/types'
+import { ManageRepoOIDCModal } from './ManageRepoOIDC'
+
+const GITHUB_ACTIONS_ISSUER = 'https://token.actions.githubusercontent.com'
+
+const ManageRepoOIDCModalContainer = ({
+  repoFullName,
+  ...props
+}: { repoFullName: string } & Record<string, any>) => {
+  const { org } = useOrg()
+  const config = useConfig()
+  const queryClient = useQueryClient()
+  const { addToast } = useToast()
+
+  const {
+    data: policies,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['oidc-trust-policies', org.id],
+    queryFn: () => getCurrentOrgOIDCTrustPolicies({ orgId: org.id }),
+  })
+
+  const repoPolicies = (policies ?? []).filter((policy) =>
+    policy.claim_conditions?.sub?.startsWith(`repo:${repoFullName}:`)
+  )
+
+  const {
+    mutate: toggle,
+    isPending: isToggling,
+    variables: togglingVars,
+  } = useMutation({
+    mutationFn: ({
+      policy,
+      next,
+    }: {
+      policy: TOIDCTrustPolicy
+      next: boolean
+    }) =>
+      updateCurrentOrgOIDCTrustPolicy({
+        body: { enabled: next },
+        orgId: org.id,
+        policyId: policy.id ?? '',
+      }),
+    onSuccess: (_res, { policy, next }) => {
+      queryClient.invalidateQueries({
+        queryKey: ['oidc-trust-policies', org.id],
+      })
+      addToast(
+        <Toast
+          heading={next ? 'Trust policy enabled' : 'Trust policy disabled'}
+          theme="success"
+        >
+          <Text>
+            {policy.name} {next ? 'can now' : 'can no longer'} exchange OIDC
+            tokens.
+          </Text>
+        </Toast>
+      )
+    },
+    onError: (err: TAPIError) => {
+      addToast(
+        <Toast heading="Unable to update trust policy" theme="error">
+          <Text>{err?.description || err?.error || 'Try again.'}</Text>
+        </Toast>
+      )
+    },
+  })
+
+  const repoName = repoFullName.split('/').pop() ?? repoFullName
+  const reservedNames = (policies ?? []).map((policy) => policy.name ?? '')
+  const takenNames = new Set(reservedNames.map((name) => name.toLowerCase()))
+  const baseName = `github-${repoName}`
+  let defaultName = baseName
+  for (let n = 2; takenNames.has(defaultName.toLowerCase()); n++) {
+    defaultName = `${baseName}-${n}`
+  }
+
+  return (
+    <ManageRepoOIDCModal
+      policies={repoPolicies}
+      isLoading={isLoading}
+      error={error as TAPIError | null}
+      togglingId={isToggling ? togglingVars?.policy.id : undefined}
+      onToggle={(policy, next) => toggle({ policy, next })}
+      renderDelete={(policy) => (
+        <DeleteOIDCTrustPolicyButton policy={policy} size="sm" />
+      )}
+      createSlot={
+        <CreateOIDCTrustPolicyButton
+          variant="secondary"
+          size="sm"
+          className="w-fit"
+          initialValues={{
+            name: defaultName,
+            issuerUrl: GITHUB_ACTIONS_ISSUER,
+            audience: config.apiUrl ?? '',
+            role: 'org_read_only',
+            claimConditions: [
+              { key: 'sub', value: `repo:${repoFullName}:ref:refs/heads/*` },
+            ],
+          }}
+          reservedNames={reservedNames}
+          lockIssuer
+        >
+          <Icon variant="PlusIcon" size={14} />
+          Create trust policy
+        </CreateOIDCTrustPolicyButton>
+      }
+      {...props}
+    />
+  )
+}
+
+export const ManageRepoOIDCButton = ({
+  repoFullName,
+  ...props
+}: { repoFullName: string } & Omit<IButtonAsButton, 'children'>) => {
+  const { addModal } = useSurfaces()
+  const modal = <ManageRepoOIDCModalContainer repoFullName={repoFullName} />
+
+  return (
+    <Button variant="secondary" onClick={() => addModal(modal)} {...props}>
+      <Icon variant="ShieldCheckIcon" size={14} />
+      Manage OIDC
+    </Button>
+  )
+}

--- a/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/index.ts
+++ b/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/index.ts
@@ -1,0 +1,2 @@
+export { ManageRepoOIDCButton } from './ManageRepoOIDCContainer'
+export { ManageRepoOIDCModal } from './ManageRepoOIDC'

--- a/services/dashboard-ui/client/views/org/OIDCTrustPolicies.tsx
+++ b/services/dashboard-ui/client/views/org/OIDCTrustPolicies.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query'
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Text } from '@/components/common/Text'
 import { PageLayout } from '@/components/layout/PageLayout'
@@ -11,9 +12,15 @@ import {
   OIDCTrustPoliciesTable,
 } from '@/components/oidc-trust-policies'
 import { useOrg } from '@/hooks/use-org'
+import { getCurrentOrgOIDCTrustPolicies } from '@/lib'
 
 export const OIDCTrustPolicies = () => {
   const { org } = useOrg()
+
+  const { data: policies } = useQuery({
+    queryKey: ['oidc-trust-policies', org.id],
+    queryFn: () => getCurrentOrgOIDCTrustPolicies({ orgId: org.id }),
+  })
 
   return (
     <PageLayout className="pb-6">
@@ -30,11 +37,13 @@ export const OIDCTrustPolicies = () => {
             OIDC federation
           </Text>
           <Text theme="neutral">
-            Let CI/CD providers exchange OIDC tokens for short-lived org
-            access without storing a static API token.
+            Let CI/CD providers exchange OIDC tokens for short-lived org access
+            without storing a static API token.
           </Text>
         </HeadingGroup>
-        <CreateOIDCTrustPolicyButton />
+        <CreateOIDCTrustPolicyButton
+          reservedNames={(policies ?? []).map((policy) => policy.name ?? '')}
+        />
       </PageHeader>
       <PageContent>
         <PageSection>


### PR DESCRIPTION
## Summary

We want to continue investing in first-class support for OIDC on Github Actions. In addition to the CLI detecting that it's running in Github actions, we want vendors to be able to easily manage OIDC access directly from the VCS settings page.

This PR adds a "Manage OIDC" button for connected repos on the VCS settings page. Vendors can create, enable/disable, and delete trust policies for a specific repo. For convenience, the trust policy subject will be auto-populated with the values for the selected repo.

<img width="3024" height="1964" alt="Screenshot 2026-08-02 at 08 54 25" src="https://github.com/user-attachments/assets/8d4d6f7d-d21c-4d1d-ad6f-b66b172405f7" />
<img width="3024" height="1964" alt="Screenshot 2026-08-02 at 08 54 28" src="https://github.com/user-attachments/assets/29383ef0-4041-421b-bcea-7c20d8e2c9c4" />
<img width="3024" height="1964" alt="Screenshot 2026-08-02 at 08 54 37" src="https://github.com/user-attachments/assets/912869db-8ff6-465a-8969-eee80871ce5e" />
<img width="3024" height="1964" alt="Screenshot 2026-08-02 at 08 54 41" src="https://github.com/user-attachments/assets/89acf0de-f457-4361-bb6a-5c530a318dde" />
