### PR TITLE
refactor: Harden runner job execution result reporting

### DIFF
--- a/bins/runner/internal/pkg/jobloop/exec_job.go
+++ b/bins/runner/internal/pkg/jobloop/exec_job.go
@@ -150,6 +150,9 @@ func (j *jobLoop) executeJob(ctx context.Context, job *models.AppRunnerJob) erro
 			zap.Error(err),
 		)
 		description := fmt.Sprintf("no valid job handler for job type %s: %s", job.Type, err.Error())
+		if resultErr := j.writeFallbackJobExecutionResult(ctx, job, execution, "jobloop", "get-handler", err); resultErr != nil {
+			j.errRecorder.Record("write fallback job execution result", resultErr)
+		}
 		if updateErr := j.updateJobExecutionStatusWithDescription(ctx, job.ID, execution.ID, models.AppRunnerJobExecutionStatusFailed, description); updateErr != nil {
 			j.errRecorder.Record("no handler found", updateErr)
 		}

--- a/bins/runner/internal/pkg/jobloop/exec_job_step.go
+++ b/bins/runner/internal/pkg/jobloop/exec_job_step.go
@@ -21,7 +21,10 @@ import (
 // so a long stack trace doesn't bloat the stored status history.
 const jobExecutionStatusDescriptionMaxLen = 2048
 
-const jobExecutionResultWriteTimeout = 30 * time.Second
+const (
+	jobExecutionResultWriteTimeout         = 30 * time.Second
+	jobExecutionTerminalStatusWriteTimeout = 30 * time.Second
+)
 
 // writeJobExecutionStatus is the synchronous, retry-wrapped API call.
 // It's the writer the coalescer's background goroutine drives and also
@@ -61,10 +64,17 @@ func (j *jobLoop) updateJobExecutionStatus(ctx context.Context, jobID, jobExecut
 }
 
 func (j *jobLoop) updateJobExecutionStatusWithDescription(ctx context.Context, jobID, jobExecutionID string, status models.AppRunnerJobExecutionStatus, description string) error {
-	if c := j.coalescerFor(jobExecutionID); c != nil {
-		if isTerminalExecutionStatus(status) {
-			return c.WriteTerminal(ctx, status, description)
+	if isTerminalExecutionStatus(status) {
+		statusCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), jobExecutionTerminalStatusWriteTimeout)
+		defer cancel()
+
+		if c := j.coalescerFor(jobExecutionID); c != nil {
+			return c.WriteTerminal(statusCtx, status, description)
 		}
+		return j.writeJobExecutionStatus(statusCtx, jobID, jobExecutionID, status, description)
+	}
+
+	if c := j.coalescerFor(jobExecutionID); c != nil {
 		c.EnqueueNonTerminal(status, description)
 		return nil
 	}

--- a/bins/runner/internal/pkg/jobloop/exec_job_step.go
+++ b/bins/runner/internal/pkg/jobloop/exec_job_step.go
@@ -21,6 +21,8 @@ import (
 // so a long stack trace doesn't bloat the stored status history.
 const jobExecutionStatusDescriptionMaxLen = 2048
 
+const jobExecutionResultWriteTimeout = 30 * time.Second
+
 // writeJobExecutionStatus is the synchronous, retry-wrapped API call.
 // It's the writer the coalescer's background goroutine drives and also
 // the call terminal updates fall through to directly. Intermediate
@@ -102,6 +104,29 @@ func (j *jobLoop) errToStatus(err error) models.AppRunnerJobExecutionStatus {
 	return models.AppRunnerJobExecutionStatusFailed
 }
 
+func (j *jobLoop) writeFallbackJobExecutionResult(ctx context.Context, job *models.AppRunnerJob, execution *models.AppRunnerJobExecution, handler, step string, jobErr error) error {
+	resultCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), jobExecutionResultWriteTimeout)
+	defer cancel()
+
+	req := &models.ServiceCreateRunnerJobExecutionResultRequest{
+		Success:   false,
+		ErrorCode: 0,
+		ErrorMetadata: map[string]string{
+			"step":     step,
+			"handler":  handler,
+			"job_type": string(job.Type),
+			"message":  jobErr.Error(),
+		},
+	}
+	writeResult := func(ctx context.Context) error {
+		if _, err := j.apiClient.CreateJobExecutionResult(ctx, job.ID, execution.ID, req); err != nil {
+			return fmt.Errorf("unable to create fallback job execution result: %w", err)
+		}
+		return nil
+	}
+	return retry.Retry(resultCtx, writeResult, retry.WithMaxAttempts(3), retry.WithSleep(time.Second))
+}
+
 func (j *jobLoop) execJobStep(ctx context.Context, l *zap.Logger, logProvider *log.LoggerProvider, step *executeJobStep, job *models.AppRunnerJob, jobExecution *models.AppRunnerJobExecution) error {
 	// Attach pkgctx.ContextField(ctx) to BOTH the local `l` and the
 	// ctx-stored logger so the otelzap bridge can extract the per-step span
@@ -142,6 +167,14 @@ func (j *jobLoop) execJobStep(ctx context.Context, l *zap.Logger, logProvider *l
 	if recovered != nil {
 		status := models.AppRunnerJobExecutionStatusFailed
 		description := fmt.Sprintf("panic in %s: %s", step.name, recovered.String())
+		panicErr := fmt.Errorf("panic in %s: %v", step.name, recovered.Value)
+
+		l.Error("panic in "+step.name, zap.Error(panicErr))
+		l.Error(string(debug.Stack()))
+
+		if resultErr := j.writeFallbackJobExecutionResult(ctx, job, jobExecution, step.handler.Name(), step.name, panicErr); resultErr != nil {
+			j.errRecorder.Record("write fallback job execution result", resultErr)
+		}
 		if updateErr := j.updateJobExecutionStatusWithDescription(ctx, job.ID, jobExecution.ID, status, description); updateErr != nil {
 			j.errRecorder.Record("update_job_execution", updateErr)
 		}
@@ -154,10 +187,6 @@ func (j *jobLoop) execJobStep(ctx context.Context, l *zap.Logger, logProvider *l
 			"status":   "error",
 			"err_type": "panic",
 		}))
-
-		l.Error("panic in " + step.name)
-		l.Error(recovered.String())
-		l.Error(string(debug.Stack()))
 
 		if flushErr := logProvider.ForceFlush(ctx); flushErr != nil {
 			if !errors.Is(flushErr, context.Canceled) {
@@ -180,6 +209,9 @@ func (j *jobLoop) execJobStep(ctx context.Context, l *zap.Logger, logProvider *l
 	}
 
 	l.Error("job step errored "+err.Error(), zap.String("step", step.name), zap.Error(err))
+	if resultErr := j.writeFallbackJobExecutionResult(ctx, job, jobExecution, step.handler.Name(), step.name, err); resultErr != nil {
+		j.errRecorder.Record("write fallback job execution result", resultErr)
+	}
 
 	// handle the error by cleaning up the execution using the handler.
 	status := j.errToStatus(err)

--- a/bins/runner/internal/pkg/jobloop/exec_job_step_test.go
+++ b/bins/runner/internal/pkg/jobloop/exec_job_step_test.go
@@ -3,6 +3,7 @@ package jobloop
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -156,4 +157,36 @@ func TestWriteFallbackJobExecutionResultDetachesCanceledContextAndRetries(t *tes
 	)
 	require.NoError(t, err)
 	require.Equal(t, 2, attempts)
+}
+
+func TestTerminalJobExecutionStatusDetachesCanceledContext(t *testing.T) {
+	for _, withCoalescer := range []bool{false, true} {
+		t.Run(fmt.Sprintf("coalescer=%t", withCoalescer), func(t *testing.T) {
+			client := &jobLoopTestClient{
+				updateExecution: func(ctx context.Context, jobID, executionID string, req *models.ServiceUpdateRunnerJobExecutionRequest) (*models.AppRunnerJobExecution, error) {
+					require.NoError(t, ctx.Err())
+					require.Equal(t, models.AppRunnerJobExecutionStatusTimedDashOut, req.Status)
+					return &models.AppRunnerJobExecution{ID: executionID}, nil
+				},
+			}
+			j := &jobLoop{apiClient: client}
+			if withCoalescer {
+				coalescer := newStatusCoalescer("job-id", "execution-id", zap.NewNop(), j.writeJobExecutionStatus)
+				j.attachCoalescer("execution-id", coalescer)
+				defer j.detachCoalescer("execution-id")
+				defer coalescer.Close()
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			err := j.updateJobExecutionStatusWithDescription(
+				ctx,
+				"job-id",
+				"execution-id",
+				models.AppRunnerJobExecutionStatusTimedDashOut,
+				"execution timed out",
+			)
+			require.NoError(t, err)
+		})
+	}
 }

--- a/bins/runner/internal/pkg/jobloop/exec_job_step_test.go
+++ b/bins/runner/internal/pkg/jobloop/exec_job_step_test.go
@@ -1,0 +1,159 @@
+package jobloop
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/pkg/metrics"
+	"github.com/nuonco/nuon/pkg/runner/jobs"
+	nuonrunner "github.com/nuonco/nuon/sdks/nuon-runner-go"
+	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
+)
+
+type jobLoopTestClient struct {
+	nuonrunner.Client
+	createResult    func(context.Context, string, string, *models.ServiceCreateRunnerJobExecutionResultRequest) (*models.AppRunnerJobExecutionResult, error)
+	updateExecution func(context.Context, string, string, *models.ServiceUpdateRunnerJobExecutionRequest) (*models.AppRunnerJobExecution, error)
+}
+
+func (c *jobLoopTestClient) CreateJobExecutionResult(ctx context.Context, jobID, executionID string, req *models.ServiceCreateRunnerJobExecutionResultRequest) (*models.AppRunnerJobExecutionResult, error) {
+	return c.createResult(ctx, jobID, executionID, req)
+}
+
+func (c *jobLoopTestClient) UpdateJobExecution(ctx context.Context, jobID, executionID string, req *models.ServiceUpdateRunnerJobExecutionRequest) (*models.AppRunnerJobExecution, error) {
+	return c.updateExecution(ctx, jobID, executionID, req)
+}
+
+type jobLoopTestMetrics struct {
+	metrics.Writer
+}
+
+func (*jobLoopTestMetrics) Incr(string, []string)                  {}
+func (*jobLoopTestMetrics) Timing(string, time.Duration, []string) {}
+
+type jobLoopTestHandler struct {
+	jobs.JobHandler
+	name string
+}
+
+func (h *jobLoopTestHandler) Name() string { return h.name }
+
+func TestExecJobStepWritesFallbackResultBeforeFailedStatus(t *testing.T) {
+	events := make([]string, 0, 3)
+	var resultReq *models.ServiceCreateRunnerJobExecutionResultRequest
+	client := &jobLoopTestClient{
+		createResult: func(ctx context.Context, jobID, executionID string, req *models.ServiceCreateRunnerJobExecutionResultRequest) (*models.AppRunnerJobExecutionResult, error) {
+			events = append(events, "result")
+			resultReq = req
+			return &models.AppRunnerJobExecutionResult{ID: "result-id"}, nil
+		},
+		updateExecution: func(ctx context.Context, jobID, executionID string, req *models.ServiceUpdateRunnerJobExecutionRequest) (*models.AppRunnerJobExecution, error) {
+			events = append(events, "status:"+string(req.Status))
+			return &models.AppRunnerJobExecution{ID: executionID}, nil
+		},
+	}
+	j := &jobLoop{apiClient: client, mw: &jobLoopTestMetrics{}}
+	handlerErr := errors.New("terraform apply failed")
+	step := &executeJobStep{
+		name:        "execute",
+		handler:     &jobLoopTestHandler{name: "terraform"},
+		startStatus: models.AppRunnerJobExecutionStatusInDashProgress,
+		fn: func(context.Context, jobs.JobHandler, *models.AppRunnerJob, *models.AppRunnerJobExecution) error {
+			return handlerErr
+		},
+	}
+	job := &models.AppRunnerJob{ID: "job-id", Type: models.AppRunnerJobTypeTerraformDashDeploy}
+	execution := &models.AppRunnerJobExecution{ID: "execution-id"}
+
+	err := j.execJobStep(context.Background(), zap.NewNop(), nil, step, job, execution)
+	require.ErrorIs(t, err, handlerErr)
+	require.Equal(t, []string{
+		"status:in-progress",
+		"result",
+		"status:failed",
+	}, events)
+	require.False(t, resultReq.Success)
+	require.Equal(t, map[string]string{
+		"step":     "execute",
+		"handler":  "terraform",
+		"job_type": "terraform-deploy",
+		"message":  handlerErr.Error(),
+	}, resultReq.ErrorMetadata)
+}
+
+func TestExecJobStepWritesFallbackResultOnPanic(t *testing.T) {
+	events := make([]string, 0, 3)
+	var resultReq *models.ServiceCreateRunnerJobExecutionResultRequest
+	client := &jobLoopTestClient{
+		createResult: func(ctx context.Context, jobID, executionID string, req *models.ServiceCreateRunnerJobExecutionResultRequest) (*models.AppRunnerJobExecutionResult, error) {
+			events = append(events, "result")
+			resultReq = req
+			return &models.AppRunnerJobExecutionResult{ID: "result-id"}, nil
+		},
+		updateExecution: func(ctx context.Context, jobID, executionID string, req *models.ServiceUpdateRunnerJobExecutionRequest) (*models.AppRunnerJobExecution, error) {
+			events = append(events, "status:"+string(req.Status))
+			return &models.AppRunnerJobExecution{ID: executionID}, nil
+		},
+	}
+	j := &jobLoop{apiClient: client, mw: &jobLoopTestMetrics{}}
+	step := &executeJobStep{
+		name:        "execute",
+		handler:     &jobLoopTestHandler{name: "helm"},
+		startStatus: models.AppRunnerJobExecutionStatusInDashProgress,
+		fn: func(context.Context, jobs.JobHandler, *models.AppRunnerJob, *models.AppRunnerJobExecution) error {
+			panic("boom")
+		},
+	}
+	job := &models.AppRunnerJob{ID: "job-id", Type: models.AppRunnerJobTypeHelmDashChartDashDeploy}
+	execution := &models.AppRunnerJobExecution{ID: "execution-id"}
+
+	require.Panics(t, func() {
+		j.execJobStep(context.Background(), zap.NewNop(), sdklog.NewLoggerProvider(), step, job, execution)
+	})
+	require.Equal(t, []string{
+		"status:in-progress",
+		"result",
+		"status:failed",
+	}, events)
+	require.False(t, resultReq.Success)
+	require.Equal(t, "execute", resultReq.ErrorMetadata["step"])
+	require.Equal(t, "helm", resultReq.ErrorMetadata["handler"])
+	require.Equal(t, "helm-chart-deploy", resultReq.ErrorMetadata["job_type"])
+	require.Contains(t, resultReq.ErrorMetadata["message"], "panic in execute: boom")
+}
+
+func TestWriteFallbackJobExecutionResultDetachesCanceledContextAndRetries(t *testing.T) {
+	attempts := 0
+	client := &jobLoopTestClient{
+		createResult: func(ctx context.Context, jobID, executionID string, req *models.ServiceCreateRunnerJobExecutionResultRequest) (*models.AppRunnerJobExecutionResult, error) {
+			attempts++
+			require.NoError(t, ctx.Err())
+			require.Equal(t, "job-id", jobID)
+			require.Equal(t, "execution-id", executionID)
+			if attempts == 1 {
+				return nil, errors.New("temporary API failure")
+			}
+			return &models.AppRunnerJobExecutionResult{ID: "result-id"}, nil
+		},
+	}
+	j := &jobLoop{apiClient: client}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := j.writeFallbackJobExecutionResult(
+		ctx,
+		&models.AppRunnerJob{ID: "job-id", Type: models.AppRunnerJobTypeTerraformDashDeploy},
+		&models.AppRunnerJobExecution{ID: "execution-id"},
+		"terraform",
+		"execute",
+		context.DeadlineExceeded,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts)
+}

--- a/services/ctl-api/internal/app/runners/helpers/jobs.go
+++ b/services/ctl-api/internal/app/runners/helpers/jobs.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"time"
 
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
 
@@ -58,4 +61,31 @@ func (s *Helpers) getJob(ctx context.Context, jobID string) (*app.RunnerJob, err
 	}
 
 	return &runnerJob, nil
+}
+
+// CreateJobExecutionResultIfAbsent atomically preserves the first result written for an execution.
+func CreateJobExecutionResultIfAbsent(ctx context.Context, db *gorm.DB, result *app.RunnerJobExecutionResult) (*app.RunnerJobExecutionResult, bool, error) {
+	res := db.WithContext(ctx).
+		Clauses(clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "deleted_at"},
+				{Name: "runner_job_execution_id"},
+			},
+			DoNothing: true,
+		}).
+		Create(result)
+	if res.Error != nil {
+		return nil, false, fmt.Errorf("unable to create runner job execution result: %w", res.Error)
+	}
+	if res.RowsAffected == 1 {
+		return result, true, nil
+	}
+
+	var existing app.RunnerJobExecutionResult
+	if err := db.WithContext(ctx).
+		Where(&app.RunnerJobExecutionResult{RunnerJobExecutionID: result.RunnerJobExecutionID}).
+		First(&existing).Error; err != nil {
+		return nil, false, fmt.Errorf("unable to get existing runner job execution result: %w", err)
+	}
+	return &existing, false, nil
 }

