### PR TITLE
fix: serialize install inputs writers

### DIFF
--- a/services/ctl-api/internal/app/installs/helpers/lock_install_inputs.go
+++ b/services/ctl-api/internal/app/installs/helpers/lock_install_inputs.go
@@ -1,0 +1,21 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// LockInstallInputs serializes an install's inputs writers for the rest of the
+// transaction. Rows are whole-snapshot appends and readers take the newest, so
+// unserialized read-modify-append drops concurrent writes. The lock releases at the
+// outermost commit, so callers taking several must order them.
+func LockInstallInputs(ctx context.Context, tx *gorm.DB, installID string) error {
+	if err := tx.WithContext(ctx).
+		Exec("select pg_advisory_xact_lock(hashtext(?)::bigint)", "install_inputs:"+installID).
+		Error; err != nil {
+		return fmt.Errorf("unable to lock install inputs for %s: %w", installID, err)
+	}
+	return nil
+}

--- a/services/ctl-api/internal/app/installs/helpers/migrate_install_inputs.go
+++ b/services/ctl-api/internal/app/installs/helpers/migrate_install_inputs.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -40,61 +41,56 @@ func (h *Helpers) MigrateInstallInputsToNewConfig(
 		validInputs[inp.Name] = true
 	}
 
-	for installID, oldAppConfigID := range installConfigMap {
-		if err := h.migrateInstallInputs(
-			ctx,
-			txn,
-			installID,
-			oldAppConfigID,
-			newAppConfig.InputConfig.ID,
-			validInputs); err != nil {
-			return fmt.Errorf("unable to migrate inputs for install %s: %w", installID, err)
-		}
+	// sorted so concurrent batches take the locks in the same order
+	installIDs := make([]string, 0, len(installConfigMap))
+	for installID := range installConfigMap {
+		installIDs = append(installIDs, installID)
 	}
+	sort.Strings(installIDs)
 
-	return nil
+	// own transaction so the locks are real when handed a plain handle
+	return txn.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for _, installID := range installIDs {
+			if err := LockInstallInputs(ctx, tx, installID); err != nil {
+				return err
+			}
+			if err := h.migrateInstallInputs(ctx, tx, installID, newAppConfig.InputConfig.ID, validInputs); err != nil {
+				return fmt.Errorf("unable to migrate inputs for install %s: %w", installID, err)
+			}
+
+			// config-derived partials go stale even when no value moved
+			if err := h.MarkInstallStatePartialsStale(ctx, tx, installID,
+				state.HintToPartials[state.HintAppConfigUpdated]...); err != nil {
+				return fmt.Errorf("unable to mark state partials stale for install %s: %w", installID, err)
+			}
+		}
+		return nil
+	})
 }
 
 func (h *Helpers) migrateInstallInputs(
 	ctx context.Context,
 	txn *gorm.DB,
 	installID string,
-	oldAppConfigID string,
 	newAppInputConfigID string,
 	validInputs map[string]bool,
 ) error {
-	var oldAppConfig app.AppConfig
-	res := txn.WithContext(ctx).
-		Where("id = ?", oldAppConfigID).
-		Preload("InputConfig").
-		First(&oldAppConfig)
-
-	if res.Error != nil {
-		return fmt.Errorf("unable to fetch old app config: %w", res.Error)
-	}
-
-	var existingInputs app.InstallInputs
-	res = txn.WithContext(ctx).
+	// a writer already targeted the incoming config; migrating on top would revert it
+	var onNewConfig int64
+	if err := txn.WithContext(ctx).
+		Model(&app.InstallInputs{}).
 		Where(app.InstallInputs{
 			InstallID:        installID,
-			AppInputConfigID: oldAppConfig.InputConfig.ID,
+			AppInputConfigID: newAppInputConfigID,
 		}).
-		Order("created_at DESC").
-		Limit(1).
-		Find(&existingInputs)
-	if res.Error != nil {
-		return fmt.Errorf("unable to fetch existing inputs: %w", res.Error)
+		Count(&onNewConfig).Error; err != nil {
+		return fmt.Errorf("unable to check inputs on new config: %w", err)
 	}
 
-	// Find reports "no rows" through RowsAffected, never gorm.ErrRecordNotFound.
-	// Testing the error instead leaves existingInputs zero-valued on a miss, which
-	// writes empty values over the install's inputs and, because the next
-	// migration then reads that empty row, keeps them empty for good.
-	if res.RowsAffected == 0 {
-		// An install whose inputs were never tied to the outgoing config — created
-		// before this migration existed, or tied to a different config version —
-		// still has values worth carrying forward.
-		res = txn.WithContext(ctx).
+	if onNewConfig == 0 {
+		// newest row, not the outgoing config's: that read cannot see a write pinned to the new one
+		var existingInputs app.InstallInputs
+		res := txn.WithContext(ctx).
 			Where(app.InstallInputs{
 				InstallID: installID,
 			}).
@@ -104,30 +100,26 @@ func (h *Helpers) migrateInstallInputs(
 		if res.Error != nil {
 			return errors.Wrap(res.Error, fmt.Sprintf("unable to fetch install inputs for installID %s", installID))
 		}
-	}
 
-	migratedValues := make(pgtype.Hstore)
-	for key, value := range existingInputs.Values {
-		if validInputs[key] {
-			migratedValues[key] = value
+		migratedValues := make(pgtype.Hstore)
+		for key, value := range existingInputs.Values {
+			if validInputs[key] {
+				migratedValues[key] = value
+			}
 		}
-	}
 
-	newInputs := app.InstallInputs{
-		InstallID:        installID,
-		AppInputConfigID: newAppInputConfigID,
-		Values:           migratedValues,
-		OrgID:            existingInputs.OrgID,
-	}
-
-	if err := txn.WithContext(ctx).Create(&newInputs).Error; err != nil {
-		return fmt.Errorf("unable to create migrated inputs: %w", err)
-	}
-
-	// inputs changed -> mark the inputs partial of this install's state stale so it is
-	// regenerated lazily on next read.
-	if err := h.MarkInstallStatePartialsStale(ctx, txn, installID, state.PartialInputs); err != nil {
-		return fmt.Errorf("unable to mark inputs partial stale: %w", err)
+		// nothing dropped means nothing to migrate: readers ignore the pin
+		if len(migratedValues) != len(existingInputs.Values) {
+			// OrgID is set by the model's BeforeCreate hook from context.
+			newInputs := app.InstallInputs{
+				InstallID:        installID,
+				AppInputConfigID: newAppInputConfigID,
+				Values:           migratedValues,
+			}
+			if err := txn.WithContext(ctx).Create(&newInputs).Error; err != nil {
+				return fmt.Errorf("unable to create migrated inputs: %w", err)
+			}
+		}
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/installs/helpers/migrate_install_inputs_test.go
+++ b/services/ctl-api/internal/app/installs/helpers/migrate_install_inputs_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/suite"
 	tclient "go.temporal.io/sdk/client"
 	"go.uber.org/fx"
@@ -222,4 +224,128 @@ func (s *MigrateInstallInputsTestSuite) TestCreateInstallPinsInputsToItsOwnAppCo
 	s.Require().NotNil(got.Values["region"])
 	s.Equal("us-west-2", *got.Values["region"])
 	s.Equal(activeCfg.ID, install.AppConfigID)
+}
+
+// Aug 4 incident: a read keyed on the outgoing config cannot see an update already
+// pinned to the incoming one, so it copied a stale snapshot forward.
+func (s *MigrateInstallInputsTestSuite) TestMigrationDoesNotRevertUpdateOnNewConfig() {
+	ctx := context.Background()
+	ctx, _ = s.deps.Seed.EnsureAccount(ctx, s.T())
+	ctx, _ = s.deps.Seed.EnsureOrg(ctx, s.T())
+
+	testApp := s.deps.Seed.CreateApp(ctx, s.T())
+	oldCfg := s.deps.Seed.CreateAppConfig(ctx, s.T(), testApp.ID)
+	install := s.deps.Seed.CreateInstall(ctx, s.T(), testApp)
+
+	var oldInputCfg app.AppInputConfig
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.AppInputConfig{AppConfigID: oldCfg.ID}).First(&oldInputCfg).Error)
+	s.deps.Seed.CreateInstallInputs(ctx, s.T(), install.ID, oldInputCfg.ID,
+		map[string]*string{"region": ptrTo("us-west-2")})
+
+	newCfg := s.seedAppConfigWithInputs(ctx, testApp.ID)
+	var newInputCfg app.AppInputConfig
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.AppInputConfig{AppConfigID: newCfg.ID}).First(&newInputCfg).Error)
+
+	s.deps.Seed.CreateInstallInputs(ctx, s.T(), install.ID, newInputCfg.ID, map[string]*string{
+		"region": ptrTo("us-west-2"),
+		"gate":   ptrTo("true"),
+	})
+
+	s.Require().NoError(s.deps.Helpers.MigrateInstallInputsToNewConfig(ctx, s.deps.DB,
+		map[string]string{install.ID: oldCfg.ID}, newCfg.ID))
+
+	got := s.latestInstallInputs(ctx, install.ID)
+	s.Require().NotNil(got.Values["gate"], "migration must not revert an update already on the new config")
+	s.Equal("true", *got.Values["gate"])
+	s.Equal("us-west-2", *got.Values["region"])
+}
+
+func (s *MigrateInstallInputsTestSuite) TestMigrationBeforeUpdateStillCarriesValues() {
+	ctx := context.Background()
+	ctx, _ = s.deps.Seed.EnsureAccount(ctx, s.T())
+	ctx, _ = s.deps.Seed.EnsureOrg(ctx, s.T())
+
+	testApp := s.deps.Seed.CreateApp(ctx, s.T())
+	oldCfg := s.deps.Seed.CreateAppConfig(ctx, s.T(), testApp.ID)
+	install := s.deps.Seed.CreateInstall(ctx, s.T(), testApp)
+
+	var oldInputCfg app.AppInputConfig
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.AppInputConfig{AppConfigID: oldCfg.ID}).First(&oldInputCfg).Error)
+	s.deps.Seed.CreateInstallInputs(ctx, s.T(), install.ID, oldInputCfg.ID,
+		map[string]*string{"region": ptrTo("eu-west-1")})
+
+	newCfg := s.seedAppConfigWithInputs(ctx, testApp.ID)
+	s.Require().NoError(s.deps.Helpers.MigrateInstallInputsToNewConfig(ctx, s.deps.DB,
+		map[string]string{install.ID: oldCfg.ID}, newCfg.ID))
+
+	got := s.latestInstallInputs(ctx, install.ID)
+	s.Require().NotNil(got.Values["region"])
+	s.Equal("eu-west-1", *got.Values["region"])
+}
+
+// Without the lock the migration's append discards an update that landed after its read.
+func (s *MigrateInstallInputsTestSuite) TestConcurrentUpdateIsNotLost() {
+	ctx := context.Background()
+	ctx, _ = s.deps.Seed.EnsureAccount(ctx, s.T())
+	ctx, _ = s.deps.Seed.EnsureOrg(ctx, s.T())
+
+	testApp := s.deps.Seed.CreateApp(ctx, s.T())
+	oldCfg := s.deps.Seed.CreateAppConfig(ctx, s.T(), testApp.ID)
+	install := s.deps.Seed.CreateInstall(ctx, s.T(), testApp)
+
+	var oldInputCfg app.AppInputConfig
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.AppInputConfig{AppConfigID: oldCfg.ID}).First(&oldInputCfg).Error)
+	s.deps.Seed.CreateInstallInputs(ctx, s.T(), install.ID, oldInputCfg.ID,
+		map[string]*string{"region": ptrTo("us-west-2"), "legacy": ptrTo("drop-me")})
+
+	newCfg := s.seedAppConfigWithInputs(ctx, testApp.ID)
+
+	held := make(chan struct{})
+	release := make(chan struct{})
+	updateDone := make(chan error, 1)
+	migrateDone := make(chan error, 1)
+
+	go func() {
+		updateDone <- s.deps.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			if err := installhelpers.LockInstallInputs(ctx, tx, install.ID); err != nil {
+				return err
+			}
+			close(held)
+			<-release
+
+			return tx.WithContext(ctx).Create(&app.InstallInputs{
+				InstallID:        install.ID,
+				AppInputConfigID: oldInputCfg.ID,
+				Values: pgtype.Hstore{
+					"region": ptrTo("eu-central-1"),
+					"legacy": ptrTo("drop-me"),
+				},
+			}).Error
+		})
+	}()
+
+	<-held
+	go func() {
+		migrateDone <- s.deps.Helpers.MigrateInstallInputsToNewConfig(ctx, s.deps.DB,
+			map[string]string{install.ID: oldCfg.ID}, newCfg.ID)
+	}()
+
+	select {
+	case err := <-migrateDone:
+		s.Require().Failf("migration ran unserialized", "finished while an inputs writer held the lock: %v", err)
+	case <-time.After(time.Second):
+	}
+
+	close(release)
+	s.Require().NoError(<-updateDone)
+	s.Require().NoError(<-migrateDone)
+
+	got := s.latestInstallInputs(ctx, install.ID)
+	s.Require().NotNil(got.Values["region"])
+	s.Equal("eu-central-1", *got.Values["region"])
+	s.NotContains(got.Values, "legacy")
 }

