### PR TITLE
feat: (runner) enable audit log export on Azure

### DIFF
--- a/bins/runner/internal/pkg/auditexport/auditexport.go
+++ b/bins/runner/internal/pkg/auditexport/auditexport.go
@@ -23,7 +23,7 @@ import (
 const collectorBinary = "/bin/nuon-runner-otelcol"
 const secretSyncInterval = 30 * time.Second
 
-var Module = fx.Options(fx.Provide(newAWSFactory, newConfigSourceResolver, New), fx.Invoke(func(*Supervisor) {}))
+var Module = fx.Options(fx.Provide(newAWSFactory, newAzureFactory, newConfigSourceResolver, New), fx.Invoke(func(*Supervisor) {}))
 
 type Params struct {
 	fx.In

--- a/bins/runner/internal/pkg/auditexport/source.go
+++ b/bins/runner/internal/pkg/auditexport/source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -30,6 +31,59 @@ type configSource interface {
 
 type configSourceResolver interface {
 	Resolve(string, string) configSource
+}
+
+type sourceResolver struct {
+	awsFactory   awsClientFactory
+	azureFactory azureClientFactory
+}
+
+func newConfigSourceResolver(awsFactory awsClientFactory, azureFactory azureClientFactory) configSourceResolver {
+	return &sourceResolver{awsFactory: awsFactory, azureFactory: azureFactory}
+}
+
+func (r *sourceResolver) Resolve(platform, installID string) configSource {
+	if installID == "" {
+		return nil
+	}
+	platform = strings.ToLower(platform)
+	switch {
+	case strings.HasPrefix(platform, "aws"):
+		return newAWSConfigSource(r.awsFactory, installID)
+	case strings.HasPrefix(platform, "azure"):
+		return newAzureConfigSource(r.azureFactory, installID)
+	default:
+		return nil
+	}
+}
+
+func watchConfig(ctx context.Context, interval time.Duration, fetch func() configUpdate) <-chan configUpdate {
+	updates := make(chan configUpdate)
+	go func() {
+		defer close(updates)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		var observation configObservation
+		refresh := func() bool {
+			return publishConfigUpdate(ctx, updates, &observation, fetch())
+		}
+
+		if !refresh() {
+			return
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if !refresh() {
+					return
+				}
+			}
+		}
+	}()
+	return updates
 }
 
 func publishConfigUpdate(ctx context.Context, updates chan<- configUpdate, observation *configObservation, update configUpdate) bool {

--- a/bins/runner/internal/pkg/auditexport/source_aws.go
+++ b/bins/runner/internal/pkg/auditexport/source_aws.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -41,20 +40,9 @@ func (awsFactory) New(ctx context.Context) (awsSecretClient, error) {
 	return secretsmanager.NewFromConfig(cfg), nil
 }
 
-type sourceResolver struct {
-	awsFactory awsClientFactory
-}
-
-func newConfigSourceResolver(factory awsClientFactory) configSourceResolver {
-	return &sourceResolver{awsFactory: factory}
-}
-
-func (r *sourceResolver) Resolve(platform, installID string) configSource {
-	if installID == "" || !strings.HasPrefix(strings.ToLower(platform), "aws") {
-		return nil
-	}
+func newAWSConfigSource(factory awsClientFactory, installID string) configSource {
 	return &awsConfigSource{
-		factory: r.awsFactory,
+		factory: factory,
 		name:    "nuon/" + installID + "/runner-audit-export",
 	}
 }
@@ -65,47 +53,24 @@ type awsConfigSource struct {
 }
 
 func (s *awsConfigSource) Watch(ctx context.Context, interval time.Duration) <-chan configUpdate {
-	updates := make(chan configUpdate)
-	go func() {
-		defer close(updates)
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-
-		var client awsSecretClient
-		var observation configObservation
-		refresh := func() bool {
-			if client == nil {
-				var err error
-				client, err = s.factory.New(ctx)
-				if err != nil {
-					client = nil
-					return publishConfigUpdate(ctx, updates, &observation, configUpdate{
-						state:         configSourceInitializationFailed,
-						err:           err,
-						errorIdentity: awsErrorIdentity(err),
-					})
-				}
-			}
-
-			result, err := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{SecretId: &s.name})
-			return publishConfigUpdate(ctx, updates, &observation, newAWSConfigUpdate(result, err))
-		}
-
-		if !refresh() {
-			return
-		}
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				if !refresh() {
-					return
+	var client awsSecretClient
+	return watchConfig(ctx, interval, func() configUpdate {
+		if client == nil {
+			var err error
+			client, err = s.factory.New(ctx)
+			if err != nil {
+				client = nil
+				return configUpdate{
+					state:         configSourceInitializationFailed,
+					err:           err,
+					errorIdentity: awsErrorIdentity(err),
 				}
 			}
 		}
-	}()
-	return updates
+
+		result, err := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{SecretId: &s.name})
+		return newAWSConfigUpdate(result, err)
+	})
 }
 
 func newAWSConfigUpdate(result *secretsmanager.GetSecretValueOutput, err error) configUpdate {

--- a/bins/runner/internal/pkg/auditexport/source_azure.go
+++ b/bins/runner/internal/pkg/auditexport/source_azure.go
@@ -1,0 +1,136 @@
+package auditexport
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+)
+
+const azureAuditExportSecretName = "runner-audit-export"
+
+type azureSecretClient interface {
+	GetSecret(context.Context, string, string, *azsecrets.GetSecretOptions) (azsecrets.GetSecretResponse, error)
+}
+
+type azureClientFactory interface {
+	New(string) (azureSecretClient, error)
+}
+
+type azureFactory struct{}
+
+func newAzureFactory() azureClientFactory { return azureFactory{} }
+
+func (azureFactory) New(vaultURL string) (azureSecretClient, error) {
+	credential, err := azidentity.NewManagedIdentityCredential(nil)
+	if err != nil {
+		return nil, err
+	}
+	return azsecrets.NewClient(vaultURL, credential, nil)
+}
+
+type azureConfigSource struct {
+	factory  azureClientFactory
+	vaultURL string
+	name     string
+}
+
+func newAzureConfigSource(factory azureClientFactory, installID string) configSource {
+	vaultName := installID
+	if len(vaultName) > 24 {
+		vaultName = vaultName[:24]
+	}
+	return &azureConfigSource{
+		factory:  factory,
+		vaultURL: "https://" + vaultName + ".vault.azure.net",
+		name:     azureAuditExportSecretName,
+	}
+}
+
+func (s *azureConfigSource) Watch(ctx context.Context, interval time.Duration) <-chan configUpdate {
+	var client azureSecretClient
+	return watchConfig(ctx, interval, func() configUpdate {
+		if client == nil {
+			var err error
+			client, err = s.factory.New(s.vaultURL)
+			if err != nil {
+				client = nil
+				return configUpdate{
+					state:         configSourceInitializationFailed,
+					err:           err,
+					errorIdentity: azureErrorIdentity(err),
+				}
+			}
+		}
+
+		result, err := client.GetSecret(ctx, s.name, "", nil)
+		return newAzureConfigUpdate(result, err)
+	})
+}
+
+func newAzureConfigUpdate(result azsecrets.GetSecretResponse, err error) configUpdate {
+	if err != nil {
+		state := configLookupFailed
+		var responseError *azcore.ResponseError
+		if errors.As(err, &responseError) {
+			switch {
+			case responseError.StatusCode == http.StatusNotFound:
+				state = configNotFound
+			case responseError.StatusCode == http.StatusForbidden && azureSecretDisabled(responseError):
+				state = configUnavailable
+			}
+		}
+		return configUpdate{state: state, err: err, errorIdentity: azureErrorIdentity(err)}
+	}
+	if result.Value == nil {
+		return configUpdate{state: configAvailable}
+	}
+	return configUpdate{state: configAvailable, value: *result.Value}
+}
+
+func azureSecretDisabled(responseError *azcore.ResponseError) bool {
+	if responseError.ErrorCode == "SecretDisabled" {
+		return true
+	}
+	if responseError.RawResponse == nil {
+		return false
+	}
+	payload, err := azruntime.Payload(responseError.RawResponse)
+	if err != nil {
+		return false
+	}
+	var envelope struct {
+		Error struct {
+			InnerError struct {
+				Code string `json:"code"`
+			} `json:"innererror"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return false
+	}
+	return envelope.Error.InnerError.Code == "SecretDisabled"
+}
+
+func azureErrorIdentity(err error) string {
+	var responseError *azcore.ResponseError
+	if errors.As(err, &responseError) {
+		return fmt.Sprintf("%T:%d:%s", responseError, responseError.StatusCode, responseError.ErrorCode)
+	}
+	var authenticationError *azidentity.AuthenticationFailedError
+	if errors.As(err, &authenticationError) {
+		statusCode := 0
+		if authenticationError.RawResponse != nil {
+			statusCode = authenticationError.RawResponse.StatusCode
+		}
+		return fmt.Sprintf("%T:%d", authenticationError, statusCode)
+	}
+	return fmt.Sprintf("%T:%s", err, err.Error())
+}

--- a/bins/runner/internal/pkg/auditexport/source_azure_test.go
+++ b/bins/runner/internal/pkg/auditexport/source_azure_test.go
@@ -1,0 +1,114 @@
+package auditexport
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+)
+
+type azureFactoryStub struct {
+	vaultURL string
+	client   azureSecretClient
+}
+
+func (f *azureFactoryStub) New(vaultURL string) (azureSecretClient, error) {
+	f.vaultURL = vaultURL
+	return f.client, nil
+}
+
+type azureSecretClientStub struct {
+	name    string
+	version string
+	result  azsecrets.GetSecretResponse
+}
+
+func (c *azureSecretClientStub) GetSecret(_ context.Context, name, version string, _ *azsecrets.GetSecretOptions) (azsecrets.GetSecretResponse, error) {
+	c.name = name
+	c.version = version
+	return c.result, nil
+}
+
+func TestNewAzureConfigUpdateClassifiesResults(t *testing.T) {
+	value := "config"
+	disabledError := &azcore.ResponseError{
+		StatusCode: http.StatusForbidden,
+		ErrorCode:  "Forbidden",
+		RawResponse: &http.Response{
+			StatusCode: http.StatusForbidden,
+			Status:     "403 Forbidden",
+			Body:       io.NopCloser(strings.NewReader("{\"error\":{\"code\":\"Forbidden\",\"innererror\":{\"code\":\"SecretDisabled\"}}}")),
+		},
+	}
+	tests := []struct {
+		name   string
+		result azsecrets.GetSecretResponse
+		err    error
+		state  configUpdateState
+		value  string
+	}{
+		{name: "available", result: azsecrets.GetSecretResponse{Secret: azsecrets.Secret{Value: &value}}, state: configAvailable, value: value},
+		{name: "empty", result: azsecrets.GetSecretResponse{}, state: configAvailable},
+		{name: "disabled", err: disabledError, state: configUnavailable},
+		{name: "not found", err: &azcore.ResponseError{StatusCode: http.StatusNotFound, ErrorCode: "SecretNotFound"}, state: configNotFound},
+		{name: "permission denied", err: &azcore.ResponseError{StatusCode: http.StatusForbidden, ErrorCode: "Forbidden"}, state: configLookupFailed},
+		{name: "lookup failure", err: errors.New("lookup failed"), state: configLookupFailed},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			update := newAzureConfigUpdate(test.result, test.err)
+			if update.state != test.state || update.value != test.value {
+				t.Fatalf("expected state=%d value=%q, got state=%d value=%q", test.state, test.value, update.state, update.value)
+			}
+		})
+	}
+}
+
+func TestAzureConfigSourceReadsLatestSecret(t *testing.T) {
+	value := "config"
+	client := &azureSecretClientStub{result: azsecrets.GetSecretResponse{Secret: azsecrets.Secret{Value: &value}}}
+	factory := &azureFactoryStub{client: client}
+	source := newAzureConfigSource(factory, "instabcdefghijklmnopqrstuv")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	update := <-source.Watch(ctx, time.Hour)
+	if update.state != configAvailable || update.value != value {
+		t.Fatalf("unexpected configuration update: %#v", update)
+	}
+	if factory.vaultURL != "https://instabcdefghijklmnopqrst.vault.azure.net" {
+		t.Fatalf("unexpected vault URL: %q", factory.vaultURL)
+	}
+	if client.name != azureAuditExportSecretName || client.version != "" {
+		t.Fatalf("unexpected secret request: name=%q version=%q", client.name, client.version)
+	}
+}
+
+func TestConfigObservationDeduplicatesEquivalentAzureErrors(t *testing.T) {
+	var observation configObservation
+	first := &azcore.ResponseError{StatusCode: http.StatusForbidden, ErrorCode: "Forbidden"}
+	second := &azcore.ResponseError{StatusCode: http.StatusForbidden, ErrorCode: "Forbidden"}
+
+	if !observation.changed(configUpdate{state: configLookupFailed, err: first, errorIdentity: azureErrorIdentity(first)}) {
+		t.Fatal("first Azure error was not emitted")
+	}
+	if observation.changed(configUpdate{state: configLookupFailed, err: second, errorIdentity: azureErrorIdentity(second)}) {
+		t.Fatal("equivalent Azure error was emitted again")
+	}
+}
+
+func TestAzureErrorIdentityDeduplicatesAuthenticationFailures(t *testing.T) {
+	first := &azidentity.AuthenticationFailedError{RawResponse: &http.Response{StatusCode: http.StatusBadRequest}}
+	second := &azidentity.AuthenticationFailedError{RawResponse: &http.Response{StatusCode: http.StatusBadRequest}}
+	if azureErrorIdentity(first) != azureErrorIdentity(second) {
+		t.Fatal("equivalent Azure authentication errors have different identities")
+	}
+}

--- a/bins/runner/internal/pkg/auditexport/source_test.go
+++ b/bins/runner/internal/pkg/auditexport/source_test.go
@@ -78,17 +78,20 @@ func TestNewAWSConfigUpdateClassifiesResults(t *testing.T) {
 	}
 }
 
-func TestConfigSourceResolverSelectsAWS(t *testing.T) {
-	resolver := newConfigSourceResolver(awsFactory{})
+func TestConfigSourceResolverSelectsPlatformSource(t *testing.T) {
+	resolver := newConfigSourceResolver(awsFactory{}, azureFactory{})
 	tests := []struct {
-		name      string
-		platform  string
-		installID string
-		wantName  string
+		name         string
+		platform     string
+		installID    string
+		wantName     string
+		wantVaultURL string
 	}{
 		{name: "aws", platform: "aws", installID: "inst-test", wantName: "nuon/inst-test/runner-audit-export"},
 		{name: "aws variant", platform: "aws-eks", installID: "inst-test", wantName: "nuon/inst-test/runner-audit-export"},
-		{name: "unsupported platform", platform: "azure", installID: "inst-test"},
+		{name: "azure", platform: "azure", installID: "instabcdefghijklmnopqrstuv", wantName: azureAuditExportSecretName, wantVaultURL: "https://instabcdefghijklmnopqrst.vault.azure.net"},
+		{name: "azure variant", platform: "azure-aks", installID: "inst-test", wantName: azureAuditExportSecretName, wantVaultURL: "https://inst-test.vault.azure.net"},
+		{name: "unsupported platform", platform: "gcp", installID: "inst-test"},
 		{name: "missing install", platform: "aws"},
 	}
 
@@ -101,12 +104,19 @@ func TestConfigSourceResolverSelectsAWS(t *testing.T) {
 				}
 				return
 			}
-			awsSource, ok := source.(*awsConfigSource)
-			if !ok {
-				t.Fatalf("expected AWS configuration source, got %T", source)
+			if test.wantVaultURL != "" {
+				azureSource, ok := source.(*azureConfigSource)
+				if !ok {
+					t.Fatalf("expected Azure configuration source, got %T", source)
+				}
+				if azureSource.name != test.wantName || azureSource.vaultURL != test.wantVaultURL {
+					t.Fatalf("unexpected Azure source: name=%q vault=%q", azureSource.name, azureSource.vaultURL)
+				}
+				return
 			}
-			if awsSource.name != test.wantName {
-				t.Fatalf("expected secret name %q, got %q", test.wantName, awsSource.name)
+			awsSource, ok := source.(*awsConfigSource)
+			if !ok || awsSource.name != test.wantName {
+				t.Fatalf("unexpected AWS source: %#v", source)
 			}
 		})
 	}

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.stories.tsx
@@ -6,6 +6,7 @@ import {
   AwaitAzureDetails,
   AwaitAzureDetailsSkeleton,
 } from './AwaitAzureDetails'
+import type { TAppSecretConfig } from '@/types'
 
 const mockStack = {
   versions: [
@@ -20,6 +21,16 @@ const mockStep = {
   status: { status: 'active' },
 } as any
 
+const mockSecrets = [
+  {
+    name: 'database_password',
+    display_name: 'Database password',
+    description: 'Password used by the application database.',
+    required: true,
+    auto_generate: false,
+  },
+] satisfies TAppSecretConfig[]
+
 export const Default = () => (
   <div className="max-w-2xl p-4">
     <AwaitAzureDetails
@@ -27,6 +38,18 @@ export const Default = () => (
       step={mockStep}
       installId="install-1"
       azureLocation="eastus"
+    />
+  </div>
+)
+
+export const WithApplicationSecrets = () => (
+  <div className="max-w-2xl p-4">
+    <AwaitAzureDetails
+      stack={mockStack}
+      step={mockStep}
+      installId="install-1"
+      azureLocation="eastus"
+      secrets={mockSecrets}
     />
   </div>
 )

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.tsx
@@ -23,12 +23,16 @@ export const AwaitAzureDetails = ({
 }: IAwaitAzureDetails) => {
   const vaultName = installId.slice(0, 24)
   const customerSecrets = secrets?.filter((s) => !s.auto_generate)
+  const hasCustomerSecrets = (customerSecrets?.length ?? 0) > 0
   const requiredSecrets = customerSecrets?.filter(
     (s) => s.required || (!s.default && !s.required)
   )
   const overridableSecrets = customerSecrets?.filter(
     (s) => !s.required && !!s.default
   )
+  const grantSecretsPermissionCmd = `az role assignment create --assignee "$(az ad signed-in-user show --query id -o tsv)" --role "Key Vault Secrets Officer" --scope "$(az keyvault show --name ${vaultName} --resource-group ${installId}-rg --query id -o tsv)"`
+  const auditExportConfigCmd = `export RUNNER_AUDIT_EXPORT_CONFIG="<base64-encoded YAML>"`
+  const createAuditExportSecretCmd = `az keyvault secret set --vault-name ${vaultName} --name runner-audit-export --value "$RUNNER_AUDIT_EXPORT_CONFIG"`
 
   const renderSecretCard = (secret: TAppSecretConfig) => {
     const kvName = secret.name.replaceAll('_', '-')
@@ -104,7 +108,7 @@ export const AwaitAzureDetails = ({
         </Card>
       </div>
 
-      {customerSecrets && customerSecrets.length > 0 && (
+      {hasCustomerSecrets && (
         <div className="flex flex-col gap-4">
           <Text variant="base" weight="strong">
             Create secrets in the Key Vault
@@ -119,12 +123,10 @@ export const AwaitAzureDetails = ({
               <Text>Grant yourself permission to set secrets</Text>
               <ClickToCopyButton
                 className="w-fit self-end"
-                textToCopy={`az role assignment create --assignee "$(az ad signed-in-user show --query id -o tsv)" --role "Key Vault Secrets Officer" --scope "$(az keyvault show --name ${vaultName} --resource-group ${installId}-rg --query id -o tsv)"`}
+                textToCopy={grantSecretsPermissionCmd}
               />
             </span>
-            <Code>{`
-              az role assignment create --assignee "$(az ad signed-in-user show --query id -o tsv)" --role "Key Vault Secrets Officer" --scope "$(az keyvault show --name ${vaultName} --resource-group ${installId}-rg --query id -o tsv)"
-            `}</Code>
+            <Code>{grantSecretsPermissionCmd}</Code>
           </Card>
 
           {requiredSecrets?.map(renderSecretCard)}
@@ -148,6 +150,69 @@ export const AwaitAzureDetails = ({
           )}
         </div>
       )}
+
+      <Expand
+        id="runner-audit-export"
+        heading={
+          <Text variant="base" weight="strong">
+            Configure runner audit export (optional)
+          </Text>
+        }
+      >
+        <div className="flex flex-col gap-4 p-2">
+          <Text variant="subtext">
+            Store a base64-encoded OTLP exporter configuration in Key Vault to
+            send runner audit logs to an OTLP/HTTP backend. Skip this step to
+            leave audit export disabled.
+          </Text>
+
+          {!hasCustomerSecrets && (
+            <Card>
+              <span className="flex justify-between items-center">
+                <Text>Grant permission to set the audit export secret</Text>
+                <ClickToCopyButton
+                  className="w-fit self-end"
+                  textToCopy={grantSecretsPermissionCmd}
+                />
+              </span>
+              <Code>{grantSecretsPermissionCmd}</Code>
+            </Card>
+          )}
+
+          <Card>
+            <span className="flex justify-between items-center">
+              <Text>Export the audit export configuration</Text>
+              <ClickToCopyButton
+                className="w-fit self-end"
+                textToCopy={auditExportConfigCmd}
+              />
+            </span>
+            <Text variant="subtext">
+              Use the{' '}
+              <Link
+                href="https://docs.nuon.co/guides/export-runner-audit-logs"
+                isExternal
+              >
+                audit export guide
+              </Link>{' '}
+              to build the exporter configuration, then export it as an
+              environment variable.
+            </Text>
+            <Code>{auditExportConfigCmd}</Code>
+          </Card>
+
+          <Card>
+            <span className="flex justify-between items-center">
+              <Text>Create the audit export secret</Text>
+              <ClickToCopyButton
+                className="w-fit self-end"
+                textToCopy={createAuditExportSecretCmd}
+              />
+            </span>
+            <Code>{createAuditExportSecretCmd}</Code>
+          </Card>
+        </div>
+      </Expand>
 
       <div className="flex flex-col gap-4">
         <Text variant="base" weight="strong">


### PR DESCRIPTION
This patch adds support for Azure customers to enable audit log export to thier own OTLP backend in the runner. The configuration (which includes customer's credentials) needs to be created in the secret vault for the install, and is sourced by the runner to switch on audit log export.

Also added step-by-step instructions in the UI for an Azure install customer to follow as optional steps.