### PR TITLE
fix: Runner job post cleanup hook to use find

### DIFF
--- a/bins/runner/internal/pkg/monitor/templates/runner-service.aws.service
+++ b/bins/runner/internal/pkg/monitor/templates/runner-service.aws.service
@@ -12,7 +12,7 @@ EnvironmentFile=/opt/nuon/runner/image
 EnvironmentFile=/opt/nuon/runner/env
 ExecStartPre=/usr/bin/docker pull ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG}
 ExecStart=/usr/bin/docker run --network host --volume /tmp/nuon-runner:/tmp --rm --name %n --memory "3750g" --cpus="1.75" --env-file /opt/nuon/runner/env --log-driver=awslogs --log-opt awslogs-region=${AWS_REGION} --log-opt awslogs-group=runner-${RUNNER_ID} ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG} install
-ExecStopPost=-/usr/bin/rm -rf /tmp/nuon-runner/*"
+ExecStopPost=-+/usr/bin/find /tmp/nuon-runner -mindepth 1 -delete
 ExecStopPost=-/bin/sh -c "/usr/bin/docker rmi $(/usr/bin/docker images -a -q)"
 ExecStopPost=-/bin/sh -c "yes | /usr/bin/docker system prune -a"
 Restart=always

--- a/bins/runner/internal/pkg/monitor/templates/runner-service.azure.service
+++ b/bins/runner/internal/pkg/monitor/templates/runner-service.azure.service
@@ -12,7 +12,7 @@ EnvironmentFile=/opt/nuon/runner/image
 EnvironmentFile=/opt/nuon/runner/env
 ExecStartPre=/usr/bin/docker pull ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG}
 ExecStart=/usr/bin/docker run --network host --volume /tmp/nuon-runner:/tmp --rm --name %n --memory "3750g" --cpus="1.75" --env-file /opt/nuon/runner/env ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG} install
-ExecStopPost=-/usr/bin/rm -rf /tmp/nuon-runner/*"
+ExecStopPost=-+/usr/bin/find /tmp/nuon-runner -mindepth 1 -delete
 ExecStopPost=-/bin/sh -c "/usr/bin/docker rmi $(/usr/bin/docker images -a -q)"
 ExecStopPost=-/bin/sh -c "yes | /usr/bin/docker system prune -a"
 Restart=always

--- a/bins/runner/internal/pkg/monitor/templates/runner-service.gcp.service
+++ b/bins/runner/internal/pkg/monitor/templates/runner-service.gcp.service
@@ -12,7 +12,7 @@ EnvironmentFile=/opt/nuon/runner/image
 EnvironmentFile=/opt/nuon/runner/env
 ExecStartPre=/usr/bin/docker pull ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG}
 ExecStart=/usr/bin/docker run --network host --volume /tmp/nuon-runner:/tmp --rm --name %n --memory "3750m" --cpus="1.75" --env-file /opt/nuon/runner/env ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG} install
-ExecStopPost=-/usr/bin/rm -rf /tmp/nuon-runner/*"
+ExecStopPost=-+/usr/bin/find /tmp/nuon-runner -mindepth 1 -delete
 ExecStopPost=-/bin/sh -c "/usr/bin/docker rmi $(/usr/bin/docker images -a -q)"
 ExecStopPost=-/bin/sh -c "yes | /usr/bin/docker system prune -a"
 Restart=always


### PR DESCRIPTION
The post cleanup command here was failing as 
1. it was incorrectly quoted
2. The `*` would not be expanded in a hook
3. The files there were owned by `root` (the user inside the container) so wont be cleaned up with `User=runner`

This patch fixes all three things, by using find instead of `rm` and prefixing with `+` to run this cleanup as root.