--- a/services/ctl-api/internal/app/installs/helpers/sync_install_inputs_test.go
+++ b/services/ctl-api/internal/app/installs/helpers/sync_install_inputs_test.go
@@ -1,0 +1,70 @@
+package helpers_test
+
+import (
+	"context"
+
+	"github.com/nuonco/nuon/pkg/config"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	installsyncer "github.com/nuonco/nuon/services/ctl-api/internal/pkg/config/syncer/installs"
+	pkgstate "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
+)
+
+// A config sync declares only the inputs it knows about. Replacing the snapshot with
+// just those drops everything set out of band — a dashboard update, or customer stack
+// outputs — and leaving the row unpinned hides it from the config migration.
+func (s *StackOutputInputsTestSuite) TestConfigSyncMergesAndPinsInputs() {
+	ctx := context.Background()
+	ctx, _ = s.deps.Seed.EnsureAccount(ctx, s.T())
+	ctx, _ = s.deps.Seed.EnsureOrg(ctx, s.T())
+
+	testApp := s.deps.Seed.CreateApp(ctx, s.T())
+	cfg := s.deps.Seed.CreateAppConfig(ctx, s.T(), testApp.ID)
+	install := s.deps.Seed.CreateInstall(ctx, s.T(), testApp)
+
+	var inputCfg app.AppInputConfig
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.AppInputConfig{AppConfigID: cfg.ID}).First(&inputCfg).Error)
+
+	s.deps.Seed.CreateInstallInputs(ctx, s.T(), install.ID, inputCfg.ID, map[string]*string{
+		"region":       ptrTo("us-west-2"),
+		"set_by_hand":  ptrTo("keep-me"),
+		"from_a_stack": ptrTo("also-keep-me"),
+	})
+
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Model(&app.InstallState{}).
+		Create(&app.InstallState{InstallID: install.ID}).Error)
+
+	installCfg := &config.Install{
+		Name:           install.Name,
+		ApprovalOption: config.InstallApprovalOptionApproveAll,
+		InputGroups: []config.InputGroup{
+			{Inputs: map[string]string{"region": "eu-central-1"}},
+		},
+	}
+
+	res, err := installsyncer.SyncInstall(ctx, s.deps.DB, s.deps.Helpers, testApp.ID, installCfg)
+	s.Require().NoError(err)
+	s.Require().True(res.Changed, "config declared a different region, so the sync must apply")
+
+	var newest app.InstallInputs
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.InstallInputs{InstallID: install.ID}).
+		Order("created_at DESC").
+		First(&newest).Error)
+
+	s.Equal(inputCfg.ID, newest.AppInputConfigID, "synced inputs must be pinned to the install's config")
+
+	s.Require().NotNil(newest.Values["region"])
+	s.Equal("eu-central-1", *newest.Values["region"], "config-declared value must win")
+	s.Require().NotNil(newest.Values["set_by_hand"], "out-of-band input was dropped")
+	s.Equal("keep-me", *newest.Values["set_by_hand"])
+	s.Require().NotNil(newest.Values["from_a_stack"], "customer stack output was dropped")
+
+	var st app.InstallState
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.InstallState{InstallID: install.ID}).
+		Order("created_at DESC").
+		First(&st).Error)
+	s.Contains(st.StalePartials, pkgstate.PartialInputs, "state was not invalidated, so the install keeps the old inputs")
+}

