### PR TITLE
chore: Escalate stuck progressing, explain blank verdicts

### DIFF
--- a/bins/runner/internal/pkg/componenthealth/assess.go
+++ b/bins/runner/internal/pkg/componenthealth/assess.go
@@ -37,7 +37,38 @@ func assessResource(obj *unstructured.Unstructured) (health, message, nativeStat
 		// follow, then admit the resource has no signal.
 		return assessByConditions(obj)
 	}
-	return mapHealth(hs.Status), hs.Message, string(hs.Status)
+	msg := hs.Message
+	if msg == "" {
+		msg = explainVerdict(obj, hs.Status)
+	}
+	return mapHealth(hs.Status), msg, string(hs.Status)
+}
+
+// explainVerdict fills in a message the library leaves blank. A verdict with no
+// message is the least actionable thing health can show — an Ingress waiting on
+// a load balancer address reported "progressing" and nothing else for 15 hours,
+// while the reason sat in the status it had already read.
+func explainVerdict(obj *unstructured.Unstructured, status gitopshealth.HealthStatusCode) string {
+	if status != gitopshealth.HealthStatusProgressing {
+		return ""
+	}
+
+	switch obj.GetKind() {
+	case "Ingress":
+		if !hasLoadBalancerAddress(obj) {
+			return "no load balancer address assigned yet"
+		}
+	case "Service":
+		if !hasLoadBalancerAddress(obj) {
+			return "waiting for a load balancer address"
+		}
+	}
+	return ""
+}
+
+func hasLoadBalancerAddress(obj *unstructured.Unstructured) bool {
+	addrs, found, err := unstructured.NestedSlice(obj.Object, "status", "loadBalancer", "ingress")
+	return err == nil && found && len(addrs) > 0
 }
 
 // readyConditionTypes are the condition types controllers conventionally use to

--- a/bins/runner/internal/pkg/componenthealth/explain_verdict_test.go
+++ b/bins/runner/internal/pkg/componenthealth/explain_verdict_test.go
@@ -1,0 +1,38 @@
+package componenthealth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// A verdict with no message is the least actionable thing health can show: the
+// reason an ingress was progressing sat in the status the engine had already read.
+func TestAssessResourceExplainsBlankProgressing(t *testing.T) {
+	ingress := func(status map[string]any) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "networking.k8s.io/v1",
+			"kind":       "Ingress",
+			"metadata":   map[string]any{"name": "public", "namespace": "whoami"},
+			"status":     status,
+		}}
+	}
+
+	t.Run("no load balancer address is named", func(t *testing.T) {
+		health, msg, native := assessResource(ingress(map[string]any{"loadBalancer": map[string]any{}}))
+		assert.Equal(t, healthProgressing, health)
+		assert.Equal(t, "Progressing", native)
+		assert.Equal(t, "no load balancer address assigned yet", msg)
+	})
+
+	t.Run("an assigned address is healthy and needs no explanation", func(t *testing.T) {
+		health, msg, _ := assessResource(ingress(map[string]any{
+			"loadBalancer": map[string]any{
+				"ingress": []any{map[string]any{"ip": "20.232.231.3"}},
+			},
+		}))
+		assert.Equal(t, healthHealthy, health)
+		assert.Empty(t, msg)
+	})
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/component_health_verdict.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/component_health_verdict.go
@@ -11,6 +11,11 @@ const (
 	// componentHealthObservationWindow bounds how far back the evaluator reads
 	// observations from ClickHouse (~10 reports at the runner's ~60s cadence).
 	componentHealthObservationWindow = 10 * time.Minute
+	// componentHealthProgressingLimit is how long a component may stay
+	// progressing before it is treated as degraded. Long enough for a slow
+	// rollout or a cluster autoscaler cold start, short enough that a genuinely
+	// stuck workload is reported the same day.
+	componentHealthProgressingLimit = 30 * time.Minute
 	// componentHealthStaleAfter marks a stale verdict unknown, never unhealthy —
 	// absence of data isn't health data. Matches the 5m runner-inactive cutoff.
 	componentHealthStaleAfter = 5 * time.Minute

--- a/services/ctl-api/internal/app/installs/worker/activities/component_health_verdict_test.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/component_health_verdict_test.go
@@ -69,3 +69,52 @@ func TestNextComponentHealthVerdict(t *testing.T) {
 		})
 	}
 }
