### PR TITLE
perf: cut redundant API calls and payload bloat from CLI commands

### DIFF
--- a/bins/cli/cmd/cli.go
+++ b/bins/cli/cmd/cli.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/nuonco/nuon/sdks/nuon-go"
+	"github.com/nuonco/nuon/sdks/nuon-go/models"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -25,6 +27,19 @@ type cli struct {
 	ctx             context.Context
 	cfg             *config.Config
 	analyticsClient analytics.Writer
+
+	currentUserOnce sync.Once
+	currentUser     *models.AppAccount
+	currentUserErr  error
+}
+
+// Cached per process: the response carries every role the account holds, and
+// several call sites need it.
+func (c *cli) getCurrentUser(ctx context.Context) (*models.AppAccount, error) {
+	c.currentUserOnce.Do(func() {
+		c.currentUser, c.currentUserErr = c.apiClient.GetCurrentUser(ctx)
+	})
+	return c.currentUser, c.currentUserErr
 }
 
 func NewCLI() (*cli, error) {

--- a/bins/cli/cmd/debug.go
+++ b/bins/cli/cmd/debug.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// debugCmd holds no-op commands for separating fixed CLI overhead from API
+// latency when profiling. Registered only when NUON_DEBUG=true.
+func (c *cli) debugCmd() *cobra.Command {
+	debug := &cobra.Command{
+		Use:    "debug",
+		Short:  "Debug helpers (requires NUON_DEBUG=true)",
+		Hidden: true,
+	}
+
+	// No PersistentPreRunE: process start and command-tree construction only.
+	debug.AddCommand(&cobra.Command{
+		Use:         "noop",
+		Short:       "Do nothing, skipping all initialization",
+		Annotations: annotations(skipAuthAnnotation(), outputsAnnotation(OutputTable)),
+		Run:         func(*cobra.Command, []string) {},
+	})
+
+	// Adds config, API client, sentry and analytics init, but no auth.
+	debug.AddCommand(&cobra.Command{
+		Use:               "noop-init",
+		Short:             "Do nothing, after init but without auth",
+		PersistentPreRunE: c.persistentPreRunE,
+		Annotations:       annotations(skipAuthAnnotation(), outputsAnnotation(OutputTable)),
+		Run:               func(*cobra.Command, []string) {},
+	})
+
+	// Adds initUser, which is one API round trip.
+	debug.AddCommand(&cobra.Command{
+		Use:               "noop-auth",
+		Short:             "Do nothing, after init with auth",
+		PersistentPreRunE: c.persistentPreRunE,
+		Annotations:       outputsAnnotation(OutputTable),
+		Run:               func(*cobra.Command, []string) {},
+	})
+
+	return debug
+}

--- a/bins/cli/cmd/execute.go
+++ b/bins/cli/cmd/execute.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/charmbracelet/fang"
 	"github.com/getsentry/sentry-go"
+	"github.com/nuonco/nuon/pkg/analytics"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +33,21 @@ func populateRootLongDescription(c *cli, rootCmd *cobra.Command, args []string) 
 	_ = c.initConfig()
 
 	rootCmd.Long = c.getLongDescription()
+}
+
+// Close makes a network round trip to Segment with the command's output already
+// printed. Bound it so an unreachable endpoint cannot stall exit indefinitely.
+func flushAnalytics(w analytics.Writer, timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w.Close()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+	}
 }
 
 // Execute is essentially the init method of the CLI. It initializes all the components and composes them together.
