### PR TITLE
fix: stop skipping helm deploys that never rolled out

### DIFF
--- a/bins/runner/internal/jobs/deploy/helm/exec.go
+++ b/bins/runner/internal/jobs/deploy/helm/exec.go
@@ -38,6 +38,9 @@ type HelmPlanContents struct {
 	Op             string              `json:"op"`
 	ContentDiff    []diff.ResourceDiff `json:"helm_content_diff"`
 	TemplateOutput string              `json:"template_output,omitempty"`
+
+	// an empty diff only means "nothing to do" when the release is actually deployed
+	ReleaseStatus string `json:"helm_release_status,omitempty"`
 }
 
 // Modify Exec function to use the common diff package
@@ -142,11 +145,21 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 			diffStr = "no changes"
 		}
 
-		helmPlan.Diff = diffStr
 		helmPlan.ContentDiff = *contentDiff
 		helmPlan.TemplateOutput = templateOutput
+		if prevRel != nil && prevRel.Info != nil {
+			helmPlan.ReleaseStatus = string(prevRel.Info.Status)
+			if len(*contentDiff) == 0 && prevRel.Info.Status != release.StatusDeployed {
+				diffStr = fmt.Sprintf(
+					"no manifest changes, but the release is %s and was never rolled out — re-applying",
+					prevRel.Info.Status,
+				)
+			}
+		}
+		helmPlan.Diff = diffStr
 
-		l.Debug("calculated helm diff", zap.String("diff", diffStr))
+		l.Debug("calculated helm diff", zap.String("diff", diffStr),
+			zap.String("helm.release_status", helmPlan.ReleaseStatus))
 	case models.AppRunnerJobOperationTypeCreateDashTeardownDashPlan:
 		// TODO(fd): figure out the best way to get a plan for this
 		helmPlan.Op = "uninstall"

--- a/pkg/plans/types/approval_plan/helm.go
+++ b/pkg/plans/types/approval_plan/helm.go
@@ -17,7 +17,20 @@ func NewHelmApprovalPlen(planJSON []byte) *HelmApprovalPlan {
 func (h *HelmApprovalPlan) IsNoop() (bool, error) {
 	result := gjson.GetBytes(h.PlanJSON, "helm_content_diff")
 	if !result.Exists() || result.IsArray() && len(result.Array()) == 0 {
-		return true, nil
+		return !h.releaseNeedsDeploy(), nil
 	}
 	return false, nil
 }
+
+// A timed-out attempt records the new manifest on a pending/failed release, so the
+// retry diffs clean even though nothing rolled out. Old runners send no status, and
+// those keep the diff-only behaviour.
+func (h *HelmApprovalPlan) releaseNeedsDeploy() bool {
+	status := gjson.GetBytes(h.PlanJSON, "helm_release_status")
+	if !status.Exists() || status.String() == "" {
+		return false
+	}
+	return status.String() != helmStatusDeployed
+}
+
+const helmStatusDeployed = "deployed"

--- a/pkg/plans/types/approval_plan/helm_test.go
+++ b/pkg/plans/types/approval_plan/helm_test.go
@@ -1,0 +1,67 @@
+package approvalplan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHelmApprovalPlan_IsNoop(t *testing.T) {
+	tests := []struct {
+		name     string
+		planJSON string
+		want     bool
+	}{
+		{
+			name:     "no content diff key",
+			planJSON: `{}`,
+			want:     true,
+		},
+		{
+			name:     "empty content diff",
+			planJSON: `{"helm_content_diff": []}`,
+			want:     true,
+		},
+		{
+			name:     "content diff present",
+			planJSON: `{"helm_content_diff": [{"name": "cm"}]}`,
+			want:     false,
+		},
+		{
+			name:     "empty diff against a deployed release",
+			planJSON: `{"helm_content_diff": [], "helm_release_status": "deployed"}`,
+			want:     true,
+		},
+		// a timed-out attempt leaves the new manifest on a pending release
+		{
+			name:     "empty diff against a pending-install release",
+			planJSON: `{"helm_content_diff": [], "helm_release_status": "pending-install"}`,
+			want:     false,
+		},
+		{
+			name:     "empty diff against a pending-upgrade release",
+			planJSON: `{"helm_content_diff": [], "helm_release_status": "pending-upgrade"}`,
+			want:     false,
+		},
+		{
+			name:     "empty diff against a failed release",
+			planJSON: `{"helm_content_diff": [], "helm_release_status": "failed"}`,
+			want:     false,
+		},
+		// old runners send no status and must not start blocking unchanged deploys
+		{
+			name:     "empty diff with an empty status",
+			planJSON: `{"helm_content_diff": [], "helm_release_status": ""}`,
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewHelmApprovalPlen([]byte(tt.planJSON)).IsNoop()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
A helm job that times out leaves the new manifest recorded on a pending/failed release, so the retry's plan diffs clean — and `IsNoop()` only looked at the manifest diff, so with `skip_noops` on it auto-skipped the deploy and reported the workflow successful with a release that never rolled out. This is what Casey hit on Coder in two orgs (thread: https://nuonco.slack.com/archives/C02HT61JG06/p1785718197099249), live since #10623.

The plan now carries the status of the release it diffed against, and an empty diff is only a noop when that release is actually `deployed`. Old runners omit the field and keep the diff-only behaviour, so they don't start blocking unchanged deploys. A `failed` release now recovers on the retry; a release stuck `pending-*` fails loudly instead of being skipped — self-healing that one needs a rollback step, which touches customer clusters, so it's not in here.

Not touched: `handleNoopDeployPlan` skips the next step by index, which Harsh flagged as brittle. It's correct today since plan and apply are always appended adjacently, and the obvious guard (comparing `StepTargetID`) doesn't work because the apply step's target isn't set until it executes.