--- a/services/ctl-api/internal/app/installs/helpers/update_install_inputs_from_stack.go
+++ b/services/ctl-api/internal/app/installs/helpers/update_install_inputs_from_stack.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/pkg/errors"
+	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -70,50 +71,69 @@ func (h *Helpers) UpdateInstallInputsFromStackOutputs(
 		return nil, nil
 	}
 
-	var installInputs app.InstallInputs
-	res = h.db.WithContext(ctx).
-		Where(app.InstallInputs{
-			InstallID:        installID,
-			AppInputConfigID: appInputConfig.ID,
-		}).
-		Order("created_at DESC").
-		Attrs(app.InstallInputs{Values: pgtype.Hstore{}}).
-		FirstOrCreate(&installInputs)
-
-	if res.Error != nil {
-		return nil, errors.Wrap(res.Error, "unable to get or create install inputs")
-	}
-
-	if installInputs.Values == nil {
-		installInputs.Values = pgtype.Hstore{}
-	}
-
 	newValuesPtr := make(map[string]*string)
 	for k, v := range filteredInputValues {
 		newValuesPtr[k] = generics.ToPtr(v)
 	}
 
-	changed, err := ComputeChangedInputs(
-		installInputs.Values,
-		newValuesPtr,
-		appInputConfig.AppInputs,
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to compute changed inputs")
-	}
+	var changed *ChangedInputsResult
+	if err := h.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := LockInstallInputs(ctx, tx, installID); err != nil {
+			return err
+		}
 
