### PR TITLE
feat(dashboard-ui): create GitHub repo trust policies from the OIDC settings page

### DIFF
--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.stories.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.stories.tsx
@@ -3,37 +3,93 @@ export default {
 }
 
 import { ModalStory } from '@/components/__stories__/helpers'
+import type { TVCSConnectionRepo } from '@/types'
 import { CreateOIDCTrustPolicyModal } from './CreateOIDCTrustPolicy'
 
 const noop = () => {}
 
+const repos = [
+  {
+    id: 1,
+    name: 'api',
+    full_name: 'acme/api',
+    private: true,
+    fork: false,
+    html_url: 'https://github.com/acme/api',
+    default_branch: 'main',
+    updated_at: '2026-07-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    name: 'infra',
+    full_name: 'acme/infra',
+    private: true,
+    fork: false,
+    html_url: 'https://github.com/acme/infra',
+    default_branch: 'trunk',
+    updated_at: '2026-07-02T00:00:00Z',
+  },
+] satisfies TVCSConnectionRepo[]
+
+const baseProps = {
+  isPending: false,
+  error: null,
+  onSubmit: noop,
+  repos,
+  hasVCSConnections: true,
+  vcsConnectionsHref: '/org-123/connections/vcs',
+  githubAudience: 'https://api.nuon.co',
+}
+
 export const Default = () => (
   <ModalStory>
+    <CreateOIDCTrustPolicyModal {...baseProps} />
+  </ModalStory>
+)
+
+export const RepoLocked = () => (
+  <ModalStory>
     <CreateOIDCTrustPolicyModal
-      isPending={false}
-      error={null}
-      onSubmit={noop}
+      {...baseProps}
+      initialRepoFullName="acme/api"
+      initialRepoDefaultBranch="main"
+      lockPreset
     />
+  </ModalStory>
+)
+
+export const NoVCSConnections = () => (
+  <ModalStory>
+    <CreateOIDCTrustPolicyModal
+      {...baseProps}
+      repos={[]}
+      hasVCSConnections={false}
+    />
+  </ModalStory>
+)
+
+export const LoadingRepos = () => (
+  <ModalStory>
+    <CreateOIDCTrustPolicyModal {...baseProps} repos={[]} isLoadingRepos />
   </ModalStory>
 )
 
 export const Pending = () => (
   <ModalStory>
-    <CreateOIDCTrustPolicyModal isPending={true} error={null} onSubmit={noop} />
+    <CreateOIDCTrustPolicyModal {...baseProps} isPending />
   </ModalStory>
 )
 
 export const WithError = () => (
   <ModalStory>
     <CreateOIDCTrustPolicyModal
-      isPending={false}
+      {...baseProps}
       error={{
         error: 'claim_conditions must include a "sub" condition',
         description: '',
         user_error: true,
         status: 400,
       }}
-      onSubmit={noop}
     />
   </ModalStory>
 )

--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
@@ -2,14 +2,17 @@ import { useState } from 'react'
 import { Banner } from '@/components/common/Banner'
 import { Button } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
+import { Link } from '@/components/common/Link'
 import { Text } from '@/components/common/Text'
 import { Input } from '@/components/common/form/Input'
 import { Label } from '@/components/common/form/Label'
 import { Select } from '@/components/common/form/Select'
 import { Modal, type IModal } from '@/components/surfaces/Modal'
-import type { TAPIError } from '@/types'
+import type { TAPIError, TVCSConnectionRepo } from '@/types'
 
 export type ClaimCondition = { key: string; value: string }
