### PR TITLE
fix: release emitters blocked by expired signals

### DIFF
--- a/services/ctl-api/internal/app/apps/signals/branches/builds/execute_test.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/builds/execute_test.go
@@ -3,10 +3,12 @@ package builds
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -26,6 +28,8 @@ func TestBuildComponentsForceSelection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var suite testsuite.WorkflowTestSuite
 			env := suite.NewTestWorkflowEnvironment()
+			// loaded CI runners starve the workflow goroutine past the 1s default
+			env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
 			sig := &Signal{RunID: "run-1"}
 
 			env.OnActivity((*branchactivities.Activities).GetComponentByID, mock.Anything, mock.Anything, mock.Anything).

--- a/services/ctl-api/internal/app/apps/signals/triggerevent/signal_test.go
+++ b/services/ctl-api/internal/app/apps/signals/triggerevent/signal_test.go
@@ -3,11 +3,13 @@ package triggerevent
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/apps/worker/activities"
@@ -38,6 +40,8 @@ func executeSignal(t *testing.T, env *testsuite.TestWorkflowEnvironment) error {
 func TestExecuteFansOutEveryDispatchAndWaiter(t *testing.T) {
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
+	// loaded CI runners starve the workflow goroutine past the 1s default
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
 
 	env.OnActivity((*activities.Activities).RouteTriggerEvent, mock.Anything, mock.Anything, mock.Anything).
 		Return(routedResponse(), nil).Once()
@@ -53,6 +57,8 @@ func TestExecuteFansOutEveryDispatchAndWaiter(t *testing.T) {
 func TestExecuteFailedDispatchEnqueueDoesNotBlockSiblingsOrWaiters(t *testing.T) {
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
+	// loaded CI runners starve the workflow goroutine past the 1s default
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
 
 	env.OnActivity((*activities.Activities).RouteTriggerEvent, mock.Anything, mock.Anything, mock.Anything).
 		Return(routedResponse(), nil).Once()
@@ -70,6 +76,8 @@ func TestExecuteFailedDispatchEnqueueDoesNotBlockSiblingsOrWaiters(t *testing.T)
 func TestExecuteFailedWaiterDoesNotBlockSiblingWaitersOrDispatches(t *testing.T) {
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
+	// loaded CI runners starve the workflow goroutine past the 1s default
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
 
 	// Register with a string name so the test env decodes the request payload
 	// into (ctx, request) args; method-expression mocks treat the receiver as

--- a/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal_test.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal_test.go
@@ -11,6 +11,7 @@ import (
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 
 	basemetrics "github.com/nuonco/nuon/pkg/metrics"
@@ -25,6 +26,8 @@ import (
 func TestFirstFailedHealthCheckMarksRunnerOfflineWithoutAlerting(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
+	// loaded CI runners starve the workflow goroutine past the 1s default
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
 	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
 	env.SetStartTime(now)
 
@@ -57,6 +60,8 @@ func TestFirstFailedHealthCheckMarksRunnerOfflineWithoutAlerting(t *testing.T) {
 func TestOfflineRunnerDoesNotAlertBeforeDelay(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
+	// loaded CI runners starve the workflow goroutine past the 1s default
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
 	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
 	env.SetStartTime(now)
 
@@ -75,6 +80,8 @@ func TestOfflineRunnerDoesNotAlertBeforeDelay(t *testing.T) {
 func TestOfflineRunnerEnqueuesIdempotentAlertAfterDelay(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
+	// loaded CI runners starve the workflow goroutine past the 1s default
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
 	env.SetDataConverter(signalDataConverter())
 	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
 	env.SetStartTime(now)
@@ -108,6 +115,8 @@ func TestOfflineRunnerEnqueuesIdempotentAlertAfterDelay(t *testing.T) {
 func TestOfflineRunnerReusesAlertIdempotencyKey(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
+	// loaded CI runners starve the workflow goroutine past the 1s default
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
 	env.SetDataConverter(signalDataConverter())
 	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
 	env.SetStartTime(now)
@@ -135,6 +144,8 @@ func TestOfflineRunnerReusesAlertIdempotencyKey(t *testing.T) {
 func TestOfflineRunnerWithoutTimestampArmsAlert(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
+	// loaded CI runners starve the workflow goroutine past the 1s default
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
 	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
 	env.SetStartTime(now)
 
@@ -157,6 +168,8 @@ func TestOfflineRunnerWithoutTimestampArmsAlert(t *testing.T) {
 func TestActiveRunnerWithOfflineTimestampDoesNotResetDelay(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
+	// loaded CI runners starve the workflow goroutine past the 1s default
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
 	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
 	env.SetStartTime(now)
 
@@ -182,6 +195,8 @@ func TestActiveRunnerWithOfflineTimestampDoesNotResetDelay(t *testing.T) {
 func TestOfflineCheckRepairsStaleStatusV2(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
+	// loaded CI runners starve the workflow goroutine past the 1s default
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
 	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
 	env.SetStartTime(now)
 
@@ -205,6 +220,8 @@ func TestOfflineCheckRepairsStaleStatusV2(t *testing.T) {
 func TestHealthyCheckClearsOfflineMetadataAndRestoresActive(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
+	// loaded CI runners starve the workflow goroutine past the 1s default
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
 
 	runner := runnerWithOfflineMetadata(app.RunnerStatusOffline, time.Now().Add(-time.Minute))
 	sig := &Signal{RunnerID: runner.ID}
@@ -235,6 +252,8 @@ func TestHealthyCheckClearsOfflineMetadataAndRestoresActive(t *testing.T) {
 func TestUpdateRunnerStatusStopsWhenLegacyUpdateFails(t *testing.T) {
 	var workflowSuite testsuite.WorkflowTestSuite
 	env := workflowSuite.NewTestWorkflowEnvironment()
+	// loaded CI runners starve the workflow goroutine past the 1s default
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
 
 	runner := testRunner(app.RunnerStatusActive)
 	sig := &Signal{RunnerID: runner.ID}

--- a/services/ctl-api/internal/pkg/queue/emitter/activities/emit_signal.go
+++ b/services/ctl-api/internal/pkg/queue/emitter/activities/emit_signal.go
@@ -60,40 +60,34 @@ func (a *Activities) EmitSignal(ctx context.Context, req *EmitSignalRequest) (*E
 	}
 
 	if len(existingSignals) > 0 {
-		if maxAge := signal.DeriveMaxInFlightAge(emitter.SignalTemplate.Signal); maxAge > 0 {
-			staleIDs := make([]string, 0, len(existingSignals))
-			live := existingSignals[:0]
-			now := time.Now()
-			for _, s := range existingSignals {
-				if now.Sub(s.CreatedAt) > maxAge {
-					staleIDs = append(staleIDs, s.ID)
-				} else {
-					live = append(live, s)
-				}
+		staleByReason, live := partitionStaleSignals(
+			existingSignals,
+			signal.DeriveMaxInFlightAge(emitter.SignalTemplate.Signal),
+			time.Now(),
+		)
+
+		for reason, ids := range staleByReason {
+			// Do NOT soft-delete: a handler may already be running this signal,
+			// and removing the row would cause its status-update activities to
+			// loop on ErrRecordNotFound. Marking status=error is enough to
+			// release EmitSignal's in-flight check; the handler will finish
+			// (or its own writes will overwrite this status) naturally.
+			if res := a.db.WithContext(ctx).Exec(`
+				UPDATE queue_signals
+				SET status = jsonb_set(status, '{status}', '"error"'::jsonb)
+				           || jsonb_build_object('metadata', jsonb_build_object('stale_drop', ?::text)),
+				    updated_at = now()
+				WHERE id IN (?)`, reason, ids); res.Error != nil {
+				return nil, errors.Wrap(res.Error, "unable to mark stale in-flight signals as failed")
 			}
-			if len(staleIDs) > 0 {
-				// Do NOT soft-delete: a handler may already be running this signal,
-				// and removing the row would cause its status-update activities to
-				// loop on ErrRecordNotFound. Marking status=error is enough to
-				// release EmitSignal's in-flight check; the handler will finish
-				// (or its own writes will overwrite this status) naturally.
-				if res := a.db.WithContext(ctx).Exec(`
-					UPDATE queue_signals
-					SET status = jsonb_set(status, '{status}', '"error"'::jsonb)
-					           || jsonb_build_object('metadata', jsonb_build_object('stale_drop', 'exceeded max_in_flight_age')),
-					    updated_at = now()
-					WHERE id IN (?)`, staleIDs); res.Error != nil {
-					return nil, errors.Wrap(res.Error, "unable to mark stale in-flight signals as failed")
-				}
-				a.l.Warn("dropped stale in-flight signals exceeding max-in-flight age",
-					zap.String("emitter-id", req.EmitterID),
-					zap.String("queue-id", req.QueueID),
-					zap.Int("stale-count", len(staleIDs)),
-					zap.Duration("max-in-flight-age", maxAge),
-				)
-			}
-			existingSignals = live
+			a.l.Warn("dropped stale in-flight signals",
+				zap.String("emitter-id", req.EmitterID),
+				zap.String("queue-id", req.QueueID),
+				zap.String("reason", reason),
+				zap.Int("stale-count", len(ids)),
+			)
 		}
+		existingSignals = live
 
 		if len(existingSignals) > 0 {
 			a.l.Info("skipping signal emission - emitter already has in-flight signal",
@@ -140,4 +134,32 @@ func (a *Activities) EmitSignal(ctx context.Context, req *EmitSignalRequest) (*E
 		QueueSignalID: enqueueResp.ID,
 		WorkflowID:    enqueueResp.WorkflowID,
 	}, nil
+}
+
+const (
+	staleReasonMaxInFlightAge = "exceeded max_in_flight_age"
+	staleReasonExpired        = "expired"
+)
+
+// partitionStaleSignals splits an emitter's in-flight signals into ones that should
+// no longer hold the emitter back, keyed by why, and ones still considered live.
+//
+// Expiry is otherwise only enforced by the handler itself, so a handler that died
+// leaves its row in-flight forever and the emitter never fires again.
+func partitionStaleSignals(signals []*app.QueueSignal, maxAge time.Duration, now time.Time) (map[string][]string, []*app.QueueSignal) {
+	staleByReason := map[string][]string{}
+	live := make([]*app.QueueSignal, 0, len(signals))
+
+	for _, s := range signals {
+		switch {
+		case maxAge > 0 && now.Sub(s.CreatedAt) > maxAge:
+			staleByReason[staleReasonMaxInFlightAge] = append(staleByReason[staleReasonMaxInFlightAge], s.ID)
+		case s.ExpiresAt != nil && now.After(*s.ExpiresAt):
+			staleByReason[staleReasonExpired] = append(staleByReason[staleReasonExpired], s.ID)
+		default:
+			live = append(live, s)
+		}
+	}
+
+	return staleByReason, live
 }

--- a/services/ctl-api/internal/pkg/queue/emitter/activities/emit_signal_test.go
+++ b/services/ctl-api/internal/pkg/queue/emitter/activities/emit_signal_test.go
@@ -1,0 +1,79 @@
+package activities
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+func TestPartitionStaleSignals(t *testing.T) {
+	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	ptr := func(t time.Time) *time.Time { return &t }
+
+	tests := []struct {
+		name    string
+		signals []*app.QueueSignal
+		maxAge  time.Duration
+		stale   map[string][]string
+		live    []string
+	}{
+		{
+			name:    "fresh signal with no expiry holds the emitter",
+			signals: []*app.QueueSignal{{ID: "a", CreatedAt: now.Add(-time.Minute)}},
+			live:    []string{"a"},
+			stale:   map[string][]string{},
+		},
+		{
+			name:    "unexpired signal holds the emitter",
+			signals: []*app.QueueSignal{{ID: "a", CreatedAt: now.Add(-time.Minute), ExpiresAt: ptr(now.Add(time.Minute))}},
+			live:    []string{"a"},
+			stale:   map[string][]string{},
+		},
+		// The wedge: a dead handler never enforces its own expiry, so without this the
+		// emitter is blocked forever and the cron silently stops.
+		{
+			name:    "expired signal releases the emitter",
+			signals: []*app.QueueSignal{{ID: "a", CreatedAt: now.Add(-time.Hour), ExpiresAt: ptr(now.Add(-time.Minute))}},
+			live:    []string{},
+			stale:   map[string][]string{staleReasonExpired: {"a"}},
+		},
+		{
+			name:    "max-in-flight-age still applies without an expiry",
+			signals: []*app.QueueSignal{{ID: "a", CreatedAt: now.Add(-time.Hour)}},
+			maxAge:  30 * time.Minute,
+			live:    []string{},
+			stale:   map[string][]string{staleReasonMaxInFlightAge: {"a"}},
+		},
+		{
+			name: "each stale signal is reported under its own reason",
+			signals: []*app.QueueSignal{
+				{ID: "old", CreatedAt: now.Add(-time.Hour)},
+				{ID: "gone", CreatedAt: now.Add(-time.Minute), ExpiresAt: ptr(now.Add(-time.Second))},
+				{ID: "fine", CreatedAt: now.Add(-time.Minute), ExpiresAt: ptr(now.Add(time.Hour))},
+			},
+			maxAge: 30 * time.Minute,
+			live:   []string{"fine"},
+			stale: map[string][]string{
+				staleReasonMaxInFlightAge: {"old"},
+				staleReasonExpired:        {"gone"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stale, live := partitionStaleSignals(tt.signals, tt.maxAge, now)
+
+			liveIDs := make([]string, 0, len(live))
+			for _, s := range live {
+				liveIDs = append(liveIDs, s.ID)
+			}
+
+			assert.Equal(t, tt.stale, stale)
+			assert.Equal(t, tt.live, liveIDs)
+		})
+	}
+}


### PR DESCRIPTION
A cron emitter refuses to fire while it has a signal in `queued`/`in-progress`, and signal expiry is only ever enforced *inside* the handler (`handler/state.go:17` at init, and the `AliveChecker` in `handler/run.go:125`). So when a handler dies — worker OOM, terminate, continue-as-new mid-execute — its row stays in-flight forever and that emitter never fires again. The cron just silently stops.

`MaxInFlightAge` already covers this, but only four signal types declare it, and the two that don't are drift checks and cron-triggered actions — both of which set `SignalExpiresIn: 15m` and so had no external escape at all.

`EmitSignal` now treats a past-`ExpiresAt` signal as no longer holding the emitter, marking it errored the same way the max-age path does, with `stale_drop` recording which rule fired. This is a no-op when the handler is alive: it would hit the same expiry itself and set the row to error via `WithOnStopped`, releasing the emitter anyway. It only changes the case where nothing is left to do that. The decision moved into `partitionStaleSignals` so it's testable without standing up Temporal.