### PR TITLE
fix(branch-run): auto-skip install groups with zero installs

### DIFF
--- a/services/ctl-api/internal/app/apps/signals/branches/planinstallgroup/signal.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/planinstallgroup/signal.go
@@ -24,10 +24,21 @@ type Signal struct {
 
 var _ signal.Signal = (*Signal)(nil)
 var _ signal.SignalWithStepContext = (*Signal)(nil)
+var _ signal.SignalWithEmptyGroupCheck = (*Signal)(nil)
 
 func (s *Signal) SetStepContext(stepID, flowID string) {
 	s.StepID = stepID
 	s.FlowID = flowID
+}
+
+// IsEmptyInstallGroup reports whether this group resolves to zero installs;
+// empty groups are auto-skipped (see checks/emptygroup).
+func (s *Signal) IsEmptyInstallGroup(ctx workflow.Context) (bool, error) {
+	installIDs, _, err := s.resolveInstallIDs(ctx)
+	if err != nil {
+		return false, err
+	}
+	return len(installIDs) == 0, nil
 }
 
 func (s *Signal) Type() signal.SignalType {

--- a/services/ctl-api/internal/pkg/flow/checks/emptygroup/check.go
+++ b/services/ctl-api/internal/pkg/flow/checks/emptygroup/check.go
@@ -1,0 +1,73 @@
+package emptygroup
+
+import (
+	"github.com/pkg/errors"
+	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/directive"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+)
+
+// Check auto-skips an install-group plan step when the group resolves to zero
+// installs. Without it the step parks in AwaitingApproval forever, since no
+// approval request is dispatched for an empty group.
+type Check struct {
+	sig signal.Signal
+
+	// SetResultDirective writes the directive to the step's ResultDirective column.
+	SetResultDirective func(ctx workflow.Context, stepID string, d directive.Step) error
+}
+
+func New(sig signal.Signal, setDirective func(ctx workflow.Context, stepID string, d directive.Step) error) directive.ApprovalCreateCheck {
+	return &Check{sig: sig, SetResultDirective: setDirective}
+}
+
+func (c *Check) Name() string { return "empty_group" }
+
+func (c *Check) ShouldRun(step *app.WorkflowStep, flw *app.Workflow) bool {
+	_, ok := c.sig.(signal.SignalWithEmptyGroupCheck)
+	return ok
+}
+
+func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workflow) (directive.CheckResult, error) {
+	l, _ := log.WorkflowLogger(ctx)
+
+	ec := c.sig.(signal.SignalWithEmptyGroupCheck)
+	empty, err := ec.IsEmptyInstallGroup(ctx)
+	if err != nil {
+		return directive.Pass(), errors.Wrap(err, "failed to check for empty install group")
+	}
+
+	if !empty {
+		return directive.Pass(), nil
+	}
+
+	l.Debug("install group has no installs, auto-skipping plan and deploy",
+		zap.String("step_id", step.ID),
+		zap.String("workflow_id", flw.ID))
+
+	// Skip the paired deploy step: it's in a separate step group the skip-group
+	// directive won't reach, so OnSkip marks it explicitly. applyCheckResult
+	// marks the plan step itself.
+	if sk, ok := c.sig.(signal.SignalWithOnSkip); ok {
+		if err := sk.OnSkip(ctx); err != nil {
+			return directive.Pass(), errors.Wrap(err, "unable to skip deploy step for empty install group")
+		}
+	}
+
+	if err := c.SetResultDirective(ctx, step.ID, directive.StepSkipGroup); err != nil {
+		return directive.Pass(), errors.Wrap(err, "unable to set skip-group directive for empty install group")
+	}
+
+	return directive.CheckResult{
+		Directive: directive.StepSkipGroup,
+		Status:    app.StatusAutoSkipped,
+		Reason: directive.CheckReason{
+			Check:   "empty_group",
+			Summary: "Install group has no installs, automatically skipped",
+		},
+	}, nil
+}

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_plan.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_plan.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/checks/autoapproval"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/checks/emptygroup"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/checks/noop"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/checks/planonly"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/checks/policy"
@@ -122,6 +123,8 @@ func (s *Signal) approvalCreateChecks(ctx workflow.Context, sig qsignal.Signal, 
 	// Load org feature flags needed by checks. Best-effort: default false on error.
 	orgAutoSkipNoop, _ := activities.AwaitCheckOrgFeatureByFeature(ctx, string(app.OrgFeatureAutoSkipNoop))
 	return []directive.ApprovalCreateCheck{
+		// Empty install groups have nothing to approve; skip before the approval wait.
+		emptygroup.New(sig, setResultDirective),
 		noop.New(sig, checkCtx, orgAutoSkipNoop, setResultDirective),
 		policy.New(sig),
 		autoapproval.New(stepSignal, setResultDirective),

--- a/services/ctl-api/internal/pkg/queue/signal/interfaces.go
+++ b/services/ctl-api/internal/pkg/queue/signal/interfaces.go
@@ -128,6 +128,13 @@ type SignalWithPolicyEvaluation interface {
 	RequiresPolicyEvaluation() bool
 }
 
+// SignalWithEmptyGroupCheck is implemented by approval-type signals whose install
+// group can resolve to zero installs. Empty groups are auto-skipped instead of
+// parking in AwaitingApproval with no approval to grant.
+type SignalWithEmptyGroupCheck interface {
+	IsEmptyInstallGroup(ctx workflow.Context) (bool, error)
+}
+
 // SignalWithSkipNoops is implemented by plan signals that can control whether
 // noop plans are auto-skipped. When SkipNoops returns false, noop plans proceed
 // through the normal approval flow instead of being auto-skipped.


### PR DESCRIPTION
## Problem

An app branch run creates a "plan install group" step for **every** install group with `ExecutionType = Approval`, unconditionally, before installs are resolved (`apps/workflows/app_branch_run.go:130-134`).

When a group resolves to **zero installs** — empty `install_ids` with no `label_selector`, or a selector that matches nothing — the plan signal returns early without dispatching an approval request (`planinstallgroup/execute.go:43`). But the step executor still sees `ExecutionType == Approval` and calls `processPlan` → `awaitApprovalResponse`, parking the step in `AwaitingApproval` **forever**. Since no approval record is ever created, the dashboard renders no approve button and the run is permanently wedged with no way forward (no clean API/CLI unblock either — the approve endpoint needs an approval id that never got created, and the skip endpoint is gated to `installs`-owned workflows).

## Solution

Add an `emptygroup` pre-approval check, mirroring the existing `noop` check, registered first in `approvalCreateChecks`. When the group resolves to zero installs it:
- auto-skips the plan step (`StatusAutoSkipped`),
- skips the paired deploy step via the signal's existing `OnSkip`,
- emits a `StepSkipGroup` directive so the run proceeds.

Introduces `SignalWithEmptyGroupCheck`, implemented by the plan-install-group signal via its existing `resolveInstallIDs`.