+
+// Pins the gap a live install exposed: an ingress with no class never gets a
+// load balancer address, so it reports progressing forever — and because
+// progressing never alerts, 15 hours passed with nobody told.
+func TestEscalateStuckProgressing(t *testing.T) {
+	now := time.Now()
+	progressingSince := func(d time.Duration) *app.InstallComponent {
+		return &app.InstallComponent{
+			HealthStatus: app.InstallComponentHealthStatusProgressing,
+			HealthStatusV2: app.CompositeStatus{
+				Status:      app.Status(app.InstallComponentHealthStatusProgressing),
+				CreatedAtTS: now.Add(-d).Unix(),
+			},
+		}
+	}
+
+	t.Run("a slow rollout is left alone", func(t *testing.T) {
+		got := escalateStuckProgressing(app.InstallComponentHealthStatusProgressing,
+			progressingSince(10*time.Minute), now)
+		assert.Equal(t, app.InstallComponentHealthStatusProgressing, got)
+	})
+
+	t.Run("stuck past the limit becomes degraded", func(t *testing.T) {
+		got := escalateStuckProgressing(app.InstallComponentHealthStatusProgressing,
+			progressingSince(16*time.Hour), now)
+		assert.Equal(t, app.InstallComponentHealthStatusDegraded, got)
+	})
+
+	t.Run("a freshly progressing component has no elapsed time to judge", func(t *testing.T) {
+		fresh := &app.InstallComponent{
+			HealthStatus:   app.InstallComponentHealthStatusHealthy,
+			HealthStatusV2: app.CompositeStatus{CreatedAtTS: now.Add(-16 * time.Hour).Unix()},
+		}
+		got := escalateStuckProgressing(app.InstallComponentHealthStatusProgressing, fresh, now)
+		assert.Equal(t, app.InstallComponentHealthStatusProgressing, got,
+			"the old timestamp belongs to the previous verdict, not this one")
+	})
+
+	t.Run("other verdicts pass through untouched", func(t *testing.T) {
+		for _, v := range []app.InstallComponentHealthStatus{
+			app.InstallComponentHealthStatusHealthy,
+			app.InstallComponentHealthStatusUnknown,
+			app.InstallComponentHealthStatusUnhealthy,
+			app.InstallComponentHealthStatusNotApplicable,
+		} {
+			assert.Equal(t, v, escalateStuckProgressing(v, progressingSince(16*time.Hour), now))
+		}
+	})
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/evaluate_component_health.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/evaluate_component_health.go
@@ -203,7 +203,31 @@ func (a *Activities) componentVerdict(ic *app.InstallComponent, reports []compon
 		return app.InstallComponentHealthStatusUnknown
 	}
 
-	return nextComponentHealthVerdict(ic.HealthStatus, reports, now)
+	verdict := nextComponentHealthVerdict(ic.HealthStatus, reports, now)
+	return escalateStuckProgressing(verdict, ic, now)
+}
+
+// escalateStuckProgressing turns a progressing verdict that has not moved in a
+// long time into degraded.
+//
+// Progressing means "on its way", and the resource libraries have no clock, so a
+// workload that never becomes ready reports progressing forever. Since
+// progressing never alerts, the most durable failure state was also the
+// quietest: a live install sat progressing for 15h because its ingress had no
+// class and nothing ever told anyone.
+func escalateStuckProgressing(verdict app.InstallComponentHealthStatus, ic *app.InstallComponent, now time.Time) app.InstallComponentHealthStatus {
+	if verdict != app.InstallComponentHealthStatusProgressing {
+		return verdict
+	}
+	// CreatedAtTS is only meaningful while the verdict is unchanged; a fresh
+	// progressing verdict has no elapsed time to judge yet.
+	if ic.HealthStatus != app.InstallComponentHealthStatusProgressing || ic.HealthStatusV2.CreatedAtTS <= 0 {
+		return verdict
+	}
+	if now.Sub(time.Unix(ic.HealthStatusV2.CreatedAtTS, 0)) < componentHealthProgressingLimit {
+		return verdict
+	}
+	return app.InstallComponentHealthStatusDegraded
 }
 
 func clusterWatchedComponent(t app.ComponentType) bool {


### PR DESCRIPTION
A prod Azure install sat `progressing` for 15.5 hours across 926 observations with an empty message. Its ingress had no `ingressClassName`, so nginx ignored it and never assigned a load balancer address. Health read that correctly every minute and was structurally unable to say so: `progressing` never alerts, and the verdict carried no message.

Two fixes. The resource libraries have no clock, so a workload that never becomes ready reports progressing forever — a component that has not moved off progressing for 30m is now degraded, which alerts. The window starts from `HealthStatusV2.CreatedAtTS`, so a freshly-progressing component is never judged on the previous verdict's clock, and a slow rollout is untouched.

Second, a blank message is filled in from the status the engine already read — an ingress or service with no load balancer address now says so instead of showing nothing.

Verified against the live install: patching `ingressClassName: nginx` made nginx publish the address within 48s and health flipped to healthy on the next poll. The config bug itself is nuonco/example-app-configs#266.