@@ -63,7 +80,7 @@ func Execute() {
 	if c.cfg != nil && !c.cfg.DisableTelemetry {
 		sentry.Flush(c.cfg.CleanupTimeout)
 		if c.analyticsClient != nil {
-			c.analyticsClient.Close()
+			flushAnalytics(c.analyticsClient, c.cfg.CleanupTimeout)
 		}
 	}
 

--- a/bins/cli/cmd/execute.go
+++ b/bins/cli/cmd/execute.go
@@ -8,7 +8,30 @@ import (
 
 	"github.com/charmbracelet/fang"
 	"github.com/getsentry/sentry-go"
+	"github.com/spf13/cobra"
 )
+
+// Building the description calls the API, so only do it when root help will
+// actually render it. Flags are parsed first so --config is respected.
+func populateRootLongDescription(c *cli, rootCmd *cobra.Command, args []string) {
+	rootCmd.InitDefaultHelpFlag()
+	if err := rootCmd.ParseFlags(args); err != nil {
+		return
+	}
+
+	positional := rootCmd.Flags().Args()
+	switch {
+	case len(positional) == 0:
+	case len(positional) == 1 && positional[0] == "help":
+	default:
+		return
+	}
+
+	// rootCmd already loaded config from the default path.
+	_ = c.initConfig()
+
+	rootCmd.Long = c.getLongDescription()
+}
 
 // Execute is essentially the init method of the CLI. It initializes all the components and composes them together.
 func Execute() {
@@ -27,6 +50,8 @@ func Execute() {
 	}()
 
 	rootCmd := c.rootCmd()
+	populateRootLongDescription(c, rootCmd, os.Args[1:])
+
 	err = fang.Execute(
 		context.Background(),
 		rootCmd,

--- a/bins/cli/cmd/init.go
+++ b/bins/cli/cmd/init.go
@@ -125,7 +125,7 @@ func (c *cli) initUser() error {
 	if c.cfg.APIToken == "" {
 		return nil
 	}
-	user, err := c.apiClient.GetCurrentUser(c.ctx)
+	user, err := c.getCurrentUser(c.ctx)
 	if err != nil {
 		return errors.Wrap(err, "unable to get current user")
 	}
@@ -135,7 +135,7 @@ func (c *cli) initUser() error {
 }
 
 func (c *cli) identifyFn(ctx context.Context) (*segment.Identify, error) {
-	user, err := c.apiClient.GetCurrentUser(ctx)
+	user, err := c.getCurrentUser(ctx)
 
 	if err != nil {
 		wrappedErr := errors.Wrap(err, "unable to get current user")
@@ -150,7 +150,7 @@ func (c *cli) identifyFn(ctx context.Context) (*segment.Identify, error) {
 }
 
 func (c *cli) analyticsIDFn(ctx context.Context) (string, error) {
-	user, err := c.apiClient.GetCurrentUser(ctx)
+	user, err := c.getCurrentUser(ctx)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get current user")
 	}

--- a/bins/cli/cmd/readonly.go
+++ b/bins/cli/cmd/readonly.go
@@ -15,6 +15,9 @@ const readOnlyEnvVar = "NUON_READ_ONLY"
 // does not mutate remote state (local config selection and scaffolding are
 // allowed). Default-deny: new read commands must be added here explicitly.
 var readOnlyCommands = map[string]struct{}{
+	"noop":                 {},
+	"noop-init":            {},
+	"noop-auth":            {},
 	"list":                 {},
 	"get":                  {},
 	"health":               {},

--- a/bins/cli/cmd/root.go
+++ b/bins/cli/cmd/root.go
@@ -29,10 +29,15 @@ var (
 // newRootCmd constructs a new root cobra command, which all other commands will be nested under. If there are any flags
 // or other settings that we want to be "global", they should be configured on this command.
 func (c *cli) rootCmd() *cobra.Command {
+	// Commands read cfg while being constructed (cfg.Preview gates required flags).
+	if c.cfg == nil {
+		_ = c.initConfig()
+	}
+
+	// Long is set by populateRootLongDescription: building it calls the API.
 	rootCmd := &cobra.Command{
 		Use:   "nuon",
 		Short: "Work with Nuon from the command line.",
-		Long:  c.getLongDescription(),
 		Example: `nuon auth login
 nuon sync
 `,
@@ -132,7 +137,7 @@ func (c *cli) getLongDescription() string {
 	}
 
 	// Try to validate the token by getting current user
-	_, err := c.apiClient.GetCurrentUser(context.Background())
+	_, err := c.getCurrentUser(context.Background())
 	if err != nil {
 		status += styles.TextError.Render("Your session has expired. Run `nuon auth login` to sign in again.")
 		return status

--- a/bins/cli/cmd/root.go
+++ b/bins/cli/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/nuonco/nuon/bins/cli/internal/config"
 	"github.com/nuonco/nuon/bins/cli/internal/extensions"
 	"github.com/nuonco/nuon/pkg/cli/styles"
 )
@@ -93,6 +94,10 @@ nuon sync
 		c.runbooksCmd(),
 		c.triggersCmd(),
 		c.mcpCmd(),
+	}
+
+	if config.Debug() {
+		cmds = append(cmds, c.debugCmd())
 	}
 
 	for _, cmd := range cmds {

--- a/pkg/analytics/methods.go
+++ b/pkg/analytics/methods.go
@@ -11,14 +11,14 @@ import (
 )
 
 func (w *writer) Identify(ctx context.Context) {
-	ident, err := w.IdentifyFn(ctx)
-	if err != nil {
-		w.handleErr("identify", errors.Wrap(err, "unable to get identity"))
+	if w.Disable {
+		w.Logger.Debug("skipping identify")
 		return
 	}
 
-	if w.Disable {
-		w.Logger.Debug("skipping identify")
+	ident, err := w.IdentifyFn(ctx)
+	if err != nil {
+		w.handleErr("identify", errors.Wrap(err, "unable to get identity"))
 		return
 	}
 
@@ -28,14 +28,14 @@ func (w *writer) Identify(ctx context.Context) {
 }
 
 func (w *writer) Group(ctx context.Context) {
-	grp, err := w.GroupFn(ctx)
-	if err != nil {
-		w.handleErr("group", errors.Wrap(err, "unable to get group using fn"))
+	if w.Disable {
+		w.Logger.Debug("skipping group")
 		return
 	}
 
-	if w.Disable {
-		w.Logger.Debug("skipping group")
+	grp, err := w.GroupFn(ctx)
+	if err != nil {
+		w.handleErr("group", errors.Wrap(err, "unable to get group using fn"))
 		return
 	}
 
@@ -45,14 +45,14 @@ func (w *writer) Group(ctx context.Context) {
 }
 
 func (w *writer) Track(ctx context.Context, ev events.Event, props map[string]interface{}) {
-	userID, err := w.UserIDFn(ctx)
-	if err != nil {
-		w.handleErr("track", errors.Wrap(err, "unable to get user id"))
+	if w.Disable {
+		w.Logger.Debug("tracking event", zap.String("event", string(ev)))
 		return
 	}
 
-	if w.Disable {
-		w.Logger.Debug("tracking event", zap.String("event", string(ev)))
+	userID, err := w.UserIDFn(ctx)
+	if err != nil {
+		w.handleErr("track", errors.Wrap(err, "unable to get user id"))
 		return
 	}
 

--- a/services/ctl-api/internal/app/apps/service/get_apps.go
+++ b/services/ctl-api/internal/app/apps/service/get_apps.go
@@ -57,7 +57,11 @@ func (s *service) getApps(ctx *gin.Context, orgID, q string) ([]*app.App, error)
 	tx := s.db.WithContext(ctx).
 		Scopes(scopes.WithOffsetPagination).
 		Preload("AppConfigs", func(db *gorm.DB) *gorm.DB {
-			return db.Scopes(scopes.WithOverrideTable("app_configs_latest_view_v1"))
+			// readme and state are large blobs no list consumer reads. version must
+			// be omitted too: Omit switches to an explicit column list, and Version
+			// has no backing column.
+			return db.Omit("readme", "state", "version").
+				Scopes(scopes.WithOverrideTable("app_configs_latest_view_v1"))
 		}).
 		Preload("AppRunnerConfigs", func(db *gorm.DB) *gorm.DB {
 			return db.Scopes(scopes.WithOverrideTable("app_runner_configs_latest_view_v1"))

--- a/services/ctl-api/internal/app/general/service/get_current_user.go
+++ b/services/ctl-api/internal/app/general/service/get_current_user.go
@@ -28,5 +28,10 @@ func (s *service) GetCurrentUser(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, acct)
+	// Roles are loaded to derive org_ids and permissions, but serializing them
+	// dominates the response for accounts in many orgs.
+	trimmed := *acct
+	trimmed.Roles = nil
+
+	ctx.JSON(http.StatusOK, &trimmed)
 }


### PR DESCRIPTION
`nuon apps list` made 6 API calls where 2 are needed: 4 were the same uncached `GetCurrentUser`, and 2 more came from the root command's help text being built eagerly on every invocation — which also ignored `-f`, sending them to whatever `~/.nuon` pointed at. Measured against prod on a 280ms-RTT link: 6 requests → 2, 630KB → 29KB, `nuon apps list` 5.61s → 3.64s median, and `nuon version` (which needs no network at all) 2.95s → 0.02s.

Server side, `current-user` no longer serializes the account's roles (116KB → 10KB; trimmed in the handler, not the model, since the service-account endpoints do need `Account.Roles`) and `/v1/apps` omits the `readme`/`state` blobs from its app-config preload (154KB → 19KB for 4 apps). Also fixes `disable_telemetry`, which was still making two of those round trips before checking the flag. The 3.64s figure is CLI-side only — the payload trims land once ctl-api deploys, worth roughly another 1.2s of body transfer.

Not included: api.nuon.co's ALB is on `ELBSecurityPolicy-2016-08` (TLS 1.2 only, 2-RTT handshake ≈ 280ms wasted); the ingress isn't in this repo.

Overhead breakdown via a new `NUON_DEBUG=true nuon debug noop` command (hidden, no-op): fixed CLI cost — process start, cobra tree, config, API client, Sentry and Segment init — is **20ms, 0.6%** of `apps list`, so essentially all the remaining time is network. Of the 3.4s: ~1740ms `current-user`, ~610ms the apps call, ~1080ms the Segment flush at exit. The analytics `Close()` is now bounded by `CleanupTimeout` like `sentry.Flush` already was — that's a hang guard rather than a speedup, since the flush completes inside the 2s budget.