### PR TITLE
fix: saved-plan var-file, step-generation hang, flow/queue reliability

### DIFF
--- a/bins/cli/internal/config/config.go
+++ b/bins/cli/internal/config/config.go
@@ -162,6 +162,11 @@ func (c *Config) readConfigFile(customFP string) error {
 func (c *Config) BindCobraFlags(cmd *cobra.Command) {
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		name := strings.ReplaceAll(f.Name, "-", "_")
+		// `preview` is the NUON_PREVIEW feature gate (config.Preview()), not a
+		// flag value; don't let it bleed into the plan-only `--preview` flags.
+		if name == "preview" {
+			return
+		}
 		if !f.Changed && c.IsSet(name) {
 			val := c.Get(name)
 

--- a/pkg/terraform/workspace/terraform.go
+++ b/pkg/terraform/workspace/terraform.go
@@ -265,12 +265,13 @@ func (w *workspace) applyPlan(ctx context.Context, client Terraform, log hclog.L
 		return nil, fmt.Errorf("unable to get writer: %w", err)
 	}
 
+	// Applying a saved plan: the variable values are already baked into tfplan
+	// at plan time, and Terraform rejects -var-file (and -var) when a plan file
+	// is supplied ("Can't set variables when applying a saved plan"). So, unlike
+	// the fresh apply/plan paths, we must NOT append w.varsPaths here.
 	opts := []tfexec.ApplyOption{
 		tfexec.Refresh(true),
 		tfexec.DirOrPlan(filepath.Join(w.Root(), "tfplan")),
-	}
-	for _, fp := range w.varsPaths {
-		opts = append(opts, tfexec.VarFile(fp))
 	}
 
 	if err := client.ApplyJSON(ctx,

--- a/services/ctl-api/internal/app/installs/signals/generateworkflowsteps/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/generateworkflowsteps/signal.go
@@ -156,8 +156,14 @@ func (s *Signal) RegisterUpdateHandlers(ctx workflow.Context) error {
 	if err := workflow.SetUpdateHandlerWithOptions(ctx, "eager-step-groups",
 		func(ctx workflow.Context) (*app.GenerateStepsResult, error) {
 			defer func() { s.eagerStepGroupsCalled = true }()
-			// Block until eager step groups are ready.
-			if err := workflow.Await(ctx, func() bool { return s.eagerStepGroupsReady }); err != nil {
+			// Block until eager step groups are ready OR generation finished with
+			// an error. eagerStepGroupsReady is only set on the success path, so we
+			// must also unblock on s.done — otherwise a failed generation (e.g. a
+			// runbook step whose generator errors) leaves this handler awaiting
+			// forever, the FetchEagerStepGroups activity's update never completes,
+			// and it retries until its StartToClose timeout indefinitely. This
+			// mirrors the FetchSteps handler below, which waits on s.done.
+			if err := workflow.Await(ctx, func() bool { return s.eagerStepGroupsReady || s.done }); err != nil {
 				return nil, err
 			}
 			if s.err != nil {

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
@@ -938,11 +938,37 @@ func (s *Signal) isWorkflowComplete(ctx workflow.Context) bool {
 			app.WorkflowStepNoDrift, app.WorkflowStepDrifted:
 			continue
 		default:
+			// An error row the flow already moved past isn't blocking.
+			if stepHandledDespiteError(step) {
+				continue
+			}
 			return false
 		}
 	}
 
 	return true
+}
+
+// stepHandledDespiteError reports whether an `error` step was superseded by an
+// auto-retry clone or skipped after exhausting retries — historical, not blocking.
+func stepHandledDespiteError(step app.WorkflowStep) bool {
+	if step.Status.Status != app.StatusError {
+		return false
+	}
+	return metadataTrue(step.Status.Metadata, "auto_retried") ||
+		metadataTrue(step.Status.Metadata, "skipped_on_failure")
+}
+
+// metadataTrue reads a truthy flag as either bool or its JSON-round-tripped string.
+func metadataTrue(meta map[string]any, key string) bool {
+	switch v := meta[key].(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true"
+	default:
+		return false
+	}
 }
 
 // checkRetryable checks if the workflow is still eligible for retry.

--- a/services/ctl-api/internal/pkg/queue/handler/run.go
+++ b/services/ctl-api/internal/pkg/queue/handler/run.go
@@ -152,6 +152,17 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 		qs.Status.Status == app.StatusSuccess &&
 		!h.finished {
 		h.startAutoRewarm(ctx)
+	} else if !h.finished &&
+		(qs.Status.Status == app.StatusSuccess ||
+			qs.Status.Status == app.StatusError ||
+			qs.Status.Status == app.StatusCancelled) {
+		// Booted on a signal a prior generation already finished (e.g. a CAN
+		// raced completion). A non-AutoExecuteOnTerminalStart signal won't
+		// re-execute, so it would park below forever without delivering its
+		// callbacks. Deliver them and exit; re-delivery is harmless.
+		h.setFinished(qs.Status.Status, qs.Status.StatusHumanDescription)
+		h.sendCompletionCallbacks(ctx)
+		return true, nil
 	}
 
 	// execute the handler and handle a restart or stop
@@ -169,7 +180,9 @@ func (h *handler) run(ctx workflow.Context) (bool, error) {
 		return true, nil
 	}
 
-	if mgr.Restarted {
+	// A finished signal falls through to deliver callbacks even if a CAN was
+	// requested in the same tick; restarting here would drop the callbacks.
+	if mgr.Restarted && !h.finished {
 		return false, nil
 	}
 	if mgr.Stopped {

--- a/services/dashboard-ui/client/components/install-health/HealthTimeline/HealthTimeline.tsx
+++ b/services/dashboard-ui/client/components/install-health/HealthTimeline/HealthTimeline.tsx
@@ -150,6 +150,10 @@ function HealthBar({ day }: { day: THealthTimelineDay }) {
   return (
     <Tooltip
       position="top"
+      // The tooltip wrapper span is the actual flex child of the bar row, so
+      // it must grow — `grow` on the inner div alone leaves the bars at their
+      // 6px base width instead of filling the container.
+      className="flex grow min-w-0"
       tipContentClassName="!whitespace-normal !w-auto !p-2"
       tipContent={<DayTooltipContent day={day} />}
     >

--- a/services/dashboard-ui/client/components/triggers/event-ledger/EventDetails/EventDetails.tsx
+++ b/services/dashboard-ui/client/components/triggers/event-ledger/EventDetails/EventDetails.tsx
@@ -439,9 +439,9 @@ export const EventDetails = ({
           <LabeledValue label="Trigger">
             {event?.trigger_name || event?.trigger_id || 'Unknown'}
           </LabeledValue>
-          <LabeledValue label="External ID">
-            <ClickToCopy>
-              <Text family="mono" variant="subtext">
+          <LabeledValue label="External ID" className="min-w-0">
+            <ClickToCopy className="max-w-full">
+              <Text family="mono" variant="subtext" className="truncate">
                 {event?.external_id || '—'}
               </Text>
             </ClickToCopy>


### PR DESCRIPTION
Control-plane reliability fixes. Split out: dashboard-ui #2087, CLI NUON_PREVIEW #2089.

## Terraform: don't pass `-var-file` when applying a saved plan
`pkg/terraform/workspace/terraform.go`: a saved plan already embeds its variables; passing `-var-file` on apply is rejected by Terraform. Drop it on the saved-plan apply path.

## Runbooks: don't hang step generation when a generator errors
`generateworkflowsteps/signal.go`: a generator error left the workflow retrying forever in "Generating steps". Surface the error instead of hanging.

## Flow: don't wedge workflow completion on handled error steps
`executeflow/execute.go`: `isWorkflowComplete` treated auto-retried / skipped-on-failure `error` rows as blocking, so the conductor never exited and completion callbacks to parent workflows never fired. Skip those handled rows.

## Queue: deliver completion callbacks when CAN races signal completion
`queue/handler/run.go`: when a continue-as-new fired in the same tick a signal finished, the handler restarted without sending completion callbacks and the successor generation parked on a terminal signal forever — stranding parents (e.g. an app-branch build waiting on its sandbox build). Finished signals now always deliver callbacks; a generation booting on a terminal signal delivers them and exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)