--- a/services/ctl-api/internal/app/runners/helpers/jobs.go
+++ b/services/ctl-api/internal/app/runners/helpers/jobs.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
+	"github.com/nuonco/nuon/pkg/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
 
@@ -88,4 +89,38 @@ func CreateJobExecutionResultIfAbsent(ctx context.Context, db *gorm.DB, result *
 		return nil, false, fmt.Errorf("unable to get existing runner job execution result: %w", err)
 	}
 	return &existing, false, nil
+}
+
+const (
+	metricJobExecutionResultAudit  = "runner.execution_result_audit"
+	jobExecutionResultAuditTimeout = time.Second
+)
+
+// AuditJobExecutionResult records result presence without affecting the status transition being audited.
+func AuditJobExecutionResult(ctx context.Context, db *gorm.DB, mw metrics.Writer, executionID string, status app.RunnerJobExecutionStatus, source string) {
+	if status.IsRunning() || status == app.RunnerJobExecutionStatusFinished {
+		return
+	}
+
+	auditCtx, cancel := context.WithTimeout(ctx, jobExecutionResultAuditTimeout)
+	defer cancel()
+
+	var result app.RunnerJobExecutionResult
+	query := db.WithContext(auditCtx).
+		Select("id").
+		Where(&app.RunnerJobExecutionResult{RunnerJobExecutionID: executionID}).
+		Limit(1).
+		Find(&result)
+	outcome := "result_present"
+	if query.Error != nil {
+		outcome = "query_error"
+	} else if query.RowsAffected == 0 {
+		outcome = "result_missing"
+	}
+
+	mw.Incr(metricJobExecutionResultAudit, []string{
+		"status:" + string(status),
+		"source:" + source,
+		"outcome:" + outcome,
+	})
 }

