### PR TITLE
refactor(ui): moves org settings view to subpages

### DIFF
--- a/services/dashboard-ui/AGENTS.md
+++ b/services/dashboard-ui/AGENTS.md
@@ -565,6 +565,8 @@ import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 
 **Always use the `Icon` suffix** for variant names (e.g., `HouseIcon` not `House`). This matches the current Phosphor Icons naming convention.
 
+**NEVER use the Phosphor GitHub icon (`GithubLogoIcon`) — it is ugly.** For anything GitHub/VCS-related, ALWAYS use the custom `GitHub` icon variant (`<Icon variant="GitHub" />`), which is the one used everywhere else in the app.
+
 Browse Phosphor icons at https://phosphoricons.com. Custom icons for cloud providers and tools are also available — see the `customIcons` map in `Icon.tsx`.
 
 **Adding a new icon:** The `Icon` component uses a static map of explicitly imported Phosphor icons for tree-shaking (only used icons are bundled). If you need an icon that isn't already in the map, update `client/components/common/Icon.tsx`:

--- a/services/dashboard-ui/client/components/navigation/MainNav/MainNav.stories.tsx
+++ b/services/dashboard-ui/client/components/navigation/MainNav/MainNav.stories.tsx
@@ -15,10 +15,6 @@ export const Default = () => (
     <MainNav
       org={mockOrg}
       isSidebarOpen
-      hasServiceAccountsAndTokens
-      hasSlack
-      hasTriggers
-      hasOIDCFederation
       hasCustomerPortal={false}
       customerPortalUrl="https://customers.nuon.co"
     />
@@ -30,10 +26,6 @@ export const Collapsed = () => (
     <MainNav
       org={mockOrg}
       isSidebarOpen={false}
-      hasServiceAccountsAndTokens={false}
-      hasSlack={false}
-      hasTriggers={false}
-      hasOIDCFederation={false}
       hasCustomerPortal={false}
       customerPortalUrl="https://customers.nuon.co"
     />

--- a/services/dashboard-ui/client/components/navigation/MainNav/MainNav.tsx
+++ b/services/dashboard-ui/client/components/navigation/MainNav/MainNav.tsx
@@ -1,21 +1,12 @@
 import { Text } from '@/components/common/Text'
 import { cn } from '@/utils/classnames'
 import { MainNavLink } from '../MainNavLink'
-import {
-  MAIN_LINKS,
-  SETTINGS_LINKS,
-  SLACK_LINK,
-  SUPPORT_LINKS,
-} from '../main-nav-links'
+import { MAIN_LINKS, SETTINGS_LINKS, SUPPORT_LINKS } from '../main-nav-links'
 import type { TOrg } from '@/types'
 
 interface IMainNav {
   org: TOrg
   isSidebarOpen: boolean
-  hasServiceAccountsAndTokens: boolean
-  hasSlack: boolean
-  hasTriggers: boolean
-  hasOIDCFederation: boolean
   hasCustomerPortal: boolean
   customerPortalUrl: string
 }
@@ -53,10 +44,6 @@ const Divider = ({ isSidebarOpen }: { isSidebarOpen: boolean }) => (
 export const MainNav = ({
   org,
   isSidebarOpen,
-  hasServiceAccountsAndTokens,
-  hasSlack,
-  hasTriggers,
-  hasOIDCFederation,
   hasCustomerPortal,
   customerPortalUrl,
 }: IMainNav) => {
@@ -72,13 +59,6 @@ export const MainNav = ({
         },
       ]
     : MAIN_LINKS
-  const settingsLinks = SETTINGS_LINKS.filter(
-    (link) =>
-      (hasTriggers || link.path !== '/triggers') &&
-      (hasOIDCFederation || link.path !== '/oidc-trust-policies') &&
-      (hasServiceAccountsAndTokens ||
-        (link.path !== '/api-tokens' && link.path !== '/service-accounts'))
-  )
 
   return (
     <nav className="flex flex-col gap-4">
@@ -91,15 +71,11 @@ export const MainNav = ({
       <Divider isSidebarOpen={isSidebarOpen} />
 
       <div className="flex flex-col gap-1">
-        <NavLabel isSidebarOpen={isSidebarOpen}>Settings</NavLabel>
+        <NavLabel isSidebarOpen={isSidebarOpen}>Manage</NavLabel>
 
-        {settingsLinks.map((link) => (
+        {SETTINGS_LINKS.map((link) => (
           <MainNavLink key={link.text} basePath={basePath} {...link} />
         ))}
-
-        {hasSlack ? (
-          <MainNavLink basePath={basePath} {...SLACK_LINK} />
-        ) : null}
       </div>
 
       <Divider isSidebarOpen={isSidebarOpen} />

--- a/services/dashboard-ui/client/components/navigation/MainNav/MainNavContainer.tsx
+++ b/services/dashboard-ui/client/components/navigation/MainNav/MainNavContainer.tsx
@@ -1,13 +1,11 @@
 import { useConfig } from '@/hooks/use-config'
 import { useOrg } from '@/hooks/use-org'
-import { useCLIConfig } from '@/hooks/use-cli-config'
 import { useSidebar } from '@/hooks/use-sidebar'
 import { MainNav } from './MainNav'
 
 export const MainNavContainer = () => {
   const { org } = useOrg()
   const { datadogEnv } = useConfig()
-  const { data: cliConfig } = useCLIConfig()
   const { isSidebarOpen } = useSidebar()
 
   if (!org) return null
@@ -23,10 +21,6 @@ export const MainNavContainer = () => {
     <MainNav
       org={org}
       isSidebarOpen={isSidebarOpen}
-      hasServiceAccountsAndTokens={!!org?.features?.['service-accounts-and-tokens']}
-      hasSlack={!!org?.features?.['slack']}
-      hasTriggers={!!org?.features?.['triggers']}
-      hasOIDCFederation={!!cliConfig?.oidc_federation_enabled}
       hasCustomerPortal={false}
       customerPortalUrl={customerPortalUrl}
     />

--- a/services/dashboard-ui/client/components/navigation/main-nav-links.ts
+++ b/services/dashboard-ui/client/components/navigation/main-nav-links.ts
@@ -35,43 +35,12 @@ export const SETTINGS_LINKS: TNavLink[] = [
     shortcut: 'g r',
   },
   {
-    iconVariant: 'LightningIcon',
-    path: `/triggers`,
-    text: 'Triggers',
-    shortcut: 'g e',
-  },
-  {
-    iconVariant: 'WebhooksLogoIcon',
-    path: `/webhooks`,
-    text: 'Webhooks',
-    shortcut: 'g w',
-  },
-  {
-    iconVariant: 'KeyIcon',
-    path: `/api-tokens`,
-    text: 'API tokens',
-    shortcut: 'g k',
-  },
-  {
-    iconVariant: 'RobotIcon',
-    path: `/service-accounts`,
-    text: 'Service accounts',
-    shortcut: 'g v',
-  },
-  {
-    iconVariant: 'ShieldCheckIcon',
-    path: `/oidc-trust-policies`,
-    text: 'OIDC federation',
-    shortcut: 'g f',
+    iconVariant: 'GearIcon',
+    path: `/settings`,
+    text: 'Settings',
+    shortcut: 'g s',
   },
 ]
-
-export const SLACK_LINK: TNavLink = {
-  iconVariant: 'SlackLogoIcon',
-  path: `/slack`,
-  text: 'Slack',
-  shortcut: 'g s',
-}
 
 export const SUPPORT_LINKS: TNavLink[] = [
   {
@@ -80,9 +49,4 @@ export const SUPPORT_LINKS: TNavLink[] = [
     text: 'Developer docs',
     isExternal: true,
   },
-  // {
-  //   iconVariant: 'ListBulletsIcon',
-  //   path: `/releases`,
-  //   text: 'Releases',
-  // },
 ]

--- a/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicyContainer.tsx
+++ b/services/dashboard-ui/client/components/oidc-trust-policies/CreateOIDCTrustPolicy/CreateOIDCTrustPolicyContainer.tsx
@@ -76,7 +76,7 @@ const CreateOIDCTrustPolicyModalContainer = (props: Record<string, any>) => {
       repos={repos}
       isLoadingRepos={isLoadingRepos}
       hasVCSConnections={hasConnections}
-      vcsConnectionsHref={`/${org.id}/connections/vcs`}
+      vcsConnectionsHref={`/${org.id}/settings/vcs`}
       githubAudience={config.apiUrl ?? ''}
       {...props}
     />

--- a/services/dashboard-ui/client/components/runbooks/RunbookStepCard/RunbookStepCardContainer.tsx
+++ b/services/dashboard-ui/client/components/runbooks/RunbookStepCard/RunbookStepCardContainer.tsx
@@ -57,7 +57,7 @@ export const RunbookStepCardContainer = ({
       step={step}
       workflowUrl={workflowUrl}
       eventHref={(eventId, triggerId) =>
-        `/${orgId}/triggers/${triggerId}/events/${eventId}`
+        `/${orgId}/settings/triggers/${triggerId}/events/${eventId}`
       }
       targetData={data}
       deployOutputs={deployOutputs}

--- a/services/dashboard-ui/client/components/spotlight/types.ts
+++ b/services/dashboard-ui/client/components/spotlight/types.ts
@@ -22,7 +22,8 @@ export const STATIC_PAGES: SpotlightResult[] = [
   { label: 'Installs', path: '/installs', icon: 'CubeIcon' },
   { label: 'Team', path: '/team', icon: 'UsersThreeIcon' },
   { label: 'Build runner', path: '/runner', icon: 'HammerIcon' },
-  { label: 'Webhooks', path: '/webhooks', icon: 'WebhooksLogoIcon' },
+  { label: 'Settings', path: '/settings', icon: 'GearIcon' },
+  { label: 'Webhooks', path: '/settings/webhooks', icon: 'WebhooksLogoIcon' },
 ]
 
 export const INSTALL_SUB_PAGES = [

--- a/services/dashboard-ui/client/components/triggers/CreateTrigger/CreateTriggerContainer.tsx
+++ b/services/dashboard-ui/client/components/triggers/CreateTrigger/CreateTriggerContainer.tsx
@@ -22,7 +22,7 @@ const CreateTriggerModalContainer = (props: Omit<IModal, 'onSubmit'>) => {
       })
       removeModal(props.modalId)
       if (response?.trigger?.id)
-        navigate(`/${org?.id}/triggers/${response.trigger.id}`)
+        navigate(`/${org?.id}/settings/triggers/${response.trigger.id}`)
     },
   })
   return (

--- a/services/dashboard-ui/client/components/triggers/TriggerEvents/TriggerEvents.tsx
+++ b/services/dashboard-ui/client/components/triggers/TriggerEvents/TriggerEvents.tsx
@@ -40,7 +40,9 @@ export const TriggerEvents = ({
     onLoadMore={onLoadMore}
     onRetry={onRetry}
     orgId={orgId}
-    eventHref={(event) => `/${orgId}/triggers/${triggerId}/events/${event?.id}`}
+    eventHref={(event) =>
+      `/${orgId}/settings/triggers/${triggerId}/events/${event?.id}`
+    }
     filters={
       <div className="grid gap-3 md:grid-cols-3">
         <Input

--- a/services/dashboard-ui/client/components/triggers/TriggerRules/TriggerRules.tsx
+++ b/services/dashboard-ui/client/components/triggers/TriggerRules/TriggerRules.tsx
@@ -28,7 +28,7 @@ export const TriggerRules = ({
       accessorKey: 'name',
       cell: ({ row }) => (
         <Link
-          href={`/${orgId}/triggers/${triggerId}/rules/${row.original?.id}`}
+          href={`/${orgId}/settings/triggers/${triggerId}/rules/${row.original?.id}`}
         >
           {row.original?.name || row.original?.id || 'Unnamed rule'}
         </Link>

--- a/services/dashboard-ui/client/components/triggers/TriggersTable/TriggersTable.tsx
+++ b/services/dashboard-ui/client/components/triggers/TriggersTable/TriggersTable.tsx
@@ -31,7 +31,7 @@ export const TriggersTable = ({
         enableSorting: false,
         cell: ({ row }) => (
           <div className="flex flex-col gap-1">
-            <Link href={`/${orgId}/triggers/${row.original?.id}`}>
+            <Link href={`/${orgId}/settings/triggers/${row.original?.id}`}>
               {row.original?.name || row.original?.id || 'Unnamed trigger'}
             </Link>
             <Text variant="subtext" theme="neutral" family="mono">

--- a/services/dashboard-ui/client/components/triggers/event-ledger/EventDetails/EventDetails.tsx
+++ b/services/dashboard-ui/client/components/triggers/event-ledger/EventDetails/EventDetails.tsx
@@ -502,7 +502,7 @@ export const EventDetails = ({
               evaluation={evaluation}
               href={
                 evaluation?.rule_id && event?.trigger_id
-                  ? `/${orgId}/triggers/${event.trigger_id}/rules/${evaluation.rule_id}`
+                  ? `/${orgId}/settings/triggers/${event.trigger_id}/rules/${evaluation.rule_id}`
                   : undefined
               }
             />

--- a/services/dashboard-ui/client/components/triggers/event-ledger/EventsTable/EventsTable.tsx
+++ b/services/dashboard-ui/client/components/triggers/event-ledger/EventsTable/EventsTable.tsx
@@ -53,7 +53,7 @@ export const EventsTable = ({
             <Link
               href={
                 eventHref?.(row.original) ??
-                `/${orgId}/triggers/${row.original?.trigger_id}/events/${row.original?.id}`
+                `/${orgId}/settings/triggers/${row.original?.trigger_id}/events/${row.original?.id}`
               }
             >
               {getValue<string>()}

--- a/services/dashboard-ui/client/components/vcs-connections/VCSConnections/VCSConnectionsContainer.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/VCSConnections/VCSConnectionsContainer.tsx
@@ -20,7 +20,7 @@ const VCSConnectionWithStatus = ({
     enabled: !!org?.id && !!vcs_connection?.id,
   })
 
-  const connectionHref = `/${org?.id}/connections/vcs/${vcs_connection.id}`
+  const connectionHref = `/${org?.id}/settings/vcs/${vcs_connection.id}`
 
   return (
     <Text

--- a/services/dashboard-ui/client/components/vcs-connections/VCSConnectionsStatusIndicator/VCSConnectionsStatusIndicatorContainer.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/VCSConnectionsStatusIndicator/VCSConnectionsStatusIndicatorContainer.tsx
@@ -29,7 +29,7 @@ export const VCSConnectionsStatusIndicatorContainer = () => {
 
     return {
       id: conn.id,
-      href: `/${org.id}/connections/vcs/${conn.id}`,
+      href: `/${org.id}/settings/vcs/${conn.id}`,
       title: accountName,
       subtitle: status?.status ?? undefined,
       leftContent: (

--- a/services/dashboard-ui/client/components/vcs-connections/VCSConnectionsTable/VCSConnectionsTable.stories.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/VCSConnectionsTable/VCSConnectionsTable.stories.tsx
@@ -1,0 +1,31 @@
+export default {
+  title: 'VCSConnections/VCSConnectionsTable',
+}
+
+import { VCSConnectionsTable, type TVCSConnectionRow } from './VCSConnectionsTable'
+
+const rows: TVCSConnectionRow[] = [
+  {
+    connection: { id: 'vcs-1', github_account_name: 'powertoolsdev' },
+    href: '/org-1/settings/vcs/vcs-1',
+    status: 'active',
+    checkedAt: '2026-08-06T09:00:00Z',
+  },
+  {
+    connection: { id: 'vcs-2', github_account_name: 'nuonco-shared' },
+    href: '/org-1/settings/vcs/vcs-2',
+    status: 'suspended',
+    checkedAt: '2026-08-05T12:30:00Z',
+  },
+  {
+    connection: { id: 'vcs-3', github_account_name: 'nuonco' },
+    href: '/org-1/settings/vcs/vcs-3',
+    isLoadingStatus: true,
+  },
+]
+
+export const Default = () => <VCSConnectionsTable data={rows} />
+
+export const Loading = () => <VCSConnectionsTable data={[]} isLoading />
+
+export const Empty = () => <VCSConnectionsTable data={[]} />

--- a/services/dashboard-ui/client/components/vcs-connections/VCSConnectionsTable/VCSConnectionsTable.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/VCSConnectionsTable/VCSConnectionsTable.tsx
@@ -1,0 +1,84 @@
+import { useMemo } from 'react'
+import type { ColumnDef } from '@tanstack/react-table'
+import { Icon } from '@/components/common/Icon'
+import { Link } from '@/components/common/Link'
+import { Skeleton } from '@/components/common/Skeleton'
+import { Status } from '@/components/common/Status'
+import { Table } from '@/components/common/Table'
+import { Text } from '@/components/common/Text'
+import { Time } from '@/components/common/Time'
+import type { TVCSConnection, TVCSConnectionStatus } from '@/types'
+
+export type TVCSConnectionRow = {
+  connection: TVCSConnection
+  href: string
+  status?: TVCSConnectionStatus['status']
+  checkedAt?: string
+  isLoadingStatus?: boolean
+}
+
+const accountName = (connection: TVCSConnection) =>
+  connection.github_account_name || connection.github_account_id || 'GitHub'
+
+export const VCSConnectionsTable = ({
+  data,
+  isLoading,
+}: {
+  data: TVCSConnectionRow[]
+  isLoading?: boolean
+}) => {
+  const columns: ColumnDef<TVCSConnectionRow>[] = useMemo(
+    () => [
+      {
+        header: 'Account',
+        id: 'account',
+        accessorFn: (row) => accountName(row.connection),
+        cell: ({ row }) => (
+          <span className="flex items-center gap-2">
+            <Icon variant="GitHub" size={16} />
+            <Link href={row.original.href}>
+              {accountName(row.original.connection)}
+            </Link>
+          </span>
+        ),
+      },
+      {
+        header: 'Status',
+        id: 'status',
+        enableSorting: false,
+        cell: ({ row }) => {
+          const { status, isLoadingStatus } = row.original
+          if (isLoadingStatus) return <Skeleton height="20px" width="72px" />
+          if (!status) return <Text theme="neutral">—</Text>
+          return <Status status={status} variant="badge" />
+        },
+      },
+      {
+        header: 'Last checked',
+        id: 'checked_at',
+        enableSorting: false,
+        cell: ({ row }) =>
+          row.original.checkedAt ? (
+            <Time time={row.original.checkedAt} format="relative" />
+          ) : (
+            <Text theme="neutral">—</Text>
+          ),
+      },
+    ],
+    []
+  )
+
+  return (
+    <Table<TVCSConnectionRow>
+      columns={columns}
+      data={data}
+      isLoading={isLoading}
+      enableSearch={false}
+      emptyStateProps={{
+        emptyTitle: 'No VCS connections yet',
+        emptyMessage:
+          'Connect a GitHub account to build components from your repositories.',
+      }}
+    />
+  )
+}

--- a/services/dashboard-ui/client/components/vcs-connections/VCSConnectionsTable/VCSConnectionsTableContainer.tsx
+++ b/services/dashboard-ui/client/components/vcs-connections/VCSConnectionsTable/VCSConnectionsTableContainer.tsx
@@ -1,0 +1,32 @@
+import { useQueries } from '@tanstack/react-query'
+import { useOrg } from '@/hooks/use-org'
+import { checkVCSConnectionStatus } from '@/lib'
+import {
+  VCSConnectionsTable,
+  type TVCSConnectionRow,
+} from './VCSConnectionsTable'
+
+export const VCSConnectionsTableContainer = () => {
+  const { org } = useOrg()
+  const connections = org?.vcs_connections ?? []
+
+  const statusQueries = useQueries({
+    queries: connections.map((conn) => ({
+      queryKey: ['vcs-connection-status', org?.id, conn.id],
+      queryFn: () =>
+        checkVCSConnectionStatus({ orgId: org!.id, connectionId: conn.id! }),
+      enabled: !!org?.id && !!conn.id,
+      refetchInterval: 60_000,
+    })),
+  })
+
+  const rows: TVCSConnectionRow[] = connections.map((connection, i) => ({
+    connection,
+    href: `/${org?.id}/settings/vcs/${connection.id}`,
+    status: statusQueries[i]?.data?.status,
+    checkedAt: statusQueries[i]?.data?.checked_at,
+    isLoadingStatus: statusQueries[i]?.isLoading,
+  }))
+
+  return <VCSConnectionsTable data={rows} />
+}

--- a/services/dashboard-ui/client/components/vcs-connections/VCSConnectionsTable/index.ts
+++ b/services/dashboard-ui/client/components/vcs-connections/VCSConnectionsTable/index.ts
@@ -1,0 +1,5 @@
+export { VCSConnectionsTableContainer as VCSConnectionsTable } from './VCSConnectionsTableContainer'
+export {
+  VCSConnectionsTable as VCSConnectionsTableComponent,
+  type TVCSConnectionRow,
+} from './VCSConnectionsTable'

--- a/services/dashboard-ui/client/components/workflows/step-details/StepDetailPanel/StepDetailPanelContainer.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/StepDetailPanel/StepDetailPanelContainer.tsx
@@ -111,7 +111,7 @@ export const StepDetailPanelContainer = ({
       planOnly={planOnly}
       triggerHref={
         org?.id && step?.links?.event_wait?.trigger_id
-          ? `/${org.id}/triggers/${step.links.event_wait.trigger_id}`
+          ? `/${org.id}/settings/triggers/${step.links.event_wait.trigger_id}`
           : undefined
       }
       {...props}

--- a/services/dashboard-ui/client/hooks/use-nav-shortcuts.ts
+++ b/services/dashboard-ui/client/hooks/use-nav-shortcuts.ts
@@ -9,7 +9,8 @@ const ORG_DESTINATIONS: Record<string, string> = {
   i: '/installs',
   t: '/team',
   r: '/runner',
-  w: '/webhooks',
+  s: '/settings',
+  w: '/settings/webhooks',
 }
 
 export function useNavShortcuts() {

--- a/services/dashboard-ui/client/views/org/ApiTokens.tsx
+++ b/services/dashboard-ui/client/views/org/ApiTokens.tsx
@@ -1,6 +1,5 @@
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Text } from '@/components/common/Text'
-import { PageLayout } from '@/components/layout/PageLayout'
 import { PageContent } from '@/components/layout/PageContent'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { PageSection } from '@/components/layout/PageSection'
@@ -15,7 +14,7 @@ export const ApiTokens = () => {
   const { org } = useOrg()
 
   return (
-    <PageLayout className="pb-6">
+    <>
       <PageTitle title={`API tokens | ${org?.name}`} />
       <Breadcrumbs
         breadcrumbs={[
@@ -24,7 +23,11 @@ export const ApiTokens = () => {
             text: org?.name,
           },
           {
-            path: `/${org.id}/api-tokens`,
+            path: `/${org.id}/settings`,
+            text: 'Settings',
+          },
+          {
+            path: `/${org.id}/settings/api-tokens`,
             text: 'API tokens',
           },
         ]}
@@ -45,6 +48,6 @@ export const ApiTokens = () => {
           <ApiTokensTable shouldPoll />
         </PageSection>
       </PageContent>
-    </PageLayout>
+    </>
   )
 }

--- a/services/dashboard-ui/client/views/org/OIDCTrustPolicies.tsx
+++ b/services/dashboard-ui/client/views/org/OIDCTrustPolicies.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Text } from '@/components/common/Text'
-import { PageLayout } from '@/components/layout/PageLayout'
 import { PageContent } from '@/components/layout/PageContent'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { PageSection } from '@/components/layout/PageSection'
@@ -23,12 +22,13 @@ export const OIDCTrustPolicies = () => {
   })
 
   return (
-    <PageLayout className="pb-6">
+    <>
       <PageTitle title={`OIDC federation | ${org?.name}`} />
       <Breadcrumbs
         breadcrumbs={[
           { path: `/${org.id}`, text: org?.name },
-          { path: `/${org.id}/oidc-trust-policies`, text: 'OIDC federation' },
+          { path: `/${org.id}/settings`, text: 'Settings' },
+          { path: `/${org.id}/settings/oidc`, text: 'OIDC federation' },
         ]}
       />
       <PageHeader className="flex items-center justify-between">
@@ -55,6 +55,6 @@ export const OIDCTrustPolicies = () => {
           </div>
         </PageSection>
       </PageContent>
-    </PageLayout>
+    </>
   )
 }

--- a/services/dashboard-ui/client/views/org/ServiceAccounts.tsx
+++ b/services/dashboard-ui/client/views/org/ServiceAccounts.tsx
@@ -1,6 +1,5 @@
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Text } from '@/components/common/Text'
-import { PageLayout } from '@/components/layout/PageLayout'
 import { PageContent } from '@/components/layout/PageContent'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { PageSection } from '@/components/layout/PageSection'
@@ -16,7 +15,7 @@ export const ServiceAccounts = () => {
   const { org } = useOrg()
 
   return (
-    <PageLayout className="pb-6">
+    <>
       <PageTitle title={`Service accounts | ${org?.name}`} />
       <Breadcrumbs
         breadcrumbs={[
@@ -25,7 +24,11 @@ export const ServiceAccounts = () => {
             text: org?.name,
           },
           {
-            path: `/${org.id}/service-accounts`,
+            path: `/${org.id}/settings`,
+            text: 'Settings',
+          },
+          {
+            path: `/${org.id}/settings/service-accounts`,
             text: 'Service accounts',
           },
         ]}
@@ -49,6 +52,6 @@ export const ServiceAccounts = () => {
           <ServiceAccountsTable shouldPoll />
         </PageSection>
       </PageContent>
-    </PageLayout>
+    </>
   )
 }

--- a/services/dashboard-ui/client/views/org/Slack.tsx
+++ b/services/dashboard-ui/client/views/org/Slack.tsx
@@ -3,7 +3,6 @@ import { useSearchParams } from 'react-router'
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
-import { PageLayout } from '@/components/layout/PageLayout'
 import { PageContent } from '@/components/layout/PageContent'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { PageSection } from '@/components/layout/PageSection'
@@ -42,12 +41,13 @@ export const Slack = () => {
   }, [search, setSearch, addToast])
 
   return (
-    <PageLayout className="pb-6">
+    <>
       <PageTitle title={`Slack | ${org?.name}`} />
       <Breadcrumbs
         breadcrumbs={[
           { path: `/${org.id}`, text: org?.name },
-          { path: `/${org.id}/slack`, text: 'Slack' },
+          { path: `/${org.id}/settings`, text: 'Settings' },
+          { path: `/${org.id}/settings/slack`, text: 'Slack' },
         ]}
       />
       <PageHeader className="flex items-center justify-between">
@@ -109,6 +109,6 @@ export const Slack = () => {
           </div>
         </PageSection>
       </PageContent>
-    </PageLayout>
+    </>
   )
 }

--- a/services/dashboard-ui/client/views/org/TriggerLayout.tsx
+++ b/services/dashboard-ui/client/views/org/TriggerLayout.tsx
@@ -7,7 +7,6 @@ import { Status } from '@/components/common/Status'
 import { Text } from '@/components/common/Text'
 import { PageContent } from '@/components/layout/PageContent'
 import { PageHeader } from '@/components/layout/PageHeader'
-import { PageLayout } from '@/components/layout/PageLayout'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
 import { PageTitle } from '@/components/navigation/PageTitle'
@@ -23,14 +22,15 @@ export const TriggerLayout = () => {
     enabled: !!org?.id && !!triggerId,
   })
   const trigger = query.data
-  const base = `/${org?.id}/triggers/${triggerId}`
+  const base = `/${org?.id}/settings/triggers/${triggerId}`
   return (
-    <PageLayout>
+    <>
       <PageTitle title={`${trigger?.name || 'Trigger'} | ${org?.name}`} />
       <Breadcrumbs
         breadcrumbs={[
           { path: `/${org?.id}`, text: org?.name },
-          { path: `/${org?.id}/triggers`, text: 'Triggers' },
+          { path: `/${org?.id}/settings`, text: 'Settings' },
+          { path: `/${org?.id}/settings/triggers`, text: 'Triggers' },
           { path: base, text: trigger?.name || triggerId },
         ]}
       />
@@ -78,6 +78,6 @@ export const TriggerLayout = () => {
           )}
         </PageSection>
       </PageContent>
-    </PageLayout>
+    </>
   )
 }

--- a/services/dashboard-ui/client/views/org/VCSConnectionDetail.tsx
+++ b/services/dashboard-ui/client/views/org/VCSConnectionDetail.tsx
@@ -7,7 +7,6 @@ import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
 import { PageContent } from '@/components/layout/PageContent'
 import { PageHeader } from '@/components/layout/PageHeader'
-import { PageLayout } from '@/components/layout/PageLayout'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
 import { PageTitle } from '@/components/navigation/PageTitle'
@@ -43,13 +42,15 @@ export const VCSConnectionDetail = () => {
     'GitHub'
 
   return (
-    <PageLayout className="pb-6">
+    <>
       <PageTitle title={`${accountName} connection | ${org?.name}`} />
       <Breadcrumbs
         breadcrumbs={[
           { path: `/${org?.id}`, text: org?.name },
+          { path: `/${org?.id}/settings`, text: 'Settings' },
+          { path: `/${org?.id}/settings/vcs`, text: 'VCS connections' },
           {
-            path: `/${org?.id}/connections/vcs/${connectionId}`,
+            path: `/${org?.id}/settings/vcs/${connectionId}`,
             text: `${accountName} connection`,
           },
         ]}
@@ -90,7 +91,7 @@ export const VCSConnectionDetail = () => {
           {vcs_connection && (
             <RemoveConnectionButton
               vcs_connection={vcs_connection}
-              onRemoveSuccess={() => navigate(`/${org?.id}`)}
+              onRemoveSuccess={() => navigate(`/${org?.id}/settings/vcs`)}
             />
           )}
         </div>
@@ -102,6 +103,6 @@ export const VCSConnectionDetail = () => {
           )}
         </PageSection>
       </PageContent>
-    </PageLayout>
+    </>
   )
 }

--- a/services/dashboard-ui/client/views/org/Webhooks.tsx
+++ b/services/dashboard-ui/client/views/org/Webhooks.tsx
@@ -1,7 +1,6 @@
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
-import { PageLayout } from '@/components/layout/PageLayout'
 import { PageContent } from '@/components/layout/PageContent'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { PageSection } from '@/components/layout/PageSection'
@@ -19,12 +18,13 @@ export const Webhooks = () => {
   const { org } = useOrg()
 
   return (
-    <PageLayout className="pb-6">
+    <>
       <PageTitle title={`Webhooks | ${org?.name}`} />
       <Breadcrumbs
         breadcrumbs={[
           { path: `/${org.id}`, text: org?.name },
-          { path: `/${org.id}/webhooks`, text: 'Webhooks' },
+          { path: `/${org.id}/settings`, text: 'Settings' },
+          { path: `/${org.id}/settings/webhooks`, text: 'Webhooks' },
         ]}
       />
       <PageHeader className="flex items-center justify-between">
@@ -78,6 +78,6 @@ export const Webhooks = () => {
           <PayloadFieldReference />
         </PageSection>
       </PageContent>
-    </PageLayout>
+    </>
   )
 }

--- a/services/dashboard-ui/client/views/org/routes.tsx
+++ b/services/dashboard-ui/client/views/org/routes.tsx
@@ -21,6 +21,8 @@ import { TriggerRules } from './trigger-tabs/TriggerRules'
 import { TriggerEvents } from './trigger-tabs/TriggerEvents'
 import { TriggerRule } from './TriggerRule'
 import { TriggerEvent } from './TriggerEvent'
+import { SettingsLayout } from '@/views/settings/SettingsLayout'
+import { VCSConnections } from '@/views/settings/VCSConnections'
 import { NotFound } from '@/views/NotFound'
 import { appRoutes } from '@/views/app/routes'
 import { installRoutes } from '@/views/install/routes'
@@ -58,49 +60,97 @@ export const orgRoutes: RouteObject[] = [
         element: <ProcessSystemLogs />,
       },
       { path: ':orgId/team', element: <Team /> },
-      { path: ':orgId/api-tokens', element: <ApiTokens /> },
-      { path: ':orgId/service-accounts', element: <ServiceAccounts /> },
-      { path: ':orgId/webhooks', element: <Webhooks /> },
       {
-        element: <OIDCFederationGate />,
+        element: <SettingsLayout />,
         children: [
-          { path: ':orgId/oidc-trust-policies', element: <OIDCTrustPolicies /> },
-        ],
-      },
-      {
-        element: <TriggersGate />,
-        children: [
-          { path: ':orgId/triggers', element: <Triggers /> },
           {
-            path: ':orgId/triggers/:triggerId',
-            element: <TriggerLayout />,
+            path: ':orgId/settings',
+            loader: ({ params }) => redirect(`/${params.orgId}/settings/vcs`),
+          },
+          { path: ':orgId/settings/vcs', element: <VCSConnections /> },
+          {
+            path: ':orgId/settings/vcs/:connectionId',
+            element: <VCSConnectionDetail />,
+          },
+          { path: ':orgId/settings/webhooks', element: <Webhooks /> },
+          { path: ':orgId/settings/api-tokens', element: <ApiTokens /> },
+          {
+            path: ':orgId/settings/service-accounts',
+            element: <ServiceAccounts />,
+          },
+          {
+            element: <OIDCFederationGate />,
             children: [
-              { index: true, element: <TriggerOverview /> },
-              { path: 'rules', element: <TriggerRules /> },
-              { path: 'rules/:ruleId', element: <TriggerRule /> },
-              { path: 'events', element: <TriggerEvents /> },
-              { path: 'events/:eventId', element: <TriggerEvent /> },
+              { path: ':orgId/settings/oidc', element: <OIDCTrustPolicies /> },
             ],
           },
+          {
+            element: <TriggersGate />,
+            children: [
+              { path: ':orgId/settings/triggers', element: <Triggers /> },
+              {
+                path: ':orgId/settings/triggers/:triggerId',
+                element: <TriggerLayout />,
+                children: [
+                  { index: true, element: <TriggerOverview /> },
+                  { path: 'rules', element: <TriggerRules /> },
+                  { path: 'rules/:ruleId', element: <TriggerRule /> },
+                  { path: 'events', element: <TriggerEvents /> },
+                  { path: 'events/:eventId', element: <TriggerEvent /> },
+                ],
+              },
+            ],
+          },
+          { path: ':orgId/settings/slack', element: <Slack /> },
         ],
       },
-      { path: ':orgId/slack', element: <Slack /> },
+      {
+        path: ':orgId/webhooks',
+        loader: ({ params }) => redirect(`/${params.orgId}/settings/webhooks`),
+      },
+      {
+        path: ':orgId/api-tokens',
+        loader: ({ params }) => redirect(`/${params.orgId}/settings/api-tokens`),
+      },
+      {
+        path: ':orgId/service-accounts',
+        loader: ({ params }) =>
+          redirect(`/${params.orgId}/settings/service-accounts`),
+      },
+      {
+        path: ':orgId/oidc-trust-policies',
+        loader: ({ params }) => redirect(`/${params.orgId}/settings/oidc`),
+      },
+      {
+        path: ':orgId/triggers',
+        loader: ({ params }) => redirect(`/${params.orgId}/settings/triggers`),
+      },
+      {
+        path: ':orgId/triggers/:triggerId/*',
+        loader: ({ params }) =>
+          redirect(`/${params.orgId}/settings/triggers/${params.triggerId}`),
+      },
+      {
+        path: ':orgId/slack',
+        loader: ({ params }) => redirect(`/${params.orgId}/settings/slack`),
+      },
       {
         path: ':orgId/connections',
-        loader: ({ params }) => redirect(`/${params.orgId}`),
+        loader: ({ params }) => redirect(`/${params.orgId}/settings/vcs`),
       },
       {
         path: ':orgId/connections/vcs',
-        loader: ({ params }) => redirect(`/${params.orgId}`),
+        loader: ({ params }) => redirect(`/${params.orgId}/settings/vcs`),
       },
       {
         path: ':orgId/connections/vcs/:connectionId',
-        element: <VCSConnectionDetail />,
+        loader: ({ params }) =>
+          redirect(`/${params.orgId}/settings/vcs/${params.connectionId}`),
       },
       {
         path: ':orgId/connections/:connectionId',
         loader: ({ params }) =>
-          redirect(`/${params.orgId}/connections/vcs/${params.connectionId}`),
+          redirect(`/${params.orgId}/settings/vcs/${params.connectionId}`),
       },
       ...appRoutes,
       ...installRoutes,

--- a/services/dashboard-ui/client/views/settings/SettingsLayout.tsx
+++ b/services/dashboard-ui/client/views/settings/SettingsLayout.tsx
@@ -1,0 +1,78 @@
+import { Outlet } from 'react-router'
+import { PageLayout } from '@/components/layout/PageLayout'
+import { PageContent } from '@/components/layout/PageContent'
+import { SubNav } from '@/components/navigation/SubNav'
+import { useOrg } from '@/hooks/use-org'
+import { useCLIConfig } from '@/hooks/use-cli-config'
+import { PageSidebarProvider } from '@/providers/page-sidebar-provider'
+import type { TNavItem } from '@/types/dashboard.types'
+
+export const SettingsLayout = () => {
+  return (
+    <PageSidebarProvider>
+      <SettingsTemplate />
+    </PageSidebarProvider>
+  )
+}
+
+const SettingsTemplate = () => {
+  const { org } = useOrg()
+  const { data: cliConfig } = useCLIConfig()
+
+  if (!org) return null
+
+  const hasServiceAccountsAndTokens =
+    !!org?.features?.['service-accounts-and-tokens']
+  const hasSlack = !!org?.features?.['slack']
+  const hasTriggers = !!org?.features?.['triggers']
+  const hasOIDCFederation = !!cliConfig?.oidc_federation_enabled
+
+  const navLinks = [
+    {
+      path: `/vcs`,
+      iconVariant: 'GitHub' as const,
+      text: 'VCS connections',
+    },
+    {
+      path: `/webhooks`,
+      iconVariant: 'WebhooksLogoIcon' as const,
+      text: 'Webhooks',
+    },
+    hasSlack && {
+      path: `/slack`,
+      iconVariant: 'SlackLogoIcon' as const,
+      text: 'Slack',
+    },
+    hasTriggers && {
+      path: `/triggers`,
+      iconVariant: 'LightningIcon' as const,
+      text: 'Triggers',
+    },
+    hasServiceAccountsAndTokens && {
+      path: `/api-tokens`,
+      iconVariant: 'KeyIcon' as const,
+      text: 'API tokens',
+    },
+    hasServiceAccountsAndTokens && {
+      path: `/service-accounts`,
+      iconVariant: 'RobotIcon' as const,
+      text: 'Service accounts',
+    },
+    hasOIDCFederation && {
+      path: `/oidc`,
+      iconVariant: 'ShieldCheckIcon' as const,
+      text: 'OIDC federation',
+    },
+  ].filter(Boolean) as TNavItem[]
+
+  return (
+    <PageLayout>
+      <PageContent className="border-t" variant="row">
+        <SubNav basePath={`/${org?.id}/settings`} links={navLinks} />
+        <div className="flex flex-col flex-1 min-w-0">
+          <Outlet />
+        </div>
+      </PageContent>
+    </PageLayout>
+  )
+}

--- a/services/dashboard-ui/client/views/settings/VCSConnections.tsx
+++ b/services/dashboard-ui/client/views/settings/VCSConnections.tsx
@@ -1,4 +1,3 @@
-import { CreateTriggerButton, TriggersTable } from '@/components/triggers'
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Text } from '@/components/common/Text'
 import { PageContent } from '@/components/layout/PageContent'
@@ -6,33 +5,38 @@ import { PageHeader } from '@/components/layout/PageHeader'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
 import { PageTitle } from '@/components/navigation/PageTitle'
+import { ConnectGithubButton } from '@/components/vcs-connections/ConnectGithub'
+import { VCSConnectionsTable } from '@/components/vcs-connections/VCSConnectionsTable'
 import { useOrg } from '@/hooks/use-org'
-export const Triggers = () => {
+
+export const VCSConnections = () => {
   const { org } = useOrg()
+
   return (
     <>
-      <PageTitle title={`Triggers | ${org?.name}`} />
+      <PageTitle title={`VCS connections | ${org?.name}`} />
       <Breadcrumbs
         breadcrumbs={[
           { path: `/${org?.id}`, text: org?.name },
           { path: `/${org?.id}/settings`, text: 'Settings' },
-          { path: `/${org?.id}/settings/triggers`, text: 'Triggers' },
+          { path: `/${org?.id}/settings/vcs`, text: 'VCS connections' },
         ]}
       />
-      <PageHeader className="flex items-center justify-between gap-4">
+      <PageHeader className="flex items-center justify-between">
         <HeadingGroup>
           <Text variant="h3" weight="stronger" level={1}>
-            Triggers
+            VCS connections
           </Text>
           <Text theme="neutral">
-            Configure inbound providers and inspect their trigger activity.
+            Connect GitHub accounts so Nuon can build components from your
+            repositories.
           </Text>
         </HeadingGroup>
-        <CreateTriggerButton />
+        <ConnectGithubButton>Add connection</ConnectGithubButton>
       </PageHeader>
       <PageContent>
         <PageSection>
-          <TriggersTable />
+          <VCSConnectionsTable />
         </PageSection>
       </PageContent>
     </>


### PR DESCRIPTION
Moves most of the org setting pages from the top level route to a /:org-id/settings route