### PR TITLE
feat: containerized actions

### DIFF
--- a/bins/runner/cmd/cli.go
+++ b/bins/runner/cmd/cli.go
@@ -21,7 +21,12 @@ import (
 	"github.com/nuonco/nuon/pkg/runner/settings"
 )
 
-type cli struct{}
+type cli struct {
+	// extraProviders are appended to the install-mode providers. Used by
+	// run-local (dev) to also register the image-actions loop in-process so
+	// image-backed actions can be exercised without a separate mng process.
+	extraProviders []fx.Option
+}
 
 func (c *cli) commonProviders() []fx.Option {
 	// providers for both runner modes: mng and (org |install)

--- a/bins/runner/cmd/install.go
+++ b/bins/runner/cmd/install.go
@@ -52,6 +52,10 @@ func (c *cli) runInstall(cmd *cobra.Command, _ []string) {
 	providers = append(providers, actions.GetJobs()...)
 	providers = append(providers, audit.Module, telemetryexport.Module)
 
+	// dev-only: run-local appends the image-actions loop so image-backed
+	// actions can be exercised locally without a separate mng process.
+	providers = append(providers, c.extraProviders...)
+
 	// heartbeat, registry, job loop execution
 	providers = append(
 		providers,

--- a/bins/runner/cmd/mng.go
+++ b/bins/runner/cmd/mng.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/nuonco/nuon/bins/runner/internal/jobs/actions"
 	"github.com/nuonco/nuon/bins/runner/internal/jobs/management"
 	fetchtoken "github.com/nuonco/nuon/bins/runner/internal/jobs/management/fetch_token"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/audit"
@@ -47,6 +48,9 @@ func (c *cli) runMng(cmd *cobra.Command, _ []string) {
 	providers := []fx.Option{fx.Provide(log.NewSystem)}
 	providers = append(c.commonProviders(), providers...)
 	providers = append(providers, management.GetJobs()...)
+	// image-backed actions run on the mng host (which has docker); registering
+	// this loop only here is what gates image-backed actions to VM runners.
+	providers = append(providers, actions.GetImageActionJobs()...)
 	providers = append(providers, fx.Provide(shutdownbeacon.New))
 	providers = append(providers, audit.Module)
 	// add mng and heartbeater to the mng process

--- a/bins/runner/cmd/run_local.go
+++ b/bins/runner/cmd/run_local.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/nuonco/nuon/bins/runner/internal/jobs/actions"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/dev"
 )
 
@@ -69,6 +70,9 @@ func (c *cli) runLocalRun(cmd *cobra.Command, args []string) {
 	case "org", "build":
 		c.runBuild(cmd, nil)
 	case "install":
+		// register the image-actions loop in-process so image-backed actions
+		// can be exercised locally (they normally run only in the mng process).
+		c.extraProviders = actions.GetImageActionJobs()
 		c.runInstall(cmd, nil)
 	default:
 		log.Fatalf("we know naught of this arg: %s", arg)

--- a/bins/runner/internal/jobs/actions/image_actions.go
+++ b/bins/runner/internal/jobs/actions/image_actions.go
@@ -1,0 +1,93 @@
+package actions
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+
+	workflow "github.com/nuonco/nuon/bins/runner/internal/jobs/actions/workflow"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/jobloop"
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/launcher"
+	"github.com/nuonco/nuon/pkg/runner/jobs"
+	"github.com/nuonco/nuon/pkg/runner/workspace"
+	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
+)
+
+const (
+	imageActionsJobGroup models.AppRunnerJobGroup = models.AppRunnerJobGroupImageDashActions
+
+	// imageCollectionTimeout bounds a collection pass so a slow docker daemon
+	// can't keep the job loop from claiming its next action.
+	imageCollectionTimeout = 2 * time.Minute
+)
+
+type ImageActionJobLoopParams struct {
+	jobloop.BaseParams
+
+	Handlers   []jobs.JobHandler `group:"image-actions"`
+	ImageCache *launcher.ImageCache
+}
+
+func NewImageActionJobLoop(params ImageActionJobLoopParams) jobloop.JobLoop {
+	return jobloop.New(params.Handlers, imageActionsJobGroup, params.BaseParams,
+		// Action images are retained for reuse, so something has to bound them.
+		// Running collection from the idle hook is what keeps it from removing an
+		// image between a job's pull and its first container: the loop runs a
+		// single worker goroutine, so no job of its own can be in flight here.
+		// Leases are what make that safe against other processes.
+		//
+		// Time-boxed because this goroutine is not claiming work while it runs.
+		jobloop.WithIdleHook(func(ctx context.Context) {
+			ctx, cancel := context.WithTimeout(ctx, imageCollectionTimeout)
+			defer cancel()
+
+			params.ImageCache.CollectGarbage(ctx, params.L)
+		}),
+	)
+}
+
+// GetImageActionJobs wires the image-actions job loop and its docker launcher.
+// It is registered ONLY by the mng process (which runs natively on the VM host
+// with docker access) — that registration is what gates image-backed actions
+// to VM runners.
+func GetImageActionJobs() []fx.Option {
+	return []fx.Option{
+		fx.Provide(launcher.NewImageCache),
+		fx.Provide(fx.Annotate(launcher.NewDockerLauncher, fx.As(new(launcher.Launcher)))),
+		fx.Provide(jobloop.AsJobLoop(NewImageActionJobLoop)),
+		fx.Provide(jobs.AsJobHandler("image-actions", workflow.New)),
+		fx.Invoke(fx.Annotate(prepareActionHost, fx.ParamTags(`name:"system"`))),
+	}
+}
+
+// prepareActionHost readies the VM host for image-backed actions. Action
+// workspaces live on the root volume rather than the host's tmpfs /tmp, so this
+// creates that root, clears anything a previous process left in it, and reports
+// a filesystem that would put action content in RAM instead of on disk.
+//
+// Everything here is best effort: the process also runs management jobs, so a
+// host that can't host action workspaces must still start.
+func prepareActionHost(l *zap.Logger) {
+	// Resolving here rather than waiting for the first job means a host that
+	// can't use the preferred root says so at startup, and it logs which root
+	// jobs will actually land in.
+	root := workspace.ResolveHostActionRoot(l)
+	l.Info("image-backed action workspaces will use", zap.String("path", root))
+
+	// Every root is swept, not just the resolved one: a previous process may
+	// have been able to write a different one.
+	for _, candidate := range workspace.HostActionRoots() {
+		removed, err := workspace.SweepStale(candidate)
+		if err != nil {
+			l.Warn("unable to sweep stale action workspaces", zap.String("path", candidate), zap.Error(err))
+		}
+		if len(removed) > 0 {
+			l.Info("removed action workspaces left by a previous process",
+				zap.String("path", candidate),
+				zap.Strings("workspaces", removed),
+			)
+		}
+	}
+}

--- a/bins/runner/internal/jobs/actions/workflow/cleanup.go
+++ b/bins/runner/internal/jobs/actions/workflow/cleanup.go
@@ -17,6 +17,11 @@ func (h *handler) Cleanup(ctx context.Context, job *models.AppRunnerJob, jobExec
 	}
 
 	l.Info("cleaning up", zap.String("job_type", "actionsworkflow"))
+
+	// Drops the job's image lease so collection can reclaim the image later. The
+	// image itself is left on the host for the next run.
+	h.releaseActionImage(jobExecution.ID)
+
 	if h.state.workspace != nil {
 		return h.state.workspace.Cleanup(ctx)
 	}

--- a/bins/runner/internal/jobs/actions/workflow/env.go
+++ b/bins/runner/internal/jobs/actions/workflow/env.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -36,6 +37,58 @@ func (h *handler) getBuiltInEnv(ctx context.Context, cfg *models.AppActionWorkfl
 	} else {
 		env[hasKubeConfigEnvVar] = "false"
 	}
+
+	cloudEnv, err := h.cloudCredentialEnv(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return generics.MergeMap(env, cloudEnv), nil
+}
+
+// getContainerBuiltInEnv is the image-backed-action variant of getBuiltInEnv:
+// it maps every host path (outputs file, workspace root, kubeconfig) through
+// mapPath so the values resolve inside the container's workspace mount
+func (h *handler) getContainerBuiltInEnv(ctx context.Context, cfg *models.AppActionWorkflowStepConfig, mapPath func(string) string) (map[string]string, error) {
+	env := map[string]string{
+		outputsEnvVar: mapPath(h.outputsFP(cfg)),
+		rootEnvVar:    mapPath(h.state.workspace.Root()),
+	}
+
+	if h.state.plan.ClusterInfo != nil {
+		path := h.state.workspace.AbsPath(config.DefaultKubeConfigFilename)
+		// unlink any symlink a prior action container may have planted here
+		// before writing the kubeconfig into the shared workspace.
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return nil, errors.Wrap(err, "unable to clear existing kubeconfig path")
+		}
+		if err := config.WriteConfig(ctx, h.state.plan.ClusterInfo, path); err != nil {
+			return nil, errors.Wrap(err, "unable to write kube config")
+		}
+		// client-go writes this 0600, which a container running as a non-root
+		// user cannot read. The file holds an exec credential plugin reference
+		// rather than a token, and the workspace is already shared with the
+		// container, so widening it does not expose anything new.
+		if err := os.Chmod(path, 0o644); err != nil {
+			return nil, errors.Wrap(err, "unable to make kube config readable by the container")
+		}
+
+		env[config.DefaultKubeConfigEnvVar] = mapPath(path)
+		env[hasKubeConfigEnvVar] = "true"
+	} else {
+		env[hasKubeConfigEnvVar] = "false"
+	}
+
+	cloudEnv, err := h.cloudCredentialEnv(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return generics.MergeMap(env, cloudEnv), nil
+}
+
+func (h *handler) cloudCredentialEnv(ctx context.Context) (map[string]string, error) {
+	env := map[string]string{}
 
 	if h.state.auth.AWSAuth != nil {
 		awsEnv, err := credentials.FetchEnv(ctx, h.state.auth.AWSAuth)

--- a/bins/runner/internal/jobs/actions/workflow/exec.go
+++ b/bins/runner/internal/jobs/actions/workflow/exec.go
@@ -91,6 +91,12 @@ func (h *handler) Exec(ctx context.Context, job *models.AppRunnerJob, jobExecuti
 	execCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	if h.state.plan != nil && h.state.plan.SourceImage != "" {
+		if err := h.prepareActionImage(execCtx, l, jobExecution.ID); err != nil {
+			return errors.Wrap(err, "unable to prepare action image")
+		}
+	}
+
 	for idx, step := range h.state.run.Steps {
 		var configStepCfg *models.AppActionWorkflowStepConfig
 		if h.state.workflowCfg != nil {

--- a/bins/runner/internal/jobs/actions/workflow/exec_command.go
+++ b/bins/runner/internal/jobs/actions/workflow/exec_command.go
@@ -18,6 +18,10 @@ import (
 )
 
 func (h *handler) execCommand(ctx context.Context, l *zap.Logger, cfg *models.AppActionWorkflowStepConfig, src *plantypes.GitSource, envVars map[string]string) error {
+	if h.state.plan.SourceImage != "" {
+		return h.execCommandInContainer(ctx, l, cfg, envVars)
+	}
+
 	defaultEnvVars := map[string]string{
 		"COLUMNS": "500",
 	}

--- a/bins/runner/internal/jobs/actions/workflow/exec_env.go
+++ b/bins/runner/internal/jobs/actions/workflow/exec_env.go
@@ -15,12 +15,18 @@ import (
 func (h *handler) createExecEnv(ctx context.Context, l *zap.Logger, src *plantypes.GitSource, cfg *models.AppActionWorkflowStepConfig) error {
 	fp := h.outputsFP(cfg)
 
-	// create file for outputs
-	f, err := os.OpenFile(fp, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return errors.Wrap(err, "unable to open file")
+	// create an empty regular file for outputs, refusing to follow a symlink a
+	// prior image-backed action container may have planted at this path. An
+	// image-backed step appends to it from inside the container, which may run as
+	// a user that can't write a file owned by the runner, so that path needs the
+	// wider mode. Host steps keep the tighter one.
+	outputsPerm := os.FileMode(0o644)
+	if h.state.plan != nil && h.state.plan.SourceImage != "" {
+		outputsPerm = 0o666
 	}
-	f.Close()
+	if err := safeWriteFile(fp, nil, outputsPerm); err != nil {
+		return errors.Wrap(err, "unable to create outputs file")
+	}
 
 	if src == nil || src.URL == "" {
 		l.Warn("no connected or public vcs config configured")

--- a/bins/runner/internal/jobs/actions/workflow/exec_image.go
+++ b/bins/runner/internal/jobs/actions/workflow/exec_image.go
@@ -1,0 +1,202 @@
+package workflow
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/launcher"
+	"github.com/nuonco/nuon/pkg/actions/supervisor"
+	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/pkg/runner/op"
+	"github.com/nuonco/nuon/pkg/zapwriter"
+
+	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
+)
+
+const containerWorkspaceMount = "/nuon/work"
+
+// actionCPUShares is half docker's default weight of 1024, so an action can use
+// idle CPU but loses to the install container when the VM is saturated.
+const actionCPUShares = 512
+
+// execCommandInContainer runs an image-backed action step inside its container.
+// The workspace is bind-mounted so the supervisor writes outputs to a file the
+// runner reads back on the host after the container exits.
+func (h *handler) execCommandInContainer(ctx context.Context, l *zap.Logger, cfg *models.AppActionWorkflowStepConfig, envVars map[string]string) error {
+	if h.launcher == nil {
+		return errors.New("image-backed action received by a runner without a container launcher")
+	}
+
+	scriptHostPath, err := h.prepareInlineContentsCommand(ctx, l, cfg)
+	if err != nil {
+		return errors.Wrap(err, "unable to prepare inline command")
+	}
+
+	root := h.state.workspace.Root()
+
+	// write the supervisor shell script into the workspace (already bind-mounted)
+	supervisorHostPath, err := supervisor.Write(root)
+	if err != nil {
+		return errors.Wrap(err, "unable to write actions supervisor")
+	}
+
+	mapPath := func(hostPath string) string {
+		rel, relErr := filepath.Rel(root, hostPath)
+		if relErr != nil {
+			return hostPath
+		}
+		return filepath.Join(containerWorkspaceMount, rel)
+	}
+
+	builtInEnv, err := h.getContainerBuiltInEnv(ctx, cfg, mapPath)
+	if err != nil {
+		return errors.Wrap(err, "unable to get container env")
+	}
+
+	// same env layering as the host path, minus any inherited host environment.
+	env := map[string]string{"COLUMNS": "500"}
+	env = generics.MergeMap(env, h.state.plan.BuiltinEnvVars)
+	env = generics.MergeMap(env, builtInEnv)
+	env = generics.MergeMap(env, h.state.run.RunEnvVars)
+	env = generics.MergeMap(env, envVars)
+	env = generics.MergeMap(env, h.state.plan.OverrideEnvVars)
+
+	image, _, _, err := h.actionImageRef()
+	if err != nil {
+		return err
+	}
+
+	outL := l.With(zap.String("nuon.command_output", "true"))
+	lOut := zapwriter.New(outL, zapcore.InfoLevel, "")
+	lErr := zapwriter.New(outL, zapcore.ErrorLevel, "")
+
+	spec := launcher.RunSpec{
+		Image:         image,
+		ContainerName: fmt.Sprintf("nuon-action-%s-%d-%s", h.state.run.ID, cfg.Idx, randContainerSuffix()),
+		Mounts: []launcher.Mount{
+			{HostPath: root, ContainerPath: containerWorkspaceMount},
+		},
+		// run the supervisor via the image's own /bin/sh so it works in any
+		// base image (musl/glibc/any arch) — no mounted binary to exec.
+		Command: []string{
+			"/bin/sh", mapPath(supervisorHostPath),
+			"--script", mapPath(scriptHostPath),
+			"--workdir", containerWorkspaceMount,
+		},
+		Env: env,
+		Labels: map[string]string{
+			"nuon.install_id": h.state.plan.InstallID,
+			"nuon.run_id":     h.state.run.ID,
+		},
+		// No hard CPU quota: an action should be able to use otherwise idle VM
+		// CPU. mng and the install container get relative priority through
+		// CPUShares instead, so they win under contention without capping
+		// actions to a single core.
+		Memory:    "2g",
+		CPUShares: actionCPUShares,
+		PidsLimit: 512,
+		Stdout:    lOut,
+		Stderr:    lErr,
+	}
+
+	opCtx, end := op.Tool(ctx, "action", "image-command")
+	if err := h.launcher.Run(opCtx, spec); err != nil {
+		end(err)
+		return fmt.Errorf("unable to run action container: %w", err)
+	}
+	end(nil)
+
+	return nil
+}
+
+// prepareActionImage pulls the action's image once for the whole job and leases
+// it against host image collection. Every step then reuses that one pull, and
+// the image survives between steps instead of being re-pulled per step.
+func (h *handler) prepareActionImage(ctx context.Context, l *zap.Logger, leaseID string) error {
+	if h.launcher == nil {
+		return errors.New("image-backed action received by a runner without a container launcher")
+	}
+
+	image, username, password, err := h.actionImageRef()
+	if err != nil {
+		return err
+	}
+
+	l.Info("preparing image-backed action image", zap.String("action.image", image))
+
+	return h.launcher.Prepare(ctx, launcher.PrepareSpec{
+		Image:        image,
+		PullUsername: username,
+		PullPassword: password,
+		LeaseID:      leaseID,
+		// pull progress: INFO, untagged (not the action's command output)
+		PullLog: zapwriter.New(l, zapcore.InfoLevel, ""),
+	})
+}
+
+// releaseActionImage drops the job's lease. The image stays in the host cache so
+// the next run of the same action skips the pull.
+func (h *handler) releaseActionImage(leaseID string) {
+	if h.launcher == nil {
+		return
+	}
+	h.launcher.Release(leaseID)
+}
+
+// actionImageRef resolves the image ref and pull credentials for the launcher.
+// Production requires the digest-pinned ref that ctl-api resolved from the
+// mirror job, so a step can only ever run the exact manifest Nuon mirrored.
+// There is deliberately no mutable-tag fallback: without a digest we fail
+// rather than run whatever the tag happens to point at now. The dev-only
+// real-docker path pulls the app-authored source image directly.
+func (h *handler) actionImageRef() (image, username, password string, err error) {
+	plan := h.state.plan
+
+	if h.pullSourceImageDirectly() {
+		return plan.SourceImage, "", "", nil
+	}
+
+	if plan.ImageRegistry == nil {
+		return "", "", "", errors.New("image-backed action plan has no install image registry")
+	}
+	if plan.ImageDigestRef == "" {
+		return "", "", "", errors.New("image-backed action plan is not pinned to a mirrored image digest")
+	}
+
+	if plan.ImageRegistry.OCIAuth != nil {
+		username = plan.ImageRegistry.OCIAuth.Username
+		password = plan.ImageRegistry.OCIAuth.Password
+	}
+
+	return plan.ImageDigestRef, username, password, nil
+}
+
+// randContainerSuffix returns a short random suffix so concurrent executions of
+// the same run+step get distinct container names. Without it, two overlapping
+// attempts share a deterministic name and each attempt's docker rm -f would
+// kill the other's live container.
+func randContainerSuffix() string {
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		return "x"
+	}
+	return hex.EncodeToString(b)
+}
+
+// pullSourceImageDirectly reports whether the dev-only real-docker path is
+// active, in which case the launcher pulls the app-authored source image
+// directly (ctl-api can't know a local registry address) instead of the
+// install-registry mirror.
+func (h *handler) pullSourceImageDirectly() bool {
+	return os.Getenv("NUON_DEV_REAL_IMAGE_ACTIONS") == "true" &&
+		strings.EqualFold(os.Getenv("ENV"), "development")
+}

--- a/bins/runner/internal/jobs/actions/workflow/handler.go
+++ b/bins/runner/internal/jobs/actions/workflow/handler.go
@@ -9,14 +9,20 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/launcher"
 	"github.com/nuonco/nuon/pkg/runner/jobs"
 	"github.com/nuonco/nuon/pkg/runner/settings"
+	"github.com/nuonco/nuon/pkg/runner/workspace"
 )
 
 type handler struct {
 	v         *validator.Validate
 	apiClient nuonrunner.Client
 	settings  *settings.Settings
+
+	// launcher is only set for the image-actions handler registered by the mng
+	// process; it is nil for the in-process actions handler.
+	launcher launcher.Launcher
 
 	// state is reused between function calls, but can _not_ be reused with different jobs.
 	//
@@ -33,6 +39,7 @@ type HandlerParams struct {
 	V         *validator.Validate
 	APIClient nuonrunner.Client
 	Settings  *settings.Settings
+	Launcher  launcher.Launcher `optional:"true"`
 }
 
 func New(params HandlerParams) *handler {
@@ -40,9 +47,26 @@ func New(params HandlerParams) *handler {
 		apiClient: params.APIClient,
 		v:         params.V,
 		settings:  params.Settings,
+		launcher:  params.Launcher,
 	}
 }
 
 func (h *handler) GracefulShutdown(ctx context.Context, job *models.AppRunnerJob, l *zap.Logger) error {
 	return nil
+}
+
+// workspaceRoot returns the directory the job's workspace is created under. A
+// launcher is only wired for the image-actions handler, which mng runs natively
+// on the VM host, so that path gets the root volume instead of the host's
+// RAM-backed /tmp. The in-process handler keeps the default, which resolves
+// inside the runner container's own filesystem.
+//
+// The preferred root is not always writable (a developer machine, or an mng unit
+// whose sandboxing leaves /opt read-only), so the choice is resolved per job and
+// reported rather than silently degrading to a memory-backed directory.
+func (h *handler) workspaceRoot(l *zap.Logger) string {
+	if h.launcher == nil {
+		return workspace.DefaultTmpRootDir
+	}
+	return workspace.ResolveHostActionRoot(l)
 }

--- a/bins/runner/internal/jobs/actions/workflow/init.go
+++ b/bins/runner/internal/jobs/actions/workflow/init.go
@@ -2,8 +2,10 @@ package workflow
 
 import (
 	"context"
+	"os"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
+	"github.com/pkg/errors"
 
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	pkgctx "github.com/nuonco/nuon/pkg/runner/ctx"
@@ -24,6 +26,7 @@ func (h *handler) Initialize(ctx context.Context, job *models.AppRunnerJob, jobE
 			Path: ".",
 		}),
 		workspace.WithWorkspaceID(jobExecution.ID),
+		workspace.WithTmpRoot(h.workspaceRoot(l)),
 	)
 	if err != nil {
 		return err
@@ -32,6 +35,16 @@ func (h *handler) Initialize(ctx context.Context, job *models.AppRunnerJob, jobE
 	h.state.workspace = wkspace
 	if err := h.state.workspace.Init(ctx); err != nil {
 		return err
+	}
+
+	// An image-backed step gets this directory as its bind-mounted working dir
+	// and may run as a non-root user, so it has to be writable by any uid. The
+	// workspace is created with MkdirAll, whose mode the umask narrows, so the
+	// mode is set explicitly here rather than relying on that.
+	if h.state.plan != nil && h.state.plan.SourceImage != "" {
+		if err := os.Chmod(h.state.workspace.Root(), 0o777); err != nil {
+			return errors.Wrap(err, "unable to make action workspace writable by the container")
+		}
 	}
 
 	return nil

--- a/bins/runner/internal/jobs/actions/workflow/inline_contents.go
+++ b/bins/runner/internal/jobs/actions/workflow/inline_contents.go
@@ -3,7 +3,6 @@ package workflow
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -24,7 +23,7 @@ func (h *handler) prepareInlineContentsCommand(ctx context.Context, l *zap.Logge
 	}
 
 	fp := h.state.workspace.AbsPath(fmt.Sprintf(".inline-contents-step-%d", cfg.Idx))
-	if err := os.WriteFile(fp, []byte(contents), 0o755); err != nil {
+	if err := safeWriteFile(fp, []byte(contents), 0o755); err != nil {
 		return "", errors.Wrap(err, "unable to write inline contents")
 	}
 

--- a/bins/runner/internal/jobs/actions/workflow/outputs.go
+++ b/bins/runner/internal/jobs/actions/workflow/outputs.go
@@ -1,77 +1,26 @@
 package workflow
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
-	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 
+	"github.com/nuonco/nuon/pkg/actions/outputs"
 	"github.com/nuonco/nuon/pkg/generics"
 	pkgctx "github.com/nuonco/nuon/pkg/runner/ctx"
 )
 
-const (
-	kvDelimiter     string = "="
-	jsonObjStart    string = "{"
-	jsonArrayStart  string = "["
-	outputsFilename string = "%d.nuon-outputs.json"
-)
-
 func (h *handler) outputsFP(cfg *models.AppActionWorkflowStepConfig) string {
-	fn := fmt.Sprintf(outputsFilename, cfg.Idx)
-	return filepath.Join(h.state.workspace.Root(), fn)
-}
-
-func (h *handler) parseOutputLine(ctx context.Context, str string) (map[string]interface{}, error) {
-	l, err := pkgctx.Logger(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// look to parse the string as a json map
-	if strings.HasPrefix(str, jsonObjStart) {
-		var out map[string]interface{}
-		if err := json.Unmarshal([]byte(str), &out); err != nil {
-			return nil, errors.Wrap(err, "unable to parse as json")
-		}
-
-		return out, nil
-	}
-
-	// check to make sure it is not a json array
-	if strings.HasPrefix(str, jsonArrayStart) {
-		l.Error("outputs with top level json arrays are not yet supported")
-		return nil, errors.New("outputs with top level json arrays are not supported yet")
-	}
-
-	// check to see if it is a key value
-	pieces := strings.SplitN(str, kvDelimiter, 2)
-	if len(pieces) == 2 {
-		return map[string]interface{}{
-			pieces[0]: pieces[1],
-		}, nil
-	}
-
-	l.Error("output format not supported, must be one a json object or k=v string", zap.String("output", str))
-	return nil, errors.New("unsupported outputs format")
+	return filepath.Join(h.state.workspace.Root(), outputs.Filename(cfg.Idx))
 }
 
 func (h *handler) parseOutputs(ctx context.Context) (map[string]interface{}, error) {
-	l, err := pkgctx.Logger(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	steps := make(map[string]any, 0)
-	outputs := make(map[string]interface{}, 0)
+	merged := make(map[string]interface{}, 0)
 
 	// build the list of step configs to read outputs from
 	var stepCfgs []*models.AppActionWorkflowStepConfig
@@ -90,40 +39,21 @@ func (h *handler) parseOutputs(ctx context.Context) (map[string]interface{}, err
 	}
 
 	if len(stepCfgs) == 0 {
-		return outputs, nil
+		return merged, nil
 	}
 
 	for _, stepCfg := range stepCfgs {
-		fh, err := os.Open(h.outputsFP(stepCfg))
+		stepOutputs, err := outputs.ParseFile(h.outputsFP(stepCfg))
 		if err != nil {
-			l.Error("error opening outputs file", zap.Error(err))
-			return nil, errors.Wrap(err, "unable to get outputs file")
-		}
-		defer fh.Close()
-
-		stepOutputs := make(map[string]interface{}, 0)
-
-		scanner := bufio.NewScanner(fh)
-		for scanner.Scan() {
-			line := scanner.Text()
-			lineOutputs, err := h.parseOutputLine(ctx, line)
-			if err != nil {
-				l.Error("error parsing outputs line", zap.Error(err))
-				return nil, errors.Wrap(err, "error parsing outputs")
-			}
-
-			stepOutputs = generics.MergeMap(stepOutputs, lineOutputs)
-		}
-		if err := scanner.Err(); err != nil {
-			return nil, errors.Wrap(err, "unable to scan outputs file")
+			return nil, errors.Wrapf(err, "unable to parse outputs for step %s", stepCfg.Name)
 		}
 
-		outputs = generics.MergeMap(outputs, stepOutputs)
+		merged = generics.MergeMap(merged, stepOutputs)
 		steps[stepCfg.Name] = stepOutputs
 	}
 
-	outputs["steps"] = steps
-	return outputs, nil
+	merged["steps"] = steps
+	return merged, nil
 }
 
 func (h *handler) Outputs(ctx context.Context) (map[string]interface{}, error) {

--- a/bins/runner/internal/jobs/actions/workflow/safewrite.go
+++ b/bins/runner/internal/jobs/actions/workflow/safewrite.go
@@ -1,0 +1,38 @@
+package workflow
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+// safeWriteFile writes data to path without following a pre-existing symlink.
+// An image-backed action's container shares the workspace and could leave a
+// symlink at a predictable control-file path (a later step's script, the
+// supervisor, the outputs file); os.WriteFile would follow it and write
+// through to a host target. Steps run sequentially, so the prior container has
+// exited before we write here: unlink any existing entry, then create the file
+// exclusively so a planted symlink cannot be followed.
+func safeWriteFile(path string, data []byte, perm os.FileMode) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, "unable to clear existing path")
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, perm)
+	if err != nil {
+		return errors.Wrap(err, "unable to create file")
+	}
+	defer f.Close()
+
+	// OpenFile's mode is masked by the process umask, which would quietly drop
+	// the group/other bits a container running as a non-root user needs.
+	if err := f.Chmod(perm); err != nil {
+		return errors.Wrap(err, "unable to set file mode")
+	}
+
+	if _, err := f.Write(data); err != nil {
+		return errors.Wrap(err, "unable to write file")
+	}
+	return nil
+}

--- a/bins/runner/internal/pkg/jobloop/jobloop.go
+++ b/bins/runner/internal/pkg/jobloop/jobloop.go
@@ -68,11 +68,29 @@ type jobLoop struct {
 	coalescersMu sync.Mutex
 	coalescers   map[string]*statusCoalescer
 
+	// idleFn is optional maintenance work that must not overlap a job. The
+	// worker is a single goroutine, so calling it from the no-work branch is
+	// what guarantees nothing this loop owns is in flight.
+	idleFn   func(context.Context)
+	lastIdle time.Time
+
 	// for healthcheck
 	healthcheck Healthcheck
 }
 
-func New(handlers []jobs.JobHandler, jobGroup models.AppRunnerJobGroup, params BaseParams) *jobLoop {
+// Option configures a job loop beyond its handlers and group.
+type Option func(*jobLoop)
+
+// WithIdleHook registers work to run when a poll finds no jobs, rate-limited to
+// idleHookInterval. The image-actions loop uses it to collect cached action
+// images only while it isn't running one.
+func WithIdleHook(fn func(context.Context)) Option {
+	return func(j *jobLoop) {
+		j.idleFn = fn
+	}
+}
+
+func New(handlers []jobs.JobHandler, jobGroup models.AppRunnerJobGroup, params BaseParams, opts ...Option) *jobLoop {
 	pollCtx, pollCancel := context.WithCancel(context.Background())
 	jobCtx, jobCancel := context.WithCancel(context.Background())
 
@@ -103,6 +121,10 @@ func New(handlers []jobs.JobHandler, jobGroup models.AppRunnerJobGroup, params B
 		drainer:    params.Drainer,
 		jobDoneCh:  jobDoneCh,
 		coalescers: make(map[string]*statusCoalescer),
+	}
+
+	for _, opt := range opts {
+		opt(jl)
 	}
 
 	params.LC.Append(jl.LifecycleHook())

--- a/bins/runner/internal/pkg/jobloop/sandbox.go
+++ b/bins/runner/internal/pkg/jobloop/sandbox.go
@@ -1,6 +1,9 @@
 package jobloop
 
 import (
+	"os"
+	"strings"
+
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
 )
 
@@ -9,5 +12,16 @@ func (j *jobLoop) isSandbox(job *models.AppRunnerJob) bool {
 		return false
 	}
 
+	// dev-only: let image-backed actions run their real container locally so
+	// the supervisor + launcher contract can be validated without cloud.
+	if job.Group == models.AppRunnerJobGroupImageDashActions && devRealImageActions() {
+		return false
+	}
+
 	return j.settings.SandboxMode
+}
+
+func devRealImageActions() bool {
+	return os.Getenv("NUON_DEV_REAL_IMAGE_ACTIONS") == "true" &&
+		strings.EqualFold(os.Getenv("ENV"), "development")
 }

--- a/bins/runner/internal/pkg/jobloop/worker.go
+++ b/bins/runner/internal/pkg/jobloop/worker.go
@@ -25,6 +25,10 @@ const (
 	// the server's empty 200 reaches us before the client cancels.
 	tailJobPollWait    time.Duration = 25 * time.Second
 	tailJobPollTimeout time.Duration = tailJobPollWait + 5*time.Second
+
+	// idleHookInterval bounds how often a loop's idle hook runs, since an empty
+	// poll comes around every few seconds.
+	idleHookInterval time.Duration = 10 * time.Minute
 )
 
 func (j *jobLoop) runWorker() {
@@ -79,6 +83,8 @@ func (j *jobLoop) worker() error {
 		}
 
 		if len(jobs) < 1 {
+			j.runIdleHook()
+
 			if !useTail {
 				if err := smithytime.SleepWithContext(j.pollCtx, starvedJobPollBackoff); err != nil {
 					close(j.jobDoneCh)
@@ -119,6 +125,17 @@ func (j *jobLoop) worker() error {
 			return nil
 		}
 	}
+}
+
+// runIdleHook runs the loop's optional idle work between jobs. Polls come every
+// few seconds, so it is rate-limited to idleHookInterval.
+func (j *jobLoop) runIdleHook() {
+	if j.idleFn == nil || time.Since(j.lastIdle) < idleHookInterval {
+		return
+	}
+
+	j.lastIdle = time.Now()
+	j.idleFn(j.pollCtx)
 }
 
 // fetchAvailableJobs branches between the long-poll tail endpoint and the

--- a/bins/runner/internal/pkg/launcher/docker.go
+++ b/bins/runner/internal/pkg/launcher/docker.go
@@ -1,0 +1,258 @@
+package launcher
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/pkg/errors"
+)
+
+// DockerLauncher runs action containers via the host docker CLI. It mirrors the
+// mechanism mng already uses to launch the install container (shelling docker),
+// rather than adding a docker Go SDK dependency.
+type DockerLauncher struct {
+	dockerPath string
+	cache      *ImageCache
+}
+
+var _ Launcher = (*DockerLauncher)(nil)
+
+func NewDockerLauncher(cache *ImageCache) *DockerLauncher {
+	path := "docker"
+	if p, err := exec.LookPath("docker"); err == nil {
+		path = p
+	}
+	return &DockerLauncher{dockerPath: path, cache: cache}
+}
+
+// Prepare pulls the image once for the whole job and leases it, so every step
+// reuses that pull and collection can't remove the image between two steps.
+func (d *DockerLauncher) Prepare(ctx context.Context, spec PrepareSpec) error {
+	unlock, err := d.cache.Lock(ctx)
+	if err != nil {
+		return errors.Wrap(err, "unable to lock action image cache")
+	}
+	defer unlock()
+
+	// Lease before pulling so the image is protected for the whole window, not
+	// just from the moment the pull finishes.
+	if err := d.cache.Lease(spec.LeaseID, spec.Image); err != nil {
+		return errors.Wrap(err, "unable to lease action image")
+	}
+
+	// Pull credentials, when present, are written to a throwaway DOCKER_CONFIG
+	// so they never touch argv or the shared docker login state.
+	var dockerConfigDir string
+	if spec.PullUsername != "" || spec.PullPassword != "" {
+		dockerConfigDir, err = writeDockerConfig(spec.Image, spec.PullUsername, spec.PullPassword)
+		if err != nil {
+			return errors.Wrap(err, "unable to write docker auth config")
+		}
+		defer os.RemoveAll(dockerConfigDir)
+	}
+
+	if err := d.pull(ctx, spec, dockerConfigDir); err != nil {
+		return errors.Wrap(err, "unable to pull action image")
+	}
+
+	return d.cache.Record(spec.Image)
+}
+
+func (d *DockerLauncher) Release(leaseID string) {
+	d.cache.Unlease(leaseID)
+}
+
+func (d *DockerLauncher) Run(ctx context.Context, spec RunSpec) error {
+	// Prepare already pulled and leased the image, and nothing here removes it:
+	// the ref is content-addressed and shared by every run of the same image, so
+	// image lifetime belongs to the host-level cache, not to a single step.
+	// --rm covers the normal container teardown; the defer covers the rest.
+	defer d.remove(context.WithoutCancel(ctx), spec.ContainerName)
+
+	return d.run(ctx, spec)
+}
+
+func (d *DockerLauncher) pull(ctx context.Context, spec PrepareSpec, dockerConfigDir string) error {
+	args := []string{"pull", spec.Image}
+	cmd := exec.CommandContext(ctx, d.dockerPath, args...)
+	cmd.Env = dockerEnv(dockerConfigDir, nil)
+
+	// Pull progress goes to the dedicated pull log (INFO), not the action's
+	// stdout/stderr — docker writes it to stderr but it isn't an error.
+	cmd.Stdout = spec.PullLog
+	cmd.Stderr = spec.PullLog
+	return cmd.Run()
+}
+
+func (d *DockerLauncher) run(ctx context.Context, spec RunSpec) error {
+	args := []string{
+		"run", "--rm",
+		"--name", spec.ContainerName,
+		// Isolation: default bridge network (outbound only, so kubectl/cloud
+		// APIs still work) — never --network host. No added privileges.
+		"--security-opt", "no-new-privileges",
+	}
+
+	if spec.Memory != "" {
+		args = append(args, "--memory", spec.Memory)
+	}
+	if spec.CPUShares > 0 {
+		args = append(args, "--cpu-shares", fmt.Sprintf("%d", spec.CPUShares))
+	}
+	if spec.PidsLimit > 0 {
+		args = append(args, "--pids-limit", fmt.Sprintf("%d", spec.PidsLimit))
+	}
+
+	for _, m := range spec.Mounts {
+		vol := fmt.Sprintf("%s:%s", m.HostPath, m.ContainerPath)
+		if m.ReadOnly {
+			vol += ":ro"
+		}
+		args = append(args, "--volume", vol)
+	}
+
+	// Valueless "--env KEY" flags with the values supplied through the docker
+	// CLI's own environment: keeps secrets out of argv (ps, /proc/pid/cmdline)
+	// like an --env-file did, without silently dropping multiline values such as
+	// PEM keys that --env-file cannot express.
+	envArgs, envVars, err := containerEnvArgs(spec.Env)
+	if err != nil {
+		return errors.Wrap(err, "unable to build container environment")
+	}
+	args = append(args, envArgs...)
+	for k, v := range spec.Labels {
+		args = append(args, "--label", fmt.Sprintf("%s=%s", k, v))
+	}
+
+	if len(spec.Command) > 0 {
+		args = append(args, "--entrypoint", spec.Command[0])
+	}
+
+	args = append(args, spec.Image)
+
+	if len(spec.Command) > 1 {
+		args = append(args, spec.Command[1:]...)
+	}
+
+	cmd := exec.CommandContext(ctx, d.dockerPath, args...)
+	// No DOCKER_CONFIG: the image is already local, so running it needs no
+	// registry auth and the credentials never reach this step.
+	cmd.Env = dockerEnv("", envVars)
+	cmd.Stdout = spec.Stdout
+	cmd.Stderr = spec.Stderr
+	return cmd.Run()
+}
+
+func (d *DockerLauncher) remove(ctx context.Context, name string) {
+	if name == "" {
+		return
+	}
+	cmd := exec.CommandContext(ctx, d.dockerPath, "rm", "-f", name)
+	_ = cmd.Run()
+}
+
+// dockerEnv returns the environment for the docker CLI process: the host env so
+// it can find the daemon, then the container's env vars (which docker forwards
+// for each valueless "--env KEY"), then DOCKER_CONFIG last. os/exec keeps the
+// last duplicate of a name, so container values beat the host env while the
+// CLI's own auth settings still beat the container.
+func dockerEnv(dockerConfigDir string, containerEnv []string) []string {
+	env := os.Environ()
+	env = append(env, containerEnv...)
+	if dockerConfigDir != "" {
+		env = append(env, fmt.Sprintf("DOCKER_CONFIG=%s", dockerConfigDir))
+	}
+	return env
+}
+
+// containerEnvArgs converts the container env into valueless "--env KEY" docker
+// flags plus the matching KEY=VALUE entries for the docker CLI's environment.
+// Names are validated rather than silently corrupting the invocation, and
+// values may contain newlines. Sorted so the invocation is deterministic.
+func containerEnvArgs(env map[string]string) (args []string, vars []string, err error) {
+	names := make([]string, 0, len(env))
+	for name := range env {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if err := validateEnvName(name); err != nil {
+			return nil, nil, err
+		}
+		value := env[name]
+		if strings.ContainsRune(value, 0) {
+			return nil, nil, errors.Errorf("value for environment variable %q contains a NUL byte", name)
+		}
+
+		args = append(args, "--env", name)
+		vars = append(vars, name+"="+value)
+	}
+
+	return args, vars, nil
+}
+
+// validateEnvName rejects names that can't survive the trip through the docker
+// CLI's environment, and DOCKER_* names that would let action config redirect
+// the CLI itself (its daemon, auth, or API version).
+func validateEnvName(name string) error {
+	if name == "" {
+		return errors.New("environment variable name is empty")
+	}
+	for _, r := range name {
+		if r == '=' || r == 0 || unicode.IsSpace(r) {
+			return errors.Errorf("environment variable name %q contains an unsupported character", name)
+		}
+	}
+	if strings.HasPrefix(name, "DOCKER_") {
+		return errors.Errorf("environment variable name %q is reserved for the runner's container runtime", name)
+	}
+	return nil
+}
+
+func writeDockerConfig(image, username, password string) (string, error) {
+	registry := registryHost(image)
+	auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+
+	cfg := map[string]any{
+		"auths": map[string]any{
+			registry: map[string]string{"auth": auth},
+		},
+	}
+
+	dir, err := os.MkdirTemp("", "nuon-action-docker-cfg-")
+	if err != nil {
+		return "", err
+	}
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		os.RemoveAll(dir)
+		return "", err
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0o600); err != nil {
+		os.RemoveAll(dir)
+		return "", err
+	}
+
+	return dir, nil
+}
+
+// registryHost extracts the registry host from an image ref for the docker
+// config auths key (everything before the first "/" when it looks like a host).
+func registryHost(image string) string {
+	parts := strings.SplitN(image, "/", 2)
+	if len(parts) == 2 && (strings.ContainsAny(parts[0], ".:") || parts[0] == "localhost") {
+		return parts[0]
+	}
+	return "https://index.docker.io/v1/"
+}

--- a/bins/runner/internal/pkg/launcher/docker_test.go
+++ b/bins/runner/internal/pkg/launcher/docker_test.go
@@ -1,0 +1,110 @@
+package launcher
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestContainerEnvArgs(t *testing.T) {
+	t.Run("passes names on argv and values via env", func(t *testing.T) {
+		args, vars, err := containerEnvArgs(map[string]string{
+			"AWS_SESSION_TOKEN": "super-secret",
+			"COLUMNS":           "500",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		want := []string{"--env", "AWS_SESSION_TOKEN", "--env", "COLUMNS"}
+		if !slices.Equal(args, want) {
+			t.Fatalf("expected %v, got %v", want, args)
+		}
+
+		// the secret must never reach argv, only the process env
+		for _, a := range args {
+			if strings.Contains(a, "super-secret") {
+				t.Fatalf("secret value leaked into argv: %v", args)
+			}
+		}
+		if !slices.Contains(vars, "AWS_SESSION_TOKEN=super-secret") {
+			t.Fatalf("expected token in env vars, got %v", vars)
+		}
+	})
+
+	t.Run("multiline value survives", func(t *testing.T) {
+		pem := "-----BEGIN PRIVATE KEY-----\nabc\ndef\n-----END PRIVATE KEY-----"
+		_, vars, err := containerEnvArgs(map[string]string{"TLS_KEY": pem})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !slices.Contains(vars, "TLS_KEY="+pem) {
+			t.Fatalf("expected multiline value preserved, got %v", vars)
+		}
+	})
+
+	t.Run("empty env", func(t *testing.T) {
+		args, vars, err := containerEnvArgs(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(args) != 0 || len(vars) != 0 {
+			t.Fatalf("expected no args or vars, got %v / %v", args, vars)
+		}
+	})
+
+	t.Run("empty value is still passed", func(t *testing.T) {
+		_, vars, err := containerEnvArgs(map[string]string{"EMPTY": ""})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !slices.Contains(vars, "EMPTY=") {
+			t.Fatalf("expected EMPTY= in env vars, got %v", vars)
+		}
+	})
+
+	t.Run("rejects bad names and values", func(t *testing.T) {
+		for name, env := range map[string]map[string]string{
+			"empty name":      {"": "v"},
+			"equals in name":  {"A=B": "v"},
+			"newline in name": {"A\nB": "v"},
+			"space in name":   {"A B": "v"},
+			"tab in name":     {"A\tB": "v"},
+			"nul in name":     {"A\x00B": "v"},
+			"docker override": {"DOCKER_HOST": "tcp://evil:2375"},
+			"nul in value":    {"A": "v\x00w"},
+		} {
+			if _, _, err := containerEnvArgs(env); err == nil {
+				t.Fatalf("%s: expected error, got none", name)
+			}
+		}
+	})
+}
+
+func TestDockerEnvPrecedence(t *testing.T) {
+	t.Setenv("NUON_TEST_PRECEDENCE", "host-value")
+
+	env := dockerEnv("/tmp/docker-cfg", []string{
+		"NUON_TEST_PRECEDENCE=container-value",
+		"DOCKER_CONFIG=/tmp/hijacked",
+	})
+
+	// os/exec keeps the last duplicate, so container values must appear after
+	// the host env, and DOCKER_CONFIG must appear after the container env.
+	lastIndex := func(prefix string) int {
+		idx := -1
+		for i, e := range env {
+			if strings.HasPrefix(e, prefix) {
+				idx = i
+			}
+		}
+		return idx
+	}
+
+	if got := env[lastIndex("NUON_TEST_PRECEDENCE=")]; got != "NUON_TEST_PRECEDENCE=container-value" {
+		t.Fatalf("expected container value to win over host env, got %q", got)
+	}
+	if got := env[lastIndex("DOCKER_CONFIG=")]; got != "DOCKER_CONFIG=/tmp/docker-cfg" {
+		t.Fatalf("expected runner DOCKER_CONFIG to win over container env, got %q", got)
+	}
+}

--- a/bins/runner/internal/pkg/launcher/imagecache.go
+++ b/bins/runner/internal/pkg/launcher/imagecache.go
@@ -1,0 +1,374 @@
+package launcher
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+// ImageCache tracks the action images this host has pulled and reclaims them
+// when the volume runs low. Action images are content-addressed and shared by
+// every run of the same image, so they are deliberately NOT deleted after a run
+// — deleting one would re-pull on the next step and could drop an image another
+// job is about to start. Collection instead runs while the action job loop is
+// idle, and never touches an image a job still holds a lease on.
+//
+// Host layout under root:
+//
+//	lock         held while pulling or collecting, so the two can never overlap
+//	leases/<id>  one file per in-flight job execution, holding the image ref
+//	images/<key> one record per pulled image, holding the ref; mtime is last use
+type ImageCache struct {
+	root string
+
+	// docker and free are fields so tests can drive collection without a docker
+	// daemon or a full disk.
+	docker func(ctx context.Context, args ...string) ([]byte, error)
+	free   func(path string) (uint64, error)
+
+	spaceDirOnce sync.Once
+	spaceDir     string
+}
+
+const (
+	defaultImageCacheRoot = "/opt/nuon/action-images"
+
+	// minFreeBytes is the free-space floor on the cache volume. Collection runs
+	// below it and stops as soon as the volume is back above it, so there is
+	// always room for another multi-GiB pull and its extraction.
+	minFreeBytes uint64 = 8 << 30
+
+	// maxImageIdle retires images nothing has used in a week even when the
+	// volume has room, so a long-lived runner doesn't hold images for actions
+	// that were since reconfigured or deleted.
+	maxImageIdle = 7 * 24 * time.Hour
+
+	// maxLeaseAge bounds a lease so a process that died mid-job cannot pin an
+	// image forever. It is far above any action timeout.
+	maxLeaseAge = 24 * time.Hour
+
+	// lockWait bounds how long a caller waits for the cache lock before giving
+	// up. Collection retries on its next idle pass; a pull fails the step with a
+	// clear error rather than hanging past its timeout.
+	lockWait          = 30 * time.Second
+	lockRetryInterval = 250 * time.Millisecond
+)
+
+func NewImageCache() *ImageCache {
+	dockerPath := "docker"
+	if p, err := exec.LookPath("docker"); err == nil {
+		dockerPath = p
+	}
+
+	// run-local wires this loop on a developer machine, where /opt isn't
+	// writable. The cache only has to be a stable path the process can write.
+	root := defaultImageCacheRoot
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		root = filepath.Join(os.TempDir(), "nuon-action-images")
+	}
+
+	return &ImageCache{
+		root: root,
+		docker: func(ctx context.Context, args ...string) ([]byte, error) {
+			return exec.CommandContext(ctx, dockerPath, args...).CombinedOutput()
+		},
+		free: freeBytes,
+	}
+}
+
+// Lock serializes image pulls against collection. The returned func releases it.
+//
+// The wait is a bounded poll rather than a blocking LOCK_EX: flock cannot
+// observe context cancellation, so a holder stuck mid-pull would otherwise
+// wedge whichever caller is waiting. On the collection side that caller is the
+// job loop's own goroutine, which would stop claiming work with nothing to
+// detect it.
+func (c *ImageCache) Lock(ctx context.Context) (func(), error) {
+	if err := os.MkdirAll(c.root, 0o755); err != nil {
+		return nil, err
+	}
+
+	fh, err := os.OpenFile(filepath.Join(c.root, "lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, lockWait)
+	defer cancel()
+
+	for {
+		err := syscall.Flock(int(fh.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return func() {
+				syscall.Flock(int(fh.Fd()), syscall.LOCK_UN)
+				fh.Close()
+			}, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) {
+			fh.Close()
+			return nil, err
+		}
+
+		select {
+		case <-ctx.Done():
+			fh.Close()
+			return nil, errors.Wrap(ctx.Err(), "timed out waiting for the action image cache lock")
+		case <-time.After(lockRetryInterval):
+		}
+	}
+}
+
+// Lease marks an image as in use by a job execution.
+func (c *ImageCache) Lease(leaseID, image string) error {
+	if leaseID == "" || image == "" {
+		return errors.New("image lease requires both a lease id and an image")
+	}
+	if err := os.MkdirAll(filepath.Join(c.root, "leases"), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(c.leasePath(leaseID), []byte(image), 0o600)
+}
+
+// Unlease drops a lease. The image stays on the host.
+func (c *ImageCache) Unlease(leaseID string) {
+	if leaseID == "" {
+		return
+	}
+	_ = os.Remove(c.leasePath(leaseID))
+}
+
+// Record notes that an image is present on the host and was just used.
+func (c *ImageCache) Record(image string) error {
+	if image == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Join(c.root, "images"), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(c.recordPath(image), []byte(image), 0o600)
+}
+
+// CollectGarbage removes cached action images that no job holds a lease on,
+// once the volume is below its free-space floor or an image has gone unused for
+// maxImageIdle. Callers should bound ctx: collection gives up rather than run
+// long, since the caller is the job loop goroutine that would otherwise not be
+// claiming work.
+func (c *ImageCache) CollectGarbage(ctx context.Context, l *zap.Logger) {
+	unlock, err := c.Lock(ctx)
+	if err != nil {
+		l.Warn("unable to lock action image cache for collection", zap.Error(err))
+		return
+	}
+	defer unlock()
+
+	probeDir := c.spaceProbeDir(ctx)
+
+	leased := c.leasedRefs(l)
+
+	records, err := c.records()
+	if err != nil {
+		l.Warn("unable to read action image cache records", zap.Error(err))
+		return
+	}
+	if len(records) == 0 {
+		return
+	}
+
+	freeBefore, err := c.free(probeDir)
+	if err != nil {
+		l.Warn("unable to read free space for action image cache", zap.Error(err))
+		return
+	}
+	needSpace := freeBefore < minFreeBytes
+
+	var removed, retained int
+	for _, rec := range records {
+		if ctx.Err() != nil {
+			l.Info("stopping action image collection early",
+				zap.Error(ctx.Err()),
+				zap.Int("removed", removed),
+			)
+			break
+		}
+
+		if leased[rec.image] {
+			retained++
+			continue
+		}
+
+		expired := time.Since(rec.usedAt) > maxImageIdle
+		if !expired && !needSpace {
+			retained++
+			continue
+		}
+
+		out, rmErr := c.docker(ctx, "image", "rm", rec.image)
+		// No -f: docker refuses while a container still references the image,
+		// which is exactly the outcome we want.
+		if rmErr != nil && !strings.Contains(string(out), "No such image") {
+			retained++
+			l.Info("retained action image",
+				zap.String("action.image", rec.image),
+				zap.String("docker.output", strings.TrimSpace(string(out))),
+			)
+			continue
+		}
+
+		_ = os.Remove(rec.path)
+		removed++
+		l.Info("removed cached action image",
+			zap.String("action.image", rec.image),
+			zap.Time("last_used_at", rec.usedAt),
+		)
+
+		if needSpace {
+			if free, err := c.free(probeDir); err == nil && free >= minFreeBytes {
+				needSpace = false
+			}
+		}
+	}
+
+	freeAfter, err := c.free(probeDir)
+	if err != nil {
+		freeAfter = freeBefore
+	}
+
+	l.Info("collected action image cache",
+		zap.Int("considered", len(records)),
+		zap.Int("removed", removed),
+		zap.Int("retained", retained),
+		zap.Int("leased", len(leased)),
+		zap.Uint64("bytes_reclaimed", freeAfter-min(freeAfter, freeBefore)),
+		zap.Uint64("free_bytes", freeAfter),
+	)
+}
+
+// spaceProbeDir returns the directory whose volume free space is measured
+// against. Image layers live under docker's data root, which is the same volume
+// as the cache on a default VM runner but not on one with a separate docker
+// volume, where measuring the cache would read the wrong disk.
+func (c *ImageCache) spaceProbeDir(ctx context.Context) string {
+	c.spaceDirOnce.Do(func() {
+		c.spaceDir = c.root
+
+		out, err := c.docker(ctx, "info", "-f", "{{.DockerRootDir}}")
+		if err != nil {
+			return
+		}
+		if dir := strings.TrimSpace(string(out)); dir != "" {
+			c.spaceDir = dir
+		}
+	})
+
+	return c.spaceDir
+}
+
+type imageRecord struct {
+	image  string
+	path   string
+	usedAt time.Time
+}
+
+// records returns the tracked images, least recently used first, so collection
+// reclaims the coldest images before the ones a job is most likely to want.
+func (c *ImageCache) records() ([]imageRecord, error) {
+	entries, err := os.ReadDir(filepath.Join(c.root, "images"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	recs := make([]imageRecord, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(c.root, "images", entry.Name())
+		image, err := os.ReadFile(path)
+		if err != nil || len(image) == 0 {
+			_ = os.Remove(path)
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		recs = append(recs, imageRecord{
+			image:  strings.TrimSpace(string(image)),
+			path:   path,
+			usedAt: info.ModTime(),
+		})
+	}
+
+	sort.Slice(recs, func(i, j int) bool { return recs[i].usedAt.Before(recs[j].usedAt) })
+
+	return recs, nil
+}
+
+// leasedRefs returns the images in-flight jobs are using, reaping leases left
+// behind by a process that died mid-job.
+func (c *ImageCache) leasedRefs(l *zap.Logger) map[string]bool {
+	entries, err := os.ReadDir(filepath.Join(c.root, "leases"))
+	if err != nil {
+		return map[string]bool{}
+	}
+
+	leased := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		path := filepath.Join(c.root, "leases", entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if time.Since(info.ModTime()) > maxLeaseAge {
+			l.Warn("reaping stale action image lease",
+				zap.String("lease.id", entry.Name()),
+				zap.Time("created_at", info.ModTime()),
+			)
+			_ = os.Remove(path)
+			continue
+		}
+		image, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		leased[strings.TrimSpace(string(image))] = true
+	}
+
+	return leased
+}
+
+func (c *ImageCache) leasePath(leaseID string) string {
+	return filepath.Join(c.root, "leases", cacheKey(leaseID))
+}
+
+func (c *ImageCache) recordPath(image string) string {
+	return filepath.Join(c.root, "images", cacheKey(image))
+}
+
+// cacheKey hashes a ref or ID so it is safe to use as a filename.
+func cacheKey(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:16])
+}
+
+func freeBytes(path string) (uint64, error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(path, &st); err != nil {
+		return 0, err
+	}
+	return uint64(st.Bsize) * st.Bavail, nil
+}

--- a/bins/runner/internal/pkg/launcher/imagecache_test.go
+++ b/bins/runner/internal/pkg/launcher/imagecache_test.go
@@ -1,0 +1,306 @@
+package launcher
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// newTestCache returns a cache rooted in a temp dir, with docker calls recorded
+// instead of executed and a fixed amount of free space.
+func newTestCache(t *testing.T, freeSpace uint64) (*ImageCache, *[]string) {
+	t.Helper()
+
+	var removed []string
+	c := &ImageCache{
+		root: t.TempDir(),
+		docker: func(_ context.Context, args ...string) ([]byte, error) {
+			if len(args) > 0 && args[0] == "info" {
+				return nil, nil
+			}
+			removed = append(removed, strings.Join(args, " "))
+			return nil, nil
+		},
+		free: func(string) (uint64, error) { return freeSpace, nil },
+	}
+
+	return c, &removed
+}
+
+// age backdates an image record so it looks least-recently-used.
+func age(t *testing.T, c *ImageCache, image string, d time.Duration) {
+	t.Helper()
+
+	when := time.Now().Add(-d)
+	if err := os.Chtimes(c.recordPath(image), when, when); err != nil {
+		t.Fatalf("unable to backdate record: %v", err)
+	}
+}
+
+func TestCollectGarbage(t *testing.T) {
+	l := zap.NewNop()
+	plentyOfSpace := minFreeBytes * 2
+
+	t.Run("retains recent images when the volume has room", func(t *testing.T) {
+		c, removed := newTestCache(t, plentyOfSpace)
+		if err := c.Record("repo@sha256:aaa"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		c.CollectGarbage(context.Background(), l)
+
+		if len(*removed) != 0 {
+			t.Fatalf("expected no removals, got %v", *removed)
+		}
+		if _, err := os.Stat(c.recordPath("repo@sha256:aaa")); err != nil {
+			t.Fatalf("expected record to survive: %v", err)
+		}
+	})
+
+	t.Run("removes images under disk pressure", func(t *testing.T) {
+		c, removed := newTestCache(t, minFreeBytes/2)
+		if err := c.Record("repo@sha256:aaa"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		c.CollectGarbage(context.Background(), l)
+
+		if len(*removed) != 1 || !strings.Contains((*removed)[0], "repo@sha256:aaa") {
+			t.Fatalf("expected the image to be removed, got %v", *removed)
+		}
+		// no -f, so docker refuses while a container still uses the image
+		if strings.Contains((*removed)[0], "-f") {
+			t.Fatalf("removal must not force: %v", (*removed)[0])
+		}
+		if _, err := os.Stat(c.recordPath("repo@sha256:aaa")); !os.IsNotExist(err) {
+			t.Fatalf("expected record to be pruned, got %v", err)
+		}
+	})
+
+	t.Run("never removes a leased image", func(t *testing.T) {
+		c, removed := newTestCache(t, minFreeBytes/2)
+		if err := c.Record("repo@sha256:leased"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := c.Lease("exec-1", "repo@sha256:leased"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		c.CollectGarbage(context.Background(), l)
+
+		if len(*removed) != 0 {
+			t.Fatalf("expected leased image to be retained, got %v", *removed)
+		}
+	})
+
+	t.Run("collects a leased image once released", func(t *testing.T) {
+		c, removed := newTestCache(t, minFreeBytes/2)
+		if err := c.Record("repo@sha256:aaa"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := c.Lease("exec-1", "repo@sha256:aaa"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		c.Unlease("exec-1")
+
+		c.CollectGarbage(context.Background(), l)
+
+		if len(*removed) != 1 {
+			t.Fatalf("expected released image to be collected, got %v", *removed)
+		}
+	})
+
+	t.Run("reaps a lease left by a crashed process", func(t *testing.T) {
+		c, removed := newTestCache(t, minFreeBytes/2)
+		if err := c.Record("repo@sha256:aaa"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := c.Lease("exec-crashed", "repo@sha256:aaa"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		when := time.Now().Add(-2 * maxLeaseAge)
+		if err := os.Chtimes(c.leasePath("exec-crashed"), when, when); err != nil {
+			t.Fatalf("unable to backdate lease: %v", err)
+		}
+
+		c.CollectGarbage(context.Background(), l)
+
+		if len(*removed) != 1 {
+			t.Fatalf("expected stale lease to stop pinning the image, got %v", *removed)
+		}
+		if _, err := os.Stat(c.leasePath("exec-crashed")); !os.IsNotExist(err) {
+			t.Fatalf("expected stale lease to be reaped, got %v", err)
+		}
+	})
+
+	t.Run("retires idle images even with free space", func(t *testing.T) {
+		c, removed := newTestCache(t, plentyOfSpace)
+		if err := c.Record("repo@sha256:cold"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		age(t, c, "repo@sha256:cold", 2*maxImageIdle)
+
+		c.CollectGarbage(context.Background(), l)
+
+		if len(*removed) != 1 || !strings.Contains((*removed)[0], "repo@sha256:cold") {
+			t.Fatalf("expected the idle image to be retired, got %v", *removed)
+		}
+	})
+
+	t.Run("stops once back above the free-space floor", func(t *testing.T) {
+		free := minFreeBytes / 2
+		var removed []string
+		c := &ImageCache{
+			root: t.TempDir(),
+			docker: func(_ context.Context, args ...string) ([]byte, error) {
+				if len(args) > 0 && args[0] == "info" {
+					return nil, nil
+				}
+				removed = append(removed, strings.Join(args, " "))
+				// the first removal frees enough to clear the floor
+				free = minFreeBytes * 2
+				return nil, nil
+			},
+			free: func(string) (uint64, error) { return free, nil },
+		}
+
+		for _, image := range []string{"repo@sha256:oldest", "repo@sha256:newer"} {
+			if err := c.Record(image); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		}
+		age(t, c, "repo@sha256:oldest", time.Hour)
+
+		c.CollectGarbage(context.Background(), l)
+
+		if len(removed) != 1 {
+			t.Fatalf("expected collection to stop after one removal, got %v", removed)
+		}
+		// least-recently-used goes first
+		if !strings.Contains(removed[0], "repo@sha256:oldest") {
+			t.Fatalf("expected the coldest image to go first, got %v", removed[0])
+		}
+	})
+
+	t.Run("keeps the record when docker refuses", func(t *testing.T) {
+		c := &ImageCache{
+			root: t.TempDir(),
+			docker: func(_ context.Context, _ ...string) ([]byte, error) {
+				return []byte("image is being used by running container abc"), os.ErrPermission
+			},
+			free: func(string) (uint64, error) { return minFreeBytes / 2, nil },
+		}
+		if err := c.Record("repo@sha256:inuse"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		c.CollectGarbage(context.Background(), l)
+
+		if _, err := os.Stat(c.recordPath("repo@sha256:inuse")); err != nil {
+			t.Fatalf("expected record to be kept so the image stays tracked: %v", err)
+		}
+	})
+
+	t.Run("prunes the record when the image is already gone", func(t *testing.T) {
+		c := &ImageCache{
+			root: t.TempDir(),
+			docker: func(_ context.Context, _ ...string) ([]byte, error) {
+				return []byte("Error response from daemon: No such image: repo@sha256:gone"), os.ErrNotExist
+			},
+			free: func(string) (uint64, error) { return minFreeBytes / 2, nil },
+		}
+		if err := c.Record("repo@sha256:gone"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		c.CollectGarbage(context.Background(), l)
+
+		if _, err := os.Stat(c.recordPath("repo@sha256:gone")); !os.IsNotExist(err) {
+			t.Fatalf("expected the stale record to be pruned, got %v", err)
+		}
+	})
+}
+
+func TestImageCacheLease(t *testing.T) {
+	c, _ := newTestCache(t, minFreeBytes)
+
+	if err := c.Lease("", "repo@sha256:aaa"); err == nil {
+		t.Fatal("expected an error for an empty lease id")
+	}
+	if err := c.Lease("exec-1", ""); err == nil {
+		t.Fatal("expected an error for an empty image")
+	}
+
+	// Unlease is idempotent so cleanup can call it unconditionally
+	c.Unlease("never-leased")
+	c.Unlease("")
+}
+
+func TestImageCacheLock(t *testing.T) {
+	t.Run("is reusable once released", func(t *testing.T) {
+		c, _ := newTestCache(t, minFreeBytes)
+
+		unlock, err := c.Lock(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		unlock()
+
+		unlock, err = c.Lock(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error on relock: %v", err)
+		}
+		unlock()
+	})
+
+	t.Run("gives up instead of waiting on a held lock", func(t *testing.T) {
+		c, _ := newTestCache(t, minFreeBytes)
+
+		unlock, err := c.Lock(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer unlock()
+
+		// A holder stuck mid-pull must never wedge the caller, which on the
+		// collection side is the job loop's own goroutine.
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		if _, err := c.Lock(ctx); err == nil {
+			t.Fatal("expected the second attempt to fail while the lock is held")
+		}
+		if waited := time.Since(start); waited > 5*time.Second {
+			t.Fatalf("expected a bounded wait, waited %s", waited)
+		}
+	})
+
+	t.Run("collection skips a pass it cannot lock", func(t *testing.T) {
+		c, removed := newTestCache(t, minFreeBytes/2)
+		if err := c.Record("repo@sha256:aaa"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		unlock, err := c.Lock(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer unlock()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		c.CollectGarbage(ctx, zap.NewNop())
+
+		if len(*removed) != 0 {
+			t.Fatalf("expected collection to skip the pass, got %v", *removed)
+		}
+		if _, err := os.Stat(c.recordPath("repo@sha256:aaa")); err != nil {
+			t.Fatalf("expected the record to survive a skipped pass: %v", err)
+		}
+	})
+}

--- a/bins/runner/internal/pkg/launcher/launcher.go
+++ b/bins/runner/internal/pkg/launcher/launcher.go
@@ -1,0 +1,75 @@
+// Package launcher runs an image-backed action's container. Only a docker
+// backend exists today (used by the mng process on VM runners), but the
+// Launcher interface is the seam a future Kubernetes Pod/Job backend would
+// implement.
+package launcher
+
+import (
+	"context"
+	"io"
+)
+
+// Mount is a host-path to container-path bind mount.
+type Mount struct {
+	HostPath      string
+	ContainerPath string
+	ReadOnly      bool
+}
+
+// PrepareSpec describes the image a job is about to run steps in. Prepare is
+// called once per job so the pull is shared by every step.
+type PrepareSpec struct {
+	Image        string
+	PullUsername string
+	PullPassword string
+
+	// LeaseID scopes the lease taken on the image so host garbage collection
+	// cannot remove it mid-job. Use the job execution ID.
+	LeaseID string
+
+	// PullLog receives image-pull progress (docker writes it to stderr, but it
+	// is not an error and not the action's output — keep it separate so it logs
+	// at INFO and isn't tagged as command output).
+	PullLog io.Writer
+}
+
+// RunSpec fully describes an image-backed action container invocation. Env is
+// the ONLY environment the container receives — the host/runner environment is
+// never inherited (an RFC security requirement).
+type RunSpec struct {
+	Image         string
+	ContainerName string
+
+	Mounts []Mount
+
+	// Command is the container entrypoint + args (the mounted supervisor).
+	Command []string
+
+	Env    map[string]string
+	Labels map[string]string
+
+	Memory string
+
+	// CPUShares is a relative CPU weight (docker's default is 1024), used
+	// instead of a hard quota so an action can consume idle CPU but yields to
+	// the management and install processes under contention.
+	CPUShares int
+	PidsLimit int
+
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Launcher pulls and runs an image-backed action container.
+type Launcher interface {
+	// Prepare makes the image available on the host and leases it for the job,
+	// so every step reuses one pull and garbage collection leaves it alone
+	// until Release.
+	Prepare(ctx context.Context, spec PrepareSpec) error
+
+	// Release drops the lease Prepare took. The image stays in the host cache
+	// for later runs; only garbage collection removes images.
+	Release(leaseID string)
+
+	Run(ctx context.Context, spec RunSpec) error
+}

--- a/docs/config-ref/action.mdx
+++ b/docs/config-ref/action.mdx
@@ -20,6 +20,7 @@ title: 'Action'
 | **`break_glass_role`**<br/>string | IAM role for break-glass access to this action When set, allows the action to use a break glass role for elevated permissions during critical operations. Break glass roles are defined in CloudForma... | **Optional** | `"bucket-operations-break-glass"`, `"database-migration-break-glass"` |
 | **`role`**<br/>string | IAM role name for action execution Name of the IAM role to use when executing this action. The role must be defined in the CloudFormation stack deployed to the customer's AWS account. If not specif... | **Optional** | `"{{.nuon.install.id}}-maintenance"` |
 | **`enable_kube_config`**<br/>boolean | whether to fetch and inject kubeconfig for this action When set to false, the action runner will not fetch the install's kubeconfig or set the KUBECONFIG env var. Defaults to true. Set to false for... | **Optional** | `"true"`, `"false"` |
+| **`image`**<br/>string | container image the action's steps run inside Optional container image (e.g. ghcr.io/acme/kubernetes-tools:v1) supplying the tools the action needs. When set, Nuon mirrors the image into the instal... | **Optional** | `"ghcr.io/acme/kubernetes-tools:v1"` |
 | **`kubernetes_context`**<br/>string | kubernetes context this action targets Name of a top-level kubernetes_context binding to target when this action runs. When set, the action's runner receives the cluster connection details from tha... | **Optional** | `"compute"`, `"data-cluster"` |
 
 ### `triggers`

--- a/pkg/actions/outputs/outputs.go
+++ b/pkg/actions/outputs/outputs.go
@@ -1,0 +1,110 @@
+// Package outputs implements the action-output file grammar shared by the
+// runner's action handler and the actions-supervisor. Both ends must agree on
+// how a step's outputs file is written and parsed, so the grammar lives here
+// rather than in either binary.
+package outputs
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/pkg/generics"
+)
+
+const (
+	kvDelimiter    string = "="
+	jsonObjStart   string = "{"
+	jsonArrayStart string = "["
+
+	// FilenameFormat is the per-step outputs filename, indexed by step index.
+	FilenameFormat string = "%d.nuon-outputs.json"
+
+	// MaxFileSize bounds how much of an action's outputs file the runner will
+	// read, so a step can't exhaust runner memory by emitting an enormous file.
+	MaxFileSize int64 = 1048576
+)
+
+// Filename returns the outputs filename for a given step index.
+func Filename(idx int64) string {
+	return fmt.Sprintf(FilenameFormat, idx)
+}
+
+// ParseLine parses a single outputs line. A line beginning with "{" is a JSON
+// object; a top-level JSON array is unsupported; otherwise the line is a
+// "key=value" pair.
+func ParseLine(str string) (map[string]interface{}, error) {
+	if strings.HasPrefix(str, jsonObjStart) {
+		var out map[string]interface{}
+		if err := json.Unmarshal([]byte(str), &out); err != nil {
+			return nil, errors.Wrap(err, "unable to parse as json")
+		}
+		return out, nil
+	}
+
+	if strings.HasPrefix(str, jsonArrayStart) {
+		return nil, errors.New("outputs with top level json arrays are not supported yet")
+	}
+
+	pieces := strings.SplitN(str, kvDelimiter, 2)
+	if len(pieces) == 2 {
+		return map[string]interface{}{
+			pieces[0]: pieces[1],
+		}, nil
+	}
+
+	return nil, errors.New("unsupported outputs format, must be a json object or k=v string")
+}
+
+// ParseFile reads an outputs file and merges every line into a single map. A
+// missing file is treated as empty output. An image-backed action shares this
+// workspace, so the path is attacker-controlled: O_NOFOLLOW stops a symlink
+// redirecting the read at host state, O_NONBLOCK stops a FIFO hanging the
+// runner on open, and the fstat rejects anything but a regular file.
+func ParseFile(path string) (map[string]interface{}, error) {
+	out := make(map[string]interface{}, 0)
+
+	fh, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return out, nil
+		}
+		return nil, errors.Wrap(err, "unable to open outputs file")
+	}
+	defer fh.Close()
+
+	info, err := fh.Stat()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to stat outputs file")
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("outputs file is not a regular file")
+	}
+	if info.Size() > MaxFileSize {
+		return nil, errors.Errorf("outputs file is %d bytes, which exceeds the %d byte limit", info.Size(), MaxFileSize)
+	}
+
+	scanner := bufio.NewScanner(fh)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		lineOutputs, err := ParseLine(line)
+		if err != nil {
+			return nil, errors.Wrap(err, "error parsing outputs")
+		}
+		out = generics.MergeMap(out, lineOutputs)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, errors.Wrap(err, "unable to scan outputs file")
+	}
+
+	return out, nil
+}

--- a/pkg/actions/outputs/outputs_test.go
+++ b/pkg/actions/outputs/outputs_test.go
@@ -1,0 +1,145 @@
+package outputs
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestParseLine(t *testing.T) {
+	t.Run("key value", func(t *testing.T) {
+		out, err := ParseLine("pod_count=3")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out["pod_count"] != "3" {
+			t.Fatalf("expected pod_count=3, got %v", out["pod_count"])
+		}
+	})
+
+	t.Run("json object", func(t *testing.T) {
+		out, err := ParseLine(`{"pod_count": 3, "region": "us-west-2"}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out["region"] != "us-west-2" {
+			t.Fatalf("expected region us-west-2, got %v", out["region"])
+		}
+	})
+
+	t.Run("json array rejected", func(t *testing.T) {
+		if _, err := ParseLine(`["a", "b"]`); err == nil {
+			t.Fatal("expected error for top-level json array")
+		}
+	})
+
+	t.Run("unsupported", func(t *testing.T) {
+		if _, err := ParseLine("not-a-pair"); err == nil {
+			t.Fatal("expected error for unsupported format")
+		}
+	})
+}
+
+func TestParseFile(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("missing file is empty", func(t *testing.T) {
+		out, err := ParseFile(filepath.Join(dir, "does-not-exist.json"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(out) != 0 {
+			t.Fatalf("expected empty map, got %v", out)
+		}
+	})
+
+	t.Run("merges lines", func(t *testing.T) {
+		path := filepath.Join(dir, Filename(0))
+		contents := "pod_count=3\n\n{\"region\": \"us-west-2\"}\n"
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		out, err := ParseFile(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out["pod_count"] != "3" {
+			t.Fatalf("expected pod_count=3, got %v", out["pod_count"])
+		}
+		if out["region"] != "us-west-2" {
+			t.Fatalf("expected region us-west-2, got %v", out["region"])
+		}
+	})
+
+	t.Run("symlink rejected", func(t *testing.T) {
+		target := filepath.Join(dir, "symlink-target")
+		if err := os.WriteFile(target, []byte("leaked=secret\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		link := filepath.Join(dir, "outputs-symlink.json")
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := ParseFile(link); err == nil {
+			t.Fatal("expected error for symlinked outputs file")
+		}
+	})
+
+	t.Run("directory rejected", func(t *testing.T) {
+		path := filepath.Join(dir, "outputs-dir")
+		if err := os.Mkdir(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := ParseFile(path); err == nil {
+			t.Fatal("expected error for directory outputs path")
+		}
+	})
+
+	t.Run("fifo rejected without hanging", func(t *testing.T) {
+		path := filepath.Join(dir, "outputs-fifo")
+		if err := syscall.Mkfifo(path, 0o644); err != nil {
+			t.Skipf("unable to create fifo: %v", err)
+		}
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := ParseFile(path)
+			errCh <- err
+		}()
+
+		select {
+		case err := <-errCh:
+			if err == nil {
+				t.Fatal("expected error for fifo outputs file")
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("ParseFile blocked on a fifo instead of rejecting it")
+		}
+	})
+
+	t.Run("oversized rejected", func(t *testing.T) {
+		path := filepath.Join(dir, "outputs-oversized.json")
+		big := make([]byte, MaxFileSize+1)
+		for i := range big {
+			big[i] = 'a'
+		}
+		if err := os.WriteFile(path, big, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := ParseFile(path); err == nil {
+			t.Fatal("expected error for oversized outputs file")
+		}
+	})
+}
+
+func TestFilename(t *testing.T) {
+	if got := Filename(2); got != "2.nuon-outputs.json" {
+		t.Fatalf("expected 2.nuon-outputs.json, got %s", got)
+	}
+}

--- a/pkg/actions/supervisor/supervisor.go
+++ b/pkg/actions/supervisor/supervisor.go
@@ -1,0 +1,53 @@
+// Package supervisor provides the actions-supervisor: a small POSIX shell
+// script Nuon mounts into an image-backed action's container and runs via the
+// image's own /bin/sh. It installs the nuon_output helper and runs the
+// rendered step script. Shipping it as a shell script (rather than a compiled
+// binary) means it runs in any base image that has a shell — which
+// image-backed actions require anyway, since the customer's inline_contents is
+// itself a shell script — with no arch/libc/static-linking concerns.
+package supervisor
+
+import (
+	_ "embed"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+//go:embed supervisor.sh
+var Script []byte
+
+const (
+	// OutputFilepathEnvVar names the file the nuon_output helper appends to.
+	OutputFilepathEnvVar = "NUON_ACTIONS_OUTPUT_FILEPATH"
+	// RootEnvVar names the workspace root inside the container.
+	RootEnvVar = "NUON_ACTIONS_ROOT"
+
+	// Filename is the supervisor script name written into the workspace.
+	Filename = ".nuon-actions-supervisor.sh"
+)
+
+// Write writes the embedded supervisor script into dir and returns its path.
+// It refuses to follow a pre-existing symlink at the destination: the script
+// lands in the shared workspace, where a prior image-backed action container
+// could have planted one to redirect the write to a host file.
+func Write(dir string) (string, error) {
+	path := filepath.Join(dir, Filename)
+
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return "", errors.Wrap(err, "unable to clear existing supervisor path")
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, 0o755)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to create actions supervisor script")
+	}
+	defer f.Close()
+
+	if _, err := f.Write(Script); err != nil {
+		return "", errors.Wrap(err, "unable to write actions supervisor script")
+	}
+	return path, nil
+}

--- a/pkg/actions/supervisor/supervisor.sh
+++ b/pkg/actions/supervisor/supervisor.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# actions-supervisor: mounted into an image-backed action container and run via
+# the image's own /bin/sh. Installs the nuon_output helper on PATH, then runs
+# the rendered step script in workdir and propagates its exit code.
+set -u
+
+script=""
+workdir="."
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--script)
+		script="${2:-}"
+		shift 2
+		;;
+	--workdir)
+		workdir="${2:-}"
+		shift 2
+		;;
+	*)
+		shift
+		;;
+	esac
+done
+
+if [ -z "$script" ]; then
+	echo "actions-supervisor: --script is required" >&2
+	exit 1
+fi
+
+root="${NUON_ACTIONS_ROOT:-$workdir}"
+
+# The helper is supervisor-private, so it goes in the container's own filesystem
+# rather than the shared workspace: a non-root image often cannot write the bind
+# mount, and silently skipping the helper would leave nuon_output missing at the
+# point a step calls it.
+bindir="${TMPDIR:-/tmp}/nuon-actions-bin"
+if ! mkdir -p "$bindir" 2>/dev/null; then
+	echo "actions-supervisor: unable to create $bindir for the nuon_output helper" >&2
+	exit 1
+fi
+
+# nuon_output <key> <value>: append a key=value line to the outputs file, which
+# the runner reads back from the shared workspace mount after the container exits.
+if ! cat >"$bindir/nuon_output" <<'HELPER'
+#!/bin/sh
+printf '%s=%s\n' "$1" "$2" >>"$NUON_ACTIONS_OUTPUT_FILEPATH"
+HELPER
+then
+	echo "actions-supervisor: unable to install the nuon_output helper" >&2
+	exit 1
+fi
+chmod 0755 "$bindir/nuon_output"
+PATH="$bindir:$PATH"
+export PATH
+
+# ensure the step script carries a shebang so it runs under the image's shell
+case "$(head -n1 "$script" 2>/dev/null)" in
+'#!'*) ;;
+*)
+	tmp="$script.nuon-tmp"
+	{
+		printf '#!/bin/sh\n'
+		cat "$script"
+	} >"$tmp" && mv "$tmp" "$script"
+	;;
+esac
+chmod 0755 "$script" 2>/dev/null || true
+
+cd "$workdir" || {
+	echo "actions-supervisor: unable to cd to $workdir" >&2
+	exit 1
+}
+
+"$script"
+exit "$?"

--- a/pkg/actions/supervisor/supervisor_test.go
+++ b/pkg/actions/supervisor/supervisor_test.go
@@ -1,0 +1,156 @@
+package supervisor
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/nuonco/nuon/pkg/actions/outputs"
+)
+
+// runSupervisor writes the embedded script into workdir and runs it via /bin/sh,
+// mirroring how the launcher invokes it inside the container.
+func runSupervisor(t *testing.T, workdir, scriptPath, outputFile string) int {
+	t.Helper()
+
+	supPath, err := Write(workdir)
+	if err != nil {
+		t.Fatalf("write supervisor: %v", err)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "/bin/sh", supPath, "--script", scriptPath, "--workdir", workdir)
+	cmd.Env = append(os.Environ(),
+		RootEnvVar+"="+workdir,
+		OutputFilepathEnvVar+"="+outputFile,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if ok := asExit(err, &exitErr); ok {
+			return exitErr.ExitCode()
+		}
+		t.Fatalf("run supervisor: %v", err)
+	}
+	return 0
+}
+
+func asExit(err error, target **exec.ExitError) bool {
+	if e, ok := err.(*exec.ExitError); ok {
+		*target = e
+		return true
+	}
+	return false
+}
+
+func TestSupervisor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("supervisor is a POSIX shell script")
+	}
+
+	t.Run("runs script and collects nuon_output", func(t *testing.T) {
+		workdir := t.TempDir()
+		outputFile := filepath.Join(workdir, outputs.Filename(0))
+		script := filepath.Join(workdir, "step.sh")
+		if err := os.WriteFile(script, []byte("#!/bin/sh\nnuon_output hello world\necho done\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if code := runSupervisor(t, workdir, script, outputFile); code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+
+		out, err := outputs.ParseFile(outputFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out["hello"] != "world" {
+			t.Fatalf("expected hello=world, got %v", out["hello"])
+		}
+	})
+
+	t.Run("adds shebang when missing", func(t *testing.T) {
+		workdir := t.TempDir()
+		outputFile := filepath.Join(workdir, outputs.Filename(0))
+		script := filepath.Join(workdir, "no-shebang.sh")
+		if err := os.WriteFile(script, []byte("echo hi\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if code := runSupervisor(t, workdir, script, outputFile); code != 0 {
+			t.Fatalf("expected exit 0, got %d", code)
+		}
+
+		contents, _ := os.ReadFile(script)
+		if !strings.HasPrefix(string(contents), "#!") {
+			t.Fatalf("expected shebang to be added, got %q", string(contents))
+		}
+	})
+
+	t.Run("propagates non-zero exit", func(t *testing.T) {
+		workdir := t.TempDir()
+		outputFile := filepath.Join(workdir, outputs.Filename(0))
+		script := filepath.Join(workdir, "fail.sh")
+		if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 7\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if code := runSupervisor(t, workdir, script, outputFile); code != 7 {
+			t.Fatalf("expected exit 7, got %d", code)
+		}
+	})
+
+	// A non-root image can't create anything in a workspace owned by the runner,
+	// which used to leave nuon_output uninstalled and outputs silently empty.
+	//
+	// The workspace is made unwritable two ways because tests run as root in CI,
+	// where the mode alone is not enforced: a regular file sits where the old
+	// helper directory would go, so creating it fails with ENOTDIR for any uid.
+	t.Run("collects nuon_output without writing the workspace", func(t *testing.T) {
+		workdir := t.TempDir()
+		outputFile := filepath.Join(workdir, outputs.Filename(0))
+		script := filepath.Join(workdir, "step.sh")
+		if err := os.WriteFile(script, []byte("#!/bin/sh\nnuon_output hello world\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(outputFile, nil, 0o666); err != nil {
+			t.Fatal(err)
+		}
+
+		supPath, err := Write(workdir)
+		if err != nil {
+			t.Fatalf("write supervisor: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(workdir, ".nuon"), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(workdir, 0o555); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Chmod(workdir, 0o755) })
+
+		cmd := exec.CommandContext(context.Background(), "/bin/sh", supPath, "--script", script, "--workdir", workdir)
+		cmd.Env = append(os.Environ(),
+			RootEnvVar+"="+workdir,
+			OutputFilepathEnvVar+"="+outputFile,
+		)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("supervisor must not depend on writing the workspace: %v", err)
+		}
+
+		out, err := outputs.ParseFile(outputFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out["hello"] != "world" {
+			t.Fatalf("expected hello=world, got %v", out["hello"])
+		}
+	})
+}

--- a/pkg/config/action_config.go
+++ b/pkg/config/action_config.go
@@ -25,6 +25,11 @@ type ActionConfig struct {
 
 	EnableKubeConfig *bool `mapstructure:"enable_kube_config,omitempty" toml:"enable_kube_config,omitempty"`
 
+	// Image is an optional container image the action's steps run inside. When
+	// set, Nuon mounts the actions-supervisor into the image and executes each
+	// step's inline_contents there. Steps must use inline_contents.
+	Image string `mapstructure:"image,omitempty" toml:"image,omitempty" features:"template"`
+
 	// KubernetesContext is the name of a kubernetes_context this action
 	// targets. Empty means fall back to the implicit sandbox default (when
 	// the sandbox emits cluster outputs). See pkg/config/kubernetes_context.go.
@@ -83,6 +88,9 @@ func (a ActionConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Long("When set to false, the action runner will not fetch the install's kubeconfig or set the KUBECONFIG env var. Defaults to true. Set to false for actions that do not need Kubernetes access to avoid the overhead of fetching cluster credentials").
 		Example("true").
 		Example("false").
+		Field("image").Short("container image the action's steps run inside").
+		Long("Optional container image (e.g. ghcr.io/acme/kubernetes-tools:v1) supplying the tools the action needs. When set, Nuon mirrors the image into the install registry and runs each step's inline_contents inside the image via the mounted actions-supervisor. All steps must use inline_contents when an image is set. Only supported on VM-based runners").
+		Example("ghcr.io/acme/kubernetes-tools:v1").
 		Field("kubernetes_context").Short("kubernetes context this action targets").
 		Long("Name of a top-level kubernetes_context binding to target when this action runs. When set, the action's runner receives the cluster connection details from that context's source component. Empty falls back to the implicit sandbox default. Only takes effect when enable_kube_config is true").
 		Example("compute").
@@ -142,6 +150,16 @@ func (a *ActionConfig) parse() error {
 			return ErrConfig{
 				Description: fmt.Sprintf("unable to parse timeout %s", a.Timeout),
 				Err:         err,
+			}
+		}
+	}
+
+	if a.Image != "" {
+		for _, step := range a.Steps {
+			if step.InlineContents == "" {
+				return ErrConfig{
+					Description: fmt.Sprintf("action %s sets an image, so step %s must use inline_contents (command and repo steps are not supported with image-backed actions)", a.Name, step.Name),
+				}
 			}
 		}
 	}

--- a/pkg/plans/types/action_workflow_run.go
+++ b/pkg/plans/types/action_workflow_run.go
@@ -7,6 +7,7 @@ import (
 	azurecredentials "github.com/nuonco/nuon/pkg/azure/credentials"
 	gcpcredentials "github.com/nuonco/nuon/pkg/gcp/credentials"
 	"github.com/nuonco/nuon/pkg/kube"
+	"github.com/nuonco/nuon/pkg/plugins/configs"
 )
 
 type ActionWorkflowRunPlan struct {
@@ -31,6 +32,18 @@ type ActionWorkflowRunPlan struct {
 	AWSAuth     *awscredentials.Config   `json:"aws_auth,omitempty"`
 	AzureAuth   *azurecredentials.Config `json:"azure_auth,omitempty"`
 	GCPAuth     *gcpcredentials.Config   `json:"gcp_auth,omitempty"`
+
+	// Image-backed actions: SourceImage is the rendered app-authored ref
+	// (e.g. ghcr.io/acme/tools:v1); ImageRegistry/ImageTag point at the
+	// install-registry mirror the runner pulls from.
+	SourceImage   string                         `json:"source_image,omitempty"`
+	ImageRegistry *configs.OCIRegistryRepository `json:"image_registry,omitempty"`
+	ImageTag      string                         `json:"image_tag,omitempty"`
+	// ImageDigestRef is the digest-pinned pull reference resolved by the mirror
+	// job (<login_server>/<repository>@sha256:...). When set, the runner pulls
+	// this exact manifest instead of the mutable tag, binding execution to the
+	// content that was mirrored.
+	ImageDigestRef string `json:"image_digest_ref,omitempty"`
 
 	MinSandboxMode
 }

--- a/pkg/runner/workspace/cleanup_all.go
+++ b/pkg/runner/workspace/cleanup_all.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,10 +10,17 @@ import (
 // CleanupByID removes a single workspace directory by its ID.
 // This is safe to call with parallel runner jobs since it only
 // targets the specific workspace, not all workspace-prefixed dirs.
+//
+// It sweeps every root a workspace can be created under, since the caller is a
+// generic per-job backstop that doesn't know which root the handler chose. A
+// missing directory is not an error.
 func CleanupByID(workspaceID string) error {
-	dirPath := filepath.Join(defaultTmpRootDir, "workspace-"+workspaceID)
-	if err := os.RemoveAll(dirPath); err != nil {
-		return fmt.Errorf("failed to remove workspace directory %s: %w", dirPath, err)
+	var errs []error
+	for _, root := range HostActionRoots() {
+		dirPath := filepath.Join(root, "workspace-"+workspaceID)
+		if err := os.RemoveAll(dirPath); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove workspace directory %s: %w", dirPath, err))
+		}
 	}
-	return nil
+	return errors.Join(errs...)
 }

--- a/pkg/runner/workspace/sweep.go
+++ b/pkg/runner/workspace/sweep.go
@@ -1,0 +1,83 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const workspaceDirPrefix = "workspace-"
+
+// SweepStale removes workspace directories left under root by a previous
+// process, and returns the names it removed. A workspace is created per job
+// execution and removed when that execution ends, so anything present before
+// any job starts is the residue of a crash or a hard restart. Callers must only
+// run this at startup, before the job loop claims work.
+func SweepStale(root string) ([]string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var removed []string
+	var errs []error
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), workspaceDirPrefix) {
+			continue
+		}
+		path := filepath.Join(root, entry.Name())
+		if err := os.RemoveAll(path); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove stale workspace %s: %w", path, err))
+			continue
+		}
+		removed = append(removed, entry.Name())
+	}
+
+	return removed, errors.Join(errs...)
+}
+
+// FilesystemType returns the filesystem backing path, resolved from the longest
+// mount point that prefixes it. It returns an empty string where /proc/mounts
+// isn't available (a macOS dev machine), so callers treat unknown as fine.
+func FilesystemType(path string) string {
+	data, err := os.ReadFile("/proc/mounts")
+	if err != nil {
+		return ""
+	}
+
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return ""
+	}
+	abs = filepath.Clean(abs)
+
+	var bestPoint, bestType string
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		// mount points with spaces are octal-escaped in /proc/mounts
+		point := strings.ReplaceAll(fields[1], `\040`, " ")
+		if !isSubPath(point, abs) {
+			continue
+		}
+		if len(point) >= len(bestPoint) {
+			bestPoint, bestType = point, fields[2]
+		}
+	}
+
+	return bestType
+}
+
+func isSubPath(mountPoint, path string) bool {
+	if mountPoint == "/" || mountPoint == path {
+		return true
+	}
+	return strings.HasPrefix(path, strings.TrimSuffix(mountPoint, "/")+"/")
+}

--- a/pkg/runner/workspace/sweep_test.go
+++ b/pkg/runner/workspace/sweep_test.go
@@ -1,0 +1,149 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestSweepStale(t *testing.T) {
+	t.Run("removes only workspace directories", func(t *testing.T) {
+		root := t.TempDir()
+		for _, dir := range []string{"workspace-exec-1", "workspace-exec-2", "action-images", "lost+found"} {
+			if err := os.MkdirAll(filepath.Join(root, dir), 0o755); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(root, "workspace-not-a-dir"), []byte("x"), 0o600); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		removed, err := SweepStale(root)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		slices.Sort(removed)
+		want := []string{"workspace-exec-1", "workspace-exec-2"}
+		if !slices.Equal(removed, want) {
+			t.Fatalf("expected %v, got %v", want, removed)
+		}
+
+		for _, keep := range []string{"action-images", "lost+found", "workspace-not-a-dir"} {
+			if _, err := os.Stat(filepath.Join(root, keep)); err != nil {
+				t.Fatalf("expected %s to survive: %v", keep, err)
+			}
+		}
+	})
+
+	t.Run("removes nested workspace content", func(t *testing.T) {
+		root := t.TempDir()
+		nested := filepath.Join(root, "workspace-exec-1", "deep", "deeper")
+		if err := os.MkdirAll(nested, 0o755); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(nested, "outputs"), []byte("k=v"), 0o600); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if _, err := SweepStale(root); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if _, err := os.Stat(filepath.Join(root, "workspace-exec-1")); !os.IsNotExist(err) {
+			t.Fatalf("expected the workspace to be gone, got %v", err)
+		}
+	})
+
+	t.Run("a missing root is not an error", func(t *testing.T) {
+		removed, err := SweepStale(filepath.Join(t.TempDir(), "does-not-exist"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(removed) != 0 {
+			t.Fatalf("expected nothing removed, got %v", removed)
+		}
+	})
+}
+
+func TestFilesystemType(t *testing.T) {
+	// /proc/mounts only exists on linux; elsewhere an unknown type is reported
+	// so callers treat it as fine rather than warning spuriously.
+	if _, err := os.Stat("/proc/mounts"); err != nil {
+		if got := FilesystemType("/tmp"); got != "" {
+			t.Fatalf("expected an unknown filesystem without /proc/mounts, got %q", got)
+		}
+		return
+	}
+
+	if got := FilesystemType("/"); got == "" {
+		t.Fatal("expected a filesystem type for /")
+	}
+}
+
+// uncreatableDir returns a path that MkdirAll cannot create as any uid: a
+// regular file sits where a parent directory would have to be, so it fails with
+// ENOTDIR. Permission bits would not do, since tests run as root in CI and root
+// bypasses the directory permission check.
+func uncreatableDir(t *testing.T) string {
+	t.Helper()
+
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(blocker, "nested")
+}
+
+func TestResolveActionRoot(t *testing.T) {
+	l := zap.NewNop()
+
+	t.Run("prefers the first usable root", func(t *testing.T) {
+		first := filepath.Join(t.TempDir(), "preferred")
+		second := t.TempDir()
+
+		if got := resolveActionRoot(l, []string{first, second}); got != first {
+			t.Fatalf("expected %s, got %s", first, got)
+		}
+		if _, err := os.Stat(first); err != nil {
+			t.Fatalf("expected the root to be created: %v", err)
+		}
+	})
+
+	t.Run("falls through a root it cannot create", func(t *testing.T) {
+		fallback := t.TempDir()
+
+		if got := resolveActionRoot(l, []string{uncreatableDir(t), fallback}); got != fallback {
+			t.Fatalf("expected the fallback %s, got %s", fallback, got)
+		}
+	})
+
+	t.Run("falls back to the default when nothing is usable", func(t *testing.T) {
+		got := resolveActionRoot(l, []string{uncreatableDir(t), uncreatableDir(t)})
+		if got != DefaultTmpRootDir {
+			t.Fatalf("expected %s, got %s", DefaultTmpRootDir, got)
+		}
+	})
+}
+
+func TestIsSubPath(t *testing.T) {
+	for _, tc := range []struct {
+		mountPoint string
+		path       string
+		want       bool
+	}{
+		{"/", "/opt/nuon/action-workspaces", true},
+		{"/opt", "/opt/nuon/action-workspaces", true},
+		{"/opt/nuon", "/opt/nuon", true},
+		{"/opt/nuon/", "/opt/nuon/action-workspaces", true},
+		{"/optional", "/opt/nuon", false},
+		{"/var", "/opt/nuon", false},
+	} {
+		if got := isSubPath(tc.mountPoint, tc.path); got != tc.want {
+			t.Fatalf("isSubPath(%q, %q) = %v, want %v", tc.mountPoint, tc.path, got, tc.want)
+		}
+	}
+}

--- a/pkg/runner/workspace/workspace.go
+++ b/pkg/runner/workspace/workspace.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/go-playground/validator/v10"
 	"go.uber.org/zap"
@@ -15,10 +16,82 @@ const (
 	// did not work without having _some_ repo.
 	emptyGithubRepoURL string = "https://github.com/jonmorehouse/empty"
 
-	// default tmp root dir to be used when no root is passed in. This allows a user of this workspace to create
+	// DefaultTmpRootDir is the root used when no root is passed in. This allows a user of this workspace to create
 	// workspaces in a different directory
-	defaultTmpRootDir string = "/tmp"
+	DefaultTmpRootDir string = "/tmp"
+
+	// HostActionRootDir is the root the mng process uses for image-backed action
+	// workspaces. mng runs natively on the VM host, where /tmp is tmpfs sized at
+	// a fraction of RAM, so an action writing multi-GiB content there would
+	// consume memory rather than disk. This path is on the root volume.
+	HostActionRootDir string = "/opt/nuon/action-workspaces"
+
+	// HostActionFallbackRootDir is used when the process can't create
+	// HostActionRootDir, which happens when the mng unit's sandboxing leaves /opt
+	// read-only. /var/tmp is on the root volume on a default VM image, unlike
+	// /tmp, so it keeps action content on disk.
+	HostActionFallbackRootDir string = "/var/tmp/nuon-action-workspaces"
 )
+
+// HostActionRoots are the roots an image-backed action workspace can land in,
+// most preferred first. Cleanup has to sweep all of them, since which one a job
+// used depends on what the process could write at the time.
+func HostActionRoots() []string {
+	return []string{HostActionRootDir, HostActionFallbackRootDir, DefaultTmpRootDir}
+}
+
+// ResolveHostActionRoot returns the first root the process can create that is
+// not memory-backed, so a multi-GiB action writes to disk rather than RAM.
+// Landing on a memory-backed root is the failure this exists to prevent, so it
+// is reported rather than silently accepted.
+func ResolveHostActionRoot(l *zap.Logger) string {
+	return resolveActionRoot(l, HostActionRoots())
+}
+
+func resolveActionRoot(l *zap.Logger, candidates []string) string {
+	var firstUsable string
+
+	for _, root := range candidates {
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			l.Warn("skipping action workspace root",
+				zap.String("path", root),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		if firstUsable == "" {
+			firstUsable = root
+		}
+
+		if fsType := FilesystemType(root); fsType == "tmpfs" || fsType == "ramfs" {
+			l.Warn("skipping memory-backed action workspace root",
+				zap.String("path", root),
+				zap.String("filesystem", fsType),
+			)
+			continue
+		}
+
+		if root != candidates[0] {
+			l.Warn("action workspaces are not on the preferred root",
+				zap.String("path", root),
+				zap.String("preferred", candidates[0]),
+			)
+		}
+		return root
+	}
+
+	if firstUsable == "" {
+		l.Error("no usable action workspace root, falling back to the default",
+			zap.String("path", DefaultTmpRootDir))
+		return DefaultTmpRootDir
+	}
+
+	l.Error("every action workspace root is memory-backed, so action content will consume RAM instead of disk",
+		zap.String("path", firstUsable))
+
+	return firstUsable
+}
 
 type Workspace interface {
 	Init(context.Context) error
@@ -53,7 +126,7 @@ func New(v *validator.Validate, opts ...workspaceOption) (*workspace, error) {
 	obj := &workspace{
 		L:          l,
 		v:          v,
-		TmpRootDir: defaultTmpRootDir,
+		TmpRootDir: DefaultTmpRootDir,
 	}
 
 	for _, opt := range opts {

--- a/sdks/nuon-go/models/app_action_workflow_config.go
+++ b/sdks/nuon-go/models/app_action_workflow_config.go
@@ -47,6 +47,9 @@ type AppActionWorkflowConfig struct {
 	// id
 	ID string `json:"id,omitempty"`
 
+	// Image is an optional container image the action's steps run inside.
+	Image string `json:"image,omitempty"`
+
 	// KubernetesContextName is the name of an AppKubernetesContextConfig on
 	// the same AppConfig. Empty means fall back to the implicit sandbox
 	// default. Stored as a name (not an FK) so it remains stable across

--- a/sdks/nuon-go/models/app_runner_job_group.go
+++ b/sdks/nuon-go/models/app_runner_job_group.go
@@ -57,6 +57,9 @@ const (
 	// AppRunnerJobGroupActions captures enum value "actions"
 	AppRunnerJobGroupActions AppRunnerJobGroup = "actions"
 
+	// AppRunnerJobGroupImageDashActions captures enum value "image-actions"
+	AppRunnerJobGroupImageDashActions AppRunnerJobGroup = "image-actions"
+
 	// AppRunnerJobGroupEmpty captures enum value ""
 	AppRunnerJobGroupEmpty AppRunnerJobGroup = ""
 
@@ -69,7 +72,7 @@ var appRunnerJobGroupEnum []any
 
 func init() {
 	var res []AppRunnerJobGroup
-	if err := json.Unmarshal([]byte(`["health-checks","sync","build","deploy","sandbox","runner","operations","management","actions","","any"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["health-checks","sync","build","deploy","sandbox","runner","operations","management","actions","image-actions","","any"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/sdks/nuon-go/models/plantypes_action_workflow_run_plan.go
+++ b/sdks/nuon-go/models/plantypes_action_workflow_run_plan.go
@@ -41,6 +41,18 @@ type PlantypesActionWorkflowRunPlan struct {
 	// id
 	ID string `json:"id,omitempty"`
 
+	// ImageDigestRef is the digest-pinned pull reference resolved by the mirror
+	// job (<login_server>/<repository>@sha256:...). When set, the runner pulls
+	// this exact manifest instead of the mutable tag, binding execution to the
+	// content that was mirrored.
+	ImageDigestRef string `json:"image_digest_ref,omitempty"`
+
+	// image registry
+	ImageRegistry *ConfigsOCIRegistryRepository `json:"image_registry,omitempty"`
+
+	// image tag
+	ImageTag string `json:"image_tag,omitempty"`
+
 	// install id
 	InstallID string `json:"install_id,omitempty"`
 
@@ -49,6 +61,11 @@ type PlantypesActionWorkflowRunPlan struct {
 
 	// sandbox mode
 	SandboxMode *PlantypesSandboxMode `json:"sandbox_mode,omitempty"`
+
+	// Image-backed actions: SourceImage is the rendered app-authored ref
+	// (e.g. ghcr.io/acme/tools:v1); ImageRegistry/ImageTag point at the
+	// install-registry mirror the runner pulls from.
+	SourceImage string `json:"source_image,omitempty"`
 
 	// steps
 	Steps []*PlantypesActionWorkflowRunStepPlan `json:"steps"`
@@ -74,6 +91,10 @@ func (m *PlantypesActionWorkflowRunPlan) Validate(formats strfmt.Registry) error
 	}
 
 	if err := m.validateGcpAuth(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateImageRegistry(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -183,6 +204,29 @@ func (m *PlantypesActionWorkflowRunPlan) validateGcpAuth(formats strfmt.Registry
 	return nil
 }
 
+func (m *PlantypesActionWorkflowRunPlan) validateImageRegistry(formats strfmt.Registry) error {
+	if swag.IsZero(m.ImageRegistry) { // not required
+		return nil
+	}
+
+	if m.ImageRegistry != nil {
+		if err := m.ImageRegistry.Validate(formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("image_registry")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("image_registry")
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *PlantypesActionWorkflowRunPlan) validateSandboxMode(formats strfmt.Registry) error {
 	if swag.IsZero(m.SandboxMode) { // not required
 		return nil
@@ -253,6 +297,10 @@ func (m *PlantypesActionWorkflowRunPlan) ContextValidate(ctx context.Context, fo
 	}
 
 	if err := m.contextValidateGcpAuth(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateImageRegistry(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -361,6 +409,31 @@ func (m *PlantypesActionWorkflowRunPlan) contextValidateGcpAuth(ctx context.Cont
 			ce := new(errors.CompositeError)
 			if stderrors.As(err, &ce) {
 				return ce.ValidateName("gcp_auth")
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *PlantypesActionWorkflowRunPlan) contextValidateImageRegistry(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ImageRegistry != nil {
+
+		if swag.IsZero(m.ImageRegistry) { // not required
+			return nil
+		}
+
+		if err := m.ImageRegistry.ContextValidate(ctx, formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("image_registry")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("image_registry")
 			}
 
 			return err

--- a/sdks/nuon-go/models/service_create_action_workflow_config_request.go
+++ b/sdks/nuon-go/models/service_create_action_workflow_config_request.go
@@ -34,6 +34,9 @@ type ServiceCreateActionWorkflowConfigRequest struct {
 	// enable kube config
 	EnableKubeConfig *bool `json:"enable_kube_config,omitempty"`
 
+	// image
+	Image string `json:"image,omitempty"`
+
 	// kubernetes context
 	KubernetesContext string `json:"kubernetes_context,omitempty"`
 

--- a/sdks/nuon-runner-go/models/app_action_workflow_config.go
+++ b/sdks/nuon-runner-go/models/app_action_workflow_config.go
@@ -47,6 +47,9 @@ type AppActionWorkflowConfig struct {
 	// id
 	ID string `json:"id,omitempty"`
 
+	// Image is an optional container image the action's steps run inside.
+	Image string `json:"image,omitempty"`
+
 	// KubernetesContextName is the name of an AppKubernetesContextConfig on
 	// the same AppConfig. Empty means fall back to the implicit sandbox
 	// default. Stored as a name (not an FK) so it remains stable across

--- a/sdks/nuon-runner-go/models/app_runner_job_group.go
+++ b/sdks/nuon-runner-go/models/app_runner_job_group.go
@@ -57,6 +57,9 @@ const (
 	// AppRunnerJobGroupActions captures enum value "actions"
 	AppRunnerJobGroupActions AppRunnerJobGroup = "actions"
 
+	// AppRunnerJobGroupImageDashActions captures enum value "image-actions"
+	AppRunnerJobGroupImageDashActions AppRunnerJobGroup = "image-actions"
+
 	// AppRunnerJobGroupEmpty captures enum value ""
 	AppRunnerJobGroupEmpty AppRunnerJobGroup = ""
 
@@ -69,7 +72,7 @@ var appRunnerJobGroupEnum []any
 
 func init() {
 	var res []AppRunnerJobGroup
-	if err := json.Unmarshal([]byte(`["health-checks","sync","build","deploy","sandbox","runner","operations","management","actions","","any"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["health-checks","sync","build","deploy","sandbox","runner","operations","management","actions","image-actions","","any"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/sdks/nuon-runner-go/models/plantypes_action_workflow_run_plan.go
+++ b/sdks/nuon-runner-go/models/plantypes_action_workflow_run_plan.go
@@ -41,6 +41,18 @@ type PlantypesActionWorkflowRunPlan struct {
 	// id
 	ID string `json:"id,omitempty"`
 
+	// ImageDigestRef is the digest-pinned pull reference resolved by the mirror
+	// job (<login_server>/<repository>@sha256:...). When set, the runner pulls
+	// this exact manifest instead of the mutable tag, binding execution to the
+	// content that was mirrored.
+	ImageDigestRef string `json:"image_digest_ref,omitempty"`
+
+	// image registry
+	ImageRegistry *ConfigsOCIRegistryRepository `json:"image_registry,omitempty"`
+
+	// image tag
+	ImageTag string `json:"image_tag,omitempty"`
+
 	// install id
 	InstallID string `json:"install_id,omitempty"`
 
@@ -49,6 +61,11 @@ type PlantypesActionWorkflowRunPlan struct {
 
 	// sandbox mode
 	SandboxMode *PlantypesSandboxMode `json:"sandbox_mode,omitempty"`
+
+	// Image-backed actions: SourceImage is the rendered app-authored ref
+	// (e.g. ghcr.io/acme/tools:v1); ImageRegistry/ImageTag point at the
+	// install-registry mirror the runner pulls from.
+	SourceImage string `json:"source_image,omitempty"`
 
 	// steps
 	Steps []*PlantypesActionWorkflowRunStepPlan `json:"steps"`
@@ -74,6 +91,10 @@ func (m *PlantypesActionWorkflowRunPlan) Validate(formats strfmt.Registry) error
 	}
 
 	if err := m.validateGcpAuth(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateImageRegistry(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -183,6 +204,29 @@ func (m *PlantypesActionWorkflowRunPlan) validateGcpAuth(formats strfmt.Registry
 	return nil
 }
 
+func (m *PlantypesActionWorkflowRunPlan) validateImageRegistry(formats strfmt.Registry) error {
+	if swag.IsZero(m.ImageRegistry) { // not required
+		return nil
+	}
+
+	if m.ImageRegistry != nil {
+		if err := m.ImageRegistry.Validate(formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("image_registry")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("image_registry")
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *PlantypesActionWorkflowRunPlan) validateSandboxMode(formats strfmt.Registry) error {
 	if swag.IsZero(m.SandboxMode) { // not required
 		return nil
@@ -253,6 +297,10 @@ func (m *PlantypesActionWorkflowRunPlan) ContextValidate(ctx context.Context, fo
 	}
 
 	if err := m.contextValidateGcpAuth(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateImageRegistry(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -361,6 +409,31 @@ func (m *PlantypesActionWorkflowRunPlan) contextValidateGcpAuth(ctx context.Cont
 			ce := new(errors.CompositeError)
 			if stderrors.As(err, &ce) {
 				return ce.ValidateName("gcp_auth")
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *PlantypesActionWorkflowRunPlan) contextValidateImageRegistry(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.ImageRegistry != nil {
+
+		if swag.IsZero(m.ImageRegistry) { // not required
+			return nil
+		}
+
+		if err := m.ImageRegistry.ContextValidate(ctx, formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("image_registry")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("image_registry")
 			}
 
 			return err

--- a/services/ctl-api/internal/app/action_workflow_config.go
+++ b/services/ctl-api/internal/app/action_workflow_config.go
@@ -60,6 +60,9 @@ type ActionWorkflowConfig struct {
 
 	EnableKubeConfig sql.NullBool `json:"enable_kube_config" gorm:"default:true" temporaljson:"enable_kube_config"`
 
+	// Image is an optional container image the action's steps run inside.
+	Image string `json:"image,omitzero" gorm:"default:null" temporaljson:"image,omitzero,omitempty"`
+
 	// KubernetesContextName is the name of an AppKubernetesContextConfig on
 	// the same AppConfig. Empty means fall back to the implicit sandbox
 	// default. Stored as a name (not an FK) so it remains stable across

--- a/services/ctl-api/internal/app/actions/service/create_action_workflow_config.go
+++ b/services/ctl-api/internal/app/actions/service/create_action_workflow_config.go
@@ -93,6 +93,8 @@ type CreateActionWorkflowConfigRequest struct {
 	EnableKubeConfig *bool `json:"enable_kube_config" swaggertype:"boolean" extensions:"x-nullable"`
 
 	KubernetesContext string `json:"kubernetes_context,omitempty"`
+
+	Image string `json:"image,omitempty"`
 }
 
 type CreateActionWorkflowConfigTriggerRequest struct {
@@ -168,6 +170,18 @@ func (c *CreateActionWorkflowConfigRequest) Validate(v *validator.Validate) erro
 				Err: errors.New(fmt.Sprintf("component_name not supported for %s trigger", trigger.Type)),
 				Description: fmt.Sprintf("component_name only available for (%s) triggers",
 					strings.Join(generics.ToStringSlice(app.AllActionWorkflowComponentTriggerTypes), ", ")),
+			}
+		}
+	}
+
+	// image-backed actions require every step to use inline_contents
+	if c.Image != "" {
+		for _, step := range c.Steps {
+			if step.InlineContents == "" {
+				return stderr.ErrUser{
+					Err:         errors.New("image-backed actions require inline_contents on every step"),
+					Description: fmt.Sprintf("step %s must use inline_contents because the action sets an image (command and repo steps are not supported with image-backed actions)", step.Name),
+				}
 			}
 		}
 	}
@@ -271,6 +285,19 @@ func (s *service) CreateActionWorkflowConfig(ctx *gin.Context) {
 }
 
 func (s *service) createActionWorkflowConfig(ctx context.Context, parentApp *app.App, orgID string, awID string, req *CreateActionWorkflowConfigRequest) (*app.ActionWorkflowConfig, error) {
+	if req.Image != "" {
+		enabled, err := s.featuresClient.OrgHasFeature(ctx, orgID, app.OrgFeatureImageBackedActions)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to check image-backed-actions feature")
+		}
+		if !enabled {
+			return nil, stderr.ErrUser{
+				Err:         errors.New("image-backed actions are not enabled for this org"),
+				Description: "image-backed actions are not enabled for this organization; contact Nuon to enable the image-backed-actions feature",
+			}
+		}
+	}
+
 	timeout := req.Timeout
 	if timeout == 0 {
 		timeout = defaultTimeout
@@ -293,6 +320,7 @@ func (s *service) createActionWorkflowConfig(ctx context.Context, parentApp *app
 		Role:                  req.Role,
 		EnableKubeConfig:      req.EnableKubeConfig,
 		KubernetesContextName: req.KubernetesContext,
+		Image:                 req.Image,
 	})
 
 	res := s.db.WithContext(ctx).

--- a/services/ctl-api/internal/app/actions/service/create_action_workflow_config_test.go
+++ b/services/ctl-api/internal/app/actions/service/create_action_workflow_config_test.go
@@ -405,6 +405,133 @@ func (s *CreateAppActionConfigTestSuite) TestCreateActionConfigSuccess() {
 	}
 }
 
+func (s *CreateAppActionConfigTestSuite) TestCreateActionConfigImageBackedActions() {
+	testCases := []struct {
+		name          string
+		actionName    string
+		enableFeature bool
+		requestFunc   func(appConfigID string) CreateActionWorkflowConfigRequest
+		expectedCode  int
+		validateFunc  func(*app.ActionWorkflowConfig)
+	}{
+		{
+			name:          "image set with inline_contents steps and feature enabled succeeds",
+			actionName:    "image-action-enabled",
+			enableFeature: true,
+			requestFunc: func(appConfigID string) CreateActionWorkflowConfigRequest {
+				return CreateActionWorkflowConfigRequest{
+					AppConfigID: appConfigID,
+					Image:       "ghcr.io/nuonco/actions-runner:latest",
+					Triggers: []CreateActionWorkflowConfigTriggerRequest{
+						{Type: app.ActionWorkflowTriggerTypeManual},
+					},
+					Steps: []CreateActionWorkflowConfigStepRequest{
+						{Name: "step1", InlineContents: "echo 'one'"},
+						{Name: "step2", InlineContents: "echo 'two'"},
+					},
+				}
+			},
+			expectedCode: http.StatusCreated,
+			validateFunc: func(config *app.ActionWorkflowConfig) {
+				assert.Equal(s.T(), "ghcr.io/nuonco/actions-runner:latest", config.Image)
+				assert.Len(s.T(), config.Steps, 2)
+			},
+		},
+		{
+			name:          "image set but org feature disabled is rejected",
+			actionName:    "image-action-disabled",
+			enableFeature: false,
+			requestFunc: func(appConfigID string) CreateActionWorkflowConfigRequest {
+				return CreateActionWorkflowConfigRequest{
+					AppConfigID: appConfigID,
+					Image:       "ghcr.io/nuonco/actions-runner:latest",
+					Triggers: []CreateActionWorkflowConfigTriggerRequest{
+						{Type: app.ActionWorkflowTriggerTypeManual},
+					},
+					Steps: []CreateActionWorkflowConfigStepRequest{
+						{Name: "step1", InlineContents: "echo 'one'"},
+					},
+				}
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:          "no image set succeeds regardless of feature flag",
+			actionName:    "image-action-no-image",
+			enableFeature: false,
+			requestFunc: func(appConfigID string) CreateActionWorkflowConfigRequest {
+				return CreateActionWorkflowConfigRequest{
+					AppConfigID: appConfigID,
+					Triggers: []CreateActionWorkflowConfigTriggerRequest{
+						{Type: app.ActionWorkflowTriggerTypeManual},
+					},
+					Steps: []CreateActionWorkflowConfigStepRequest{
+						{Name: "step1", InlineContents: "echo 'one'"},
+					},
+				}
+			},
+			expectedCode: http.StatusCreated,
+			validateFunc: func(config *app.ActionWorkflowConfig) {
+				assert.Empty(s.T(), config.Image)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			if tc.enableFeature {
+				s.enableOrgFeature(app.OrgFeatureImageBackedActions)
+			} else {
+				s.disableOrgFeature(app.OrgFeatureImageBackedActions)
+			}
+
+			action := s.createActionWorkflow(s.testApp.ID, tc.actionName)
+			appConfig := s.createAppConfig(s.testApp.ID)
+
+			req := tc.requestFunc(appConfig.ID)
+			path := fmt.Sprintf("/v1/apps/%s/actions/%s/configs", s.testApp.ID, action.ID)
+			rr := s.makeRequest(http.MethodPost, path, req)
+
+			if rr.Code != tc.expectedCode {
+				s.T().Logf("Status: %d, Body: %s", rr.Code, rr.Body.String())
+			}
+			require.Equal(s.T(), tc.expectedCode, rr.Code)
+
+			if tc.expectedCode != http.StatusCreated {
+				// verify no config was persisted for the rejected request
+				var count int64
+				res := s.service.DB.WithContext(s.ctx).
+					Model(&app.ActionWorkflowConfig{}).
+					Where("action_workflow_id = ?", action.ID).
+					Count(&count)
+				require.NoError(s.T(), res.Error)
+				assert.Equal(s.T(), int64(0), count)
+				return
+			}
+
+			var config app.ActionWorkflowConfig
+			err := json.Unmarshal(rr.Body.Bytes(), &config)
+			require.NoError(s.T(), err)
+
+			// Verify database state
+			var dbConfig app.ActionWorkflowConfig
+			res := s.service.DB.WithContext(s.ctx).
+				Preload("Triggers").
+				Preload("Steps").
+				First(&dbConfig, "id = ?", config.ID)
+			require.NoError(s.T(), res.Error)
+
+			if tc.validateFunc != nil {
+				tc.validateFunc(&dbConfig)
+			}
+
+			s.T().Cleanup(func() {
+				s.service.DB.Unscoped().Where("id = ?", config.ID).Delete(&app.ActionWorkflowConfig{})
+			})
+		})
+	}
+}
+
 func (s *CreateAppActionConfigTestSuite) TestCreateActionConfigValidation() {
 	action := s.createActionWorkflow(s.testApp.ID, "validation-action")
 	appConfig := s.createAppConfig(s.testApp.ID)
@@ -548,6 +675,23 @@ func (s *CreateAppActionConfigTestSuite) TestCreateActionConfigValidation() {
 			},
 			expectedCode: http.StatusBadRequest,
 		},
+		{
+			name: "image set with a step missing inline_contents",
+			requestFunc: func() CreateActionWorkflowConfigRequest {
+				return CreateActionWorkflowConfigRequest{
+					AppConfigID: appConfig.ID,
+					Image:       "ghcr.io/nuonco/actions-runner:latest",
+					Triggers: []CreateActionWorkflowConfigTriggerRequest{
+						{Type: app.ActionWorkflowTriggerTypeManual},
+					},
+					Steps: []CreateActionWorkflowConfigStepRequest{
+						{Name: "inline-step", InlineContents: "echo 'ok'"},
+						{Name: "command-step", Command: "echo 'not allowed with image'"},
+					},
+				}
+			},
+			expectedCode: http.StatusBadRequest,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -643,6 +787,26 @@ func (s *CreateAppActionConfigTestSuite) TestCreateActionConfigCrossOrgIsolation
 }
 
 // Helper methods
+
+func (s *CreateAppActionConfigTestSuite) enableOrgFeature(feature app.OrgFeature) {
+	s.setOrgFeature(feature, true)
+}
+
+func (s *CreateAppActionConfigTestSuite) disableOrgFeature(feature app.OrgFeature) {
+	s.setOrgFeature(feature, false)
+}
+
+func (s *CreateAppActionConfigTestSuite) setOrgFeature(feature app.OrgFeature, enabled bool) {
+	features := s.testOrg.Features
+	if features == nil {
+		features = make(map[string]bool)
+	}
+	features[string(feature)] = enabled
+	require.NoError(s.T(), s.service.DB.WithContext(s.ctx).
+		Model(&app.Org{ID: s.testOrg.ID}).
+		Update("features", features).Error)
+	s.testOrg.Features = features
+}
 
 func (s *CreateAppActionConfigTestSuite) createActionWorkflow(appID, name string) *app.ActionWorkflow {
 	action := &app.ActionWorkflow{

--- a/services/ctl-api/internal/app/installs/signals/actionworkflowrun/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/actionworkflowrun/signal.go
@@ -4,12 +4,16 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/distribution/reference"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
+	"github.com/nuonco/nuon/pkg/plugins/configs"
+	"github.com/nuonco/nuon/pkg/types/state"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers/stategen"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/worker/activities"
@@ -308,6 +312,15 @@ func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, installID string
 		return errors.Wrap(err, "unable to create plan")
 	}
 
+	// image-backed actions: mirror the app image into the install registry
+	// and verify the runner can host the container before dispatching.
+	if planResponse.Plan.SourceImage != "" {
+		if err := s.mirrorActionImage(ctx, run, ls.ID, planResponse.Plan); err != nil {
+			s.updateActionRunStatus(ctx, run.ID, app.InstallActionRunStatusError, err.Error())
+			return errors.Wrap(err, "unable to prepare image-backed action")
+		}
+	}
+
 	// execute job
 	l.Info("creating runner job to execute action")
 	runnerJob, err := activities.AwaitCreateActionWorkflowRunRunnerJob(ctx, &activities.CreateActionWorkflowRunRunnerJob{
@@ -409,6 +422,177 @@ func (s *Signal) recordPreparationCompositeError(ctx workflow.Context, runID str
 	}); err != nil {
 		workflow.GetLogger(ctx).Warn("unable to record action workflow run preparation composite error", zap.Error(err))
 	}
+}
+
+// mirrorActionImage mirrors an image-backed action's app-authored image into
+// the install registry via an oci-sync job, after confirming the org has the
+// feature enabled and the install's runner platform is supported. It pins the
+// plan to the mirrored digest; any error here prevents the action job from
+// being dispatched at all.
+func (s *Signal) mirrorActionImage(ctx workflow.Context, run *app.InstallActionWorkflowRun, logStreamID string, awPlan *plantypes.ActionWorkflowRunPlan) error {
+	l := workflow.GetLogger(ctx)
+
+	enabled, err := activities.AwaitHasFeatureByFeature(ctx, string(app.OrgFeatureImageBackedActions))
+	if err != nil {
+		return errors.Wrap(err, "unable to check image-backed-actions feature")
+	}
+	if !enabled {
+		return errors.New("image-backed actions are not enabled for this organization")
+	}
+
+	platform := run.Install.RunnerGroup.Platform
+	if !supportedImageActionPlatform(platform) {
+		return fmt.Errorf("image-backed actions are only supported on AWS runners; runner platform %q is not supported", platform)
+	}
+
+	src, srcTag, err := parseActionImageSource(awPlan.SourceImage)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse action image reference")
+	}
+
+	l.Info("mirroring image-backed action image into install registry",
+		zap.String("source_image", awPlan.SourceImage))
+
+	syncJob, err := activities.AwaitCreateActionImageSyncJob(ctx, &activities.CreateActionImageSyncJobRequest{
+		ActionWorkflowRunID: run.ID,
+		RunnerID:            run.Install.RunnerID,
+		LogStreamID:         logStreamID,
+		Metadata: map[string]string{
+			"install_id":             run.InstallID,
+			"action_workflow_run_id": run.ID,
+			"source_image":           awPlan.SourceImage,
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "unable to create image sync job")
+	}
+
+	syncPlan := &plantypes.SyncOCIPlan{
+		Src:    src,
+		SrcTag: srcTag,
+		Dst:    awPlan.ImageRegistry,
+		DstTag: awPlan.ImageTag,
+	}
+	if awPlan.SandboxMode != nil {
+		syncPlan.SandboxMode = &plantypes.SandboxMode{Enabled: true}
+	}
+
+	syncPlanJSON, err := json.Marshal(syncPlan)
+	if err != nil {
+		return errors.Wrap(err, "unable to marshal sync plan")
+	}
+
+	if err := activities.AwaitSaveRunnerJobPlan(ctx, &activities.SaveRunnerJobPlanRequest{
+		JobID:         syncJob.ID,
+		PlanJSON:      string(syncPlanJSON),
+		CompositePlan: plantypes.CompositePlan{SyncOCIPlan: syncPlan},
+	}); err != nil {
+		return errors.Wrap(err, "unable to save sync job plan")
+	}
+
+	if _, err := job.AwaitExecuteJob(ctx, &job.ExecuteJobRequest{
+		RunnerID:   run.Install.RunnerID,
+		JobID:      syncJob.ID,
+		WorkflowID: "action-image-sync-exec-job-" + run.ID,
+	}); err != nil {
+		return errors.Wrap(err, "image sync job failed")
+	}
+
+	// Bind execution to the exact manifest just mirrored: read the resolved
+	// digest-pinned ref from the sync job outputs so the runner pulls by digest
+	// rather than the mutable tag. This fails closed. If the digest can't be
+	// resolved and validated we don't dispatch the action job at all, otherwise
+	// the runner would execute whatever the mutable tag points at.
+	digestRef, err := resolveMirroredDigestRef(ctx, syncJob.ID)
+	if err != nil {
+		return err
+	}
+	awPlan.ImageDigestRef = digestRef
+
+	l.Info("bound image-backed action to mirrored manifest",
+		zap.String("image_digest_ref", digestRef))
+
+	return nil
+}
+
+// resolveMirroredDigestRef reads the digest-pinned image ref the oci-sync job
+// recorded and verifies it actually carries a digest, so execution can only
+// ever run the manifest that was just mirrored.
+func resolveMirroredDigestRef(ctx workflow.Context, syncJobID string) (string, error) {
+	syncedJob, err := activities.AwaitGetJobByID(ctx, syncJobID)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to get image sync job to resolve mirrored digest")
+	}
+
+	raw, ok := syncedJob.ParsedOutputs["image"]
+	if !ok {
+		return "", errors.New("image sync job recorded no image output, unable to pin action image to a digest")
+	}
+
+	var out state.OCIArtifactOutputs
+	if err := mapstructure.Decode(raw, &out); err != nil {
+		return "", errors.Wrap(err, "unable to decode image sync job output")
+	}
+	if out.Ref == "" {
+		return "", errors.New("image sync job recorded an empty image ref, unable to pin action image to a digest")
+	}
+
+	parsed, err := reference.Parse(out.Ref)
+	if err != nil {
+		return "", fmt.Errorf("mirrored image ref %q is not a valid reference: %w", out.Ref, err)
+	}
+	if _, ok := parsed.(reference.Digested); !ok {
+		return "", fmt.Errorf("mirrored image ref %q is not digest-pinned", out.Ref)
+	}
+
+	return out.Ref, nil
+}
+
+// supportedImageActionPlatform gates image-backed actions to AWS (plus local
+// runners, which only run on a developer machine). AWS is the only platform
+// that mints the selected role's credentials on the runner and injects them, so
+// the container never needs the VM's metadata identity. GCP injects only an
+// impersonation hint and Azure injects nothing, so both fall back to the node
+// identity and need credential work before they can honor the role boundary.
+func supportedImageActionPlatform(p app.AppRunnerType) bool {
+	switch p {
+	case app.AppRunnerTypeAWS, app.AppRunnerTypeLocal:
+		return true
+	default:
+		return false
+	}
+}
+
+// parseActionImageSource splits an app-authored image ref (e.g.
+// ghcr.io/acme/tools:v1) into the source registry descriptor and tag the
+// oci-sync copier pulls from.
+func parseActionImageSource(sourceImage string) (*configs.OCIRegistryRepository, string, error) {
+	named, err := reference.ParseDockerRef(sourceImage)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid image reference %q: %w", sourceImage, err)
+	}
+
+	// Prefer a pinned digest over a tag so a digest-pinned ref actually mirrors
+	// and runs the pinned content instead of silently resolving to "latest" (or
+	// discarding the digest on a tag+digest ref). oras resolves the source ref
+	// by digest or tag, so passing the digest here is valid.
+	ref := "latest"
+	if digested, ok := named.(reference.Digested); ok {
+		ref = digested.Digest().String()
+	} else if tagged, ok := named.(reference.Tagged); ok {
+		ref = tagged.Tag()
+	}
+
+	loginServer := ""
+	if reference.Domain(named) == "docker.io" {
+		loginServer = "docker.io"
+	}
+
+	return &configs.OCIRegistryRepository{
+		RegistryType: configs.OCIRegistryTypePublicOCI,
+		Repository:   named.Name(),
+		LoginServer:  loginServer,
+	}, ref, nil
 }
 
 func (s *Signal) updateActionRunStatus(ctx workflow.Context, runID string, status app.InstallActionWorkflowRunStatus, msg string) {

--- a/services/ctl-api/internal/app/installs/signals/actionworkflowrun/signal_test.go
+++ b/services/ctl-api/internal/app/installs/signals/actionworkflowrun/signal_test.go
@@ -3,6 +3,7 @@ package actionworkflowrun
 import (
 	"testing"
 
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/testsuite"
 )
@@ -19,4 +20,26 @@ func TestSignalTestSuite(t *testing.T) {
 func (s *SignalTestSuite) TestExecute() {
 	// TODO: implement test
 	s.T().Skip("not yet implemented")
+}
+
+func (s *SignalTestSuite) TestSupportedImageActionPlatform() {
+	for _, tc := range []struct {
+		name     string
+		platform app.AppRunnerType
+		want     bool
+	}{
+		{name: "aws is supported", platform: app.AppRunnerTypeAWS, want: true},
+		{name: "local is supported for development", platform: app.AppRunnerTypeLocal, want: true},
+		{name: "azure is rejected", platform: app.AppRunnerTypeAzure, want: false},
+		{name: "gcp is rejected", platform: app.AppRunnerTypeGCP, want: false},
+		{name: "aws ecs is rejected", platform: app.AppRunnerTypeAWSECS, want: false},
+		{name: "aws eks is rejected", platform: app.AppRunnerTypeAWSEKS, want: false},
+		{name: "azure aks is rejected", platform: app.AppRunnerTypeAzureAKS, want: false},
+		{name: "gcp gke is rejected", platform: app.AppRunnerTypeGCPGKE, want: false},
+		{name: "empty is rejected", platform: app.AppRunnerType(""), want: false},
+	} {
+		s.Run(tc.name, func() {
+			s.Equal(tc.want, supportedImageActionPlatform(tc.platform))
+		})
+	}
 }

--- a/services/ctl-api/internal/app/installs/worker/activities/create_action_image_sync_job.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/create_action_image_sync_job.go
@@ -1,0 +1,41 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+)
+
+type CreateActionImageSyncJobRequest struct {
+	ActionWorkflowRunID string            `validate:"required"`
+	RunnerID            string            `validate:"required"`
+	LogStreamID         string            `validate:"required"`
+	Metadata            map[string]string `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+// @by-field ActionWorkflowRunID
+func (a *Activities) CreateActionImageSyncJob(ctx context.Context, req *CreateActionImageSyncJobRequest) (*app.RunnerJob, error) {
+	run, err := a.getInstallActionWorkflowRun(ctx, req.ActionWorkflowRunID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get action workflow run")
+	}
+
+	ctx = cctx.SetAccountIDContext(ctx, run.CreatedByID)
+	ctx = cctx.SetOrgIDContext(ctx, run.OrgID)
+
+	job, err := a.runnersHelpers.CreateActionImageSyncJob(ctx,
+		req.RunnerID,
+		req.ActionWorkflowRunID,
+		req.LogStreamID,
+		req.Metadata,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create action image sync job")
+	}
+
+	return job, nil
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/create_action_workflow_run_job.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/create_action_workflow_run_job.go
@@ -34,11 +34,19 @@ func (a *Activities) CreateActionWorkflowRunRunnerJob(ctx context.Context, req *
 	}
 	ctx = cctx.SetFlowInstallIDContext(ctx, run.InstallID)
 
+	// image-backed actions are launched by the mng process on VM runners, which
+	// polls the dedicated image-actions group.
+	group := app.RunnerJobGroupActions
+	if cfg.Image != "" {
+		group = app.RunnerJobGroupImageActions
+	}
+
 	job, err := a.runnersHelpers.CreateActionsWorkflowRunJob(ctx,
 		req.RunnerID,
 		req.ActionWorkflowRunID,
 		req.LogStreamID,
 		&cfg,
+		group,
 		req.Metadata,
 	)
 	if err != nil {

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run.go
@@ -1,6 +1,8 @@
 package plan
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -132,6 +134,22 @@ func (p *Planner) createActionWorkflowRunPlan(ctx workflow.Context, runID string
 		plan.Steps = append(plan.Steps, stepPlan)
 	}
 
+	if !run.ActionWorkflowConfigID.Empty() && run.ActionWorkflowConfig.Image != "" {
+		sourceImage, err := RenderText(run.ActionWorkflowConfig.Image, stateMap)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "unable to render action image")
+		}
+
+		imageRegistry, err := p.getOrgRegistryRepositoryConfig(ctx, run.InstallID, runID)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "unable to get registry for action image")
+		}
+
+		plan.SourceImage = sourceImage
+		plan.ImageRegistry = imageRegistry
+		plan.ImageTag = actionImageTag(sourceImage, runID)
+	}
+
 	if slimInstall.SandboxMode.Bool {
 		targetRefs := helpers.GetActionReferences(appCfg, run.ActionWorkflowConfig.ActionWorkflow.Name)
 
@@ -143,6 +161,15 @@ func (p *Planner) createActionWorkflowRunPlan(ctx workflow.Context, runID string
 
 	l.Info("successfully created plan")
 	return plan, roleSelection, nil
+}
+
+// actionImageTag derives the install-registry destination tag for a mirrored
+// action image. It includes the run ID so concurrent runs of the same source
+// ref never share a destination tag, which would let one run overwrite the tag
+// another run is about to pull (mutable-tag race).
+func actionImageTag(sourceImage, runID string) string {
+	sum := sha256.Sum256([]byte(sourceImage))
+	return fmt.Sprintf("action-%s-%s", hex.EncodeToString(sum[:])[:16], runID)
 }
 
 // TODO(ja): make this a method on the run struct?

--- a/services/ctl-api/internal/app/org.go
+++ b/services/ctl-api/internal/app/org.go
@@ -112,6 +112,11 @@ const (
 	// of cloning the sandbox git source. With it off, sandbox runs always clone
 	// git — the path every install used before artifacts existed.
 	OrgFeatureSandboxOCIArtifacts OrgFeature = "sandbox-oci-artifacts"
+	// OrgFeatureImageBackedActions lets actions declare a container image
+	// their steps run inside. Nuon mirrors the image into the install
+	// registry and the mng process runs each step's inline_contents in the
+	// image via the mounted actions-supervisor. VM-based runners only.
+	OrgFeatureImageBackedActions OrgFeature = "image-backed-actions"
 )
 
 type Org struct {
@@ -233,6 +238,7 @@ func (o *Org) BeforeCreate(tx *gorm.DB) error {
 		OrgFeatureNotebooks:               false,
 		OrgFeatureSpaceliftInstallStacks:  false,
 		OrgFeatureStackTFProvider:         false,
+		OrgFeatureImageBackedActions:      false,
 		OrgFeatureOrgRunner:               false,
 		OrgFeatureAWSAccountConnections:   false,
 		OrgFeatureComponentHealth:         false,
@@ -306,6 +312,7 @@ func GetFeatures() []OrgFeature {
 		OrgFeatureOrgHealthcheckSweeps,
 		OrgFeatureAppInstallSyncing,
 		OrgFeatureSandboxOCIArtifacts,
+		OrgFeatureImageBackedActions,
 	}
 }
 
@@ -346,6 +353,7 @@ func GetFeatureDescriptions() map[OrgFeature]string {
 		OrgFeatureOrgHealthcheckSweeps:     "Replace per-runner and per-process healthcheck cron emitters with two per-org sweep emitters that check all runners/processes in paginated batches. Toggle via POST /v1/orgs/{org_id}/migrate-healthcheck-sweeps, which also migrates the emitters.",
 		OrgFeatureAppInstallSyncing:        "Enable app install config syncing: point an app at a git repo of per-install configs so pushes to that repo sync every install's config and create missing installs behind an approval step. Gates the install syncs API, the VCS push fan-out, and the dashboard install syncs tab.",
 		OrgFeatureSandboxOCIArtifacts:      "Build the app sandbox into an OCI artifact during branch runs and resolve sandbox runs against that artifact instead of cloning the sandbox git source. With it off, sandbox runs always clone git.",
+		OrgFeatureImageBackedActions:       "Allow actions to declare a container image their steps run inside. Nuon mirrors the image into the install registry and the mng process runs each step's inline_contents in the image via the mounted actions-supervisor. VM-based runners only.",
 	}
 }
 

--- a/services/ctl-api/internal/app/runner_job.go
+++ b/services/ctl-api/internal/app/runner_job.go
@@ -85,6 +85,10 @@ const (
 	// actions workflows
 	RunnerJobGroupActions RunnerJobGroup = "actions"
 
+	// image-backed action workflows, polled only by the mng process on VM
+	// runners (which has host docker access to launch the action container).
+	RunnerJobGroupImageActions RunnerJobGroup = "image-actions"
+
 	RunnerJobGroupUnknown RunnerJobGroup = ""
 	RunnerJobGroupAny     RunnerJobGroup = "any"
 )

--- a/services/ctl-api/internal/app/runners/helpers/create_runner_queues.go
+++ b/services/ctl-api/internal/app/runners/helpers/create_runner_queues.go
@@ -18,6 +18,7 @@ var allRunnerJobGroups = []app.RunnerJobGroup{
 	app.RunnerJobGroupOperations,
 	app.RunnerJobGroupManagement,
 	app.RunnerJobGroupActions,
+	app.RunnerJobGroupImageActions,
 }
 
 // CreateRunnerQueues creates one queue per job group for the given runner.

--- a/services/ctl-api/internal/app/runners/helpers/jobs_action_image_sync.go
+++ b/services/ctl-api/internal/app/runners/helpers/jobs_action_image_sync.go
@@ -3,34 +3,32 @@ package helpers
 import (
 	"context"
 	"fmt"
-	"time"
 
 	pkggenerics "github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 )
 
-func (h *Helpers) CreateActionsWorkflowRunJob(ctx context.Context,
+// CreateActionImageSyncJob creates an oci-sync job that mirrors an
+// image-backed action's app-authored image into the install registry before
+// the action runs. It is owned by the action run so it is cancelled/cleaned up
+// alongside it.
+func (h *Helpers) CreateActionImageSyncJob(ctx context.Context,
 	runnerID string,
-	runID string, logStreamID string,
-	cfg *app.ActionWorkflowConfig,
-	group app.RunnerJobGroup,
+	runID string,
+	logStreamID string,
 	metadata map[string]string,
 ) (*app.RunnerJob, error) {
 	job := &app.RunnerJob{
-		RunnerID:     runnerID,
-		QueueTimeout: DefaultQueueTimeout,
-		// NOTE(jm): we create a buffer to allow the runner to finish cleaning up, when a job times out. If this
-		// is set to the exact timeout, the workflow can not actually cleanup. Thus, this is an arbitrary buffer
-		// that should never be hit because the runner job would timeout mid-job and mark itself as timed out
-		// first.
-		ExecutionTimeout:  cfg.Timeout + time.Minute,
+		RunnerID:          runnerID,
+		QueueTimeout:      DefaultQueueTimeout,
+		ExecutionTimeout:  h.getDefaultExecutionTimeout(app.RunnerJobTypeOCISync),
 		AvailableTimeout:  DefaultAvailableTimeout,
 		MaxExecutions:     DefaultMaxExecutions,
 		Status:            app.RunnerJobStatusQueued,
 		StatusDescription: string(app.RunnerJobStatusQueued),
-		Type:              app.RunnerJobTypeActionsWorkflowRun,
-		Group:             group,
+		Type:              app.RunnerJobTypeOCISync,
+		Group:             app.RunnerJobGroupSync,
 		Operation:         app.RunnerJobOperationTypeExec,
 		OwnerType:         "install_action_workflow_runs",
 		OwnerID:           runID,
@@ -39,7 +37,7 @@ func (h *Helpers) CreateActionsWorkflowRunJob(ctx context.Context,
 	}
 
 	if res := h.db.WithContext(ctx).Create(&job); res.Error != nil {
-		return nil, fmt.Errorf("unable to create job: %w", res.Error)
+		return nil, fmt.Errorf("unable to create action image sync job: %w", res.Error)
 	}
 
 	return job, nil

--- a/services/ctl-api/internal/pkg/config/build/actions.go
+++ b/services/ctl-api/internal/pkg/config/build/actions.go
@@ -24,6 +24,7 @@ type ActionWorkflowInput struct {
 	Role                  string
 	EnableKubeConfig      *bool
 	KubernetesContextName string
+	Image                 string
 }
 
 // ActionWorkflowConfig builds the row; the caller attaches triggers and steps.
@@ -46,5 +47,6 @@ func ActionWorkflowConfig(in ActionWorkflowInput) *app.ActionWorkflowConfig {
 		Role:                   in.Role,
 		EnableKubeConfig:       generics.NewNullBoolFromPtr(&enableKubeConfig),
 		KubernetesContextName:  in.KubernetesContextName,
+		Image:                  in.Image,
 	}
 }

--- a/services/ctl-api/internal/pkg/config/syncer/actions.go
+++ b/services/ctl-api/internal/pkg/config/syncer/actions.go
@@ -61,6 +61,22 @@ func (s *syncer) syncAction(ctx context.Context, action *config.ActionConfig) er
 		}
 	}
 
+	if action.Image != "" {
+		enabled, err := s.orgHasFeature(ctx, app.OrgFeatureImageBackedActions)
+		if err != nil {
+			return sync.SyncInternalErr{
+				Description: "unable to check image-backed-actions feature",
+				Err:         err,
+			}
+		}
+		if !enabled {
+			return sync.SyncErr{
+				Resource:    fmt.Sprintf("action-%s", action.Name),
+				Description: "image-backed actions are not enabled for this organization; contact Nuon to enable the image-backed-actions feature",
+			}
+		}
+	}
+
 	// Sync labels
 	labelRes := s.db.WithContext(ctx).
 		Model(&actionWorkflow).
@@ -235,6 +251,7 @@ func (s *syncer) syncAction(ctx context.Context, action *config.ActionConfig) er
 		Role:                  action.Role,
 		EnableKubeConfig:      action.EnableKubeConfig,
 		KubernetesContextName: action.KubernetesContext,
+		Image:                 action.Image,
 	})
 	built.Triggers = triggers
 	built.Steps = steps
@@ -264,6 +281,19 @@ func (s *syncer) syncAction(ctx context.Context, action *config.ActionConfig) er
 	})
 
 	return nil
+}
+
+func (s *syncer) orgHasFeature(ctx context.Context, feature app.OrgFeature) (bool, error) {
+	var org app.Org
+	res := s.db.WithContext(ctx).
+		Select("id", "features").
+		Where(&app.Org{ID: s.orgID}).
+		First(&org)
+	if res.Error != nil {
+		return false, res.Error
+	}
+
+	return org.Features[string(feature)], nil
 }
 
 // getAction finds an action workflow by name.

--- a/services/dashboard-ui/client/components/actions/InstallActionRunHeader/InstallActionRunHeader.stories.tsx
+++ b/services/dashboard-ui/client/components/actions/InstallActionRunHeader/InstallActionRunHeader.stories.tsx
@@ -67,3 +67,23 @@ export const NoWorkflow = () => (
     cancelWorkflowButton={null}
   />
 )
+
+export const ImageBacked = () => (
+  <InstallActionRunHeader
+    actionId="action-1"
+    actionName="healthcheck"
+    workflow={mockWorkflow}
+    installActionRun={
+      {
+        ...mockRun,
+        config: { ...mockRun.config, image: 'ghcr.io/acme/checker:v1.8.2' },
+      } as any
+    }
+    basePath="/org-1/installs/install-1"
+    isAdmin={false}
+    step={{ id: 'step-1' } as any}
+    cancelWorkflowButton={<Button variant="danger">Cancel workflow</Button>}
+    runnerJobPlanButton={<Button>View plan</Button>}
+    runActionButton={<Button>Run action</Button>}
+  />
+)

--- a/services/dashboard-ui/client/components/actions/InstallActionRunHeader/InstallActionRunHeader.tsx
+++ b/services/dashboard-ui/client/components/actions/InstallActionRunHeader/InstallActionRunHeader.tsx
@@ -11,8 +11,8 @@ import { LabeledStatus } from '@/components/common/LabeledStatus'
 import { LabeledValue } from '@/components/common/LabeledValue'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
-import { Code } from '@/components/common/Code'
 import type { TActionConfigTriggerType, TInstallActionRun, TWorkflow, TWorkflowStep } from '@/types'
+import { cn } from '@/utils/classnames'
 import { toSentenceCase } from '@/utils/string-utils'
 
 interface IInstallActionRunHeader {
@@ -83,7 +83,12 @@ export const InstallActionRunHeader = ({
       </div>
 
       <Card>
-        <div className="grid grid-cols-5">
+        <div
+          className={cn(
+            'grid',
+            installActionRun?.config?.image ? 'grid-cols-6' : 'grid-cols-5'
+          )}
+        >
           <LabeledValue
             label={`Triggered via ${installActionRun?.triggered_by_type}`}
           >
@@ -123,6 +128,14 @@ export const InstallActionRunHeader = ({
               </Text>
             )}
           </LabeledValue>
+
+          {installActionRun?.config?.image ? (
+            <LabeledValue label="Container image">
+              <Text variant="subtext" family="mono" className="text-xs break-all">
+                {installActionRun.config.image}
+              </Text>
+            </LabeledValue>
+          ) : null}
         </div>
       </Card>
 

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -3388,6 +3388,8 @@ export interface components {
       created_by_id?: string;
       enable_kube_config?: components["schemas"]["sql.NullBool"];
       id?: string;
+      /** @description Image is an optional container image the action's steps run inside. */
+      image?: string;
       /**
        * @description KubernetesContextName is the name of an AppKubernetesContextConfig on
        * the same AppConfig. Empty means fall back to the implicit sandbox
@@ -6099,7 +6101,7 @@ export interface components {
     /** @enum {string} */
     "app.RunnerJobExecutionStatus": "pending" | "initializing" | "in-progress" | "cleaning-up" | "finished" | "failed" | "timed-out" | "not-attempted" | "cancelled" | "unknown";
     /** @enum {string} */
-    "app.RunnerJobGroup": "health-checks" | "sync" | "build" | "deploy" | "sandbox" | "runner" | "operations" | "management" | "actions" | "" | "any";
+    "app.RunnerJobGroup": "health-checks" | "sync" | "build" | "deploy" | "sandbox" | "runner" | "operations" | "management" | "actions" | "image-actions" | "" | "any";
     /** @enum {string} */
     "app.RunnerJobOperationType": "exec" | "build" | "create-apply-plan" | "create-teardown-plan" | "apply-plan" | "unknown";
     "app.RunnerJobPlan": {
@@ -7095,11 +7097,26 @@ export interface components {
       cluster_info?: components["schemas"]["kube.ClusterInfo"];
       gcp_auth?: components["schemas"]["github_com_nuonco_nuon_pkg_gcp_credentials.Config"];
       id?: string;
+      /**
+       * @description ImageDigestRef is the digest-pinned pull reference resolved by the mirror
+       * job (<login_server>/<repository>@sha256:...). When set, the runner pulls
+       * this exact manifest instead of the mutable tag, binding execution to the
+       * content that was mirrored.
+       */
+      image_digest_ref?: string;
+      image_registry?: components["schemas"]["configs.OCIRegistryRepository"];
+      image_tag?: string;
       install_id?: string;
       override_env_vars?: {
         [key: string]: string;
       };
       sandbox_mode?: components["schemas"]["plantypes.SandboxMode"];
+      /**
+       * @description Image-backed actions: SourceImage is the rendered app-authored ref
+       * (e.g. ghcr.io/acme/tools:v1); ImageRegistry/ImageTag point at the
+       * install-registry mirror the runner pulls from.
+       */
+      source_image?: string;
       steps?: components["schemas"]["plantypes.ActionWorkflowRunStepPlan"][];
       timeout?: number;
     };
@@ -7782,6 +7799,7 @@ export interface components {
       break_glass_role_arn?: string;
       dependencies?: string[];
       enable_kube_config?: boolean | null;
+      image?: string;
       kubernetes_context?: string;
       references?: string[];
       role?: string;

--- a/services/dashboard-ui/client/views/app/ActionDetail.tsx
+++ b/services/dashboard-ui/client/views/app/ActionDetail.tsx
@@ -73,7 +73,8 @@ export const ActionDetail = () => {
         {config &&
         (config.triggers?.length ||
           config.break_glass_role_arn ||
-          config.role) ? (
+          config.role ||
+          config.image) ? (
           <div className="flex flex-row gap-6 items-start">
             {config?.timeout ? (
               <LabeledValue label="Timeout">
@@ -90,6 +91,12 @@ export const ActionDetail = () => {
                 {config?.enable_kube_config ? 'Enabled' : 'Disabled'}
               </Badge>
             </LabeledValue>
+
+            {config?.image ? (
+              <LabeledValue label="Container image">
+                <Code variant="inline">{config.image}</Code>
+              </LabeledValue>
+            ) : null}
             {config.triggers?.length ? (
               <LabeledValue label="Triggers">
                 <div className="flex flex-col gap-2">

--- a/services/dashboard-ui/client/views/install/ActionDetail.tsx
+++ b/services/dashboard-ui/client/views/install/ActionDetail.tsx
@@ -69,6 +69,7 @@ export const ActionDetail = () => {
     installState?.install_stack?.outputs?.break_glass_role_arns
   const kubeConfigEnabled =
     action?.action_workflow?.configs?.[0]?.enable_kube_config
+  const actionImage = action?.action_workflow?.configs?.[0]?.image
 
   if (isLoading) {
     return (
@@ -221,17 +222,19 @@ export const ActionDetail = () => {
             </div>
           </div>
 
-          {action?.runs?.[0] ? (
+          {action?.runs?.[0] || actionImage ? (
             <div className="flex flex-wrap gap-x-8 gap-y-4 items-start">
-              <LabeledStatus
-                label="Last status"
-                statusProps={{ status: action.runs[0].status_v2?.status }}
-                tooltipProps={{
-                  position: 'top',
-                  tipContent:
-                    action.runs[0].status_v2?.status_human_description,
-                }}
-              />
+              {action?.runs?.[0] ? (
+                <LabeledStatus
+                  label="Last status"
+                  statusProps={{ status: action.runs[0].status_v2?.status }}
+                  tooltipProps={{
+                    position: 'top',
+                    tipContent:
+                      action.runs[0].status_v2?.status_human_description,
+                  }}
+                />
+              ) : null}
               <LabeledValue label="Kube config">
                 <Badge
                   theme={kubeConfigEnabled ? 'info' : 'warn'}
@@ -247,16 +250,24 @@ export const ActionDetail = () => {
                   variant="subtext"
                 />
               </LabeledValue>
-              <LabeledValue label="Last trigger">
-                <ActionTriggerType
-                  size="sm"
-                  triggerType={
-                    action.runs[0].triggered_by_type as TActionConfigTriggerType
-                  }
-                  componentName={action.runs[0].run_env_vars?.COMPONENT_NAME}
-                  componentPath={`/${org?.id}/installs/${install?.id}/components/${action.runs[0].run_env_vars?.COMPONENT_ID}`}
-                />
-              </LabeledValue>
+              {actionImage ? (
+                <LabeledValue label="Container image">
+                  <Code variant="inline">{actionImage}</Code>
+                </LabeledValue>
+              ) : null}
+              {action?.runs?.[0] ? (
+                <LabeledValue label="Last trigger">
+                  <ActionTriggerType
+                    size="sm"
+                    triggerType={
+                      action.runs[0]
+                        .triggered_by_type as TActionConfigTriggerType
+                    }
+                    componentName={action.runs[0].run_env_vars?.COMPONENT_NAME}
+                    componentPath={`/${org?.id}/installs/${install?.id}/components/${action.runs[0].run_env_vars?.COMPONENT_ID}`}
+                  />
+                </LabeledValue>
+              ) : null}
             </div>
           ) : null}
         </header>


### PR DESCRIPTION
# Image-Backed Actions

Lets an action declare a container image its steps run inside, instead of relying on whatever tooling the runner image ships. Nuon mirrors the image into the install registry and runs each step's `inline_contents` inside it via a mounted shell supervisor.

## Usage

```toml
name = "healthcheck"
image = "curlimages/curl:latest"

[[steps]]
name = "check"
inline_contents = """
#!/usr/bin/env sh
set -e
STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${ENDPOINT}/status/200")
[ "$STATUS" = "200" ] || exit 1
nuon_output status "$STATUS"
"""

[steps.env_vars]
ENDPOINT = "{{.nuon.components.ec2.outputs.public_ip}}"
```

When `image` is set, every step must use `inline_contents`. Command and repo steps are rejected at config parse and API validation.

## How it works

ctl-api renders the image ref, mirrors it into the install registry via the existing `oci-sync` pipeline, resolves the mirrored digest, then dispatches an `image-actions` job. The mng process (the VM host process, which has Docker access) claims it and runs the image with `docker run`, mounting the workspace. An embedded POSIX shell supervisor installs the `nuon_output` helper on `PATH`, runs the step script, and propagates the exit code. Outputs are read back from the shared workspace mount after the container exits.

The supervisor is a shell script rather than a compiled binary so it runs in any base image (musl or glibc, any arch). Image-backed actions already require a shell, since `inline_contents` is itself a shell script.

## Key behaviors

- **Digest-pinned.** The runner pulls `repo@sha256:...`, never a tag. If the digest cannot be resolved, the run fails and the job is never dispatched. No mutable-tag fallback.
- **AWS runners only.** AWS is the only platform that mints and injects the selected role's credentials, so the container never needs the VM's metadata identity. Azure, GCP, and Kubernetes are rejected before mirroring.
- **Isolated.** Explicit env only, default bridge network, `no-new-privileges`, memory and PID limits, CPU shares rather than a hard quota, no Docker socket, no host mounts beyond the per-run workspace. Credentials never touch argv.
- **Images are cached, not deleted.** One pull per job, leased while in use, reclaimed by a host garbage collector that runs only when the job loop is idle and the volume is low on space.
- **Workspaces are on the root volume** (`/opt/nuon/action-workspaces`), not the host's tmpfs `/tmp`.

## Gating

Org feature flag `image-backed-actions`, default off, checked at config sync, API create, and again at run time. New `image-actions` job group, registered only by mng.

If an action is synced with an image and the flag is later disabled, that action fails with a clear error rather than falling back to host execution.

## Rollout

**Update runners before enabling the flag.** The `image-actions` loop lives in the mng host binary, which does not auto-update from settings. Jobs created for a runner that predates this change will sit unclaimed.