--- a/services/ctl-api/internal/app/runners/helpers/jobs_test.go
+++ b/services/ctl-api/internal/app/runners/helpers/jobs_test.go
@@ -1,0 +1,108 @@
+package helpers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+func TestCreateJobExecutionResultIfAbsent(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		CREATE TABLE runner_job_execution_results (
+			id TEXT PRIMARY KEY,
+			created_by_id TEXT NOT NULL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			deleted_at INTEGER NOT NULL DEFAULT 0,
+			org_id TEXT,
+			runner_job_execution_id TEXT NOT NULL,
+			success BOOLEAN,
+			error_code INTEGER,
+			error_metadata TEXT,
+			contents TEXT,
+			contents_display BLOB,
+			contents_gzip BLOB,
+			contents_display_gzip BLOB,
+			composite_error TEXT,
+			UNIQUE (deleted_at, runner_job_execution_id)
+		)
+	`).Error)
+
+	tests := map[string]struct {
+		first    *app.RunnerJobExecutionResult
+		fallback *app.RunnerJobExecutionResult
+	}{
+		"uncompressed": {
+			first: &app.RunnerJobExecutionResult{
+				ID:                   "uncompressed-first",
+				CreatedByID:          "account-id",
+				OrgID:                "org-id",
+				RunnerJobExecutionID: "uncompressed-execution",
+				ErrorCode:            42,
+				Contents:             "specific handler result",
+				ContentsDisplay:      []byte(`{"detail":"specific"}`),
+			},
+			fallback: &app.RunnerJobExecutionResult{
+				ID:                   "uncompressed-fallback",
+				CreatedByID:          "account-id",
+				OrgID:                "org-id",
+				RunnerJobExecutionID: "uncompressed-execution",
+				Success:              true,
+				Contents:             "generic fallback result",
+				ContentsDisplay:      []byte(`{"detail":"generic"}`),
+			},
+		},
+		"compressed": {
+			first: &app.RunnerJobExecutionResult{
+				ID:                   "compressed-first",
+				CreatedByID:          "account-id",
+				OrgID:                "org-id",
+				RunnerJobExecutionID: "compressed-execution",
+				ErrorCode:            42,
+				ContentsGzip:         []byte("compressed-specific-result"),
+				ContentsDisplayGzip:  []byte("compressed-specific-display"),
+			},
+			fallback: &app.RunnerJobExecutionResult{
+				ID:                   "compressed-fallback",
+				CreatedByID:          "account-id",
+				OrgID:                "org-id",
+				RunnerJobExecutionID: "compressed-execution",
+				Success:              true,
+				ContentsGzip:         []byte("compressed-generic-result"),
+				ContentsDisplayGzip:  []byte("compressed-generic-display"),
+			},
+		},
+	}
+
+	ctx := context.Background()
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			persisted, created, err := CreateJobExecutionResultIfAbsent(ctx, db, test.first)
+			require.NoError(t, err)
+			require.True(t, created)
+			require.Equal(t, test.first.ID, persisted.ID)
+
+			persisted, created, err = CreateJobExecutionResultIfAbsent(ctx, db, test.fallback)
+			require.NoError(t, err)
+			require.False(t, created)
+			require.Equal(t, test.first.ID, persisted.ID)
+			require.False(t, persisted.Success)
+			require.Equal(t, test.first.ErrorCode, persisted.ErrorCode)
+			require.Equal(t, test.first.Contents, persisted.Contents)
+			require.Equal(t, test.first.ContentsDisplay, persisted.ContentsDisplay)
+			require.Equal(t, test.first.ContentsGzip, persisted.ContentsGzip)
+			require.Equal(t, test.first.ContentsDisplayGzip, persisted.ContentsDisplayGzip)
+		})
+	}
+
+	var count int64
+	require.NoError(t, db.Model(&app.RunnerJobExecutionResult{}).Count(&count).Error)
+	require.EqualValues(t, len(tests), count)
+}

--- a/services/ctl-api/internal/app/runners/helpers/jobs_test.go
+++ b/services/ctl-api/internal/app/runners/helpers/jobs_test.go
@@ -8,8 +8,23 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
+	"github.com/nuonco/nuon/pkg/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
+
+type auditMetricsWriter struct {
+	metrics.Writer
+	incrs []auditMetric
+}
+
+type auditMetric struct {
+	name string
+	tags []string
+}
+
+func (w *auditMetricsWriter) Incr(name string, tags []string) {
+	w.incrs = append(w.incrs, auditMetric{name: name, tags: tags})
+}
 
 func TestCreateJobExecutionResultIfAbsent(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
@@ -105,4 +120,47 @@ func TestCreateJobExecutionResultIfAbsent(t *testing.T) {
 	var count int64
 	require.NoError(t, db.Model(&app.RunnerJobExecutionResult{}).Count(&count).Error)
 	require.EqualValues(t, len(tests), count)
+}
+
+func TestAuditJobExecutionResult(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		CREATE TABLE runner_job_execution_results (
+			id TEXT PRIMARY KEY,
+			deleted_at INTEGER NOT NULL DEFAULT 0,
+			runner_job_execution_id TEXT NOT NULL
+		)
+	`).Error)
+	require.NoError(t, db.Exec(`
+		INSERT INTO runner_job_execution_results (id, runner_job_execution_id)
+		VALUES ('result-id', 'execution-with-result')
+	`).Error)
+
+	mw := &auditMetricsWriter{}
+	ctx := context.Background()
+	AuditJobExecutionResult(ctx, db, mw, "execution-with-result", app.RunnerJobExecutionStatusFailed, "runner_workflow")
+	AuditJobExecutionResult(ctx, db, mw, "execution-without-result", app.RunnerJobExecutionStatusTimedOut, "runner_workflow")
+	AuditJobExecutionResult(ctx, db, mw, "successful-execution", app.RunnerJobExecutionStatusFinished, "runner_workflow")
+	AuditJobExecutionResult(ctx, db, mw, "running-execution", app.RunnerJobExecutionStatusInProgress, "runner_workflow")
+	require.NoError(t, db.Migrator().DropTable(&app.RunnerJobExecutionResult{}))
+	AuditJobExecutionResult(ctx, db, mw, "query-error", app.RunnerJobExecutionStatusCancelled, "cancel_workflow")
+
+	require.Len(t, mw.incrs, 3)
+	require.Equal(t, metricJobExecutionResultAudit, mw.incrs[0].name)
+	require.ElementsMatch(t, []string{
+		"status:failed",
+		"source:runner_workflow",
+		"outcome:result_present",
+	}, mw.incrs[0].tags)
+	require.ElementsMatch(t, []string{
+		"status:timed-out",
+		"source:runner_workflow",
+		"outcome:result_missing",
+	}, mw.incrs[1].tags)
+	require.ElementsMatch(t, []string{
+		"status:cancelled",
+		"source:cancel_workflow",
+		"outcome:query_error",
+	}, mw.incrs[2].tags)
 }

