### PR TITLE
fix: sandbox org broken for phone home auth

### DIFF
--- a/services/ctl-api/internal/app/installs/worker/activities/ensure_install_phone_home_secret.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/ensure_install_phone_home_secret.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"go.temporal.io/sdk/temporal"
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -29,6 +30,7 @@ const (
 	phoneHomeSkipNotAWS          = "install is not an AWS install"
 	phoneHomeSkipNoTargetAccount = "install has no target account id"
 	phoneHomeSkipNoManagement    = "control plane cannot reach management secrets manager"
+	phoneHomeSkipSandboxMode     = "install is in sandbox mode"
 )
 
 type EnsureInstallPhoneHomeSecretRequest struct {
@@ -39,11 +41,11 @@ type EnsureInstallPhoneHomeSecretRequest struct {
 	// flag rather than the other way round. Set only by the operator-initiated
 	// backfill; the flag remains the opt-in everywhere else.
 	//
-	// It waives the feature check and nothing else — an install still has to be on
-	// AWS, still has to carry a target account, and the control plane still has to
-	// reach Secrets Manager. Note the target account is itself only required at
-	// creation once the flag is on, so for an org that has never had it the backfill
-	// mostly trades one skip reason for another.
+	// It waives the feature check and nothing else: an install still has to be on
+	// AWS, must not be a sandbox, still has to carry a target account, and the
+	// control plane still has to reach Secrets Manager. Note the target account is
+	// itself only required at creation once the flag is on, so for an org that has
+	// never had it the backfill mostly trades one skip reason for another.
 	IgnoreOrgFeatureGate bool `json:"ignore_org_feature_gate,omitempty"`
 }
 
@@ -88,6 +90,7 @@ func (a *Activities) EnsureInstallPhoneHomeSecret(
 	var install app.Install
 	if res := a.db.WithContext(ctx).
 		Preload("AWSAccount").
+		Preload("Org").
 		Preload("InstallStack.InstallStackVersions").
 		Where(app.Install{ID: req.InstallID}).
 		First(&install); res.Error != nil {
@@ -140,6 +143,17 @@ func (a *Activities) EnsureInstallPhoneHomeSecret(
 	// Re-applied every run rather than only on create, so a changed target account
 	// or a policy lost to a concurrent write self-heals.
 	if err := a.secretsSvc.PutResourcePolicy(ctx, secret.ARN, policy); err != nil {
+		// An invalid target account never becomes valid, and the default policy would
+		// retry forever, stranding the provisioning step.
+		if secretsmanager.IsPermanentInputError(err) {
+			return nil, temporal.NewNonRetryableApplicationError(
+				fmt.Sprintf("unable to grant cross account read to target account %s",
+					install.CloudPlatformMetadata.TargetAccountID),
+				"phone_home_resource_policy_rejected",
+				err,
+			)
+		}
+
 		return nil, fmt.Errorf("unable to grant cross account read: %w", err)
 	}
 
@@ -183,6 +197,12 @@ func (a *Activities) phoneHomeSecretSkipReason(
 		if !enabled {
 			return phoneHomeSkipFeatureDisabled, nil
 		}
+	}
+
+	// Sandbox installs reach no real infrastructure. The org is checked too because
+	// AdminForceSandboxMode flips the org without updating installs.sandbox_mode.
+	if install.SandboxMode.Bool || install.Org.SandboxMode {
+		return phoneHomeSkipSandboxMode, nil
 	}
 
 	if install.AWSAccount == nil {

--- a/services/ctl-api/internal/app/installs/worker/activities/ensure_install_phone_home_secret_gate_test.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/ensure_install_phone_home_secret_gate_test.go
@@ -2,6 +2,7 @@ package activities
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,6 +60,31 @@ func TestPhoneHomeSecretSkipReasonIgnoringFeatureGate(t *testing.T) {
 				CloudPlatformMetadata: app.CloudPlatformMetadata{TargetAccountID: targetAccount},
 			},
 			want: phoneHomeSkipNoManagement,
+		},
+		{
+			name: "a sandbox install is still skipped",
+			cfg:  reachableCfg,
+			install: &app.Install{
+				ID:                    "inst",
+				SandboxMode:           sql.NullBool{Bool: true, Valid: true},
+				AWSAccount:            &app.AWSAccount{},
+				CloudPlatformMetadata: app.CloudPlatformMetadata{TargetAccountID: targetAccount},
+			},
+			want: phoneHomeSkipSandboxMode,
+		},
+		{
+			// An install created before AdminForceSandboxMode flipped the org keeps an
+			// explicit false that Install.AfterQuery will not override.
+			name: "an install in a sandboxed org is skipped even when its own flag is false",
+			cfg:  reachableCfg,
+			install: &app.Install{
+				ID:                    "inst",
+				SandboxMode:           sql.NullBool{Bool: false, Valid: true},
+				Org:                   app.Org{SandboxMode: true},
+				AWSAccount:            &app.AWSAccount{},
+				CloudPlatformMetadata: app.CloudPlatformMetadata{TargetAccountID: targetAccount},
+			},
+			want: phoneHomeSkipSandboxMode,
 		},
 		{
 			name: "an otherwise eligible install proceeds even with the flag off",

--- a/services/ctl-api/internal/pkg/secretsmanager/service.go
+++ b/services/ctl-api/internal/pkg/secretsmanager/service.go
@@ -26,6 +26,18 @@ import (
 // management account's Secrets Manager. Callers treat it as "skip", not "fail".
 var ErrUnsupportedCloud = errors.New("control plane cannot reach management secrets manager")
 
+// IsPermanentInputError reports whether AWS rejected the request content, so a
+// retry can only fail the same way.
+func IsPermanentInputError(err error) bool {
+	var malformed *types.MalformedPolicyDocumentException
+	var invalidParam *types.InvalidParameterException
+	var invalidReq *types.InvalidRequestException
+
+	return errors.As(err, &malformed) ||
+		errors.As(err, &invalidParam) ||
+		errors.As(err, &invalidReq)
+}
+
 // Service manages secrets in the management account.
 type Service interface {
 	// EnsureSecret creates the secret or updates its value, and returns the full

--- a/services/ctl-api/internal/pkg/secretsmanager/service_test.go
+++ b/services/ctl-api/internal/pkg/secretsmanager/service_test.go
@@ -3,6 +3,8 @@ package secretsmanager
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -347,6 +349,54 @@ func TestUnsupportedCloudSurfacesSentinel(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), ErrUnsupportedCloud.Error()) {
 		t.Errorf("expected ErrUnsupportedCloud, got %v", err)
+	}
+}
+
+// A permanent rejection must stay distinguishable from a transient one even after
+// being wrapped on the way out of the service.
+func TestIsPermanentInputError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// What a nonexistent target account id produces.
+			name: "malformed policy document",
+			err:  fmt.Errorf("unable to put resource policy: %w", &types.MalformedPolicyDocumentException{}),
+			want: true,
+		},
+		{
+			name: "invalid parameter",
+			err:  fmt.Errorf("wrapped: %w", &types.InvalidParameterException{}),
+			want: true,
+		},
+		{
+			name: "invalid request",
+			err:  &types.InvalidRequestException{},
+			want: true,
+		},
+		{
+			name: "throttling is transient and must keep retrying",
+			err:  fmt.Errorf("wrapped: %w", &types.InternalServiceError{}),
+			want: false,
+		},
+		{
+			name: "an unrelated error is not permanent",
+			err:  errors.New("dial tcp: connection refused"),
+			want: false,
+		},
+		{
+			name: "nil is not permanent",
+			err:  nil,
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPermanentInputError(tc.err); got != tc.want {
+				t.Errorf("IsPermanentInputError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

Install provisioning hangs forever on the `generate install stack` step, showing
`in-progress` with no error in the dashboard.

`EnsureInstallPhoneHomeSecret` never checks sandbox mode, so a sandbox install
makes live AWS Secrets Manager calls. Those calls fail because the resource policy
names `arn:aws:iam::<target_account_id>:root` and AWS rejects a principal in an
account that does not exist:

MalformedPolicyDocumentException: This resource policy contains an unsupported principal.

Retrying cannot fix that, but the activity has no retry cap, so it retries
indefinitely and the step never fails. `target_account_id` is user supplied, so a
mistyped account id wedges provisioning in production too.

## Fix

- Skip sandbox installs. The check covers the org as well as the install, because
  `AdminForceSandboxMode` flips `orgs.sandbox_mode` without updating
  `installs.sandbox_mode`.
- Return a non-retryable error when AWS rejects the request content, so the step
  fails visibly instead of spinning. Transient failures still retry.