### PR TITLE
fix(dashboard-ui): truncate trigger event external ID

### DIFF
--- a/services/dashboard-ui/client/components/triggers/event-ledger/EventDetails/EventDetails.tsx
+++ b/services/dashboard-ui/client/components/triggers/event-ledger/EventDetails/EventDetails.tsx
@@ -439,9 +439,9 @@ export const EventDetails = ({
           <LabeledValue label="Trigger">
             {event?.trigger_name || event?.trigger_id || 'Unknown'}
           </LabeledValue>
-          <LabeledValue label="External ID">
-            <ClickToCopy>
-              <Text family="mono" variant="subtext">
+          <LabeledValue label="External ID" className="min-w-0">
+            <ClickToCopy className="max-w-full">
+              <Text family="mono" variant="subtext" className="truncate">
                 {event?.external_id || '—'}
               </Text>
             </ClickToCopy>


### PR DESCRIPTION
Split out of #2080.

## Truncate external ID on the trigger event page
`EventDetails.tsx`: a 64-char sha256 external ID overflowed its grid cell (grid items default to `min-width:auto`, which can't shrink below the unbreakable hash). Add `min-w-0` / `max-w-full` / `truncate` so it clips with the click-to-copy affordance intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)