--- a/services/ctl-api/internal/app/runners/service/cancel_runner_job.go
+++ b/services/ctl-api/internal/app/runners/service/cancel_runner_job.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 )
 
@@ -86,6 +87,7 @@ func (s *service) cancelRunnerJob(ctx context.Context, runnerJobID string) (*app
 		if res.Error != nil {
 			return nil, fmt.Errorf("unable to cancel job execution: %w", res.Error)
 		}
+		helpers.AuditJobExecutionResult(ctx, s.db, s.mw, execution.ID, app.RunnerJobExecutionStatusCancelled, "cancel_api")
 
 	}
 

--- a/services/ctl-api/internal/app/runners/service/create_runner_job_execution_result.go
+++ b/services/ctl-api/internal/app/runners/service/create_runner_job_execution_result.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/all" // register all errparse parsers
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
 )
@@ -90,29 +91,32 @@ func (s *service) CreateRunnerJobExecutionResult(ctx *gin.Context) {
 	}
 
 	// branch on wether or not the content received is compressed.
-	var jobExecution *app.RunnerJobExecutionResult
+	var result *app.RunnerJobExecutionResult
+	var created bool
 	var err error
 	if req.ContentsCompressed != "" || req.ContentsDisplayCompressed != "" {
-		jobExecution, err = s.createRunnerJobExecutionResultFromCompressed(ctx, runnerJobID, runnerJobExecutionID, &req)
+		result, created, err = s.createRunnerJobExecutionResultFromCompressed(ctx, runnerJobID, runnerJobExecutionID, &req)
 		if err != nil {
 			ctx.Error(fmt.Errorf("unable to update runner job execution status: %w", err))
 			return
 		}
 	} else {
-		jobExecution, err = s.createRunnerJobExecutionResult(ctx, runnerJobID, runnerJobExecutionID, &req)
+		result, created, err = s.createRunnerJobExecutionResult(ctx, runnerJobID, runnerJobExecutionID, &req)
 		if err != nil {
 			ctx.Error(fmt.Errorf("unable to update runner job execution status: %w", err))
 			return
 		}
 	}
 
