### PR TITLE
fix: noisy component health alerts

### DIFF
--- a/services/ctl-api/internal/app/installs/signals/componenthealthevaluate/install_carrier_test.go
+++ b/services/ctl-api/internal/app/installs/signals/componenthealthevaluate/install_carrier_test.go
@@ -1,0 +1,41 @@
+package componenthealthevaluate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
+)
+
+func TestInstallCarrierIndex(t *testing.T) {
+	resp := func(installHealth string, recovered ...bool) *activities.EvaluateComponentHealthResponse {
+		r := &activities.EvaluateComponentHealthResponse{}
+		if installHealth != "" {
+			r.InstallNotification = &activities.InstallHealthNotification{Health: installHealth}
+		}
+		for _, rec := range recovered {
+			r.Notifications = append(r.Notifications, activities.ComponentHealthNotification{Recovered: rec})
+		}
+		return r
+	}
+
+	t.Run("no install crossing", func(t *testing.T) {
+		assert.Equal(t, -1, installCarrierIndex(resp("", false)))
+	})
+
+	t.Run("degrade rides the failing component", func(t *testing.T) {
+		assert.Equal(t, 1, installCarrierIndex(resp("degraded", true, false)))
+	})
+
+	t.Run("recovery rides the recovering component", func(t *testing.T) {
+		assert.Equal(t, 1, installCarrierIndex(resp("healthy", false, true)))
+	})
+
+	// A crossing caused by a component whose alert was suppressed has nothing to
+	// ride on, so the standalone install alert must still fire.
+	t.Run("no matching component keeps the standalone alert", func(t *testing.T) {
+		assert.Equal(t, -1, installCarrierIndex(resp("degraded", true)))
+		assert.Equal(t, -1, installCarrierIndex(resp("degraded")))
+	})
+}

