### PR TITLE
fix: make GitHub OIDC updates

### DIFF
--- a/bins/cli/cmd/orgs.go
+++ b/bins/cli/cmd/orgs.go
@@ -262,7 +262,7 @@ func (c *cli) apiTokensCmd() *cobra.Command {
 	createCmd.Flags().StringVarP(&name, "name", "n", "", "A human-friendly name to identify the token")
 	createCmd.MarkFlagRequired("name")
 	createCmd.Flags().StringVar(&duration, "duration", "8760h", "How long the token is valid (Go duration, e.g. 720h)")
-	createCmd.Flags().StringVar(&role, "role", "org_read_only", "The org role granted to the token (org_admin or org_read_only)")
+	createCmd.Flags().StringVar(&role, "role", "org_read_only", "The org role granted to the token (org_admin, org_builder, or org_read_only)")
 	apiTokensCmd.AddCommand(createCmd)
 
 	listCmd := &cobra.Command{
@@ -342,7 +342,7 @@ Example (GitHub Actions, main branch of acme/app only):
 	createCmd.MarkFlagRequired("audience")
 	createCmd.Flags().StringArrayVar(&claims, "claim", nil, "A claim condition as claim=pattern (repeatable; a sub condition is required)")
 	createCmd.MarkFlagRequired("claim")
-	createCmd.Flags().StringVar(&role, "role", "org_read_only", "The org role granted to exchanged tokens (org_admin, org_support, or org_read_only)")
+	createCmd.Flags().StringVar(&role, "role", "org_read_only", "The org role granted to exchanged tokens (org_admin, org_builder, org_support, or org_read_only)")
 	createCmd.Flags().Int64Var(&ttl, "ttl", 0, "Lifetime of exchanged tokens in seconds (default 3600, max 86400)")
 	trustPoliciesCmd.AddCommand(createCmd)
 

--- a/docs/guides/github-actions.mdx
+++ b/docs/guides/github-actions.mdx
@@ -1,77 +1,46 @@
 ---
-title: 'GitHub Actions'
-description: 'Automatically update your Apps from GitHub Actions.'
+title: "GitHub Actions"
+description: "Automatically update your Apps from GitHub Actions."
 icon: "github"
-keywords: ["CI/CD", "automated sync", "GitHub workflow", "continuous deployment", "nuon apps sync CI", "CI/CD integration", "automate Nuon deploys", "continuous deployment Nuon", "OIDC", "workload identity federation", "secretless authentication"]
+keywords:
+  [
+    "CI/CD",
+    "automated sync",
+    "GitHub workflow",
+    "continuous deployment",
+    "nuon apps sync CI",
+    "CI/CD integration",
+    "automate Nuon deploys",
+    "continuous deployment Nuon",
+    "OIDC",
+    "workload identity federation",
+    "secretless authentication",
+  ]
 ---
 
-You can use GitHub Actions to automatically build and release your Components as part of your workflow. This can be used
-to update your Nuon Apps, running in customer accounts alongside updating other platforms.
+Use GitHub Actions to build Nuon Components alongside the rest of your CI workflow. The [Build action](https://github.com/nuonco/actions-build) installs the Nuon CLI and creates a Component build.
 
-We offer the following Actions:
-- [Build](https://github.com/nuonco/actions-build)
-- [Release](https://github.com/nuonco/actions-release)
+## Authenticate without secrets
 
-Each GitHub action uses the [Nuon CLI](/cli) to perform operations. Please refer to [configuration](#configuration)
-for details on configuring each action.
+GitHub Actions can authenticate to Nuon with OIDC, so no API token needs to be stored in the repository. First, create a trust policy for the repository and its protected branch. The quickest path is from your GitHub connection page in the Dashboard (**Connections → your GitHub connection**), where each repository has a **Manage OIDC** button that prefills the policy.
 
-## Automatically Build Components
-
-In order to update customer applications with the latest version of a Component, it must be built first. You can
-automatically build a component using GitHub Actions.
-
-To automatically build from an Action:
-
-```yaml
----
-on:
-  push:
-    branches:
-      - main
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    name: Build
-    steps:
-      - name: Checkout code
-        id: checkout
-        uses: actions/checkout@v2
-
-      - name: Build component
-        id: build
-        uses: nuonco/actions-build@v1
-        with:
-          api_token: ${{ secrets.nuon_api_token }}
-          org: ${{ vars.nuon_org_id }}
-          component_id: backend
-```
-
-## Configuration
-
-Each workflow needs to authenticate to Nuon with an org ID and a credential. GitHub Actions is an OIDC issuer, so the recommended approach is [OIDC federation](/concepts/oidc-federation) — no stored secret to manage. A static API token is also supported as a fallback.
-
-<Note>
-If you do not yet have an org setup, please follow the [quickstart guide](/get-started/quickstart).
-</Note>
-
-## Authenticate without secrets (OIDC)
-
-GitHub Actions is one OIDC issuer; see [OIDC federation](/concepts/oidc-federation) for the general model and other providers. With a trust policy in place, workflows authenticate using the OIDC token GitHub issues to each job — nothing is stored in your repository.
-
-First, create a trust policy for your repository once. The quickest path is from your GitHub connection page in the Dashboard (**Connections → your GitHub connection**), where each repository has a **Manage OIDC** button that prefills the issuer, audience, and `sub` for you. You can also create one under **Settings → OIDC federation**, or with the CLI:
+You can also create the policy with the CLI:
 
 ```sh
 nuon orgs oidc-trust-policies create \
   --name github-actions \
   --issuer https://token.actions.githubusercontent.com \
   --audience https://api.nuon.co \
-  --role org_read_only \
+  --role org_builder \
+  --ttl 900 \
   --claim sub=repo:acme/app:ref:refs/heads/main
 ```
 
-Set the `sub` condition to match the repository and ref you want to trust. See [claim matching](/concepts/oidc-federation#claim-matching) for the supported patterns.
+The policy grants short-lived builder access, which can read org resources and create component builds but cannot perform other writes. Keep the `sub` condition limited to a protected branch. See [claim matching](/concepts/oidc-federation#claim-matching) for other supported patterns.
 
-Then grant the job permission to request an OIDC token and set your org ID. The [Nuon CLI](/cli) detects the ambient GitHub Actions token and exchanges it automatically — no `api_token` secret required:
+## Build a component
+
+Grant the job permission to request an OIDC token, then pass the org, app, and component to the action. The Nuon CLI detects and exchanges the GitHub Actions token automatically.
 
 ```yaml
 ---
@@ -79,26 +48,31 @@ on:
   push:
     branches:
       - main
+
 permissions:
+  contents: read
   id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
     name: Build
-    env:
-      NUON_ORG_ID: ${{ vars.nuon_org_id }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Build component
-        uses: nuonco/actions-build@v1
+        uses: nuonco/actions-build@v1.5.3
         with:
-          org: ${{ vars.nuon_org_id }}
-          component_id: backend
+          org_id: ${{ vars.nuon_org_id }}
+          app_id: ${{ vars.nuon_app_id }}
+          component_id: ${{ vars.nuon_component_id }}
 ```
 
-The `--audience` you set on the trust policy must match the audience the CLI requests, which defaults to your configured API URL. Set `NUON_OIDC_AUDIENCE` if your policy uses a different audience.
+<Note>
+  For a self-hosted control plane, pass its API URL as the `api_url` action
+  input and use the same URL as the trust policy audience.
+</Note>
 
 ## API tokens (fallback)
 
@@ -107,18 +81,19 @@ If you can't use OIDC — for example, your organization's policy disallows the 
 Create the token and copy it straight into your repository secret (it's shown only once):
 
 ```sh
-nuon orgs api-tokens create --name github-actions --output json | jq -r .api_token
+nuon orgs api-tokens create --name github-actions --role org_builder --output json | jq -r .api_token
 ```
 
 Then pass it to the action:
 
 ```yaml
-      - name: Build component
-        uses: nuonco/actions-build@v1
-        with:
-          api_token: ${{ secrets.nuon_api_token }}
-          org: ${{ vars.nuon_org_id }}
-          component_id: backend
+- name: Build component
+  uses: nuonco/actions-build@v1.5.3
+  with:
+    api_token: ${{ secrets.nuon_api_token }}
+    org_id: ${{ vars.nuon_org_id }}
+    app_id: ${{ vars.nuon_app_id }}
+    component_id: ${{ vars.nuon_component_id }}
 ```
 
 Rotate it any time by creating a new token and revoking the old one with `nuon orgs api-tokens delete --id <token-id>`. Creating tokens requires org admin access.

--- a/sdks/nuon-go/client/operations/operations_client.go
+++ b/sdks/nuon-go/client/operations/operations_client.go
@@ -5067,7 +5067,7 @@ func (a *Client) CreateSlackOrgLink(params *CreateSlackOrgLinkParams, authInfo r
 /*
 CreateStaticToken creates a static API token for your org
 
-Creates a long-lived static API token scoped to your current org. Each token gets its own dedicated service account, and only grants access to the current org. The role param controls the token's permissions (org_admin, org_support, or org_read_only) and defaults to org_read_only.
+Creates a long-lived static API token scoped to your current org. Each token gets its own dedicated service account, and only grants access to the current org. The role param controls the token's permissions (org_admin, org_support, org_read_only, or org_builder) and defaults to org_read_only.
 */
 func (a *Client) CreateStaticToken(params *CreateStaticTokenParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateStaticTokenCreated, error) {
 	// NOTE: parameters are not validated before sending

--- a/sdks/nuon-go/models/app_policy_name.go
+++ b/sdks/nuon-go/models/app_policy_name.go
@@ -39,6 +39,9 @@ const (
 	// AppPolicyNameOrgReadOnly captures enum value "org_read_only"
 	AppPolicyNameOrgReadOnly AppPolicyName = "org_read_only"
 
+	// AppPolicyNameOrgBuilder captures enum value "org_builder"
+	AppPolicyNameOrgBuilder AppPolicyName = "org_builder"
+
 	// AppPolicyNameInstaller captures enum value "installer"
 	AppPolicyNameInstaller AppPolicyName = "installer"
 
@@ -54,7 +57,7 @@ var appPolicyNameEnum []any
 
 func init() {
 	var res []AppPolicyName
-	if err := json.Unmarshal([]byte(`["org_admin","org_support","org_read_only","installer","runner","hosted_installer"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["org_admin","org_support","org_read_only","org_builder","installer","runner","hosted_installer"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/sdks/nuon-go/models/app_role_type.go
+++ b/sdks/nuon-go/models/app_role_type.go
@@ -39,6 +39,9 @@ const (
 	// AppRoleTypeOrgReadOnly captures enum value "org_read_only"
 	AppRoleTypeOrgReadOnly AppRoleType = "org_read_only"
 
+	// AppRoleTypeOrgBuilder captures enum value "org_builder"
+	AppRoleTypeOrgBuilder AppRoleType = "org_builder"
+
 	// AppRoleTypeInstaller captures enum value "installer"
 	AppRoleTypeInstaller AppRoleType = "installer"
 
@@ -54,7 +57,7 @@ var appRoleTypeEnum []any
 
 func init() {
 	var res []AppRoleType
-	if err := json.Unmarshal([]byte(`["org_admin","org_support","org_read_only","installer","runner","hosted-installer"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["org_admin","org_support","org_read_only","org_builder","installer","runner","hosted-installer"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/sdks/nuon-go/models/service_create_o_id_c_trust_policy_request.go
+++ b/sdks/nuon-go/models/service_create_o_id_c_trust_policy_request.go
@@ -38,7 +38,7 @@ type ServiceCreateOIDCTrustPolicyRequest struct {
 	Name *string `json:"name"`
 
 	// org role granted to exchanged tokens. one of org_admin, org_support,
-	// org_read_only. defaults to org_read_only.
+	// org_read_only, org_builder. defaults to org_read_only.
 	Role string `json:"role,omitempty"`
 
 	// lifetime of exchanged tokens in seconds. defaults to 3600, max 86400.

--- a/sdks/nuon-go/models/service_create_static_token_request.go
+++ b/sdks/nuon-go/models/service_create_static_token_request.go
@@ -26,7 +26,7 @@ type ServiceCreateStaticTokenRequest struct {
 	// Required: true
 	Name *string `json:"name"`
 
-	// org role granted to the token. one of org_admin, org_support, org_read_only.
+	// org role granted to the token. one of org_admin, org_support, org_read_only, org_builder.
 	// defaults to org_read_only.
 	Role string `json:"role,omitempty"`
 }

--- a/services/ctl-api/internal/app/accounts/service/service_account.go
+++ b/services/ctl-api/internal/app/accounts/service/service_account.go
@@ -43,6 +43,12 @@ var roleCatalog = []RoleInfo{
 		AppliesTo:   []string{roleAppliesToUser, roleAppliesToServiceAccount},
 	},
 	{
+		RoleType:    app.RoleTypeOrgBuilder,
+		Title:       "Builder",
+		Description: "Read access to the organization and its resources, with permission to create component builds.",
+		AppliesTo:   []string{roleAppliesToServiceAccount},
+	},
+	{
 		RoleType:    app.RoleTypeRunner,
 		Title:       "Runner",
 		Description: "Permissions for runners executing deployments.",

--- a/services/ctl-api/internal/app/accounts/service/static_token.go
+++ b/services/ctl-api/internal/app/accounts/service/static_token.go
@@ -25,7 +25,7 @@ type CreateStaticTokenRequest struct {
 	// human-friendly name to identify the token later
 	Name string `json:"name" validate:"required"`
 
-	// org role granted to the token. one of org_admin, org_support, org_read_only.
+	// org role granted to the token. one of org_admin, org_support, org_read_only, org_builder.
 	// defaults to org_read_only.
 	Role string `json:"role"`
 }
@@ -36,6 +36,7 @@ var allowedTokenRoles = map[app.RoleType]struct{}{
 	app.RoleTypeOrgAdmin:    {},
 	app.RoleTypeOrgSupport:  {},
 	app.RoleTypeOrgReadOnly: {},
+	app.RoleTypeOrgBuilder:  {},
 }
 
 func parseTokenRole(raw string) (app.RoleType, error) {
@@ -44,7 +45,7 @@ func parseTokenRole(raw string) (app.RoleType, error) {
 	}
 	role := app.RoleType(raw)
 	if _, ok := allowedTokenRoles[role]; !ok {
-		return "", fmt.Errorf("invalid role %q: must be one of %q, %q, %q", raw, app.RoleTypeOrgAdmin, app.RoleTypeOrgSupport, app.RoleTypeOrgReadOnly)
+		return "", fmt.Errorf("invalid role %q: must be one of %q, %q, %q, %q", raw, app.RoleTypeOrgAdmin, app.RoleTypeOrgSupport, app.RoleTypeOrgReadOnly, app.RoleTypeOrgBuilder)
 	}
 	return role, nil
 }
@@ -72,7 +73,7 @@ func parseTokenDuration(raw string) (time.Duration, error) {
 
 // @ID						CreateStaticToken
 // @Summary				create a static API token for your org
-// @Description			Creates a long-lived static API token scoped to your current org. Each token gets its own dedicated service account, and only grants access to the current org. The role param controls the token's permissions (org_admin, org_support, or org_read_only) and defaults to org_read_only.
+// @Description			Creates a long-lived static API token scoped to your current org. Each token gets its own dedicated service account, and only grants access to the current org. The role param controls the token's permissions (org_admin, org_support, org_read_only, or org_builder) and defaults to org_read_only.
 // @Param					req	body	CreateStaticTokenRequest	true	"Input"
 // @Tags					accounts
 // @Security				APIKey

--- a/services/ctl-api/internal/app/accounts/service/static_token_unit_test.go
+++ b/services/ctl-api/internal/app/accounts/service/static_token_unit_test.go
@@ -50,6 +50,7 @@ func TestParseTokenRole(t *testing.T) {
 		{name: "admin", raw: "org_admin", want: app.RoleTypeOrgAdmin},
 		{name: "support", raw: "org_support", want: app.RoleTypeOrgSupport},
 		{name: "read-only", raw: "org_read_only", want: app.RoleTypeOrgReadOnly},
+		{name: "builder", raw: "org_builder", want: app.RoleTypeOrgBuilder},
 		{name: "internal role is rejected", raw: "installer", wantErr: true},
 		{name: "unknown role is rejected", raw: "superuser", wantErr: true},
 	}

--- a/services/ctl-api/internal/app/oidc-federation/service/trust_policies.go
+++ b/services/ctl-api/internal/app/oidc-federation/service/trust_policies.go
@@ -23,6 +23,7 @@ var allowedTrustPolicyRoles = map[app.RoleType]struct{}{
 	app.RoleTypeOrgAdmin:    {},
 	app.RoleTypeOrgSupport:  {},
 	app.RoleTypeOrgReadOnly: {},
+	app.RoleTypeOrgBuilder:  {},
 }
 
 type CreateOIDCTrustPolicyRequest struct {
@@ -41,7 +42,7 @@ type CreateOIDCTrustPolicyRequest struct {
 	ClaimConditions map[string]string `json:"claim_conditions" validate:"required"`
 
 	// org role granted to exchanged tokens. one of org_admin, org_support,
-	// org_read_only. defaults to org_read_only.
+	// org_read_only, org_builder. defaults to org_read_only.
 	Role string `json:"role"`
 
 	// lifetime of exchanged tokens in seconds. defaults to 3600, max 86400.
@@ -65,7 +66,7 @@ func parseTrustPolicyRole(raw string) (app.RoleType, error) {
 
 	role := app.RoleType(raw)
 	if _, ok := allowedTrustPolicyRoles[role]; !ok {
-		return "", fmt.Errorf("invalid role %q: must be one of %q, %q, %q", raw, app.RoleTypeOrgAdmin, app.RoleTypeOrgSupport, app.RoleTypeOrgReadOnly)
+		return "", fmt.Errorf("invalid role %q: must be one of %q, %q, %q, %q", raw, app.RoleTypeOrgAdmin, app.RoleTypeOrgSupport, app.RoleTypeOrgReadOnly, app.RoleTypeOrgBuilder)
 	}
 
 	return role, nil

--- a/services/ctl-api/internal/app/oidc-federation/service/trust_policies_integration_test.go
+++ b/services/ctl-api/internal/app/oidc-federation/service/trust_policies_integration_test.go
@@ -108,6 +108,27 @@ func (s *OIDCFederationTestSuite) TestCreatePolicyValidation() {
 	}
 }
 
+func (s *OIDCFederationTestSuite) TestCreatePolicyAllowsBuilderRole() {
+	idp := newFakeIDP(s.T())
+	s.deps.Service.cfg.OIDCFederationAllowInsecureIssuers = true
+
+	rr := s.makeRequest(http.MethodPost, "/v1/oidc/trust-policies", CreateOIDCTrustPolicyRequest{
+		Name: "builder", IssuerURL: idp.issuer(), Audience: "nuon-test",
+		ClaimConditions: map[string]string{"sub": "repo:acme/app:*:*"},
+		Role:            string(app.RoleTypeOrgBuilder),
+	})
+	require.Equal(s.T(), http.StatusCreated, rr.Code, rr.Body.String())
+
+	var policy app.OIDCTrustPolicy
+	require.NoError(s.T(), json.Unmarshal(rr.Body.Bytes(), &policy))
+	require.Equal(s.T(), string(app.RoleTypeOrgBuilder), policy.Role)
+
+	var acct app.Account
+	require.NoError(s.T(), s.deps.DB.Preload("Roles").Where(app.Account{ID: policy.ServiceAccountID}).First(&acct).Error)
+	require.Len(s.T(), acct.Roles, 1)
+	require.Equal(s.T(), app.RoleTypeOrgBuilder, acct.Roles[0].RoleType)
+}
+
 func (s *OIDCFederationTestSuite) TestCRUDRequiresOrgAdmin() {
 	s.demoteTestAccount()
 

--- a/services/ctl-api/internal/app/oidc-federation/service/trust_policies_unit_test.go
+++ b/services/ctl-api/internal/app/oidc-federation/service/trust_policies_unit_test.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+func TestParseTrustPolicyRole(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    app.RoleType
+		wantErr bool
+	}{
+		{name: "empty defaults to read-only", want: app.RoleTypeOrgReadOnly},
+		{name: "builder", raw: "org_builder", want: app.RoleTypeOrgBuilder},
+		{name: "runner rejected", raw: "runner", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseTrustPolicyRole(tc.raw)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/services/ctl-api/internal/app/policy.go
+++ b/services/ctl-api/internal/app/policy.go
@@ -21,6 +21,7 @@ const (
 	PolicyNameOrgAdmin    PolicyName = "org_admin"
 	PolicyNameOrgSupport  PolicyName = "org_support"
 	PolicyNameOrgReadOnly PolicyName = "org_read_only"
+	PolicyNameOrgBuilder  PolicyName = "org_builder"
 	PolicyNameInstaller   PolicyName = "installer"
 	PolicyNameRunner      PolicyName = "runner"
 

--- a/services/ctl-api/internal/app/role.go
+++ b/services/ctl-api/internal/app/role.go
@@ -19,6 +19,7 @@ const (
 	// Deprecated: org_support is no longer assignable to new members; use org_admin or org_read_only.
 	RoleTypeOrgSupport  RoleType = "org_support"
 	RoleTypeOrgReadOnly RoleType = "org_read_only"
+	RoleTypeOrgBuilder  RoleType = "org_builder"
 
 	// service account roles
 	// Deprecated: installer is no longer assignable; it grants full org access, use org_admin instead.

--- a/services/ctl-api/internal/middlewares/org/org.go
+++ b/services/ctl-api/internal/middlewares/org/org.go
@@ -81,11 +81,12 @@ func (m middleware) Handler() gin.HandlerFunc {
 
 		// make sure account has access to org
 		perm := permissions.FromRequest(ctx)
-		err = acct.AllPermissions.CanPerform(org.ID, perm)
+		object := permissions.RequestObject(ctx, org.ID)
+		err = acct.AllPermissions.CanPerform(object, perm)
 		if err != nil {
 			ctx.Error(stderr.ErrAuthorization{
-				Err:         fmt.Errorf("unable to perform %s on org %s", perm, org.ID),
-				Description: fmt.Sprintf("Please make sure you have the correct permissions for %s", org.ID),
+				Err:         fmt.Errorf("unable to perform %s on object %s", perm, object),
+				Description: fmt.Sprintf("Please make sure you have the correct permissions for %s", object),
 			})
 			ctx.Abort()
 			return

--- a/services/ctl-api/internal/pkg/authz/create_org_roles.go
+++ b/services/ctl-api/internal/pkg/authz/create_org_roles.go
@@ -11,7 +11,20 @@ import (
 )
 
 func (c *Client) CreateOrgRoles(ctx context.Context, orgID string) error {
-	roles := []app.Role{
+	roles := standardOrgRoles(orgID)
+
+	res := c.db.
+		WithContext(ctx).
+		Create(roles)
+	if res.Error != nil {
+		return res.Error
+	}
+
+	return nil
+}
+
+func standardOrgRoles(orgID string) []app.Role {
+	return []app.Role{
 		// create admin role
 		{
 			OrgID:    generics.NewNullString(orgID),
@@ -22,6 +35,21 @@ func (c *Client) CreateOrgRoles(ctx context.Context, orgID string) error {
 					Name:  app.PolicyNameOrgAdmin,
 					Permissions: pgtype.Hstore(map[string]*string{
 						orgID: permissions.PermissionAll.ToStrPtr(),
+					}),
+				},
+			},
+		},
+
+		{
+			OrgID:    generics.NewNullString(orgID),
+			RoleType: app.RoleTypeOrgBuilder,
+			Policies: []app.Policy{
+				{
+					OrgID: generics.NewNullString(orgID),
+					Name:  app.PolicyNameOrgBuilder,
+					Permissions: pgtype.Hstore(map[string]*string{
+						orgID:                                    permissions.PermissionRead.ToStrPtr(),
+						permissions.ComponentBuildsObject(orgID): permissions.PermissionCreate.ToStrPtr(),
 					}),
 				},
 			},
@@ -87,13 +115,4 @@ func (c *Client) CreateOrgRoles(ctx context.Context, orgID string) error {
 			},
 		},
 	}
-
-	res := c.db.
-		WithContext(ctx).
-		Create(roles)
-	if res.Error != nil {
-		return res.Error
-	}
-
-	return nil
 }

--- a/services/ctl-api/internal/pkg/authz/create_org_roles_test.go
+++ b/services/ctl-api/internal/pkg/authz/create_org_roles_test.go
@@ -1,0 +1,39 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/authz/permissions"
+)
+
+func TestStandardOrgRolesBuilderPermissions(t *testing.T) {
+	const orgID = "org_one"
+
+	var builder *app.Role
+	roles := standardOrgRoles(orgID)
+	for i := range roles {
+		role := roles[i]
+		if role.RoleType == app.RoleTypeOrgBuilder {
+			builder = &role
+			break
+		}
+	}
+
+	require.NotNil(t, builder)
+	require.Len(t, builder.Policies, 1)
+	require.Equal(t, app.PolicyNameOrgBuilder, builder.Policies[0].Name)
+	require.Equal(t, permissions.PermissionRead.ToStrPtr(), builder.Policies[0].Permissions[orgID])
+	require.Equal(t, permissions.PermissionCreate.ToStrPtr(), builder.Policies[0].Permissions[permissions.ComponentBuildsObject(orgID)])
+	require.Len(t, builder.Policies[0].Permissions, 2)
+
+	set := permissions.Set(permissions.NewSet())
+	require.NoError(t, set.Add(builder.Policies[0].Permissions))
+	require.NoError(t, set.CanPerform(orgID, permissions.PermissionRead))
+	require.NoError(t, set.CanPerform(permissions.ComponentBuildsObject(orgID), permissions.PermissionCreate))
+	require.Error(t, set.CanPerform(orgID, permissions.PermissionCreate))
+	require.Error(t, set.CanPerform(permissions.ComponentBuildsObject(orgID), permissions.PermissionUpdate))
+	require.Error(t, set.CanPerform(permissions.ComponentBuildsObject("org_two"), permissions.PermissionCreate))
+}

--- a/services/ctl-api/internal/pkg/authz/permissions/request.go
+++ b/services/ctl-api/internal/pkg/authz/permissions/request.go
@@ -1,10 +1,30 @@
 package permissions
 
 import (
+	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 )
+
+const componentBuildsObjectSuffix = ":component_builds"
+
+func ComponentBuildsObject(orgID string) string {
+	return orgID + componentBuildsObjectSuffix
+}
+
+func RequestObject(ctx *gin.Context, orgID string) string {
+	if ctx.Request.Method != http.MethodPost {
+		return orgID
+	}
+
+	switch ctx.FullPath() {
+	case "/v1/apps/:app_id/components/:component_id/builds", "/v1/components/:component_id/builds":
+		return ComponentBuildsObject(orgID)
+	default:
+		return orgID
+	}
+}
 
 func FromRequest(ctx *gin.Context) Permission {
 	method := strings.ToLower(ctx.Request.Method)

--- a/services/ctl-api/internal/pkg/authz/permissions/request_test.go
+++ b/services/ctl-api/internal/pkg/authz/permissions/request_test.go
@@ -1,0 +1,56 @@
+package permissions
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestObject(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const orgID = "org_one"
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		want   string
+	}{
+		{name: "app component build", method: http.MethodPost, path: "/v1/apps/app_one/components/cmp_one/builds", want: ComponentBuildsObject(orgID)},
+		{name: "component build", method: http.MethodPost, path: "/v1/components/cmp_one/builds", want: ComponentBuildsObject(orgID)},
+		{name: "build cancel", method: http.MethodPost, path: "/v1/apps/app_one/components/cmp_one/builds/bld_one/cancel", want: orgID},
+		{name: "other post", method: http.MethodPost, path: "/v1/apps", want: orgID},
+		{name: "read build route", method: http.MethodGet, path: "/v1/components/cmp_one/builds", want: orgID},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			router := gin.New()
+			router.Handle(tc.method, routePattern(tc.path), func(ctx *gin.Context) {
+				got = RequestObject(ctx, orgID)
+			})
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			router.ServeHTTP(httptest.NewRecorder(), req)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	assert.NotEqual(t, ComponentBuildsObject("org_two"), ComponentBuildsObject(orgID))
+}
+
+func routePattern(path string) string {
+	switch path {
+	case "/v1/apps/app_one/components/cmp_one/builds":
+		return "/v1/apps/:app_id/components/:component_id/builds"
+	case "/v1/components/cmp_one/builds":
+		return "/v1/components/:component_id/builds"
+	case "/v1/apps/app_one/components/cmp_one/builds/bld_one/cancel":
+		return "/v1/apps/:app_id/components/:component_id/builds/:build_id/cancel"
+	default:
+		return path
+	}
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/121_backfill_org_builder_role.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/121_backfill_org_builder_role.go
@@ -1,0 +1,67 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/authz/permissions"
+)
+
+func (m *Migrations) Migration121BackfillOrgBuilderRole(ctx context.Context, db *gorm.DB) error {
+	const batchSize = 20
+	var offset int
+
+	for {
+		var orgs []app.Org
+		if err := db.WithContext(ctx).Limit(batchSize).Offset(offset).Find(&orgs).Error; err != nil {
+			return fmt.Errorf("unable to fetch orgs: %w", err)
+		}
+		if len(orgs) == 0 {
+			break
+		}
+
+		for _, org := range orgs {
+			var existingRole app.Role
+			err := db.WithContext(ctx).
+				Where(app.Role{OrgID: generics.NewNullString(org.ID), RoleType: app.RoleTypeOrgBuilder}).
+				First(&existingRole).Error
+			if err == nil {
+				continue
+			}
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("unable to check org_builder role for org %s: %w", org.ID, err)
+			}
+
+			role := app.Role{
+				OrgID:       generics.NewNullString(org.ID),
+				CreatedByID: org.CreatedByID,
+				RoleType:    app.RoleTypeOrgBuilder,
+				Policies: []app.Policy{
+					{
+						OrgID:       generics.NewNullString(org.ID),
+						CreatedByID: org.CreatedByID,
+						Name:        app.PolicyNameOrgBuilder,
+						Permissions: pgtype.Hstore(map[string]*string{
+							org.ID: permissions.PermissionRead.ToStrPtr(),
+							permissions.ComponentBuildsObject(org.ID): permissions.PermissionCreate.ToStrPtr(),
+						}),
+					},
+				},
+			}
+
+			if err := db.WithContext(ctx).Create(&role).Error; err != nil {
+				return fmt.Errorf("unable to create org_builder role for org %s: %w", org.ID, err)
+			}
+		}
+
+		offset += batchSize
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/all.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/all.go
@@ -156,5 +156,9 @@ func (m *Migrations) All() []migrations.Migration {
 			Name: "120-installs-last-health-report-at-index",
 			Fn:   m.Migration120InstallsLastHealthReportAtIndex,
 		},
+		{
+			Name: "121-backfill-org-builder-role",
+			Fn:   m.Migration121BackfillOrgBuilderRole,
+		},
 	}
 }

--- a/services/dashboard-ui/client/components/api-tokens/ApiTokensTable/ApiTokensTable.tsx
+++ b/services/dashboard-ui/client/components/api-tokens/ApiTokensTable/ApiTokensTable.tsx
@@ -14,6 +14,7 @@ export const API_TOKENS_TABLE_LIMIT = 20
 
 const ROLE_LABELS: Record<string, string> = {
   org_admin: 'Admin',
+  org_builder: 'Builder',
   org_support: 'Support',
   org_read_only: 'Read-only',
 }
@@ -66,12 +67,16 @@ export const ApiTokensTable = ({
       {
         header: 'Created',
         accessorKey: 'created_at',
-        cell: (props) => <Time time={props.getValue<string>()} format="relative" />,
+        cell: (props) => (
+          <Time time={props.getValue<string>()} format="relative" />
+        ),
       },
       {
         header: 'Expires',
         accessorKey: 'expires_at',
-        cell: (props) => <Time time={props.getValue<string>()} format="short-datetime" />,
+        cell: (props) => (
+          <Time time={props.getValue<string>()} format="short-datetime" />
+        ),
       },
       {
         id: 'action',

--- a/services/dashboard-ui/client/components/api-tokens/CreateApiToken/CreateApiToken.tsx
+++ b/services/dashboard-ui/client/components/api-tokens/CreateApiToken/CreateApiToken.tsx
@@ -19,6 +19,7 @@ export const DURATION_OPTIONS = [
 
 export const ROLE_OPTIONS = [
   { value: 'org_read_only', label: 'Read-only' },
+  { value: 'org_builder', label: 'Builder' },
   { value: 'org_admin', label: 'Admin' },
 ]
 

--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
@@ -22,6 +22,7 @@ export type OIDCTrustPolicyFormInput = {
 
 const ROLE_OPTIONS = [
   { value: 'org_read_only', label: 'org_read_only' },
+  { value: 'org_builder', label: 'org_builder' },
   { value: 'org_support', label: 'org_support' },
   { value: 'org_admin', label: 'org_admin' },
 ]

--- a/services/dashboard-ui/client/components/oidc-trust-policies/EditOIDCTrustPolicy/EditOIDCTrustPolicy.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/EditOIDCTrustPolicy/EditOIDCTrustPolicy.tsx
@@ -26,6 +26,7 @@ export type EditOIDCTrustPolicyFormInput = {
 
 const ROLE_OPTIONS = [
   { value: 'org_read_only', label: 'org_read_only' },
+  { value: 'org_builder', label: 'org_builder' },
   { value: 'org_support', label: 'org_support' },
   { value: 'org_admin', label: 'org_admin' },
 ]
@@ -34,9 +35,9 @@ const conditionsToRows = (
   claimConditions: TOIDCTrustPolicy['claim_conditions']
 ): ClaimCondition[] => {
   const entries = Object.entries(claimConditions ?? {})
-  return entries.length ? entries.map(([key, value]) => ({ key, value })) : [
-    { key: 'sub', value: '' },
-  ]
+  return entries.length
+    ? entries.map(([key, value]) => ({ key, value }))
+    : [{ key: 'sub', value: '' }]
 }
 
 export const EditOIDCTrustPolicyModal = ({
@@ -59,8 +60,8 @@ export const EditOIDCTrustPolicyModal = ({
     policy.token_duration_seconds ? String(policy.token_duration_seconds) : ''
   )
   const [enabled, setEnabled] = useState(policy.enabled ?? true)
-  const [claimConditions, setClaimConditions] = useState<ClaimCondition[]>(
-    () => conditionsToRows(policy.claim_conditions)
+  const [claimConditions, setClaimConditions] = useState<ClaimCondition[]>(() =>
+    conditionsToRows(policy.claim_conditions)
   )
 
   const trimmedName = name.trim()
@@ -203,8 +204,8 @@ export const EditOIDCTrustPolicyModal = ({
         <div className="flex flex-col gap-2">
           <Label>Claim conditions</Label>
           <Text variant="subtext" theme="neutral">
-            All conditions must match the presented token. A `sub` condition
-            is required.
+            All conditions must match the presented token. A `sub` condition is
+            required.
           </Text>
           <div className="flex flex-col gap-2">
             {claimConditions.map((condition, index) => (

--- a/services/dashboard-ui/client/components/oidc-trust-policies/OIDCTrustPoliciesTable/OIDCTrustPoliciesTable.stories.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/OIDCTrustPoliciesTable/OIDCTrustPoliciesTable.stories.tsx
@@ -16,7 +16,7 @@ const mockPolicies: TOIDCTrustPolicy[] = [
     issuer_url: 'https://token.actions.githubusercontent.com',
     audience: 'https://api.nuon.co',
     claim_conditions: { sub: 'repo:acme/app:ref:refs/heads/main' },
-    role: 'org_support',
+    role: 'org_builder',
     token_duration_seconds: 3600,
     enabled: true,
     created_by_id: 'acct-1',

--- a/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/RepositoriesSection.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ConnectionDetail/RepositoriesSection.tsx
@@ -156,8 +156,9 @@ export const RepositoriesSection = ({
                       {repo.description}
                     </Text>
                   )}
-                  {oidcEnabled && (
+                  {oidcEnabled && repo.default_branch && (
                     <ManageRepoOIDCButton
+                      defaultBranch={repo.default_branch}
                       repoFullName={repo.full_name}
                       size="sm"
                       className="w-fit"

--- a/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/ManageRepoOIDC.stories.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/ManageRepoOIDC.stories.tsx
@@ -26,9 +26,10 @@ const policies: TOIDCTrustPolicy[] = [
   {
     id: 'oidcpolicy1',
     name: 'github-app',
-    role: 'org_read_only',
+    role: 'org_builder',
     enabled: true,
-    claim_conditions: { sub: 'repo:acme/app:ref:refs/heads/*' },
+    token_duration_seconds: 900,
+    claim_conditions: { sub: 'repo:acme/app:ref:refs/heads/main' },
   },
 ]
 

--- a/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/ManageRepoOIDCContainer.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/ManageRepoOIDCContainer.tsx
@@ -19,9 +19,10 @@ import { ManageRepoOIDCModal } from './ManageRepoOIDC'
 const GITHUB_ACTIONS_ISSUER = 'https://token.actions.githubusercontent.com'
 
 const ManageRepoOIDCModalContainer = ({
+  defaultBranch,
   repoFullName,
   ...props
-}: { repoFullName: string } & Record<string, any>) => {
+}: { defaultBranch: string; repoFullName: string } & Record<string, any>) => {
   const { org } = useOrg()
   const config = useConfig()
   const queryClient = useQueryClient()
@@ -110,9 +111,13 @@ const ManageRepoOIDCModalContainer = ({
             name: defaultName,
             issuerUrl: GITHUB_ACTIONS_ISSUER,
             audience: config.apiUrl ?? '',
-            role: 'org_read_only',
+            role: 'org_builder',
+            tokenDurationSeconds: '900',
             claimConditions: [
-              { key: 'sub', value: `repo:${repoFullName}:ref:refs/heads/*` },
+              {
+                key: 'sub',
+                value: `repo:${repoFullName}:ref:refs/heads/${defaultBranch}`,
+              },
             ],
           }}
           reservedNames={reservedNames}
@@ -128,11 +133,20 @@ const ManageRepoOIDCModalContainer = ({
 }
 
 export const ManageRepoOIDCButton = ({
+  defaultBranch,
   repoFullName,
   ...props
-}: { repoFullName: string } & Omit<IButtonAsButton, 'children'>) => {
+}: { defaultBranch: string; repoFullName: string } & Omit<
+  IButtonAsButton,
+  'children'
+>) => {
   const { addModal } = useSurfaces()
-  const modal = <ManageRepoOIDCModalContainer repoFullName={repoFullName} />
+  const modal = (
+    <ManageRepoOIDCModalContainer
+      defaultBranch={defaultBranch}
+      repoFullName={repoFullName}
+    />
+  )
 
   return (
     <Button variant="secondary" onClick={() => addModal(modal)} {...props}>


### PR DESCRIPTION
## Summary

- add a scoped Builder role for component builds
- use 15-minute, default-branch GitHub OIDC trust
- update dashboard, CLI, SDK, and docs workflows

Builder can read org resources and create component builds only. Other writes remain denied.

## Test

Focused Go tests, SDK tests, CLI tests, TypeScript, lint, and formatting pass.

Merge nuonco/actions-build#24 first and verify exact tag `v1.5.3`.