-	if err := s.applyComponentBuildSourceIdentity(ctx, runnerJobID, &req); err != nil {
-		// Non-fatal: source-identity persistence shouldn't fail the result
-		// write. The build's status workflow runs independently.
-		s.l.Warn("unable to apply component build source identity", zap.Error(err))
+	if created {
+		if err := s.applyComponentBuildSourceIdentity(ctx, runnerJobID, &req); err != nil {
+			// Non-fatal: source-identity persistence shouldn't fail the result
+			// write. The build's status workflow runs independently.
+			s.l.Warn("unable to apply component build source identity", zap.Error(err))
+		}
 	}
 
-	ctx.JSON(http.StatusCreated, jobExecution)
+	ctx.JSON(http.StatusCreated, result)
 }
 
 // applyComponentBuildSourceIdentity persists source-identity fields
@@ -158,18 +162,13 @@ func (s *service) applyComponentBuildSourceIdentity(ctx context.Context, runnerJ
 	return nil
 }
 
-// metricCompositeErrorParse counts every failed-result parse attempt, tagged
+// metricCompositeErrorParse counts every persisted failed-result parse, tagged
 // with the execution tool, job group, and matched composite-error type (or
 // "miss"/"generic"). A high rate of matched_type:generic for a given tool is
 // the data-driven backlog signal for which specific parser to write next.
 const metricCompositeErrorParse = "runner.composite_error_parse"
 
-// parseResultCompositeError parses a failed result into a typed CompositeError
-// and records the parse-outcome metric. It delegates the pure parsing to
-// parseCompositeError and emits exactly one metric per failed result so parse
-// coverage is observable without any per-parser wiring.
-func (s *service) parseResultCompositeError(req *CreateRunnerJobExecutionResultRequest, runnerJob *app.RunnerJob) *compositeerrors.CompositeErrorData {
-	ce := s.parseCompositeError(req, runnerJob)
+func (s *service) recordCompositeErrorParse(req *CreateRunnerJobExecutionResultRequest, runnerJob *app.RunnerJob, ce *compositeerrors.CompositeErrorData) {
 	if !req.Success {
 		// Default empty facets to "unknown" so Datadog never sees a bare
 		// "tool:" tag; matched_type stays "miss" for a nil/typeless parse.
@@ -191,7 +190,6 @@ func (s *service) parseResultCompositeError(req *CreateRunnerJobExecutionResultR
 			"matched_type:" + matched,
 		})
 	}
-	return ce
 }
 
 // parseCompositeError parses a failed execution's untruncated error message