-	newInputMap := installInputs.Values
-	for key, value := range filteredInputValues {
-		newInputMap[key] = generics.ToPtr(value)
-	}
+		// newest row for the install: a row this config no longer pins is never read
+		var installInputs app.InstallInputs
+		res := tx.WithContext(ctx).
+			Where(app.InstallInputs{
+				InstallID: installID,
+			}).
+			Order("created_at DESC").
+			Limit(1).
+			Find(&installInputs)
+		if res.Error != nil {
+			return errors.Wrap(res.Error, "unable to get install inputs")
+		}
 
-	installInputs.Values = newInputMap
+		if installInputs.Values == nil {
+			installInputs.Values = pgtype.Hstore{}
+		}
 
-	if res := h.db.WithContext(ctx).
-		Model(&installInputs).
-		Where("id = ?", installInputs.ID).
-		Update("values", installInputs.Values); res.Error != nil {
-		return nil, errors.Wrap(res.Error, "unable to update install inputs")
+		var err error
+		changed, err = ComputeChangedInputs(
+			installInputs.Values,
+			newValuesPtr,
+			appInputConfig.AppInputs,
+		)
+		if err != nil {
+			return errors.Wrap(err, "unable to compute changed inputs")
+		}
+
+		for key, value := range filteredInputValues {
+			installInputs.Values[key] = generics.ToPtr(value)
+		}
+
+		if res.RowsAffected == 0 {
+			newInputs := app.InstallInputs{
+				InstallID:        installID,
+				AppInputConfigID: appInputConfig.ID,
+				Values:           installInputs.Values,
+			}
+			if err := tx.WithContext(ctx).Create(&newInputs).Error; err != nil {
+				return errors.Wrap(err, "unable to create install inputs")
+			}
+			return nil
+		}
+
+		if err := tx.WithContext(ctx).
+			Model(&app.InstallInputs{}).
+			Where("id = ?", installInputs.ID).
+			Update("values", installInputs.Values).Error; err != nil {
+			return errors.Wrap(err, "unable to update install inputs")
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	if len(changed.Names) > 0 && !skipInputUpdateWorkflow {

--- a/services/ctl-api/internal/app/installs/helpers/update_install_inputs_from_stack_test.go
+++ b/services/ctl-api/internal/app/installs/helpers/update_install_inputs_from_stack_test.go
@@ -1,0 +1,146 @@
+package helpers_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/suite"
+	tclient "go.temporal.io/sdk/client"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+	"gorm.io/gorm"
+
+	temporal "github.com/nuonco/nuon/pkg/temporal/client"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	installhelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/tests"
+	"github.com/nuonco/nuon/services/ctl-api/tests/testseed"
+)
+
+type stackInputsDeps struct {
+	fx.In
+
+	DB      *gorm.DB `name:"psql"`
+	Seed    *testseed.Seeder
+	Helpers *installhelpers.Helpers
+}
+
+type StackOutputInputsTestSuite struct {
+	tests.BaseDBTestSuite
+
+	app  *fxtest.App
+	deps stackInputsDeps
+}
+
+func TestStackOutputInputsSuite(t *testing.T) {
+	if os.Getenv("INTEGRATION") != "true" {
+		t.Skip("INTEGRATION is not set, skipping")
+		return
+	}
+	suite.Run(t, new(StackOutputInputsTestSuite))
+}
+
+type stackInputsWorkflowRun struct{}
+
+func (r *stackInputsWorkflowRun) GetID() string    { return "test-workflow-id" }
+func (r *stackInputsWorkflowRun) GetRunID() string { return "test-run-id" }
+func (r *stackInputsWorkflowRun) Get(context.Context, any) error {
+	return nil
+}
+func (r *stackInputsWorkflowRun) GetWithOptions(context.Context, any, tclient.WorkflowRunGetOptions) error {
+	return nil
+}
+
+func (s *StackOutputInputsTestSuite) SetupSuite() {
+	s.BaseDBTestSuite.SetupSuite()
+
+	ctrl := gomock.NewController(s.T())
+	mockTC := temporal.NewMockClient(ctrl)
+	mockTC.EXPECT().ExecuteWorkflowInNamespace(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(&stackInputsWorkflowRun{}, nil).AnyTimes()
+
+	options := append(tests.CtlApiFXOptionsWithMocks(tests.TestOpts{
+		T:     s.T(),
+		Mocks: &tests.TestMocks{MockTC: mockTC},
+	}), fx.Populate(&s.deps))
+	s.app = fxtest.New(s.T(), options...)
+	s.app.RequireStart()
+	s.SetDB(s.deps.DB)
+}
+
+func (s *StackOutputInputsTestSuite) TearDownSuite() {
+	s.app.RequireStop()
+}
+
+// Customer stack outputs must land on the row readers actually resolve. Keying the
+// write on the input config the caller was handed writes to a row a newer config pin
+// already supersedes, and the outputs never take effect.
+func (s *StackOutputInputsTestSuite) TestOutputsMergeOntoNewestRow() {
+	ctx := context.Background()
+	ctx, _ = s.deps.Seed.EnsureAccount(ctx, s.T())
+	ctx, _ = s.deps.Seed.EnsureOrg(ctx, s.T())
+
+	testApp := s.deps.Seed.CreateApp(ctx, s.T())
+	oldCfg := s.deps.Seed.CreateAppConfig(ctx, s.T(), testApp.ID)
+	install := s.deps.Seed.CreateInstall(ctx, s.T(), testApp)
+
+	var oldInputCfg app.AppInputConfig
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.AppInputConfig{AppConfigID: oldCfg.ID}).First(&oldInputCfg).Error)
+
+	var oldGroup app.AppInputGroup
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.AppInputGroup{AppInputConfigID: oldInputCfg.ID}).First(&oldGroup).Error)
+
+	// The stack can only write inputs it declares as customer-sourced.
+	s.Require().NoError(s.deps.DB.WithContext(ctx).Create(&app.AppInput{
+		AppInputConfigID: oldInputCfg.ID,
+		AppInputGroupID:  oldGroup.ID,
+		Name:             "account_id",
+		DisplayName:      "Account ID",
+		Description:      "customer account id, reported by the stack",
+		Type:             app.AppInputTypeString,
+		Source:           app.AppInputSourceCustomer,
+	}).Error)
+
+	s.deps.Seed.CreateInstallInputs(ctx, s.T(), install.ID, oldInputCfg.ID,
+		map[string]*string{"region": ptrTo("us-west-2")})
+
+	// The install has since rolled onto a newer config, so the newest row — the one
+	// every reader resolves — is pinned somewhere else.
+	newCfg := s.deps.Seed.CreateBareAppConfig(ctx, s.T(), testApp.ID)
+	newInputCfg := s.deps.Seed.CreateAppInputConfig(ctx, s.T(), testApp.ID, newCfg.ID)
+	s.deps.Seed.CreateInstallInputs(ctx, s.T(), install.ID, newInputCfg.ID,
+		map[string]*string{"region": ptrTo("eu-central-1")})
+
+	stackVersionID := "istv" + install.ID
+	stackAccount := testseed.BuildAccount()
+	stackAccount.Subject = stackVersionID
+	stackAccount.AccountType = app.AccountTypeService
+	s.Require().NoError(s.deps.DB.WithContext(ctx).Create(stackAccount).Error)
+
+	_, err := s.deps.Helpers.UpdateInstallInputsFromStackOutputs(
+		ctx,
+		stackVersionID,
+		install.ID,
+		oldInputCfg.ID,
+		map[string]string{"account_id": "123456789012"},
+		true,
+	)
+	s.Require().NoError(err)
+
+	var newest app.InstallInputs
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.InstallInputs{InstallID: install.ID}).
+		Order("created_at DESC").
+		First(&newest).Error)
+
+	s.Require().NotNil(newest.Values["account_id"], "stack output did not reach the newest row")
+	s.Equal("123456789012", *newest.Values["account_id"])
+	s.Require().NotNil(newest.Values["region"])
+	s.Equal("eu-central-1", *newest.Values["region"])
+}

