### PR TITLE
fix: nuon lsp not able to handle array type

### DIFF
--- a/bins/lsp/handlers/diagnostics.go
+++ b/bins/lsp/handlers/diagnostics.go
@@ -532,6 +532,8 @@ func tomlTypeOf(value any) string {
 		return "number"
 	case bool:
 		return "boolean"
+	case []any, []string, []map[string]any:
+		return "array"
 	case map[string]any:
 		return "object"
 	default:
@@ -601,20 +603,25 @@ func extractRawValues(text string, doc *tomlparser.TomlDocument) map[string]any 
 		// This helps catch cases like "1.2.3" which are invalid floats
 		var value any = rawValue
 
-		// Try parsing as number
-		if f, err := strconv.ParseFloat(rawValue, 64); err == nil {
-			// Check if it looks like a float or integer
-			if strings.Contains(rawValue, ".") {
-				value = f
-			} else {
-				value = int64(f)
-			}
-		} else {
-			// For values that failed to parse as floats, check if they look like
-			// they were attempting to be numbers (e.g., "1.2.3" which has multiple dots)
-			// We want to treat these as numeric types for type checking purposes
-			if looksLikeNumber(rawValue) {
-				// Can't parse as valid float, but looks like a number attempt
+		switch {
+		case strings.HasPrefix(rawValue, "["):
+			value = []any{}
+		case strings.HasPrefix(rawValue, "{"):
+			value = map[string]any{}
+		case rawValue == "true" || rawValue == "false":
+			value = rawValue == "true"
+		default:
+			// Try parsing as number
+			if f, err := strconv.ParseFloat(rawValue, 64); err == nil {
+				// Check if it looks like a float or integer
+				if strings.Contains(rawValue, ".") {
+					value = f
+				} else {
+					value = int64(f)
+				}
+			} else if looksLikeNumber(rawValue) {
+				// For values that failed to parse as floats, check if they look like
+				// they were attempting to be numbers (e.g., "1.2.3" which has multiple dots)
 				// Treat as a float64 for type mismatch detection
 				value = 0.0
 			}

--- a/bins/lsp/handlers/diagnostics_test.go
+++ b/bins/lsp/handlers/diagnostics_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"math"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -92,6 +93,114 @@ func TestDiagnostics_TerraformVersionTypeMismatch(t *testing.T) {
 	}
 }
 
+// TestDiagnostics_ArrayTypes tests that array values are typed as arrays rather than
+// falling through to "unknown", which produced a bogus
+// "Type mismatch for 'dependencies': expected array, got unknown" on every array field.
+func TestDiagnostics_ArrayTypes(t *testing.T) {
+	props := jsonschema.NewProperties()
+	props.Set("dependencies", &jsonschema.Schema{
+		Type:  "array",
+		Items: &jsonschema.Schema{Type: "string"},
+	})
+	props.Set("name", &jsonschema.Schema{Type: "string"})
+
+	schema := &jsonschema.Schema{
+		Type:        "object",
+		Properties:  props,
+		Definitions: map[string]*jsonschema.Schema{},
+	}
+
+	testCases := []struct {
+		name            string
+		tomlContent     string
+		shouldHaveError bool
+	}{
+		{
+			name:            "String array should not error",
+			tomlContent:     `dependencies = ["a", "b"]`,
+			shouldHaveError: false,
+		},
+		{
+			name:            "Empty array should not error",
+			tomlContent:     `dependencies = []`,
+			shouldHaveError: false,
+		},
+		{
+			name:            "Multiline array should not error",
+			tomlContent:     "dependencies = [\n  \"a\",\n  \"b\",\n]",
+			shouldHaveError: false,
+		},
+		{
+			name:            "Array in a document with invalid syntax should not error",
+			tomlContent:     "name = unquoted\ndependencies = [\"a\", \"b\"]",
+			shouldHaveError: false,
+		},
+		{
+			name:            "String value should error",
+			tomlContent:     `dependencies = "a"`,
+			shouldHaveError: true,
+		},
+		{
+			name:            "Integer value should error",
+			tomlContent:     `dependencies = 42`,
+			shouldHaveError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := tomlparser.ParseToml(tc.tomlContent)
+			if strictDoc, err := tomlparser.ParseStrict(tc.tomlContent); err == nil {
+				doc.Values = strictDoc.Values
+			} else {
+				doc.Values = extractRawValues(tc.tomlContent, doc)
+			}
+
+			diags := DiagnoseDocument("file:///test.toml", doc, schema)
+
+			hasTypeMismatch := false
+			for _, diag := range diags {
+				if strings.Contains(diag.Message, "Type mismatch for 'dependencies'") {
+					hasTypeMismatch = true
+					break
+				}
+			}
+
+			if tc.shouldHaveError && !hasTypeMismatch {
+				t.Errorf("Expected type mismatch error for %q, but got none. Diagnostics: %v", tc.tomlContent, diags)
+			}
+			if !tc.shouldHaveError && hasTypeMismatch {
+				t.Errorf("Expected no type mismatch error for %q, but got one: %v", tc.tomlContent, diags)
+			}
+		})
+	}
+}
+
+// TestTomlTypeOf covers the value-to-JSON-schema type mapping used for type checking.
+func TestTomlTypeOf(t *testing.T) {
+	testCases := []struct {
+		value    any
+		expected string
+	}{
+		{"str", "string"},
+		{int64(1), "integer"},
+		{1.5, "number"},
+		{true, "boolean"},
+		{[]any{"a", "b"}, "array"},
+		{[]any{}, "array"},
+		{[]string{"a"}, "array"},
+		{[]map[string]any{{"a": 1}}, "array"},
+		{map[string]any{"a": 1}, "object"},
+		{nil, "unknown"},
+	}
+
+	for _, tc := range testCases {
+		if got := tomlTypeOf(tc.value); got != tc.expected {
+			t.Errorf("tomlTypeOf(%#v) = %q, want %q", tc.value, got, tc.expected)
+		}
+	}
+}
+
 // TestExtractRawValues_ParsesValuesFromInvalidTOML tests that extractRawValues
 // correctly extracts values even when TOML is syntactically invalid
 func TestExtractRawValues_ParsesValuesFromInvalidTOML(t *testing.T) {
@@ -125,6 +234,30 @@ func TestExtractRawValues_ParsesValuesFromInvalidTOML(t *testing.T) {
 			expectedKey:   "url",
 			expectedValue: "https://example.com",
 		},
+		{
+			name:          "Should parse array as array, not string",
+			tomlContent:   `dependencies = ["a", "b"]`,
+			expectedKey:   "dependencies",
+			expectedValue: []any{},
+		},
+		{
+			name:          "Should parse multiline array opener as array",
+			tomlContent:   "dependencies = [",
+			expectedKey:   "dependencies",
+			expectedValue: []any{},
+		},
+		{
+			name:          "Should parse inline table as object",
+			tomlContent:   `env = { a = "b" }`,
+			expectedKey:   "env",
+			expectedValue: map[string]any{},
+		},
+		{
+			name:          "Should parse bool as bool, not string",
+			tomlContent:   `deploy_dependencies = true`,
+			expectedKey:   "deploy_dependencies",
+			expectedValue: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -146,8 +279,8 @@ func TestExtractRawValues_ParsesValuesFromInvalidTOML(t *testing.T) {
 				} else {
 					t.Errorf("Expected float64, got %T with value %v", val, val)
 				}
-			} else if tc.expectedValue != val {
-				t.Errorf("Expected value %v, got %v", tc.expectedValue, val)
+			} else if !reflect.DeepEqual(tc.expectedValue, val) {
+				t.Errorf("Expected value %#v, got %#v", tc.expectedValue, val)
 			}
 		})
 	}

