### PR TITLE
feat: dynamic install labels via nuon templates

### DIFF
--- a/bins/cli/internal/services/apps/config_reader.go
+++ b/bins/cli/internal/services/apps/config_reader.go
@@ -136,6 +136,7 @@ func ConvertToConfigStructure(appConfig *config.AppConfig, targetPath string) (*
 			SlackWebhookURL: appConfig.SlackWebhookURL,
 			Readme:          appConfig.Readme,
 			LabelColors:     appConfig.LabelColors,
+			DefaultLabels:   appConfig.DefaultLabels,
 		}
 		if err := structure.UpdateMetadata(metadataConfig); err != nil {
 			return nil, errors.Wrap(err, "failed to update metadata")

--- a/docs/config-ref/install.mdx
+++ b/docs/config-ref/install.mdx
@@ -13,7 +13,7 @@ title: 'Install'
 |----------|----------|----------|----------|
 | **`name`**<br/>string | name of the install Unique identifier for this install configuration | **✅ Required** | `"production"`, `"staging"`, `"customer-acme"` |
 | **`approval_option`**<br/>string | approval option for the install Controls how deployments are approved. Options: 'approve-all' (automatic approval) or 'prompt' (requires confirmation) | **Optional** | `"approve-all"`, `"prompt"` |
-| **`labels`**<br/>object | key/value labels for the install Tag installs with arbitrary metadata like environment, region, or version. | **Optional** | `{"env":"production","region":"us-east"}` |
+| **`labels`**<br/>object | key/value labels for the install Tag installs with arbitrary metadata like environment, region, or version. Values can use the .nuon interpolation syntax to render from install state, and re-render... | **Optional** | `{"env":"production","region":"{{ .nuon.cloud_account.aws.region }}"}` |
 | **`aws_account`**<br/>[AWSAccount](#aws_account) | AWS account configuration AWS-specific settings for this install, including region and other account details | **Optional** | - |
 | **`gcp_account`**<br/>[GCPAccount](#gcp_account) | GCP account configuration GCP-specific settings for this install, including project ID and region | **Optional** | - |
 | **`azure_account`**<br/>[AzureAccount](#azure_account) | Azure account configuration Azure-specific settings for this install, including the deployment location | **Optional** | - |

--- a/docs/config-ref/metadata.mdx
+++ b/docs/config-ref/metadata.mdx
@@ -17,4 +17,5 @@ title: 'Metadata'
 | **`slack_webhook_url`**<br/>string | Slack webhook URL Slack webhook URL to receive deployment notifications and updates | **Optional** | `"https://hooks.slack.com/services/YOUR/WEBHOOK/URL"` |
 | **`readme`**<br/>string | README content Markdown content displayed as README documentation for the application | **Optional** | `"./README.md"` |
 | **`label_colors`**<br/>object | label key color codes Map of label key names to hex color codes for customizing label display in the dashboard | **Optional** | `"{\"env\": \"#FF5733\", \"region\": \"#33FF57\"}"` |
+| **`default_labels`**<br/>object | default labels for all installs Labels applied to every install of the app. Values may use the interpolation syntax (\{\{ .nuon.* \}\}). These labels cannot be edited or removed on individual insta... | **Optional** | `"{\"tier\": \"prod\", \"region\": \"{{ .nuon.cloud_account.aws.region }}\"}"` |
 

--- a/docs/guides/install-configs.mdx
+++ b/docs/guides/install-configs.mdx
@@ -37,6 +37,32 @@ tier = "enterprise"
 
 See [Label badges](/guides/using-readmes#label-badge) for how labels render in install READMEs.
 
+### Dynamic labels
+
+Label values can use the [interpolation syntax](/guides/using-variables) to render from install state:
+
+```toml install.toml
+name = "customer-acme"
+
+[labels]
+env    = "production"
+region = "{{ .nuon.cloud_account.aws.region }}"
+tier   = "{{ .nuon.install.inputs.tier }}"
+```
+
+Dynamic values are rendered when the install install state changes — deploys, input updates, and config updates all trigger a refresh.
+The rendered value is displayed in the dashboard and what [webhook and Slack label selectors](/guides/webhooks) match against.
+
+If a template references state that doesn't exist yet (for example, a component output before its first
+deploy), the label is skipped rather than failing the sync; it appears once the referenced state is
+available.
+
+### Default labels
+
+Labels defined in the app's [`default_labels`](/guides/managing-apps#default-labels) apply to every install
+and are owned by the app config — an install config cannot override or remove those keys, and a sync that
+tries to set a different value for one fails with an error.
+
 ## Toggling components
 
 If your app has [toggleable components](/guides/toggleable-components), the install config decides which ones are enabled. Set the state per component in a `[component_toggles]` section, keyed by component name:

--- a/docs/guides/managing-apps.mdx
+++ b/docs/guides/managing-apps.mdx
@@ -84,3 +84,18 @@ customer = "#3357FF"
 ```
 
 The colors apply wherever those label keys appear in the dashboard — on apps, installs, and components. You can also set label colors directly in the dashboard; either source can be updated later, and a sync will reconcile the values from your config.
+
+### Default labels
+
+Apply labels to every install of an app with a `default_labels` table in `metadata.toml`:
+
+```toml metadata.toml
+[default_labels]
+service_tier   = "{{ .nuon.inputs.service_tier }}"
+```
+
+Values can use the [interpolation syntax](/guides/using-variables) to render per install from install state,
+and re-render automatically as that state changes.
+
+Default labels are owned by the app config. They locked on each install and cannot be updated manually or via install config.
+To change or remove a default label, you must edit `default_labels` in the app config. The change will propagate to each install when the new version of that app is released.

--- a/docs/guides/using-variables.mdx
+++ b/docs/guides/using-variables.mdx
@@ -56,6 +56,11 @@ For example, the install id can be passed as a variable to the Sandbox for an EK
 cluster_name    = "n-{{.nuon.install.id}}"
 ```
 
+## Labels
+
+Interpolation also works in [install labels](/guides/install-configs#dynamic-labels) and app-level [default labels](/guides/managing-apps#default-labels).
+Label values re-render automatically as the install state changes.
+
 ## Variable Data Sources
 
 ### Nuon Information

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,8 @@ type AppConfig struct {
 	Readme string `mapstructure:"readme,omitempty" toml:"readme,omitempty" features:"get,template"`
 	// Color codes for label keys
 	LabelColors map[string]string `mapstructure:"label_colors,omitempty" toml:"label_colors,omitempty"`
+	// Labels applied to every install of the app; editable only via app config
+	DefaultLabels map[string]string `mapstructure:"default_labels,omitempty" toml:"default_labels,omitempty"`
 
 	// Default App Branch config
 	Branch *AppBranchConfig `mapstructure:"branch,omitempty" toml:"branch,omitempty"`
@@ -96,6 +98,8 @@ func (a AppConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Long("Markdown file with app documentation. Supports templating and external file sources: HTTP(S) URLs (https://example.com/readme.md), git repositories (git::https://github.com/org/repo//readme.md), file paths (file:///path/to/readme.md), and relative paths (./readme.md)").
 		Field("label_colors").Short("label key color codes").
 		Long("Map of label key names to hex color codes for customizing label display in the dashboard").
+		Field("default_labels").Short("default labels for all installs").
+		Long("Labels applied to every install of the app. Values may use the interpolation syntax. Editable only via app config").
 		Field("branch").Short("default app branch configuration").
 		Long("Default branch configuration for all installs. Can be overridden per install").
 		Field("inputs").Short("input configuration").

--- a/pkg/config/install.go
+++ b/pkg/config/install.go
@@ -213,8 +213,8 @@ func (a Install) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Example("approve-all").
 		Example("prompt").
 		Field("labels").Short("key/value labels for the install").
-		Long("Tag installs with arbitrary metadata like environment, region, or version.").
-		Example(map[string]string{"env": "production", "region": "us-east"}).
+		Long("Tag installs with arbitrary metadata like environment, region, or version. Values can use the .nuon interpolation syntax to render from install state, and re-render as state changes.").
+		Example(map[string]string{"env": "production", "region": "{{ .nuon.cloud_account.aws.region }}"}).
 		Field("aws_account").Short("AWS account configuration").
 		Long("AWS-specific settings for this install, including region and other account details").
 		Field("gcp_account").Short("GCP account configuration").

--- a/pkg/config/install.go
+++ b/pkg/config/install.go
@@ -4,9 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/invopop/jsonschema"
 	"github.com/nuonco/nuon/pkg/config/diff"
+	"github.com/nuonco/nuon/pkg/labels"
+	"github.com/nuonco/nuon/pkg/render"
 	"github.com/nuonco/nuon/sdks/nuon-go/models"
 	"github.com/pelletier/go-toml/v2"
 )
@@ -240,6 +243,28 @@ func (i *Install) Parse() error {
 func (i *Install) Validate() error {
 	if i == nil {
 		return nil
+	}
+
+	// Label keys are lookup identifiers on every matching surface (SQL
+	// containment, selectors, pickers), so they can never be templated; values
+	// using the interpolation syntax become dynamic labels and must parse now
+	// rather than fail at render time.
+	for key, val := range i.Labels {
+		if strings.Contains(key, "{{") {
+			return ErrConfig{
+				Description: fmt.Sprintf("install %q label key %q must not use the interpolation syntax", i.Name, key),
+				Err:         fmt.Errorf("install %q label key %q is templated; only label values may be templated", i.Name, key),
+			}
+		}
+		if !labels.IsTemplatedValue(val) {
+			continue
+		}
+		if err := render.ValidateTextTemplate(val); err != nil {
+			return ErrConfig{
+				Description: fmt.Sprintf("install %q label %q is not a valid template", i.Name, key),
+				Err:         fmt.Errorf("install %q label %q template: %w", i.Name, key, err),
+			}
+		}
 	}
 
 	// Catch malformed override documents at config-parse time, before any API

--- a/pkg/config/install.go
+++ b/pkg/config/install.go
@@ -245,10 +245,8 @@ func (i *Install) Validate() error {
 		return nil
 	}
 
-	// Label keys are lookup identifiers on every matching surface (SQL
-	// containment, selectors, pickers), so they can never be templated; values
-	// using the interpolation syntax become dynamic labels and must parse now
-	// rather than fail at render time.
+	// Keys are lookup identifiers on every matching surface, so they can never
+	// be templated; templated values must parse now, not fail at render time.
 	for key, val := range i.Labels {
 		if strings.Contains(key, "{{") {
 			return ErrConfig{

--- a/pkg/config/install_test.go
+++ b/pkg/config/install_test.go
@@ -807,3 +807,52 @@ account_id = "123456789012"
 	assert.Equal(t, "us-west-2", install.AWSAccount.Region)
 	assert.Equal(t, "123456789012", install.AWSAccount.AccountID)
 }
+
+func TestInstallValidate_Labels(t *testing.T) {
+	t.Run("static labels pass", func(t *testing.T) {
+		install := Install{
+			Name:   "prod",
+			Labels: map[string]string{"env": "production", "team": "platform"},
+		}
+		require.NoError(t, install.Validate())
+	})
+
+	t.Run("valid dynamic label values pass", func(t *testing.T) {
+		install := Install{
+			Name: "prod",
+			Labels: map[string]string{
+				"region":  "{{ .nuon.cloud_account.aws.region }}",
+				"version": "{{ .nuon.components.api.outputs.version }}",
+			},
+		}
+		require.NoError(t, install.Validate())
+	})
+
+	t.Run("unparsable template is rejected", func(t *testing.T) {
+		install := Install{
+			Name:   "prod",
+			Labels: map[string]string{"region": "{{ .nuon.cloud_account.aws.region "},
+		}
+		err := install.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "region")
+	})
+
+	t.Run("templated key is rejected", func(t *testing.T) {
+		install := Install{
+			Name:   "prod",
+			Labels: map[string]string{"{{ .nuon.id }}": "value"},
+		}
+		err := install.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "label key")
+	})
+
+	t.Run("braces without nuon namespace stay literal", func(t *testing.T) {
+		install := Install{
+			Name:   "prod",
+			Labels: map[string]string{"note": "{{ literal braces }}"},
+		}
+		require.NoError(t, install.Validate())
+	})
+}

--- a/pkg/config/metadata.go
+++ b/pkg/config/metadata.go
@@ -18,6 +18,8 @@ type MetadataConfig struct {
 	Readme string `mapstructure:"readme,omitempty" toml:"readme,omitempty"`
 	// Color codes for label keys, keyed by label key name
 	LabelColors map[string]string `mapstructure:"label_colors,omitempty" toml:"label_colors,omitempty"`
+	// Labels applied to every install of the app; editable only via app config
+	DefaultLabels map[string]string `mapstructure:"default_labels,omitempty" toml:"default_labels,omitempty"`
 }
 
 func (m MetadataConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
@@ -41,5 +43,8 @@ func (m MetadataConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Example("./README.md").
 		Field("label_colors").Short("label key color codes").
 		Long("Map of label key names to hex color codes for customizing label display in the dashboard").
-		Example(`{"env": "#FF5733", "region": "#33FF57"}`)
+		Example(`{"env": "#FF5733", "region": "#33FF57"}`).
+		Field("default_labels").Short("default labels for all installs").
+		Long("Labels applied to every install of the app. Values may use the interpolation syntax ({{ .nuon.* }}). These labels cannot be edited or removed on individual installs — only via the app config").
+		Example(`{"tier": "prod", "region": "{{ .nuon.cloud_account.aws.region }}"}`)
 }

--- a/pkg/config/parse/dir.go
+++ b/pkg/config/parse/dir.go
@@ -253,6 +253,7 @@ func (c *ConfigDir) toAppConfig() (*config.AppConfig, error) {
 		cfg.SlackWebhookURL = c.Metadata.SlackWebhookURL
 		cfg.Readme = c.Metadata.Readme
 		cfg.LabelColors = c.Metadata.LabelColors
+		cfg.DefaultLabels = c.Metadata.DefaultLabels
 	}
 
 	return cfg, nil

--- a/pkg/config/validate/validate.go
+++ b/pkg/config/validate/validate.go
@@ -49,6 +49,14 @@ func Validate(ctx context.Context, v *validator.Validate, a *config.AppConfig) e
 			}
 			return nil
 		},
+		func() error {
+			for _, install := range a.Installs {
+				if err := install.Validate(); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
 		// TBH, this does not really work
 		func() error {
 			// return ValidateVars(ctx, a)

--- a/pkg/config/validate/validate.go
+++ b/pkg/config/validate/validate.go
@@ -57,6 +57,9 @@ func Validate(ctx context.Context, v *validator.Validate, a *config.AppConfig) e
 			}
 			return nil
 		},
+		func() error {
+			return ValidateDefaultLabels(a)
+		},
 		// TBH, this does not really work
 		func() error {
 			// return ValidateVars(ctx, a)

--- a/pkg/config/validate/validate_default_labels.go
+++ b/pkg/config/validate/validate_default_labels.go
@@ -1,0 +1,50 @@
+package validate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nuonco/nuon/pkg/config"
+	"github.com/nuonco/nuon/pkg/labels"
+	"github.com/nuonco/nuon/pkg/render"
+)
+
+// ValidateDefaultLabels enforces the same label rules as install labels, and
+// rejects per-install label keys that collide with a default — the app-level
+// block is the only place a default key may be set.
+func ValidateDefaultLabels(a *config.AppConfig) error {
+	for key, val := range a.DefaultLabels {
+		if strings.Contains(key, "{{") {
+			return config.ErrConfig{
+				Description: fmt.Sprintf("default label key %q must not use the interpolation syntax", key),
+				Err:         fmt.Errorf("default label key %q is templated; only label values may be templated", key),
+			}
+		}
+		if !labels.IsTemplatedValue(val) {
+			continue
+		}
+		if err := render.ValidateTextTemplate(val); err != nil {
+			return config.ErrConfig{
+				Description: fmt.Sprintf("default label %q is not a valid template", key),
+				Err:         fmt.Errorf("default label %q template: %w", key, err),
+			}
+		}
+	}
+
+	if len(a.DefaultLabels) == 0 {
+		return nil
+	}
+
+	for _, install := range a.Installs {
+		for key := range install.Labels {
+			if _, ok := a.DefaultLabels[key]; ok {
+				return config.ErrConfig{
+					Description: fmt.Sprintf("install %q label %q is a default label; set it only in default_labels", install.Name, key),
+					Err:         fmt.Errorf("install %q label %q collides with a default label", install.Name, key),
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/config/validate/validate_default_labels_test.go
+++ b/pkg/config/validate/validate_default_labels_test.go
@@ -1,0 +1,53 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/pkg/config"
+)
+
+func TestValidateDefaultLabels(t *testing.T) {
+	t.Run("static and valid templated values pass", func(t *testing.T) {
+		require.NoError(t, ValidateDefaultLabels(&config.AppConfig{
+			DefaultLabels: map[string]string{
+				"tier":   "prod",
+				"region": "{{ .nuon.cloud_account.aws.region }}",
+			},
+		}))
+	})
+
+	t.Run("templated key rejected", func(t *testing.T) {
+		err := ValidateDefaultLabels(&config.AppConfig{
+			DefaultLabels: map[string]string{"{{ .nuon.install.id }}": "v"},
+		})
+		require.ErrorContains(t, err, "only label values may be templated")
+	})
+
+	t.Run("unparsable template rejected", func(t *testing.T) {
+		err := ValidateDefaultLabels(&config.AppConfig{
+			DefaultLabels: map[string]string{"region": "{{ .nuon.cloud_account"},
+		})
+		require.ErrorContains(t, err, "template")
+	})
+
+	t.Run("install label colliding with default rejected", func(t *testing.T) {
+		err := ValidateDefaultLabels(&config.AppConfig{
+			DefaultLabels: map[string]string{"tier": "prod"},
+			Installs: []*config.Install{
+				{Name: "customer-a", Labels: map[string]string{"tier": "gold"}},
+			},
+		})
+		require.ErrorContains(t, err, "collides with a default label")
+	})
+
+	t.Run("install labels without collisions pass", func(t *testing.T) {
+		require.NoError(t, ValidateDefaultLabels(&config.AppConfig{
+			DefaultLabels: map[string]string{"tier": "prod"},
+			Installs: []*config.Install{
+				{Name: "customer-a", Labels: map[string]string{"env": "prod"}},
+			},
+		}))
+	})
+}

--- a/pkg/labels/defaults.go
+++ b/pkg/labels/defaults.go
@@ -1,0 +1,33 @@
+package labels
+
+import "maps"
+
+// ApplyDefaults reconciles an install's labels against its app's default
+// labels. snapshot is the set of defaults previously applied — it is what lets
+// a removed default be told apart from a user-set label. Templated defaults go
+// to templates for later rendering; static defaults land in labels directly.
+func ApplyDefaults(current, templates, snapshot, defaults Labels) (newLabels, newTemplates Labels, changed bool) {
+	newLabels = make(Labels, len(current)+len(defaults))
+	maps.Copy(newLabels, current)
+	newTemplates = make(Labels, len(templates)+len(defaults))
+	maps.Copy(newTemplates, templates)
+
+	for key := range snapshot {
+		if _, ok := defaults[key]; !ok {
+			delete(newLabels, key)
+			delete(newTemplates, key)
+		}
+	}
+
+	for key, val := range defaults {
+		if IsTemplatedValue(val) {
+			newTemplates[key] = val
+			continue
+		}
+		newLabels[key] = val
+		delete(newTemplates, key)
+	}
+
+	changed = !maps.Equal(newLabels, current) || !maps.Equal(newTemplates, templates)
+	return newLabels, newTemplates, changed
+}

--- a/pkg/labels/defaults_test.go
+++ b/pkg/labels/defaults_test.go
@@ -1,0 +1,66 @@
+package labels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyDefaults(t *testing.T) {
+	t.Run("applies static and templated defaults", func(t *testing.T) {
+		newLabels, newTemplates, changed := ApplyDefaults(
+			Labels{"env": "prod"},
+			nil,
+			nil,
+			Labels{"tier": "gold", "region": "{{ .nuon.cloud_account.aws.region }}"},
+		)
+		require.True(t, changed)
+		require.Equal(t, Labels{"env": "prod", "tier": "gold"}, newLabels)
+		require.Equal(t, Labels{"region": "{{ .nuon.cloud_account.aws.region }}"}, newTemplates)
+	})
+
+	t.Run("removes defaults dropped from the app config", func(t *testing.T) {
+		newLabels, newTemplates, changed := ApplyDefaults(
+			Labels{"env": "prod", "tier": "gold", "region": "us-west-2"},
+			Labels{"region": "{{ .nuon.cloud_account.aws.region }}"},
+			Labels{"tier": "gold", "region": "{{ .nuon.cloud_account.aws.region }}"},
+			nil,
+		)
+		require.True(t, changed)
+		require.Equal(t, Labels{"env": "prod"}, newLabels)
+		require.Empty(t, newTemplates)
+	})
+
+	t.Run("keeps user labels not in the snapshot", func(t *testing.T) {
+		newLabels, _, changed := ApplyDefaults(
+			Labels{"custom": "value", "tier": "gold"},
+			nil,
+			Labels{"tier": "gold"},
+			Labels{"tier": "silver"},
+		)
+		require.True(t, changed)
+		require.Equal(t, Labels{"custom": "value", "tier": "silver"}, newLabels)
+	})
+
+	t.Run("default switching from templated to static clears the template", func(t *testing.T) {
+		newLabels, newTemplates, changed := ApplyDefaults(
+			Labels{"region": "us-west-2"},
+			Labels{"region": "{{ .nuon.cloud_account.aws.region }}"},
+			Labels{"region": "{{ .nuon.cloud_account.aws.region }}"},
+			Labels{"region": "static-region"},
+		)
+		require.True(t, changed)
+		require.Equal(t, Labels{"region": "static-region"}, newLabels)
+		require.Empty(t, newTemplates)
+	})
+
+	t.Run("no changes reports unchanged", func(t *testing.T) {
+		_, _, changed := ApplyDefaults(
+			Labels{"tier": "gold"},
+			Labels{"region": "{{ .nuon.cloud_account.aws.region }}"},
+			Labels{"tier": "gold", "region": "{{ .nuon.cloud_account.aws.region }}"},
+			Labels{"tier": "gold", "region": "{{ .nuon.cloud_account.aws.region }}"},
+		)
+		require.False(t, changed)
+	})
+}

--- a/pkg/labels/dynamic.go
+++ b/pkg/labels/dynamic.go
@@ -3,15 +3,13 @@ package labels
 import "strings"
 
 // IsTemplatedValue reports whether a label value is a dynamic label template.
-// It mirrors the render package's fast path: a value is only ever rendered
-// when it references the .nuon namespace inside an interpolation expression,
-// so anything else — including braces without .nuon — stays a literal.
+// Mirrors the render package's fast path: only values referencing .nuon inside
+// braces are ever rendered; anything else stays a literal.
 func IsTemplatedValue(value string) bool {
 	return strings.Contains(value, "{{") && strings.Contains(value, ".nuon")
 }
 
-// SplitTemplated partitions labels into static literal values and templated
-// values that must be rendered against install state before use.
+// SplitTemplated partitions labels into static literals and templated values.
 func (l Labels) SplitTemplated() (static Labels, templated Labels) {
 	static = make(Labels)
 	templated = make(Labels)

--- a/pkg/labels/dynamic.go
+++ b/pkg/labels/dynamic.go
@@ -1,0 +1,26 @@
+package labels
+
+import "strings"
+
+// IsTemplatedValue reports whether a label value is a dynamic label template.
+// It mirrors the render package's fast path: a value is only ever rendered
+// when it references the .nuon namespace inside an interpolation expression,
+// so anything else — including braces without .nuon — stays a literal.
+func IsTemplatedValue(value string) bool {
+	return strings.Contains(value, "{{") && strings.Contains(value, ".nuon")
+}
+
+// SplitTemplated partitions labels into static literal values and templated
+// values that must be rendered against install state before use.
+func (l Labels) SplitTemplated() (static Labels, templated Labels) {
+	static = make(Labels)
+	templated = make(Labels)
+	for k, v := range l {
+		if IsTemplatedValue(v) {
+			templated[k] = v
+		} else {
+			static[k] = v
+		}
+	}
+	return static, templated
+}

--- a/pkg/labels/dynamic_test.go
+++ b/pkg/labels/dynamic_test.go
@@ -1,0 +1,51 @@
+package labels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsTemplatedValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"plain literal", "production", false},
+		{"nuon reference", "{{ .nuon.install.id }}", true},
+		{"nuon reference no spaces", "{{.nuon.components.api.outputs.version}}", true},
+		{"mixed literal and template", "region-{{ .nuon.cloud_account.aws.region }}", true},
+		{"braces without nuon", "{{ now }}", false},
+		{"nuon without braces", ".nuon.install.id", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsTemplatedValue(tt.value))
+		})
+	}
+}
+
+func TestSplitTemplated(t *testing.T) {
+	l := Labels{
+		"env":     "production",
+		"region":  "{{ .nuon.cloud_account.aws.region }}",
+		"version": "{{ .nuon.components.api.outputs.version }}",
+		"team":    "platform",
+	}
+
+	static, templated := l.SplitTemplated()
+
+	assert.Equal(t, Labels{"env": "production", "team": "platform"}, static)
+	assert.Equal(t, Labels{
+		"region":  "{{ .nuon.cloud_account.aws.region }}",
+		"version": "{{ .nuon.components.api.outputs.version }}",
+	}, templated)
+}
+
+func TestSplitTemplatedEmpty(t *testing.T) {
+	static, templated := Labels(nil).SplitTemplated()
+	assert.Empty(t, static)
+	assert.Empty(t, templated)
+}

--- a/sdks/nuon-go/client/nuon_client.go
+++ b/sdks/nuon-go/client/nuon_client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-
 	"github.com/nuonco/nuon/sdks/nuon-go/client/operations"
 )
 

--- a/sdks/nuon-go/client/operations/operations_client.go
+++ b/sdks/nuon-go/client/operations/operations_client.go
@@ -1162,7 +1162,7 @@ func (a *Client) AddAppComponentLabels(params *AddAppComponentLabelsParams, auth
 /*
 AddInstallLabels adds labels to an install
 
-Merge the provided labels into the install's existing labels. Existing keys are overwritten.
+Merge the provided labels into the install's existing labels. Existing keys are overwritten. A value using the .nuon interpolation syntax becomes a dynamic label: the template is stored and its rendered value is re-materialized whenever install state changes. Keys managed by the app config's default_labels cannot be changed here.
 */
 func (a *Client) AddInstallLabels(params *AddInstallLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*AddInstallLabelsOK, error) {
 	// NOTE: parameters are not validated before sending
@@ -18897,7 +18897,7 @@ func (a *Client) RemoveAppComponentLabels(params *RemoveAppComponentLabelsParams
 /*
 RemoveInstallLabels removes labels from an install
 
-Remove the specified label keys from the install.
+Remove the specified label keys from the install. Removing a dynamic label's key also removes its template. Keys managed by the app config's default_labels cannot be removed here.
 */
 func (a *Client) RemoveInstallLabels(params *RemoveInstallLabelsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*RemoveInstallLabelsOK, error) {
 	// NOTE: parameters are not validated before sending

--- a/sdks/nuon-go/models/app_app.go
+++ b/sdks/nuon-go/models/app_app.go
@@ -41,6 +41,10 @@ type AppApp struct {
 	// created by id
 	CreatedByID string `json:"created_by_id,omitempty"`
 
+	// DefaultLabels are applied to every install of the app and can only be
+	// changed via app config sync — install label endpoints reject these keys.
+	DefaultLabels map[string]string `json:"default_labels,omitempty"`
+
 	// description
 	Description string `json:"description,omitempty"`
 

--- a/sdks/nuon-go/models/app_install.go
+++ b/sdks/nuon-go/models/app_install.go
@@ -32,6 +32,11 @@ type AppInstall struct {
 	// app config id
 	AppConfigID string `json:"app_config_id,omitempty"`
 
+	// AppDefaultLabels is the snapshot of the app's default labels applied to
+	// this install. It is the lock set for label mutation endpoints, and lets
+	// reconciliation tell a removed default apart from a user-set label.
+	AppDefaultLabels map[string]string `json:"app_default_labels,omitempty"`
+
 	// app id
 	AppID string `json:"app_id,omitempty"`
 
@@ -134,6 +139,14 @@ type AppInstall struct {
 
 	// install states
 	InstallStates []*AppInstallState `json:"install_states"`
+
+	// LabelTemplates holds label values written with the .nuon interpolation
+	// syntax. Rendered values are materialized into Labels whenever install
+	// state changes, so downstream consumers (SQL label matching, subscription
+	// dispatch, pickers) only ever read literal values. NOTE: this comment ends
+	// up in the swagger spec, which swag executes as a Go text/template —
+	// literal moustaches here break spec generation.
+	LabelTemplates map[string]string `json:"label_templates,omitempty"`
 
 	// labels
 	Labels GithubComNuoncoNuonPkgLabelsLabels `json:"labels,omitempty"`

--- a/services/ctl-api/internal/app/admin-dashboard/service/install_labels.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/install_labels.go
@@ -39,6 +39,11 @@ func (s *service) AddInstallLabel(c *gin.Context) {
 		return
 	}
 
+	if _, isDefault := install.AppDefaultLabels[req.Key]; isDefault {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Label is a default label defined in the app config"})
+		return
+	}
+
 	install.Labels.Merge(labels.Labels{req.Key: req.Value})
 
 	if err := s.db.WithContext(ctx).Model(&install).Select("labels").Updates(&install).Error; err != nil {
@@ -68,6 +73,11 @@ func (s *service) RemoveInstallLabel(c *gin.Context) {
 	if err := s.db.WithContext(ctx).First(&install, "id = ?", installID).Error; err != nil {
 		s.l.Error("failed to get install", zap.String("install_id", installID), zap.Error(err))
 		c.JSON(http.StatusNotFound, gin.H{"error": "Install not found"})
+		return
+	}
+
+	if _, isDefault := install.AppDefaultLabels[key]; isDefault {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Label is a default label defined in the app config"})
 		return
 	}
 

--- a/services/ctl-api/internal/app/app.go
+++ b/services/ctl-api/internal/app/app.go
@@ -37,6 +37,10 @@ type App struct {
 	DisplayName generics.NullString `json:"display_name,omitzero" swaggertype:"string" temporaljson:"display_name,omitzero,omitempty"`
 	LabelColors labels.Labels       `json:"label_colors,omitzero" gorm:"type:jsonb" temporaljson:"label_colors,omitzero,omitempty" swaggertype:"object"`
 
+	// DefaultLabels are applied to every install of the app and can only be
+	// changed via app config sync — install label endpoints reject these keys.
+	DefaultLabels labels.Labels `json:"default_labels,omitzero" gorm:"type:jsonb" temporaljson:"default_labels,omitzero,omitempty" swaggertype:"object,string"`
+
 	OrgID string `json:"org_id,omitzero" gorm:"index:idx_app_name,unique" temporaljson:"org_id,omitzero,omitempty"`
 	Org   *Org   `faker:"-" json:"-" temporaljson:"org,omitzero,omitempty"`
 

--- a/services/ctl-api/internal/app/install.go
+++ b/services/ctl-api/internal/app/install.go
@@ -38,6 +38,14 @@ type Install struct {
 	LifecyclePhase lifecyclephase.LifecyclePhase `json:"lifecycle_phase,omitzero" gorm:"type:jsonb" swaggertype:"object" temporaljson:"lifecycle_phase,omitzero,omitempty"`
 	labels.Labeled
 
+	// LabelTemplates holds label values written with the app-config interpolation
+	// syntax ({{ .nuon.* }}), keyed by label key. Rendered values are materialized
+	// into Labels whenever install state changes, so every downstream consumer
+	// (SQL label matching, subscription dispatch, label-key pickers) keeps reading
+	// literal values. Keys present here are template-managed and rejected by the
+	// direct label mutation endpoints.
+	LabelTemplates labels.Labels `json:"label_templates,omitzero" gorm:"default null" swaggertype:"object,string" temporaljson:"label_templates,omitzero,omitempty"`
+
 	// used for RLS
 	OrgID string `json:"org_id,omitzero" gorm:"notnull" swaggerignore:"true" temporaljson:"org_id,omitzero,omitempty"`
 	Org   Org    `json:"-" faker:"-" temporaljson:"org,omitzero,omitempty"`

--- a/services/ctl-api/internal/app/install.go
+++ b/services/ctl-api/internal/app/install.go
@@ -38,10 +38,12 @@ type Install struct {
 	LifecyclePhase lifecyclephase.LifecyclePhase `json:"lifecycle_phase,omitzero" gorm:"type:jsonb" swaggertype:"object" temporaljson:"lifecycle_phase,omitzero,omitempty"`
 	labels.Labeled
 
-	// LabelTemplates holds label values written with the interpolation syntax
-	// ({{ .nuon.* }}). Rendered values are materialized into Labels whenever
-	// install state changes, so downstream consumers (SQL label matching,
-	// subscription dispatch, pickers) only ever read literal values.
+	// LabelTemplates holds label values written with the .nuon interpolation
+	// syntax. Rendered values are materialized into Labels whenever install
+	// state changes, so downstream consumers (SQL label matching, subscription
+	// dispatch, pickers) only ever read literal values. NOTE: this comment ends
+	// up in the swagger spec, which swag executes as a Go text/template —
+	// literal moustaches here break spec generation.
 	LabelTemplates labels.Labels `json:"label_templates,omitzero" gorm:"default null" swaggertype:"object,string" temporaljson:"label_templates,omitzero,omitempty"`
 
 	// AppDefaultLabels is the snapshot of the app's default labels applied to

--- a/services/ctl-api/internal/app/install.go
+++ b/services/ctl-api/internal/app/install.go
@@ -38,12 +38,10 @@ type Install struct {
 	LifecyclePhase lifecyclephase.LifecyclePhase `json:"lifecycle_phase,omitzero" gorm:"type:jsonb" swaggertype:"object" temporaljson:"lifecycle_phase,omitzero,omitempty"`
 	labels.Labeled
 
-	// LabelTemplates holds label values written with the app-config interpolation
-	// syntax ({{ .nuon.* }}), keyed by label key. Rendered values are materialized
-	// into Labels whenever install state changes, so every downstream consumer
-	// (SQL label matching, subscription dispatch, label-key pickers) keeps reading
-	// literal values. Keys present here are template-managed and rejected by the
-	// direct label mutation endpoints.
+	// LabelTemplates holds label values written with the interpolation syntax
+	// ({{ .nuon.* }}). Rendered values are materialized into Labels whenever
+	// install state changes, so downstream consumers (SQL label matching,
+	// subscription dispatch, pickers) only ever read literal values.
 	LabelTemplates labels.Labels `json:"label_templates,omitzero" gorm:"default null" swaggertype:"object,string" temporaljson:"label_templates,omitzero,omitempty"`
 
 	// used for RLS

--- a/services/ctl-api/internal/app/install.go
+++ b/services/ctl-api/internal/app/install.go
@@ -44,6 +44,11 @@ type Install struct {
 	// subscription dispatch, pickers) only ever read literal values.
 	LabelTemplates labels.Labels `json:"label_templates,omitzero" gorm:"default null" swaggertype:"object,string" temporaljson:"label_templates,omitzero,omitempty"`
 
+	// AppDefaultLabels is the snapshot of the app's default labels applied to
+	// this install. It is the lock set for label mutation endpoints, and lets
+	// reconciliation tell a removed default apart from a user-set label.
+	AppDefaultLabels labels.Labels `json:"app_default_labels,omitzero" gorm:"default null" swaggertype:"object,string" temporaljson:"app_default_labels,omitzero,omitempty"`
+
 	// used for RLS
 	OrgID string `json:"org_id,omitzero" gorm:"notnull" swaggerignore:"true" temporaljson:"org_id,omitzero,omitempty"`
 	Org   Org    `json:"-" faker:"-" temporaljson:"org,omitzero,omitempty"`

--- a/services/ctl-api/internal/app/installs/helpers/apply_app_default_labels.go
+++ b/services/ctl-api/internal/app/installs/helpers/apply_app_default_labels.go
@@ -1,0 +1,55 @@
+package helpers
+
+import (
+	"context"
+	"maps"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/pkg/labels"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// ApplyAppDefaultLabels reconciles the install's labels against the app's
+// current default labels, using the install's snapshot to clean up defaults
+// that were removed from the app config.
+func (h *Helpers) ApplyAppDefaultLabels(ctx context.Context, installID string) error {
+	var install app.Install
+	if err := h.db.WithContext(ctx).
+		Select("id", "app_id", "labels", "label_templates", "app_default_labels").
+		First(&install, "id = ?", installID).Error; err != nil {
+		return errors.Wrap(err, "unable to get install")
+	}
+
+	var parentApp app.App
+	if err := h.db.WithContext(ctx).
+		Select("id", "default_labels").
+		First(&parentApp, "id = ?", install.AppID).Error; err != nil {
+		return errors.Wrap(err, "unable to get app")
+	}
+
+	newLabels, newTemplates, changed := labels.ApplyDefaults(
+		install.Labels, install.LabelTemplates, install.AppDefaultLabels, parentApp.DefaultLabels)
+	snapshotChanged := !maps.Equal(
+		map[string]string(install.AppDefaultLabels), map[string]string(parentApp.DefaultLabels))
+	if !changed && !snapshotChanged {
+		return nil
+	}
+
+	updates := map[string]any{
+		"labels":             newLabels,
+		"label_templates":    newTemplates,
+		"app_default_labels": parentApp.DefaultLabels,
+	}
+	if err := h.db.WithContext(ctx).Model(&app.Install{}).
+		Where("id = ?", installID).
+		Updates(updates).Error; err != nil {
+		return errors.Wrap(err, "unable to persist default labels")
+	}
+
+	if len(newTemplates) > 0 {
+		return h.RenderInstallLabels(ctx, installID)
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/app/installs/helpers/create_install.go
+++ b/services/ctl-api/internal/app/installs/helpers/create_install.go
@@ -136,6 +136,24 @@ func (s *Helpers) CreateInstall(ctx context.Context, appID string, req *CreateIn
 		}),
 	}
 
+	if len(parentApp.DefaultLabels) > 0 {
+		combined := make(map[string]string, len(req.Labels)+len(parentApp.DefaultLabels))
+		for k, v := range req.Labels {
+			combined[k] = v
+		}
+		for key, val := range parentApp.DefaultLabels {
+			if cur, ok := combined[key]; ok && cur != val {
+				return nil, stderr.ErrUser{
+					Err:         fmt.Errorf("label %q is a default label defined in the app config and cannot be overridden", key),
+					Description: fmt.Sprintf("label %q is a default label defined in the app config and cannot be overridden", key),
+				}
+			}
+			combined[key] = val
+		}
+		req.Labels = combined
+		install.AppDefaultLabels = parentApp.DefaultLabels
+	}
+
 	if len(req.Labels) > 0 {
 		static, templated := labels.Labels(req.Labels).SplitTemplated()
 		for key, tmpl := range templated {

--- a/services/ctl-api/internal/app/installs/helpers/create_install.go
+++ b/services/ctl-api/internal/app/installs/helpers/create_install.go
@@ -10,6 +10,7 @@ import (
 	pkggenerics "github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/pkg/metrics"
+	"github.com/nuonco/nuon/pkg/render"
 	"github.com/nuonco/nuon/pkg/shortid/domains"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
@@ -136,7 +137,20 @@ func (s *Helpers) CreateInstall(ctx context.Context, appID string, req *CreateIn
 	}
 
 	if len(req.Labels) > 0 {
-		install.Labels = labels.Labels(req.Labels)
+		static, templated := labels.Labels(req.Labels).SplitTemplated()
+		for key, tmpl := range templated {
+			if err := render.ValidateTextTemplate(tmpl); err != nil {
+				return nil, stderr.ErrUser{
+					Err:         fmt.Errorf("label %q template is invalid: %w", key, err),
+					Description: fmt.Sprintf("label %q uses the interpolation syntax but is not a valid template", key),
+				}
+			}
+		}
+		install.Labels = static
+		if len(templated) > 0 {
+			// Rendered once install state exists; the keys stay absent until then.
+			install.LabelTemplates = templated
+		}
 	}
 
 	// When enabled, every install must declare which cloud account it targets, so a

--- a/services/ctl-api/internal/app/installs/helpers/render_install_labels.go
+++ b/services/ctl-api/internal/app/installs/helpers/render_install_labels.go
@@ -1,0 +1,83 @@
+package helpers
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/pkg/labels"
+	"github.com/nuonco/nuon/pkg/render"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+)
+
+// RenderInstallLabels renders the install's label templates against current
+// install state and materializes the results into the labels column, so label
+// matching (SQL containment, subscription dispatch, branch selectors) only
+// ever sees literal values. Called after state (re)generation and after a
+// config sync writes new templates.
+//
+// A template that cannot be resolved yet — e.g. it references a component
+// output that has not populated — keeps the key's previous rendered value, or
+// leaves the key absent if it never rendered. Render failures never propagate:
+// labels must not fail state generation or config sync.
+func (h *Helpers) RenderInstallLabels(ctx context.Context, installID string) error {
+	var install app.Install
+	if err := h.db.WithContext(ctx).
+		Select("id", "labels", "label_templates").
+		First(&install, "id = ?", installID).Error; err != nil {
+		return errors.Wrap(err, "unable to get install")
+	}
+
+	if len(install.LabelTemplates) == 0 {
+		return nil
+	}
+
+	// Redacted state so a template referencing a sensitive input can never
+	// leak its value into a label, which is visible org-wide and in events.
+	is, err := h.GetInstallState(ctx, installID, true, true)
+	if err != nil {
+		return errors.Wrap(err, "unable to get install state")
+	}
+
+	// Label templates must not reference labels themselves.
+	is.Labels = nil
+	data, err := is.AsMap()
+	if err != nil {
+		return errors.Wrap(err, "unable to convert state to map")
+	}
+
+	merged := make(labels.Labels, len(install.Labels)+len(install.LabelTemplates))
+	for k, v := range install.Labels {
+		merged[k] = v
+	}
+
+	changed := false
+	for key, tmpl := range install.LabelTemplates {
+		rendered, err := render.RenderTextV2(tmpl, data)
+		if err != nil || rendered == "" {
+			cctx.GetLogger(ctx, h.l).Warn("unable to render install label template",
+				zap.String("install_id", installID),
+				zap.String("label_key", key),
+				zap.Error(err))
+			continue
+		}
+		if merged[key] != rendered {
+			merged[key] = rendered
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	if err := h.db.WithContext(ctx).Model(&app.Install{}).
+		Where("id = ?", installID).
+		Update("labels", merged).Error; err != nil {
+		return errors.Wrap(err, "unable to persist rendered labels")
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/app/installs/helpers/render_install_labels.go
+++ b/services/ctl-api/internal/app/installs/helpers/render_install_labels.go
@@ -12,16 +12,47 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 )
 
-// RenderInstallLabels renders the install's label templates against current
-// install state and materializes the results into the labels column, so label
-// matching (SQL containment, subscription dispatch, branch selectors) only
-// ever sees literal values. Called after state (re)generation and after a
-// config sync writes new templates.
-//
-// A template that cannot be resolved yet — e.g. it references a component
-// output that has not populated — keeps the key's previous rendered value, or
-// leaves the key absent if it never rendered. Render failures never propagate:
-// labels must not fail state generation or config sync.
+// RenderLabelTemplates renders label templates against current install state,
+// returning only keys that rendered non-empty. Unresolvable templates (e.g. a
+// component output not yet populated) are skipped with a warning, never an
+// error. State is redacted so sensitive inputs can't leak into org-visible
+// labels, and labels are stripped from the context to prevent self-reference.
+func (h *Helpers) RenderLabelTemplates(ctx context.Context, installID string, templates labels.Labels) (labels.Labels, error) {
+	rendered := make(labels.Labels, len(templates))
+	if len(templates) == 0 {
+		return rendered, nil
+	}
+
+	is, err := h.GetInstallState(ctx, installID, true, true)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get install state")
+	}
+
+	is.Labels = nil
+	data, err := is.AsMap()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to convert state to map")
+	}
+
+	for key, tmpl := range templates {
+		out, err := render.RenderTextV2(tmpl, data)
+		if err != nil || out == "" {
+			cctx.GetLogger(ctx, h.l).Warn("unable to render install label template",
+				zap.String("install_id", installID),
+				zap.String("label_key", key),
+				zap.Error(err))
+			continue
+		}
+		rendered[key] = out
+	}
+
+	return rendered, nil
+}
+
+// RenderInstallLabels materializes the install's label templates into the
+// labels column so label matching only ever sees literal values. Unresolvable
+// keys keep their previous rendered value, or stay absent if they never
+// rendered.
 func (h *Helpers) RenderInstallLabels(ctx context.Context, installID string) error {
 	var install app.Install
 	if err := h.db.WithContext(ctx).
@@ -34,37 +65,20 @@ func (h *Helpers) RenderInstallLabels(ctx context.Context, installID string) err
 		return nil
 	}
 
-	// Redacted state so a template referencing a sensitive input can never
-	// leak its value into a label, which is visible org-wide and in events.
-	is, err := h.GetInstallState(ctx, installID, true, true)
+	rendered, err := h.RenderLabelTemplates(ctx, installID, install.LabelTemplates)
 	if err != nil {
-		return errors.Wrap(err, "unable to get install state")
+		return err
 	}
 
-	// Label templates must not reference labels themselves.
-	is.Labels = nil
-	data, err := is.AsMap()
-	if err != nil {
-		return errors.Wrap(err, "unable to convert state to map")
-	}
-
-	merged := make(labels.Labels, len(install.Labels)+len(install.LabelTemplates))
+	merged := make(labels.Labels, len(install.Labels)+len(rendered))
 	for k, v := range install.Labels {
 		merged[k] = v
 	}
 
 	changed := false
-	for key, tmpl := range install.LabelTemplates {
-		rendered, err := render.RenderTextV2(tmpl, data)
-		if err != nil || rendered == "" {
-			cctx.GetLogger(ctx, h.l).Warn("unable to render install label template",
-				zap.String("install_id", installID),
-				zap.String("label_key", key),
-				zap.Error(err))
-			continue
-		}
-		if merged[key] != rendered {
-			merged[key] = rendered
+	for key, val := range rendered {
+		if merged[key] != val {
+			merged[key] = val
 			changed = true
 		}
 	}

--- a/services/ctl-api/internal/app/installs/service/add_install_labels.go
+++ b/services/ctl-api/internal/app/installs/service/add_install_labels.go
@@ -27,7 +27,7 @@ func (r *AddInstallLabelsRequest) Validate(v *validator.Validate) error {
 
 // @ID						AddInstallLabels
 // @Summary				add labels to an install
-// @Description			Merge the provided labels into the install's existing labels. Existing keys are overwritten. A value using the interpolation syntax ({{ .nuon.* }}) becomes a dynamic label: the template is stored and its rendered value is re-materialized whenever install state changes. Keys managed by the app config's default_labels cannot be changed here.
+// @Description			Merge the provided labels into the install's existing labels. Existing keys are overwritten. A value using the .nuon interpolation syntax becomes a dynamic label: the template is stored and its rendered value is re-materialized whenever install state changes. Keys managed by the app config's default_labels cannot be changed here.
 // @Param					install_id	path	string					true	"install ID"
 // @Param					req			body	AddInstallLabelsRequest	true	"Input"
 // @Tags					installs

--- a/services/ctl-api/internal/app/installs/service/add_install_labels.go
+++ b/services/ctl-api/internal/app/installs/service/add_install_labels.go
@@ -60,6 +60,23 @@ func (s *service) AddInstallLabels(ctx *gin.Context) {
 		return
 	}
 
+	for key, val := range req.Labels {
+		if _, ok := install.LabelTemplates[key]; ok {
+			ctx.Error(stderr.ErrUser{
+				Err:         fmt.Errorf("label %q is template-managed", key),
+				Description: fmt.Sprintf("label %q is a dynamic label managed by an app config template; update the template in the app config instead", key),
+			})
+			return
+		}
+		if labels.IsTemplatedValue(val) {
+			ctx.Error(stderr.ErrUser{
+				Err:         fmt.Errorf("label %q value uses the interpolation syntax", key),
+				Description: fmt.Sprintf("label %q uses the interpolation syntax; dynamic labels are defined on the install in the app config", key),
+			})
+			return
+		}
+	}
+
 	merged := make(labels.Labels)
 	for k, v := range install.Labels {
 		merged[k] = v

--- a/services/ctl-api/internal/app/installs/service/add_install_labels.go
+++ b/services/ctl-api/internal/app/installs/service/add_install_labels.go
@@ -27,7 +27,7 @@ func (r *AddInstallLabelsRequest) Validate(v *validator.Validate) error {
 
 // @ID						AddInstallLabels
 // @Summary				add labels to an install
-// @Description			Merge the provided labels into the install's existing labels. Existing keys are overwritten. A value using the interpolation syntax ({{ .nuon.* }}) becomes a dynamic label: the template is stored and its rendered value is re-materialized whenever install state changes.
+// @Description			Merge the provided labels into the install's existing labels. Existing keys are overwritten. A value using the interpolation syntax ({{ .nuon.* }}) becomes a dynamic label: the template is stored and its rendered value is re-materialized whenever install state changes. Keys managed by the app config's default_labels cannot be changed here.
 // @Param					install_id	path	string					true	"install ID"
 // @Param					req			body	AddInstallLabelsRequest	true	"Input"
 // @Tags					installs
@@ -58,6 +58,25 @@ func (s *service) AddInstallLabels(ctx *gin.Context) {
 	var install app.Install
 	if err := s.db.WithContext(ctx).First(&install, "id = ?", installID).Error; err != nil {
 		ctx.Error(fmt.Errorf("unable to get install %s: %w", installID, err))
+		return
+	}
+
+	// Default labels are set in the app config; a write that echoes the current
+	// rendered value or the default itself is a harmless round-trip, anything
+	// else is rejected.
+	for key, val := range req.Labels {
+		def, isDefault := install.AppDefaultLabels[key]
+		if !isDefault {
+			continue
+		}
+		if val == install.Labels[key] || val == def {
+			delete(req.Labels, key)
+			continue
+		}
+		ctx.Error(stderr.ErrUser{
+			Err:         fmt.Errorf("label %q is a default label; edit default_labels in the app config and sync", key),
+			Description: fmt.Sprintf("label %q is a default label; edit default_labels in the app config and sync", key),
+		})
 		return
 	}
 

--- a/services/ctl-api/internal/app/installs/service/add_install_labels.go
+++ b/services/ctl-api/internal/app/installs/service/add_install_labels.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-playground/validator/v10"
 
 	"github.com/nuonco/nuon/pkg/labels"
+	"github.com/nuonco/nuon/pkg/render"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
@@ -26,7 +27,7 @@ func (r *AddInstallLabelsRequest) Validate(v *validator.Validate) error {
 
 // @ID						AddInstallLabels
 // @Summary				add labels to an install
-// @Description			Merge the provided labels into the install's existing labels. Existing keys are overwritten.
+// @Description			Merge the provided labels into the install's existing labels. Existing keys are overwritten. A value using the interpolation syntax ({{ .nuon.* }}) becomes a dynamic label: the template is stored and its rendered value is re-materialized whenever install state changes.
 // @Param					install_id	path	string					true	"install ID"
 // @Param					req			body	AddInstallLabelsRequest	true	"Input"
 // @Tags					installs
@@ -60,37 +61,57 @@ func (s *service) AddInstallLabels(ctx *gin.Context) {
 		return
 	}
 
-	for key, val := range req.Labels {
-		if _, ok := install.LabelTemplates[key]; ok {
+	static, templated := labels.Labels(req.Labels).SplitTemplated()
+	for key, tmpl := range templated {
+		if err := render.ValidateTextTemplate(tmpl); err != nil {
 			ctx.Error(stderr.ErrUser{
-				Err:         fmt.Errorf("label %q is a dynamic label managed by the app config; update its template there instead", key),
-				Description: fmt.Sprintf("label %q is a dynamic label managed by an app config template; update the template in the app config instead", key),
-			})
-			return
-		}
-		if labels.IsTemplatedValue(val) {
-			ctx.Error(stderr.ErrUser{
-				Err:         fmt.Errorf("label %q value uses the interpolation syntax; define dynamic labels on the install in the app config", key),
-				Description: fmt.Sprintf("label %q uses the interpolation syntax; dynamic labels are defined on the install in the app config", key),
+				Err:         fmt.Errorf("label %q uses the interpolation syntax but is not a valid template: %w", key, err),
+				Description: fmt.Sprintf("label %q uses the interpolation syntax but is not a valid template", key),
 			})
 			return
 		}
 	}
 
-	merged := make(labels.Labels)
+	// A static write echoing a template-managed key's rendered value is a
+	// round-trip from a client that only sees rendered labels — keep the
+	// template. A differing value converts the key back to static.
+	for key, val := range static {
+		if _, managed := install.LabelTemplates[key]; managed && install.Labels[key] == val {
+			delete(static, key)
+		}
+	}
+
+	newTemplates := make(labels.Labels, len(install.LabelTemplates)+len(templated))
+	for k, v := range install.LabelTemplates {
+		newTemplates[k] = v
+	}
+	newTemplates.RemoveKeys(mapKeys(static))
+	newTemplates.Merge(templated)
+
+	merged := make(labels.Labels, len(install.Labels)+len(req.Labels))
 	for k, v := range install.Labels {
 		merged[k] = v
 	}
-	merged.Merge(labels.Labels(req.Labels))
+	merged.Merge(static)
+
+	if len(templated) > 0 {
+		rendered, err := s.helpers.RenderLabelTemplates(ctx, installID, templated)
+		if err != nil {
+			ctx.Error(fmt.Errorf("unable to render label templates: %w", err))
+			return
+		}
+		merged.Merge(rendered)
+	}
 
 	if err := s.appsHelpers.ValidateInstallBranchExclusivity(ctx, &install, merged); err != nil {
 		ctx.Error(err)
 		return
 	}
 
-	install.Labels.Merge(labels.Labels(req.Labels))
+	install.Labels = merged
+	install.LabelTemplates = newTemplates
 
-	if err := s.db.WithContext(ctx).Model(&install).Select("labels").Updates(&install).Error; err != nil {
+	if err := s.db.WithContext(ctx).Model(&install).Select("labels", "label_templates").Updates(&install).Error; err != nil {
 		ctx.Error(fmt.Errorf("unable to update install labels: %w", err))
 		return
 	}
@@ -101,4 +122,12 @@ func (s *service) AddInstallLabels(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, install)
+}
+
+func mapKeys(m labels.Labels) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/services/ctl-api/internal/app/installs/service/add_install_labels.go
+++ b/services/ctl-api/internal/app/installs/service/add_install_labels.go
@@ -63,14 +63,14 @@ func (s *service) AddInstallLabels(ctx *gin.Context) {
 	for key, val := range req.Labels {
 		if _, ok := install.LabelTemplates[key]; ok {
 			ctx.Error(stderr.ErrUser{
-				Err:         fmt.Errorf("label %q is template-managed", key),
+				Err:         fmt.Errorf("label %q is a dynamic label managed by the app config; update its template there instead", key),
 				Description: fmt.Sprintf("label %q is a dynamic label managed by an app config template; update the template in the app config instead", key),
 			})
 			return
 		}
 		if labels.IsTemplatedValue(val) {
 			ctx.Error(stderr.ErrUser{
-				Err:         fmt.Errorf("label %q value uses the interpolation syntax", key),
+				Err:         fmt.Errorf("label %q value uses the interpolation syntax; define dynamic labels on the install in the app config", key),
 				Description: fmt.Sprintf("label %q uses the interpolation syntax; dynamic labels are defined on the install in the app config", key),
 			})
 			return

--- a/services/ctl-api/internal/app/installs/service/generate_cli_install_config.go
+++ b/services/ctl-api/internal/app/installs/service/generate_cli_install_config.go
@@ -79,9 +79,23 @@ func (s *service) genCLIInstallConfig(ctx context.Context, installID string) (*c
 		return nil, fmt.Errorf("unable to get install %s: %w", installID, err)
 	}
 
+	// Template-managed keys echo template text, and app-default keys are
+	// omitted — otherwise every CLI sync diffs against rendered values it can
+	// never declare. Kept in step with upstreamLabels in the installs syncer.
+	installLabels := make(map[string]string, len(install.Labels)+len(install.LabelTemplates))
+	for k, v := range install.Labels {
+		installLabels[k] = v
+	}
+	for k, v := range install.LabelTemplates {
+		installLabels[k] = v
+	}
+	for key := range install.AppDefaultLabels {
+		delete(installLabels, key)
+	}
+
 	installCfg := config.Install{
 		Name:   install.Name,
-		Labels: map[string]string(install.Labels),
+		Labels: installLabels,
 	}
 
 	// The target identifiers must be echoed back, otherwise a config that legitimately

--- a/services/ctl-api/internal/app/installs/service/remove_install_labels.go
+++ b/services/ctl-api/internal/app/installs/service/remove_install_labels.go
@@ -25,7 +25,7 @@ func (r *RemoveInstallLabelsRequest) Validate(v *validator.Validate) error {
 
 // @ID						RemoveInstallLabels
 // @Summary				remove labels from an install
-// @Description			Remove the specified label keys from the install. Removing a dynamic label's key also removes its template.
+// @Description			Remove the specified label keys from the install. Removing a dynamic label's key also removes its template. Keys managed by the app config's default_labels cannot be removed here.
 // @Param					install_id	path	string						true	"install ID"
 // @Param					req			body	RemoveInstallLabelsRequest	true	"Input"
 // @Tags					installs
@@ -57,6 +57,16 @@ func (s *service) RemoveInstallLabels(ctx *gin.Context) {
 	if err := s.db.WithContext(ctx).First(&install, "id = ?", installID).Error; err != nil {
 		ctx.Error(fmt.Errorf("unable to get install %s: %w", installID, err))
 		return
+	}
+
+	for _, key := range req.Keys {
+		if _, isDefault := install.AppDefaultLabels[key]; isDefault {
+			ctx.Error(stderr.ErrUser{
+				Err:         fmt.Errorf("label %q is a default label; remove it from default_labels in the app config and sync", key),
+				Description: fmt.Sprintf("label %q is a default label; remove it from default_labels in the app config and sync", key),
+			})
+			return
+		}
 	}
 
 	install.Labels.RemoveKeys(req.Keys)

--- a/services/ctl-api/internal/app/installs/service/remove_install_labels.go
+++ b/services/ctl-api/internal/app/installs/service/remove_install_labels.go
@@ -62,7 +62,7 @@ func (s *service) RemoveInstallLabels(ctx *gin.Context) {
 	for _, key := range req.Keys {
 		if _, ok := install.LabelTemplates[key]; ok {
 			ctx.Error(stderr.ErrUser{
-				Err:         fmt.Errorf("label %q is template-managed", key),
+				Err:         fmt.Errorf("label %q is a dynamic label managed by the app config; remove its template there instead", key),
 				Description: fmt.Sprintf("label %q is a dynamic label managed by an app config template; remove the template from the app config instead", key),
 			})
 			return

--- a/services/ctl-api/internal/app/installs/service/remove_install_labels.go
+++ b/services/ctl-api/internal/app/installs/service/remove_install_labels.go
@@ -25,7 +25,7 @@ func (r *RemoveInstallLabelsRequest) Validate(v *validator.Validate) error {
 
 // @ID						RemoveInstallLabels
 // @Summary				remove labels from an install
-// @Description			Remove the specified label keys from the install.
+// @Description			Remove the specified label keys from the install. Removing a dynamic label's key also removes its template.
 // @Param					install_id	path	string						true	"install ID"
 // @Param					req			body	RemoveInstallLabelsRequest	true	"Input"
 // @Tags					installs
@@ -59,19 +59,10 @@ func (s *service) RemoveInstallLabels(ctx *gin.Context) {
 		return
 	}
 
-	for _, key := range req.Keys {
-		if _, ok := install.LabelTemplates[key]; ok {
-			ctx.Error(stderr.ErrUser{
-				Err:         fmt.Errorf("label %q is a dynamic label managed by the app config; remove its template there instead", key),
-				Description: fmt.Sprintf("label %q is a dynamic label managed by an app config template; remove the template from the app config instead", key),
-			})
-			return
-		}
-	}
-
 	install.Labels.RemoveKeys(req.Keys)
+	install.LabelTemplates.RemoveKeys(req.Keys)
 
-	if err := s.db.WithContext(ctx).Model(&install).Select("labels").Updates(&install).Error; err != nil {
+	if err := s.db.WithContext(ctx).Model(&install).Select("labels", "label_templates").Updates(&install).Error; err != nil {
 		ctx.Error(fmt.Errorf("unable to update install labels: %w", err))
 		return
 	}

--- a/services/ctl-api/internal/app/installs/service/remove_install_labels.go
+++ b/services/ctl-api/internal/app/installs/service/remove_install_labels.go
@@ -59,6 +59,16 @@ func (s *service) RemoveInstallLabels(ctx *gin.Context) {
 		return
 	}
 
+	for _, key := range req.Keys {
+		if _, ok := install.LabelTemplates[key]; ok {
+			ctx.Error(stderr.ErrUser{
+				Err:         fmt.Errorf("label %q is template-managed", key),
+				Description: fmt.Sprintf("label %q is a dynamic label managed by an app config template; remove the template from the app config instead", key),
+			})
+			return
+		}
+	}
+
 	install.Labels.RemoveKeys(req.Keys)
 
 	if err := s.db.WithContext(ctx).Model(&install).Select("labels").Updates(&install).Error; err != nil {

--- a/services/ctl-api/internal/app/installs/service/update_install.go
+++ b/services/ctl-api/internal/app/installs/service/update_install.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/patcher"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
+	pkgstate "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
 
@@ -144,6 +145,13 @@ func (s *service) updateInstall(ctx context.Context, installID string, req *Upda
 
 	if res.Error != nil {
 		return nil, fmt.Errorf("unable to get install: %w", res.Error)
+	}
+
+	// The cloud partial (and the install identity fields is.ID/is.Name) derive
+	// from the install row; stale_at alone never lazily regenerates, so without a
+	// named partial the updated signal's label render reads the old name.
+	if err := s.helpers.MarkInstallStatePartialsStale(ctx, s.db, installID, pkgstate.PartialCloud); err != nil {
+		return nil, fmt.Errorf("unable to mark install state partials stale: %w", err)
 	}
 
 	return &currentInstall, nil

--- a/services/ctl-api/internal/app/installs/service/update_install_inputs.go
+++ b/services/ctl-api/internal/app/installs/service/update_install_inputs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	executeflow "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeflow"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/installvalidate"
+	pkgstate "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
 	validatorPkg "github.com/nuonco/nuon/services/ctl-api/internal/pkg/validator"
 )
 
@@ -148,7 +149,9 @@ func (s *service) applyInstallInputsUpdate(ctx context.Context, install *app.Ins
 		if err != nil {
 			return fmt.Errorf("unable to create install inputs: %w", err)
 		}
-		return nil
+		// stale_at alone is inert: the partial has to be named or state (and the
+		// updated signal's label render) serves the old inputs
+		return s.helpers.MarkInstallStatePartialsStale(ctx, tx, install.ID, pkgstate.PartialInputs)
 	}); err != nil {
 		return nil, err
 	}

--- a/services/ctl-api/internal/app/installs/signals/appconfigupdated/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/appconfigupdated/signal.go
@@ -87,6 +87,18 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 			zap.Error(err))
 	}
 
+	// A config change can move config-derived state (.nuon.app, migrated inputs)
+	// without touching the default-label set, and ApplyAppDefaultLabels only
+	// renders when that set changed. Best-effort re-render so templates pick up
+	// the new config; reads regenerate the partials marked stale above.
+	if err := activities.AwaitRenderInstallLabels(ctx, &activities.RenderInstallLabelsRequest{
+		InstallID: s.InstallID,
+	}); err != nil {
+		l.Warn("unable to render install label templates",
+			zap.String("install_id", s.InstallID),
+			zap.Error(err))
+	}
+
 	signalsQueue, err := activities.AwaitGetInstallSignalsQueueByInstallID(ctx, s.InstallID)
 	if err != nil {
 		return fmt.Errorf("unable to get install signals queue: %w", err)

--- a/services/ctl-api/internal/app/installs/signals/appconfigupdated/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/appconfigupdated/signal.go
@@ -78,6 +78,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		}
 	}
 
+	// Best-effort: default-label reconciliation must not fail config updates.
+	if err := activities.AwaitApplyAppDefaultLabels(ctx, &activities.ApplyAppDefaultLabelsRequest{
+		InstallID: s.InstallID,
+	}); err != nil {
+		l.Warn("unable to apply app default labels",
+			zap.String("install_id", s.InstallID),
+			zap.Error(err))
+	}
+
 	signalsQueue, err := activities.AwaitGetInstallSignalsQueueByInstallID(ctx, s.InstallID)
 	if err != nil {
 		return fmt.Errorf("unable to get install signals queue: %w", err)

--- a/services/ctl-api/internal/app/installs/signals/state/regenerate.go
+++ b/services/ctl-api/internal/app/installs/signals/state/regenerate.go
@@ -103,6 +103,15 @@ func Regenerate(ctx workflow.Context, req *state.ExecuteRegenerationRequest) (*s
 		}); err != nil {
 			return nil, errors.Wrap(err, "error while archiving state")
 		}
+
+		// Dynamic labels are materialized from the state that was just saved.
+		// Best-effort: an unresolvable template must not fail state generation.
+		if err := installactivities.AwaitRenderInstallLabels(ctx, &installactivities.RenderInstallLabelsRequest{
+			InstallID: req.InstallID,
+		}); err != nil {
+			workflow.GetLogger(ctx).Warn("unable to render install label templates",
+				"install_id", req.InstallID, "error", err)
+		}
 	}
 
 	return &state.ExecuteRegenerationResponse{

--- a/services/ctl-api/internal/app/installs/signals/state/regenerate.go
+++ b/services/ctl-api/internal/app/installs/signals/state/regenerate.go
@@ -104,8 +104,7 @@ func Regenerate(ctx workflow.Context, req *state.ExecuteRegenerationRequest) (*s
 			return nil, errors.Wrap(err, "error while archiving state")
 		}
 
-		// Dynamic labels are materialized from the state that was just saved.
-		// Best-effort: an unresolvable template must not fail state generation.
+		// Best-effort: label rendering must not fail state generation.
 		if err := installactivities.AwaitRenderInstallLabels(ctx, &installactivities.RenderInstallLabelsRequest{
 			InstallID: req.InstallID,
 		}); err != nil {

--- a/services/ctl-api/internal/app/installs/signals/updated/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/updated/signal.go
@@ -59,5 +59,17 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 			return errors.Wrap(err, "unable to mark state as stale")
 		}
 	}
+
+	// Dynamic labels are materialized from install state; nothing else regenerates
+	// state on this path (input/install updates only mark it stale), so render here
+	// or templated values sit stale until an unrelated deploy. The render reads
+	// state through GetInstallState, which regenerates the partials the enqueueing
+	// endpoint marked stale. Best-effort: label rendering must not fail the update.
+	if err := activities.AwaitRenderInstallLabels(ctx, &activities.RenderInstallLabelsRequest{
+		InstallID: s.InstallID,
+	}); err != nil {
+		workflow.GetLogger(ctx).Warn("unable to render install label templates",
+			"install_id", s.InstallID, "error", err)
+	}
 	return nil
 }

--- a/services/ctl-api/internal/app/installs/worker/activities/apply_app_default_labels.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/apply_app_default_labels.go
@@ -1,0 +1,14 @@
+package activities
+
+import (
+	"context"
+)
+
+type ApplyAppDefaultLabelsRequest struct {
+	InstallID string `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) ApplyAppDefaultLabels(ctx context.Context, req *ApplyAppDefaultLabelsRequest) error {
+	return a.helpers.ApplyAppDefaultLabels(ctx, req.InstallID)
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/render_install_labels.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/render_install_labels.go
@@ -1,0 +1,14 @@
+package activities
+
+import (
+	"context"
+)
+
+type RenderInstallLabelsRequest struct {
+	InstallID string `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+func (a *Activities) RenderInstallLabels(ctx context.Context, req *RenderInstallLabelsRequest) error {
+	return a.helpers.RenderInstallLabels(ctx, req.InstallID)
+}

--- a/services/ctl-api/internal/app/installs/worker/state/generate_state.go
+++ b/services/ctl-api/internal/app/installs/worker/state/generate_state.go
@@ -240,8 +240,7 @@ func (w *Workflows) GenerateState(ctx workflow.Context, req *GenerateStateReques
 		return nil, errors.Wrap(err, "unable to purge stale state")
 	}
 
-	// Dynamic labels are materialized from the state that was just saved.
-	// Best-effort: an unresolvable template must not fail state generation.
+	// Best-effort: label rendering must not fail state generation.
 	if err := activities.AwaitRenderInstallLabels(ctx, &activities.RenderInstallLabelsRequest{
 		InstallID: req.InstallID,
 	}); err != nil {

--- a/services/ctl-api/internal/app/installs/worker/state/generate_state.go
+++ b/services/ctl-api/internal/app/installs/worker/state/generate_state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
 
 	"github.com/pkg/errors"
 
@@ -237,6 +238,14 @@ func (w *Workflows) GenerateState(ctx workflow.Context, req *GenerateStateReques
 		InstallID: req.InstallID,
 	}); err != nil {
 		return nil, errors.Wrap(err, "unable to purge stale state")
+	}
+
+	// Dynamic labels are materialized from the state that was just saved.
+	// Best-effort: an unresolvable template must not fail state generation.
+	if err := activities.AwaitRenderInstallLabels(ctx, &activities.RenderInstallLabelsRequest{
+		InstallID: req.InstallID,
+	}); err != nil {
+		l.Warn("unable to render install label templates", zap.Error(err))
 	}
 
 	tags := metrics.ToTags(map[string]string{

--- a/services/ctl-api/internal/pkg/config/syncer/app_metadata.go
+++ b/services/ctl-api/internal/pkg/config/syncer/app_metadata.go
@@ -17,13 +17,14 @@ func (s *syncer) syncApp(ctx context.Context) error {
 	}
 
 	updates := app.App{
-		Description: generics.NewNullString(s.cfg.Description),
-		DisplayName: generics.NewNullString(s.cfg.DisplayName),
-		LabelColors: labels.Labels(s.cfg.LabelColors),
+		Description:   generics.NewNullString(s.cfg.Description),
+		DisplayName:   generics.NewNullString(s.cfg.DisplayName),
+		LabelColors:   labels.Labels(s.cfg.LabelColors),
+		DefaultLabels: labels.Labels(s.cfg.DefaultLabels),
 	}
 
 	res := s.db.WithContext(ctx).
-		Select("description", "display_name", "label_colors").
+		Select("description", "display_name", "label_colors", "default_labels").
 		Model(&currentApp).
 		Updates(updates)
 	if res.Error != nil {

--- a/services/ctl-api/internal/pkg/config/syncer/installs/sync.go
+++ b/services/ctl-api/internal/pkg/config/syncer/installs/sync.go
@@ -3,6 +3,7 @@ package installs
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"gorm.io/gorm"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/pkg/config/sync"
 	"github.com/nuonco/nuon/pkg/labels"
+	"github.com/nuonco/nuon/pkg/render"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	installhelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	pkgstate "github.com/nuonco/nuon/services/ctl-api/internal/pkg/state"
@@ -187,8 +189,10 @@ func updateInstall(ctx context.Context, db *gorm.DB, installHelpers *installhelp
 		}
 	}
 
-	if len(installCfg.Labels) > 0 || len(existing.Labels) > 0 {
-		syncLabels(ctx, db, existing.ID, installCfg.Labels, existing.Labels)
+	if len(installCfg.Labels) > 0 || len(existing.Labels) > 0 || len(existing.LabelTemplates) > 0 {
+		if err := syncLabels(ctx, db, installHelpers, existing, installCfg.Labels); err != nil {
+			return nil, fmt.Errorf("unable to sync labels for install %s: %w", installCfg.Name, err)
+		}
 	}
 
 	db.WithContext(ctx).Model(&app.Install{}).Where("id = ?", existing.ID).Updates(map[string]any{
@@ -204,23 +208,61 @@ func updateInstall(ctx context.Context, db *gorm.DB, installHelpers *installhelp
 	}, nil
 }
 
-func syncLabels(ctx context.Context, db *gorm.DB, installID string, desired, current labels.Labels) {
-	toSet := make(labels.Labels)
-	for k, v := range desired {
-		if cur, ok := current[k]; !ok || cur != v {
-			toSet[k] = v
+// syncLabels merges config labels over the install's current labels so values
+// set out of band survive a sync; keys removed from the config are only
+// cleaned up when they were template-managed, since a stale rendered value
+// would otherwise keep matching selectors forever. Templated values are stored
+// on label_templates and rendered against install state, never written to the
+// labels column as raw template text.
+func syncLabels(ctx context.Context, db *gorm.DB, installHelpers *installhelpers.Helpers, existing *app.Install, desired labels.Labels) error {
+	static, templated := desired.SplitTemplated()
+	for key, tmpl := range templated {
+		if err := render.ValidateTextTemplate(tmpl); err != nil {
+			return fmt.Errorf("label %q template is invalid: %w", key, err)
 		}
 	}
 
-	if len(toSet) > 0 {
-		db.WithContext(ctx).Model(&app.Install{}).Where("id = ?", installID).Update("labels", toSet)
+	merged := make(labels.Labels, len(existing.Labels)+len(static))
+	for k, v := range existing.Labels {
+		merged[k] = v
 	}
+	for key := range existing.LabelTemplates {
+		if _, ok := templated[key]; !ok {
+			delete(merged, key)
+		}
+	}
+	merged.Merge(static)
+
+	updates := map[string]any{}
+	if !maps.Equal(map[string]string(existing.LabelTemplates), map[string]string(templated)) {
+		updates["label_templates"] = templated
+	}
+	if !maps.Equal(map[string]string(existing.Labels), map[string]string(merged)) {
+		updates["labels"] = merged
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+
+	if err := db.WithContext(ctx).Model(&app.Install{}).Where("id = ?", existing.ID).Updates(updates).Error; err != nil {
+		return fmt.Errorf("unable to update install labels: %w", err)
+	}
+
+	// Render immediately so a new template does not wait for the next state
+	// change; unresolvable templates stay absent until state populates.
+	if len(templated) > 0 {
+		if err := installHelpers.RenderInstallLabels(ctx, existing.ID); err != nil {
+			return fmt.Errorf("unable to render install label templates: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func existingToConfig(install *app.Install) *config.Install {
 	cfg := &config.Install{
 		Name:   install.Name,
-		Labels: install.Labels,
+		Labels: upstreamLabels(install),
 	}
 
 	// The target identifiers must be echoed back, otherwise a config that legitimately
@@ -272,6 +314,22 @@ func existingToConfig(install *app.Install) *config.Install {
 	}
 
 	return cfg
+}
+
+// upstreamLabels echoes template text back for template-managed keys, so a
+// config that declares a dynamic label diffs clean against its rendered value
+// instead of showing drift on every sync.
+func upstreamLabels(install *app.Install) labels.Labels {
+	if len(install.LabelTemplates) == 0 {
+		return install.Labels
+	}
+
+	merged := make(labels.Labels, len(install.Labels)+len(install.LabelTemplates))
+	for k, v := range install.Labels {
+		merged[k] = v
+	}
+	merged.Merge(install.LabelTemplates)
+	return merged
 }
 
 func firstNonEmpty(vals ...string) string {

--- a/services/ctl-api/internal/pkg/config/syncer/installs/sync.go
+++ b/services/ctl-api/internal/pkg/config/syncer/installs/sync.go
@@ -213,6 +213,24 @@ func updateInstall(ctx context.Context, db *gorm.DB, installHelpers *installhelp
 // stale rendered value would otherwise keep matching selectors forever.
 // Template text is never written to the labels column.
 func syncLabels(ctx context.Context, db *gorm.DB, installHelpers *installhelpers.Helpers, existing *app.Install, desired labels.Labels) error {
+	// Default-label keys are owned by the app config; an install config echoing
+	// the rendered value or the default itself round-trips, anything else fails.
+	if len(existing.AppDefaultLabels) > 0 && len(desired) > 0 {
+		pruned := make(labels.Labels, len(desired))
+		for key, val := range desired {
+			def, isDefault := existing.AppDefaultLabels[key]
+			if !isDefault {
+				pruned[key] = val
+				continue
+			}
+			if val == existing.Labels[key] || val == def {
+				continue
+			}
+			return fmt.Errorf("label %q is a default label; edit default_labels in the app config", key)
+		}
+		desired = pruned
+	}
+
 	static, templated := desired.SplitTemplated()
 	for key, tmpl := range templated {
 		if err := render.ValidateTextTemplate(tmpl); err != nil {
@@ -220,11 +238,20 @@ func syncLabels(ctx context.Context, db *gorm.DB, installHelpers *installhelpers
 		}
 	}
 
+	newTemplates := make(labels.Labels, len(templated)+len(existing.AppDefaultLabels))
+	for k, v := range templated {
+		newTemplates[k] = v
+	}
+
 	merged := make(labels.Labels, len(existing.Labels)+len(static))
 	for k, v := range existing.Labels {
 		merged[k] = v
 	}
-	for key := range existing.LabelTemplates {
+	for key, tmpl := range existing.LabelTemplates {
+		if _, isDefault := existing.AppDefaultLabels[key]; isDefault {
+			newTemplates[key] = tmpl
+			continue
+		}
 		if _, ok := templated[key]; !ok {
 			delete(merged, key)
 		}
@@ -232,8 +259,8 @@ func syncLabels(ctx context.Context, db *gorm.DB, installHelpers *installhelpers
 	merged.Merge(static)
 
 	updates := map[string]any{}
-	if !maps.Equal(map[string]string(existing.LabelTemplates), map[string]string(templated)) {
-		updates["label_templates"] = templated
+	if !maps.Equal(map[string]string(existing.LabelTemplates), map[string]string(newTemplates)) {
+		updates["label_templates"] = newTemplates
 	}
 	if !maps.Equal(map[string]string(existing.Labels), map[string]string(merged)) {
 		updates["labels"] = merged
@@ -314,9 +341,10 @@ func existingToConfig(install *app.Install) *config.Install {
 }
 
 // upstreamLabels echoes template text for template-managed keys so a dynamic
-// label diffs clean instead of showing drift against its rendered value.
+// label diffs clean instead of showing drift against its rendered value, and
+// strips app-default keys, which install configs never declare.
 func upstreamLabels(install *app.Install) labels.Labels {
-	if len(install.LabelTemplates) == 0 {
+	if len(install.LabelTemplates) == 0 && len(install.AppDefaultLabels) == 0 {
 		return install.Labels
 	}
 
@@ -325,6 +353,9 @@ func upstreamLabels(install *app.Install) labels.Labels {
 		merged[k] = v
 	}
 	merged.Merge(install.LabelTemplates)
+	for key := range install.AppDefaultLabels {
+		delete(merged, key)
+	}
 	return merged
 }
 

--- a/services/ctl-api/internal/pkg/config/syncer/installs/sync.go
+++ b/services/ctl-api/internal/pkg/config/syncer/installs/sync.go
@@ -150,6 +150,13 @@ func updateInstall(ctx context.Context, db *gorm.DB, installHelpers *installhelp
 		if err := syncInstallInputs(ctx, db, installHelpers, existing, definedInputs); err != nil {
 			return nil, fmt.Errorf("unable to update inputs for install %s: %w", installCfg.Name, err)
 		}
+		// syncLabels only renders when the label config itself changed; an
+		// inputs-only sync still moves state that templates can reference.
+		if len(existing.LabelTemplates) > 0 {
+			if err := installHelpers.RenderInstallLabels(ctx, existing.ID); err != nil {
+				return nil, fmt.Errorf("unable to render install label templates for install %s: %w", installCfg.Name, err)
+			}
+		}
 	}
 
 	hasConfigFields := installCfg.ApprovalOption != config.InstallApprovalOptionUnknown ||

--- a/services/ctl-api/internal/pkg/config/syncer/installs/sync.go
+++ b/services/ctl-api/internal/pkg/config/syncer/installs/sync.go
@@ -208,12 +208,10 @@ func updateInstall(ctx context.Context, db *gorm.DB, installHelpers *installhelp
 	}, nil
 }
 
-// syncLabels merges config labels over the install's current labels so values
-// set out of band survive a sync; keys removed from the config are only
-// cleaned up when they were template-managed, since a stale rendered value
-// would otherwise keep matching selectors forever. Templated values are stored
-// on label_templates and rendered against install state, never written to the
-// labels column as raw template text.
+// syncLabels merges config labels over current labels so out-of-band values
+// survive a sync. Removed keys are only cleaned up when template-managed — a
+// stale rendered value would otherwise keep matching selectors forever.
+// Template text is never written to the labels column.
 func syncLabels(ctx context.Context, db *gorm.DB, installHelpers *installhelpers.Helpers, existing *app.Install, desired labels.Labels) error {
 	static, templated := desired.SplitTemplated()
 	for key, tmpl := range templated {
@@ -248,8 +246,7 @@ func syncLabels(ctx context.Context, db *gorm.DB, installHelpers *installhelpers
 		return fmt.Errorf("unable to update install labels: %w", err)
 	}
 
-	// Render immediately so a new template does not wait for the next state
-	// change; unresolvable templates stay absent until state populates.
+	// Render now so a new template doesn't wait for the next state change.
 	if len(templated) > 0 {
 		if err := installHelpers.RenderInstallLabels(ctx, existing.ID); err != nil {
 			return fmt.Errorf("unable to render install label templates: %w", err)
@@ -316,9 +313,8 @@ func existingToConfig(install *app.Install) *config.Install {
 	return cfg
 }
 
-// upstreamLabels echoes template text back for template-managed keys, so a
-// config that declares a dynamic label diffs clean against its rendered value
-// instead of showing drift on every sync.
+// upstreamLabels echoes template text for template-managed keys so a dynamic
+// label diffs clean instead of showing drift against its rendered value.
 func upstreamLabels(install *app.Install) labels.Labels {
 	if len(install.LabelTemplates) == 0 {
 		return install.Labels

--- a/services/ctl-api/internal/pkg/config/syncer/installs/sync_test.go
+++ b/services/ctl-api/internal/pkg/config/syncer/installs/sync_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nuonco/nuon/pkg/config"
+	"github.com/nuonco/nuon/pkg/labels"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
 
@@ -90,4 +91,77 @@ func TestExistingToConfigRoundTripsWithoutDrift(t *testing.T) {
 	require.Error(t, err, "a changed account id must be refused, not silently ignored")
 	assert.Contains(t, err.Error(), "aws_account.account_id")
 	assert.Contains(t, err.Error(), "immutable")
+}
+
+// Template-managed keys must echo the template text back to the diff: a config that
+// declares a dynamic label otherwise diffs against its rendered value and shows
+// drift on every sync.
+func TestExistingToConfigEchoesLabelTemplates(t *testing.T) {
+	t.Run("templates overlay rendered values", func(t *testing.T) {
+		cfg := existingToConfig(&app.Install{
+			Name: "inst",
+			Labeled: labels.Labeled{
+				Labels: labels.Labels{
+					"env":    "production",
+					"region": "us-west-2",
+				},
+			},
+			LabelTemplates: labels.Labels{
+				"region": "{{ .nuon.cloud_account.aws.region }}",
+			},
+		})
+
+		assert.Equal(t, map[string]string{
+			"env":    "production",
+			"region": "{{ .nuon.cloud_account.aws.region }}",
+		}, cfg.Labels)
+	})
+
+	t.Run("a template that never rendered still echoes", func(t *testing.T) {
+		cfg := existingToConfig(&app.Install{
+			Name: "inst",
+			LabelTemplates: labels.Labels{
+				"version": "{{ .nuon.components.api.outputs.version }}",
+			},
+		})
+
+		assert.Equal(t, map[string]string{
+			"version": "{{ .nuon.components.api.outputs.version }}",
+		}, cfg.Labels)
+	})
+
+	t.Run("no templates leaves labels untouched", func(t *testing.T) {
+		cfg := existingToConfig(&app.Install{
+			Name:    "inst",
+			Labeled: labels.Labeled{Labels: labels.Labels{"env": "staging"}},
+		})
+
+		assert.Equal(t, map[string]string{"env": "staging"}, cfg.Labels)
+	})
+
+	t.Run("a dynamic label config diffs clean against its rendered value", func(t *testing.T) {
+		desired := &config.Install{
+			Name: "inst",
+			Labels: map[string]string{
+				"env":    "production",
+				"region": "{{ .nuon.cloud_account.aws.region }}",
+			},
+		}
+		upstream := existingToConfig(&app.Install{
+			Name: "inst",
+			Labeled: labels.Labeled{
+				Labels: labels.Labels{
+					"env":    "production",
+					"region": "us-west-2",
+				},
+			},
+			LabelTemplates: labels.Labels{
+				"region": "{{ .nuon.cloud_account.aws.region }}",
+			},
+		})
+
+		d, err := desired.Diff(upstream)
+		require.NoError(t, err)
+		assert.False(t, d.Summary().HasChanged)
+	})
 }

--- a/services/ctl-api/internal/pkg/config/syncer/installs/sync_test.go
+++ b/services/ctl-api/internal/pkg/config/syncer/installs/sync_test.go
@@ -139,6 +139,39 @@ func TestExistingToConfigEchoesLabelTemplates(t *testing.T) {
 		assert.Equal(t, map[string]string{"env": "staging"}, cfg.Labels)
 	})
 
+	// App-default keys never appear in install configs, so echoing them shows
+	// permanent "removed" drift on every sync.
+	t.Run("app-default keys are stripped from the upstream echo", func(t *testing.T) {
+		install := &app.Install{
+			Name: "inst",
+			Labeled: labels.Labeled{
+				Labels: labels.Labels{
+					"env":    "production",
+					"tier":   "gold",
+					"region": "us-west-2",
+				},
+			},
+			LabelTemplates: labels.Labels{
+				"region": "{{ .nuon.cloud_account.aws.region }}",
+			},
+			AppDefaultLabels: labels.Labels{
+				"tier":   "gold",
+				"region": "{{ .nuon.cloud_account.aws.region }}",
+			},
+		}
+
+		cfg := existingToConfig(install)
+		assert.Equal(t, map[string]string{"env": "production"}, cfg.Labels)
+
+		desired := &config.Install{
+			Name:   "inst",
+			Labels: map[string]string{"env": "production"},
+		}
+		d, err := desired.Diff(cfg)
+		require.NoError(t, err)
+		assert.False(t, d.Summary().HasChanged)
+	})
+
 	t.Run("a dynamic label config diffs clean against its rendered value", func(t *testing.T) {
 		desired := &config.Install{
 			Name: "inst",

--- a/services/dashboard-ui/client/components/apps/AppLabels/AppLabels.stories.tsx
+++ b/services/dashboard-ui/client/components/apps/AppLabels/AppLabels.stories.tsx
@@ -55,6 +55,20 @@ export const Default = () => (
   />
 )
 
+export const WithDefaultLabels = () => (
+  <AppLabels
+    labels={mockLabels}
+    defaultLabels={{
+      service: 'eks',
+      tier: 'standard',
+      region: '{{ .nuon.cloud_account.aws.region }}',
+    }}
+    resetAction={<ResetAction />}
+    onOverride={noop}
+    onRemoveOverride={noop}
+  />
+)
+
 export const Loading = () => (
   <AppLabels labels={[]} isLoading onOverride={noop} onRemoveOverride={noop} />
 )

--- a/services/dashboard-ui/client/components/apps/AppLabels/AppLabels.tsx
+++ b/services/dashboard-ui/client/components/apps/AppLabels/AppLabels.tsx
@@ -40,10 +40,12 @@ export const AppLabels = ({
         <Text variant="h3" weight="stronger" level={1}>Labels</Text>
         {resetAction}
       </div>
-      <Text variant="subtext" theme="neutral">
-        Every label key used across components, actions, runbooks, and installs. Each key gets a
-        color automatically — override any you want to customize.
-      </Text>
+      {defaultEntries.length === 0 && (
+        <Text variant="subtext" theme="neutral">
+          One-off labels applied to components, actions, runbooks, and installs of this app. Each
+          key gets a color automatically — override any you want to customize.
+        </Text>
+      )}
     </HeadingGroup>
 
     {defaultEntries.length > 0 && (
@@ -81,6 +83,13 @@ export const AppLabels = ({
             ))}
           </div>
         </Card>
+        <HeadingGroup className="gap-1.5">
+          <Text variant="base" weight="stronger" level={2}>Other labels</Text>
+          <Text variant="subtext" theme="neutral">
+            One-off labels applied to components, actions, runbooks, and installs of this app.
+            Each key gets a color automatically — override any you want to customize.
+          </Text>
+        </HeadingGroup>
       </>
     )}
 

--- a/services/dashboard-ui/client/components/apps/AppLabels/AppLabels.tsx
+++ b/services/dashboard-ui/client/components/apps/AppLabels/AppLabels.tsx
@@ -2,13 +2,17 @@ import type { ReactNode } from 'react'
 import { Card } from '@/components/common/Card'
 import { EmptyState } from '@/components/common/EmptyState/EmptyState'
 import { HeadingGroup } from '@/components/common/HeadingGroup'
+import { Icon } from '@/components/common/Icon'
+import { LabelBadge } from '@/components/common/LabelBadge'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Text } from '@/components/common/Text'
+import { Tooltip } from '@/components/common/Tooltip'
 import type { TAppLabelKey } from '@/lib/ctl-api/apps/get-app-labels'
 import { LabelRow } from './LabelRow'
 
 interface IAppLabels {
   labels: TAppLabelKey[]
+  defaultLabels?: Record<string, string>
   isLoading?: boolean
   isPending?: boolean
   resetAction?: ReactNode
@@ -18,12 +22,18 @@ interface IAppLabels {
 
 export const AppLabels = ({
   labels,
+  defaultLabels = {},
   isLoading,
   isPending,
   resetAction,
   onOverride,
   onRemoveOverride,
-}: IAppLabels) => (
+}: IAppLabels) => {
+  const defaultEntries = Object.entries(defaultLabels).sort(([a], [b]) =>
+    a.localeCompare(b),
+  )
+
+  return (
   <>
     <HeadingGroup className="gap-1.5">
       <div className="flex items-center justify-between gap-4">
@@ -35,6 +45,44 @@ export const AppLabels = ({
         color automatically — override any you want to customize.
       </Text>
     </HeadingGroup>
+
+    {defaultEntries.length > 0 && (
+      <>
+        <HeadingGroup className="gap-1.5">
+          <Text variant="base" weight="stronger" level={2}>Default labels</Text>
+          <Text variant="subtext" theme="neutral">
+            Applied to every install of this app. Edit them via default_labels in the app config
+            and sync.
+          </Text>
+        </HeadingGroup>
+        <Card>
+          <div className="flex flex-col divide-y">
+            {defaultEntries.map(([key, value]) => (
+              <div
+                key={key}
+                className="flex items-center justify-between gap-4 py-4 first:pt-0 last:pb-0"
+              >
+                <LabelBadge
+                  labelKey={key}
+                  labelValue={value}
+                  customColor={labels.find((l) => l.key === key)?.color}
+                  size="sm"
+                />
+                <Tooltip
+                  tipContent="Defined in the app config's default_labels"
+                  position="left"
+                  tipContentClassName="!whitespace-normal !w-auto max-w-[200px] text-xs"
+                >
+                  <span className="flex">
+                    <Icon variant="LockIcon" size="16" />
+                  </span>
+                </Tooltip>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </>
+    )}
 
     {isLoading ? (
       <Card>
@@ -66,4 +114,5 @@ export const AppLabels = ({
       </Card>
     )}
   </>
-)
+  )
+}

--- a/services/dashboard-ui/client/components/apps/AppLabels/AppLabels.tsx
+++ b/services/dashboard-ui/client/components/apps/AppLabels/AppLabels.tsx
@@ -53,8 +53,7 @@ export const AppLabels = ({
         <HeadingGroup className="gap-1.5">
           <Text variant="base" weight="stronger" level={2}>Default labels</Text>
           <Text variant="subtext" theme="neutral">
-            Applied to every install of this app. Edit them via default_labels in the app config
-            and sync.
+            Applied to every install of this app. Edit them via default_labels in the app config.
           </Text>
         </HeadingGroup>
         <Card>

--- a/services/dashboard-ui/client/components/apps/AppLabels/AppLabelsContainer.tsx
+++ b/services/dashboard-ui/client/components/apps/AppLabels/AppLabelsContainer.tsx
@@ -62,6 +62,7 @@ export const AppLabelsContainer = () => {
   return (
     <AppLabels
       labels={labels}
+      defaultLabels={app?.default_labels ?? {}}
       isLoading={isLoading}
       isPending={isPending}
       resetAction={

--- a/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabels.stories.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabels.stories.tsx
@@ -18,6 +18,21 @@ export const Default = () => (
   </ModalStory>
 )
 
+export const WithDefaultLabels = () => (
+  <ModalStory>
+    <EditLabelsModal
+      labels={{ env: 'production' }}
+      defaultLabels={{
+        tier: 'gold',
+        region: '{{ .nuon.cloud_account.aws.region }}',
+      }}
+      isPending={false}
+      error={null}
+      onSubmit={noop}
+    />
+  </ModalStory>
+)
+
 export const Empty = () => (
   <ModalStory>
     <EditLabelsModal labels={{}} isPending={false} error={null} onSubmit={noop} />

--- a/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabels.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabels.tsx
@@ -1,8 +1,8 @@
 import { useForm, useStore } from '@tanstack/react-form'
+import { Banner } from '@/components/common/Banner'
 import { Button } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
-import { Tooltip } from '@/components/common/Tooltip'
 import { FormErrorBanner } from '@/components/common/form/FormErrorBanner'
 import { FormInput } from '@/components/common/form/FormInput'
 import { Input } from '@/components/common/form/Input'
@@ -76,7 +76,7 @@ export const EditLabelsModal = ({
         <div className="flex flex-col gap-2">
           <div className="flex items-center justify-between">
             <Text variant="label" weight="strong">
-              Labels
+              Install labels
             </Text>
             <form.Field name="labels" mode="array">
               {(labelsField) => (
@@ -100,39 +100,10 @@ export const EditLabelsModal = ({
             values update as install state changes.
           </Text>
 
-          {Object.entries(defaultLabels)
-            .sort(([a], [b]) => a.localeCompare(b))
-            .map(([key, value]) => (
-              <fieldset
-                key={`default:${key}`}
-                className="grid grid-cols-[1fr_1fr_auto] gap-2 items-end border-t pt-2 opacity-60"
-              >
-                <label className="flex flex-col gap-1">
-                  <Text variant="label">Key</Text>
-                  <Input name="" type="text" disabled defaultValue={key} />
-                </label>
-                <label className="flex flex-col gap-1">
-                  <Text variant="label">Value</Text>
-                  <Input name="" type="text" disabled defaultValue={value} />
-                </label>
-                <Tooltip
-                  tipContent="Defined in the app config's default_labels"
-                  position="left"
-                  tipContentClassName="!whitespace-normal !w-auto max-w-[200px] text-xs"
-                >
-                  <span className="mb-3 flex">
-                    <Icon variant="LockIcon" size="16" />
-                  </span>
-                </Tooltip>
-              </fieldset>
-            ))}
-
           <form.Field name="labels" mode="array">
             {(labelsField) =>
               labelsField.state.value.length === 0 ? (
-                Object.keys(defaultLabels).length === 0 ? (
-                  <Text variant="subtext">No labels added</Text>
-                ) : null
+                <Text variant="subtext">No labels added</Text>
               ) : (
                 <>
                   {labelsField.state.value.map((_, idx) => (
@@ -178,6 +149,46 @@ export const EditLabelsModal = ({
               )
             }
           </form.Field>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Text variant="label" weight="strong">
+            Default labels
+          </Text>
+          <Text variant="subtext">
+            Applied to every install of this app. Edit them via{' '}
+            <code>default_labels</code> in the app config.
+          </Text>
+
+          {Object.keys(defaultLabels).length === 0 ? (
+            <Banner theme="neutral">
+              <Text>
+                No default labels yet. Add a <code>default_labels</code> block
+                to the app config to label every install of this app.
+              </Text>
+            </Banner>
+          ) : (
+            Object.entries(defaultLabels)
+              .sort(([a], [b]) => a.localeCompare(b))
+              .map(([key, value]) => (
+                <fieldset
+                  key={`default:${key}`}
+                  className="grid grid-cols-[1fr_1fr_auto] gap-2 items-end border-t pt-2 opacity-60"
+                >
+                  <label className="flex flex-col gap-1">
+                    <Text variant="label">Key</Text>
+                    <Input name="" type="text" disabled defaultValue={key} />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <Text variant="label">Value</Text>
+                    <Input name="" type="text" disabled defaultValue={value} />
+                  </label>
+                  <span className="mb-3 flex">
+                    <Icon variant="LockIcon" size="16" />
+                  </span>
+                </fieldset>
+              ))
+          )}
         </div>
       </form>
     </Modal>

--- a/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabels.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabels.tsx
@@ -90,6 +90,12 @@ export const EditLabelsModal = ({
             </form.Field>
           </div>
 
+          <Text variant="subtext">
+            Values can use the interpolation syntax, e.g.{' '}
+            <code>{'{{ .nuon.cloud_account.aws.region }}'}</code>. Dynamic
+            values update as install state changes.
+          </Text>
+
           <form.Field name="labels" mode="array">
             {(labelsField) =>
               labelsField.state.value.length === 0 ? (

--- a/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabels.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabels.tsx
@@ -2,14 +2,17 @@ import { useForm, useStore } from '@tanstack/react-form'
 import { Button } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
+import { Tooltip } from '@/components/common/Tooltip'
 import { FormErrorBanner } from '@/components/common/form/FormErrorBanner'
 import { FormInput } from '@/components/common/form/FormInput'
+import { Input } from '@/components/common/form/Input'
 import { Modal, type IModal } from '@/components/surfaces/Modal'
 import type { TAPIError } from '@/types'
 import { editLabelsSchema, type EditLabelsValues } from './schema'
 
 interface IEditLabelsModal extends Omit<IModal, 'onSubmit'> {
   labels: Record<string, string>
+  defaultLabels?: Record<string, string>
   isPending: boolean
   error: TAPIError | null
   onSubmit: (labels: Record<string, string>) => void
@@ -17,6 +20,7 @@ interface IEditLabelsModal extends Omit<IModal, 'onSubmit'> {
 
 export const EditLabelsModal = ({
   labels: initialLabels,
+  defaultLabels = {},
   isPending,
   error,
   onSubmit,
@@ -96,10 +100,39 @@ export const EditLabelsModal = ({
             values update as install state changes.
           </Text>
 
+          {Object.entries(defaultLabels)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([key, value]) => (
+              <fieldset
+                key={`default:${key}`}
+                className="grid grid-cols-[1fr_1fr_auto] gap-2 items-end border-t pt-2 opacity-60"
+              >
+                <label className="flex flex-col gap-1">
+                  <Text variant="label">Key</Text>
+                  <Input name="" type="text" disabled defaultValue={key} />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <Text variant="label">Value</Text>
+                  <Input name="" type="text" disabled defaultValue={value} />
+                </label>
+                <Tooltip
+                  tipContent="Defined in the app config's default_labels"
+                  position="left"
+                  tipContentClassName="!whitespace-normal !w-auto max-w-[200px] text-xs"
+                >
+                  <span className="mb-3 flex">
+                    <Icon variant="LockIcon" size="16" />
+                  </span>
+                </Tooltip>
+              </fieldset>
+            ))}
+
           <form.Field name="labels" mode="array">
             {(labelsField) =>
               labelsField.state.value.length === 0 ? (
-                <Text variant="subtext">No labels added</Text>
+                Object.keys(defaultLabels).length === 0 ? (
+                  <Text variant="subtext">No labels added</Text>
+                ) : null
               ) : (
                 <>
                   {labelsField.state.value.map((_, idx) => (

--- a/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabelsContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabelsContainer.tsx
@@ -21,7 +21,12 @@ export const EditLabelsModalContainer = ({ ...props }: IModal) => {
   const { addToast } = useToast()
   const queryClient = useQueryClient()
 
-  const currentLabels: Record<string, string> = install?.labels || {}
+  // Template-managed keys edit as template text so saving unchanged rows
+  // round-trips the template instead of converting the label to static.
+  const currentLabels: Record<string, string> = {
+    ...(install?.labels || {}),
+    ...(install?.label_templates || {}),
+  }
 
   const { mutate, isPending, error } = useMutation({
     mutationFn: async (newLabels: Record<string, string>) => {

--- a/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabelsContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabelsContainer.tsx
@@ -23,10 +23,14 @@ export const EditLabelsModalContainer = ({ ...props }: IModal) => {
 
   // Template-managed keys edit as template text so saving unchanged rows
   // round-trips the template instead of converting the label to static.
-  const currentLabels: Record<string, string> = {
-    ...(install?.labels || {}),
-    ...(install?.label_templates || {}),
-  }
+  // App-default keys are excluded — they are read-only per install.
+  const defaultLabels = install?.app_default_labels || {}
+  const currentLabels: Record<string, string> = Object.fromEntries(
+    Object.entries({
+      ...(install?.labels || {}),
+      ...(install?.label_templates || {}),
+    }).filter(([key]) => !(key in defaultLabels)),
+  )
 
   const { mutate, isPending, error } = useMutation({
     mutationFn: async (newLabels: Record<string, string>) => {
@@ -66,6 +70,7 @@ export const EditLabelsModalContainer = ({ ...props }: IModal) => {
     <EditLabelsModal
       {...props}
       labels={currentLabels}
+      defaultLabels={defaultLabels}
       isPending={isPending}
       error={error}
       onSubmit={(labels) => mutate(labels)}

--- a/services/dashboard-ui/client/types/ctl-api.types.ts
+++ b/services/dashboard-ui/client/types/ctl-api.types.ts
@@ -14,7 +14,10 @@ export type TCreateAppBranchRequest =
   components['schemas']['service.CreateAppBranchRequest']
 export type TVCSBranch = { name: string }
 
-export type TApp = components['schemas']['app.App']
+export type TApp = components['schemas']['app.App'] & {
+  // labels from the app config's default_labels, applied to every install
+  default_labels?: Record<string, string>
+}
 export type TAppConfig = components['schemas']['app.AppConfig']
 export type TAppInputConfig = components['schemas']['app.AppInputConfig']
 export type TAppInput = components['schemas']['app.AppInput']

--- a/services/dashboard-ui/client/types/ctl-api.types.ts
+++ b/services/dashboard-ui/client/types/ctl-api.types.ts
@@ -445,6 +445,8 @@ export type TInstall = Omit<components['schemas']['app.Install'], 'sandbox'> & {
   // label values written with the {{ .nuon.* }} interpolation syntax, keyed by
   // label key; `labels` holds their rendered values
   label_templates?: Record<string, string>
+  // labels inherited from the app config's default_labels; read-only per install
+  app_default_labels?: Record<string, string>
   lifecycle_phase?: {
     phase?: string
     description?: string

--- a/services/dashboard-ui/client/types/ctl-api.types.ts
+++ b/services/dashboard-ui/client/types/ctl-api.types.ts
@@ -442,6 +442,9 @@ export type TInstall = Omit<components['schemas']['app.Install'], 'sandbox'> & {
   app?: components['schemas']['app.App']
   created_by?: components['schemas']['app.Account']
   gcp_account?: { project_id?: string; region?: string }
+  // label values written with the {{ .nuon.* }} interpolation syntax, keyed by
+  // label key; `labels` holds their rendered values
+  label_templates?: Record<string, string>
   lifecycle_phase?: {
     phase?: string
     description?: string


### PR DESCRIPTION
## Summary

Exploring two additions to install labels:

### Dynamic labels

Label values written with the same `{{ .nuon.* }}` interpolation syntax already used in app config files:

```toml
[install.labels]
env = "production"
region = "{{ .nuon.cloud_account.aws.region }}"
api_version = "{{ .nuon.components.api.outputs.version }}"
```

<img width="1358" height="850" alt="Screenshot 2026-08-06 at 18 33 28" src="https://github.com/user-attachments/assets/01257967-917f-4062-ae4e-d9c7decd0c33" />
<img width="900" height="348" alt="Screenshot 2026-08-06 at 18 35 22" src="https://github.com/user-attachments/assets/42f239ed-3bb2-4b8e-824c-e5e8c0a1e0e4" />

### Default labels

A `[default_labels]` block in `metadata.toml` that applies to every install of the app. Values support the same interpolation, so a default can render differently per install:

```toml
# metadata.toml
[default_labels]
vendor = "acme"
tier = "standard"
region = "{{ .nuon.cloud_account.aws.region }}"
```

<img width="2486" height="1210" alt="Screenshot 2026-08-07 at 20 44 33" src="https://github.com/user-attachments/assets/451b48d4-7be5-4d69-bdb0-95e4426e1fb4" />

## Why materialized rendering

Labels aren't display-only metadata — they're matched both in Go (subscription dispatch, branch exclusivity) and in Postgres (`labels @> ...` containment predicates for list filtering, the label-key picker view, and install-group resolution). A value that only exists at read time can't participate in a SQL predicate, so rendering lazily at read time was ruled out.

Instead, templates are stored in a new `label_templates` column and their rendered values are materialized into the ordinary `labels` column, so every downstream consumer keeps working unchanged. The trade-off is brief staleness between a state change and the re-render — the same window install-state snapshots already tolerate.

## How it works

### Dynamic labels

- New `label_templates` JSONB column on `installs`; `labels` always holds rendered, literal values.
- Templates render immediately when written (config sync or the label API), and re-render after install state generation.
- Templates are validated at `nuon apps sync` time, so bad templates fail early.
- Rendering is best-effort: an unresolvable template keeps its previous value or omits the key with a warning — it never fails a deploy or state generation.
- `POST /v1/installs/{id}/labels` accepts templated values, so the dashboard's Edit labels modal and the CLI can create dynamic labels too. The dashboard and older clients round-trip rendered values without converting dynamic labels back to static.

### App default labels

- Defaults are applied when an install is created, and reconciled on every `nuon apps sync` — adding, updating, or removing a default propagates to all existing installs.
- Default labels are read-only per install: the label API, dashboard, and install config sync all reject changes to a default-managed key. The only way to edit or remove one is to change `default_labels` in the app config and sync.
- A per-install key that collides with a default fails validation at sync time; a create request that sets a default key to a different value is rejected.
- The dashboard shows the configured defaults on the app's Labels page, and as locked rows in the install's Edit labels modal.
