### PR TITLE
feat: denormalize install/app ancestry onto polymorphic-owner tables

### DIFF
--- a/sdks/nuon-go/models/app_log_stream.go
+++ b/sdks/nuon-go/models/app_log_stream.go
@@ -17,6 +17,9 @@ import (
 // swagger:model app.LogStream
 type AppLogStream struct {
 
+	// app id
+	AppID string `json:"app_id,omitempty"`
+
 	// attrs
 	Attrs map[string]string `json:"attrs,omitempty"`
 
@@ -28,6 +31,10 @@ type AppLogStream struct {
 
 	// id
 	ID string `json:"id,omitempty"`
+
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID string `json:"install_id,omitempty"`
 
 	// open
 	Open bool `json:"open,omitempty"`

--- a/sdks/nuon-go/models/app_queue.go
+++ b/sdks/nuon-go/models/app_queue.go
@@ -20,6 +20,9 @@ import (
 // swagger:model app.Queue
 type AppQueue struct {
 
+	// app id
+	AppID string `json:"app_id,omitempty"`
+
 	// created at
 	CreatedAt string `json:"created_at,omitempty"`
 
@@ -34,6 +37,10 @@ type AppQueue struct {
 
 	// idle timeout
 	IdleTimeout int64 `json:"idle_timeout,omitempty"`
+
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID string `json:"install_id,omitempty"`
 
 	// max depth
 	MaxDepth int64 `json:"max_depth,omitempty"`

--- a/sdks/nuon-go/models/app_runner_job.go
+++ b/sdks/nuon-go/models/app_runner_job.go
@@ -20,6 +20,9 @@ import (
 // swagger:model app.RunnerJob
 type AppRunnerJob struct {
 
+	// app id
+	AppID string `json:"app_id,omitempty"`
+
 	// available timeout is how long a job can be marked as "available" before being requeued
 	AvailableTimeout int64 `json:"available_timeout,omitempty"`
 
@@ -55,6 +58,10 @@ type AppRunnerJob struct {
 
 	// id
 	ID string `json:"id,omitempty"`
+
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID string `json:"install_id,omitempty"`
 
 	// install role usage
 	InstallRoleUsage *AppInstallRoleUsage `json:"install_role_usage,omitempty"`

--- a/sdks/nuon-go/models/app_terraform_workspace.go
+++ b/sdks/nuon-go/models/app_terraform_workspace.go
@@ -17,6 +17,9 @@ import (
 // swagger:model app.TerraformWorkspace
 type AppTerraformWorkspace struct {
 
+	// app id
+	AppID string `json:"app_id,omitempty"`
+
 	// created at
 	CreatedAt string `json:"created_at,omitempty"`
 
@@ -25,6 +28,10 @@ type AppTerraformWorkspace struct {
 
 	// id
 	ID string `json:"id,omitempty"`
+
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID string `json:"install_id,omitempty"`
 
 	// org id
 	OrgID string `json:"org_id,omitempty"`

--- a/sdks/nuon-go/models/app_workflow.go
+++ b/sdks/nuon-go/models/app_workflow.go
@@ -23,6 +23,9 @@ type AppWorkflow struct {
 	// app branch runs
 	AppBranchRuns []*AppAppBranchRun `json:"app_branch_runs"`
 
+	// app id
+	AppID string `json:"app_id,omitempty"`
+
 	// approval option
 	ApprovalOption AppInstallApprovalOption `json:"approval_option,omitempty"`
 
@@ -59,6 +62,10 @@ type AppWorkflow struct {
 
 	// install deploys
 	InstallDeploys []*AppInstallDeploy `json:"install_deploys"`
+
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID string `json:"install_id,omitempty"`
 
 	// install sandbox runs
 	InstallSandboxRuns []*AppInstallSandboxRun `json:"install_sandbox_runs"`

--- a/sdks/nuon-runner-go/models/app_log_stream.go
+++ b/sdks/nuon-runner-go/models/app_log_stream.go
@@ -17,6 +17,9 @@ import (
 // swagger:model app.LogStream
 type AppLogStream struct {
 
+	// app id
+	AppID string `json:"app_id,omitempty"`
+
 	// attrs
 	Attrs map[string]string `json:"attrs,omitempty"`
 
@@ -28,6 +31,10 @@ type AppLogStream struct {
 
 	// id
 	ID string `json:"id,omitempty"`
+
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID string `json:"install_id,omitempty"`
 
 	// open
 	Open bool `json:"open,omitempty"`

--- a/sdks/nuon-runner-go/models/app_queue.go
+++ b/sdks/nuon-runner-go/models/app_queue.go
@@ -20,6 +20,9 @@ import (
 // swagger:model app.Queue
 type AppQueue struct {
 
+	// app id
+	AppID string `json:"app_id,omitempty"`
+
 	// created at
 	CreatedAt string `json:"created_at,omitempty"`
 
@@ -34,6 +37,10 @@ type AppQueue struct {
 
 	// idle timeout
 	IdleTimeout int64 `json:"idle_timeout,omitempty"`
+
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID string `json:"install_id,omitempty"`
 
 	// max depth
 	MaxDepth int64 `json:"max_depth,omitempty"`

--- a/sdks/nuon-runner-go/models/app_runner_job.go
+++ b/sdks/nuon-runner-go/models/app_runner_job.go
@@ -20,6 +20,9 @@ import (
 // swagger:model app.RunnerJob
 type AppRunnerJob struct {
 
+	// app id
+	AppID string `json:"app_id,omitempty"`
+
 	// available timeout is how long a job can be marked as "available" before being requeued
 	AvailableTimeout int64 `json:"available_timeout,omitempty"`
 
@@ -55,6 +58,10 @@ type AppRunnerJob struct {
 
 	// id
 	ID string `json:"id,omitempty"`
+
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID string `json:"install_id,omitempty"`
 
 	// install role usage
 	InstallRoleUsage *AppInstallRoleUsage `json:"install_role_usage,omitempty"`

--- a/sdks/nuon-runner-go/models/app_terraform_workspace.go
+++ b/sdks/nuon-runner-go/models/app_terraform_workspace.go
@@ -17,6 +17,9 @@ import (
 // swagger:model app.TerraformWorkspace
 type AppTerraformWorkspace struct {
 
+	// app id
+	AppID string `json:"app_id,omitempty"`
+
 	// created at
 	CreatedAt string `json:"created_at,omitempty"`
 
@@ -25,6 +28,10 @@ type AppTerraformWorkspace struct {
 
 	// id
 	ID string `json:"id,omitempty"`
+
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID string `json:"install_id,omitempty"`
 
 	// org id
 	OrgID string `json:"org_id,omitempty"`

--- a/sdks/nuon-runner-go/models/app_workflow.go
+++ b/sdks/nuon-runner-go/models/app_workflow.go
@@ -23,6 +23,9 @@ type AppWorkflow struct {
 	// app branch runs
 	AppBranchRuns []*AppAppBranchRun `json:"app_branch_runs"`
 
+	// app id
+	AppID string `json:"app_id,omitempty"`
+
 	// approval option
 	ApprovalOption AppInstallApprovalOption `json:"approval_option,omitempty"`
 
@@ -59,6 +62,10 @@ type AppWorkflow struct {
 
 	// install deploys
 	InstallDeploys []*AppInstallDeploy `json:"install_deploys"`
+
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID string `json:"install_id,omitempty"`
 
 	// install sandbox runs
 	InstallSandboxRuns []*AppInstallSandboxRun `json:"install_sandbox_runs"`

--- a/services/ctl-api/internal/app/log_stream.go
+++ b/services/ctl-api/internal/app/log_stream.go
@@ -29,6 +29,11 @@ type LogStream struct {
 	OwnerID   string `json:"owner_id,omitzero" gorm:"type:text;check:owner_id_checker,char_length(id)=26" temporaljson:"owner_id,omitzero,omitempty"`
 	OwnerType string `json:"owner_type,omitzero" gorm:"type:text;" temporaljson:"owner_type,omitzero,omitempty"`
 
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID *string `json:"install_id,omitzero" gorm:"index" temporaljson:"install_id,omitzero,omitempty"`
+	AppID     *string `json:"app_id,omitzero" gorm:"index" temporaljson:"app_id,omitzero,omitempty"`
+
 	Open bool `json:"open,omitzero" temporaljson:"open,omitzero,omitempty"`
 
 	Attrs pgtype.Hstore `json:"attrs,omitzero" gorm:"type:hstore" swaggertype:"object,string" temporaljson:"attrs,omitzero,omitempty"`
@@ -55,6 +60,14 @@ func (r *LogStream) BeforeCreate(tx *gorm.DB) error {
 
 	if r.OrgID == "" {
 		r.OrgID = orgIDFromContext(tx.Statement.Context)
+	}
+
+	if r.InstallID == nil && r.AppID == nil {
+		installID, appID, err := ResolveOwnerAncestry(tx, r.OrgID, r.OwnerType, r.OwnerID)
+		if err != nil {
+			return err
+		}
+		r.InstallID, r.AppID = installID, appID
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/owner_ancestry.go
+++ b/services/ctl-api/internal/app/owner_ancestry.go
@@ -1,0 +1,231 @@
+package app
+
+import (
+	"errors"
+
+	"gorm.io/gorm"
+)
+
+// ResolveOwnerAncestry maps a polymorphic (owner_type, owner_id) reference to
+// the owning install and/or app — the grantable ancestry stored on child rows
+// (install_workflows, runner_jobs, queues, log_streams, terraform_workspaces)
+// and used for authorization chains and list filtering.
+//
+// Both results nil means the resource sits at the org tier (management
+// runners, org/VCS queues, unknown or runner-supplied owner types): callers
+// must treat that as "org-wide permission required", never as "unowned".
+// Unknown owner types and dangling references resolve to the org tier rather
+// than erroring, so creation paths never break on ancestry resolution.
+//
+// Owner types that are themselves denormalized (install_workflows,
+// runner_jobs) are read from their own columns, so resolution costs at most
+// two point queries and never recurses. Queries deliberately bypass model
+// hooks, views, and soft-delete scoping (plain Table reads): ancestry of a
+// soft-deleted parent still resolves, matching the backfill.
+func ResolveOwnerAncestry(tx *gorm.DB, orgID, ownerType, ownerID string) (installID, appID *string, err error) {
+	if ownerID == "" || orgID == "" {
+		return nil, nil, nil
+	}
+
+	switch ownerType {
+	case "orgs", "org":
+		return nil, nil, nil
+	case "installs", "install":
+		return installAncestry(tx, orgID, ownerID)
+	case "apps", "app":
+		return nil, &ownerID, nil
+	case "app_branches":
+		return appAncestryVia(tx, orgID, "app_branches", "app_id", ownerID)
+	case "components":
+		return appAncestryVia(tx, orgID, "components", "app_id", ownerID)
+	case "app_sandbox_builds":
+		return appAncestryVia(tx, orgID, "app_sandbox_builds", "app_id", ownerID)
+	case "component_builds":
+		return componentBuildAncestry(tx, orgID, ownerID)
+	case "app_branch_runs":
+		return appBranchRunAncestry(tx, orgID, ownerID)
+	case "install_deploys":
+		return installDeployAncestry(tx, orgID, ownerID)
+	case "install_sandbox_runs":
+		return installAncestryVia(tx, orgID, "install_sandbox_runs", ownerID)
+	case "install_action_workflow_runs":
+		return installAncestryVia(tx, orgID, "install_action_workflow_runs", ownerID)
+	case "install_sandboxes":
+		return installAncestryVia(tx, orgID, "install_sandboxes", ownerID)
+	case "install_components":
+		return installAncestryVia(tx, orgID, "install_components", ownerID)
+	case "notebooks":
+		return installAncestryVia(tx, orgID, "notebooks", ownerID)
+	case "install_workflows":
+		return denormalizedAncestry(tx, orgID, "install_workflows", ownerID)
+	case "runner_jobs":
+		return denormalizedAncestry(tx, orgID, "runner_jobs", ownerID)
+	case "install_workflow_steps":
+		return workflowStepAncestry(tx, orgID, ownerID)
+	case "runners", "runner_operations":
+		return runnerAncestry(tx, orgID, ownerID)
+	case "runner_groups":
+		return runnerGroupAncestry(tx, orgID, ownerID)
+	default:
+		return nil, nil, nil
+	}
+}
+
+// installAncestry returns (installID, appID) for an install, or the org tier
+// if the install row does not exist.
+func installAncestry(tx *gorm.DB, orgID, installID string) (*string, *string, error) {
+	var row struct{ AppID string }
+	err := tx.Table("installs").
+		Select("app_id").
+		Where("org_id = ?", orgID).
+		Where("id = ?", installID).
+		Take(&row).Error
+	if err != nil {
+		return orgTierOnNotFound(err)
+	}
+	return &installID, &row.AppID, nil
+}
+
+// installAncestryVia resolves through a table carrying a direct install_id
+// column (install_sandbox_runs, install_components, notebooks, ...).
+func installAncestryVia(tx *gorm.DB, orgID, table, id string) (*string, *string, error) {
+	var row struct{ InstallID string }
+	err := tx.Table(table).
+		Select("install_id").
+		Where("org_id = ?", orgID).
+		Where("id = ?", id).
+		Take(&row).Error
+	if err != nil {
+		return orgTierOnNotFound(err)
+	}
+	return installAncestry(tx, orgID, row.InstallID)
+}
+
+// appAncestryVia resolves through a table carrying a direct app column.
+func appAncestryVia(tx *gorm.DB, orgID, table, column, id string) (*string, *string, error) {
+	var row struct{ AppID string }
+	err := tx.Table(table).
+		Select(column+" AS app_id").
+		Where("org_id = ?", orgID).
+		Where("id = ?", id).
+		Take(&row).Error
+	if err != nil {
+		return orgTierOnNotFound(err)
+	}
+	return nil, &row.AppID, nil
+}
+
+// denormalizedAncestry reads the ancestry columns of a table that is itself
+// denormalized, so owner chains never recurse through polymorphic links.
+func denormalizedAncestry(tx *gorm.DB, orgID, table, id string) (*string, *string, error) {
+	var row struct {
+		InstallID *string
+		AppID     *string
+	}
+	err := tx.Table(table).
+		Select("install_id, app_id").
+		Where("org_id = ?", orgID).
+		Where("id = ?", id).
+		Take(&row).Error
+	if err != nil {
+		return orgTierOnNotFound(err)
+	}
+	return row.InstallID, row.AppID, nil
+}
+
+func componentBuildAncestry(tx *gorm.DB, orgID, buildID string) (*string, *string, error) {
+	var row struct{ AppID string }
+	err := tx.Table("component_builds").
+		Select("components.app_id").
+		Joins("JOIN component_config_connections ON component_config_connections.id = component_builds.component_config_connection_id").
+		Joins("JOIN components ON components.id = component_config_connections.component_id").
+		Where("component_builds.org_id = ?", orgID).
+		Where("component_builds.id = ?", buildID).
+		Take(&row).Error
+	if err != nil {
+		return orgTierOnNotFound(err)
+	}
+	return nil, &row.AppID, nil
+}
+
+func appBranchRunAncestry(tx *gorm.DB, orgID, runID string) (*string, *string, error) {
+	var row struct{ AppID string }
+	err := tx.Table("app_branch_runs").
+		Select("app_branches.app_id").
+		Joins("JOIN app_branches ON app_branches.id = app_branch_runs.app_branch_id").
+		Where("app_branch_runs.org_id = ?", orgID).
+		Where("app_branch_runs.id = ?", runID).
+		Take(&row).Error
+	if err != nil {
+		return orgTierOnNotFound(err)
+	}
+	return nil, &row.AppID, nil
+}
+
+func installDeployAncestry(tx *gorm.DB, orgID, deployID string) (*string, *string, error) {
+	var row struct{ InstallID string }
+	err := tx.Table("install_deploys").
+		Select("install_components.install_id").
+		Joins("JOIN install_components ON install_components.id = install_deploys.install_component_id").
+		Where("install_deploys.org_id = ?", orgID).
+		Where("install_deploys.id = ?", deployID).
+		Take(&row).Error
+	if err != nil {
+		return orgTierOnNotFound(err)
+	}
+	return installAncestry(tx, orgID, row.InstallID)
+}
+
+func workflowStepAncestry(tx *gorm.DB, orgID, stepID string) (*string, *string, error) {
+	var row struct{ InstallWorkflowID string }
+	err := tx.Table("install_workflow_steps").
+		Select("install_workflow_id").
+		Where("org_id = ?", orgID).
+		Where("id = ?", stepID).
+		Take(&row).Error
+	if err != nil {
+		return orgTierOnNotFound(err)
+	}
+	return denormalizedAncestry(tx, orgID, "install_workflows", row.InstallWorkflowID)
+}
+
+func runnerAncestry(tx *gorm.DB, orgID, runnerID string) (*string, *string, error) {
+	var row struct{ RunnerGroupID string }
+	err := tx.Table("runners").
+		Select("runner_group_id").
+		Where("org_id = ?", orgID).
+		Where("id = ?", runnerID).
+		Take(&row).Error
+	if err != nil {
+		return orgTierOnNotFound(err)
+	}
+	return runnerGroupAncestry(tx, orgID, row.RunnerGroupID)
+}
+
+// runnerGroupAncestry resolves a runner group's owner: install-owned groups
+// inherit the install's ancestry, org-owned groups are the org tier.
+func runnerGroupAncestry(tx *gorm.DB, orgID, groupID string) (*string, *string, error) {
+	var row struct {
+		OwnerID   string
+		OwnerType string
+	}
+	err := tx.Table("runner_groups").
+		Select("owner_id, owner_type").
+		Where("org_id = ?", orgID).
+		Where("id = ?", groupID).
+		Take(&row).Error
+	if err != nil {
+		return orgTierOnNotFound(err)
+	}
+	if row.OwnerType == "installs" || row.OwnerType == "install" {
+		return installAncestry(tx, orgID, row.OwnerID)
+	}
+	return nil, nil, nil
+}
+
+func orgTierOnNotFound(err error) (*string, *string, error) {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil, nil
+	}
+	return nil, nil, err
+}

--- a/services/ctl-api/internal/app/queue.go
+++ b/services/ctl-api/internal/app/queue.go
@@ -30,6 +30,11 @@ type Queue struct {
 	OwnerID   string `json:"owner_id,omitzero" gorm:"type:text;check:owner_id_checker,char_length(id)=26;" temporaljson:"owner_id,omitzero,omitempty"`
 	OwnerType string `json:"owner_type,omitzero" gorm:"type:text;" temporaljson:"owner_type,omitzero,omitempty"`
 
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID *string `json:"install_id,omitzero" gorm:"index" temporaljson:"install_id,omitzero,omitempty"`
+	AppID     *string `json:"app_id,omitzero" gorm:"index" temporaljson:"app_id,omitzero,omitempty"`
+
 	Name        string          `json:"name,omitzero" gorm:"default:''" temporaljson:"name,omitzero,omitempty"`
 	MaxDepth    int             `json:"max_depth,omitzero"`
 	MaxInFlight int             `json:"max_in_flight,omitzero"`
@@ -88,6 +93,14 @@ func (r *Queue) BeforeCreate(tx *gorm.DB) error {
 		if orgID := orgIDFromContext(tx.Statement.Context); orgID != "" {
 			r.OrgID = &orgID
 		}
+	}
+
+	if r.InstallID == nil && r.AppID == nil && r.OrgID != nil {
+		installID, appID, err := ResolveOwnerAncestry(tx, *r.OrgID, r.OwnerType, r.OwnerID)
+		if err != nil {
+			return err
+		}
+		r.InstallID, r.AppID = installID, appID
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/runner_job.go
+++ b/services/ctl-api/internal/app/runner_job.go
@@ -255,6 +255,11 @@ type RunnerJob struct {
 	OwnerType       string  `json:"owner_type,omitzero" gorm:"type:text;" temporaljson:"owner_type,omitzero,omitempty"`
 	LogStreamID     *string `json:"log_stream_id,omitzero" temporaljson:"log_stream_id,omitzero,omitempty"`
 
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID *string `json:"install_id,omitzero" gorm:"index" temporaljson:"install_id,omitzero,omitempty"`
+	AppID     *string `json:"app_id,omitzero" gorm:"index" temporaljson:"app_id,omitzero,omitempty"`
+
 	// queue timeout is how long a job can be queued, before being made available
 	QueueTimeout time.Duration `json:"queue_timeout,omitzero" gorm:"default null;not null" swaggertype:"primitive,integer" temporaljson:"queue_timeout,omitzero,omitempty"`
 	// available timeout is how long a job can be marked as "available" before being requeued
@@ -395,6 +400,14 @@ func (r *RunnerJob) BeforeCreate(tx *gorm.DB) error {
 	// the overall timeout can be derived by combining the various lower level timeouts.
 	if r.OverallTimeout == 0 {
 		r.OverallTimeout = r.QueueTimeout + time.Duration(r.MaxExecutions)*(r.AvailableTimeout+r.ExecutionTimeout)
+	}
+
+	if r.InstallID == nil && r.AppID == nil {
+		installID, appID, err := ResolveOwnerAncestry(tx, r.OrgID, r.OwnerType, r.OwnerID)
+		if err != nil {
+			return err
+		}
+		r.InstallID, r.AppID = installID, appID
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/terraform_workspace.go
+++ b/services/ctl-api/internal/app/terraform_workspace.go
@@ -26,6 +26,11 @@ type TerraformWorkspace struct {
 	OwnerID   string `json:"owner_id,omitzero" gorm:"type:text;check:owner_id_checker,char_length(id)=26;uniqueIndex:idx_owner" temporaljson:"owner_id,omitzero,omitempty"`
 	OwnerType string `json:"owner_type,omitzero" gorm:"type:text;uniqueIndex:idx_owner" temporaljson:"owner_type,omitzero,omitempty"`
 
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID *string `json:"install_id,omitzero" gorm:"index" temporaljson:"install_id,omitzero,omitempty"`
+	AppID     *string `json:"app_id,omitzero" gorm:"index" temporaljson:"app_id,omitzero,omitempty"`
+
 	States      []TerraformWorkspaceState `faker:"-" json:"-" swaggerignore:"true" gorm:"constraint:OnDelete:CASCADE;" temporaljson:"states,omitzero,omitempty"`
 	LockHistory []TerraformWorkspaceLock  `faker:"-" json:"lock_history" swaggerignore:"true" gorm:"foreignKey:WorkspaceID;references:ID;constraint:OnDelete:CASCADE;" temporaljson:"lock_history,omitzero,omitempty"`
 
@@ -55,5 +60,14 @@ func (r *TerraformWorkspace) BeforeCreate(tx *gorm.DB) (err error) {
 	if r.OrgID == "" {
 		r.OrgID = orgIDFromContext(tx.Statement.Context)
 	}
+
+	if r.InstallID == nil && r.AppID == nil {
+		installID, appID, err := ResolveOwnerAncestry(tx, r.OrgID, r.OwnerType, r.OwnerID)
+		if err != nil {
+			return err
+		}
+		r.InstallID, r.AppID = installID, appID
+	}
+
 	return nil
 }

--- a/services/ctl-api/internal/app/workflow.go
+++ b/services/ctl-api/internal/app/workflow.go
@@ -237,6 +237,11 @@ type Workflow struct {
 	// explicitly fills it.
 	OwnerName string `json:"owner_name,omitzero" gorm:"-" temporaljson:"owner_name,omitzero,omitempty"`
 
+	// denormalized grantable ancestry, resolved from the polymorphic owner at
+	// creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+	InstallID *string `json:"install_id,omitzero" gorm:"index" temporaljson:"install_id,omitzero,omitempty"`
+	AppID     *string `json:"app_id,omitzero" gorm:"index" temporaljson:"app_id,omitzero,omitempty"`
+
 	// used for RLS
 	OrgID string `json:"org_id,omitzero" gorm:"notnull" swaggerignore:"true" temporaljson:"org_id,omitzero,omitempty"`
 	Org   Org    `json:"-" faker:"-" temporaljson:"org,omitzero,omitempty"`
@@ -303,6 +308,14 @@ func (i *Workflow) BeforeCreate(tx *gorm.DB) error {
 
 	i.CreatedByID = createdByIDFromContext(tx.Statement.Context)
 	i.OrgID = orgIDFromContext(tx.Statement.Context)
+
+	if i.InstallID == nil && i.AppID == nil {
+		installID, appID, err := ResolveOwnerAncestry(tx, i.OrgID, i.OwnerType, i.OwnerID)
+		if err != nil {
+			return err
+		}
+		i.InstallID, i.AppID = installID, appID
+	}
 
 	return nil
 }

--- a/services/ctl-api/internal/pkg/db/psql/migrations/126_denormalize_owner_ancestry.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/126_denormalize_owner_ancestry.go
@@ -1,0 +1,122 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+const ancestryBackfillBatchSize = 5000
+
+// ancestryBackfill fills the denormalized install_id/app_id ancestry columns
+// for one (table, owner_type) pair. installID/appID are SQL expressions valid
+// under the joins (or the literal NULL for tiers that don't apply).
+type ancestryBackfill struct {
+	table     string
+	ownerType string
+	joins     string
+	installID string
+	appID     string
+}
+
+const (
+	joinInstallOwner     = `JOIN installs i ON i.id = t.owner_id`
+	joinAppOwner         = `JOIN apps a ON a.id = t.owner_id`
+	joinAppBranchOwner   = `JOIN app_branches ab ON ab.id = t.owner_id`
+	joinComponentOwner   = `JOIN components c ON c.id = t.owner_id`
+	joinDeployOwner      = `JOIN install_deploys d ON d.id = t.owner_id JOIN install_components ic ON ic.id = d.install_component_id JOIN installs i ON i.id = ic.install_id`
+	joinSandboxRunOwner  = `JOIN install_sandbox_runs sr ON sr.id = t.owner_id JOIN installs i ON i.id = sr.install_id`
+	joinActionRunOwner   = `JOIN install_action_workflow_runs ar ON ar.id = t.owner_id JOIN installs i ON i.id = ar.install_id`
+	joinWorkflowStep     = `JOIN install_workflow_steps s ON s.id = t.owner_id JOIN install_workflows w ON w.id = s.install_workflow_id`
+	joinComponentBuild   = `JOIN component_builds cb ON cb.id = t.owner_id JOIN component_config_connections ccc ON ccc.id = cb.component_config_connection_id JOIN components c ON c.id = ccc.component_id`
+	joinAppSandboxBuild  = `JOIN app_sandbox_builds asb ON asb.id = t.owner_id`
+	joinAppBranchRun     = `JOIN app_branch_runs br ON br.id = t.owner_id JOIN app_branches ab ON ab.id = br.app_branch_id`
+	joinInstallRunner    = `JOIN runners r ON r.id = t.owner_id JOIN runner_groups g ON g.id = r.runner_group_id AND g.owner_type = 'installs' JOIN installs i ON i.id = g.owner_id`
+	joinInstallComponent = `JOIN install_components ic ON ic.id = t.owner_id JOIN installs i ON i.id = ic.install_id`
+	joinInstallSandbox   = `JOIN install_sandboxes isb ON isb.id = t.owner_id JOIN installs i ON i.id = isb.install_id`
+)
+
+// ancestryBackfills covers every owner_type observed at the tables' creation
+// sites. Owner types with no install/app tier (orgs, vcs_connections,
+// onboardings, empty/admin-created, runner-supplied unknowns, org-owned
+// runner groups) are deliberately absent: their rows keep NULL columns,
+// which authorization reads as the org tier.
+//
+// install_workflows fills first — runner_jobs and log_streams owned by
+// install_workflow_steps read the workflow's fresh columns.
+var ancestryBackfills = []ancestryBackfill{
+	{"install_workflows", "installs", joinInstallOwner, "i.id", "i.app_id"},
+	{"install_workflows", "apps", joinAppOwner, "NULL", "a.id"},
+	{"install_workflows", "app_branches", joinAppBranchOwner, "NULL", "ab.app_id"},
+
+	{"runner_jobs", "install_deploys", joinDeployOwner, "i.id", "i.app_id"},
+	{"runner_jobs", "install_sandbox_runs", joinSandboxRunOwner, "i.id", "i.app_id"},
+	{"runner_jobs", "install_action_workflow_runs", joinActionRunOwner, "i.id", "i.app_id"},
+	{"runner_jobs", "install_workflow_steps", joinWorkflowStep, "w.install_id", "w.app_id"},
+	{"runner_jobs", "component_builds", joinComponentBuild, "NULL", "c.app_id"},
+	{"runner_jobs", "app_sandbox_builds", joinAppSandboxBuild, "NULL", "asb.app_id"},
+	{"runner_jobs", "runners", joinInstallRunner, "i.id", "i.app_id"},
+
+	{"log_streams", "install_deploys", joinDeployOwner, "i.id", "i.app_id"},
+	{"log_streams", "install_sandbox_runs", joinSandboxRunOwner, "i.id", "i.app_id"},
+	{"log_streams", "install_action_workflow_runs", joinActionRunOwner, "i.id", "i.app_id"},
+	{"log_streams", "install_workflow_steps", joinWorkflowStep, "w.install_id", "w.app_id"},
+	{"log_streams", "component_builds", joinComponentBuild, "NULL", "c.app_id"},
+	{"log_streams", "app_sandbox_builds", joinAppSandboxBuild, "NULL", "asb.app_id"},
+	{"log_streams", "app_branch_runs", joinAppBranchRun, "NULL", "ab.app_id"},
+	{"log_streams", "runners", joinInstallRunner, "i.id", "i.app_id"},
+	{"log_streams", "runner_operations", joinInstallRunner, "i.id", "i.app_id"},
+
+	{"queues", "installs", joinInstallOwner, "i.id", "i.app_id"},
+	{"queues", "apps", joinAppOwner, "NULL", "a.id"},
+	{"queues", "app_branches", joinAppBranchOwner, "NULL", "ab.app_id"},
+	{"queues", "components", joinComponentOwner, "NULL", "c.app_id"},
+	{"queues", "notebooks", `JOIN notebooks n ON n.id = t.owner_id JOIN installs i ON i.id = n.install_id`, "i.id", "i.app_id"},
+	{"queues", "runners", joinInstallRunner, "i.id", "i.app_id"},
+
+	{"terraform_workspaces", "install_components", joinInstallComponent, "i.id", "i.app_id"},
+	{"terraform_workspaces", "install_sandboxes", joinInstallSandbox, "i.id", "i.app_id"},
+}
+
+// Migration126DenormalizeOwnerAncestry backfills the install_id/app_id
+// ancestry columns added to the five polymorphic-owner tables. New rows are
+// populated by the models' BeforeCreate hooks (ResolveOwnerAncestry); this
+// fills everything created before the hooks shipped. Rows written by
+// not-yet-updated pods during the deploy rollout stay NULL (org tier) — an
+// accepted, fail-closed window.
+//
+// Each pair drains in batches keyed on still-NULL columns, so the migration
+// is idempotent and resumable. The COALESCE guard keeps rows that legitimately
+// resolve to (NULL, NULL) out of the batch, guaranteeing termination.
+func (m *Migrations) Migration126DenormalizeOwnerAncestry(ctx context.Context, db *gorm.DB) error {
+	for _, b := range ancestryBackfills {
+		stmt := fmt.Sprintf(`WITH batch AS (
+	SELECT t.id AS id, %s AS install_id, %s AS app_id
+	FROM %s t
+	%s
+	WHERE t.owner_type = '%s'
+	  AND t.install_id IS NULL AND t.app_id IS NULL
+	  AND COALESCE(%s, %s) IS NOT NULL
+	LIMIT %d
+)
+UPDATE %s u
+SET install_id = b.install_id, app_id = b.app_id
+FROM batch b
+WHERE u.id = b.id;`,
+			b.installID, b.appID, b.table, b.joins, b.ownerType,
+			b.installID, b.appID, ancestryBackfillBatchSize, b.table)
+
+		for {
+			res := db.WithContext(ctx).Exec(stmt)
+			if res.Error != nil {
+				return fmt.Errorf("backfill %s/%s: %w", b.table, b.ownerType, res.Error)
+			}
+			if res.RowsAffected == 0 {
+				break
+			}
+		}
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/all.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/all.go
@@ -176,5 +176,9 @@ func (m *Migrations) All() []migrations.Migration {
 			Name: "125-backfill-role-metadata",
 			Fn:   m.Migration125BackfillRoleMetadata,
 		},
+		{
+			Name: "126-denormalize-owner-ancestry",
+			Fn:   m.Migration126DenormalizeOwnerAncestry,
+		},
 	}
 }

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -5102,12 +5102,18 @@ export interface components {
       version?: string;
     };
     "app.LogStream": {
+      app_id?: string;
       attrs?: {
         [key: string]: string;
       };
       created_at?: string;
       created_by_id?: string;
       id?: string;
+      /**
+       * @description denormalized grantable ancestry, resolved from the polymorphic owner at
+       * creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+       */
+      install_id?: string;
       open?: boolean;
       org_id?: string;
       owner_id?: string;
@@ -5478,11 +5484,17 @@ export interface components {
       version?: string;
     };
     "app.Queue": {
+      app_id?: string;
       created_at?: string;
       created_by_id?: string;
       emitters?: components["schemas"]["app.QueueEmitter"][];
       id?: string;
       idle_timeout?: number;
+      /**
+       * @description denormalized grantable ancestry, resolved from the polymorphic owner at
+       * creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+       */
+      install_id?: string;
       max_depth?: number;
       max_in_flight?: number;
       metadata?: {
@@ -5797,6 +5809,7 @@ export interface components {
       version?: string;
     };
     "app.RunnerJob": {
+      app_id?: string;
       /** @description available timeout is how long a job can be marked as "available" before being requeued */
       available_timeout?: number;
       created_at?: string;
@@ -5811,6 +5824,11 @@ export interface components {
       finished_at?: string;
       group?: components["schemas"]["app.RunnerJobGroup"];
       id?: string;
+      /**
+       * @description denormalized grantable ancestry, resolved from the polymorphic owner at
+       * creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+       */
+      install_id?: string;
       install_role_usage?: components["schemas"]["app.InstallRoleUsage"];
       json?: components["schemas"]["app.RunnerJobPlan"];
       log_stream_id?: string;
@@ -6094,9 +6112,15 @@ export interface components {
       type?: string;
     };
     "app.TerraformWorkspace": {
+      app_id?: string;
       created_at?: string;
       created_by_id?: string;
       id?: string;
+      /**
+       * @description denormalized grantable ancestry, resolved from the polymorphic owner at
+       * creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+       */
+      install_id?: string;
       org_id?: string;
       owner_id?: string;
       owner_type?: string;
@@ -6258,6 +6282,7 @@ export interface components {
     };
     "app.Workflow": {
       app_branch_runs?: components["schemas"]["app.AppBranchRun"][];
+      app_id?: string;
       approval_option?: components["schemas"]["app.InstallApprovalOption"];
       created_at?: string;
       created_by?: components["schemas"]["app.Account"];
@@ -6274,6 +6299,11 @@ export interface components {
       id?: string;
       install_action_workflow_runs?: components["schemas"]["app.InstallActionWorkflowRun"][];
       install_deploys?: components["schemas"]["app.InstallDeploy"][];
+      /**
+       * @description denormalized grantable ancestry, resolved from the polymorphic owner at
+       * creation (ResolveOwnerAncestry); both nil ⇒ org-tier resource
+       */
+      install_id?: string;
       install_sandbox_runs?: components["schemas"]["app.InstallSandboxRun"][];
       links?: {
         [key: string]: unknown;

--- a/specs/auth/public-api-authorization-audit.html
+++ b/specs/auth/public-api-authorization-audit.html
@@ -1,0 +1,581 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Public API Authorization Audit</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --ink: #e6e9ef; --muted: #9aa4b2;
+    --accent: #6ea8fe; --good: #3fb950; --warn: #d29922; --bad: #f85149;
+    --border: #2a2f3a; --code: #1e232c;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--ink);
+    font: 15px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 48px 24px 120px; }
+  h1 { font-size: 30px; margin: 0 0 4px; letter-spacing: -0.02em; }
+  h2 { font-size: 22px; margin: 48px 0 8px; padding-top: 16px; border-top: 1px solid var(--border); }
+  .sub { color: var(--muted); margin: 0 0 8px; }
+  code, .mono { background: var(--code); padding: 1px 6px; border-radius: 4px;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 13px; }
+  table { width: 100%; border-collapse: collapse; margin: 14px 0; font-size: 13px; }
+  th, td { text-align: left; padding: 5px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; position: sticky; top: 0; background: var(--bg); }
+  td.m { font-family: ui-monospace, Menlo, monospace; font-size: 12px; white-space: nowrap; }
+  td.p { font-family: ui-monospace, Menlo, monospace; font-size: 12px; }
+  .meta { color: var(--muted); font-size: 13px; }
+  .tag { display: inline-block; font-size: 11px; padding: 1px 7px; border-radius: 999px; font-weight: 600; }
+  .tag.nested { background: rgba(63,185,80,.15); color: var(--good); }
+  .tag.lookup { background: rgba(110,168,254,.15); color: var(--accent); }
+  .tag.type { background: rgba(110,168,254,.15); color: var(--accent); }
+  .tag.filtered { background: rgba(210,153,34,.15); color: var(--warn); }
+  .tag.org { background: rgba(248,81,73,.15); color: var(--bad); }
+  .tag.exempt { background: rgba(154,164,178,.15); color: var(--muted); }
+  .desc { color: var(--muted); margin: 4px 0 10px; max-width: 900px; }
+  .panel { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 16px 18px; margin: 14px 0; }
+  ul { margin: 8px 0; padding-left: 22px; }
+  a { color: var(--accent); }
+</style>
+</head>
+<body>
+<div class="wrap">
+<h1>Public API Authorization Audit</h1>
+<p class="sub">Every public-API route (port 8081) and what authorization allows access to it. Generated from the route inventory and the live middleware classifiers on <code>ja/account-resource-grants</code> &mdash; the branch carrying the enforcement and grant layer. <code>ja/resource-grants-v2</code> carries only the denormalized ancestry schema; on it (and on main today) authorization is the unchanged org-wide gate.</p>
+<p class="meta">480 routes &middot; 2026-08-09 &middot; companion to <a href="resource-grant-denormalized-owners.html">resource-grant-denormalized-owners.html</a> and <a href="resource-grants.html">resource-grants.html</a></p>
+
+<div class="panel">
+<b>How to read this.</b>
+<ul>
+<li>Accounts holding an org role short-circuit on the org-wide permission check and can reach every route (subject to the method permission). The per-route rules below describe <b>grant-scoped accounts</b> — accounts whose access comes from resource grants.</li>
+<li>The permission required is derived from the HTTP method: <code>GET/HEAD &rarr; read</code>, <code>POST &rarr; create</code>, <code>PUT/PATCH &rarr; update</code>, <code>DELETE &rarr; delete</code>. A grant must carry at least that permission on some link of the resource&rsquo;s chain.</li>
+<li>A resource&rsquo;s <b>chain</b> is <code>[install &rarr; app &rarr; org]</code> (or the applicable suffix). A grant on any link authorizes the request &mdash; grants elevate, they never restrict.</li>
+<li>Special case: <code>POST .../components/:component_id/builds</code> authorizes against the org&rsquo;s <code>component_builds</code> object for org-wide accounts (runner role), in addition to the chain rules below.</li>
+</ul>
+</div>
+
+<h2>Install-scoped routes <span class="tag nested">109 routes</span></h2>
+<p class="desc">The path names an install (<code>:install_id</code>, id or name). Access: a grant with the required permission on <b>that install</b>, <b>its app</b>, or <b>the org</b> — or any org role. One org-scoped point query resolves the chain.</p>
+<table><tr><th>Method</th><th>Path</th><th>Permission</th><th>Access granted by</th></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/installs/:install_id</td><td>update</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/installs/:install_id</td><td>delete</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/action-workflows</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/action-workflows/:action_workflow_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/action-workflows/:action_workflow_id/recent-runs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/action-workflows/latest-runs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/action-workflows/runs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/action-workflows/runs</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/action-workflows/runs/:run_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/action-workflows/runs/:run_id/steps/:step_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/actions</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/actions/:action_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/actions/:action_id/outputs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/actions/:action_id/recent-runs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/actions/adhoc-run</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/actions/latest-runs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/actions/runs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/actions/runs</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/actions/runs/:run_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/actions/runs/:run_id/steps/:step_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/app-config-updates</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/app-config-versions</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/app-config-versions/:version_id/diff</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/app-permissions-config</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/audit_logs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/available-roles</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/components</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/components/:component_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/components/:component_id/deploys</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/components/:component_id/deploys</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/components/:component_id/deploys/:deploy_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/components/:component_id/deploys/latest</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/components/:component_id/forget</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/components/:component_id/health/checks</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">PUT</td><td class="p">/v1/installs/:install_id/components/:component_id/health/checks/:check_name</td><td>update</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/components/:component_id/health/incident</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/components/:component_id/health/timeline</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/components/:component_id/outputs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/components/:component_id/teardown</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/components/:component_id/toggle</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/components/deploy-all</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/components/deploys</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/components/teardown-all</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/config-syncs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/config-versions</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/config-versions/:version_id/diff</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/configs</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/installs/:install_id/configs/:config_id</td><td>update</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/deploys</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/deploys</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/deploys/:deploy_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/deploys/latest</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/deprovision</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/deprovision-sandbox</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/dns/check</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/drifted-objects</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/events</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/events/:event_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/forget</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/generate-cli-install-config</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/generate-terraform-installer-config</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/health/baseline</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/health/cluster-access</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/health/timeline</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/inputs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/inputs</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/installs/:install_id/inputs</td><td>update</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/inputs/current</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/labels</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/installs/:install_id/labels</td><td>delete</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/notebooks</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/notebooks</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/notebooks/:notebook_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/installs/:install_id/notebooks/:notebook_id</td><td>update</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/installs/:install_id/notebooks/:notebook_id</td><td>delete</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/notebooks/:notebook_id/cells</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/installs/:install_id/notebooks/:notebook_id/cells/:cell_id</td><td>update</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/installs/:install_id/notebooks/:notebook_id/cells/:cell_id</td><td>delete</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/notebooks/:notebook_id/cells/:cell_id/runs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/notebooks/:notebook_id/cells/:cell_id/runs</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">PUT</td><td class="p">/v1/installs/:install_id/notebooks/:notebook_id/cells/reorder</td><td>update</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/notebooks/:notebook_id/runs/:run_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/readme</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/reprovision</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/reprovision-sandbox</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/reprovision-stack</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/resources</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/retry-workflow</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/roles</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/installs/:install_id/roles/:role_id</td><td>update</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/roles/latest</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/roles/usages</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/runbook-runs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/runbook-runs/:run_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/runbooks</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/runbooks/:runbook_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/runbooks/:runbook_id/runs</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/runner-bootstrap-token</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/runner-group</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/sandbox-runs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/sandbox-runs/:run_id</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/stack</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/stack-runs</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/state</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/state-history</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/sync-config</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/sync-secrets</td><td>create</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/:install_id/workflows</td><td>read</td><td>grant on the <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+</table>
+<h2>App-scoped routes <span class="tag nested">125 routes</span></h2>
+<p class="desc">The path names an app (<code>:app_id</code>, id or name). Access: a grant on <b>that app</b> or <b>the org</b>, or any org role.</p>
+<table><tr><th>Method</th><th>Path</th><th>Permission</th><th>Access granted by</th></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/apps/:app_id</td><td>update</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/apps/:app_id</td><td>delete</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/action-workflows</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/action-workflows</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/action-workflows/:action_workflow_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/actions</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/actions</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/actions/:action_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/apps/:app_id/actions/:action_id</td><td>update</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/apps/:app_id/actions/:action_id</td><td>delete</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/actions/:action_id/configs</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/actions/:action_id/configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/actions/:action_id/labels</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/apps/:app_id/actions/:action_id/labels</td><td>delete</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/actions/:action_id/latest-config</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/actions/configs/:action_config_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/actions/label-keys</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/branches</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/branches</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/branches/:app_branch_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/apps/:app_id/branches/:app_branch_id</td><td>update</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/apps/:app_id/branches/:app_branch_id</td><td>delete</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/branches/:app_branch_id/configs</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/branches/:app_branch_id/configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/branches/:app_branch_id/latest-config</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/branches/:app_branch_id/runs</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/branches/:app_branch_id/runs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/branches/:app_branch_id/runs/:run_id/builds</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/branches/:app_branch_id/runs/:run_id/install-group-runs</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/branches/:app_branch_id/runs/:run_id/install-group-runs/:install_group_run_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/branches/:app_branch_id/runs/:run_id/install-groups</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/branches/:app_branch_id/sync-install-configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/break-glass-configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/break-glass-configs/:config_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/component/:component_name_or_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/components</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/components</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/apps/:app_id/components/:component_id</td><td>update</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/apps/:app_id/components/:component_id</td><td>delete</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/components/:component_id/builds</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/components/:component_id/builds</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/components/:component_id/builds/:build_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/components/:component_id/builds/:build_id/cancel</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/components/:component_id/builds/latest</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/components/:component_id/configs</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/components/:component_id/configs/:config_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/components/:component_id/configs/docker-build</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/components/:component_id/configs/external-image</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/components/:component_id/configs/helm</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/components/:component_id/configs/job</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/components/:component_id/configs/kubernetes-manifest</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/components/:component_id/configs/latest</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/components/:component_id/configs/pulumi</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/components/:component_id/configs/terraform-module</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/components/:component_id/dependencies</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/components/:component_id/dependents</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/components/:component_id/labels</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/apps/:app_id/components/:component_id/labels</td><td>delete</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/components/build-all</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/components/label-keys</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/config</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/config/:app_config_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/apps/:app_id/config/:app_config_id</td><td>update</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/config/:app_config_id/graph</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/config/:app_config_id/update-installs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/configs</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/configs/:config_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/apps/:app_id/configs/:config_id</td><td>update</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/configs/:config_id/build</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/configs/:config_id/diff</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/configs/:config_id/graph</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/configs/:config_id/sync</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/configs/:config_id/update-installs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/input-config</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/input-configs</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/input-configs/:input_config_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/input-latest-config</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/installs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/kubernetes-contexts-configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/labels</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/latest-break-glass-config</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/latest-config</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/latest-permissions-config</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/latest-policies-config</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/latest-secrets-config</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/operation-role-configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/operation-role-configs/:operation_role_config_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/permissions-configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/permissions-configs/:config_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/policies-configs</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/policies-configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/policies-configs/:config_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/policy-analytics/breakdown</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/policy-analytics/summary</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/policy-analytics/timeseries</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/policy-config/:policy_config_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/runbooks</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/runbooks</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/runbooks/:runbook_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/apps/:app_id/runbooks/:runbook_id</td><td>update</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/apps/:app_id/runbooks/:runbook_id</td><td>delete</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/runbooks/:runbook_id/configs</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/runbooks/:runbook_id/configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/runner-configs</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/runner-configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/runner-latest-config</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/sandbox-config</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/sandbox-configs</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/sandbox-configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/sandbox-latest-config</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/sandbox/builds</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/sandbox/builds</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/sandbox/builds/:build_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/secret</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/apps/:app_id/secret/:secret_id</td><td>delete</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/secrets</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/secrets</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/secrets-configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/secrets-configs/:config_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/apps/:app_id/secrets/:secret_id</td><td>delete</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps/:app_id/stack-configs</td><td>create</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/stack-configs/:config_id</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/template-config</td><td>read</td><td>grant on the <b>app</b> or the <b>org</b></td></tr>
+</table>
+<h2>Owned-child routes (bare detail routes) <span class="tag lookup">109 routes</span></h2>
+<p class="desc">The request names a child resource &mdash; via a path param, the terraform backend&rsquo;s <code>?workspace_id=</code> query param, or the owner reference in a create body &mdash; whose grantable ancestry is resolved with a single point read of its denormalized <code>install_id</code>/<code>app_id</code> columns (or direct owner column). The request authorizes exactly like a request against the owner. Rows with no install/app tier (management runners, org queues, unresolved legacy rows) require org-wide permission.</p>
+<table><tr><th>Method</th><th>Path</th><th>Permission</th><th>Access granted by</th></tr>
+<tr><td class="m">GET</td><td class="p">/v1/action-workflows/:action_workflow_id</td><td>read</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/action-workflows/:action_workflow_id</td><td>update</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/action-workflows/:action_workflow_id</td><td>delete</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/action-workflows/:action_workflow_id/configs</td><td>read</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/action-workflows/:action_workflow_id/configs</td><td>create</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/action-workflows/:action_workflow_id/latest-config</td><td>read</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/action-workflows/configs/:action_workflow_config_id</td><td>read</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/components/:component_id</td><td>read</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/components/:component_id</td><td>update</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/components/:component_id</td><td>delete</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/components/:component_id/builds</td><td>create</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/components/:component_id/builds/:build_id</td><td>read</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/components/:component_id/builds/latest</td><td>read</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/components/:component_id/configs</td><td>read</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/components/:component_id/configs/:config_id</td><td>read</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/components/:component_id/configs/docker-build</td><td>create</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/components/:component_id/configs/external-image</td><td>create</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/components/:component_id/configs/helm</td><td>create</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/components/:component_id/configs/job</td><td>create</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/components/:component_id/configs/kubernetes-manifest</td><td>create</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/components/:component_id/configs/latest</td><td>read</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/components/:component_id/configs/pulumi</td><td>create</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/components/:component_id/configs/terraform-module</td><td>create</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/components/:component_id/dependencies</td><td>read</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/components/:component_id/dependents</td><td>read</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/components/builds/:build_id</td><td>read</td><td>grant on the owning <b>app</b> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/install-workflows/:install_workflow_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/install-workflows/:install_workflow_id</td><td>update</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/install-workflows/:install_workflow_id/cancel</td><td>create</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/install-workflows/:install_workflow_id/steps</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/install-workflows/:install_workflow_id/steps/:install_workflow_step_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/install-workflows/:install_workflow_id/steps/:install_workflow_step_id/approvals/:approval_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/sandbox-runs/:run_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/stacks/:stack_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/log-streams/:log_stream_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/log-streams/:log_stream_id/logs</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/log-streams/:log_stream_id/logs/tail</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/log-streams/:log_stream_id/spans</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/policy-reports/:report_id</td><td>read</td><td>grant on the report&rsquo;s <b>install</b> (when install-scoped), its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/policy-reports/:report_id/export</td><td>read</td><td>grant on the report&rsquo;s <b>install</b> (when install-scoped), its <b>app</b>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/queues/:queue_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/queues/:queue_id/signals</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/queues/:queue_id/signals/:signal_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/queues/:queue_id/signals/:signal_id/await</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/queues/:queue_id/signals/:signal_id/graph</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/queues/:queue_id/status</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runner-jobs/:runner_job_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/runner-jobs/:runner_job_id/cancel</td><td>create</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runner-jobs/:runner_job_id/composite-plan</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runner-jobs/:runner_job_id/plan</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/:runner_id</td><td>read</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/:runner_id/card-details</td><td>read</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/:runner_id/connected</td><td>read</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/runners/:runner_id/force-shutdown</td><td>create</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/runners/:runner_id/graceful-shutdown</td><td>create</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/:runner_id/heart-beats/latest</td><td>read</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/:runner_id/jobs</td><td>read</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/:runner_id/latest-heart-beat</td><td>read</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/runners/:runner_id/mng/restart</td><td>create</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/runners/:runner_id/mng/shutdown</td><td>create</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/runners/:runner_id/mng/shutdown-vm</td><td>create</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/runners/:runner_id/mng/update</td><td>create</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/:runner_id/processes</td><td>read</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/:runner_id/processes/:process_id</td><td>read</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/:runner_id/processes/:process_id/heart-beats/latest</td><td>read</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/runners/:runner_id/processes/:process_id/shutdown</td><td>create</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/:runner_id/processes/current</td><td>read</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/runners/:runner_id/prune-tokens</td><td>create</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/:runner_id/recent-health-checks</td><td>read</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/:runner_id/settings</td><td>read</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/runners/:runner_id/settings</td><td>update</td><td>install runners: grant on the <b>install</b>, its <b>app</b>, or the <b>org</b>; org (management) runners: <b>org</b> only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/terraform-workspace/:workspace_id/state-json</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/terraform-workspace/:workspace_id/state-json/:state_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/terraform-workspace/:workspace_id/state-json/:state_id/raw</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/terraform-workspace/:workspace_id/state-json/:state_id/resources</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/terraform-workspace/:workspace_id/states</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/terraform-workspace/:workspace_id/states/:state_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runners/terraform-workspace/:workspace_id/states/:state_id/resources</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/terraform-workspaces/:workspace_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/terraform-workspaces/:workspace_id</td><td>delete</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/terraform-workspaces/:workspace_id/lock</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/terraform-workspaces/:workspace_id/lock</td><td>create</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/terraform-workspaces/:workspace_id/state-json</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/terraform-workspaces/:workspace_id/state-json/:state_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/terraform-workspaces/:workspace_id/state-json/:state_id/raw</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/terraform-workspaces/:workspace_id/state-json/:state_id/resources</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/terraform-workspaces/:workspace_id/states</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/terraform-workspaces/:workspace_id/states/:state_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/terraform-workspaces/:workspace_id/states/:state_id/resources</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/terraform-workspaces/:workspace_id/unlock</td><td>create</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/workflows/:workflow_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/workflows/:workflow_id</td><td>update</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/workflows/:workflow_id/cancel</td><td>create</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/workflows/:workflow_id/queue-position</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/workflows/:workflow_id/step-groups</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/workflows/:workflow_id/step-groups/:step_group_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/workflows/:workflow_id/steps</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/workflows/:workflow_id/steps/:step_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/workflows/:workflow_id/steps/:step_id/approvals/:approval_id</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/workflows/:workflow_id/steps/:step_id/approvals/:approval_id/contents</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/workflows/:workflow_id/steps/:step_id/approvals/:approval_id/response</td><td>create</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/workflows/:workflow_id/steps/:step_id/await</td><td>read</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/workflows/:workflow_id/steps/:step_id/cancel</td><td>create</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/workflows/:workflow_id/steps/:step_id/retry</td><td>create</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/workflows/:workflow_id/steps/:step_id/skip</td><td>create</td><td>grant on the owning <b>install</b>, its <b>app</b>, or the <b>org</b>; org-tier rows: org only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/terraform-workspace</td><td>create</td><td>grant on the tier of the owner named in the request body (<code>owner_type</code>/<code>owner_id</code> &rarr; install/app), or the <b>org</b> for unknown owners</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/terraform-workspaces</td><td>create</td><td>grant on the tier of the owner named in the request body (<code>owner_type</code>/<code>owner_id</code> &rarr; install/app), or the <b>org</b> for unknown owners</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/terraform-backend</td><td>read</td><td>grant on the workspace&rsquo;s owning <b>install</b>, its <b>app</b>, or the <b>org</b> (workspace addressed via <code>?workspace_id=</code>)</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/terraform-backend</td><td>create</td><td>grant on the workspace&rsquo;s owning <b>install</b>, its <b>app</b>, or the <b>org</b> (workspace addressed via <code>?workspace_id=</code>)</td></tr>
+</table>
+<h2>Org-owned resources (specific) <span class="tag nested">11 routes</span></h2>
+<p class="desc">The path names a delegable org-owned resource. Access: a grant on <b>that resource</b>, a <b>wildcard grant on its type</b>, or <b>the org</b>.</p>
+<table><tr><th>Method</th><th>Path</th><th>Permission</th><th>Access granted by</th></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/orgs/:org_id/slack/channel-subscriptions/:sub_id</td><td>update</td><td>grant on this <code>slack_subscription</code>, wildcard <code>slack_subscription:*</code>, or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/orgs/:org_id/slack/channel-subscriptions/:sub_id</td><td>delete</td><td>grant on this <code>slack_subscription</code>, wildcard <code>slack_subscription:*</code>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/vcs/connections/:connection_id</td><td>read</td><td>grant on this <code>vcs_connection</code>, wildcard <code>vcs_connection:*</code>, or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/vcs/connections/:connection_id</td><td>delete</td><td>grant on this <code>vcs_connection</code>, wildcard <code>vcs_connection:*</code>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/vcs/connections/:connection_id/branches</td><td>read</td><td>grant on this <code>vcs_connection</code>, wildcard <code>vcs_connection:*</code>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/vcs/connections/:connection_id/check-status</td><td>read</td><td>grant on this <code>vcs_connection</code>, wildcard <code>vcs_connection:*</code>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/vcs/connections/:connection_id/repos</td><td>read</td><td>grant on this <code>vcs_connection</code>, wildcard <code>vcs_connection:*</code>, or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/vcs/connections/:connection_id/webhook-subscription</td><td>read</td><td>grant on this <code>vcs_connection</code>, wildcard <code>vcs_connection:*</code>, or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/vcs/connections/:connection_id/webhook-subscription</td><td>create</td><td>grant on this <code>vcs_connection</code>, wildcard <code>vcs_connection:*</code>, or the <b>org</b></td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/orgs/current/webhooks/:webhook_id</td><td>update</td><td>grant on this <code>webhook</code>, wildcard <code>webhook:*</code>, or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/orgs/current/webhooks/:webhook_id</td><td>delete</td><td>grant on this <code>webhook</code>, wildcard <code>webhook:*</code>, or the <b>org</b></td></tr>
+</table>
+<h2>Org-owned resources (collections / creates / type surface) <span class="tag type">11 routes</span></h2>
+<p class="desc">No specific resource in the path. Access: a <b>wildcard grant on the type</b> or <b>the org</b>.</p>
+<table><tr><th>Method</th><th>Path</th><th>Permission</th><th>Access granted by</th></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs/:org_id/slack/channel-subscriptions</td><td>read</td><td>wildcard <code>slack_subscription:*</code> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/orgs/:org_id/slack/channel-subscriptions</td><td>create</td><td>wildcard <code>slack_subscription:*</code> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs/:org_id/slack/install-url</td><td>read</td><td>wildcard <code>slack_subscription:*</code> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs/:org_id/slack/installations</td><td>read</td><td>wildcard <code>slack_subscription:*</code> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs/:org_id/slack/installations/:installation_id/channels</td><td>read</td><td>wildcard <code>slack_subscription:*</code> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs/:org_id/slack/org-links</td><td>read</td><td>wildcard <code>slack_subscription:*</code> or the <b>org</b></td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/orgs/:org_id/slack/org-links/:link_id</td><td>delete</td><td>wildcard <code>slack_subscription:*</code> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/vcs/connections</td><td>read</td><td>wildcard <code>vcs_connection:*</code> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/vcs/connections</td><td>create</td><td>wildcard <code>vcs_connection:*</code> or the <b>org</b></td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs/current/webhooks</td><td>read</td><td>wildcard <code>webhook:*</code> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/orgs/current/webhooks</td><td>create</td><td>wildcard <code>webhook:*</code> or the <b>org</b></td></tr>
+</table>
+<h2>Top-level creates <span class="tag type">2 routes</span></h2>
+<p class="desc">Creates a new install/app with no parent in the path. Access: a <b>wildcard grant on the created tier</b> (<code>install:*</code> / <code>app:*</code>) or <b>the org</b>.</p>
+<table><tr><th>Method</th><th>Path</th><th>Permission</th><th>Access granted by</th></tr>
+<tr><td class="m">POST</td><td class="p">/v1/apps</td><td>create</td><td>wildcard <code>app:*</code> or the <b>org</b></td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs</td><td>create</td><td>wildcard <code>install:*</code> or the <b>org</b></td></tr>
+</table>
+<h2>Filtered collections <span class="tag filtered">4 routes</span></h2>
+<p class="desc">Always passes the middleware for any org member; the handler filters results to rows the account is entitled to see (org-wide accounts see everything; grant-scoped accounts see granted installs/apps and their upward context).</p>
+<table><tr><th>Method</th><th>Path</th><th>Permission</th><th>Access granted by</th></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps</td><td>read</td><td>any org member; results filtered to entitlements</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/apps/:app_id/installs</td><td>read</td><td>any org member; results filtered to entitlements</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/components</td><td>read</td><td>any org member; results filtered to entitlements</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs</td><td>read</td><td>any org member; results filtered to entitlements</td></tr>
+</table>
+<h2>Org-level routes <span class="tag org">76 routes</span></h2>
+<p class="desc">Org settings, team/credential management, the grant surface itself, org-wide collections/aggregates, and triggers (org-owned entities with no install/app tier &mdash; a candidate delegable org-owned type, like webhooks). Access: an <b>org-wide permission</b> (org role, or an org-tier grant). Grant-scoped accounts are denied by design.</p>
+<table><tr><th>Method</th><th>Path</th><th>Permission</th><th>Access granted by</th></tr>
+<tr><td class="m">POST</td><td class="p">/v1/account/static-token</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/account/static-tokens</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/account/static-tokens/:token_id</td><td>delete</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/aws-account-connections</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/aws-account-connections</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/aws-account-connections/:connection_id</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/aws-account-connections/:connection_id</td><td>update</td><td>org-wide permission only</td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/aws-account-connections/:connection_id</td><td>delete</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/aws-account-connections/:connection_id/verify</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/builds</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/component-builds</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/grants</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/grants</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/grants/:grant_id</td><td>delete</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/health</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/installs/label-keys</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/oidc/trust-policies</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/oidc/trust-policies</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/oidc/trust-policies/:policy_id</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/oidc/trust-policies/:policy_id</td><td>update</td><td>org-wide permission only</td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/oidc/trust-policies/:policy_id</td><td>delete</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/onboarding/current/steps/deploy</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/onboarding/current/steps/get-started</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/onboarding/current/steps/install</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/onboarding/current/steps/your-stack</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs/current</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/orgs/current</td><td>update</td><td>org-wide permission only</td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/orgs/current</td><td>delete</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs/current/accounts</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/orgs/current/accounts/:account_id/role</td><td>update</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs/current/features</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/orgs/current/features</td><td>update</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs/current/invites</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/orgs/current/invites</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/orgs/current/invites/:invite_id/resend</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/orgs/current/invites/:invite_id/revoke</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/orgs/current/remove-user</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs/current/runner-group</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs/current/stats</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/orgs/current/user</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs/features</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/policy-reports</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/queues</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/roles</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/runner-jobs</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/service-accounts</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/service-accounts</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/service-accounts/:account_id</td><td>update</td><td>org-wide permission only</td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/service-accounts/:account_id</td><td>delete</td><td>org-wide permission only</td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/service-accounts/:account_id/role</td><td>update</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/service-accounts/:account_id/tokens</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/terraform-workspaces</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/triggers</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/triggers</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/triggers/:trigger_id</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/triggers/:trigger_id</td><td>delete</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/triggers/:trigger_id/disable</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/triggers/:trigger_id/enable</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/triggers/:trigger_id/event-types</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/triggers/:trigger_id/events</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/triggers/:trigger_id/ingress-url</td><td>update</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/triggers/:trigger_id/rotate-ingress-url</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/triggers/:trigger_id/rotate-secret</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/triggers/:trigger_id/rules</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/triggers/:trigger_id/rules/:rule_id</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/triggers/:trigger_id/secrets/:secret_id/reveal</td><td>update</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/triggers/:trigger_id/secrets/:secret_id/revoke</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/triggers/dispatches</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/triggers/dispatches/:dispatch_id</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/triggers/dispatches/:dispatch_id/retry</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/triggers/events/:event_id</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/triggers/events/:event_id/raw</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/triggers/events/:event_id/replay</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/workflows</td><td>read</td><td>org-wide permission only</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/workflows/cancel</td><td>create</td><td>org-wide permission only</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/workflows/pending-approvals</td><td>read</td><td>org-wide permission only</td></tr>
+</table>
+<h2>Global routes <span class="tag exempt">17 routes</span></h2>
+<p class="desc">Account-level: any authenticated account, no org context or org permission involved.</p>
+<table><tr><th>Method</th><th>Path</th><th>Permission</th><th>Access granted by</th></tr>
+<tr><td class="m">GET</td><td class="p">/v1/account</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/account/user-journeys</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/account/user-journeys</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/account/user-journeys/:journey_name/complete</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/account/user-journeys/:journey_name/reset</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">PATCH</td><td class="p">/v1/account/user-journeys/:journey_name/steps/:step_name</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/auth/me</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/auth/validate</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/general/current-user</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/general/waitlist</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/installs/:install_id/phone-home/:phone_home_id</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/onboarding</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/onboarding/current</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">DELETE</td><td class="p">/v1/onboarding/current</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/onboarding/current/steps/organization</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/orgs</td><td>&mdash;</td><td>any authenticated account</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/orgs</td><td>&mdash;</td><td>any authenticated account</td></tr>
+</table>
+<h2>Public routes <span class="tag exempt">9 routes</span></h2>
+<p class="desc">Unauthenticated (webhooks callbacks, config schemas, OIDC token exchange, event ingress).</p>
+<table><tr><th>Method</th><th>Path</th><th>Permission</th><th>Access granted by</th></tr>
+<tr><td class="m">POST</td><td class="p">/v1/event-ingress/:ingress_key</td><td>&mdash;</td><td>unauthenticated</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/general/cli-config</td><td>&mdash;</td><td>unauthenticated</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/general/cloud-platform/:cloud_platform/regions</td><td>&mdash;</td><td>unauthenticated</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/general/config-schema</td><td>&mdash;</td><td>unauthenticated</td></tr>
+<tr><td class="m">GET</td><td class="p">/v1/general/config-schema/:type</td><td>&mdash;</td><td>unauthenticated</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/oidc/token</td><td>&mdash;</td><td>unauthenticated</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/vcs/:vcs_connection_id/events</td><td>&mdash;</td><td>unauthenticated</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/vcs/connection-callback</td><td>&mdash;</td><td>unauthenticated</td></tr>
+<tr><td class="m">POST</td><td class="p">/v1/vcs/webhooks/:subscription_id/events</td><td>&mdash;</td><td>unauthenticated</td></tr>
+</table>
+<h2>Infrastructure <span class="tag exempt">7 routes</span></h2>
+<p class="desc">Health checks, docs, version — outside the <code>/v1</code> authorization surface.</p>
+<table><tr><th>Method</th><th>Path</th><th>Permission</th><th>Access granted by</th></tr>
+<tr><td class="m">GET</td><td class="p">/docs/*any</td><td>&mdash;</td><td>n/a</td></tr>
+<tr><td class="m">GET</td><td class="p">/httpbin/*any</td><td>&mdash;</td><td>n/a</td></tr>
+<tr><td class="m">GET</td><td class="p">/livez</td><td>&mdash;</td><td>n/a</td></tr>
+<tr><td class="m">GET</td><td class="p">/readyz</td><td>&mdash;</td><td>n/a</td></tr>
+<tr><td class="m">GET</td><td class="p">/version</td><td>&mdash;</td><td>n/a</td></tr>
+<tr><td class="m">GET</td><td class="p">/oapi/v2</td><td>&mdash;</td><td>n/a</td></tr>
+<tr><td class="m">GET</td><td class="p">/oapi/v3</td><td>&mdash;</td><td>n/a</td></tr>
+</table>
+</div></body></html>

--- a/specs/auth/resource-grant-denormalized-owners.html
+++ b/specs/auth/resource-grant-denormalized-owners.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Design: Denormalized Ancestors for Resource-Grant Authorization</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --ink: #e6e9ef; --muted: #9aa4b2;
+    --accent: #6ea8fe; --good: #3fb950; --warn: #d29922; --bad: #f85149;
+    --border: #2a2f3a; --code: #1e232c;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font: 15px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+  .wrap { max-width: 960px; margin: 0 auto; padding: 48px 24px 120px; }
+  h1 { font-size: 30px; margin: 0 0 4px; letter-spacing: -0.02em; }
+  h2 { font-size: 22px; margin: 48px 0 12px; padding-top: 16px; border-top: 1px solid var(--border); letter-spacing: -0.01em; }
+  h3 { font-size: 17px; margin: 28px 0 8px; color: var(--accent); }
+  .sub { color: var(--muted); margin: 0 0 8px; }
+  code { background: var(--code); padding: 1px 6px; border-radius: 4px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 13px; }
+  pre { background: var(--code); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; overflow-x: auto; font-size: 13px; }
+  pre code { background: none; padding: 0; }
+  table { width: 100%; border-collapse: collapse; margin: 14px 0; font-size: 14px; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; }
+  .tag { display: inline-block; font-size: 11px; padding: 1px 7px; border-radius: 999px; font-weight: 600; }
+  .tag.good { background: rgba(63,185,80,.15); color: var(--good); }
+  .tag.warn { background: rgba(210,153,34,.15); color: var(--warn); }
+  .tag.bad  { background: rgba(248,81,73,.15);  color: var(--bad); }
+  .tag.info { background: rgba(110,168,254,.15); color: var(--accent); }
+  .panel { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 16px 18px; margin: 14px 0; }
+  .callout { border-left: 3px solid var(--accent); padding-left: 14px; margin: 14px 0; color: var(--muted); }
+  .callout.warn { border-color: var(--warn); }
+  .callout.bad { border-color: var(--bad); }
+  ul { margin: 8px 0; padding-left: 22px; }
+  li { margin: 3px 0; }
+  .meta { color: var(--muted); font-size: 13px; }
+  .tree { font-family: ui-monospace, monospace; font-size: 13px; white-space: pre; color: var(--ink); }
+  hr { border: none; border-top: 1px solid var(--border); margin: 40px 0; }
+  a { color: var(--accent); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Denormalized Ancestors for Resource-Grant Authorization</h1>
+<p class="sub">Give every grant-relevant child resource direct <code>install_id</code> / <code>app_id</code> columns, so authorization is always a single point query &mdash; replacing the polymorphic owner walk.</p>
+<p class="meta">Status: <strong>Implemented.</strong> Schema (columns, hooks, <code>ResolveOwnerAncestry</code>, migration 126) on <code>ja/resource-grants-v2</code>; the enforcement that consumes it on the stacked <code>ja/account-resource-grants</code> &middot; Fallback: <code>ja/resource-grants</code> (walk-based, frozen) &middot; 2026-08-09</p>
+
+<h2>1. Context</h2>
+<p>The hierarchical resource-grants design (<a href="resource-grants.html">resource-grants.html</a>) authorizes a grant-scoped account by resolving the resource named by a request into an ownership chain &mdash; <code>[install, app, org]</code> &mdash; and matching grants against any tier of it. Accounts holding org roles never take this path; they short-circuit on the org-wide permission check.</p>
+<p>The first implementation (branch <code>ja/resource-grants</code>) resolved that chain at request time. An audit of the full public-API surface (480 routes) showed how that lands:</p>
+
+<table>
+<tr><th>Group</th><th>Routes</th><th>Authorization</th></tr>
+<tr><td><strong>A &mdash; route-classified</strong></td><td>107</td><td>Decided from the registered route pattern alone: org-level surfaces (57), type-only creates and org-owned resource collections (13), handler-filtered collections (4), global/public/infra exemptions (33)</td></tr>
+<tr><td><strong>B &mdash; one point lookup</strong></td><td>275</td><td>URL names the resource; one org-scoped <code>SELECT</code> resolves the chain. <code>:install_id</code> (109), <code>:app_id</code> (125), org-owned resources with ID (11), children with direct owner columns (30)</td></tr>
+<tr><td><strong>C &mdash; polymorphic owner walk</strong></td><td>75</td><td>URL names a child whose table stores only <code>owner_type</code>/<code>owner_id</code>, where the owner may itself be a child. Requires a recursive walk (1&ndash;4 queries): workflows (21), runners (21), terraform workspaces (19), queues/runner-jobs/log-streams (14)</td></tr>
+<tr><td><strong>D &mdash; uncovered, fail closed</strong></td><td>23</td><td>Triggers (19, org-owned) and terraform-backend/workspace routes (4, resource named in query param or body). <em>Subsequently eliminated on this branch: the terraform routes resolve via <code>?workspace_id=</code> / the body owner's ancestry, and triggers are org-level by design (no tier below the org). Uncovered no longer exists as a category.</em></td></tr>
+</table>
+
+<h3>1.1 The two-group model</h3>
+<p>The audit reduces to a simple invariant the API <em>should</em> have:</p>
+<div class="panel">
+<p><strong>Nested route</strong> (names an install/app in the path) &rarr; authorized by a grant on the resource or any ancestor.<br>
+<strong>Top-level route</strong> &rarr; org-level permission required.</p>
+</div>
+<p>Group C is the violation: five child types &mdash; workflows, runner jobs, queues, log streams, terraform workspaces &mdash; whose <em>only</em> detail routes are top-level (<code>GET /v1/workflows/:workflow_id</code>). Applying &ldquo;top-level &rArr; org-level&rdquo; to them would lock a grant-scoped account (e.g. an Install Manager with admin on one install) out of its own install&rsquo;s workflows, jobs, and logs, because no nested alternatives exist. The walk was a shim that makes those routes behave as if they were nested, by re-deriving the parent per request.</p>
+
+<h3>1.2 Why a walk, not a lookup</h3>
+<p>Two deficits stack. The URL lacks the owner (forcing <em>a</em> lookup), and the schema also lacks it: these tables store only a pointer to their <em>immediate</em> owner, which is often another child:</p>
+<pre class="tree">log stream &rarr; owner: runner_job
+runner_job &rarr; owner: install_deploy
+install_deploy &rarr; install_component &rarr; install   &larr; finally a grantable tier</pre>
+<p>The proof that the schema is the culprit: <code>policy_reports</code> and <code>components</code> have the same bare-route shape but carry direct <code>app_id</code>/<code>install_id</code> columns &mdash; they resolve in one query and sit in Group B.</p>
+
+<h2>2. Options considered</h2>
+<p>Both options materialize the same fact &mdash; <em>every child must know its grantable ancestor</em> &mdash; at different layers.</p>
+
+<table>
+<tr><th></th><th>Option 2: nested routes</th><th>Option 3: denormalized columns</th></tr>
+<tr><td>What changes</td><td>~75 new detail routes, swagger/SDK regen, CLI + dashboard migration; bare routes downgraded to org-level</td><td>Migrations on 5 tables, write-path population, one backfill</td></tr>
+<tr><td>Blast radius</td><td>Every consumer surface, incl. customer SDKs</td><td>ctl-api only; zero API-contract change</td></tr>
+<tr><td>Org-wide lists</td><td>Not helped; grantees iterate per-install nested lists</td><td>Enables grant filtering of <code>GET /v1/workflows</code> etc. via <code>WHERE install_id IN (...)</code></td></tr>
+<tr><td>Deep links by bare ID</td><td>Break until clients resolve parents</td><td>Keep working</td></tr>
+<tr><td>Hidden dependency</td><td>Deep children (log streams) still need a materialized ancestor for the handler&rsquo;s parent-membership check &mdash; option 2 needs option 3&rsquo;s columns anyway</td><td>None</td></tr>
+<tr><td>Long-term API shape</td><td>Self-describing: the URL is the authorization story</td><td>Bare-route pattern persists; model legible only in middleware</td></tr>
+</table>
+
+<div class="callout"><strong>Decision:</strong> implement option 3 now &mdash; it is the authorization fix: small, contained in ctl-api, unlocks list filtering, and is prerequisite-grade for the deep child types under any future design. Option 2 remains available later as an API-surface evolution on top; the write-time ancestor resolution built here is exactly the scoping primitive its nested handlers would use.</div>
+
+<h2>3. Design</h2>
+
+<h3>3.1 Schema</h3>
+<p>Add nullable <code>install_id</code> and <code>app_id</code> columns (indexed, no FK constraints, matching sibling denormalized columns elsewhere) to:</p>
+<ul>
+<li><code>install_workflows</code></li>
+<li><code>runner_jobs</code></li>
+<li><code>queues</code></li>
+<li><code>log_streams</code></li>
+<li><code>terraform_workspaces</code></li>
+</ul>
+<p><strong>NULL is meaningful, not unknown:</strong> both columns NULL &rArr; the row is an org-tier resource (e.g. a management-runner job). Its chain is <code>[org]</code>, satisfiable only by org-wide permission. <code>app_id</code> set, <code>install_id</code> NULL &rArr; app-tier. Both set &rArr; install-tier.</p>
+
+<h3>3.2 Write-time population</h3>
+<p>Centralized, not per-call-site: creation resolves the ancestor from the row&rsquo;s <code>owner_type</code>/<code>owner_id</code> when the new columns are not already set, short-circuiting through the owner&rsquo;s own denormalized columns (a log stream created for a runner job copies the job&rsquo;s <code>install_id</code>/<code>app_id</code> &mdash; one point read, no recursion in steady state). Centralizing prevents the drift failure mode where a future creation site forgets the columns.</p>
+
+<h3>3.3 Backfill</h3>
+<p>Batched, idempotent migration; one targeted <code>UPDATE &hellip; FROM</code> per (table, owner-type) pair, derived from a complete inventory of creation sites. Tables fill in topological order &mdash; parents before children that reference them (<code>runner_jobs</code> before <code>log_streams</code>/<code>queues</code> owned by jobs) &mdash; so child backfills can read parents&rsquo; fresh columns. Rows whose owners are org-tier legitimately stay NULL.</p>
+
+<h3>3.4 Authorization</h3>
+<p>Resource resolution for these five types becomes a single org-scoped point read of <code>(install_id, app_id)</code> &rarr; chain <code>[install?, app?, org]</code> &mdash; identical in shape and cost to the <code>:install_id</code> routes in Group B. <strong>No recursive walk exists on this branch.</strong> Runners keep their single bounded hop (runner &rarr; runner group, whose owner is directly an org or install). Group C collapses into Group B, and Group D is eliminated (terraform routes resolve via query param / body owner; triggers are org-level by design). The remaining taxonomy: route-classified or one lookup.</p>
+
+<h3>3.5 Relationship to <code>ja/resource-grants</code> (fallback)</h3>
+<p>The v2 line shares no git ancestry with <code>ja/resource-grants</code>; the enforcement layer (grants API, chain authorization, org-middleware deferred path, startup route-coverage validation, filtered collections) is re-implemented column-first. It is split across two stacked branches: <code>ja/resource-grants-v2</code> carries only the schema of this document (columns, hooks, <code>ResolveOwnerAncestry</code>, migration 126 &mdash; no behavioral change, mergeable ahead of the roles work), and <code>ja/account-resource-grants</code> carries the enforcement and grant layer on top. The v1 and v2 lines are mutually exclusive alternatives:</p>
+<ul>
+<li><code>ja/resource-grants</code> &mdash; frozen; request-time polymorphic walk; no schema changes. Merge this if the denormalization approach fails.</li>
+<li><code>ja/resource-grants-v2</code> + stacked <code>ja/account-resource-grants</code> &mdash; this design; schema carries the ancestors; resolvers are point reads.</li>
+</ul>
+<p>Whichever merges, the other is discarded; fixes do not flow between them automatically.</p>
+
+<h3>3.6 Enabling option 2 later</h3>
+<ul>
+<li>Nested detail routes (<code>/v1/installs/:install_id/workflows/:workflow_id</code>) scope children to the claimed parent with <code>WHERE install_id = ?</code> &mdash; the column, not a join chain.</li>
+<li>The write-time resolution helper is the single source of &ldquo;who is your grantable ancestor&rdquo;, reusable by any handler.</li>
+<li>Bare routes can then be <em>downgraded</em> to org-level (no deletion, no client break for org-role accounts) once clients migrate.</li>
+</ul>
+
+<h2>4. Risks</h2>
+<table>
+<tr><th>Risk</th><th>Mitigation</th></tr>
+<tr><td>Backfill misses an owner type &rarr; rows silently NULL &rarr; over-restriction (org-level required)</td><td>Backfill derived from an exhaustive creation-site inventory; fails <em>closed</em> (never grants too much); post-backfill count checks per owner type</td></tr>
+<tr><td>Future creation site skips population</td><td>Population is centralized at the model layer, not per call site</td></tr>
+<tr><td>Ownership changes post-create would stale the columns</td><td>Ownership is set at creation and treated as immutable; verified against update sites during implementation</td></tr>
+<tr><td>Large-table backfill (<code>runner_jobs</code>)</td><td>Batched SQL updates; idempotent; safe to re-run</td></tr>
+</table>
+
+<h2>5. Related</h2>
+<ul>
+<li><a href="resource-grants.html">resource-grants.html</a> &mdash; the hierarchical grants design (tiers, wildcard semantics, elevate-only)</li>
+<li><code>ja/resource-grants</code> branch &mdash; walk-based implementation: <code>middlewares/org/owners.go</code> (the walk), <code>coverage.go</code> (route classification), <code>docs/design/resource-grant-collection-filtering.md</code> (list-filtering tiers; Tier&nbsp;3 is subsumed by this design)</li>
+</ul>
+
+</div>
+</body>
+</html>

--- a/specs/auth/resource-grants.html
+++ b/specs/auth/resource-grants.html
@@ -1,0 +1,415 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Design: Hierarchical Resource Grants (ctl-api RBAC)</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --ink: #e6e9ef; --muted: #9aa4b2;
+    --accent: #6ea8fe; --good: #3fb950; --warn: #d29922; --bad: #f85149;
+    --border: #2a2f3a; --code: #1e232c;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font: 15px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+  .wrap { max-width: 960px; margin: 0 auto; padding: 48px 24px 120px; }
+  h1 { font-size: 30px; margin: 0 0 4px; letter-spacing: -0.02em; }
+  h2 { font-size: 22px; margin: 48px 0 12px; padding-top: 16px; border-top: 1px solid var(--border); letter-spacing: -0.01em; }
+  h3 { font-size: 17px; margin: 28px 0 8px; color: var(--accent); }
+  .sub { color: var(--muted); margin: 0 0 8px; }
+  code { background: var(--code); padding: 1px 6px; border-radius: 4px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 13px; }
+  pre { background: var(--code); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; overflow-x: auto; font-size: 13px; }
+  pre code { background: none; padding: 0; }
+  table { width: 100%; border-collapse: collapse; margin: 14px 0; font-size: 14px; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; }
+  .tag { display: inline-block; font-size: 11px; padding: 1px 7px; border-radius: 999px; font-weight: 600; }
+  .tag.good { background: rgba(63,185,80,.15); color: var(--good); }
+  .tag.warn { background: rgba(210,153,34,.15); color: var(--warn); }
+  .tag.bad  { background: rgba(248,81,73,.15);  color: var(--bad); }
+  .tag.info { background: rgba(110,168,254,.15); color: var(--accent); }
+  .panel { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 16px 18px; margin: 14px 0; }
+  .callout { border-left: 3px solid var(--accent); padding-left: 14px; margin: 14px 0; color: var(--muted); }
+  .callout.warn { border-color: var(--warn); }
+  .callout.bad { border-color: var(--bad); }
+  ul { margin: 8px 0; padding-left: 22px; }
+  li { margin: 3px 0; }
+  .meta { color: var(--muted); font-size: 13px; }
+  .tree { font-family: ui-monospace, monospace; font-size: 13px; white-space: pre; color: var(--ink); }
+  .scenario { margin: 10px 0; }
+  .scenario .req { font-family: ui-monospace, monospace; font-size: 13px; color: var(--accent); }
+  hr { border: none; border-top: 1px solid var(--border); margin: 40px 0; }
+  a { color: var(--accent); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Hierarchical Resource Grants</h1>
+<p class="sub">Object-level RBAC for ctl-api &mdash; grants that scope an account down to a single app, install, or delegable org-owned resource, alongside the existing org roles.</p>
+<p class="meta">Status: <strong>Implemented, split across two branches.</strong> <code>ja/resource-grants-v2</code> carries only what the near-term roles-only plan requires: the denormalized ancestry schema (columns, write-path hooks, <code>ResolveOwnerAncestry</code>, migration 126) &mdash; a passive schema change with no behavioral impact. Everything else in this document &mdash; the <code>ResourceGrant</code> model and <code>/v1/grants</code> API, the org-gate split behind <code>ResourceGrantsEnabled</code>, the chain-walk authorization and route resolution, coverage validation, and collection filtering &mdash; lives on <code>ja/account-resource-grants</code>, which stacks on v2 and merges when per-account grants are needed. Fallback implementation (request-time owner walk): <code>ja/resource-grants</code>, frozen &middot; Last revised 2026-08-09.</p>
+
+<h2>1. Motivation</h2>
+<p>Before grants, the org roles (<code>org_admin</code>, <code>org_support</code>, <code>installer</code>, <code>runner</code>) all resolved to the same policy: <code>{&lt;orgID&gt;: "all"}</code>. Authorization happened once, in the org middleware, as <code>acct.AllPermissions.CanPerform(org.ID, methodPerm)</code>. The role type was effectively metadata &mdash; there was no way to say &ldquo;read-only&rdquo; or &ldquo;only this app&rdquo;.</p>
+<p>The original ask was <code>apps_read_only</code> and <code>installs_read_only</code> role types. Investigation showed that scoping to a <em>specific</em> resource fits the existing model almost for free &mdash; the permission <code>Set</code> is already <code>map[objectID]Permission</code>. This design adds specific-resource grants, plus per-type wildcards (&sect;9b) for the &ldquo;all resources of one tier&rdquo; case.</p>
+
+<h2>2. Existing building blocks</h2>
+<table>
+  <tr><th>Piece</th><th>Location</th><th>Relevance</th></tr>
+  <tr><td><code>permissions.Set</code> &mdash; <code>map[string]Permission</code>, <code>CanPerform(obj, perm)</code> with <code>"*"</code> fallback</td><td><code>internal/pkg/authz/permissions/set.go</code></td><td>Already supports keying on any object ID, not just org ID.</td></tr>
+  <tr><td><code>FromRequest</code> &mdash; HTTP verb &rarr; permission</td><td><code>.../permissions/request.go</code></td><td>GET&rarr;read, POST&rarr;create, PUT/PATCH&rarr;update, DELETE&rarr;delete. Gives read-only for free.</td></tr>
+  <tr><td>Org middleware</td><td><code>internal/middlewares/org/org.go</code></td><td>Single enforcement point; previously checked only <code>CanPerform(org.ID, perm)</code>.</td></tr>
+  <tr><td>Account <code>AfterQuery</code> hook</td><td><code>internal/app/account.go</code></td><td>Flattens role policies into <code>AllPermissions</code>; builds <code>OrgIDs</code>. Grants fold in here too.</td></tr>
+  <tr><td>Denormalized ancestry columns</td><td><code>install_id</code>/<code>app_id</code> on the polymorphic-owner tables</td><td>Added by this work stream (migration 126); make every child resolvable in one point read. See <a href="resource-grant-denormalized-owners.html">the decision record</a>.</td></tr>
+</table>
+
+<h2>3. The ownership tree</h2>
+<p>Every resource has a parent chain terminating at the org. Authorization <strong>walks up</strong> this chain: a request is allowed if the requested resource <em>or any ancestor</em> carries a grant satisfying the verb. Chains are built from a single org-scoped point read per request &mdash; children either carry a direct owner column (components, policy reports) or denormalized <code>install_id</code>/<code>app_id</code> ancestry columns (workflows, runner jobs, queues, log streams, terraform workspaces). There is no request-time recursive owner walk.</p>
+<div class="tree">org  ← grant target (root)
+├─ app  ← grant target                                    chain: app → org
+│  ├─ install  ← grant target                             chain: install → app → org
+│  │  ├─ install components  (future target)
+│  │  │  ├─ install deploys → runner jobs ◆, log streams ◆
+│  │  │  └─ terraform workspaces ◆  (component infra state)
+│  │  ├─ install sandbox → terraform workspace ◆  (sandbox infra state)
+│  │  ├─ install sandbox runs → runner jobs ◆, log streams ◆
+│  │  ├─ workflows ◆ → steps → approvals
+│  │  │     (steps also own runner jobs ◆ — secret syncs — and log streams ◆)
+│  │  ├─ action workflow runs → runner jobs ◆, log streams ◆
+│  │  ├─ install stacks, stack runs, runbook runs
+│  │  ├─ notebooks → queues ◆
+│  │  ├─ queues ◆  (install signal queues)
+│  │  ├─ events, audit logs, config versions, inputs, state, roles, drift
+│  │  │     (route-level children under /v1/installs/:install_id)
+│  │  └─ install runner group → runners → runner jobs ◆, log streams ◆,
+│  │        queues ◆, processes
+│  ├─ components  (future target)
+│  │  └─ config connections → component builds → runner jobs ◆, log streams ◆
+│  ├─ app branches → branch runs (→ log streams ◆), branch queues ◆, workflows ◆
+│  ├─ app sandbox builds → runner jobs ◆, log streams ◆
+│  ├─ workflows ◆  (app-owned: config builds)
+│  ├─ app configs  (+ sandbox / runner / secrets / policies / permissions /
+│  │     break-glass / stack / input / template configs)
+│  ├─ actions, action workflows → action workflow configs
+│  ├─ runbooks, secrets
+│  ├─ policy reports  (install-scoped reports also carry their install)
+│  └─ queues ◆  (app signal queues)
+├─ webhook  ← grant target                                chain: webhook → org
+├─ vcs_connection  ← grant target                         chain: vcs_connection → org
+│  └─ vcs webhook subscriptions  (their queues ◆ resolve org tier)
+├─ slack_subscription  ← grant target                     chain: slack_subscription → org
+└─ org tier  (no install/app ancestor — org-wide permission only)
+   ├─ management runner group → runners → runner jobs ◆, log streams ◆, queues ◆
+   ├─ admin-created runner jobs ◆  (health-check / noop; no owner recorded)
+   ├─ org queues ◆  (org signals, health-check sweeps, trigger ingress,
+   │     onboarding, the 'general' queue)
+   ├─ triggers → dispatches, events, rules, secrets  (candidate delegable type)
+   ├─ AWS account connections  (deliberately not grantable)
+   └─ org settings, team, invites, service accounts, trust policies,
+         static tokens, grants</div>
+<p class="meta"><strong>← grant target</strong>: can carry a grant directly (<code>org</code>, <code>app</code>, <code>install</code>, <code>webhook</code>, <code>vcs_connection</code>, <code>slack_subscription</code>). <strong>(future target)</strong>: promotion planned to be additive. <strong>◆</strong>: row in one of the five polymorphic-owner tables (<code>install_workflows</code>, <code>runner_jobs</code>, <code>queues</code>, <code>log_streams</code>, <code>terraform_workspaces</code>) &mdash; its grantable ancestry is stored in denormalized <code>install_id</code>/<code>app_id</code> columns, populated at creation (<code>app.ResolveOwnerAncestry</code>) and backfilled by migration 126. Both columns NULL means <strong>org tier</strong> &mdash; a defined state, never &ldquo;unknown&rdquo;; such rows require org-wide permission. Everything without a marker inherits its parent's chain and is never a grant target itself.</p>
+<ul>
+  <li><strong>Runners are dual-owned</strong>, so they appear twice: a runner belongs to a runner group, and the group is owned by an install <em>or</em> the org. Install runners inherit their install's chain (an install grantee can see and operate their runner); the management (org) runner group and everything under it is org tier.</li>
+  <li><strong>Workflows and queues are multi-homed</strong> the same way: a workflow is owned by an install, an app, or an app branch; a queue by an install, app, branch, component, notebook, runner, or the org. Each row's tier is whatever its owner resolves to &mdash; the ◆ columns capture it per row.</li>
+</ul>
+
+<h2>4. Grant-target set</h2>
+<table>
+  <tr><th>Target</th><th>Model</th><th>Chain</th><th>Wildcard (<code>"*"</code>)</th></tr>
+  <tr><td><code>org</code></td><td><code>Org</code></td><td><code>[org]</code></td><td>no (already a single resource)</td></tr>
+  <tr><td><code>app</code></td><td><code>App</code></td><td><code>[app, org]</code></td><td>yes</td></tr>
+  <tr><td><code>install</code></td><td><code>Install</code></td><td><code>[install, app, org]</code></td><td>yes</td></tr>
+  <tr><td><code>webhook</code></td><td><code>Webhook</code></td><td><code>[webhook, org]</code></td><td>yes</td></tr>
+  <tr><td><code>vcs_connection</code></td><td><code>VCSConnection</code></td><td><code>[vcs_connection, org]</code></td><td>yes</td></tr>
+  <tr><td><code>slack_subscription</code></td><td><code>SlackChannelSubscription</code></td><td><code>[slack_subscription, org]</code></td><td>yes</td></tr>
+</table>
+<p><strong>Future targets</strong> (additive: a new <code>GrantResourceType</code> constant plus a chain-builder entry):</p>
+<ul>
+  <li><code>component</code> &mdash; leaf under app; chain <code>[component, app, org]</code>. Its personas are covered acceptably by <code>app</code> grants for now.</li>
+  <li><code>install-component</code> &mdash; leaf under install; same rationale.</li>
+  <li><code>trigger</code> &mdash; org-owned entity with no install/app tier; the natural next delegable org-owned type (like webhooks). Until then the trigger routes are org-level (&sect;8c).</li>
+  <li>Runbooks/actions &mdash; pending an <code>execute</code> verb (&sect;9, deferred).</li>
+</ul>
+
+<h2>5. Persona &rarr; grant mapping</h2>
+<table>
+  <tr><th>Persona</th><th>Grant</th><th>Effect</th></tr>
+  <tr><td>Org admin</td><td><code>org &middot; all</code></td><td>Everything (existing behavior).</td></tr>
+  <tr><td>Org read-only / auditor</td><td><code>org &middot; read</code></td><td>Read all descendants; no writes. (Original <code>org_read_only</code>.)</td></tr>
+  <tr><td>App owner</td><td><code>app &middot; all</code></td><td>Full control of one app + its installs/components.</td></tr>
+  <tr><td>App read-only</td><td><code>app &middot; read</code></td><td>Read one app subtree. (Original <code>apps_read_only</code>, scoped.)</td></tr>
+  <tr><td>Install operator</td><td><code>install &middot; all</code></td><td>Drive one install; no app-config writes.</td></tr>
+  <tr><td>Install read-only / support</td><td><code>install &middot; read</code></td><td>View one install. (Original <code>installs_read_only</code>, scoped.)</td></tr>
+  <tr><td>Install manager (all installs)</td><td><code>install &middot; * &middot; all</code></td><td>Admin on every install in the org, nothing else. Basis for a planned standard role (grant folded into the role's policy) &mdash; not yet built.</td></tr>
+  <tr><td>Integration manager</td><td><code>webhook/vcs_connection/slack_subscription &middot; * or id</code></td><td>Manage the org's notification/VCS surface without org admin.</td></tr>
+  <tr><td class="meta">Component maintainer <span class="tag info">future</span></td><td class="meta"><code>component &middot; all/read</code></td><td class="meta">One app component's config + builds. Covered by an <code>app</code> grant until <code>component</code> is promoted.</td></tr>
+</table>
+<div class="callout"><strong>Key simplification:</strong> &ldquo;read-only&rdquo; is a <em>permission verb</em>, not a role type. Every <code>*_read_only</code> persona is just <code>&lt;target&gt; &middot; read</code>. We do not add per-resource read-only role types.</div>
+
+<h2>6. Data model</h2>
+<p>One unified table (<code>internal/app/resource_grant.go</code>), folded into the account's permissions alongside role policies.</p>
+<pre><code>ResourceGrant {
+  ID, CreatedByID, CreatedAt, UpdatedAt, DeletedAt
+  OrgID         // org the grant lives in (drives membership/OrgIDs)
+  AccountID
+  ResourceType  // org | app | install | webhook | vcs_connection | slack_subscription
+  ResourceID    // canonical ID of the granted resource, or "*" (type wildcard)
+  Permission    // "read" | "all"
+}
+// unique on (org_id, account_id, resource_type, resource_id, deleted_at);
+// create is an upsert on that key (re-granting updates the permission)</code></pre>
+<p>In <code>account.go</code> <code>AfterQuery</code>, after merging role policies:</p>
+<ul>
+  <li>each specific grant merges as <code>{ResourceID: Permission}</code> into <code>AllPermissions</code>;</li>
+  <li>each wildcard grant lands in <code>TypeGrants map[orgID]map[resourceType]Permission</code> (exposed per-org via <code>OrgTypeGrants(orgID)</code>) &mdash; kept out of the flat Set so a tier wildcard cannot leak to other tiers;</li>
+  <li>the grant's <code>OrgID</code> joins <code>OrgIDs</code>, so an otherwise org-less account passes org membership.</li>
+</ul>
+
+<h2>7. Authorization primitive: walk-up-the-chain</h2>
+<pre><code>// internal/pkg/authz/authorize.go
+type Link struct{ Type, ID string }   // one tier: grant resource type + object id
+
+// most-specific -&gt; least-specific; allow if any link satisfies perm,
+// via a specific-object grant (perms) or a tier wildcard (wildcards).
+// A Link with empty ID is type-only (creates/collections) and is
+// satisfiable only by that tier's wildcard.
+func Authorize(perms permissions.Set, wildcards map[string]permissions.Permission,
+    chain []Link, perm permissions.Permission) error</code></pre>
+<p>Chains per resource, each built from at most one org-scoped point read:</p>
+<ul>
+  <li><code>org</code>: <code>[org]</code> &mdash; the org-admin case is just the last link, unifying the old org gate with grants</li>
+  <li><code>app</code>: <code>[app, org]</code>; <code>install</code>: <code>[install, app, org]</code> (install row carries <code>app_id</code>)</li>
+  <li>org-owned siblings: <code>[webhook|vcs_connection|slack_subscription, org]</code>, or type-only <code>[{type}, org]</code> for their collection/create routes</li>
+  <li>owned children: the owner's chain, read from the child's direct owner column or its denormalized <code>install_id</code>/<code>app_id</code>; both NULL &rArr; bare <code>[org]</code></li>
+  <li>runners: one fixed hop through the runner group (install- or org-owned; never recursive)</li>
+</ul>
+
+<h2>8. Enforcement wiring</h2>
+<h3>8a. Org-gate rework <span class="tag warn">only non-additive change</span></h3>
+<p>Resource authorization is folded into the existing <code>org</code> middleware. The whole feature is gated behind one flag, <code>ResourceGrantsEnabled</code> (<code>internal.Config</code> &rarr; env <code>RESOURCE_GRANTS_ENABLED</code>, default off). When it is off, the gate behaves exactly as before. When on, <code>org.go</code> splits membership from authorization:</p>
+<pre><code>orgErr := acct.AllPermissions.CanPerform(object, perm)
+if orgErr == nil {
+    cctx.SetOrgAuthorized(ctx, true)                  // org-wide grant/role: fast path
+} else {
+    if !acct.HasOrg(org.ID) { 403 }                   // not a member at all
+    cctx.SetOrgAuthorized(ctx, false)                 // member via a narrow grant; defer
+    if !isFilteredCollection(ctx) {
+        authorizeResource(ctx, acct, org.ID, perm)    // resolve resource in path + walk up
+    }
+}</code></pre>
+<p><strong>Fail-closed:</strong> a deferred request whose route cannot be resolved to a chain (and is not a filtered collection) is denied. Folding enforcement into the org gate (rather than per-group middlewares) means one flag enables the whole feature and there is no flag-on-but-middleware-not-wired gap.</p>
+<p class="meta">One special case predates grants and is preserved: <code>POST &hellip;/components/:component_id/builds</code> checks the org's <code>&lt;orgID&gt;:component_builds</code> object on the fast path (<code>permissions.RequestObject</code>), which the runner role carries.</p>
+
+<h3>8b. Route &rarr; chain resolution</h3>
+<p><code>resourceChain</code> (<code>middlewares/org/org.go</code>, <code>resources.go</code>, <code>owners.go</code>) resolves the most specific resource named by the route, in order:</p>
+<ol>
+  <li><code>:install_id</code> param (id-or-name, org-scoped) &rarr; <code>[install, app, org]</code></li>
+  <li><code>:app_id</code> param (id-or-name) &rarr; <code>[app, org]</code></li>
+  <li>org-owned resource prefixes (<code>orgResourceRoutes</code>: webhooks, VCS connections, the Slack surface) &rarr; <code>[{type}&nbsp;(+id), org]</code>; routes under the prefix without the id param resolve type-only</li>
+  <li>owned-child prefixes (<code>ownedResourceRoutes</code>: workflows, runner jobs, queues, log streams, terraform workspaces, runners, top-level components/builds/action-workflows, sandbox runs, stacks, policy reports) &rarr; single point read of the owner columns &rarr; the owner's chain</li>
+  <li>parentless creates (<code>POST /v1/installs</code>, <code>POST /v1/apps</code>) &rarr; type-only link for the created tier</li>
+  <li>terraform backend routes (<code>GET/POST /v1/terraform-backend</code>) &rarr; the workspace named by the <code>?workspace_id=</code> query param &rarr; its ancestry chain</li>
+  <li>body-owned creates (<code>POST /v1/terraform-workspace(s)</code>) &rarr; the owner named by <code>owner_type</code>/<code>owner_id</code> in the JSON body (read once and restored for the handler) &rarr; its ancestry chain; unknown owners resolve to the org tier</li>
+  <li>anything else: fail closed (unless explicitly classified, 8c)</li>
+</ol>
+
+<h3>8c. Route-coverage validation <span class="tag good">boot-time guarantee</span></h3>
+<p>Every <code>/v1</code> route on the public server must be consciously classified: resolvable by 8b, exempt (global/public), a filtered collection (8d), or explicitly <strong>org-level</strong> (<code>orgLevelRoutes</code>: org settings, team/credential surfaces, the grant surface itself, all org-wide collections/aggregates, and the trigger family &mdash; org-owned entities with no tier below the org). A route a grant semantically covers must resolve &mdash; this validator makes that constraint structural. <code>ValidateRouteCoverage</code> runs at startup &mdash; an unclassified route fails the boot (and CI) of the PR that adds it instead of silently 403ing grant-scoped accounts in production. A snapshot test pins the full route inventory. The complete per-endpoint mapping lives in <a href="public-api-authorization-audit.html">the authorization audit</a>.</p>
+
+<h3>8d. Collection-endpoint grant-scope filtering</h3>
+<p>Walk-up authorizes a single addressed resource; list endpoints return collections. Four core navigation lists let deferred (<code>OrgAuthorized=false</code>) members through and filter results to entitled rows instead of gating the endpoint: <code>GET /v1/installs</code>, <code>GET /v1/apps/:app_id/installs</code>, <code>GET /v1/apps</code>, <code>GET /v1/components</code>.</p>
+<ul>
+  <li><strong>Shared helper</strong> <code>scope.ForList(acct, perm)</code> (<code>internal/pkg/authz/scope</code>) turns the caller's grants into per-tier ID sets &mdash; <code>OrgIDs</code>/<code>AppIDs</code>/<code>InstallIDs</code> plus <code>AppWildcardOrgs</code>/<code>InstallWildcardOrgs</code> for type wildcards.</li>
+  <li><strong>Per-table GORM scopes</strong> (<code>IDSets.Installs/Apps/Components</code>, column names parameterized for the view-backed tables) drop into <code>.Scopes(...)</code>. A row is visible if any tier it belongs to is granted; the <code>Apps</code> scope adds <strong>upward visibility</strong> &mdash; the parent app of a granted install is listed (metadata only; sibling installs stay filtered) so navigation stays coherent.</li>
+  <li><strong>Per-service guards</strong> (<code>grant_scope.go</code> in the installs/apps/components services): no-op when <code>cctx.OrgAuthorized</code> (org-wide callers keep their unfiltered plan), the real filter for deferred members, and <code>WHERE 1=0</code> if no account is resolvable (fail closed).</li>
+</ul>
+<div class="callout"><strong>All other org-wide collections are org-level by design</strong> (user decision): <code>GET /v1/builds</code>, <code>/v1/workflows</code>, <code>/v1/runner-jobs</code>, <code>/v1/queues</code>, <code>/v1/terraform-workspaces</code>, <code>/v1/policy-reports</code>, health/label aggregates, etc. enumerate resources across the whole org and require an org-level permission rather than per-grant result filtering. The denormalized ancestry columns make extending filtering to them a mechanical follow-up (each is one <code>WHERE install_id IN (&hellip;)</code> away) if a product need appears; detail routes for those resources already resolve per-row, so the lists are navigation, not capability.</div>
+
+<h3>8e. Query performance</h3>
+<p>Every list query AND's an unconditional <code>WHERE org_id = ?</code> before the grant scope, so the OR-of-INs only ever evaluates within one org's rows &mdash; never a whole-table scan. For a narrow grantee <code>OrgIDs</code> is empty (an org grant would have taken the fast path), so the effective filter is <code>id IN (&hellip;) OR app_id IN (&hellip;) [OR org_id IN (wildcard orgs)]</code> over an already-narrow set. Org-wide callers skip the filter entirely &mdash; no regression on the large-org path. Two things need active attention as filtering extends: each filtered column stays independently indexed, and pagination <code>COUNT</code> queries apply the same scope (a correctness bug if missed, not just a slow query). If per-account grant cardinality ever reaches thousands, the materialized IN lists can be swapped for a JOIN against <code>resource_grants</code>; not needed at expected scale.</p>
+
+<h3>8f. Denormalized ancestry (how children resolve)</h3>
+<p>The five polymorphic-owner tables carry <code>install_id</code>/<code>app_id</code> directly (see <a href="resource-grant-denormalized-owners.html">the decision record</a> for the full option analysis vs. nested routes and the request-time walk):</p>
+<ul>
+  <li><strong>Write path:</strong> <code>BeforeCreate</code> hooks call <code>app.ResolveOwnerAncestry(tx, orgID, ownerType, ownerID)</code>, which maps every owner type observed at the tables' creation sites to its grantable ancestors. Unknown owner types and dangling references resolve to the org tier (never an error &mdash; creation must not break). Owners that are themselves denormalized are read from their own columns, so resolution is at most two point queries and never recursive.</li>
+  <li><strong>Backfill:</strong> migration 126, batched and idempotent, one targeted update per (table, owner-type) pair; <code>install_workflows</code> first so rows owned by workflow steps read the workflow's fresh columns. Rows whose owners are org-tier (management-runner jobs, org queues, admin-created jobs with no owner, runner-supplied unknown workspace owners) legitimately stay NULL. Rows written by not-yet-updated pods during the deploy rollout stay NULL too &mdash; an accepted, fail-closed window.</li>
+  <li><strong>Read path (authorization):</strong> <code>denormOwned(table)</code> in <code>middlewares/org/owners.go</code> &mdash; one org-scoped <code>SELECT install_id, app_id</code>, then <code>ownerChain</code>. Ownership is create-time-only on all five tables (verified: no code updates owner columns post-insert), so the columns cannot go stale.</li>
+</ul>
+
+<h2>9. Decisions</h2>
+
+<h3>Resolved</h3>
+<table>
+  <tr><th>Question</th><th>Decision</th><th>Status</th></tr>
+  <tr>
+    <td>Who can grant?</td>
+    <td><span class="tag good">Org-admins only</span></td>
+    <td>Implemented: grant CRUD requires an org-wide <code>all</code> caller (<code>requireOrgAdmin</code>). No delegation, no re-grant/escalation checks; delegation can be added later without breaking the model.</td>
+  </tr>
+  <tr>
+    <td>Grantee scope?</td>
+    <td><span class="tag warn">External invitees &mdash; decided, not implemented</span></td>
+    <td>Today a grant requires an <em>existing</em> account (by <code>account_id</code> or <code>email</code> lookup; unknown email is an error). The scoped-invite path &mdash; <code>create_invite.go</code> accepting a resource-scoped invite whose acceptance creates the <code>ResourceGrant</code> &mdash; remains to build.</td>
+  </tr>
+  <tr>
+    <td>Upward visibility in lists?</td>
+    <td><span class="tag good">Navigable (show parent app)</span></td>
+    <td>Implemented in the <code>Apps</code> scope: a narrow grantee sees the parent app of a granted install (metadata only; siblings stay filtered). The strict-isolation variant is not used.</td>
+  </tr>
+  <tr>
+    <td>Collections beyond the four navigation lists?</td>
+    <td><span class="tag good">Org-level by design</span></td>
+    <td>Org-wide collection/aggregate endpoints belong to the org (&sect;8d callout). No per-grant result filtering there for now.</td>
+  </tr>
+  <tr>
+    <td>How do bare child routes resolve their owner?</td>
+    <td><span class="tag good">Denormalized ancestry columns</span></td>
+    <td>Chosen over (a) a request-time recursive owner walk &mdash; built on the frozen <code>ja/resource-grants</code> branch, kept as fallback &mdash; and (b) adding owner-nested routes and downgrading bare routes to org-level, which remains available later as an API-surface evolution the columns already enable (nested handlers would scope children with <code>WHERE install_id = ?</code>).</td>
+  </tr>
+</table>
+
+<h3>9a. Grant management API <span class="tag good">implemented: unified surface</span></h3>
+<p>Grants are managed through a single resource-agnostic surface &mdash; the resource is named in the request body (create) or query (list), not the path. This keeps the API flat as more tiers become grantable and makes the org tier a first-class target with no extra endpoints.</p>
+<table>
+  <tr><th>Method</th><th>Route</th><th>Notes</th></tr>
+  <tr><td><code>POST</code></td><td><code>/v1/grants</code></td><td>Create/upsert (re-granting the same resource updates the permission). Body: <code>{ resource_type, resource_id, account_id|email, permission }</code>. <code>resource_type</code> is <code>oneof=org app install webhook vcs_connection slack_subscription</code>; <code>permission</code> is <code>oneof=read all</code>. Apps/installs accept name-or-id (resolved &amp; validated against the caller org); every non-org type accepts the <code>"*"</code> wildcard; <code>org</code> must be the caller's own org. Org-admin only.</td></tr>
+  <tr><td><code>GET</code></td><td><code>/v1/grants</code></td><td>List grants in the org; optional <code>?resource_type=&amp;resource_id=</code> filter.</td></tr>
+  <tr><td><code>DELETE</code></td><td><code>/v1/grants/:grant_id</code></td><td>Revoke (soft delete). Org-admin only.</td></tr>
+</table>
+<p><strong>Org-wide read</strong> is a single <code>org &middot; read</code> grant &mdash; it cascades to every descendant via walk-up and is bucketed at the org tier by the collection filter. An <code>app &middot; read</code> grant similarly covers all installs under that app. For &ldquo;all resources of one tier&rdquo;, use a type wildcard.</p>
+
+<h3>9b. Type-wildcard grants <span class="tag good">implemented</span></h3>
+<p>A grant whose <code>resource_id</code> is <code>"*"</code> scopes to <strong>every resource of its <code>resource_type</code> within the org</strong> &mdash; e.g. <code>{ resource_type: "install", resource_id: "*", permission: "all" }</code> grants write on all installs in the org, and crucially <em>not</em> apps or other tiers (which <code>org &middot; all</code> cannot express). Supported for every type except <code>org</code> (already a single resource).</p>
+<p>The wildcard deliberately does <strong>not</strong> reuse the <code>permissions.Set</code> <code>"*"</code> key, which <code>CanPerform</code> falls back to for <em>any</em> object regardless of tier &mdash; using it would leak an <code>install &middot; *</code> grant to apps and the org. Instead the tier is carried explicitly:</p>
+<ul>
+  <li><strong>Aggregation</strong> (<code>account.go</code> <code>AfterQuery</code>): wildcard grants collect into <code>Account.TypeGrants</code>, keyed by org id then resource type, separate from the flat <code>AllPermissions</code> Set.</li>
+  <li><strong>Walk-up</strong> (<code>authz.Authorize</code>): the chain is <code>[]Link{Type, ID}</code>; a link is authorized by a specific-object grant <em>or</em> a <code>TypeGrants</code> entry matching that link's tier. An <code>install &middot; *</code> grant matches the install link but never the app or org link. Type-only links (creates, org-resource collections) are satisfiable <em>only</em> by the tier wildcard.</li>
+  <li><strong>Collection filter</strong> (<code>scope</code>): <code>IDSets.AppWildcardOrgs</code>/<code>InstallWildcardOrgs</code> widen the list queries to <code>org_id IN (&hellip;)</code> for the wildcard tier, with the same upward-visibility semantics as specific grants.</li>
+</ul>
+
+<h3>Deferred</h3>
+<ul>
+  <li><strong>Execute verb:</strong> runbooks/actions want an <code>execute</code> permission, not CRUD. The <code>Permission</code> enum and <code>FromRequest</code> mapping are extensible, so adding it later is additive.</li>
+  <li><strong>Scoped invites:</strong> the external-grantee path (&sect;9 resolved table).</li>
+  <li><strong>Leaf-target promotion:</strong> <code>component</code> / <code>install-component</code> as grant types; <code>trigger</code> as a delegable org-owned type.</li>
+  <li><strong>Standard roles built on grants:</strong> e.g. an Install Manager role whose policy folds in an <code>install &middot; *</code> type grant. Requires the role catalog work (<code>ja/roles</code>, PR #2123) plus a policy-key fold; sequenced after this branch lands.</li>
+</ul>
+
+<h2>10. Pressure test <span class="tag info">historical record, outcomes updated</span></h2>
+<p class="meta">Each scenario traces a concrete request through org-gate &rarr; handler. These drove the design; the Result column reflects where each landed in the final implementation.</p>
+<div id="pressure-test">
+
+<table>
+  <tr><th>#</th><th>Request &amp; grant</th><th>Trace</th><th>Result</th></tr>
+
+  <tr>
+    <td>S1</td>
+    <td class="req">GET /v1/installs/:id<br>grant: install&middot;read</td>
+    <td>Org gate: member (grant put org in <code>OrgIDs</code>), no org-wide &rarr; defer. Chain <code>[install,app,org]</code>, <code>CanPerform(install,read)</code> hits.</td>
+    <td><span class="tag good">PASS</span></td>
+  </tr>
+
+  <tr>
+    <td>S2</td>
+    <td class="req">PATCH /v1/installs/:id<br>grant: install&middot;read</td>
+    <td><code>FromRequest</code>&rarr;update; no chain link satisfies update.</td>
+    <td><span class="tag good">DENY (correct)</span> &mdash; read-only enforced for free.</td>
+  </tr>
+
+  <tr>
+    <td>S5</td>
+    <td class="req">GET /v1/installs/:id<br>grant: app&middot;read (parent app)</td>
+    <td>Chain <code>[install,app,org]</code>; <code>CanPerform(app,read)</code> hits via walk-up.</td>
+    <td><span class="tag good">PASS</span> &mdash; cascade works.</td>
+  </tr>
+
+  <tr>
+    <td>S8</td>
+    <td class="req">GET /v1/apps/my-app-name<br>grant: app&middot;read (by canonical id)</td>
+    <td>The gate resolves name&rarr;canonical id <em>before</em> keying, then <code>CanPerform(canonicalID,read)</code>.</td>
+    <td><span class="tag good">PASS</span> &mdash; name-or-id resolution is part of chain building.</td>
+  </tr>
+
+  <tr>
+    <td>S9</td>
+    <td class="req">any, X-Nuon-Org-ID=orgB<br>grant: install&middot;read in orgA</td>
+    <td>Org gate: <code>HasOrg(orgB)</code> false (grant added only orgA).</td>
+    <td><span class="tag good">DENY (correct)</span> &mdash; cross-org isolation holds.</td>
+  </tr>
+
+  <tr>
+    <td>S12</td>
+    <td class="req">PATCH /v1/installs/:id<br>grants: app&middot;read + install&middot;all</td>
+    <td>Chain <code>[install,app,org]</code>: install&middot;<code>all</code> satisfies update.</td>
+    <td><span class="tag good">PASS</span> &mdash; any-link-wins + <code>all</code>; grants accumulate independently.</td>
+  </tr>
+
+  <tr>
+    <td>S3/S4</td>
+    <td class="req">GET /v1/installs<br>GET /v1/apps/:id/installs<br>grant: install&middot;read (one install)</td>
+    <td>Found as the biggest gap (F1): list handlers did no per-item filtering, so narrow grantees were either denied their own resource or shown everything.</td>
+    <td><span class="tag good">RESOLVED</span> &mdash; filtered collections (&sect;8d).</td>
+  </tr>
+
+  <tr>
+    <td>S6</td>
+    <td class="req">GET /v1/installs/:iid/components/:cid<br>grant: install-component&middot;read</td>
+    <td class="meta"><em>Future target.</em> An <code>install</code> grant covers this route today (chain <code>[install,app,org]</code>). Promotion of <code>install-component</code> adds a deeper chain, keyed on <code>InstallComponent.ID</code>.</td>
+    <td><span class="tag info">FUTURE</span></td>
+  </tr>
+
+  <tr>
+    <td>S10</td>
+    <td class="req">GET /v1/workflows/:wid<br>grant: install&middot;read (owning install)</td>
+    <td>Found as F3: the route names no install/app, and the workflow row's polymorphic owner wasn't resolved &rarr; fail-closed even for the rightful grantee.</td>
+    <td><span class="tag good">RESOLVED</span> &mdash; denormalized ancestry (&sect;8f): one point read of <code>install_workflows.install_id/app_id</code> rebuilds the chain.</td>
+  </tr>
+
+  <tr>
+    <td>S11</td>
+    <td class="req">GET /v1/components/:cid<br>grant: component&middot;read</td>
+    <td class="meta"><em>Future target.</em> The route resolves today via the component's <code>app_id</code> (app chain); an <code>app</code> grant covers it. Direct component grants await promotion.</td>
+    <td><span class="tag info">FUTURE</span></td>
+  </tr>
+</table>
+
+<div class="callout">
+  <strong>Where the findings landed.</strong>
+  <strong>F1</strong> (collections) &rarr; the four filtered navigation lists (&sect;8d); all other collections org-level by design.
+  <strong>F3</strong> (routes that don't name their resource) &rarr; solved structurally by denormalized ancestry + the owned-child resolver registry (&sect;8b/8f), not by per-handler checks; the boot-time coverage validator (&sect;8c) prevents the gap from ever silently reappearing on new routes.
+  <strong>F2/F4</strong> (leaf-target promotion mechanics) &rarr; still future, unchanged in shape.
+  Confirmed sound and still true: read-only-as-verb (S2), ancestor cascade (S5), name-or-id ordering (S8), cross-org isolation (S9), independent grant accumulation (S12).
+</div>
+
+</div>
+
+<h2>11. Implementation status</h2>
+<table>
+  <tr><th>Piece</th><th>Status</th></tr>
+  <tr><td>Denormalized ancestry columns + write-path hooks + backfill (migration 126)</td><td><span class="tag good">done (ja/resource-grants-v2)</span></td></tr>
+  <tr><td><code>ResourceGrant</code> model, <code>AfterQuery</code> aggregation (incl. <code>TypeGrants</code>)</td><td><span class="tag good">done (ja/account-resource-grants)</span></td></tr>
+  <tr><td><code>Authorize</code> + chain building for all current targets and owned children</td><td><span class="tag good">done (ja/account-resource-grants)</span></td></tr>
+  <tr><td>Org-gate rework behind <code>ResourceGrantsEnabled</code> (default off)</td><td><span class="tag good">done (ja/account-resource-grants)</span></td></tr>
+  <tr><td>Route-coverage validation at boot + inventory snapshot test</td><td><span class="tag good">done (ja/account-resource-grants)</span></td></tr>
+  <tr><td>Collection filtering (4 navigation lists) + <code>scope</code> package</td><td><span class="tag good">done (ja/account-resource-grants)</span></td></tr>
+  <tr><td>Grant CRUD API (<code>/v1/grants</code>), SDKs + dashboard types regenerated</td><td><span class="tag good">done (ja/account-resource-grants)</span></td></tr>
+  <tr><td>DB-backed integration test for migration 126 backfill</td><td><span class="tag warn">recommended pre-merge</span></td></tr>
+  <tr><td>Scoped invites (grants to external emails)</td><td><span class="tag warn">not built</span></td></tr>
+  <tr><td>Dashboard + CLI grant management UX</td><td><span class="tag warn">not built</span></td></tr>
+  <tr><td>Feature flag on when per-account grants are needed</td><td><span class="tag warn">sequenced after ja/account-resource-grants merges</span></td></tr>
+</table>
+<div class="callout warn"><strong>Branch relationship.</strong> This design is implemented twice. <code>ja/resource-grants</code> (frozen) resolves owned children with a request-time recursive owner walk; the v2 line replaces the walk with denormalized ancestry columns and is the intended path. The v2 line is split in two: <code>ja/resource-grants-v2</code> carries the schema (merges first &mdash; passive, unblocks roles work), and <code>ja/account-resource-grants</code> stacks the enforcement and grant layer on top (merges later, when per-account grants are needed; roles authorize at the org gate and use none of it). The v1 and v2 lines share no git ancestry and are mutually exclusive &mdash; whichever merges, the other is discarded, and fixes do not flow between them.</div>
+
+<h2>12. Related</h2>
+<ul>
+  <li><a href="resource-grant-denormalized-owners.html">resource-grant-denormalized-owners.html</a> &mdash; the denormalization decision record: route-audit groups, the two-group model, nested-routes vs. columns</li>
+  <li><a href="public-api-authorization-audit.html">public-api-authorization-audit.html</a> &mdash; every public-API endpoint and the grant that allows access</li>
+  <li><code>docs/design/resource-grant-collection-filtering.md</code> (on <code>ja/resource-grants</code>) &mdash; the earlier list-filtering tier analysis; its Tier&nbsp;3 is subsumed by the denormalized columns</li>
+</ul>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
Adds nullable install_id/app_id columns to install_workflows, runner_jobs, queues, log_streams, and terraform_workspaces. Both NULL means org-tier, a defined state. Columns are populated in BeforeCreate via app.ResolveOwnerAncestry and backfilled by migration 126, batched and idempotent, one targeted update per (table, owner-type) pair.

A passive schema change: nothing reads the columns yet. The authorization enforcement and per-account grant layer that consume them live on ja/account-resource-grants, which stacks on this branch. Design docs in specs/auth.