### PR TITLE
feat: (runner) standardize multi-cloud runner telemetry export config

### DIFF
--- a/bins/runner/build-config.yaml
+++ b/bins/runner/build-config.yaml
@@ -1,7 +1,7 @@
 ---
 dist:
   name: nuon-runner-otelcol
-  description: Nuon Runner Audit Log Collector
+  description: Nuon Runner Telemetry Export Collector
   otelcol_version: 0.150.0
   output_path: ./otelcol-build
   version: 1.0.0

--- a/bins/runner/internal/pkg/jobloop/exec_job.go
+++ b/bins/runner/internal/pkg/jobloop/exec_job.go
@@ -37,7 +37,7 @@ func (j *jobLoop) executeJob(ctx context.Context, job *models.AppRunnerJob) erro
 
 	var auditExportAvailable func() bool
 	if j.telemetryExport != nil {
-		auditExportAvailable = j.telemetryExport.Available
+		auditExportAvailable = j.telemetryExport.AuditExportAvailable
 	}
 	jl, err := slog.NewOTELProvider(j.cfg, j.settings, job.LogStreamID, auditExportAvailable)
 	if err != nil {

--- a/bins/runner/internal/pkg/telemetryexport/config.go
+++ b/bins/runner/internal/pkg/telemetryexport/config.go
@@ -17,23 +17,45 @@ import (
 var headerNamePattern = regexp.MustCompile(`^[!#$%&'*+.^_` + "`" + `|~0-9A-Za-z-]+$`)
 
 const (
-	maxSecretSize  = 64 * 1024
-	maxEndpointLen = 4096
-	maxHeaders     = 32
-	maxHeaderLen   = 4096
+	configVersionV1 = "v1"
+	maxSecretSize   = 64 * 1024
+	maxEndpointLen  = 4096
+	maxHeaders      = 32
+	maxHeaderLen    = 4096
 )
 
-type secretConfig struct {
+type configEnvelope struct {
+	Version string `yaml:"version"`
+}
+
+type configV1 struct {
+	Version   string            `yaml:"version"`
+	Telemetry telemetryConfigV1 `yaml:"telemetry,omitempty"`
 	Exporters struct {
-		OTLPHTTP struct {
-			Endpoint string            `yaml:"endpoint"`
-			Headers  map[string]string `yaml:"headers,omitempty"`
-		} `yaml:"otlphttp"`
+		OTLPHTTP otlpHTTPExporter `yaml:"otlphttp,omitempty"`
 	} `yaml:"exporters"`
 }
 
-func parseSecret(value string) (secretConfig, error) {
-	var cfg secretConfig
+type telemetryConfigV1 struct {
+	Logs struct {
+		Audit struct {
+			Enabled bool `yaml:"enabled"`
+		} `yaml:"audit,omitempty"`
+	} `yaml:"logs,omitempty"`
+}
+
+type config struct {
+	AuditLogsEnabled bool
+	OTLPHTTP         otlpHTTPExporter
+}
+
+type otlpHTTPExporter struct {
+	Endpoint string            `yaml:"endpoint"`
+	Headers  map[string]string `yaml:"headers,omitempty"`
+}
+
+func parseSecret(value string) (config, error) {
+	var cfg config
 	if len(value) == 0 || len(value) > maxSecretSize {
 		return cfg, fmt.Errorf("telemetry export configuration has invalid size")
 	}
@@ -43,79 +65,124 @@ func parseSecret(value string) (secretConfig, error) {
 	if len(value) == 0 || len(value) > maxSecretSize {
 		return cfg, fmt.Errorf("decoded telemetry export configuration has invalid size")
 	}
-	decoder := yaml.NewDecoder(strings.NewReader(value))
-	decoder.KnownFields(true)
-	if err := decoder.Decode(&cfg); err != nil {
-		return cfg, fmt.Errorf("decode telemetry export configuration: %w", err)
-	}
-	var trailing any
-	if err := decoder.Decode(&trailing); err == nil {
-		return cfg, fmt.Errorf("telemetry export configuration contains trailing document")
-	} else if !errors.Is(err, io.EOF) {
-		return cfg, fmt.Errorf("decode trailing telemetry export configuration: %w", err)
-	}
 
-	endpoint := cfg.Exporters.OTLPHTTP.Endpoint
-	if endpoint == "" || len(endpoint) > maxEndpointLen {
-		return cfg, fmt.Errorf("telemetry export endpoint is required or too long")
+	var envelope configEnvelope
+	if err := decodeConfigDocument(value, &envelope, false); err != nil {
+		return cfg, fmt.Errorf("decode telemetry export configuration version: %w", err)
 	}
-	u, err := url.Parse(endpoint)
-	if err != nil || u.Scheme != "https" || u.Host == "" || u.User != nil || u.Fragment != "" || u.RawQuery != "" || strings.Contains(endpoint, "${") {
-		return cfg, fmt.Errorf("telemetry export endpoint must be an HTTPS URL with a host and no userinfo, query, fragment, or environment expansion")
+	switch envelope.Version {
+	case "":
+		return cfg, fmt.Errorf("telemetry export configuration version is required")
+	case configVersionV1:
+		return parseConfigV1(value)
+	default:
+		return cfg, fmt.Errorf("unsupported telemetry export configuration version %q", envelope.Version)
 	}
-	if len(cfg.Exporters.OTLPHTTP.Headers) > maxHeaders {
-		return cfg, fmt.Errorf("telemetry export configuration has too many headers")
+}
+
+func parseConfigV1(value string) (config, error) {
+	var wire configV1
+	if err := decodeConfigDocument(value, &wire, true); err != nil {
+		return config{}, fmt.Errorf("decode telemetry export configuration: %w", err)
 	}
-	for name, value := range cfg.Exporters.OTLPHTTP.Headers {
-		if name == "" || len(name) > 256 || http.CanonicalHeaderKey(name) == "" || !headerNamePattern.MatchString(name) {
-			return cfg, fmt.Errorf("telemetry export configuration has an invalid header name")
-		}
-		if value == "" || len(value) > maxHeaderLen || strings.ContainsAny(value, "\r\n\x00") || strings.Contains(value, "${") {
-			return cfg, fmt.Errorf("telemetry export configuration has an invalid header value")
-		}
+	cfg := config{
+		AuditLogsEnabled: wire.Telemetry.Logs.Audit.Enabled,
+		OTLPHTTP:         wire.Exporters.OTLPHTTP,
+	}
+	if !cfg.AuditLogsEnabled {
+		return cfg, nil
+	}
+	if err := validateOTLPHTTPExporter(cfg.OTLPHTTP); err != nil {
+		return config{}, err
 	}
 	return cfg, nil
 }
 
-func collectorConfig(cfg secretConfig) ([]byte, []string, error) {
-	headers := make(map[string]string, len(cfg.Exporters.OTLPHTTP.Headers))
-	headerNames := make([]string, 0, len(cfg.Exporters.OTLPHTTP.Headers))
-	for name := range cfg.Exporters.OTLPHTTP.Headers {
+func decodeConfigDocument(value string, destination any, knownFields bool) error {
+	decoder := yaml.NewDecoder(strings.NewReader(value))
+	decoder.KnownFields(knownFields)
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err == nil {
+		return fmt.Errorf("telemetry export configuration contains trailing document")
+	} else if !errors.Is(err, io.EOF) {
+		return fmt.Errorf("decode trailing telemetry export configuration: %w", err)
+	}
+	return nil
+}
+
+func validateOTLPHTTPExporter(exporter otlpHTTPExporter) error {
+	endpoint := exporter.Endpoint
+	if endpoint == "" || len(endpoint) > maxEndpointLen {
+		return fmt.Errorf("telemetry export endpoint is required or too long")
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Scheme != "https" || u.Host == "" || u.User != nil || u.Fragment != "" || u.RawQuery != "" || strings.Contains(endpoint, "${") {
+		return fmt.Errorf("telemetry export endpoint must be an HTTPS URL with a host and no userinfo, query, fragment, or environment expansion")
+	}
+	if len(exporter.Headers) > maxHeaders {
+		return fmt.Errorf("telemetry export configuration has too many headers")
+	}
+	for name, value := range exporter.Headers {
+		if name == "" || len(name) > 256 || http.CanonicalHeaderKey(name) == "" || !headerNamePattern.MatchString(name) {
+			return fmt.Errorf("telemetry export configuration has an invalid header name")
+		}
+		if value == "" || len(value) > maxHeaderLen || strings.ContainsAny(value, "\r\n\x00") || strings.Contains(value, "${") {
+			return fmt.Errorf("telemetry export configuration has an invalid header value")
+		}
+	}
+	return nil
+}
+
+func collectorConfig(cfg config) ([]byte, []string, error) {
+	pipelines := make(map[string]any)
+	document := map[string]any{
+		"extensions": map[string]any{"health_check": map[string]any{"endpoint": "127.0.0.1:13133"}},
+		"service": map[string]any{
+			"extensions": []string{"health_check"},
+			"pipelines":  pipelines,
+			"telemetry":  map[string]any{"logs": map[string]any{"level": "warn"}},
+		},
+	}
+	if !cfg.AuditLogsEnabled {
+		contents, err := yaml.Marshal(document)
+		return contents, nil, err
+	}
+
+	headers := make(map[string]string, len(cfg.OTLPHTTP.Headers))
+	headerNames := make([]string, 0, len(cfg.OTLPHTTP.Headers))
+	for name := range cfg.OTLPHTTP.Headers {
 		headerNames = append(headerNames, name)
 	}
 	sort.Strings(headerNames)
 
 	environment := make([]string, 0, len(headerNames))
 	for i, name := range headerNames {
-		value := cfg.Exporters.OTLPHTTP.Headers[name]
+		value := cfg.OTLPHTTP.Headers[name]
 		envName := fmt.Sprintf("NUON_TELEMETRY_EXPORT_HEADER_%d", i)
 		headers[name] = "${env:" + envName + "}"
 		environment = append(environment, envName+"="+value)
 	}
-	document := map[string]any{
-		"receivers": map[string]any{"otlp": map[string]any{"protocols": map[string]any{"http": map[string]any{"endpoint": "127.0.0.1:4318"}}}},
-		"processors": map[string]any{
-			"memory_limiter": map[string]any{"check_interval": "1s", "limit_mib": 128, "spike_limit_mib": 32},
-			"filter/audit": map[string]any{
-				"error_mode": "ignore",
-				"logs": map[string]any{
-					"log_record": []string{`attributes["nuon.audit"] != "true"`},
-				},
+	document["receivers"] = map[string]any{"otlp": map[string]any{"protocols": map[string]any{"http": map[string]any{"endpoint": "127.0.0.1:4318"}}}}
+	document["processors"] = map[string]any{
+		"memory_limiter": map[string]any{"check_interval": "1s", "limit_mib": 128, "spike_limit_mib": 32},
+		"filter/audit": map[string]any{
+			"error_mode": "ignore",
+			"logs": map[string]any{
+				"log_record": []string{`attributes["nuon.audit"] != "true"`},
 			},
-			"batch": map[string]any{"send_batch_size": 512, "timeout": "5s"},
 		},
-		"exporters": map[string]any{"otlp_http": map[string]any{
-			"endpoint": cfg.Exporters.OTLPHTTP.Endpoint, "headers": headers, "compression": "gzip",
-			"sending_queue":    map[string]any{"enabled": true, "queue_size": 1000, "num_consumers": 2},
-			"retry_on_failure": map[string]any{"enabled": true, "initial_interval": "1s", "max_interval": "30s", "max_elapsed_time": "5m"},
-		}},
-		"extensions": map[string]any{"health_check": map[string]any{"endpoint": "127.0.0.1:13133"}},
-		"service": map[string]any{
-			"extensions": []string{"health_check"},
-			"pipelines":  map[string]any{"logs": map[string]any{"receivers": []string{"otlp"}, "processors": []string{"memory_limiter", "filter/audit", "batch"}, "exporters": []string{"otlp_http"}}},
-			"telemetry":  map[string]any{"logs": map[string]any{"level": "warn"}},
-		},
+		"batch": map[string]any{"send_batch_size": 512, "timeout": "5s"},
 	}
+	document["exporters"] = map[string]any{"otlp_http": map[string]any{
+		"endpoint": cfg.OTLPHTTP.Endpoint, "headers": headers, "compression": "gzip",
+		"sending_queue":    map[string]any{"enabled": true, "queue_size": 1000, "num_consumers": 2},
+		"retry_on_failure": map[string]any{"enabled": true, "initial_interval": "1s", "max_interval": "30s", "max_elapsed_time": "5m"},
+	}}
+	pipelines["logs/audit"] = map[string]any{"receivers": []string{"otlp"}, "processors": []string{"memory_limiter", "filter/audit", "batch"}, "exporters": []string{"otlp_http"}}
+
 	contents, err := yaml.Marshal(document)
 	return contents, environment, err
 }

--- a/bins/runner/internal/pkg/telemetryexport/config_test.go
+++ b/bins/runner/internal/pkg/telemetryexport/config_test.go
@@ -2,12 +2,25 @@ package telemetryexport
 
 import (
 	"encoding/base64"
+	"fmt"
 	"strings"
 	"testing"
 )
 
-func TestParseSecret(t *testing.T) {
-	valid := "exporters:\n  otlphttp:\n    endpoint: https://otlp.example.com\n    headers:\n      Authorization: Bearer token\n"
+func auditEnabledConfig(endpoint string) string {
+	return fmt.Sprintf(`version: v1
+telemetry:
+  logs:
+    audit:
+      enabled: true
+exporters:
+  otlphttp:
+    endpoint: %s
+`, endpoint)
+}
+
+func TestParseSecretV1(t *testing.T) {
+	valid := auditEnabledConfig("https://otlp.example.com") + "    headers:\n      Authorization: Bearer token\n"
 	if _, err := parseSecret(valid); err != nil {
 		t.Fatalf("expected valid configuration: %v", err)
 	}
@@ -15,23 +28,55 @@ func TestParseSecret(t *testing.T) {
 	if _, err := parseSecret(encoded); err != nil {
 		t.Fatalf("expected valid base64-encoded configuration: %v", err)
 	}
+	cfg, err := parseSecret(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.AuditLogsEnabled || cfg.OTLPHTTP.Endpoint != "https://otlp.example.com" {
+		t.Fatalf("unexpected parsed configuration: %#v", cfg)
+	}
+}
 
+func TestParseSecretAllowsAuditLogsToBeDisabled(t *testing.T) {
 	tests := []string{
-		"exporters:\n  otlphttp:\n    endpoint: http://otlp.example.com\n",
-		"exporters:\n  otlphttp:\n    endpoint: https://user@example.com\n",
-		"exporters:\n  otlphttp:\n    endpoint: https://example.com/#fragment\n",
-		"exporters:\n  otlphttp:\n    endpoint: https://example.com/?token=value\n",
-		"exporters:\n  otlphttp:\n    endpoint: https://${env:RUNNER_API_TOKEN}\n",
-		"exporters:\n  otlphttp:\n    endpoint: https://example.com\n    unknown: true\n",
-		"exporters:\n  otlphttp:\n    endpoint: https://example.com\n---\nexporters: {}\n",
-		"exporters:\n  otlphttp:\n    endpoint: https://example.com\n    headers:\n      'bad header': value\n",
-		"exporters:\n  otlphttp:\n    endpoint: https://example.com\n    headers:\n      Authorization: ''\n",
-		"exporters:\n  otlphttp:\n    endpoint: https://example.com\n    headers:\n      Authorization: '${env:RUNNER_API_TOKEN}'\n",
+		"version: v1\n",
+		"version: v1\ntelemetry:\n  logs:\n    audit:\n      enabled: false\n",
 	}
 	for _, value := range tests {
-		if _, err := parseSecret(value); err == nil {
-			t.Errorf("expected configuration to be rejected: %q", value)
+		cfg, err := parseSecret(value)
+		if err != nil {
+			t.Fatalf("expected disabled configuration to be valid: %v", err)
 		}
+		if cfg.AuditLogsEnabled {
+			t.Fatal("disabled configuration enabled audit logs")
+		}
+	}
+}
+
+func TestParseSecretRejectsInvalidV1(t *testing.T) {
+	tests := map[string]string{
+		"missing version":            strings.TrimPrefix(auditEnabledConfig("https://example.com"), "version: v1\n"),
+		"unsupported version":        "version: v2\n",
+		"enabled without exporter":   "version: v1\ntelemetry:\n  logs:\n    audit:\n      enabled: true\n",
+		"insecure endpoint":          auditEnabledConfig("http://otlp.example.com"),
+		"endpoint with user info":    auditEnabledConfig("https://user@example.com"),
+		"endpoint with fragment":     auditEnabledConfig("https://example.com/#fragment"),
+		"endpoint with query":        auditEnabledConfig("https://example.com/?token=value"),
+		"endpoint with expansion":    auditEnabledConfig("https://${env:RUNNER_API_TOKEN}"),
+		"unknown exporter field":     auditEnabledConfig("https://example.com") + "    unknown: true\n",
+		"unknown telemetry category": "version: v1\ntelemetry:\n  logs:\n    billing:\n      enabled: true\n",
+		"unknown top-level field":    "version: v1\nunknown: true\n",
+		"trailing document":          auditEnabledConfig("https://example.com") + "---\nversion: v1\n",
+		"invalid header name":        auditEnabledConfig("https://example.com") + "    headers:\n      'bad header': value\n",
+		"empty header value":         auditEnabledConfig("https://example.com") + "    headers:\n      Authorization: ''\n",
+		"header with expansion":      auditEnabledConfig("https://example.com") + "    headers:\n      Authorization: '${env:RUNNER_API_TOKEN}'\n",
+	}
+	for name, value := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseSecret(value); err == nil {
+				t.Errorf("expected configuration to be rejected: %q", value)
+			}
+		})
 	}
 }
 
@@ -52,7 +97,7 @@ func TestChildEnvironmentOmitsRunnerCredentials(t *testing.T) {
 }
 
 func TestCollectorConfigKeepsHeaderValuesOutOfFile(t *testing.T) {
-	cfg, err := parseSecret("exporters:\n  otlphttp:\n    endpoint: https://otlp.example.com\n    headers:\n      Authorization: super-secret-value\n")
+	cfg, err := parseSecret(auditEnabledConfig("https://otlp.example.com") + "    headers:\n      Authorization: super-secret-value\n")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +114,7 @@ func TestCollectorConfigKeepsHeaderValuesOutOfFile(t *testing.T) {
 	if len(environment) != 1 || !strings.HasSuffix(environment[0], "=super-secret-value") {
 		t.Fatalf("unexpected child environment: %q", environment)
 	}
-	if !strings.Contains(string(contents), "127.0.0.1:4318") || !strings.Contains(string(contents), "logs:") {
+	if !strings.Contains(string(contents), "127.0.0.1:4318") || !strings.Contains(string(contents), "logs/audit:") {
 		t.Fatal("generated collector configuration lacks loopback logs pipeline")
 	}
 	if !strings.Contains(string(contents), `attributes["nuon.audit"] != "true"`) {
@@ -77,5 +122,28 @@ func TestCollectorConfigKeepsHeaderValuesOutOfFile(t *testing.T) {
 	}
 	if !strings.Contains(string(contents), "- filter/audit") {
 		t.Fatal("generated collector pipeline does not use the audit filter")
+	}
+}
+
+func TestCollectorConfigOmitsAuditPipelineWhenDisabled(t *testing.T) {
+	cfg, err := parseSecret("version: v1\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents, environment, err := collectorConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(environment) != 0 {
+		t.Fatalf("disabled audit pipeline produced an environment: %q", environment)
+	}
+	config := string(contents)
+	if !strings.Contains(config, "health_check:") || !strings.Contains(config, "pipelines: {}") {
+		t.Fatalf("generated collector configuration does not contain an empty service: %s", config)
+	}
+	for _, unexpected := range []string{"127.0.0.1:4318", "logs/audit:", "filter/audit:", "otlp_http:"} {
+		if strings.Contains(config, unexpected) {
+			t.Fatalf("generated collector configuration contains disabled audit component %q", unexpected)
+		}
 	}
 }

--- a/bins/runner/internal/pkg/telemetryexport/source_aws.go
+++ b/bins/runner/internal/pkg/telemetryexport/source_aws.go
@@ -80,7 +80,7 @@ func newAWSConfigUpdate(result *secretsmanager.GetSecretValueOutput, err error) 
 		switch {
 		case errors.As(err, &notFound):
 			return configUpdate{state: configNotFound, err: err, errorIdentity: awsErrorIdentity(err)}
-		case errors.As(err, &invalidRequest):
+		case errors.As(err, &invalidRequest), awsAccessDenied(err):
 			return configUpdate{state: configUnavailable, err: err, errorIdentity: awsErrorIdentity(err)}
 		default:
 			return configUpdate{state: configLookupFailed, err: err, errorIdentity: awsErrorIdentity(err)}
@@ -90,6 +90,11 @@ func newAWSConfigUpdate(result *secretsmanager.GetSecretValueOutput, err error) 
 		return configUpdate{state: configAvailable}
 	}
 	return configUpdate{state: configAvailable, value: *result.SecretString}
+}
+
+func awsAccessDenied(err error) bool {
+	var apiError smithy.APIError
+	return errors.As(err, &apiError) && apiError.ErrorCode() == "AccessDeniedException"
 }
 
 func awsErrorIdentity(err error) string {

--- a/bins/runner/internal/pkg/telemetryexport/source_azure.go
+++ b/bins/runner/internal/pkg/telemetryexport/source_azure.go
@@ -2,14 +2,12 @@ package telemetryexport
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 )
@@ -81,7 +79,7 @@ func newAzureConfigUpdate(result azsecrets.GetSecretResponse, err error) configU
 			switch {
 			case responseError.StatusCode == http.StatusNotFound:
 				state = configNotFound
-			case responseError.StatusCode == http.StatusForbidden && azureSecretDisabled(responseError):
+			case responseError.StatusCode == http.StatusForbidden || responseError.StatusCode == http.StatusUnauthorized:
 				state = configUnavailable
 			}
 		}
@@ -91,30 +89,6 @@ func newAzureConfigUpdate(result azsecrets.GetSecretResponse, err error) configU
 		return configUpdate{state: configAvailable}
 	}
 	return configUpdate{state: configAvailable, value: *result.Value}
-}
-
-func azureSecretDisabled(responseError *azcore.ResponseError) bool {
-	if responseError.ErrorCode == "SecretDisabled" {
-		return true
-	}
-	if responseError.RawResponse == nil {
-		return false
-	}
-	payload, err := azruntime.Payload(responseError.RawResponse)
-	if err != nil {
-		return false
-	}
-	var envelope struct {
-		Error struct {
-			InnerError struct {
-				Code string `json:"code"`
-			} `json:"innererror"`
-		} `json:"error"`
-	}
-	if err := json.Unmarshal(payload, &envelope); err != nil {
-		return false
-	}
-	return envelope.Error.InnerError.Code == "SecretDisabled"
 }
 
 func azureErrorIdentity(err error) string {

--- a/bins/runner/internal/pkg/telemetryexport/source_azure_test.go
+++ b/bins/runner/internal/pkg/telemetryexport/source_azure_test.go
@@ -58,7 +58,8 @@ func TestNewAzureConfigUpdateClassifiesResults(t *testing.T) {
 		{name: "empty", result: azsecrets.GetSecretResponse{}, state: configAvailable},
 		{name: "disabled", err: disabledError, state: configUnavailable},
 		{name: "not found", err: &azcore.ResponseError{StatusCode: http.StatusNotFound, ErrorCode: "SecretNotFound"}, state: configNotFound},
-		{name: "permission denied", err: &azcore.ResponseError{StatusCode: http.StatusForbidden, ErrorCode: "Forbidden"}, state: configLookupFailed},
+		{name: "permission denied", err: &azcore.ResponseError{StatusCode: http.StatusForbidden, ErrorCode: "Forbidden"}, state: configUnavailable},
+		{name: "unauthenticated", err: &azcore.ResponseError{StatusCode: http.StatusUnauthorized, ErrorCode: "Unauthorized"}, state: configUnavailable},
 		{name: "lookup failure", err: errors.New("lookup failed"), state: configLookupFailed},
 	}
 

--- a/bins/runner/internal/pkg/telemetryexport/source_gcp.go
+++ b/bins/runner/internal/pkg/telemetryexport/source_gcp.go
@@ -84,7 +84,7 @@ func newGCPConfigUpdate(result *secretmanagerpb.AccessSecretVersionResponse, err
 		switch status.Code(err) {
 		case codes.NotFound:
 			state = configNotFound
-		case codes.FailedPrecondition:
+		case codes.FailedPrecondition, codes.PermissionDenied, codes.Unauthenticated:
 			state = configUnavailable
 		}
 		return configUpdate{state: state, err: err, errorIdentity: gcpErrorIdentity(err)}

--- a/bins/runner/internal/pkg/telemetryexport/source_gcp_test.go
+++ b/bins/runner/internal/pkg/telemetryexport/source_gcp_test.go
@@ -51,7 +51,8 @@ func TestNewGCPConfigUpdateClassifiesResults(t *testing.T) {
 		{name: "empty", result: &secretmanagerpb.AccessSecretVersionResponse{}, state: configAvailable},
 		{name: "not found", err: status.Error(codes.NotFound, "secret version not found"), state: configNotFound},
 		{name: "disabled", err: status.Error(codes.FailedPrecondition, "secret version is disabled"), state: configUnavailable},
-		{name: "permission denied", err: status.Error(codes.PermissionDenied, "permission denied"), state: configLookupFailed},
+		{name: "permission denied", err: status.Error(codes.PermissionDenied, "permission denied"), state: configUnavailable},
+		{name: "unauthenticated", err: status.Error(codes.Unauthenticated, "unauthenticated"), state: configUnavailable},
 		{name: "lookup failure", err: errors.New("lookup failed"), state: configLookupFailed},
 	}
 

--- a/bins/runner/internal/pkg/telemetryexport/source_test.go
+++ b/bins/runner/internal/pkg/telemetryexport/source_test.go
@@ -62,6 +62,7 @@ func TestNewAWSConfigUpdateClassifiesResults(t *testing.T) {
 		{name: "available", value: &secretsmanager.GetSecretValueOutput{SecretString: &value}, state: configAvailable},
 		{name: "not found", err: &types.ResourceNotFoundException{}, state: configNotFound},
 		{name: "unavailable", err: &types.InvalidRequestException{}, state: configUnavailable},
+		{name: "permission denied", err: &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "access denied"}, state: configUnavailable},
 		{name: "lookup failure", err: errors.New("lookup failed"), state: configLookupFailed},
 	}
 

--- a/bins/runner/internal/pkg/telemetryexport/telemetryexport.go
+++ b/bins/runner/internal/pkg/telemetryexport/telemetryexport.go
@@ -34,22 +34,23 @@ type Params struct {
 }
 
 type Supervisor struct {
-	installID string
-	platform  string
-	local     bool
-	logger    *zap.Logger
-	sources   configSourceResolver
-	cancel    context.CancelFunc
-	done      chan struct{}
-	mu        sync.Mutex
-	child     *childProcess
-	active    string
-	backoff   time.Duration
-	nextStart time.Time
-	reported  bool
-	enabled   bool
+	installID          string
+	platform           string
+	local              bool
+	logger             *zap.Logger
+	sources            configSourceResolver
+	cancel             context.CancelFunc
+	done               chan struct{}
+	mu                 sync.Mutex
+	child              *childProcess
+	active             string
+	backoff            time.Duration
+	nextStart          time.Time
+	reported           bool
+	collectorEnabled   bool
+	auditExportEnabled bool
 
-	replaceChildFn func(secretConfig) error
+	replaceChildFn func(config) error
 	stopChildFn    func()
 }
 
@@ -88,10 +89,10 @@ func (s *Supervisor) stop(ctx context.Context) error {
 	return nil
 }
 
-func (s *Supervisor) Available() bool {
+func (s *Supervisor) AuditExportAvailable() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.child == nil {
+	if !s.auditExportEnabled || s.child == nil {
 		return false
 	}
 	select {
@@ -163,7 +164,7 @@ func (s *Supervisor) reconcile(update configUpdate) {
 		return
 	}
 	if err := s.replaceChildFn(cfg); err != nil {
-		s.logger.Warn("audit export collector failed to start")
+		s.logger.Warn("telemetry export collector failed to start")
 		if s.active != "" {
 			if previous, parseErr := parseSecret(s.active); parseErr == nil {
 				if rollbackErr := s.replaceChildFn(previous); rollbackErr != nil {
@@ -176,35 +177,50 @@ func (s *Supervisor) reconcile(update configUpdate) {
 	s.active = value
 	s.backoff = time.Second
 	s.nextStart = time.Time{}
+	s.setAuditExportEnabled(cfg.AuditLogsEnabled)
 	s.logEnabled(cfg)
 }
 
 func (s *Supervisor) disable(reason string) {
 	s.stopChildFn()
+	s.setAuditExportEnabled(false)
 	s.active = ""
 	s.nextStart = time.Time{}
-	if !s.reported || s.enabled {
-		s.logger.Info("runner audit export disabled",
+	if !s.reported || s.collectorEnabled {
+		s.logger.Info("runner telemetry export collector disabled",
+			zap.Bool("telemetry_export.enabled", false),
 			zap.Bool("audit_export.enabled", false),
-			zap.String("audit_export.reason", reason),
+			zap.String("telemetry_export.reason", reason),
 		)
 	}
 	s.reported = true
-	s.enabled = false
+	s.collectorEnabled = false
 }
 
-func (s *Supervisor) logEnabled(cfg secretConfig) {
-	endpoint, _ := url.Parse(cfg.Exporters.OTLPHTTP.Endpoint)
-	s.logger.Info("runner audit export enabled",
-		zap.Bool("audit_export.enabled", true),
-		zap.String("audit_export.exporter", "otlphttp"),
-		zap.String("audit_export.backend", endpoint.Host),
-	)
+func (s *Supervisor) logEnabled(cfg config) {
+	fields := []zap.Field{
+		zap.Bool("telemetry_export.enabled", true),
+		zap.Bool("audit_export.enabled", cfg.AuditLogsEnabled),
+	}
+	if cfg.AuditLogsEnabled {
+		endpoint, _ := url.Parse(cfg.OTLPHTTP.Endpoint)
+		fields = append(fields,
+			zap.String("audit_export.exporter", "otlphttp"),
+			zap.String("audit_export.backend", endpoint.Host),
+		)
+	}
+	s.logger.Info("runner telemetry export collector enabled", fields...)
 	s.reported = true
-	s.enabled = true
+	s.collectorEnabled = true
 }
 
-func (s *Supervisor) replaceChild(cfg secretConfig) error {
+func (s *Supervisor) setAuditExportEnabled(enabled bool) {
+	s.mu.Lock()
+	s.auditExportEnabled = enabled
+	s.mu.Unlock()
+}
+
+func (s *Supervisor) replaceChild(cfg config) error {
 	if _, err := os.Stat(collectorBinary); err != nil {
 		return err
 	}
@@ -212,7 +228,7 @@ func (s *Supervisor) replaceChild(cfg secretConfig) error {
 	if err != nil {
 		return err
 	}
-	tempDir, err := os.MkdirTemp("", "nuon-audit-export-")
+	tempDir, err := os.MkdirTemp("", "nuon-telemetry-export-")
 	if err != nil {
 		return err
 	}
@@ -221,10 +237,10 @@ func (s *Supervisor) replaceChild(cfg secretConfig) error {
 		os.RemoveAll(tempDir)
 		return err
 	}
-	cmd := exec.Command(collectorBinary, "--config", path)
+	cmd := exec.Command(collectorBinary, "--config", path, "--feature-gates=service.AllowNoPipelines")
 	cmd.Env = childEnvironment(environment)
-	stdout := &zapio.Writer{Log: s.logger.Named("audit-export-collector").With(zap.String("stream", "stdout")), Level: zapcore.WarnLevel}
-	stderr := &zapio.Writer{Log: s.logger.Named("audit-export-collector").With(zap.String("stream", "stderr")), Level: zapcore.WarnLevel}
+	stdout := &zapio.Writer{Log: s.logger.Named("telemetry-export-collector").With(zap.String("stream", "stdout")), Level: zapcore.WarnLevel}
+	stderr := &zapio.Writer{Log: s.logger.Named("telemetry-export-collector").With(zap.String("stream", "stderr")), Level: zapcore.WarnLevel}
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	s.stopChild()
@@ -237,6 +253,7 @@ func (s *Supervisor) replaceChild(cfg secretConfig) error {
 	child := &childProcess{cmd: cmd, tempDir: tempDir, done: make(chan struct{}), startedAt: time.Now(), outputWriters: []io.Closer{stdout, stderr}}
 	s.mu.Lock()
 	s.child = child
+	s.auditExportEnabled = cfg.AuditLogsEnabled
 	s.mu.Unlock()
 	go func() {
 		_ = cmd.Wait()
@@ -276,7 +293,7 @@ func (s *Supervisor) restartCrashed(_ context.Context) {
 		select {
 		case <-child.done:
 			s.stopChild()
-			s.logger.Warn("audit export collector exited; scheduling restart")
+			s.logger.Warn("telemetry export collector exited; scheduling restart")
 			if time.Since(child.startedAt) >= 30*time.Second {
 				s.backoff = time.Second
 			}
@@ -299,7 +316,7 @@ func (s *Supervisor) restartCrashed(_ context.Context) {
 	}
 	s.nextStart = time.Now().Add(s.backoff)
 	if err := s.replaceChildFn(cfg); err != nil {
-		s.logger.Warn("audit export collector restart failed")
+		s.logger.Warn("telemetry export collector restart failed")
 		return
 	}
 	s.nextStart = time.Time{}

--- a/bins/runner/internal/pkg/telemetryexport/telemetryexport_test.go
+++ b/bins/runner/internal/pkg/telemetryexport/telemetryexport_test.go
@@ -11,15 +11,15 @@ import (
 )
 
 func TestReconcilePreservesLastKnownGoodConfiguration(t *testing.T) {
-	valid := "exporters:\n  otlphttp:\n    endpoint: https://otlp.example.com\n"
-	invalid := "exporters:\n  otlphttp:\n    endpoint: http://otlp.example.com\n"
+	valid := auditEnabledConfig("https://otlp.example.com")
+	invalid := "version: v2\n"
 	replacements := 0
 	stops := 0
 	s := &Supervisor{
 		installID: "inst-test",
 		logger:    zap.NewNop(),
 		active:    valid,
-		replaceChildFn: func(secretConfig) error {
+		replaceChildFn: func(config) error {
 			replacements++
 			return nil
 		},
@@ -43,12 +43,12 @@ func TestReconcilePreservesLastKnownGoodConfiguration(t *testing.T) {
 }
 
 func TestReconcileAppliesChangedValidConfigurationOnce(t *testing.T) {
-	valid := "exporters:\n  otlphttp:\n    endpoint: https://otlp.example.com\n"
+	valid := auditEnabledConfig("https://otlp.example.com")
 	replacements := 0
 	s := &Supervisor{
 		installID: "inst-test",
 		logger:    zap.NewNop(),
-		replaceChildFn: func(secretConfig) error {
+		replaceChildFn: func(config) error {
 			replacements++
 			return nil
 		},
@@ -63,14 +63,14 @@ func TestReconcileAppliesChangedValidConfigurationOnce(t *testing.T) {
 }
 
 func TestReconcileSchedulesRestartWhenUpdateAndRollbackFail(t *testing.T) {
-	current := "exporters:\n  otlphttp:\n    endpoint: https://current.example.com\n"
-	updated := "exporters:\n  otlphttp:\n    endpoint: https://updated.example.com\n"
+	current := auditEnabledConfig("https://current.example.com")
+	updated := auditEnabledConfig("https://updated.example.com")
 	s := &Supervisor{
 		installID: "inst-test",
 		logger:    zap.NewNop(),
 		active:    current,
 		backoff:   time.Second,
-		replaceChildFn: func(secretConfig) error {
+		replaceChildFn: func(config) error {
 			return errors.New("start failed")
 		},
 		stopChildFn: func() {},
@@ -83,20 +83,47 @@ func TestReconcileSchedulesRestartWhenUpdateAndRollbackFail(t *testing.T) {
 }
 
 func TestReconcileDisablesUnavailableSecret(t *testing.T) {
-	valid := "exporters:\n  otlphttp:\n    endpoint: https://otlp.example.com\n"
+	valid := auditEnabledConfig("https://otlp.example.com")
 	stops := 0
 	s := &Supervisor{
-		installID:   "inst-test",
-		logger:      zap.NewNop(),
-		active:      valid,
-		enabled:     true,
-		reported:    true,
-		stopChildFn: func() { stops++ },
+		installID:          "inst-test",
+		logger:             zap.NewNop(),
+		active:             valid,
+		collectorEnabled:   true,
+		auditExportEnabled: true,
+		reported:           true,
+		stopChildFn:        func() { stops++ },
 	}
 
 	s.reconcile(configUpdate{state: configUnavailable})
-	if stops != 1 || s.active != "" || s.enabled {
+	if stops != 1 || s.active != "" || s.collectorEnabled || s.auditExportEnabled {
 		t.Fatal("unavailable secret did not disable the collector")
+	}
+}
+
+func TestReconcileKeepsCollectorWithoutAuditPipeline(t *testing.T) {
+	active := auditEnabledConfig("https://otlp.example.com")
+	disabledAudit := "version: v1\ntelemetry:\n  logs:\n    audit:\n      enabled: false\n"
+	replacements := 0
+	stops := 0
+	s := &Supervisor{
+		installID:          "inst-test",
+		logger:             zap.NewNop(),
+		active:             active,
+		nextStart:          time.Now().Add(time.Minute),
+		collectorEnabled:   true,
+		auditExportEnabled: true,
+		reported:           true,
+		replaceChildFn: func(config) error {
+			replacements++
+			return nil
+		},
+		stopChildFn: func() { stops++ },
+	}
+
+	s.reconcile(configUpdate{state: configAvailable, value: disabledAudit})
+	if replacements != 1 || stops != 0 || s.active != disabledAudit || !s.nextStart.IsZero() || !s.collectorEnabled || s.auditExportEnabled {
+		t.Fatal("disabled audit logs did not leave the collector running without the audit pipeline")
 	}
 }
 
@@ -121,7 +148,7 @@ func TestEmptySecretDoesNotStartCollector(t *testing.T) {
 	s := &Supervisor{
 		installID: "inst-test",
 		logger:    zap.NewNop(),
-		replaceChildFn: func(secretConfig) error {
+		replaceChildFn: func(config) error {
 			replacements++
 			return nil
 		},
@@ -129,25 +156,30 @@ func TestEmptySecretDoesNotStartCollector(t *testing.T) {
 	}
 
 	s.reconcile(configUpdate{state: configAvailable})
-	if replacements != 0 || s.active != "" || s.enabled {
+	if replacements != 0 || s.active != "" || s.collectorEnabled || s.auditExportEnabled {
 		t.Fatal("empty secret started the audit export collector")
 	}
 }
 
-func TestAvailableTracksCollectorProcess(t *testing.T) {
+func TestAuditExportAvailableTracksPipelineAndCollectorProcess(t *testing.T) {
 	s := &Supervisor{}
-	if s.Available() {
+	if s.AuditExportAvailable() {
 		t.Fatal("supervisor without a collector is available")
 	}
 
 	done := make(chan struct{})
 	s.child = &childProcess{done: done}
-	if !s.Available() {
+	if s.AuditExportAvailable() {
+		t.Fatal("collector without an audit pipeline reported audit export as available")
+	}
+
+	s.auditExportEnabled = true
+	if !s.AuditExportAvailable() {
 		t.Fatal("running collector is unavailable")
 	}
 
 	close(done)
-	if s.Available() {
+	if s.AuditExportAvailable() {
 		t.Fatal("exited collector is available")
 	}
 }
@@ -155,11 +187,11 @@ func TestAvailableTracksCollectorProcess(t *testing.T) {
 func TestReconcileLogsEnabledBackendAndDisabledTransition(t *testing.T) {
 	core, observed := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
-	valid := "exporters:\n  otlphttp:\n    endpoint: https://otlp.example.com/tenant\n    headers:\n      Authorization: secret-value\n"
+	valid := auditEnabledConfig("https://otlp.example.com/tenant") + "    headers:\n      Authorization: secret-value\n"
 	s := &Supervisor{
 		installID: "inst-test",
 		logger:    logger,
-		replaceChildFn: func(secretConfig) error {
+		replaceChildFn: func(config) error {
 			return nil
 		},
 		stopChildFn: func() {},
@@ -173,15 +205,42 @@ func TestReconcileLogsEnabledBackendAndDisabledTransition(t *testing.T) {
 	if len(entries) != 2 {
 		t.Fatalf("expected enabled and disabled logs, got %d", len(entries))
 	}
-	if entries[0].Message != "runner audit export enabled" || entries[0].ContextMap()["audit_export.backend"] != "otlp.example.com" {
+	if entries[0].Message != "runner telemetry export collector enabled" || entries[0].ContextMap()["audit_export.backend"] != "otlp.example.com" {
 		t.Fatalf("unexpected enabled log: %#v", entries[0])
 	}
-	if entries[1].Message != "runner audit export disabled" || entries[1].ContextMap()["audit_export.reason"] != "secret not found" {
+	if entries[1].Message != "runner telemetry export collector disabled" || entries[1].ContextMap()["telemetry_export.reason"] != "secret not found" {
 		t.Fatalf("unexpected disabled log: %#v", entries[1])
 	}
 	for _, entry := range entries {
 		if entry.ContextMap()["audit_export.backend"] == "secret-value" {
 			t.Fatal("audit export log exposed a credential")
 		}
+	}
+}
+
+func TestReconcileLogsCollectorWithoutAuditPipeline(t *testing.T) {
+	core, observed := observer.New(zap.InfoLevel)
+	s := &Supervisor{
+		installID: "inst-test",
+		logger:    zap.New(core),
+		replaceChildFn: func(config) error {
+			return nil
+		},
+		stopChildFn: func() {},
+	}
+
+	s.reconcile(configUpdate{state: configAvailable, value: "version: v1\n"})
+
+	entries := observed.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected one collector enabled log, got %d", len(entries))
+	}
+	entry := entries[0]
+	fields := entry.ContextMap()
+	if entry.Message != "runner telemetry export collector enabled" || fields["telemetry_export.enabled"] != true || fields["audit_export.enabled"] != false {
+		t.Fatalf("unexpected collector enabled log: %#v", entry)
+	}
+	if _, ok := fields["audit_export.backend"]; ok {
+		t.Fatal("collector without an audit pipeline logged an audit backend")
 	}
 }

--- a/docs/concepts/app-secrets.mdx
+++ b/docs/concepts/app-secrets.mdx
@@ -15,23 +15,24 @@ keywords:
     'secrets.toml',
     'kubernetes sync',
     'customer owned secrets',
+    'Azure Key Vault',
+    'GCP Secret Manager',
   ]
 ---
 
 Secrets allow you to configure components with sensitive values and keys.
 
-Secret metadata (not the secret) are defined with a `secrets.toml` and incorporated in the CloudFormation stack deployed
-by the customer. This allows the customer to enter values when clicking on the stack link provided by the vendor, during
-the initial step of an install where the runner is created as a VM. Secrets are then stored in the user's AWS Secrets
-Manager.
+Secret metadata, but not secret values, is defined in `secrets.toml` and incorporated into the install instructions.
+The customer supplies values while setting up the install with their own cloud credentials. Values are stored in AWS
+Secrets Manager, Azure Key Vault, or GCP Secret Manager, depending on the install's cloud provider.
 
 <Note>
-  Because the customer creates the CloudFormation stack from that Nuon-generated CloudFormation template using their
-  cloud credentials, the customer (not the vendor) can enter the secret values at that time. Nuon nor the vendor will
-  never see the secret values, as they are not stored in the Nuon data plane.
+  Because the customer deploys the Nuon-generated Stack using their cloud credentials, the customer, not the vendor,
+  supplies the secret values. Neither Nuon nor the vendor sees these values because they are not stored in the Nuon
+  Control Plane.
 </Note>
 
-Secret can be used to configure components and actions using [variables](/guides/using-variables).
+Secrets can be used to configure components and actions using [variables](/guides/using-variables).
 
 ## How do you configure a secret?
 
@@ -87,8 +88,8 @@ Kubernetes secret.
 
 ## Configuring components with secrets
 
-Reference the secrets from AWS Secrets Manager as outputs from the CloudFormation stack, and then use them in your
-component config.
+Reference secret identifiers from Stack outputs, and then use them in your component configuration. The following
+examples use AWS Secrets Manager and CloudFormation; Azure and GCP Stacks provide equivalent provider-specific outputs.
 
 ### Terraform components with secrets
 
@@ -184,11 +185,16 @@ secret=`aws --region $region secretsmanager get-secret-value --secret-id=$secret
 
 ## Changing Secrets Outside of the App
 
-If you need to change a secret value outside of the app, e.g., in AWS Secrets Manager or update the CloudFormation
-stack, understand that Nuon will not detect the change.
+If you change an app secret directly in your cloud secret manager or by updating the Stack, Nuon will not automatically
+detect the change.
 
 In order for Nuon to be aware of the change, you will have to either reprovision the install or review the dependency
 graph in the dashboard and manually redeploy the components or actions that depend on the secret.
+
+<Note>
+  `telemetry-export-config` is runner configuration, not an app-defined secret. The runner automatically detects changes
+  to that secret. See [Export Runner Audit Logs](/guides/export-runner-audit-logs).
+</Note>
 
 If your secrets are configured to sync with Kubernetes, go to the install dashboard and manually select sync secrets in
 the Manage drop-down.

--- a/docs/concepts/runners.mdx
+++ b/docs/concepts/runners.mdx
@@ -3,7 +3,7 @@ title: 'Runners'
 icon: "shoe-prints"
 description: "Egress-only agents deployed in customer cloud accounts that execute all provisioning, deployment, and day-2 operations."
 boost: 2.5
-keywords: ["runners", "what is a runner", "install runner", "build runner", "runner VM", "runner jobs", "runner permissions", "data plane", "agent", "what is the agent", "agent architecture", "what permissions does the agent need", "egress only agent", "BYOC agent", "runner agent", "agent vs runner", "VPC peering", "PrivateLink", "network connectivity requirements", "air-gapped deployment", "no cross-account access"]
+keywords: ["runners", "what is a runner", "install runner", "build runner", "runner VM", "runner jobs", "runner permissions", "data plane", "agent", "what is the agent", "agent architecture", "what permissions does the agent need", "egress only agent", "BYOC agent", "runner agent", "agent vs runner", "VPC peering", "PrivateLink", "network connectivity requirements", "air-gapped deployment", "no cross-account access", "telemetry export", "runner audit logs", "OTLP"]
 ---
 
 Runners are deployed into each install, and are responsible for updating, monitoring and managing your running app. 
@@ -25,7 +25,17 @@ The runner performs the following jobs, inside of an install:
 * monitoring running components by way of actions e.g., health checks
 * running actions, which can be used to perform Day 2 operational tasks
 * executing Terraform 
-* returning telemetry and log data upon request
+* forwarding configured telemetry to customer-controlled observability backends
+
+## Customer-Owned Telemetry Export
+
+Customers can configure runners on AWS, Azure, and GCP to send runner audit events directly to their own OTLP-compatible
+backend. The destination and credentials are stored in the customer's cloud secret manager, and are not stored in the
+Nuon Control Plane.
+
+The install instructions identify the `telemetry-export-config` secret and configure the runner's access to it. The
+customer updates this secret after provisioning the Stack. See [Export Runner Audit Logs](/guides/export-runner-audit-logs)
+for the configuration reference and cloud-specific steps.
 
 ## Runner Permissions
 
@@ -34,8 +44,5 @@ Each runner works by listening for jobs from the Nuon managed data plane server 
 The runner will use different IAM roles for different component jobs, to minimize the permissions available on each job. These IAM roles are defined in each sandbox, and outputs are used to allow the runner to use them.
 
 Since the runner is deployed _into_ the customer install, no long-lived permissions are required after the initial install. This creates a more secure operating environment, as the _only_ thing that can dispatch work to the runner is the customer's data plane server it belongs to.
-
-For even more visibility, the runner can also forward audit events directly to a customer-controlled OTLP logging
-backend. See [Export Runner Audit Logs](/guides/export-runner-audit-logs) for supported events and configuration.
 
 ![Runner](../images/concepts/runner/runner.png)

--- a/docs/concepts/stacks.mdx
+++ b/docs/concepts/stacks.mdx
@@ -45,6 +45,6 @@ This means the customer always has a killswitch. See [Customer-Controlled Runner
 
 Stacks accept customer-provided values at deploy time. They come in three forms:
 
-- **[Secrets](/concepts/app-secrets)** — entered by the customer as CloudFormation/Bicep parameters or Terraform variables, then stored in the customer's cloud secret manager (e.g., AWS Secrets Manager).
+- **[Secrets](/concepts/app-secrets)** — entered by the customer as CloudFormation/Bicep parameters or Terraform variables, then stored in AWS Secrets Manager, Azure Key Vault, or GCP Secret Manager.
 - **[Customer-facing inputs](/concepts/app-inputs#customer-facing-inputs)** marked `user_configurable` — passed through the Stack at deploy time.
 - **VPC and cluster IDs** — required when the app uses the [Customer VPC](/concepts/stacks/customer-vpc) or [Customer Cluster](/concepts/stacks/customer-cluster) pattern. The customer enters them in the Stack's parameter form alongside any other inputs.

--- a/docs/get-started/day-2-operations.mdx
+++ b/docs/get-started/day-2-operations.mdx
@@ -17,9 +17,9 @@ Each workflow run's logs and step state are visible in the dashboard, CLI, and T
 
 ## Audit Logs
 
-AWS install runners can forward deployment, action workflow, and sandbox audit events directly to a
-customer-controlled OTLP logging backend. Only Nuon audit events are forwarded, not application logs or general
-runner logs.
+Install runners on AWS, Azure, and GCP can forward deployment, action workflow, and sandbox audit events directly to a
+customer-controlled OTLP logging backend. The destination and credentials remain in the customer's cloud account. Only
+Nuon audit events are forwarded, not application logs or general runner logs.
 
 [How to → Export Runner Audit Logs](/guides/export-runner-audit-logs)
 

--- a/docs/guides/byoc/aws.mdx
+++ b/docs/guides/byoc/aws.mdx
@@ -144,13 +144,6 @@ base64 -i your-github-app-key.pem
 
 </Note>
 
-### Runner Audit Log Export (Optional)
-
-The generated CloudFormation stack creates the `nuon/<install-id>/telemetry-export-config` secret and grants the
-runner read access. After provisioning, update the secret to forward Nuon runner audit events to an
-OTLP-compatible logging backend. See [Export Runner Audit Logs](/guides/export-runner-audit-logs) for the configuration,
-update, and verification steps.
-
 ## Provision
 
 Once all inputs and secrets are configured
@@ -158,6 +151,13 @@ Once all inputs and secrets are configured
 1. Return to your install in the Nuon dashboard
 2. Click **Reprovision Install** from the Manage menu
 3. Wait for the provision workflow to complete
+
+### Configure Telemetry Export (Optional)
+
+The generated CloudFormation stack creates the `nuon/<install-id>/telemetry-export-config` secret and grants the
+runner read access. Update the secret to configure telemetry export to your own OTLP-compatible backend, starting with
+runner audit logs. See [Export Runner Audit Logs](/guides/export-runner-audit-logs) for the configuration reference,
+cloud-specific steps, and verification guidance.
 
 ## Configure DNS (Optional)
 

--- a/docs/guides/byoc/aws.mdx
+++ b/docs/guides/byoc/aws.mdx
@@ -146,10 +146,10 @@ base64 -i your-github-app-key.pem
 
 ### Runner Audit Log Export (Optional)
 
-The generated CloudFormation stack can forward Nuon runner audit events to an OTLP-compatible logging backend. Set the
-`RunnerAuditExportConfig` stack parameter when provisioning, or update the parameter on an existing stack. See
-[Export Runner Audit Logs](/guides/export-runner-audit-logs#configure-aws-cloudformation) for the configuration format
-and verification steps.
+The generated CloudFormation stack creates the `nuon/<install-id>/telemetry-export-config` secret and grants the
+runner read access. After provisioning, update the secret to forward Nuon runner audit events to an
+OTLP-compatible logging backend. See [Export Runner Audit Logs](/guides/export-runner-audit-logs) for the configuration,
+update, and verification steps.
 
 ## Provision
 

--- a/docs/guides/byoc/azure.mdx
+++ b/docs/guides/byoc/azure.mdx
@@ -11,4 +11,8 @@ Nuon can install Nuon on your cloud. [Please reach out to sales.](https://nuon.c
 
 Nuon BYOC on Azure runs the control plane on AKS using Azure-native primitives. Managed remotely by Nuon the same way as the AWS BYOC offering.
 
+Runner telemetry export is available for Azure installs. Create the install Key Vault as shown in the dashboard before
+deploying the Stack, then update its `telemetry-export-config` secret. See [Export Runner Audit
+Logs](/guides/export-runner-audit-logs) for the configuration reference and verification steps.
+
 Guide is currently under construction. Chat with us in the corner or [contact support](/support/support#support) for guidance on Azure installs.

--- a/docs/guides/byoc/gcp.mdx
+++ b/docs/guides/byoc/gcp.mdx
@@ -212,7 +212,7 @@ the Slack integration.
 
 #### Secrets
 
-The `secrets` map must be popoulated with the following:
+The `secrets` map must be populated with the following:
 
 | Secret                    | Value                                                                         |
 | ------------------------- | ----------------------------------------------------------------------------- |
@@ -222,7 +222,7 @@ The `secrets` map must be popoulated with the following:
 | `slack_signing_secret`    | Signing Secret from your Slack app (optional — required only if using Slack). |
 
 <Note>
-The GitHub App PEM key must be base64 encoded because AWS CloudFormation doesn't preserve newlines in text fields.
+The `github_app_key` secret expects a base64-encoded GitHub App PEM key.
 
 To encode your PEM key:
 
@@ -243,6 +243,19 @@ terraform apply
 
 All of the core-infra will be created with your `gcloud` permissions. After this, the Nuon Runner will be deployed in
 your project and will poll Nuon Cloud for jobs to deploy the control plane components.
+
+### 5. Configure telemetry export (optional)
+
+Terraform creates the `<install-id>-telemetry-export-config` secret and grants the runner service account permission to
+read it. To configure telemetry export to your own backend, starting with runner audit logs, create
+`telemetry-export-config.yaml` using the [telemetry export reference](/guides/export-runner-audit-logs), then update the
+secret:
+
+```bash
+gcloud secrets versions add "<install-id>-telemetry-export-config" \
+  --data-file="telemetry-export-config.yaml" \
+  --project="<gcp-project-id>"
+```
 
 ## Configure DNS
 

--- a/docs/guides/component-health.mdx
+++ b/docs/guides/component-health.mdx
@@ -144,7 +144,7 @@ single per-resource flag:
 Two things are deliberately quiet. A verdict of `unknown` never alerts, because a runner going
 offline is already reported as runner inactivity and would otherwise page you once per component. And
 when a component fails because something it depends on failed, the dependents are labelled
-"downstream of <component>" and only the root cause alerts — one outage, one alert.
+`downstream of <component>` and only the root cause alerts — one outage, one alert.
 
 See [Webhooks](/guides/webhooks) for the full subscription model.
 

--- a/docs/guides/export-runner-audit-logs.mdx
+++ b/docs/guides/export-runner-audit-logs.mdx
@@ -13,23 +13,41 @@ infrastructure logs are not included.
 
 ## Supported environments
 
-Runner audit log export currently supports AWS install runners provisioned with a generated CloudFormation stack.
-Support for Terraform install stacks, Azure, and GCP is planned.
+Runner audit log export supports AWS, Azure, and GCP install runners:
+
+| Provider | Supported install stack | Configuration secret |
+| --- | --- | --- |
+| AWS | Generated CloudFormation stack or Nuon Terraform install stack | `nuon/<install-id>/telemetry-export-config` |
+| Azure | Generated Azure install stack | `telemetry-export-config` in the install Key Vault |
+| GCP | Nuon Terraform install stack | `<install-id>-telemetry-export-config` |
+
+The AWS and GCP stacks create the configuration secret and grant the runner read access. On Azure, create the install
+Key Vault before deploying the stack; the stack grants its runner managed identity read access. In every case, update
+the secret after the stack is provisioned. Backend credentials stay in your cloud account and are not stored by the
+Nuon control plane or in Terraform state.
 
 ## Prerequisites
 
 You will need:
 
-- An AWS install with a current Nuon runner and generated CloudFormation stack
-- Permission to create or update the install's CloudFormation stack
+- A current Nuon runner on AWS, Azure, or GCP
+- The current install stack, applied to create the configuration secret and runner read permissions
 - An OTLP/HTTP logs endpoint available over HTTPS
 - Any headers required to authenticate with your logging backend
+- Permission to add a secret value in your cloud account
 
-## Configure AWS CloudFormation
+## Create the configuration
 
-Create a YAML file containing your OTLP/HTTP exporter configuration:
+Save the following configuration as `telemetry-export-config.yaml`:
 
-```yaml exporter.yaml
+```yaml telemetry-export-config.yaml
+version: v1
+
+telemetry:
+  logs:
+    audit:
+      enabled: true
+
 exporters:
   otlphttp:
     endpoint: https://otlp.example.com
@@ -39,25 +57,52 @@ exporters:
 
 The endpoint must be an HTTPS URL. Omit `headers` if your backend does not require them.
 
-Encode the configuration as a single-line base64 value:
+Keep `version` set to `v1`. Set `telemetry.logs.audit.enabled` to control audit log export, and use
+`exporters.otlphttp` to configure your destination.
+
+## Update the configuration secret
+
+Apply or update the install stack first, then use the command for your provider to update the configuration secret.
+
+### AWS
+
+Generated CloudFormation stacks and Nuon Terraform install stacks both create the same secret. Update it after the
+stack finishes provisioning:
 
 ```sh
-base64 < exporter.yaml | tr -d '\n'
+aws secretsmanager put-secret-value \
+  --secret-id "nuon/<install-id>/telemetry-export-config" \
+  --secret-string file://telemetry-export-config.yaml \
+  --region "<aws-region>"
 ```
 
-When creating the generated CloudFormation stack, set **Runner Audit Export Configuration (Base64-encoded YAML)**,
-also named `RunnerAuditExportConfig`, to the encoded value.
+For an existing CloudFormation install, reprovision the install to generate the current template and update the stack
+before uploading the value. For a Terraform install, update the install stack module and run `terraform apply` first.
 
-For an existing install, reprovision the install to generate the latest template, then update the existing
-CloudFormation stack and supply `RunnerAuditExportConfig`. The update creates the required IAM permission and stores
-the configuration in AWS Secrets Manager at:
+### Azure
 
-```text
-nuon/<install-id>/runner-audit-export
+The install Key Vault name is the first 24 characters of the install ID. Update the secret after the Azure stack finishes
+provisioning:
+
+```sh
+az keyvault secret set \
+  --vault-name "<install-key-vault>" \
+  --name "telemetry-export-config" \
+  --file "telemetry-export-config.yaml" \
+  --encoding utf-8
 ```
 
-The runner checks this secret for configuration changes. The endpoint and authentication headers remain in your AWS
-account and are not stored by the Nuon control plane.
+### GCP
+
+The Nuon Terraform install stack creates the secret. Update it after `terraform apply` finishes:
+
+```sh
+gcloud secrets versions add "<install-id>-telemetry-export-config" \
+  --data-file="telemetry-export-config.yaml" \
+  --project="<gcp-project-id>"
+```
+
+The runner checks for changes every 30 seconds and applies a changed valid configuration without restarting the runner.
 
 ## Exported attributes
 
@@ -78,8 +123,8 @@ Records also include relevant identifiers such as `org.id`, `install.id`, `runne
 
 ## Verify export
 
-1. Update the stack with a valid exporter configuration.
-2. Check the runner logs for `runner audit export enabled`.
+1. Upload a valid configuration.
+2. Check the runner logs for `runner telemetry export collector enabled` with `audit_export.enabled=true`.
 3. Trigger a deployment, action workflow, or sandbox operation.
 4. Query your logging backend for records where `service.namespace="nuon"` and `nuon.audit="true"`.
 
@@ -88,37 +133,55 @@ of these operations runs.
 
 ## Update, rotate, or disable export
 
-Update `RunnerAuditExportConfig` on the existing CloudFormation stack to change the endpoint or rotate authentication
-headers. The runner detects configuration changes without a restart.
+Edit `telemetry-export-config.yaml` and run the same provider upload command to change the endpoint or rotate
+authentication headers. The runner detects the new secret value automatically.
 
-To disable export, update the stack and clear `RunnerAuditExportConfig`. This removes the managed secret and stops the
-local collector. Normal runner operations and Nuon-managed runner logging continue unchanged.
+To disable audit export while leaving the telemetry collector available for future telemetry types, set
+`telemetry.logs.audit.enabled` to `false` and upload the file. The collector runs without an audit log pipeline. To stop
+the telemetry collector entirely, remove or disable the secret value or remove runner access to it. Normal runner
+operations and Nuon-managed logging continue unchanged.
 
 ## Failure behavior
 
-Audit export does not block runner jobs. If the secret is missing or inaccessible, the configuration is invalid, or
-the logging backend is unavailable, the runner continues operating normally. Once a valid configuration becomes
-available, the runner detects it automatically.
+Audit export does not block runner jobs. If the secret is missing or inaccessible, or the logging backend is
+unavailable, the runner continues operating normally. An invalid changed value does not replace the last valid
+configuration. Once a valid configuration becomes available, the runner detects it automatically.
 
 ## Troubleshooting
 
-### The stack does not show `RunnerAuditExportConfig`
+### The configuration secret does not exist
 
-Reprovision the install to generate the latest CloudFormation template, then apply it as an update to the existing
-stack.
+Reprovision the install and apply the latest generated CloudFormation or Terraform stack. On Azure, create the Key
+Vault shown in the dashboard before deploying the install stack.
+
+### AWS reports that the secret is scheduled for deletion
+
+An older conditional CloudFormation stack may have scheduled the secret for deletion when audit export was cleared.
+If the value does not need to be retained, permanently delete the scheduled secret, wait for deletion to complete, and
+retry the stack update:
+
+```sh
+aws secretsmanager delete-secret \
+  --secret-id "nuon/<install-id>/telemetry-export-config" \
+  --force-delete-without-recovery \
+  --region "<aws-region>"
+```
+
+If the value must be retained, restore and copy it before permanently deleting the old secret.
 
 ### The runner reports that audit export is disabled
 
-Confirm that the `nuon/<install-id>/runner-audit-export` secret exists and that the runner instance role can read it.
-The generated CloudFormation template creates both the secret and the required IAM permission when
-`RunnerAuditExportConfig` is set.
+Confirm that the provider-specific secret shown above contains a current value and that the runner identity can read it.
+Check the runner logs for `telemetry_export.reason`, which distinguishes a missing, empty, or inaccessible secret.
 
 ### The configuration is rejected
 
 Confirm that:
 
-- The value supplied to CloudFormation is single-line base64-encoded YAML
-- The YAML contains only `exporters.otlphttp.endpoint` and optional `exporters.otlphttp.headers`
+- The secret contains valid YAML matching the configuration example
+- The YAML has `version: v1`
+- `telemetry.logs.audit.enabled` is a boolean
+- The YAML contains `exporters.otlphttp.endpoint` and optional `exporters.otlphttp.headers` when audit export is enabled
 - The endpoint uses HTTPS and does not contain credentials, a query string, or a fragment
 - Header names are valid HTTP header names and header values do not contain line breaks
 

--- a/docs/guides/export-runner-audit-logs.mdx
+++ b/docs/guides/export-runner-audit-logs.mdx
@@ -2,7 +2,7 @@
 title: 'Export Runner Audit Logs'
 description: 'Forward Nuon runner audit events to your own OTLP-compatible logging backend.'
 icon: 'file-shield'
-keywords: ["runner audit logs", "OTLP logs", "OpenTelemetry", "audit log export", "customer observability", "runner logs"]
+keywords: ["runner audit logs", "OTLP logs", "OpenTelemetry", "audit log export", "customer observability", "runner logs", "telemetry-export-config", "AWS Secrets Manager", "Azure Key Vault", "GCP Secret Manager"]
 ---
 
 Nuon runners can forward audit events directly from your cloud account to an OTLP-compatible logging backend. This
@@ -17,9 +17,9 @@ Runner audit log export supports AWS, Azure, and GCP install runners:
 
 | Provider | Supported install stack | Configuration secret |
 | --- | --- | --- |
-| AWS | Generated CloudFormation stack or Nuon Terraform install stack | `nuon/<install-id>/telemetry-export-config` |
+| AWS | Generated CloudFormation stack or [Nuon Terraform install stack](https://github.com/nuonco/install-stacks) | `nuon/<install-id>/telemetry-export-config` |
 | Azure | Generated Azure install stack | `telemetry-export-config` in the install Key Vault |
-| GCP | Nuon Terraform install stack | `<install-id>-telemetry-export-config` |
+| GCP | [Nuon Terraform install stack](https://github.com/nuonco/install-stacks) | `<install-id>-telemetry-export-config` |
 
 The AWS and GCP stacks create the configuration secret and grant the runner read access. On Azure, create the install
 Key Vault before deploying the stack; the stack grants its runner managed identity read access. In every case, update
@@ -31,7 +31,7 @@ Nuon control plane or in Terraform state.
 You will need:
 
 - A current Nuon runner on AWS, Azure, or GCP
-- The current install stack, applied to create the configuration secret and runner read permissions
+- The current install stack, applied to configure runner access to the cloud secret manager
 - An OTLP/HTTP logs endpoint available over HTTPS
 - Any headers required to authenticate with your logging backend
 - Permission to add a secret value in your cloud account
@@ -55,10 +55,17 @@ exporters:
       Authorization: Bearer <token>
 ```
 
-The endpoint must be an HTTPS URL. Omit `headers` if your backend does not require them.
+## Configuration reference
 
-Keep `version` set to `v1`. Set `telemetry.logs.audit.enabled` to control audit log export, and use
-`exporters.otlphttp` to configure your destination.
+| Field | Required | Description |
+| --- | --- | --- |
+| `version` | Yes | Configuration format version. Set to `v1`. |
+| `telemetry.logs.audit.enabled` | No | Set to `true` to enable runner audit log export. Defaults to `false`. |
+| `exporters.otlphttp.endpoint` | Yes, when telemetry is enabled | HTTPS URL for the OTLP/HTTP backend. |
+| `exporters.otlphttp.headers` | No | Headers used to authenticate with the backend. |
+
+The endpoint cannot contain credentials, a query string, a fragment, or environment-variable expansion. Omit
+`headers` if your backend does not require them.
 
 ## Update the configuration secret
 
@@ -77,7 +84,7 @@ aws secretsmanager put-secret-value \
 ```
 
 For an existing CloudFormation install, reprovision the install to generate the current template and update the stack
-before uploading the value. For a Terraform install, update the install stack module and run `terraform apply` first.
+before updating the secret. For a Terraform install, update the install stack module and run `terraform apply` first.
 
 ### Azure
 
@@ -104,6 +111,17 @@ gcloud secrets versions add "<install-id>-telemetry-export-config" \
 
 The runner checks for changes every 30 seconds and applies a changed valid configuration without restarting the runner.
 
+## Runner access to the configuration
+
+Nuon-generated Stacks grant the runner the required read access:
+
+| Provider | Runner identity | Access |
+| --- | --- | --- |
+| AWS | Runner instance role | `secretsmanager:GetSecretValue` and `secretsmanager:DescribeSecret` |
+| Azure | Runner VMSS system-assigned managed identity | Key Vault Secrets User |
+| GCP | Runner service account | Secret Manager Secret Accessor |
+
+
 ## Exported attributes
 
 Every exported record includes attributes that identify it as a Nuon runner audit event:
@@ -123,7 +141,7 @@ Records also include relevant identifiers such as `org.id`, `install.id`, `runne
 
 ## Verify export
 
-1. Upload a valid configuration.
+1. Update the secret with a valid configuration.
 2. Check the runner logs for `runner telemetry export collector enabled` with `audit_export.enabled=true`.
 3. Trigger a deployment, action workflow, or sandbox operation.
 4. Query your logging backend for records where `service.namespace="nuon"` and `nuon.audit="true"`.
@@ -137,15 +155,18 @@ Edit `telemetry-export-config.yaml` and run the same provider upload command to 
 authentication headers. The runner detects the new secret value automatically.
 
 To disable audit export while leaving the telemetry collector available for future telemetry types, set
-`telemetry.logs.audit.enabled` to `false` and upload the file. The collector runs without an audit log pipeline. To stop
+`telemetry.logs.audit.enabled` to `false` and update the secret. The collector runs without an audit log pipeline. To stop
 the telemetry collector entirely, remove or disable the secret value or remove runner access to it. Normal runner
 operations and Nuon-managed logging continue unchanged.
 
 ## Failure behavior
 
-Audit export does not block runner jobs. If the secret is missing or inaccessible, or the logging backend is
-unavailable, the runner continues operating normally. An invalid changed value does not replace the last valid
+Audit export does not block runner jobs. A missing, empty, disabled, or inaccessible secret stops the telemetry
+collector. An invalid changed value or a transient read or startup failure does not replace a previously active valid
 configuration. Once a valid configuration becomes available, the runner detects it automatically.
+
+Delivery is best effort. The collector queues and retries exports, but records may be dropped during a prolonged backend
+outage. Runner jobs continue operating normally while the backend is unavailable.
 
 ## Troubleshooting
 
@@ -156,9 +177,8 @@ Vault shown in the dashboard before deploying the install stack.
 
 ### AWS reports that the secret is scheduled for deletion
 
-An older conditional CloudFormation stack may have scheduled the secret for deletion when audit export was cleared.
-If the value does not need to be retained, permanently delete the scheduled secret, wait for deletion to complete, and
-retry the stack update:
+If a secret with the same name is already scheduled for deletion, the Stack cannot create it. If the value does not
+need to be retained, permanently delete the scheduled secret, wait for deletion to complete, and retry the Stack update:
 
 ```sh
 aws secretsmanager delete-secret \
@@ -182,7 +202,7 @@ Confirm that:
 - The YAML has `version: v1`
 - `telemetry.logs.audit.enabled` is a boolean
 - The YAML contains `exporters.otlphttp.endpoint` and optional `exporters.otlphttp.headers` when audit export is enabled
-- The endpoint uses HTTPS and does not contain credentials, a query string, or a fragment
+- The endpoint uses HTTPS and does not contain credentials, a query string, a fragment, or environment-variable expansion
 - Header names are valid HTTP header names and header values do not contain line breaks
 
 ### Export is enabled, but no records appear

--- a/docs/guides/vendor-customers.mdx
+++ b/docs/guides/vendor-customers.mdx
@@ -11,7 +11,7 @@ For a technical overview of all security properties, see the [Security](/securit
 
 ### Secrets and Sensitive Values
 
-In Nuon, secrets and sensitive values are entered by the customer, not the vendor, when they deploy the [Stack](/concepts/stacks). They are then stored in the customer's cloud secret manager (e.g., AWS Secrets Manager) and are retrieved programmatically by the Nuon [Runner](/concepts/runners) in the customer cloud account to insert into [components](/concepts/components) as the vendor's software is provisioned or updated.
+In Nuon, secrets and sensitive values are entered by the customer, not the vendor, when they deploy the [Stack](/concepts/stacks). They are then stored in AWS Secrets Manager, Azure Key Vault, or GCP Secret Manager and are retrieved programmatically by the Nuon [Runner](/concepts/runners) in the customer cloud account to insert into [components](/concepts/components) as the vendor's software is provisioned or updated.
 
 Nuon can automatically sync secrets to a Kubernetes cluster deployed by the Runner, which can then be referenced in components like Helm charts, Kubernetes manifests, and Terraform modules.
 
@@ -20,6 +20,10 @@ The vendor by default cannot access the secrets unless the customer happened to 
 ### Log Viewing and Exfiltration Prevention
 
 By default, Nuon only stores logs of the infrastructure changing in the customer account, e.g., creating a Kubernetes cluster, deploying a Helm chart, running Terraform. Application logs are not accessible or sent to the Nuon control plane.
+
+Customers can independently [export runner audit logs](/guides/export-runner-audit-logs) from AWS, Azure, or GCP to an
+OTLP-compatible backend they control. The destination and credentials remain in the customer's cloud secret manager;
+they are not sent to the Nuon control plane.
 
 One of Nuon's concepts is an [action](/concepts/actions), which are vendor-defined scripts to deploy infrastructure but are also useful in troubleshooting and debugging. Outputs of actions are stored in the Nuon control plane. Actions are defined by IAM roles and permissions that vendor's customers would approve beforehand. If those roles were elevated enough to execute commands that can access sensitive data like a database table with `psql` or view a Kubernetes secret with `kubectl`, the outputs would be stored in the Nuon control plane.
 

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -30,15 +30,16 @@ Vendors can define break glass roles for temporary elevated access during emerge
 
 ## Secrets Stay in the Customer's Cloud
 
-[Secrets](/concepts/app-secrets) are entered by the customer when deploying the Stack and stored in their cloud's secret manager (e.g., AWS Secrets Manager). Neither Nuon nor the vendor ever sees secret values.
+[Secrets](/concepts/app-secrets) are entered by the customer when deploying the Stack and stored in their cloud's secret manager: AWS Secrets Manager, Azure Key Vault, or GCP Secret Manager. Neither Nuon nor the vendor ever sees secret values.
 
 ## Log Visibility
 
 Nuon only stores logs of infrastructure operations (e.g., creating a Kubernetes cluster, deploying a Helm chart, running Terraform). Application logs are never sent to the Control Plane. [Actions](/concepts/actions) can execute operational scripts, but the IAM roles they use are defined by the vendor and approved by the customer through the Stack.
 
-Customers can optionally [export detailed runner audit logs](/guides/export-runner-audit-logs) directly from their cloud account
-to an OTLP-compatible logging backend they control. Only Nuon audit events are forwarded. Application logs and general
-runner logs are excluded, and exporter credentials remain in the customer's cloud secret manager.
+Customers running installs on AWS, Azure, or GCP can optionally [export detailed runner audit
+logs](/guides/export-runner-audit-logs) directly from their cloud account to an OTLP-compatible logging backend they
+control. Only Nuon audit events are forwarded. Application logs and general runner logs are excluded, and the
+destination and credentials remain in the customer's cloud secret manager.
 
 ## Build Isolation
 

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
@@ -44,11 +44,6 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 	// PhoneHome resources are always created as the provision workflow depends on
 	// the phone home callback to proceed.
 	if !t.cfg.UseLocalRunners {
-		telemetryExportParams := t.getTelemetryExportParameters()
-		maps.Copy(tmpl.Parameters, telemetryExportParams)
-		maps.Copy(runnerParams, telemetryExportParams)
-		maps.Copy(tmpl.Conditions, t.getTelemetryExportConditions())
-
 		// NOTE(fd): this uses the configurable nested runner asg cf stack
 		runnerASG, err := t.getRunnerASGNestedStack(inp, tb)
 		if err != nil {
@@ -61,7 +56,6 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 		tmpl.Resources["RunnerCloudWatchLogStream"] = t.getRunnerCloudWatchLogStream(inp, tb)
 		tmpl.Resources["RunnerCloudWatchLogPolicy"] = t.getRunnerCloudWatchLogPolicy(inp, tb)
 		maps.Copy(tmpl.Resources, t.getTelemetryExportResources(inp, tb))
-		maps.Copy(paramlabels, t.getTelemetryExportParamLabels())
 	}
 
 	// build roles (before custom nested stacks so they can depend on them)

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/resource_telemetry_export.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/resource_telemetry_export.go
@@ -12,43 +12,13 @@ import (
 )
 
 const (
-	telemetryExportConfigParameter = "TelemetryExportConfig"
-	telemetryExportCondition       = "TelemetryExportConfigProvided"
-	telemetryExportSecret          = "TelemetryExportSecret"
+	telemetryExportSecret = "TelemetryExportSecret"
 )
-
-func (a *Templates) getTelemetryExportParameters() map[string]cloudformation.Parameter {
-	return map[string]cloudformation.Parameter{
-		telemetryExportConfigParameter: {
-			Type:        "String",
-			NoEcho:      generics.ToPtr(true),
-			Default:     generics.ToPtr(""),
-			MaxLength:   generics.ToPtr(4096),
-			Description: generics.ToPtr("Optional base64-encoded YAML telemetry export configuration, shaped like an OTEL Collector exporter block: exporters.otlphttp.endpoint with optional headers. The current release exports runner audit logs. Encode with: base64 < config.yaml | tr -d '\\n'. Leave empty to disable."),
-		},
-	}
-}
-
-func (a *Templates) getTelemetryExportConditions() map[string]any {
-	return map[string]any{
-		telemetryExportCondition: cloudformation.Not([]string{
-			cloudformation.Equals(cloudformation.Ref(telemetryExportConfigParameter), ""),
-		}),
-	}
-}
-
-func (a *Templates) getTelemetryExportParamLabels() map[string]any {
-	return map[string]any{
-		telemetryExportConfigParameter: "Telemetry Export Configuration (Base64-encoded YAML)",
-	}
-}
 
 func (a *Templates) getTelemetryExportResources(inp *stacks.TemplateInput, t tagBuilder) map[string]cloudformation.Resource {
 	secret := &secretsmanager.Secret{
-		Name:                       generics.ToPtr(fmt.Sprintf("nuon/%s/telemetry-export-config", inp.Install.ID)),
-		SecretString:               generics.ToPtr(cloudformation.Ref(telemetryExportConfigParameter)),
-		Tags:                       t.apply(nil, "telemetry-export-config"),
-		AWSCloudFormationCondition: telemetryExportCondition,
+		Name: generics.ToPtr(fmt.Sprintf("nuon/%s/telemetry-export-config", inp.Install.ID)),
+		Tags: t.apply(nil, "telemetry-export-config"),
 	}
 
 	policy := &iam.Policy{

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/resource_telemetry_export_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/resource_telemetry_export_test.go
@@ -15,31 +15,6 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
 )
 
-func TestTelemetryExportParameterAndCondition(t *testing.T) {
-	tpl := &Templates{}
-	parameter := tpl.getTelemetryExportParameters()[telemetryExportConfigParameter]
-
-	assert.Equal(t, "String", parameter.Type)
-	require.NotNil(t, parameter.NoEcho)
-	assert.True(t, *parameter.NoEcho)
-	require.NotNil(t, parameter.MaxLength)
-	assert.Equal(t, 4096, *parameter.MaxLength)
-	defaultValue, ok := parameter.Default.(*string)
-	require.True(t, ok)
-	assert.Empty(t, *defaultValue)
-	require.NotNil(t, parameter.Description)
-	assert.Contains(t, *parameter.Description, "base64-encoded YAML")
-	assert.Contains(t, *parameter.Description, "exporters.otlphttp.endpoint")
-	assert.Contains(t, *parameter.Description, "optional headers")
-	assert.Contains(t, *parameter.Description, "current release exports runner audit logs")
-	assert.Equal(t, "Telemetry Export Configuration (Base64-encoded YAML)", tpl.getTelemetryExportParamLabels()[telemetryExportConfigParameter])
-
-	assert.Equal(t,
-		cloudformation.Not([]string{cloudformation.Equals(cloudformation.Ref(telemetryExportConfigParameter), "")}),
-		tpl.getTelemetryExportConditions()[telemetryExportCondition],
-	)
-}
-
 func TestTelemetryExportResources(t *testing.T) {
 	tpl := &Templates{cfg: &internal.Config{}}
 	inp := &stacks.TemplateInput{
@@ -53,8 +28,8 @@ func TestTelemetryExportResources(t *testing.T) {
 	secret, ok := resources[telemetryExportSecret].(*secretsmanager.Secret)
 	require.True(t, ok)
 	assert.Equal(t, "nuon/inst-test/telemetry-export-config", *secret.Name)
-	assert.Equal(t, cloudformation.Ref(telemetryExportConfigParameter), *secret.SecretString)
-	assert.Equal(t, telemetryExportCondition, secret.AWSCloudFormationCondition)
+	assert.Nil(t, secret.SecretString)
+	assert.Empty(t, secret.AWSCloudFormationCondition)
 
 	policy, ok := resources["TelemetryExportSecretPolicy"].(*iam.Policy)
 	require.True(t, ok)
@@ -77,6 +52,5 @@ func TestTelemetryExportIsNotAddedToPhoneHome(t *testing.T) {
 
 	phoneHomeJSON, err := json.Marshal(tpl.getRunnerPhoneHomeProps(inp, nil))
 	require.NoError(t, err)
-	assert.NotContains(t, string(phoneHomeJSON), telemetryExportConfigParameter)
 	assert.NotContains(t, string(phoneHomeJSON), telemetryExportSecret)
 }

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAWSDetails/AwaitAWSDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAWSDetails/AwaitAWSDetails.tsx
@@ -4,6 +4,7 @@ import { Card } from '@/components/common/Card'
 import { ClickToCopyButton } from '@/components/common/ClickToCopy'
 import { Code } from '@/components/common/Code'
 import { Divider } from '@/components/common/Divider'
+import { Expand } from '@/components/common/Expand'
 import { Link } from '@/components/common/Link'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Tabs } from '@/components/common/Tabs'
@@ -17,6 +18,20 @@ interface IAwaitAWSDetails extends IStackDetails {
   installAwsRegion?: string
   tfProvider?: boolean
 }
+
+const telemetryExportConfigFilename = 'telemetry-export-config.yaml'
+const telemetryExportConfig = `version: v1
+
+telemetry:
+  logs:
+    audit:
+      enabled: true
+
+exporters:
+  otlphttp:
+    endpoint: https://otlp.example.com
+    headers:
+      Authorization: Bearer <token>`
 
 // The tfvars envelope ctl-api stores in `terraform_contents` is a JSON
 // document of shape `{"inputs_tfvars": "<hcl>", "secrets_tfvars": "<hcl>"}`.
@@ -61,7 +76,6 @@ function parseTfvars(contents: unknown): TfvarsEnvelope {
 
 export const AwaitAWSDetails = ({
   stack,
-  orgId,
   installId,
   installAwsRegion,
   tfProvider = false,
@@ -102,6 +116,7 @@ export const AwaitAWSDetails = ({
             terraform: (
               <TerraformTab
                 inputsTfvars={tfvars.inputs}
+                installAwsRegion={installAwsRegion}
                 providerTfvars={tfvars.providerInputs}
                 tfProvider={tfProvider}
                 secretsTfvars={tfvars.secrets}
@@ -281,12 +296,18 @@ const CloudFormationTab = ({
           </Button>
         </Card>
       </div>
+
+      <AWSTelemetryExportInstructions
+        installAwsRegion={regionForCmd}
+        installId={installId}
+      />
     </div>
   )
 }
 
 interface ITerraformTab {
   inputsTfvars: string
+  installAwsRegion?: string
   providerTfvars: string
   tfProvider: boolean
   secretsTfvars: string
@@ -295,6 +316,7 @@ interface ITerraformTab {
 
 const TerraformTab = ({
   inputsTfvars,
+  installAwsRegion,
   providerTfvars,
   tfProvider,
   secretsTfvars,
@@ -426,7 +448,84 @@ cd install-stacks/aws`
           <Code variant="preformated">{applyCmd}</Code>
         </Card>
       </div>
+
+      <AWSTelemetryExportInstructions
+        installAwsRegion={installAwsRegion}
+        installId={installId}
+      />
     </div>
+  )
+}
+
+const AWSTelemetryExportInstructions = ({
+  installAwsRegion,
+  installId,
+}: {
+  installAwsRegion?: string
+  installId?: string
+}) => {
+  const secretID = `nuon/${installId || '<install-id>'}/telemetry-export-config`
+  const uploadCmd = `aws secretsmanager put-secret-value \\
+  --secret-id "${secretID}" \\
+  --secret-string file://${telemetryExportConfigFilename} \\
+  --region "${installAwsRegion || '<aws-region>'}"`
+
+  return (
+    <Expand
+      id="telemetry-export"
+      heading={
+        <Text variant="base" weight="strong">
+          Configure telemetry export (optional)
+        </Text>
+      }
+    >
+      <div className="flex flex-col gap-4 p-2">
+        <Text variant="subtext">
+          To export runner audit logs and other telemetry to your own backend,
+          update the <code>telemetry-export-config</code> secret in AWS Secrets
+          Manager after the stack is provisioned. See the{' '}
+          <Link
+            href="https://docs.nuon.co/guides/export-runner-audit-logs"
+            isExternal
+          >
+            telemetry export reference
+          </Link>{' '}
+          for available settings.
+        </Text>
+
+        <Card>
+          <span className="flex justify-between items-center">
+            <Text>
+              Save this as <code>{telemetryExportConfigFilename}</code>
+            </Text>
+            <span className="flex gap-2 items-center">
+              <ClickToCopyButton textToCopy={telemetryExportConfig} />
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() =>
+                  createFileDownload(
+                    telemetryExportConfig,
+                    telemetryExportConfigFilename
+                  )
+                }
+              >
+                Download
+              </Button>
+            </span>
+          </span>
+          <Code variant="preformated">{telemetryExportConfig}</Code>
+        </Card>
+
+        <Card>
+          <span className="flex justify-between items-center">
+            <Text>Update the telemetry export secret</Text>
+            <ClickToCopyButton textToCopy={uploadCmd} />
+          </span>
+          <Code variant="preformated">{uploadCmd}</Code>
+        </Card>
+      </div>
+    </Expand>
   )
 }
 

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@/components/common/Button'
 import { Card } from '@/components/common/Card'
 import { ClickToCopyButton } from '@/components/common/ClickToCopy'
 import { Code } from '@/components/common/Code'
@@ -7,6 +8,7 @@ import { Link } from '@/components/common/Link'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Text } from '@/components/common/Text'
 import type { TAppSecretConfig } from '@/types'
+import { createFileDownload } from '@/utils/file-download'
 import type { IStackDetails } from '../types'
 
 interface IAwaitAzureDetails extends IStackDetails {
@@ -14,6 +16,20 @@ interface IAwaitAzureDetails extends IStackDetails {
   azureLocation?: string
   secrets?: TAppSecretConfig[]
 }
+
+const telemetryExportConfigFilename = 'telemetry-export-config.yaml'
+const telemetryExportConfig = `version: v1
+
+telemetry:
+  logs:
+    audit:
+      enabled: true
+
+exporters:
+  otlphttp:
+    endpoint: https://otlp.example.com
+    headers:
+      Authorization: Bearer <token>`
 
 export const AwaitAzureDetails = ({
   stack,
@@ -31,8 +47,11 @@ export const AwaitAzureDetails = ({
     (s) => !s.required && !!s.default
   )
   const grantSecretsPermissionCmd = `az role assignment create --assignee "$(az ad signed-in-user show --query id -o tsv)" --role "Key Vault Secrets Officer" --scope "$(az keyvault show --name ${vaultName} --resource-group ${installId}-rg --query id -o tsv)"`
-  const telemetryExportConfigCmd = `export NUON_TELEMETRY_EXPORT_CONFIG="<base64-encoded YAML>"`
-  const createTelemetryExportSecretCmd = `az keyvault secret set --vault-name ${vaultName} --name telemetry-export-config --value "$NUON_TELEMETRY_EXPORT_CONFIG"`
+  const createTelemetryExportSecretCmd = `az keyvault secret set \\
+  --vault-name "${vaultName}" \\
+  --name "telemetry-export-config" \\
+  --file "${telemetryExportConfigFilename}" \\
+  --encoding utf-8`
 
   const renderSecretCard = (secret: TAppSecretConfig) => {
     const kvName = secret.name.replaceAll('_', '-')
@@ -151,69 +170,6 @@ export const AwaitAzureDetails = ({
         </div>
       )}
 
-      <Expand
-        id="telemetry-export"
-        heading={
-          <Text variant="base" weight="strong">
-            Configure runner audit export (optional)
-          </Text>
-        }
-      >
-        <div className="flex flex-col gap-4 p-2">
-          <Text variant="subtext">
-            Store a base64-encoded OTLP exporter configuration in Key Vault to
-            send runner audit logs to an OTLP/HTTP backend. Skip this step to
-            leave audit export disabled.
-          </Text>
-
-          {!hasCustomerSecrets && (
-            <Card>
-              <span className="flex justify-between items-center">
-                <Text>Grant permission to set the telemetry export secret</Text>
-                <ClickToCopyButton
-                  className="w-fit self-end"
-                  textToCopy={grantSecretsPermissionCmd}
-                />
-              </span>
-              <Code>{grantSecretsPermissionCmd}</Code>
-            </Card>
-          )}
-
-          <Card>
-            <span className="flex justify-between items-center">
-              <Text>Export the telemetry export configuration</Text>
-              <ClickToCopyButton
-                className="w-fit self-end"
-                textToCopy={telemetryExportConfigCmd}
-              />
-            </span>
-            <Text variant="subtext">
-              Use the{' '}
-              <Link
-                href="https://docs.nuon.co/guides/export-runner-audit-logs"
-                isExternal
-              >
-                audit export guide
-              </Link>{' '}
-              to build the exporter configuration, then export it as an
-              environment variable.
-            </Text>
-            <Code>{telemetryExportConfigCmd}</Code>
-          </Card>
-
-          <Card>
-            <span className="flex justify-between items-center">
-              <Text>Create the telemetry export secret</Text>
-              <ClickToCopyButton
-                className="w-fit self-end"
-                textToCopy={createTelemetryExportSecretCmd}
-              />
-            </span>
-            <Code>{createTelemetryExportSecretCmd}</Code>
-          </Card>
-        </div>
-      </Expand>
-
       <div className="flex flex-col gap-4">
         <Text variant="base" weight="strong">
           Deploy the install stack
@@ -245,6 +201,78 @@ export const AwaitAzureDetails = ({
           `}</Code>
         </Card>
       </div>
+
+      <Expand
+        id="telemetry-export"
+        heading={
+          <Text variant="base" weight="strong">
+            Configure telemetry export (optional)
+          </Text>
+        }
+      >
+        <div className="flex flex-col gap-4 p-2">
+          <Text variant="subtext">
+            To export runner audit logs and other telemetry to your own backend,
+            update the <code>telemetry-export-config</code> secret in Azure Key
+            Vault after the stack is provisioned. See the{' '}
+            <Link
+              href="https://docs.nuon.co/guides/export-runner-audit-logs"
+              isExternal
+            >
+              telemetry export reference
+            </Link>{' '}
+            for available settings.
+          </Text>
+
+          {!hasCustomerSecrets && (
+            <Card>
+              <span className="flex justify-between items-center">
+                <Text>Grant permission to set the telemetry export secret</Text>
+                <ClickToCopyButton
+                  className="w-fit self-end"
+                  textToCopy={grantSecretsPermissionCmd}
+                />
+              </span>
+              <Code>{grantSecretsPermissionCmd}</Code>
+            </Card>
+          )}
+
+          <Card>
+            <span className="flex justify-between items-center">
+              <Text>
+                Save this as <code>{telemetryExportConfigFilename}</code>
+              </Text>
+              <span className="flex gap-2 items-center">
+                <ClickToCopyButton textToCopy={telemetryExportConfig} />
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() =>
+                    createFileDownload(
+                      telemetryExportConfig,
+                      telemetryExportConfigFilename
+                    )
+                  }
+                >
+                  Download
+                </Button>
+              </span>
+            </span>
+            <Code variant="preformated">{telemetryExportConfig}</Code>
+          </Card>
+
+          <Card>
+            <span className="flex justify-between items-center">
+              <Text>Update the telemetry export secret</Text>
+              <ClickToCopyButton
+                className="w-fit self-end"
+                textToCopy={createTelemetryExportSecretCmd}
+              />
+            </span>
+            <Code variant="preformated">{createTelemetryExportSecretCmd}</Code>
+          </Card>
+        </div>
+      </Expand>
 
       <Divider dividerWord="or" />
 

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
@@ -80,6 +80,20 @@ interface IAwaitGCPDetails extends IStackDetails {
   tfProvider?: boolean
 }
 
+const telemetryExportConfigFilename = 'telemetry-export-config.yaml'
+const telemetryExportConfig = `version: v1
+
+telemetry:
+  logs:
+    audit:
+      enabled: true
+
+exporters:
+  otlphttp:
+    endpoint: https://otlp.example.com
+    headers:
+      Authorization: Bearer <token>`
+
 export const AwaitGCPDetails = ({
   stack,
   installId,
@@ -96,13 +110,11 @@ export const AwaitGCPDetails = ({
     !!spaceliftEnabled &&
     (envelope.spaceliftAdminTf.length > 0 ||
       envelope.spaceliftBlueprintYaml.length > 0)
-  const telemetryExportConfigCmd = `export NUON_TELEMETRY_EXPORT_CONFIG="<base64-encoded YAML>"`
   const telemetryExportSecretID = `${installId || '<install-id>'}-telemetry-export-config`
   const projectID = gcpProjectId || '<gcp-project-id>'
-  const createTelemetryExportSecretVersionCmd = `printf '%s' "$NUON_TELEMETRY_EXPORT_CONFIG" | \
-  gcloud secrets versions add "${telemetryExportSecretID}" \
-    --project "${projectID}" \
-    --data-file=-`
+  const createTelemetryExportSecretVersionCmd = `gcloud secrets versions add "${telemetryExportSecretID}" \\
+  --data-file="${telemetryExportConfigFilename}" \\
+  --project="${projectID}"`
 
   return (
     <div className="flex flex-col gap-4">
@@ -148,42 +160,51 @@ export const AwaitGCPDetails = ({
         id="telemetry-export"
         heading={
           <Text variant="base" weight="strong">
-            Configure runner audit export (optional)
+            Configure telemetry export (optional)
           </Text>
         }
       >
         <div className="flex flex-col gap-4 p-2">
           <Text variant="subtext">
-            After the install stack is applied, add an OTLP exporter
-            configuration to Secret Manager. Skip this step to leave audit
-            export disabled.
+            To export runner audit logs and other telemetry to your own backend,
+            update the <code>telemetry-export-config</code> secret in Secret
+            Manager after the stack is applied. See the{' '}
+            <Link
+              href="https://docs.nuon.co/guides/export-runner-audit-logs"
+              isExternal
+            >
+              telemetry export reference
+            </Link>{' '}
+            for available settings.
           </Text>
 
           <Card>
             <span className="flex justify-between items-center">
-              <Text>Export the telemetry export configuration</Text>
-              <ClickToCopyButton
-                className="w-fit self-end"
-                textToCopy={telemetryExportConfigCmd}
-              />
+              <Text>
+                Save this as <code>{telemetryExportConfigFilename}</code>
+              </Text>
+              <span className="flex gap-2 items-center">
+                <ClickToCopyButton textToCopy={telemetryExportConfig} />
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() =>
+                    createFileDownload(
+                      telemetryExportConfig,
+                      telemetryExportConfigFilename
+                    )
+                  }
+                >
+                  Download
+                </Button>
+              </span>
             </span>
-            <Text variant="subtext">
-              Use the{' '}
-              <Link
-                href="https://docs.nuon.co/guides/export-runner-audit-logs"
-                isExternal
-              >
-                audit export guide
-              </Link>{' '}
-              to encode the exporter configuration, then export it as an
-              environment variable.
-            </Text>
-            <Code variant="preformated">{telemetryExportConfigCmd}</Code>
+            <Code variant="preformated">{telemetryExportConfig}</Code>
           </Card>
 
           <Card>
             <span className="flex justify-between items-center">
-              <Text>Add the telemetry export secret version</Text>
+              <Text>Update the telemetry export secret</Text>
               <ClickToCopyButton
                 className="w-fit self-end"
                 textToCopy={createTelemetryExportSecretVersionCmd}


### PR DESCRIPTION
This PR introduces a versioned configuration format for exporting runner telemetry.  Audit logs can now be enabled or disabled using this config.

It standardizes configuration delivery through customer-managed secrets on AWS, Azure, and GCP.  The secret containers are created automatically with required permissions, and the customer updates it as per their usage. Runners hot-reload valid changes without restarting and handle unavailable or invalid secrets consistently.  

The PR also adds provider-specific setup instructions to the dashboard and documentation. As well as the docs are updated to reflect the latest status and now document our support for all three cloud providers.

## Summary

- Adds the `v1` telemetry export configuration.
- Supports explicitly enabling runner audit log export.
- Keeps exporter credentials in customer cloud accounts.
- Normalizes secret handling across providers.