--- a/services/ctl-api/internal/app/installs/service/create_install_inputs.go
+++ b/services/ctl-api/internal/app/installs/service/create_install_inputs.go
@@ -8,10 +8,13 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
 	"github.com/jackc/pgx/v5/pgtype"
+	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	installupdated "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/updated"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+	pkgstate "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
 
@@ -112,9 +115,19 @@ func (s *service) createInstallInputs(ctx context.Context, install *app.Install,
 		InstallID:        install.ID,
 		Values:           pgtype.Hstore(inputs),
 	}
-	res := s.db.WithContext(ctx).Create(&obj)
-	if res.Error != nil {
-		return nil, fmt.Errorf("unable to create install inputs: %w", res.Error)
+
+	// under the lock so a migration cannot append a stale copy after this row
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := helpers.LockInstallInputs(ctx, tx, install.ID); err != nil {
+			return err
+		}
+		if err := tx.WithContext(ctx).Create(&obj).Error; err != nil {
+			return err
+		}
+		// stale_at alone is inert: the partial has to be named or state serves the old inputs
+		return s.helpers.MarkInstallStatePartialsStale(ctx, tx, install.ID, pkgstate.PartialInputs)
+	}); err != nil {
+		return nil, fmt.Errorf("unable to create install inputs: %w", err)
 	}
 
 	return obj, nil

