### PR TITLE
fix(cli): stop NUON_PREVIEW from forcing plan-only runs

### DIFF
--- a/bins/cli/internal/config/config.go
+++ b/bins/cli/internal/config/config.go
@@ -162,6 +162,11 @@ func (c *Config) readConfigFile(customFP string) error {
 func (c *Config) BindCobraFlags(cmd *cobra.Command) {
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		name := strings.ReplaceAll(f.Name, "-", "_")
+		// `preview` is the NUON_PREVIEW feature gate (config.Preview()), not a
+		// flag value; don't let it bleed into the plan-only `--preview` flags.
+		if name == "preview" {
+			return
+		}
 		if !f.Changed && c.IsSet(name) {
 			val := c.Get(name)
 


### PR DESCRIPTION
Split out of #2080.

`BindCobraFlags` populates any unset flag from viper, and `AutomaticEnv()` exposes the `NUON_PREVIEW` feature-gate env var as the key `preview`. Commands with a plan-only flag literally named `--preview` (`apps branches trigger`, `sync`) then get forced plan-only whenever `NUON_PREVIEW=true` — its documented use is gating preview CLI features, not toggling apply. Treat `preview` as a reserved feature-gate key in `BindCobraFlags` so it no longer bleeds into those flags; `--preview` still works when passed explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)