### PR TITLE
feat: add Nuon identity to runner OTEL resources

### DIFF
--- a/bins/runner/internal/pkg/slog/resource.go
+++ b/bins/runner/internal/pkg/slog/resource.go
@@ -3,15 +3,24 @@ package slog
 import (
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/pkg/runner/settings"
+	"github.com/nuonco/nuon/pkg/runner/version"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 func getResource(set *settings.Settings, logStreamID string) *resource.Resource {
 	attrs := []attribute.KeyValue{}
 	builtInAttrs := map[string]string{
-		"service.name": "runner",
+		string(semconv.ServiceNamespaceKey): "nuon",
+		string(semconv.ServiceNameKey):      "runner",
+	}
+	if version.Version != "" {
+		builtInAttrs[string(semconv.ServiceVersionKey)] = version.Version
+	}
+	if runnerID := set.Metadata["runner.id"]; runnerID != "" {
+		builtInAttrs[string(semconv.ServiceInstanceIDKey)] = runnerID
 	}
 	if logStreamID != "" {
 		builtInAttrs["log_stream.id"] = logStreamID

--- a/bins/runner/internal/pkg/slog/resource_test.go
+++ b/bins/runner/internal/pkg/slog/resource_test.go
@@ -1,0 +1,41 @@
+package slog
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+
+	"github.com/nuonco/nuon/pkg/runner/settings"
+	"github.com/nuonco/nuon/pkg/runner/version"
+)
+
+func TestResourceIncludesNuonServiceIdentity(t *testing.T) {
+	set := &settings.Settings{Metadata: map[string]string{
+		"runner.id":         "run123",
+		"service.name":      "overridden",
+		"service.namespace": "overridden",
+	}}
+	rsrc := getResource(set, "log123")
+
+	want := map[attribute.Key]string{
+		semconv.ServiceNamespaceKey:    "nuon",
+		semconv.ServiceNameKey:         "runner",
+		semconv.ServiceVersionKey:      version.Version,
+		semconv.ServiceInstanceIDKey:   "run123",
+		attribute.Key("log_stream.id"): "log123",
+	}
+	for key, value := range want {
+		got, ok := rsrc.Set().Value(key)
+		if !ok || got.AsString() != value {
+			t.Errorf("%s = %q, want %q", key, got.AsString(), value)
+		}
+	}
+}
+
+func TestResourceOmitsEmptyServiceInstanceID(t *testing.T) {
+	rsrc := getResource(&settings.Settings{Metadata: map[string]string{}}, "")
+	if _, ok := rsrc.Set().Value(semconv.ServiceInstanceIDKey); ok {
+		t.Fatal("empty service.instance.id was included")
+	}
+}


### PR DESCRIPTION
Add global nuon attributes to all the audit log related OTEL signal data as per semantic conventions.