--- a/services/ctl-api/internal/app/installs/signals/componenthealthevaluate/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componenthealthevaluate/signal.go
@@ -6,6 +6,7 @@ import (
 
 	"go.temporal.io/sdk/workflow"
 
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/componenthealthnotify"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
@@ -69,7 +70,11 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 func (s *Signal) notify(ctx workflow.Context, resp *activities.EvaluateComponentHealthResponse) error {
 	l := workflow.GetLogger(ctx)
 
-	for _, n := range resp.Notifications {
+	// A crossing driven by a suppressed component has no carrier, so it still
+	// needs the standalone alert.
+	carrier := installCarrierIndex(resp)
+
+	for i, n := range resp.Notifications {
 		body := componenthealthnotify.ComponentSignal{
 			InstallID:             s.InstallID,
 			InstallName:           resp.InstallName,
@@ -82,6 +87,10 @@ func (s *Signal) notify(ctx workflow.Context, resp *activities.EvaluateComponent
 			RootResourceKind:      n.RootResourceKind,
 			RootResourceNamespace: n.RootResourceNamespace,
 			RootResourceName:      n.RootResourceName,
+		}
+		if i == carrier {
+			body.InstallHealth = resp.InstallNotification.Health
+			body.InstallPreviousHealth = resp.InstallNotification.PreviousHealth
 		}
 
 		var sig signal.Signal
@@ -100,7 +109,7 @@ func (s *Signal) notify(ctx workflow.Context, resp *activities.EvaluateComponent
 		}
 	}
 
-	if in := resp.InstallNotification; in != nil {
+	if in := resp.InstallNotification; in != nil && carrier < 0 {
 		sig := &componenthealthnotify.InstallDegradedSignal{
 			InstallID:               s.InstallID,
 			InstallName:             resp.InstallName,
@@ -129,4 +138,20 @@ func (s *Signal) enqueue(ctx workflow.Context, sig signal.Signal) error {
 		Signal:    sig,
 	})
 	return err
+}
+
+// installCarrierIndex returns -1 when no component notification can carry the
+// install crossing.
+func installCarrierIndex(resp *activities.EvaluateComponentHealthResponse) int {
+	in := resp.InstallNotification
+	if in == nil {
+		return -1
+	}
+	recovered := !app.InstallComponentHealthStatus(in.Health).IsBadHealth()
+	for i, n := range resp.Notifications {
+		if n.Recovered == recovered {
+			return i
+		}
+	}
+	return -1
 }

--- a/services/ctl-api/internal/app/installs/signals/componenthealthnotify/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componenthealthnotify/signal.go
@@ -27,6 +27,8 @@ const (
 	MetadataKeyResourceName   = "root_resource_name"
 	MetadataKeyUnhealthyCount = "unhealthy_component_count"
 	MetadataKeyDegradedCount  = "degraded_component_count"
+	MetadataKeyInstallHealth  = "install_health"
+	MetadataKeyInstallPrev    = "install_previous_health"
 )
 
 // ComponentSignal is the shared body of the two component-level health
@@ -45,6 +47,10 @@ type ComponentSignal struct {
 	RootResourceKind      string `json:"root_resource_kind"`
 	RootResourceNamespace string `json:"root_resource_namespace"`
 	RootResourceName      string `json:"root_resource_name"`
+
+	// Set only when this crossing also moved the install composite.
+	InstallHealth         string `json:"install_health,omitempty"`
+	InstallPreviousHealth string `json:"install_previous_health,omitempty"`
 }
 
 func (s *ComponentSignal) validate() error {
@@ -82,6 +88,8 @@ func (s *ComponentSignal) lifecycleContext(operation string) signal.SignalLifecy
 			MetadataKeyResourceKind:   s.RootResourceKind,
 			MetadataKeyResourceNS:     s.RootResourceNamespace,
 			MetadataKeyResourceName:   s.RootResourceName,
+			MetadataKeyInstallHealth:  s.InstallHealth,
+			MetadataKeyInstallPrev:    s.InstallPreviousHealth,
 		},
 	}
 }

--- a/services/ctl-api/internal/app/installs/worker/activities/evaluate_component_health.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/evaluate_component_health.go
@@ -447,6 +447,7 @@ func collapseComponentHealthRows(rows []app.InstallComponentResourceState) map[s
 	// nothing in that report could be assessed.
 	knownSeen := map[reportKey]bool{}
 	unknownFallback := map[reportKey]app.InstallComponentResourceState{}
+	naFallback := map[reportKey]app.InstallComponentResourceState{}
 
 	for _, r := range rows {
 		if !bearsVerdict(r.Provider) {
@@ -491,6 +492,16 @@ func collapseComponentHealthRows(rows []app.InstallComponentResourceState) map[s
 			}
 			continue
 		}
+		// not-applicable is not a severity either: it says this resource has no
+		// signal, which must never outrank one that does. It shares unknown's
+		// zero severity, so whichever row the store returned first won and the
+		// same cluster state reported healthy or not-applicable at random.
+		if health == app.InstallComponentHealthStatusNotApplicable {
+			if _, seen := naFallback[key]; !seen {
+				naFallback[key] = r
+			}
+			continue
+		}
 
 		if !knownSeen[key] || componentHealthSeverity[health] > componentHealthSeverity[rep.Health] {
 			knownSeen[key] = true
@@ -502,16 +513,23 @@ func collapseComponentHealthRows(rows []app.InstallComponentResourceState) map[s
 		}
 	}
 
-	// Only a report in which nothing at all could be assessed is unknown.
+	// Only a report in which nothing at all could be assessed falls back, and
+	// unknown outranks not-applicable: "tried and could not tell" is more
+	// informative than "nothing here exposes health".
 	for key, rep := range merged {
 		if knownSeen[key] {
 			continue
 		}
 		fallback, ok := unknownFallback[key]
+		health := app.InstallComponentHealthStatusUnknown
+		if !ok {
+			fallback, ok = naFallback[key]
+			health = app.InstallComponentHealthStatusNotApplicable
+		}
 		if !ok {
 			continue
 		}
-		rep.Health = app.InstallComponentHealthStatusUnknown
+		rep.Health = health
 		rep.RootKind = fallback.Kind
 		rep.RootNamespace = fallback.Namespace
 		rep.RootName = fallback.Name

--- a/services/ctl-api/internal/app/installs/worker/activities/na_masking_test.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/na_masking_test.go
@@ -1,0 +1,68 @@
+package activities
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// Pins a prod flap: a component reporting 19 not-applicable and 33 healthy
+// resources read not-applicable, because not-applicable shares unknown's zero
+// severity and whichever row the store returned first won. The same cluster
+// state reported healthy or not-applicable at random, and each round trip reset
+// the alert baseline and re-notified.
+func TestNotApplicableNeverMasksAssessedResources(t *testing.T) {
+	at := time.Now().Truncate(time.Second)
+	row := func(kind, name, health string) app.InstallComponentResourceState {
+		return app.InstallComponentResourceState{
+			InstallComponentID: "inc1",
+			Provider:           providerKubernetes,
+			Kind:               kind,
+			Name:               name,
+			Health:             health,
+			ObservedAt:         at,
+		}
+	}
+
+	t.Run("not-applicable listed first does not mask healthy", func(t *testing.T) {
+		rows := []app.InstallComponentResourceState{
+			row("ClusterRole", "rbac", "not-applicable"),
+			row("ConfigMap", "cm", "not-applicable"),
+			row("Deployment", "api", "healthy"),
+		}
+		got := collapseComponentHealthRows(rows)["inc1"]
+		assert.Len(t, got, 1)
+		assert.Equal(t, app.InstallComponentHealthStatusHealthy, got[0].Health)
+	})
+
+	t.Run("a genuinely bad resource still wins", func(t *testing.T) {
+		rows := []app.InstallComponentResourceState{
+			row("ClusterRole", "rbac", "not-applicable"),
+			row("Deployment", "api", "healthy"),
+			row("Deployment", "admin", "degraded"),
+		}
+		got := collapseComponentHealthRows(rows)["inc1"]
+		assert.Equal(t, app.InstallComponentHealthStatusDegraded, got[0].Health)
+	})
+
+	t.Run("unknown outranks not-applicable when nothing is assessed", func(t *testing.T) {
+		rows := []app.InstallComponentResourceState{
+			row("ClusterRole", "rbac", "not-applicable"),
+			row("Certificate", "cert", "unknown"),
+		}
+		got := collapseComponentHealthRows(rows)["inc1"]
+		assert.Equal(t, app.InstallComponentHealthStatusUnknown, got[0].Health)
+	})
+
+	t.Run("only non-assessable resources is still not-applicable", func(t *testing.T) {
+		rows := []app.InstallComponentResourceState{
+			row("ClusterRole", "rbac", "not-applicable"),
+			row("ConfigMap", "cm", "not-applicable"),
+		}
+		got := collapseComponentHealthRows(rows)["inc1"]
+		assert.Equal(t, app.InstallComponentHealthStatusNotApplicable, got[0].Health)
+	})
+}

--- a/services/ctl-api/internal/pkg/queue/signal/hooks/slackrender/message.go
+++ b/services/ctl-api/internal/pkg/queue/signal/hooks/slackrender/message.go
@@ -1018,6 +1018,13 @@ func componentHealthHeadline(e Event, recovered, installLevel bool) string {
 		text = "🔴 Component unhealthy"
 	}
 
+	if !installLevel && !recovered && metadataString(e, "install_health") != "" {
+		text += " · install degraded"
+	}
+	if !installLevel && recovered && metadataString(e, "install_health") != "" {
+		text += " · install recovered"
+	}
+
 	if subject != "" {
 		text = text + " · " + slackEscape(subject)
 	}
@@ -1045,6 +1052,13 @@ func componentHealthFields(e Event, installLevel bool) []kv {
 	// responder would go looking for in the cluster.
 	if resource := componentHealthResource(e); resource != "" {
 		fields = append(fields, kv{"Resource", slackEscape(resource)})
+	}
+	if ih := metadataString(e, "install_health"); ih != "" && !installLevel {
+		label := slackEscape(ih)
+		if prev := metadataString(e, "install_previous_health"); prev != "" {
+			label = slackEscape(prev) + " → " + label
+		}
+		fields = append(fields, kv{"Install health", label})
 	}
 	if name := e.Workflow.OwnerName; name != "" && !installLevel {
 		fields = append(fields, kv{"Install", slackEscape(name)})


### PR DESCRIPTION
#bots-byoc-installs has been re-alerting on one component every ~30 minutes, two messages each time. Two causes.

**not-applicable was masking healthy.** The Lovable install's `ctl_api` reports 19 not-applicable and 33 healthy resources with nothing degraded, and its verdict read not-applicable. `not-applicable` is missing from `componentHealthSeverity`, so it scores 0 — the same as healthy. The first row seen sets the report's health unconditionally, and later healthy rows then fail `0 > 0`. Row order from ClickHouse isn't stable, so the same cluster state collapsed to healthy or not-applicable at random. Each trip through not-applicable cleared the baseline, which skips the consecutive-bad debounce and re-arms the alert latch, so the next degraded reading notified again — every alert in the channel says `Previously: not-applicable` for that reason.

not-applicable is not a severity, for the same reason unknown isn't: it says the resource exposes no signal, which must never outrank one that does. It now falls back the way unknown already did, with unknown preferred. A report whose resources are genuinely all non-assessable still reports not-applicable. Same shape as the stage finding where one unrunnable probe masked a whole component; that fix covered unknown and missed this.

**The install alert was redundant.** `installHealthNotification` is a pure rollup of the same component verdicts, so a component crossing and the install crossing it caused were posting two messages. The component alert now carries the install transition — headline suffix plus an `Install health` field — and the standalone alert is dropped. It still fires when the crossing came from a component whose own alert was suppressed, since nothing else would report it.

No change to the interests/match contract — these are new fields on an existing signal, and the webhook passes metadata through, so subscribers get them without a payload change.