### PR TITLE
chore(dashboard-ui): sandbox - render multiple files

### DIFF
--- a/services/dashboard-ui/client/components/sandbox/SandboxConfigModals.stories.tsx
+++ b/services/dashboard-ui/client/components/sandbox/SandboxConfigModals.stories.tsx
@@ -21,12 +21,21 @@ export const EnvironmentVariables = () => (
   </ModalStory>
 )
 
+export const VariablesFilesSingle = () => (
+  <ModalStory label="Open variables files modal">
+    <SandboxVariablesFilesModal
+      variablesFiles={['region = "us-west-2"\ninstance_type = "t3.medium"']}
+    />
+  </ModalStory>
+)
+
 export const VariablesFiles = () => (
   <ModalStory label="Open variables files modal">
     <SandboxVariablesFilesModal
       variablesFiles={[
         'region = "us-west-2"\ninstance_type = "t3.medium"',
         'vpc_id = "vpc-12345"\nsubnet_ids = ["subnet-1", "subnet-2"]',
+        'tags = {\n  Environment = "production"\n  Team        = "platform"\n}',
       ]}
     />
   </ModalStory>

--- a/services/dashboard-ui/client/components/sandbox/SandboxConfigModals.tsx
+++ b/services/dashboard-ui/client/components/sandbox/SandboxConfigModals.tsx
@@ -1,7 +1,9 @@
+import type { ReactNode } from 'react'
 import { CodeBlock } from '@/components/common/CodeBlock'
 import { ClickToCopyButton } from '@/components/common/ClickToCopy'
 import { Icon } from '@/components/common/Icon'
 import { KeyValueList } from '@/components/common/KeyValueList'
+import { Tabs } from '@/components/common/Tabs'
 import { Text } from '@/components/common/Text'
 import { Modal, type IModal } from '@/components/surfaces/Modal'
 import type { TKeyValue } from '@/types'
@@ -105,6 +107,16 @@ export const SandboxVariablesFilesModal = ({
   ...props
 }: SandboxVariablesFilesModalProps) => {
   const variablesFilesContent = variablesFiles.join('\n---\n')
+  const hasMultipleFiles = variablesFiles.length > 1
+
+  const fileTabs: Record<string, ReactNode> = {}
+  variablesFiles.forEach((file, idx) => {
+    fileTabs[`file ${idx + 1}`] = (
+      <CodeBlock language="hcl" className="!max-h-fit">
+        {file}
+      </CodeBlock>
+    )
+  })
 
   return (
     <Modal
@@ -128,9 +140,13 @@ export const SandboxVariablesFilesModal = ({
             <ClickToCopyButton textToCopy={variablesFilesContent} className="w-fit" />
           </div>
         </div>
-        <CodeBlock language="hcl" className="!max-h-fit">
-          {variablesFilesContent}
-        </CodeBlock>
+        {hasMultipleFiles ? (
+          <Tabs tabs={fileTabs} />
+        ) : (
+          <CodeBlock language="hcl" className="!max-h-fit">
+            {variablesFilesContent}
+          </CodeBlock>
+        )}
       </div>
     </Modal>
   )


### PR DESCRIPTION
### Description

The sandbox can be configured using multiple tfvars files but we only ever show one.

This PR adds a tabbed view so we can see them all.