--- a/pkg/parser/toml/parser_test.go
+++ b/pkg/parser/toml/parser_test.go
@@ -134,6 +134,33 @@ name = "second"
 	}
 }
 
+func TestParseStrict_ArrayValues(t *testing.T) {
+	input := `
+dependencies = ["a", "b"]
+empty = []
+`
+	doc, err := ParseStrict(input)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	for _, key := range []string{"dependencies", "empty"} {
+		val, ok := doc.Values[key]
+		if !ok {
+			t.Fatalf("Expected %q to be recorded as a value, got values: %#v", key, doc.Values)
+		}
+		if _, isSlice := val.([]any); !isSlice {
+			t.Errorf("Expected %q to be []any, got %T", key, val)
+		}
+	}
+
+	for _, table := range doc.Tables {
+		if table.Name == "empty" {
+			t.Error("Empty array was misclassified as an array of tables")
+		}
+	}
+}
+
 func TestParseToml_OnlyComments(t *testing.T) {
 	input := `
 # This is a comment

--- a/pkg/parser/toml/strict.go
+++ b/pkg/parser/toml/strict.go
@@ -45,8 +45,8 @@ func extractTablesAndKeys(data map[string]any, parentPath []string, doc *TomlDoc
 			// Recursively extract nested keys
 			extractTablesAndKeys(valueMap, currentPath, doc)
 		} else if valueSlice, ok := value.([]any); ok {
-			// Check if it's an array of tables
-			allMaps := true
+			// An empty array is a value, not an array of tables
+			allMaps := len(valueSlice) > 0
 			for _, item := range valueSlice {
 				if _, isMap := item.(map[string]any); !isMap {
 					allMaps = false


### PR DESCRIPTION
**Problem**

  The LSP flags a false error on every array-typed field in every schema type:

  Type mismatch for 'dependencies': expected array, got unknown

 dependencies appears in component, action, and runbook configs, so this affects most real app configs. Measured across the 273 component TOMLs in example-app-configs: 73 bogus errors before this change, 0 after.

  This is not a schema-generation problem, The generated schema is correct (Dependencies []string → "type": "array"). The bug is in the LSP's own type checker.

  **Root cause**

  tomlTypeOf (bins/lsp/handlers/diagnostics.go) enumerated the four scalars plus objects, but never arrays. ParseStrict stores array values verbatim as []any, so they fell through to default: return "unknown". schemaTypeMatches then compared the schema's "array" against "unknown", found no match, and emitted a confident, specific, wrong error.

  The permissive default is what made this ship quietly: instead of failing loudly on an unhandled case, it manufactured a plausible-looking type name that flowed straight into a user-facing message. Existing tests only exercised terraform_version, a string field, so the entire array surface was uncovered while the suite stayed green.