### PR TITLE
fix(ctl-api): low-cardinality gorm span operation names

### DIFF
--- a/services/ctl-api/internal/pkg/db/plugins/tracing/tracing_plugin.go
+++ b/services/ctl-api/internal/pkg/db/plugins/tracing/tracing_plugin.go
@@ -118,14 +118,19 @@ func (p *tracingPlugin) after(tx *gorm.DB, op operationType) {
 		tableName = tx.Statement.Schema.Table
 	}
 
-	span.SetName(fmt.Sprintf("gorm.%s %s", op, tableName))
-
 	dbSystem := "postgresql"
 	if p.dbType == "ch" {
 		dbSystem = "clickhouse"
 	}
 
+	// The ddotel bridge turns the span name into the Datadog operation name, and Datadog
+	// creates one APM stats metric family per operation name (trace.<operation>.*). Keep the
+	// operation low-cardinality (postgresql.query / clickhouse.query, matching Datadog's own
+	// database integrations) and put the op + table in resource.name, which becomes the
+	// resource_name tag on those metrics.
 	attrs := []attribute.KeyValue{
+		attribute.String("operation.name", dbSystem+".query"),
+		attribute.String("resource.name", fmt.Sprintf("%s %s", op, tableName)),
 		attribute.String("db.system", dbSystem),
 		attribute.String("db.operation", string(op)),
 		attribute.String("db.sql.table", tableName),

--- a/services/ctl-api/internal/pkg/db/plugins/tracing/tracing_plugin_test.go
+++ b/services/ctl-api/internal/pkg/db/plugins/tracing/tracing_plugin_test.go
@@ -60,14 +60,14 @@ func attrMap(span sdktrace.ReadOnlySpan) map[attribute.Key]attribute.Value {
 	return m
 }
 
-func findSpan(t *testing.T, spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+func findSpan(t *testing.T, spans []sdktrace.ReadOnlySpan, name, table string) sdktrace.ReadOnlySpan {
 	t.Helper()
 	for _, s := range spans {
-		if s.Name() == name {
+		if s.Name() == name && attrMap(s)["db.sql.table"].AsString() == table {
 			return s
 		}
 	}
-	t.Fatalf("span %q not found in %d spans", name, len(spans))
+	t.Fatalf("span %q for table %q not found in %d spans", name, table, len(spans))
 	return nil
 }
 
@@ -79,9 +79,11 @@ func TestQuerySpanAttributes(t *testing.T) {
 	var authors []testAuthor
 	require.NoError(t, db.Where(testAuthor{Name: "amy"}).Find(&authors).Error)
 
-	span := findSpan(t, recorder.Ended(), "gorm.query test_authors")
+	span := findSpan(t, recorder.Ended(), "gorm.query", "test_authors")
 	attrs := attrMap(span)
 
+	require.Equal(t, "postgresql.query", attrs["operation.name"].AsString())
+	require.Equal(t, "query test_authors", attrs["resource.name"].AsString())
 	require.Equal(t, "postgresql", attrs["db.system"].AsString())
 	require.Equal(t, "query", attrs["db.operation"].AsString())
 	require.Equal(t, "test_authors", attrs["db.sql.table"].AsString())
@@ -111,7 +113,7 @@ func TestRequestContextAttributesAndParenting(t *testing.T) {
 	require.NoError(t, db.WithContext(ctx).Find(&authors).Error)
 	parent.End()
 
-	span := findSpan(t, recorder.Ended(), "gorm.query test_authors")
+	span := findSpan(t, recorder.Ended(), "gorm.query", "test_authors")
 	attrs := attrMap(span)
 
 	require.Equal(t, "/v1/apps/:app_id", attrs["http.route"].AsString())
@@ -137,10 +139,15 @@ func TestPreloadQueriesBecomeChildSpans(t *testing.T) {
 
 	var root, preload sdktrace.ReadOnlySpan
 	for _, s := range recorder.Ended() {
-		if s.Name() == "gorm.query test_authors" && !s.Parent().IsValid() {
-			root = s
+		if s.Name() != "gorm.query" {
+			continue
 		}
-		if s.Name() == "gorm.query test_books" {
+		switch attrMap(s)["db.sql.table"].AsString() {
+		case "test_authors":
+			if !s.Parent().IsValid() {
+				root = s
+			}
+		case "test_books":
 			preload = s
 		}
 	}
@@ -174,7 +181,7 @@ func TestRecordNotFoundIsNotAnError(t *testing.T) {
 	err := db.Where(testAuthor{Name: "ghost"}).First(&author).Error
 	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
 
-	span := findSpan(t, recorder.Ended(), "gorm.query test_authors")
+	span := findSpan(t, recorder.Ended(), "gorm.query", "test_authors")
 	require.Equal(t, codes.Unset, span.Status().Code)
 }
 
@@ -213,7 +220,7 @@ func TestGinContextQueryParentsToRootSpan(t *testing.T) {
 	require.NoError(t, db.WithContext(ginCtx).Where(testAuthor{Name: "gin"}).Find(&authors).Error)
 	rootSpan.End()
 
-	span := findSpan(t, recorder.Ended(), "gorm.query test_authors")
+	span := findSpan(t, recorder.Ended(), "gorm.query", "test_authors")
 	require.Equal(t, rootSpan.SpanContext().TraceID(), span.SpanContext().TraceID())
 	require.Equal(t, rootSpan.SpanContext().SpanID(), span.Parent().SpanID())
 
@@ -241,7 +248,7 @@ func TestWrappedGinContextStillParentsToRootSpan(t *testing.T) {
 	require.NoError(t, db.WithContext(wrapped).Where(testAuthor{Name: "wrapped"}).Find(&authors).Error)
 	rootSpan.End()
 
-	span := findSpan(t, recorder.Ended(), "gorm.query test_authors")
+	span := findSpan(t, recorder.Ended(), "gorm.query", "test_authors")
 	require.Equal(t, rootSpan.SpanContext().TraceID(), span.SpanContext().TraceID())
 	require.Equal(t, rootSpan.SpanContext().SpanID(), span.Parent().SpanID())
 }


### PR DESCRIPTION
## Problem

The ddotel bridge maps the OTel span name to the Datadog **operation name**, and Datadog creates one APM stats metric family per operation (`trace.<operation>.*`). The tracing plugin was naming spans per table (`gorm.query_tokens`, `gorm.create_endpoint_audits`, …), so stage started generating one metric family per table/op combination — recreating the cardinality problem the tracing migration is meant to eliminate.

## Fix

- Datadog operation name is now low-cardinality via the `operation.name` attribute: `postgresql.query` / `clickhouse.query`, matching Datadog's own DB integrations.
- The op + table move to `resource.name` (`query tokens`), which becomes the `resource_name` tag on APM stats metrics — still fully groupable/searchable.
- OTel span name stays `gorm.<op>` (bounded), so an OTLP/Grafana backend also sees low-cardinality names.
- All detail remains as span attributes: `db.operation`, `db.sql.table`, `db.statement` (placeholders only), endpoint/org context.

## Testing

- Updated plugin tests to find spans by name + `db.sql.table` and assert `operation.name` / `resource.name`.
- `go test ./services/ctl-api/internal/pkg/db/plugins/tracing/...` passes.