+
+export type OIDCPreset = 'github_actions' | 'custom'
 
 export type OIDCTrustPolicyFormInput = {
   name: string
@@ -19,6 +22,14 @@ export type OIDCTrustPolicyFormInput = {
   tokenDurationSeconds: string
   claimConditions: ClaimCondition[]
 }
+
+export const GITHUB_ACTIONS_ISSUER =
+  'https://token.actions.githubusercontent.com'
+
+const PRESET_OPTIONS = [
+  { value: 'github_actions', label: 'GitHub Actions' },
+  { value: 'custom', label: 'Custom' },
+]
 
 const ROLE_OPTIONS = [
   { value: 'org_read_only', label: 'org_read_only' },
@@ -32,32 +43,78 @@ export const hasSubCondition = (claimConditions: ClaimCondition[]) =>
     (condition) => condition.key.trim() === 'sub' && condition.value.trim()
   )
 
+export const githubSubClaim = (repoFullName: string, branch: string) =>
+  `repo:${repoFullName}:ref:refs/heads/${branch}`
+
+export const defaultRepoPolicyName = (
+  repoFullName: string,
+  reservedNames: string[] = []
+) => {
+  const taken = new Set(
+    reservedNames.map((reserved) => reserved.trim().toLowerCase())
+  )
+  const baseName = `github-${repoFullName.split('/').pop() ?? repoFullName}`
+  let name = baseName
+  for (let n = 2; taken.has(name.toLowerCase()); n++) {
+    name = `${baseName}-${n}`
+  }
+  return name
+}
+
 export const CreateOIDCTrustPolicyModal = ({
   isPending,
   error,
   onSubmit,
-  initialValues,
-  lockIssuer,
+  repos,
+  isLoadingRepos,
+  hasVCSConnections,
+  vcsConnectionsHref,
+  githubAudience,
+  initialRepoFullName,
+  initialRepoDefaultBranch,
+  lockPreset,
   reservedNames,
   ...props
 }: {
   isPending: boolean
   error: TAPIError | null
   onSubmit: (input: OIDCTrustPolicyFormInput) => void
-  initialValues?: Partial<OIDCTrustPolicyFormInput>
-  lockIssuer?: boolean
+  repos: TVCSConnectionRepo[]
+  isLoadingRepos?: boolean
+  hasVCSConnections?: boolean
+  vcsConnectionsHref: string
+  githubAudience: string
+  initialRepoFullName?: string
+  initialRepoDefaultBranch?: string
+  lockPreset?: boolean
   reservedNames?: string[]
 } & Omit<IModal, 'onSubmit'>) => {
-  const [name, setName] = useState(initialValues?.name ?? '')
-  const [issuerUrl, setIssuerUrl] = useState(initialValues?.issuerUrl ?? '')
-  const [audience, setAudience] = useState(initialValues?.audience ?? '')
-  const [role, setRole] = useState(initialValues?.role ?? 'org_read_only')
-  const [tokenDurationSeconds, setTokenDurationSeconds] = useState(
-    initialValues?.tokenDurationSeconds ?? ''
+  const [preset, setPreset] = useState<OIDCPreset>('github_actions')
+  const [repoFullName, setRepoFullName] = useState(initialRepoFullName ?? '')
+
+  const [name, setName] = useState(
+    initialRepoFullName
+      ? defaultRepoPolicyName(initialRepoFullName, reservedNames)
+      : ''
   )
-  const [claimConditions, setClaimConditions] = useState<ClaimCondition[]>(
-    initialValues?.claimConditions ?? [{ key: 'sub', value: '' }]
-  )
+  const [issuerUrl, setIssuerUrl] = useState(GITHUB_ACTIONS_ISSUER)
+  const [audience, setAudience] = useState(githubAudience)
+  const [role, setRole] = useState('org_builder')
+  const [tokenDurationSeconds, setTokenDurationSeconds] = useState('900')
+  const [claimConditions, setClaimConditions] = useState<ClaimCondition[]>([
+    {
+      key: 'sub',
+      value:
+        initialRepoFullName && initialRepoDefaultBranch
+          ? githubSubClaim(initialRepoFullName, initialRepoDefaultBranch)
+          : '',
+    },
+  ])
+
+  const [isNameDirty, setIsNameDirty] = useState(false)
+  const [isSubDirty, setIsSubDirty] = useState(false)
+
+  const isGithub = preset === 'github_actions'
 
   const trimmedName = name.trim()
   const trimmedIssuerUrl = issuerUrl.trim()
@@ -74,11 +131,55 @@ export const CreateOIDCTrustPolicyModal = ({
     !!trimmedAudience &&
     hasSubCondition(claimConditions)
 
+  const setSubCondition = (value: string) =>
+    setClaimConditions((prev) => {
+      const hasSub = prev.some((condition) => condition.key.trim() === 'sub')
+      return hasSub
+        ? prev.map((condition) =>
+            condition.key.trim() === 'sub' ? { ...condition, value } : condition
+          )
+        : [{ key: 'sub', value }, ...prev]
+    })
+
+  const selectPreset = (nextPreset: OIDCPreset) => {
+    setPreset(nextPreset)
+    if (nextPreset === 'custom') {
+      setRepoFullName('')
+      setIssuerUrl('')
+      setAudience('')
+      setRole('org_read_only')
+      setTokenDurationSeconds('')
+      setClaimConditions([{ key: 'sub', value: '' }])
+      if (!isNameDirty) setName('')
+      return
+    }
+    setIssuerUrl(GITHUB_ACTIONS_ISSUER)
+    setAudience(githubAudience)
+    setRole('org_builder')
+    setTokenDurationSeconds('900')
+  }
+
+  const selectRepo = (nextRepoFullName: string) => {
+    setRepoFullName(nextRepoFullName)
+    const branch = repos.find(
+      (repo) => repo.full_name === nextRepoFullName
+    )?.default_branch
+    if (!isNameDirty) {
+      setName(defaultRepoPolicyName(nextRepoFullName, reservedNames))
+    }
+    if (!isSubDirty && branch) {
+      setSubCondition(githubSubClaim(nextRepoFullName, branch))
+    }
+  }
+
   const updateClaimCondition = (
     index: number,
     field: 'key' | 'value',
     value: string
   ) => {
+    if (field === 'value' && claimConditions[index]?.key.trim() === 'sub') {
+      setIsSubDirty(true)
+    }
     setClaimConditions((prev) =>
       prev.map((condition, i) =>
         i === index ? { ...condition, [field]: value } : condition
@@ -137,13 +238,55 @@ export const CreateOIDCTrustPolicyModal = ({
           short-lived org access, without storing a static API token.
         </Text>
 
+        {lockPreset ? null : (
+          <Select
+            labelProps={{ labelText: 'Provider' }}
+            options={PRESET_OPTIONS}
+            value={preset}
+            onChange={(e) => selectPreset(e.target.value as OIDCPreset)}
+            helperText="GitHub Actions fills in the issuer, audience and subject claim for a connected repository. You can still edit them."
+          />
+        )}
+
+        {isGithub ? (
+          hasVCSConnections === false && !isLoadingRepos ? (
+            <Banner theme="warn">
+              Connect a GitHub organization to fill this in from one of your
+              repositories.{' '}
+              <Link href={vcsConnectionsHref}>Manage VCS connections</Link>
+            </Banner>
+          ) : (
+            <Select
+              labelProps={{ labelText: 'Repository' }}
+              options={repos.map((repo) => ({
+                value: repo.full_name,
+                label: repo.full_name,
+                badge: { label: repo.default_branch },
+              }))}
+              value={repoFullName}
+              onChange={(e) => selectRepo(e.target.value)}
+              disabled={!!initialRepoFullName || isLoadingRepos}
+              searchable
+              placeholder={
+                isLoadingRepos
+                  ? 'Loading repositories...'
+                  : 'Select a repository'
+              }
+              helperText="Fills in the name and subject claim for this repository's default branch."
+            />
+          )
+        ) : null}
+
         <div className="flex flex-col gap-2">
           <Label htmlFor="policy-name">Name</Label>
           <Input
             id="policy-name"
             placeholder="GitHub Actions CI"
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => {
+              setIsNameDirty(true)
+              setName(e.target.value)
+            }}
             required
           />
           {isNameTaken ? (
@@ -163,8 +306,6 @@ export const CreateOIDCTrustPolicyModal = ({
             value={issuerUrl}
             onChange={(e) => setIssuerUrl(e.target.value)}
             required
-            readOnly={lockIssuer}
-            disabled={lockIssuer}
           />
           <Text variant="subtext" theme="neutral">
             Must be an absolute http or https URL.

--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
@@ -239,7 +239,6 @@ export const CreateOIDCTrustPolicyModal = ({
             options={PRESET_OPTIONS}
             value={preset}
             onChange={(e) => selectPreset(e.target.value as OIDCPreset)}
-            helperText="GitHub Actions fills in the issuer, audience and subject claim for a connected repository. You can still edit them."
           />
         )}
 

--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
@@ -266,7 +266,6 @@ export const CreateOIDCTrustPolicyModal = ({
                   ? 'Loading repositories...'
                   : 'Select a repository'
               }
-              helperText="Fills in the name and subject claim for this repository's default branch."
             />
           )
         ) : null}

--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
@@ -233,11 +233,6 @@ export const CreateOIDCTrustPolicyModal = ({
           </Banner>
         ) : null}
 
-        <Text variant="body" theme="neutral">
-          Trust policies let a CI/CD provider exchange an OIDC token for
-          short-lived org access, without storing a static API token.
-        </Text>
-
         {lockPreset ? null : (
           <Select
             labelProps={{ labelText: 'Provider' }}

--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
@@ -294,7 +294,7 @@ export const CreateOIDCTrustPolicyModal = ({
           <Label htmlFor="policy-issuer-url">Issuer URL</Label>
           <Input
             id="policy-issuer-url"
-            placeholder="https://gitlab.com"
+            placeholder="https://oidc.example.com"
             type="url"
             value={issuerUrl}
             onChange={(e) => setIssuerUrl(e.target.value)}
@@ -362,7 +362,7 @@ export const CreateOIDCTrustPolicyModal = ({
                   }
                 />
                 <Input
-                  placeholder="project_path:acme/app:ref_type:branch:ref:main"
+                  placeholder="acme/app:main"
                   value={condition.value}
                   onChange={(e) =>
                     updateClaimCondition(index, 'value', e.target.value)

--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
@@ -348,7 +348,7 @@ export const CreateOIDCTrustPolicyModal = ({
             onChange={(e) => setTokenDurationSeconds(e.target.value)}
           />
           <Text variant="subtext" theme="neutral">
-            Defaults to 3600. Maximum is 86400.
+            Maximum is 86400.
           </Text>
         </div>
 

--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicy.tsx
@@ -274,7 +274,7 @@ export const CreateOIDCTrustPolicyModal = ({
           <Label htmlFor="policy-name">Name</Label>
           <Input
             id="policy-name"
-            placeholder="GitHub Actions CI"
+            placeholder="ci-deploy"
             value={name}
             onChange={(e) => {
               setIsNameDirty(true)
@@ -294,7 +294,7 @@ export const CreateOIDCTrustPolicyModal = ({
           <Label htmlFor="policy-issuer-url">Issuer URL</Label>
           <Input
             id="policy-issuer-url"
-            placeholder="https://token.actions.githubusercontent.com"
+            placeholder="https://gitlab.com"
             type="url"
             value={issuerUrl}
             onChange={(e) => setIssuerUrl(e.target.value)}
@@ -362,7 +362,7 @@ export const CreateOIDCTrustPolicyModal = ({
                   }
                 />
                 <Input
-                  placeholder="repo:acme/app:ref:refs/heads/main"
+                  placeholder="project_path:acme/app:ref_type:branch:ref:main"
                   value={condition.value}
                   onChange={(e) =>
                     updateClaimCondition(index, 'value', e.target.value)

--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicyContainer.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicyContainer.tsx
@@ -4,9 +4,11 @@ import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
 import { Toast } from '@/components/surfaces/Toast'
+import { useConfig } from '@/hooks/use-config'
 import { useOrg } from '@/hooks/use-org'
 import { useToast } from '@/hooks/use-toast'
 import { useSurfaces } from '@/hooks/use-surfaces'
+import { useVCSRepos } from '@/hooks/use-vcs-repos'
 import { createCurrentOrgOIDCTrustPolicy } from '@/lib'
 import type { TAPIError } from '@/types'
 import {
@@ -16,6 +18,8 @@ import {
 
 const CreateOIDCTrustPolicyModalContainer = (props: Record<string, any>) => {
   const { org } = useOrg()
+  const config = useConfig()
+  const { repos, isLoading: isLoadingRepos, hasConnections } = useVCSRepos()
   const queryClient = useQueryClient()
   const { removeModal } = useSurfaces()
   const { addToast } = useToast()
@@ -69,29 +73,37 @@ const CreateOIDCTrustPolicyModalContainer = (props: Record<string, any>) => {
       isPending={isPending}
       error={error}
       onSubmit={(input) => mutate(input)}
+      repos={repos}
+      isLoadingRepos={isLoadingRepos}
+      hasVCSConnections={hasConnections}
+      vcsConnectionsHref={`/${org.id}/connections/vcs`}
+      githubAudience={config.apiUrl ?? ''}
       {...props}
     />
   )
 }
 
 export const CreateOIDCTrustPolicyButton = ({
-  initialValues,
-  lockIssuer,
+  initialRepoFullName,
+  initialRepoDefaultBranch,
+  lockPreset,
   reservedNames,
   children,
   variant = 'primary',
   ...props
 }: Omit<IButtonAsButton, 'children'> & {
-  initialValues?: Partial<OIDCTrustPolicyFormInput>
-  lockIssuer?: boolean
+  initialRepoFullName?: string
+  initialRepoDefaultBranch?: string
+  lockPreset?: boolean
   reservedNames?: string[]
   children?: ReactNode
 }) => {
   const { addModal } = useSurfaces()
   const modal = (
     <CreateOIDCTrustPolicyModalContainer
-      initialValues={initialValues}
-      lockIssuer={lockIssuer}
+      initialRepoFullName={initialRepoFullName}
+      initialRepoDefaultBranch={initialRepoDefaultBranch}
+      lockPreset={lockPreset}
       reservedNames={reservedNames}
     />
   )

--- a/services/dashboard-ui/client/components/oidc-trust-policies/EditOIDCTrustPolicy/EditOIDCTrustPolicy.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/EditOIDCTrustPolicy/EditOIDCTrustPolicy.tsx
@@ -197,7 +197,7 @@ export const EditOIDCTrustPolicyModal = ({
             onChange={(e) => setTokenDurationSeconds(e.target.value)}
           />
           <Text variant="subtext" theme="neutral">
-            Defaults to 3600. Maximum is 86400.
+            Maximum is 86400.
           </Text>
         </div>
 

--- a/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/ManageRepoOIDCContainer.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/ManageRepoOIDC/ManageRepoOIDCContainer.tsx
@@ -5,7 +5,6 @@ import { Text } from '@/components/common/Text'
 import { CreateOIDCTrustPolicyButton } from '@/components/oidc-trust-policies/CreateOIDCTrustPolicy'
 import { DeleteOIDCTrustPolicyButton } from '@/components/oidc-trust-policies/DeleteOIDCTrustPolicy'
 import { Toast } from '@/components/surfaces/Toast'
-import { useConfig } from '@/hooks/use-config'
 import { useOrg } from '@/hooks/use-org'
 import { useSurfaces } from '@/hooks/use-surfaces'
 import { useToast } from '@/hooks/use-toast'
@@ -16,15 +15,12 @@ import {
 import type { TAPIError, TOIDCTrustPolicy } from '@/types'
 import { ManageRepoOIDCModal } from './ManageRepoOIDC'
 
-const GITHUB_ACTIONS_ISSUER = 'https://token.actions.githubusercontent.com'
-
 const ManageRepoOIDCModalContainer = ({
   defaultBranch,
   repoFullName,
   ...props
 }: { defaultBranch: string; repoFullName: string } & Record<string, any>) => {
   const { org } = useOrg()
-  const config = useConfig()
   const queryClient = useQueryClient()
   const { addToast } = useToast()
 
@@ -83,14 +79,7 @@ const ManageRepoOIDCModalContainer = ({
     },
   })
 
-  const repoName = repoFullName.split('/').pop() ?? repoFullName
   const reservedNames = (policies ?? []).map((policy) => policy.name ?? '')
-  const takenNames = new Set(reservedNames.map((name) => name.toLowerCase()))
-  const baseName = `github-${repoName}`
-  let defaultName = baseName
-  for (let n = 2; takenNames.has(defaultName.toLowerCase()); n++) {
-    defaultName = `${baseName}-${n}`
-  }
 
   return (
     <ManageRepoOIDCModal
@@ -107,21 +96,10 @@ const ManageRepoOIDCModalContainer = ({
           variant="secondary"
           size="sm"
           className="w-fit"
-          initialValues={{
-            name: defaultName,
-            issuerUrl: GITHUB_ACTIONS_ISSUER,
-            audience: config.apiUrl ?? '',
-            role: 'org_builder',
-            tokenDurationSeconds: '900',
-            claimConditions: [
-              {
-                key: 'sub',
-                value: `repo:${repoFullName}:ref:refs/heads/${defaultBranch}`,
-              },
-            ],
-          }}
+          initialRepoFullName={repoFullName}
+          initialRepoDefaultBranch={defaultBranch}
           reservedNames={reservedNames}
-          lockIssuer
+          lockPreset
         >
           <Icon variant="PlusIcon" size={14} />
           Create trust policy

--- a/services/dashboard-ui/client/hooks/use-vcs-repos.ts
+++ b/services/dashboard-ui/client/hooks/use-vcs-repos.ts
@@ -1,0 +1,43 @@
+import { useQueries, useQuery } from '@tanstack/react-query'
+import { getVCSConnectionRepos, getVCSConnections } from '@/lib'
+import { useOrg } from '@/hooks/use-org'
+import type { TVCSConnectionRepo } from '@/types'
+
+export function useVCSRepos({ enabled = true }: { enabled?: boolean } = {}) {
+  const { org } = useOrg()
+
+  const { data: connections, isLoading: isLoadingConnections } = useQuery({
+    queryKey: ['vcs-connections', org?.id],
+    queryFn: () => getVCSConnections({ orgId: org!.id }),
+    enabled: enabled && !!org?.id,
+  })
+
+  const repoQueries = useQueries({
+    queries: (connections ?? []).map((connection) => ({
+      queryKey: ['vcs-connection-repos', org?.id, connection.id],
+      queryFn: () =>
+        getVCSConnectionRepos({ orgId: org!.id, connectionId: connection.id! }),
+      enabled: enabled && !!org?.id && !!connection.id,
+    })),
+  })
+
+  const byFullName = new Map<string, TVCSConnectionRepo>()
+  for (const query of repoQueries) {
+    for (const repo of query.data?.repositories ?? []) {
+      if (repo.full_name && !byFullName.has(repo.full_name)) {
+        byFullName.set(repo.full_name, repo)
+      }
+    }
+  }
+
+  const repos = [...byFullName.values()].sort((a, b) =>
+    a.full_name.localeCompare(b.full_name)
+  )
+
+  return {
+    repos,
+    isLoading:
+      isLoadingConnections || repoQueries.some((query) => query.isLoading),
+    hasConnections: !!connections?.length,
+  }
+}

--- a/services/dashboard-ui/client/views/org/OIDCTrustPolicies.tsx
+++ b/services/dashboard-ui/client/views/org/OIDCTrustPolicies.tsx
@@ -37,8 +37,8 @@ export const OIDCTrustPolicies = () => {
             OIDC federation
           </Text>
           <Text theme="neutral">
-            Let CI/CD providers exchange OIDC tokens for short-lived org access
-            without storing a static API token.
+            Grant OIDC providers access to the Nuon control plane without
+            storing long-live static tokens.
           </Text>
         </HeadingGroup>
         <CreateOIDCTrustPolicyButton

--- a/services/dashboard-ui/client/views/org/OIDCTrustPolicies.tsx
+++ b/services/dashboard-ui/client/views/org/OIDCTrustPolicies.tsx
@@ -38,7 +38,7 @@ export const OIDCTrustPolicies = () => {
           </Text>
           <Text theme="neutral">
             Grant OIDC providers access to the Nuon control plane without
-            storing long-live static tokens.
+            storing long-lived static tokens.
           </Text>
         </HeadingGroup>
         <CreateOIDCTrustPolicyButton


### PR DESCRIPTION
## Summary

The create modal now has a **Provider** selector — `GitHub Actions` (default) or `Custom`.

- **GitHub Actions**: pick a repo from a searchable list of every repo across all VCS connections. That fills in the name (`github-<repo>`, deduped), issuer, audience and `sub` claim (`repo:<full_name>:ref:refs/heads/<default_branch>`).
- **Custom**: same form, empty — unchanged from today.

Every field stays editable in both presets; the preset only seeds them. Name and `sub` track whether the user edited them, so changing repo afterwards won't clobber an edit. With no VCS connection, the GitHub path shows a banner linking to VCS connections.

<img width="3024" height="1716" alt="Screenshot 2026-08-05 at 20 40 17" src="https://github.com/user-attachments/assets/f794e545-eb2c-419a-aa28-9a6a6ba2dac5" />