### PR TITLE
feat: trace API requests and gorm queries in Datadog

### DIFF
--- a/services/ctl-api/internal/middlewares/tracer/middleware.go
+++ b/services/ctl-api/internal/middlewares/tracer/middleware.go
@@ -1,8 +1,14 @@
 package tracer
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
@@ -31,6 +37,8 @@ func (m middleware) Name() string {
 }
 
 func (m middleware) Handler() gin.HandlerFunc {
+	tracer := otel.Tracer("github.com/nuonco/nuon/services/ctl-api/internal/middlewares/tracer")
+
 	return func(ctx *gin.Context) {
 		traceID := ctx.Request.Header.Get(traceIDHeaderKey)
 		if traceID == "" {
@@ -43,7 +51,45 @@ func (m middleware) Handler() gin.HandlerFunc {
 		// set trace id header for all responses
 		ctx.Writer.Header().Set(traceIDHeaderKey, traceID)
 
+		route := ctx.FullPath()
+		if route == "" {
+			route = "unmatched"
+		}
+
+		// Downstream instrumentation (e.g. the gorm tracing plugin) parents to this span
+		// through the request context; gin's own Value does not expose it because
+		// engine.ContextWithFallback is off.
+		spanCtx, span := tracer.Start(ctx.Request.Context(),
+			ctx.Request.Method+" "+route,
+			trace.WithSpanKind(trace.SpanKindServer),
+			trace.WithAttributes(
+				attribute.String("http.method", ctx.Request.Method),
+				attribute.String("http.route", route),
+				attribute.String("nuon.trace_id", traceID),
+			),
+		)
+		defer span.End()
+		ctx.Request = ctx.Request.WithContext(spanCtx)
+
 		ctx.Next()
+
+		status := ctx.Writer.Status()
+		span.SetAttributes(attribute.Int("http.status_code", status))
+
+		if metricCtx, err := cctx.MetricsContextFromGinContext(ctx); err == nil {
+			span.SetAttributes(
+				attribute.String("nuon.org_id", metricCtx.OrgID),
+				attribute.String("nuon.namespace", metricCtx.Namespace),
+				attribute.String("nuon.context", metricCtx.Context),
+			)
+		}
+
+		if status >= 500 {
+			span.SetStatus(codes.Error, http.StatusText(status))
+		}
+		if len(ctx.Errors) > 0 {
+			span.RecordError(ctx.Errors[0].Err)
+		}
 	}
 }
 

--- a/services/ctl-api/internal/middlewares/tracer/middleware_test.go
+++ b/services/ctl-api/internal/middlewares/tracer/middleware_test.go
@@ -1,0 +1,207 @@
+package tracer
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+func setupTest(t *testing.T) (*gin.Engine, *tracetest.SpanRecorder) {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.Use(middleware{}.Handler())
+
+	return engine, recorder
+}
+
+func attrMap(span sdktrace.ReadOnlySpan) map[attribute.Key]attribute.Value {
+	m := map[attribute.Key]attribute.Value{}
+	for _, kv := range span.Attributes() {
+		m[kv.Key] = kv.Value
+	}
+	return m
+}
+
+func TestRootSpanAttributes(t *testing.T) {
+	engine, recorder := setupTest(t)
+
+	engine.GET("/v1/apps/:app_id", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/apps/app123", nil)
+	engine.ServeHTTP(w, req)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	span := spans[0]
+
+	require.Equal(t, "GET /v1/apps/:app_id", span.Name())
+	require.Equal(t, oteltrace.SpanKindServer, span.SpanKind())
+
+	attrs := attrMap(span)
+	require.Equal(t, "GET", attrs["http.method"].AsString())
+	require.Equal(t, "/v1/apps/:app_id", attrs["http.route"].AsString())
+	require.Equal(t, int64(http.StatusOK), attrs["http.status_code"].AsInt64())
+	require.NotEmpty(t, attrs["nuon.trace_id"].AsString())
+	require.Equal(t, codes.Unset, span.Status().Code)
+}
+
+func TestDownstreamSpansParentToRootSpan(t *testing.T) {
+	engine, recorder := setupTest(t)
+
+	engine.GET("/v1/things", func(c *gin.Context) {
+		_, child := otel.Tracer("test").Start(c.Request.Context(), "child.op")
+		child.End()
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/things", nil)
+	engine.ServeHTTP(w, req)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 2)
+
+	var child, root sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		switch s.Name() {
+		case "child.op":
+			child = s
+		case "GET /v1/things":
+			root = s
+		}
+	}
+	require.NotNil(t, child)
+	require.NotNil(t, root)
+	require.Equal(t, root.SpanContext().TraceID(), child.SpanContext().TraceID())
+	require.Equal(t, root.SpanContext().SpanID(), child.Parent().SpanID())
+}
+
+func TestServerErrorMarksSpanError(t *testing.T) {
+	engine, recorder := setupTest(t)
+
+	engine.GET("/v1/broken", func(c *gin.Context) {
+		_ = c.Error(errors.New("boom"))
+		c.Status(http.StatusInternalServerError)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/broken", nil)
+	engine.ServeHTTP(w, req)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	span := spans[0]
+
+	require.Equal(t, codes.Error, span.Status().Code)
+	attrs := attrMap(span)
+	require.Equal(t, int64(http.StatusInternalServerError), attrs["http.status_code"].AsInt64())
+
+	var recorded bool
+	for _, ev := range span.Events() {
+		if ev.Name == "exception" {
+			recorded = true
+		}
+	}
+	require.True(t, recorded)
+}
+
+func TestClientErrorNotMarkedAsSpanError(t *testing.T) {
+	engine, recorder := setupTest(t)
+
+	engine.GET("/v1/things", func(c *gin.Context) {
+		c.Status(http.StatusNotFound)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/things", nil)
+	engine.ServeHTTP(w, req)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code)
+}
+
+func TestMetricContextAttributes(t *testing.T) {
+	engine, recorder := setupTest(t)
+
+	engine.GET("/v1/things", func(c *gin.Context) {
+		c.Set(keys.MetricsKey, &cctx.MetricContext{
+			OrgID:     "org123",
+			Namespace: "public",
+			Context:   "api",
+		})
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/things", nil)
+	engine.ServeHTTP(w, req)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	attrs := attrMap(spans[0])
+	require.Equal(t, "org123", attrs["nuon.org_id"].AsString())
+	require.Equal(t, "public", attrs["nuon.namespace"].AsString())
+	require.Equal(t, "api", attrs["nuon.context"].AsString())
+}
+
+func TestNuonTraceIDHeaderPreserved(t *testing.T) {
+	engine, _ := setupTest(t)
+
+	engine.GET("/v1/things", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	t.Run("generated when missing", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/things", nil)
+		engine.ServeHTTP(w, req)
+		require.NotEmpty(t, w.Header().Get("X-Nuon-Trace-ID"))
+	})
+
+	t.Run("propagated when provided", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/things", nil)
+		req.Header.Set("X-Nuon-Trace-ID", "incoming-trace-id")
+		engine.ServeHTTP(w, req)
+		require.Equal(t, "incoming-trace-id", w.Header().Get("X-Nuon-Trace-ID"))
+	})
+}
+
+func TestUnmatchedRoute(t *testing.T) {
+	engine, recorder := setupTest(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/nope", nil)
+	engine.ServeHTTP(w, req)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "GET unmatched", spans[0].Name())
+	attrs := attrMap(spans[0])
+	require.Equal(t, "unmatched", attrs["http.route"].AsString())
+}

--- a/services/ctl-api/internal/pkg/db/ch/plugins.go
+++ b/services/ctl-api/internal/pkg/db/ch/plugins.go
@@ -8,12 +8,17 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/afterquery"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/querycollector"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/tracing"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
 )
 
 func (d *database) registerPlugins(db *gorm.DB) error {
 	if err := db.Use(metrics.NewMetricsPlugin(d.MetricsWriter, "ch", &d.Logger)); err != nil {
 		return errors.Wrap(err, "unable to register metrics plugin")
+	}
+
+	if err := db.Use(tracing.NewTracingPlugin("ch")); err != nil {
+		return errors.Wrap(err, "unable to register tracing plugin")
 	}
 
 	if err := db.Use(afterquery.NewAfterQueryPlugin()); err != nil {

--- a/services/ctl-api/internal/pkg/db/plugins/tracing/tracing_plugin.go
+++ b/services/ctl-api/internal/pkg/db/plugins/tracing/tracing_plugin.go
@@ -1,0 +1,170 @@
+package tracing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"gorm.io/gorm"
+
+	"github.com/gin-gonic/gin"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/routing"
+)
+
+type contextKey string
+
+const spanContextKey contextKey = "gorm_tracing_plugin_span"
+
+var _ gorm.Plugin = (*tracingPlugin)(nil)
+
+// This plugin emits OpenTelemetry spans for every gorm operation, mirroring the tags emitted by the
+// metrics plugin so high-cardinality dimensions (endpoint, table, org) live on traces instead of
+// metric tags. Preload queries re-enter the Query callback pipeline with the parent operation's
+// context, so they show up as child spans automatically.
+//
+// Spans only ever carry the prepared SQL with placeholders, never bound values.
+func NewTracingPlugin(dbType string) *tracingPlugin {
+	return &tracingPlugin{
+		dbType: dbType,
+		tracer: otel.Tracer("github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/tracing"),
+	}
+}
+
+type tracingPlugin struct {
+	dbType string
+	tracer trace.Tracer
+}
+
+func (p *tracingPlugin) Name() string {
+	return "otel-tracing"
+}
+
+type operationType string
+
+const (
+	createOperation operationType = "create"
+	queryOperation  operationType = "query"
+	updateOperation operationType = "update"
+	deleteOperation operationType = "delete"
+	rawOperation    operationType = "raw"
+	rowOperation    operationType = "row"
+)
+
+func (p *tracingPlugin) Initialize(db *gorm.DB) error {
+	db.Callback().Create().Before("*").Register("otel_before", func(tx *gorm.DB) { p.before(tx, createOperation) })
+	db.Callback().Create().After("*").Register("otel_after", func(tx *gorm.DB) { p.after(tx, createOperation) })
+
+	db.Callback().Query().Before("*").Register("otel_before", func(tx *gorm.DB) { p.before(tx, queryOperation) })
+	db.Callback().Query().After("*").Register("otel_after", func(tx *gorm.DB) { p.after(tx, queryOperation) })
+
+	db.Callback().Update().Before("*").Register("otel_before", func(tx *gorm.DB) { p.before(tx, updateOperation) })
+	db.Callback().Update().After("*").Register("otel_after", func(tx *gorm.DB) { p.after(tx, updateOperation) })
+
+	db.Callback().Delete().Before("*").Register("otel_before", func(tx *gorm.DB) { p.before(tx, deleteOperation) })
+	db.Callback().Delete().After("*").Register("otel_after", func(tx *gorm.DB) { p.after(tx, deleteOperation) })
+
+	db.Callback().Raw().Before("*").Register("otel_before", func(tx *gorm.DB) { p.before(tx, rawOperation) })
+	db.Callback().Raw().After("*").Register("otel_after", func(tx *gorm.DB) { p.after(tx, rawOperation) })
+
+	db.Callback().Row().Before("*").Register("otel_before", func(tx *gorm.DB) { p.before(tx, rowOperation) })
+	db.Callback().Row().After("*").Register("otel_after", func(tx *gorm.DB) { p.after(tx, rowOperation) })
+
+	return nil
+}
+
+func (p *tracingPlugin) before(tx *gorm.DB, op operationType) {
+	spanParent := tx.Statement.Context
+	// Handlers pass the *gin.Context to WithContext, and other callbacks (e.g. routing) may
+	// have wrapped it by now. Gin only exposes request-context values (like the root HTTP
+	// span) through Value when engine.ContextWithFallback is on, which it isn't, so recover
+	// the gin context through its self-key and parent from the request context, while keeping
+	// the original statement chain for Keys-based values like MetricContext.
+	if gc, ok := spanParent.Value(gin.ContextKey).(*gin.Context); ok && gc.Request != nil {
+		spanParent = gc.Request.Context()
+	}
+
+	_, span := p.tracer.Start(spanParent, "gorm."+string(op), trace.WithSpanKind(trace.SpanKindClient))
+	if !span.IsRecording() {
+		span.End()
+		return
+	}
+	ctx := trace.ContextWithSpan(tx.Statement.Context, span)
+	ctx = context.WithValue(ctx, spanContextKey, span)
+	tx.Statement.Context = ctx
+}
+
+func (p *tracingPlugin) after(tx *gorm.DB, op operationType) {
+	ctx := tx.Statement.Context
+
+	val := ctx.Value(spanContextKey)
+	if val == nil {
+		return
+	}
+	span := val.(trace.Span)
+	defer span.End()
+
+	if !span.IsRecording() {
+		return
+	}
+
+	tableName := "raw_sql"
+	if tx.Statement.Schema != nil {
+		tableName = tx.Statement.Schema.Table
+	}
+
+	span.SetName(fmt.Sprintf("gorm.%s %s", op, tableName))
+
+	dbSystem := "postgresql"
+	if p.dbType == "ch" {
+		dbSystem = "clickhouse"
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("db.system", dbSystem),
+		attribute.String("db.operation", string(op)),
+		attribute.String("db.sql.table", tableName),
+		attribute.String("db.statement", tx.Statement.SQL.String()),
+		attribute.Int64("db.rows_affected", tx.RowsAffected),
+		attribute.Int("nuon.db.preload_count", len(tx.Statement.Preloads)),
+		attribute.Int("nuon.db.response_size", responseSize(tx)),
+	}
+	if p.dbType == "psql" {
+		attrs = append(attrs, attribute.String("nuon.db.pool", string(routing.DecisionFromContext(ctx))))
+	}
+
+	if metricCtx, err := cctx.MetricsContextFromGinContext(ctx); err == nil {
+		attrs = append(attrs,
+			attribute.String("nuon.context", metricCtx.Context),
+			attribute.String("http.method", metricCtx.Method),
+			attribute.String("http.route", metricCtx.Endpoint),
+			attribute.String("nuon.org_id", metricCtx.OrgID),
+			attribute.String("nuon.namespace", metricCtx.Namespace),
+		)
+	}
+
+	span.SetAttributes(attrs...)
+
+	if tx.Error != nil && !errors.Is(tx.Error, gorm.ErrRecordNotFound) {
+		span.RecordError(tx.Error)
+		span.SetStatus(codes.Error, tx.Error.Error())
+	}
+}
+
+func responseSize(tx *gorm.DB) int {
+	if !tx.Statement.ReflectValue.IsValid() {
+		return 0
+	}
+	if tx.Statement.ReflectValue.Kind() == reflect.Slice {
+		return tx.Statement.ReflectValue.Len()
+	}
+	if !tx.Statement.ReflectValue.IsZero() {
+		return 1
+	}
+	return 0
+}

--- a/services/ctl-api/internal/pkg/db/plugins/tracing/tracing_plugin_test.go
+++ b/services/ctl-api/internal/pkg/db/plugins/tracing/tracing_plugin_test.go
@@ -1,0 +1,247 @@
+package tracing
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+type testAuthor struct {
+	ID    uint
+	Name  string
+	Books []testBook `gorm:"foreignKey:AuthorID"`
+}
+
+type testBook struct {
+	ID       uint
+	AuthorID uint
+	Title    string
+}
+
+func setupTest(t *testing.T) (*gorm.DB, *tracetest.SpanRecorder) {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&testAuthor{}, &testBook{}))
+	require.NoError(t, db.Use(NewTracingPlugin("psql")))
+
+	return db, recorder
+}
+
+func attrMap(span sdktrace.ReadOnlySpan) map[attribute.Key]attribute.Value {
+	m := map[attribute.Key]attribute.Value{}
+	for _, kv := range span.Attributes() {
+		m[kv.Key] = kv.Value
+	}
+	return m
+}
+
+func findSpan(t *testing.T, spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	for _, s := range spans {
+		if s.Name() == name {
+			return s
+		}
+	}
+	t.Fatalf("span %q not found in %d spans", name, len(spans))
+	return nil
+}
+
+func TestQuerySpanAttributes(t *testing.T) {
+	db, recorder := setupTest(t)
+
+	require.NoError(t, db.Create(&testAuthor{Name: "amy"}).Error)
+
+	var authors []testAuthor
+	require.NoError(t, db.Where(testAuthor{Name: "amy"}).Find(&authors).Error)
+
+	span := findSpan(t, recorder.Ended(), "gorm.query test_authors")
+	attrs := attrMap(span)
+
+	require.Equal(t, "postgresql", attrs["db.system"].AsString())
+	require.Equal(t, "query", attrs["db.operation"].AsString())
+	require.Equal(t, "test_authors", attrs["db.sql.table"].AsString())
+	require.Contains(t, attrs["db.statement"].AsString(), "SELECT")
+	require.Contains(t, attrs["db.statement"].AsString(), "?")
+	require.NotContains(t, attrs["db.statement"].AsString(), "amy")
+	require.Equal(t, int64(1), attrs["db.rows_affected"].AsInt64())
+	require.Equal(t, int64(1), attrs["nuon.db.response_size"].AsInt64())
+	require.Equal(t, codes.Unset, span.Status().Code)
+}
+
+func TestRequestContextAttributesAndParenting(t *testing.T) {
+	db, recorder := setupTest(t)
+
+	metricCtx := &cctx.MetricContext{
+		Endpoint:  "/v1/apps/:app_id",
+		Method:    "GET",
+		OrgID:     "org123",
+		Context:   "public",
+		Namespace: "ns1",
+	}
+	ctx := context.WithValue(context.Background(), keys.MetricsKey, metricCtx)
+
+	ctx, parent := otel.Tracer("test").Start(ctx, "http.request")
+
+	var authors []testAuthor
+	require.NoError(t, db.WithContext(ctx).Find(&authors).Error)
+	parent.End()
+
+	span := findSpan(t, recorder.Ended(), "gorm.query test_authors")
+	attrs := attrMap(span)
+
+	require.Equal(t, "/v1/apps/:app_id", attrs["http.route"].AsString())
+	require.Equal(t, "GET", attrs["http.method"].AsString())
+	require.Equal(t, "org123", attrs["nuon.org_id"].AsString())
+	require.Equal(t, "public", attrs["nuon.context"].AsString())
+	require.Equal(t, "ns1", attrs["nuon.namespace"].AsString())
+
+	require.Equal(t, parent.SpanContext().SpanID(), span.Parent().SpanID())
+	require.Equal(t, parent.SpanContext().TraceID(), span.SpanContext().TraceID())
+}
+
+func TestPreloadQueriesBecomeChildSpans(t *testing.T) {
+	db, recorder := setupTest(t)
+
+	require.NoError(t, db.Create(&testAuthor{
+		Name:  "amy",
+		Books: []testBook{{Title: "one"}, {Title: "two"}},
+	}).Error)
+
+	var authors []testAuthor
+	require.NoError(t, db.Preload("Books").Find(&authors).Error)
+
+	var root, preload sdktrace.ReadOnlySpan
+	for _, s := range recorder.Ended() {
+		if s.Name() == "gorm.query test_authors" && !s.Parent().IsValid() {
+			root = s
+		}
+		if s.Name() == "gorm.query test_books" {
+			preload = s
+		}
+	}
+	require.NotNil(t, root, "root query span not found")
+	require.NotNil(t, preload, "preload query span not found")
+
+	require.Equal(t, root.SpanContext().SpanID(), preload.Parent().SpanID())
+	require.Equal(t, root.SpanContext().TraceID(), preload.SpanContext().TraceID())
+	require.Equal(t, int64(1), attrMap(root)["nuon.db.preload_count"].AsInt64())
+}
+
+func TestErrorsAreRecorded(t *testing.T) {
+	db, recorder := setupTest(t)
+
+	require.Error(t, db.Raw("SELECT * FROM missing_table").Scan(&map[string]any{}).Error)
+
+	var errSpan sdktrace.ReadOnlySpan
+	for _, s := range recorder.Ended() {
+		if s.Status().Code == codes.Error {
+			errSpan = s
+		}
+	}
+	require.NotNil(t, errSpan, "expected a span with error status")
+	require.NotEmpty(t, errSpan.Events(), "expected recorded error event")
+}
+
+func TestRecordNotFoundIsNotAnError(t *testing.T) {
+	db, recorder := setupTest(t)
+
+	var author testAuthor
+	err := db.Where(testAuthor{Name: "ghost"}).First(&author).Error
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+
+	span := findSpan(t, recorder.Ended(), "gorm.query test_authors")
+	require.Equal(t, codes.Unset, span.Status().Code)
+}
+
+func TestNoopProviderAddsNoOverheadPath(t *testing.T) {
+	otel.SetTracerProvider(trace.NewNoopTracerProvider())
+
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&testAuthor{}))
+	require.NoError(t, db.Use(NewTracingPlugin("psql")))
+
+	var authors []testAuthor
+	require.NoError(t, db.Find(&authors).Error)
+}
+
+func TestGinContextQueryParentsToRootSpan(t *testing.T) {
+	db, recorder := setupTest(t)
+	require.NoError(t, db.Create(&testAuthor{Name: "gin"}).Error)
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(w)
+	ginCtx.Request = httptest.NewRequest(http.MethodGet, "/v1/things", nil)
+	ginCtx.Set(keys.MetricsKey, &cctx.MetricContext{
+		Endpoint: "/v1/things",
+		Method:   "GET",
+		OrgID:    "org123",
+	})
+
+	rootCtx, rootSpan := otel.Tracer("test").Start(context.Background(), "GET /v1/things")
+	ginCtx.Request = ginCtx.Request.WithContext(rootCtx)
+
+	var authors []testAuthor
+	require.NoError(t, db.WithContext(ginCtx).Where(testAuthor{Name: "gin"}).Find(&authors).Error)
+	rootSpan.End()
+
+	span := findSpan(t, recorder.Ended(), "gorm.query test_authors")
+	require.Equal(t, rootSpan.SpanContext().TraceID(), span.SpanContext().TraceID())
+	require.Equal(t, rootSpan.SpanContext().SpanID(), span.Parent().SpanID())
+
+	attrs := attrMap(span)
+	require.Equal(t, "/v1/things", attrs["http.route"].AsString())
+	require.Equal(t, "org123", attrs["nuon.org_id"].AsString())
+}
+
+func TestWrappedGinContextStillParentsToRootSpan(t *testing.T) {
+	db, recorder := setupTest(t)
+	require.NoError(t, db.Create(&testAuthor{Name: "wrapped"}).Error)
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(w)
+	ginCtx.Request = httptest.NewRequest(http.MethodGet, "/v1/things", nil)
+
+	rootCtx, rootSpan := otel.Tracer("test").Start(context.Background(), "GET /v1/things")
+	ginCtx.Request = ginCtx.Request.WithContext(rootCtx)
+
+	type wrapperKey string
+	wrapped := context.WithValue(ginCtx, wrapperKey("routing_decision"), "replica")
+
+	var authors []testAuthor
+	require.NoError(t, db.WithContext(wrapped).Where(testAuthor{Name: "wrapped"}).Find(&authors).Error)
+	rootSpan.End()
+
+	span := findSpan(t, recorder.Ended(), "gorm.query test_authors")
+	require.Equal(t, rootSpan.SpanContext().TraceID(), span.SpanContext().TraceID())
+	require.Equal(t, rootSpan.SpanContext().SpanID(), span.Parent().SpanID())
+}

--- a/services/ctl-api/internal/pkg/db/psql/plugins.go
+++ b/services/ctl-api/internal/pkg/db/psql/plugins.go
@@ -8,11 +8,13 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/pagination"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/patcher"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/querycollector"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/tracing"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
 )
 
 func (d *database) registerPlugins(db *gorm.DB) error {
 	db.Use(metrics.NewMetricsPlugin(d.MetricsWriter, "psql", &d.Logger))
+	db.Use(tracing.NewTracingPlugin("psql"))
 	db.Use(afterquery.NewAfterQueryPlugin())
 	db.Use(views.NewViewsPlugin(AllModels()))
 	db.Use(pagination.NewOffsetPaginationPlugin())

--- a/services/ctl-api/internal/pkg/metrics/metrics.go
+++ b/services/ctl-api/internal/pkg/metrics/metrics.go
@@ -1,13 +1,22 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
 	"os"
 
+	ddotel "github.com/DataDog/dd-trace-go/v2/ddtrace/opentelemetry"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/go-playground/validator/v10"
 	"github.com/nuonco/nuon/pkg/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.uber.org/zap"
 )
 
@@ -27,11 +36,55 @@ func New(v *validator.Validate, l *zap.Logger, cfg *internal.Config) (metrics.Wr
 		return nil, fmt.Errorf("unable to create new metrics writer: %w", err)
 	}
 
+	// Local-dev affordances mirroring the metric debug log lines: dump spans to a JSON-lines
+	// file and/or a local OTLP viewer (e.g. otel-desktop-viewer, Jaeger) so traces can be
+	// inspected without a Datadog agent.
+	var localExporters []sdktrace.TracerProviderOption
+	if traceFile := os.Getenv("OTEL_LOCAL_TRACE_FILE"); traceFile != "" {
+		f, err := os.OpenFile(traceFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			return nil, fmt.Errorf("unable to open local trace file: %w", err)
+		}
+		exp, err := stdouttrace.New(stdouttrace.WithWriter(f))
+		if err != nil {
+			return nil, fmt.Errorf("unable to create local trace exporter: %w", err)
+		}
+		localExporters = append(localExporters, sdktrace.WithSyncer(exp))
+		l.Info("local OTel trace export enabled", zap.String("file", traceFile))
+	}
+	if otlpEndpoint := os.Getenv("OTEL_LOCAL_TRACE_OTLP"); otlpEndpoint != "" {
+		exp, err := otlptracehttp.New(context.Background(),
+			otlptracehttp.WithEndpoint(otlpEndpoint),
+			otlptracehttp.WithInsecure(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create local OTLP trace exporter: %w", err)
+		}
+		localExporters = append(localExporters, sdktrace.WithBatcher(exp))
+		l.Info("local OTel trace export enabled", zap.String("otlp_endpoint", otlpEndpoint))
+	}
+	if len(localExporters) > 0 {
+		opts := append(localExporters, sdktrace.WithResource(resource.NewSchemaless(
+			semconv.ServiceName("ctl-api"),
+			attribute.String("service_deployment", cfg.ServiceDeployment),
+		)))
+		otel.SetTracerProvider(sdktrace.NewTracerProvider(opts...))
+		return mw, nil
+	}
+
 	if !cfg.DisableMetrics {
-		tracer.Start(
+		// The ddotel bridge starts the Datadog tracer internally and exposes it behind the
+		// vendor-neutral OTel API, so instrumentation (e.g. the gorm tracing plugin) can later be
+		// pointed at an OTLP backend by swapping the provider without re-instrumenting.
+		// The node-level agent listens on hostPort 8126 for APM (apm.portEnabled), so the
+		// trace agent address must target HOST_IP like dogstatsd does; the default
+		// localhost:8126 would resolve to the pod itself and traces would be dropped.
+		tp := ddotel.NewTracerProvider(
 			tracer.WithRuntimeMetrics(),
 			tracer.WithDogstatsdAddr(fmt.Sprintf("%s:8125", os.Getenv("HOST_IP"))),
+			tracer.WithAgentAddr(fmt.Sprintf("%s:8126", os.Getenv("HOST_IP"))),
 		)
+		otel.SetTracerProvider(tp)
 	}
 
 	return mw, nil


### PR DESCRIPTION
## Summary

ctl-api now emits OpenTelemetry traces to Datadog. Every API request gets a root span named after its matched route, and every gorm query nests under it, so a request shows up as a waterfall of the queries it ran. Existing metrics keep emitting unchanged; this is the dual-emission step ahead of dropping the high cardinality gorm metric tags.

## What you can do after this PR

**Jump from a slow endpoint straight to the queries behind it.** Each request trace carries the method, route, status, org, and every query it ran with per-query latency, operation, table, rows returned, and connection pool.

**Search traces by the dimensions we are moving off metrics.** Endpoint, table, and org id live on spans, so per-org or per-table latency questions no longer need metric tags.

**See preload cost.** Preloaded associations show up as child query spans under the operation that triggered them, which the current latency metric cannot show.

## What stays the same

All gorm and HTTP metrics emit exactly as before, so dashboards and monitors are unaffected. The Nuon trace id header behaves as it always has. Spans only ever record prepared SQL with placeholders, never bound customer values. Requests returning 4xx are not marked as errors; 5xx are.

## Mechanics worth flagging

Instrumentation is vendor-neutral OTel with the Datadog bridge as the backend, so it can be pointed at an OTLP collector later without re-instrumenting. Traces ship to the node-level agent's APM port, mirroring the existing dogstatsd wiring.

## Verifying locally without a Datadog agent

Two env-gated local exporters make traces inspectable in dev, mirroring the metric debug log lines. `OTEL_LOCAL_TRACE_FILE=/tmp/ctl-api-traces.jsonl` writes each span as a JSON line for `tail`/`jq`; `OTEL_LOCAL_TRACE_OTLP=localhost:4318` streams spans to a local OTLP viewer such as otel-desktop-viewer or Jaeger, giving the full waterfall UI. Both are unset in deployed environments, where behavior is unchanged. Verified against the local stack: HTTP root spans parent their gorm queries (including through the wrapped psql routing context), preload chains appear as child spans, and prepared SQL carries placeholders only.