--- a/services/ctl-api/internal/app/installs/service/update_install_inputs.go
+++ b/services/ctl-api/internal/app/installs/service/update_install_inputs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
 	"github.com/jackc/pgx/v5/pgtype"
+	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -96,11 +97,6 @@ func (s *service) UpdateInstallInputs(ctx *gin.Context) {
 // inputs PATCH endpoint and any flow that drives install inputs (e.g. the
 // component enable/disable toggle, which writes the synthetic enabled input).
 func (s *service) applyInstallInputsUpdate(ctx context.Context, install *app.Install, patch map[string]*string, role string, deployDependents bool, planOnly bool, workflowType app.WorkflowType) (*app.InstallInputs, error) {
-	latestLatestInstallInputs, err := s.getLatestInstallInputs(ctx, install.ID)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get latest install inputs: %w", err)
-	}
-
 	pinnedAppInputConfig, err := s.helpers.GetPinnedAppInputConfig(ctx, install.AppID, install.AppConfigID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get latest app input config: %w", err)
@@ -119,29 +115,42 @@ func (s *service) applyInstallInputsUpdate(ctx context.Context, install *app.Ins
 		return nil, err
 	}
 
-	// Merge the provided subset over the install's current inputs, then validate the
-	// full resulting set so required inputs remain satisfied after a partial update.
-	merged := mergeInstallInputs(latestLatestInstallInputs.Values, patch, pinnedAppInputConfig)
-	if err := s.helpers.ValidateInstallInputs(ctx, pinnedAppInputConfig, merged); err != nil {
-		return nil, err
-	}
+	var inputs *app.InstallInputs
+	var changedInputs *[]string
+	var changedInputValues string
 
-	// Reject an inputs update that would leave the install in an inconsistent
-	// component-enablement state (e.g. an enabled component depending on a
-	// disabled one). Validated against the full resulting desired state.
-	if err := s.validateInstallToggles(ctx, install, patch, merged); err != nil {
-		return nil, err
-	}
+	// read-modify-append, so serialized against the other inputs writers
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := helpers.LockInstallInputs(ctx, tx, install.ID); err != nil {
+			return err
+		}
 
-	inputs, changedInputs, changedInputValues, err := s.newInstallInputs(
-		ctx,
-		latestLatestInstallInputs,
-		pinnedAppInputConfig,
-		merged,
-		patch,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create install inputs: %w", err)
+		latest, err := s.getLatestInstallInputsTx(ctx, tx, install.ID)
+		if err != nil {
+			return fmt.Errorf("unable to get latest install inputs: %w", err)
+		}
+
+		// Merge the provided subset over the install's current inputs, then validate the
+		// full resulting set so required inputs remain satisfied after a partial update.
+		merged := mergeInstallInputs(latest.Values, patch, pinnedAppInputConfig)
+		if err := s.helpers.ValidateInstallInputs(ctx, pinnedAppInputConfig, merged); err != nil {
+			return err
+		}
+
+		// Reject an inputs update that would leave the install in an inconsistent
+		// component-enablement state (e.g. an enabled component depending on a
+		// disabled one). Validated against the full resulting desired state.
+		if err := s.validateInstallToggles(ctx, install, patch, merged); err != nil {
+			return err
+		}
+
+		inputs, changedInputs, changedInputValues, err = s.newInstallInputs(ctx, tx, latest, pinnedAppInputConfig, merged, patch)
+		if err != nil {
+			return fmt.Errorf("unable to create install inputs: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	workflow, err := s.helpers.CreateAndStartInputUpdateWorkflow(
@@ -183,8 +192,12 @@ func (s *service) applyInstallInputsUpdate(ctx context.Context, install *app.Ins
 }
 
 func (s *service) getLatestInstallInputs(ctx context.Context, installID string) (*app.InstallInputs, error) {
+	return s.getLatestInstallInputsTx(ctx, s.db, installID)
+}
+
+func (s *service) getLatestInstallInputsTx(ctx context.Context, db *gorm.DB, installID string) (*app.InstallInputs, error) {
 	installInputs := app.InstallInputs{}
-	res := s.db.WithContext(ctx).
+	res := db.WithContext(ctx).
 		Where("install_id = ?", installID).
 		Order("created_at DESC").
 		First(&installInputs)
@@ -211,6 +224,7 @@ func (s *service) getLatestAppInputConfig(ctx context.Context, appID string) (*a
 
 func (s *service) newInstallInputs(
 	ctx context.Context,
+	db *gorm.DB,
 	installInputs *app.InstallInputs,
 	appInputConfig *app.AppInputConfig,
 	merged map[string]*string,
@@ -231,12 +245,12 @@ func (s *service) newInstallInputs(
 		InstallID:        installInputs.InstallID,
 		Values:           pgtype.Hstore(merged),
 	}
-	res := s.db.WithContext(ctx).Create(&obj)
+	res := db.WithContext(ctx).Create(&obj)
 	if res.Error != nil {
 		return nil, nil, "", fmt.Errorf("unable to create install inputs: %w", res.Error)
 	}
 
-	latestInstallInputs, err := s.getLatestInstallInputs(ctx, installInputs.InstallID)
+	latestInstallInputs, err := s.getLatestInstallInputsTx(ctx, db, installInputs.InstallID)
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("unable to get latest install inputs: %w", err)
 	}

--- a/services/ctl-api/internal/pkg/config/syncer/installs/sync.go
+++ b/services/ctl-api/internal/pkg/config/syncer/installs/sync.go
@@ -6,11 +6,13 @@ import (
 
 	"gorm.io/gorm"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/pkg/config/sync"
 	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	installhelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	pkgstate "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
 )
 
 const ManagedByGitInstallConfig = "nuon/git/install-config"
@@ -143,16 +145,7 @@ func updateInstall(ctx context.Context, db *gorm.DB, installHelpers *installhelp
 
 	definedInputs := installCfg.FlattenedInputs()
 	if len(definedInputs) > 0 {
-		inputs := make(map[string]*string)
-		for k, v := range definedInputs {
-			val := v
-			inputs[k] = &val
-		}
-		installInputs := app.InstallInputs{
-			InstallID: existing.ID,
-			Values:    inputs,
-		}
-		if err := db.WithContext(ctx).Create(&installInputs).Error; err != nil {
+		if err := syncInstallInputs(ctx, db, installHelpers, existing, definedInputs); err != nil {
 			return nil, fmt.Errorf("unable to update inputs for install %s: %w", installCfg.Name, err)
 		}
 	}
@@ -292,3 +285,56 @@ func firstNonEmpty(vals ...string) string {
 }
 
 var _ func(ctx context.Context, db *gorm.DB, h *installhelpers.Helpers, appID string, i *config.Install) (*sync.InstallSyncResult, error) = SyncInstall
+
+// syncInstallInputs merges rather than replaces so values set out of band survive a sync.
+func syncInstallInputs(
+	ctx context.Context,
+	db *gorm.DB,
+	installHelpers *installhelpers.Helpers,
+	existing *app.Install,
+	definedInputs map[string]string,
+) error {
+	pinned, err := installHelpers.GetPinnedAppInputConfig(ctx, existing.AppID, existing.AppConfigID)
+	if err != nil {
+		return fmt.Errorf("unable to get pinned app input config: %w", err)
+	}
+	if pinned == nil {
+		return fmt.Errorf("no app input config on app config %s", existing.AppConfigID)
+	}
+
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := installhelpers.LockInstallInputs(ctx, tx, existing.ID); err != nil {
+			return err
+		}
+
+		var latest app.InstallInputs
+		if err := tx.WithContext(ctx).
+			Where(app.InstallInputs{InstallID: existing.ID}).
+			Order("created_at DESC").
+			Limit(1).
+			Find(&latest).Error; err != nil {
+			return fmt.Errorf("unable to get install inputs: %w", err)
+		}
+
+		merged := make(pgtype.Hstore, len(latest.Values)+len(definedInputs))
+		for k, v := range latest.Values {
+			merged[k] = v
+		}
+		for k, v := range definedInputs {
+			val := v
+			merged[k] = &val
+		}
+
+		installInputs := app.InstallInputs{
+			InstallID:        existing.ID,
+			AppInputConfigID: pinned.ID,
+			Values:           merged,
+		}
+		if err := tx.WithContext(ctx).Create(&installInputs).Error; err != nil {
+			return err
+		}
+
+		// nothing else on this path invalidates state
+		return installHelpers.MarkInstallStatePartialsStale(ctx, tx, existing.ID, pkgstate.PartialInputs)
+	})
+}

--- a/services/ctl-api/internal/pkg/state/partials.go
+++ b/services/ctl-api/internal/pkg/state/partials.go
@@ -72,7 +72,7 @@ var HintToPartials = map[HintType][]PartialName{
 	HintInputsUpdated:        {PartialInputs},
 	HintSecretsUpdated:       {PartialSecrets},
 	HintRunnerUpdated:        {PartialRunner},
-	HintAppConfigUpdated:     {PartialApp, PartialInputs},
+	HintAppConfigUpdated:     {PartialApp, PartialInputs, PartialActions},
 	HintInstallCreated:       {PartialOrg, PartialApp, PartialRunner, PartialCloud, PartialInputs},
 }
 


### PR DESCRIPTION
Customer hit input values getting silently reverted during `apps sync` — the migration raced an inputs update and copied a stale snapshot forward.

`install_inputs` rows are whole-snapshot appends and readers take the newest, so any writer that reads a snapshot and appends a modified copy can discard one that landed after its read. All five writers now take a per-install advisory lock: the config migration, the inputs PATCH, the create-inputs POST, the install-stack outputs path, and the config syncer. The migration reads the install's newest row instead of the outgoing config's, and skips writing when no keys are dropped.

Two more found on the way: the stack-outputs path mutated a row a newer config pin could supersede, and the config syncer's inputs write was unpinned and replaced the snapshot instead of merging.

Also fixes state not catching up. The POST path and the config syncer named no partial, and a config roll invalidated nothing despite reconciling components and actions — `app-config-updated` existed for that with no emitter.

Regression test asserts a migration blocks while an inputs writer holds the lock; it fails without it.