### PR TITLE
fix: make create buttons consistent

### DIFF
--- a/services/dashboard-ui/client/components/apps/AppsTable/AppsTableContainer.tsx
+++ b/services/dashboard-ui/client/components/apps/AppsTable/AppsTableContainer.tsx
@@ -37,7 +37,7 @@ export const AppsTableContainer = ({
       isLoading={isLoading}
       emptyStateAction={
         <Button href={`/onboarding?org_id=${org.id}`}>
-          <Icon size="14" variant="AppWindowIcon" />
+          <Icon variant="PlusIcon" size={16} />
           Create app
         </Button>
       }

--- a/services/dashboard-ui/client/components/apps/CreateInstall/CreateInstall.tsx
+++ b/services/dashboard-ui/client/components/apps/CreateInstall/CreateInstall.tsx
@@ -155,7 +155,7 @@ export const CreateInstallModal = ({
                 </span>
               ) : (
                 <span className="flex items-center gap-2">
-                  <Icon variant="CubeIcon" />
+                  <Icon variant="PlusIcon" />
                   Create install
                 </span>
               ),
@@ -203,7 +203,7 @@ export const CreateInstallButton = ({
 }: { onClick: () => void } & Omit<IButtonAsButton, 'onClick'>) => {
   return (
     <Button onClick={onClick} {...props}>
-      <Icon variant="CubeIcon" />
+      <Icon variant="PlusIcon" size={16} />
       Create install
     </Button>
   )

--- a/services/dashboard-ui/client/components/installs/CreateInstall/CreateInstallButton/CreateInstallButton.tsx
+++ b/services/dashboard-ui/client/components/installs/CreateInstall/CreateInstallButton/CreateInstallButton.tsx
@@ -8,7 +8,7 @@ interface ICreateInstallButton extends IButtonAsButton {
 export const CreateInstallButton = ({ onOpen, ...props }: ICreateInstallButton) => {
   return (
     <Button onClick={onOpen} {...props}>
-      <Icon variant="CubeIcon" />
+      <Icon variant="PlusIcon" size={16} />
       Create install
     </Button>
   )

--- a/services/dashboard-ui/client/components/installs/CreateInstall/CreateInstallModal.tsx
+++ b/services/dashboard-ui/client/components/installs/CreateInstall/CreateInstallModal.tsx
@@ -38,7 +38,7 @@ export const CreateInstallModal = ({ ...props }: ICreateInstall & IModal) => {
             </span>
           ) : (
             <span className="flex items-center gap-2">
-              <Icon variant="CubeIcon" />
+              <Icon variant="PlusIcon" />
               Create install
             </span>
           ),


### PR DESCRIPTION
## Make create buttons consistent

Create actions used three different icons: `PlusIcon` (webhooks, tokens, branches,
labels, groups), `CubeIcon` (create install), and `AppWindowIcon` (apps empty state).
Standardized on the plus.

<img width="190" height="76" alt="image" src="https://github.com/user-attachments/assets/3ca7111a-2c41-4372-83bf-0b38d83cdf5e" />
