### PR TITLE
fix: org-wide grants cover scoped permission objects

### DIFF
--- a/services/ctl-api/internal/pkg/authz/permissions/set.go
+++ b/services/ctl-api/internal/pkg/authz/permissions/set.go
@@ -1,5 +1,7 @@
 package permissions
 
+import "strings"
+
 type Set map[string]Permission
 
 func NewSet() map[string]Permission {
@@ -29,6 +31,15 @@ func (p Set) Add(set map[string]*string) error {
 
 func (p Set) CanPerform(obj string, perm Permission) error {
 	val, ok := p[obj]
+
+	// A scoped object like "<orgID>:component_builds" inherits the org-wide
+	// grant unless the set holds a more specific grant for it. Without this,
+	// an org admin's "<orgID>: all" grant would not cover scoped objects.
+	if !ok {
+		if parent, _, found := strings.Cut(obj, ":"); found {
+			val, ok = p[parent]
+		}
+	}
 
 	// if the object is not in the permission set, look up the "*" wildcard.
 	if !ok {

--- a/services/ctl-api/internal/pkg/authz/permissions/set_test.go
+++ b/services/ctl-api/internal/pkg/authz/permissions/set_test.go
@@ -37,3 +37,52 @@ func TestSetAddKeepsStrongerGrant(t *testing.T) {
 		assert.Error(t, set.CanPerform(org, PermissionDelete))
 	})
 }
+
+func TestCanPerformScopedObjects(t *testing.T) {
+	const org = "org_abc"
+	scoped := ComponentBuildsObject(org)
+
+	t.Run("org-wide all grant covers scoped objects", func(t *testing.T) {
+		set := Set(NewSet())
+		require.NoError(t, set.Add(map[string]*string{org: strPtr(string(PermissionAll))}))
+
+		assert.NoError(t, set.CanPerform(scoped, PermissionCreate))
+	})
+
+	t.Run("org-wide read grant does not allow scoped create", func(t *testing.T) {
+		set := Set(NewSet())
+		require.NoError(t, set.Add(map[string]*string{org: strPtr(string(PermissionRead))}))
+
+		assert.NoError(t, set.CanPerform(scoped, PermissionRead))
+		assert.Error(t, set.CanPerform(scoped, PermissionCreate))
+	})
+
+	t.Run("builder grant allows scoped create but not org-wide mutation", func(t *testing.T) {
+		set := Set(NewSet())
+		require.NoError(t, set.Add(map[string]*string{
+			org:    strPtr(string(PermissionRead)),
+			scoped: strPtr(string(PermissionCreate)),
+		}))
+
+		assert.NoError(t, set.CanPerform(scoped, PermissionCreate))
+		assert.NoError(t, set.CanPerform(org, PermissionRead))
+		assert.Error(t, set.CanPerform(org, PermissionCreate))
+	})
+
+	t.Run("specific scoped grant is not widened by org grant lookup order", func(t *testing.T) {
+		set := Set(NewSet())
+		require.NoError(t, set.Add(map[string]*string{
+			org:    strPtr(string(PermissionAll)),
+			scoped: strPtr(string(PermissionCreate)),
+		}))
+
+		assert.NoError(t, set.CanPerform(scoped, PermissionCreate))
+		assert.Error(t, set.CanPerform(scoped, PermissionDelete))
+	})
+
+	t.Run("no grants at all is denied", func(t *testing.T) {
+		set := Set(NewSet())
+
+		assert.Error(t, set.CanPerform(scoped, PermissionCreate))
+	})
+}


### PR DESCRIPTION
## Problem

#2050 introduced a scoped permission object for component-build creation (`<orgID>:component_builds`), checked by the org middleware on `POST .../builds`. But `Set.CanPerform` only does an exact key lookup (plus a `"*"` wildcard fallback), and existing roles — org_admin, installer, support — only hold the plain `<orgID>` grant.

**Result: every non-builder token/session is denied component build creation in prod** with:

```
unable to perform create on object <orgID>:component_builds
```

Only tokens using the new Builder role (whose policy holds the scoped key) can build.

## Fix

When a scoped object has no specific grant, `CanPerform` now falls back to the org-wide grant (the part before `:`). Behavior:

- **org_admin / installer / support** (`<orgID>: all`) → build creation allowed again
- **read-only** (`<orgID>: read`) → still denied create
- **builder** (`<orgID>: read` + `<orgID>:component_builds: create`) → unchanged
- a specific scoped grant still takes precedence over the org-wide grant

Added unit tests covering all of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)