@@ -293,22 +291,23 @@ func (s *service) refreshOwnerCompositeError(ctx context.Context, runnerJob *app
 	}
 }
 
-func (s *service) createRunnerJobExecutionResultFromCompressed(ctx context.Context, runnerJobID, runnerJobExecutionID string, req *CreateRunnerJobExecutionResultRequest) (*app.RunnerJobExecutionResult, error) {
+func (s *service) createRunnerJobExecutionResultFromCompressed(ctx context.Context, runnerJobID, runnerJobExecutionID string, req *CreateRunnerJobExecutionResultRequest) (*app.RunnerJobExecutionResult, bool, error) {
 	runnerJob, err := s.getRunnerJob(ctx, runnerJobID)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	// Runner sends gzip-compressed payloads encoded as base64 strings.
 	// We decode once here and persist the raw gzip bytes for later decompression.
 	contentsGzip, err := base64.URLEncoding.DecodeString(req.ContentsCompressed)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to decode contents")
+		return nil, false, errors.Wrap(err, "unable to decode contents")
 	}
 	contentsDisplayGzip, err := base64.URLEncoding.DecodeString(req.ContentsDisplayCompressed)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to decode contents display")
+		return nil, false, errors.Wrap(err, "unable to decode contents display")
 	}
+	compositeError := s.parseCompositeError(req, runnerJob)
 	result := app.RunnerJobExecutionResult{
 		OrgID:                runnerJob.OrgID,
 		RunnerJobExecutionID: runnerJobExecutionID,
@@ -317,59 +316,56 @@ func (s *service) createRunnerJobExecutionResultFromCompressed(ctx context.Conte
 		ContentsDisplayGzip:  contentsDisplayGzip,
 		ErrorCode:            req.ErrorCode,
 		ErrorMetadata:        pgtype.Hstore(req.ErrorMetadata),
-		CompositeError:       s.parseResultCompositeError(req, runnerJob),
+		CompositeError:       compositeError,
 	}
 
-	res := s.db.WithContext(ctx).Create(&result)
-	if res.Error != nil {
-		return nil, errors.Wrap(res.Error, "unable to write runner job execution result: %w")
+	persisted, created, err := helpers.CreateJobExecutionResultIfAbsent(ctx, s.db, &result)
+	if err != nil {
+		return nil, false, err
+	}
+	if created {
+		s.recordCompositeErrorParse(req, runnerJob, compositeError)
+		s.refreshOwnerCompositeError(ctx, runnerJob, compositeError)
 	}
 
-	s.refreshOwnerCompositeError(ctx, runnerJob, result.CompositeError)
-
-	return &result, nil
+	return persisted, created, nil
 }
 
-func (s *service) createRunnerJobExecutionResult(ctx context.Context, runnerJobID, runnerJobExecutionID string, req *CreateRunnerJobExecutionResultRequest) (*app.RunnerJobExecutionResult, error) {
+func (s *service) createRunnerJobExecutionResult(ctx context.Context, runnerJobID, runnerJobExecutionID string, req *CreateRunnerJobExecutionResultRequest) (*app.RunnerJobExecutionResult, bool, error) {
 	runnerJob, err := s.getRunnerJob(ctx, runnerJobID)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
+	var contentsDisplay []byte
+	if req.ContentsDisplay != nil {
+		contentsDisplay, err = json.Marshal(req.ContentsDisplay)
+		if err != nil {
+			return nil, false, errors.Wrap(err, "unable to marshal contents display")
+		}
+	}
+
+	compositeError := s.parseCompositeError(req, runnerJob)
 	result := app.RunnerJobExecutionResult{
 		OrgID:                runnerJob.OrgID,
 		RunnerJobExecutionID: runnerJobExecutionID,
 		Success:              req.Success,
 		Contents:             req.Contents,
+		ContentsDisplay:      contentsDisplay,
 		ErrorCode:            req.ErrorCode,
 		ErrorMetadata:        pgtype.Hstore(req.ErrorMetadata),
-		CompositeError:       s.parseResultCompositeError(req, runnerJob),
+		CompositeError:       compositeError,
 	}
 
-	res := s.db.WithContext(ctx).Create(&result)
-	if res.Error != nil {
-		return nil, errors.Wrap(res.Error, "unable to write runner job execution result: %w")
+	persisted, created, err := helpers.CreateJobExecutionResultIfAbsent(ctx, s.db, &result)
+	if err != nil {
+		return nil, false, err
 	}
 
-	if req.ContentsDisplay != nil {
-		// NOTE(fd): we split up the write because this column can be rather large.
-		// TODO(fd): return a 206 partial content, ensure the client knows how to handle it.
-		byts, err := json.Marshal(req.ContentsDisplay)
-		if err != nil {
-			return nil, errors.Wrap(res.Error, "unable to marshal contents display")
-		}
-		rjer := app.RunnerJobExecutionResult{
-			ID: result.ID,
-		}
-		updateRes := s.db.WithContext(ctx).Model(&rjer).Updates(app.RunnerJobExecutionResult{
-			ContentsDisplay: byts,
-		})
-		if updateRes.Error != nil {
-			return &result, errors.Wrap(res.Error, "failed to set display content on runner job execution")
-		}
+	if created {
+		s.recordCompositeErrorParse(req, runnerJob, compositeError)
+		s.refreshOwnerCompositeError(ctx, runnerJob, compositeError)
 	}
 
-	s.refreshOwnerCompositeError(ctx, runnerJob, result.CompositeError)
-
-	return &result, nil
+	return persisted, created, nil
 }

--- a/services/ctl-api/internal/app/runners/service/parse_result_composite_error_test.go
+++ b/services/ctl-api/internal/app/runners/service/parse_result_composite_error_test.go
@@ -132,10 +132,11 @@ func TestParseResultCompositeError_Metric(t *testing.T) {
 	t.Run("specific match tags the matched type", func(t *testing.T) {
 		mw := &fakeMetricsWriter{}
 		s := &service{mw: mw, l: zap.NewNop()}
-		s.parseResultCompositeError(&CreateRunnerJobExecutionResultRequest{
+		req := &CreateRunnerJobExecutionResultRequest{
 			Success:       false,
 			ErrorMetadata: map[string]*string{"message": ptr(awsMsg)},
-		}, tfDeploy)
+		}
+		s.recordCompositeErrorParse(req, tfDeploy, s.parseCompositeError(req, tfDeploy))
 
 		if len(mw.incrs) != 1 {
 			t.Fatalf("expected 1 metric, got %d", len(mw.incrs))
@@ -154,10 +155,11 @@ func TestParseResultCompositeError_Metric(t *testing.T) {
 	t.Run("parse miss is tagged generic", func(t *testing.T) {
 		mw := &fakeMetricsWriter{}
 		s := &service{mw: mw, l: zap.NewNop()}
-		s.parseResultCompositeError(&CreateRunnerJobExecutionResultRequest{
+		req := &CreateRunnerJobExecutionResultRequest{
 			Success:       false,
 			ErrorMetadata: map[string]*string{"message": ptr("some unrelated failure")},
-		}, tfDeploy)
+		}
+		s.recordCompositeErrorParse(req, tfDeploy, s.parseCompositeError(req, tfDeploy))
 
 		if len(mw.incrs) != 1 {
 			t.Fatalf("expected 1 metric, got %d", len(mw.incrs))
@@ -170,7 +172,8 @@ func TestParseResultCompositeError_Metric(t *testing.T) {
 	t.Run("empty output is tagged miss", func(t *testing.T) {
 		mw := &fakeMetricsWriter{}
 		s := &service{mw: mw, l: zap.NewNop()}
-		s.parseResultCompositeError(&CreateRunnerJobExecutionResultRequest{Success: false}, tfDeploy)
+		req := &CreateRunnerJobExecutionResultRequest{Success: false}
+		s.recordCompositeErrorParse(req, tfDeploy, s.parseCompositeError(req, tfDeploy))
 
 		if len(mw.incrs) != 1 {
 			t.Fatalf("expected 1 metric, got %d", len(mw.incrs))
@@ -183,10 +186,12 @@ func TestParseResultCompositeError_Metric(t *testing.T) {
 	t.Run("unknown tool falls back to unknown tag", func(t *testing.T) {
 		mw := &fakeMetricsWriter{}
 		s := &service{mw: mw, l: zap.NewNop()}
-		s.parseResultCompositeError(&CreateRunnerJobExecutionResultRequest{
+		req := &CreateRunnerJobExecutionResultRequest{
 			Success:       false,
 			ErrorMetadata: map[string]*string{"message": ptr("boom")},
-		}, &app.RunnerJob{OwnerType: "install_deploys", OwnerID: "x"})
+		}
+		job := &app.RunnerJob{OwnerType: "install_deploys", OwnerID: "x"}
+		s.recordCompositeErrorParse(req, job, s.parseCompositeError(req, job))
 
 		if !hasTag(mw.incrs[0].tags, "tool:unknown") || !hasTag(mw.incrs[0].tags, "group:unknown") {
 			t.Errorf("expected unknown fallback tags, got %v", mw.incrs[0].tags)
@@ -196,7 +201,8 @@ func TestParseResultCompositeError_Metric(t *testing.T) {
 	t.Run("success emits no metric", func(t *testing.T) {
 		mw := &fakeMetricsWriter{}
 		s := &service{mw: mw, l: zap.NewNop()}
-		s.parseResultCompositeError(&CreateRunnerJobExecutionResultRequest{Success: true}, tfDeploy)
+		req := &CreateRunnerJobExecutionResultRequest{Success: true}
+		s.recordCompositeErrorParse(req, tfDeploy, s.parseCompositeError(req, tfDeploy))
 
 		if len(mw.incrs) != 0 {
 			t.Fatalf("expected no metric on success, got %d", len(mw.incrs))

--- a/services/ctl-api/internal/app/runners/service/update_runner_job_execution.go
+++ b/services/ctl-api/internal/app/runners/service/update_runner_job_execution.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/signals/processjob"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 )
@@ -50,6 +51,7 @@ func (s *service) UpdateRunnerJobExecution(ctx *gin.Context) {
 		ctx.Error(fmt.Errorf("unable to update runner job execution status: %w", err))
 		return
 	}
+	helpers.AuditJobExecutionResult(ctx, s.db, s.mw, runnerJobExecutionID, req.Status, "runner_api")
 
 	// On a terminal status, wake the process_job workflow so it finalizes
 	// (stamps finished_at) on this request instead of on its next poll tick.

--- a/services/ctl-api/internal/app/runners/worker/activities/update_job_execution_status.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/update_job_execution_status.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
 )
 
 type UpdateJobExecutionStatusRequest struct {
@@ -28,6 +29,7 @@ func (a *Activities) UpdateJobExecutionStatus(ctx context.Context, req UpdateJob
 	if res.RowsAffected < 1 {
 		return fmt.Errorf("no job execution found: %s %w", req.JobExecutionID, gorm.ErrRecordNotFound)
 	}
+	helpers.AuditJobExecutionResult(ctx, a.db, a.mw, req.JobExecutionID, req.Status, "runner_workflow")
 
 	return nil
 }

--- a/services/ctl-api/internal/pkg/workflows/controlplanejob/activities.go
+++ b/services/ctl-api/internal/pkg/workflows/controlplanejob/activities.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/generic"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/helm"
 	_ "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/errparse/terraform"
+	runnerhelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
@@ -399,21 +400,6 @@ func (a *Activities) CreateJobExecutionResult(ctx context.Context, jobID, execut
 		ErrorMetadata:        stringMapToHstore(req.ErrorMetadata),
 		CompositeError:       compositeError,
 	}
-	if !req.Success {
-		matched := "miss"
-		if result.CompositeError != nil && result.CompositeError.Type != "" {
-			matched = string(result.CompositeError.Type)
-		}
-		tool := string(errparse.ToolForRunnerJob(job))
-		if tool == "" {
-			tool = "unknown"
-		}
-		group := string(job.Group)
-		if group == "" {
-			group = "unknown"
-		}
-		a.mw.Incr("runner.composite_error_parse", []string{"tool:" + tool, "group:" + group, "matched_type:" + matched})
-	}
 	if req.ContentsCompressed != "" {
 		contents, err := base64.URLEncoding.DecodeString(req.ContentsCompressed)
 		if err != nil {
@@ -436,40 +422,34 @@ func (a *Activities) CreateJobExecutionResult(ctx context.Context, jobID, execut
 		result.ContentsDisplay = byts
 	}
 
-	var existing app.RunnerJobExecutionResult
-	res := a.db.WithContext(ctx).Where(&app.RunnerJobExecutionResult{RunnerJobExecutionID: executionID}).First(&existing)
-	if res.Error != nil && res.Error != gorm.ErrRecordNotFound {
-		return nil, fmt.Errorf("unable to get existing runner job execution result: %w", res.Error)
+	persisted, created, err := runnerhelpers.CreateJobExecutionResultIfAbsent(ctx, a.db, &result)
+	if err != nil {
+		return nil, err
 	}
-	var response *models.AppRunnerJobExecutionResult
-	if res.Error == gorm.ErrRecordNotFound {
-		if err := a.db.WithContext(ctx).Create(&result).Error; err != nil {
-			return nil, fmt.Errorf("unable to create runner job execution result: %w", err)
+	if created && !req.Success {
+		matched := "miss"
+		if result.CompositeError != nil && result.CompositeError.Type != "" {
+			matched = string(result.CompositeError.Type)
 		}
-		response = &models.AppRunnerJobExecutionResult{ID: result.ID, Success: result.Success}
-	} else {
-		if err := a.db.WithContext(ctx).Model(&existing).Updates(map[string]any{
-			"org_id":                result.OrgID,
-			"success":               result.Success,
-			"error_code":            result.ErrorCode,
-			"error_metadata":        result.ErrorMetadata,
-			"contents":              result.Contents,
-			"contents_gzip":         result.ContentsGzip,
-			"contents_display":      result.ContentsDisplay,
-			"contents_display_gzip": result.ContentsDisplayGzip,
-			"composite_error":       result.CompositeError,
-		}).Error; err != nil {
-			return nil, fmt.Errorf("unable to update runner job execution result: %w", err)
+		tool := string(errparse.ToolForRunnerJob(job))
+		if tool == "" {
+			tool = "unknown"
 		}
-		response = &models.AppRunnerJobExecutionResult{ID: existing.ID, Success: result.Success}
+		group := string(job.Group)
+		if group == "" {
+			group = "unknown"
+		}
+		a.mw.Incr("runner.composite_error_parse", []string{"tool:" + tool, "group:" + group, "matched_type:" + matched})
 	}
 
-	if err := a.applyComponentBuildSourceIdentity(ctx, job, req); err != nil {
-		a.l.Warn("unable to apply component build source identity", zap.Error(err))
+	if created {
+		if err := a.applyComponentBuildSourceIdentity(ctx, job, req); err != nil {
+			a.l.Warn("unable to apply component build source identity", zap.Error(err))
+		}
+		a.refreshOwnerCompositeError(ctx, job, result.CompositeError)
 	}
-	a.refreshOwnerCompositeError(ctx, job, result.CompositeError)
 
-	return response, nil
+	return &models.AppRunnerJobExecutionResult{ID: persisted.ID, Success: persisted.Success}, nil
 }
 
 func (a *Activities) refreshOwnerCompositeError(ctx context.Context, job *app.RunnerJob, compositeError any) {

--- a/services/ctl-api/internal/pkg/workflows/controlplanejob/activities.go
+++ b/services/ctl-api/internal/pkg/workflows/controlplanejob/activities.go
@@ -334,6 +334,7 @@ func (a *Activities) UpdateJobExecution(ctx context.Context, jobID, executionID 
 	}); err != nil {
 		return nil, err
 	}
+	runnerhelpers.AuditJobExecutionResult(ctx, a.db, a.mw, execution.ID, execution.Status, "control_plane")
 
 	description := req.StatusDescription
 	if execution.Status != requestedStatus {

--- a/services/ctl-api/internal/pkg/workflows/job/activities/activities.go
+++ b/services/ctl-api/internal/pkg/workflows/job/activities/activities.go
@@ -3,20 +3,25 @@ package activities
 import (
 	"go.uber.org/fx"
 	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/pkg/metrics"
 )
 
 type Params struct {
 	fx.In
 
 	DB *gorm.DB `name:"psql"`
+	MW metrics.Writer
 }
 
 type Activities struct {
 	db *gorm.DB
+	mw metrics.Writer
 }
 
 func New(params Params) *Activities {
 	return &Activities{
 		db: params.DB,
+		mw: params.MW,
 	}
 }

--- a/services/ctl-api/internal/pkg/workflows/job/activities/cancel_job.go
+++ b/services/ctl-api/internal/pkg/workflows/job/activities/cancel_job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -59,6 +60,7 @@ func (a *Activities) PkgWorkflowsJobCancelJob(ctx context.Context, req *CancelJo
 		if res.Error != nil {
 			return errors.Wrap(res.Error, "unable to cancel job execution")
 		}
+		helpers.AuditJobExecutionResult(ctx, a.db, a.mw, execution.ID, app.RunnerJobExecutionStatusCancelled, "cancel_workflow")
 
 	}
 

--- a/services/ctl-api/internal/pkg/workflows/job/activities/cancel_job.go
+++ b/services/ctl-api/internal/pkg/workflows/job/activities/cancel_job.go
@@ -40,7 +40,7 @@ func (a *Activities) PkgWorkflowsJobCancelJob(ctx context.Context, req *CancelJo
 		}).
 		First(&job, "id = ?", req.ID)
 	if jres.Error != nil {
-		return errors.Wrap(res.Error, "unable to get runner job")
+		return errors.Wrap(jres.Error, "unable to get runner job")
 	}
 
 	for _, execution := range job.Executions {


### PR DESCRIPTION
This PR makes runner execution-result persistence atomic, idempotent, and first-write-wins, preserving rich handler results over generic fallbacks. It adds fallback results for runner step failures and panics before terminal status updates. Terminal status writes now survive cancelled execution contexts, and audit-only metrics expose unsuccessful executions without results.

### Changes

- Persist result contents and display contents atomically.
- Make runner and control-plane result writes idempotent.
- Write fallback error results for handler lookup failures, step errors, and panics.
- Detach fallback result and terminal status writes from cancelled contexts.
- Emit runner.execution_result_audit metrics without blocking status transitions.
- Fix incorrect error propagation in workflow-driven job cancellation.