### PR TITLE
feat: CLI + docs for access control, plus role-reconcile perf

### DIFF
--- a/bins/cli/internal/services/roles/list.go
+++ b/bins/cli/internal/services/roles/list.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/nuonco/nuon/bins/cli/internal/ui"
+	"github.com/nuonco/nuon/sdks/nuon-go/models"
 )
 
 func (s *Service) ListRoles(ctx context.Context, asJSON bool) error {
@@ -15,9 +16,18 @@ func (s *Service) ListRoles(ctx context.Context, asJSON bool) error {
 
 	view := ui.NewListView()
 
-	roles, err := s.api.ListRoles(ctx)
+	allRoles, err := s.api.ListRoles(ctx)
 	if err != nil {
 		return view.Error(err)
+	}
+
+	// Only list roles that can be assigned somewhere; held-only roles
+	// (deprecated or machine-only) carry no assignment contexts.
+	roles := make([]*models.AppRole, 0, len(allRoles))
+	for _, r := range allRoles {
+		if len(r.AppliesTo) > 0 {
+			roles = append(roles, r)
+		}
 	}
 
 	if asJSON {

--- a/docs/cli-commands.mdx
+++ b/docs/cli-commands.mdx
@@ -31,10 +31,10 @@ These work on every command.
 |---------|--------------|
 | `nuon orgs select` | Switch your active org. A new trial account has a single org that's selected automatically when you log in, so you only need this once you belong to more than one. |
 | `nuon orgs current` | Show the active org. |
-| `nuon orgs api-tokens create --name <name>` | Create a durable API token for the current org (shown once). Requires org admin. Add `--role` (`org_admin`, `org_support`, `org_read_only`; defaults to `org_read_only`) to set the token's permissions. |
+| `nuon orgs api-tokens create --name <name>` | Create a durable API token for the current org (shown once). Requires org admin. Add `--role` (defaults to `org_read_only`; run `nuon roles list` or see [Access control](/concepts/access-control)) to set the token's permissions. |
 | `nuon orgs api-tokens list` | List the current org's API tokens. |
 | `nuon orgs api-tokens delete --id <token-id>` | Revoke an API token. |
-| `nuon orgs update-user-role --user-id <id> --role <role>` | Change an org member's role (`org_admin`, `org_read_only`). Requires org admin. |
+| `nuon orgs update-user-role --user-id <id> --role <role>` | Change an org member's role (run `nuon roles list` or see [Access control](/concepts/access-control)). Requires org admin. |
 
 ## Apps & config
 

--- a/docs/concepts/access-control.mdx
+++ b/docs/concepts/access-control.mdx
@@ -1,0 +1,40 @@
+---
+title: "Access Control"
+icon: "shield-halved"
+description: "How to control what team members and service accounts can do in your Nuon org."
+keywords: ["roles", "RBAC", "access control", "permissions", "org admin", "read-only", "team", "service account", "API token", "OIDC"]
+---
+
+Every identity in your Nuon org — whether a team member or a [service account](/concepts/service-accounts) — must be assigned a **role**. The role determines what that identity can read and change in the org.
+
+Roles are org-scoped: a role assigned in one org grants no access in any other org.
+
+## Available roles
+
+| Role | Value | Grants |
+| --- | --- | --- |
+| **Admin** | `org_admin` | Full access to the org and everything in it, including team and credential management. |
+| **Read-only** | `org_read_only` | Read-only access to everything in the org; cannot make changes. |
+
+## Assigning roles
+
+The same role set applies everywhere an identity is created. You choose a role when you:
+
+- [Invite a team member](/guides/team-management) — or change an existing member's role
+- Create a [service account](/concepts/service-accounts)
+- Create an [API token](/concepts/api-tokens)
+- Create an [OIDC trust policy](/concepts/oidc-federation)
+
+[API tokens](/concepts/api-tokens) and [OIDC trust policies](/concepts/oidc-federation) are each backed by a dedicated [service account](/concepts/service-accounts) that carries the role — so a token or an exchanged token acts as that service account, with exactly the access its role grants.
+
+<Note>
+An identity holds one role at a time; assigning a new role replaces the old one.
+</Note>
+
+## Permission errors
+
+When an identity attempts something its role does not allow, Nuon returns a message describing the access the action requires and the role you currently hold — for example, "this action requires write access to installs in this organization." Ask an org admin to assign a role that grants the needed access.
+
+## Reserved roles
+
+The **Runner** role is reserved for the machine accounts Nuon provisions for your runners. It is assigned automatically and is never user-selectable.

--- a/docs/concepts/api-tokens.mdx
+++ b/docs/concepts/api-tokens.mdx
@@ -12,10 +12,10 @@ An **API token** authenticates requests to the [Nuon Control Plane API](/concept
 | Property | Description |
 | --- | --- |
 | **Name** | A human-readable label to identify the token. Required. |
-| **Role** | The permissions the token grants — `org_admin` or `org_read_only`. Defaults to `org_read_only`. |
+| **Role** | The permissions the token grants. Defaults to `org_read_only`. See [Access control](/concepts/access-control) for the available roles. |
 | **Duration** | How long the token is valid. Defaults to `8760h` (one year). |
 
-Each API token is backed by a dedicated machine identity in your org. For a named, reusable machine identity that you manage explicitly and can mint multiple tokens for, use a [service account](/concepts/service-accounts) instead.
+Each API token is backed by its own [service account](/concepts/service-accounts), which carries the token's role — the token acts as that service account when it calls the API. This service account is created and managed for you. If you want a service account you manage explicitly and can mint multiple tokens for, create one directly instead.
 
 Creating and managing API tokens requires **org admin** access.
 

--- a/docs/concepts/oidc-federation.mdx
+++ b/docs/concepts/oidc-federation.mdx
@@ -9,6 +9,8 @@ keywords: ["OIDC", "workload identity federation", "token exchange", "GitHub Act
 
 This works with **any OIDC-compatible identity**, and from any client, since the exchange is a plain API call. Unlike an [API token](/concepts/api-tokens) or a token minted for a [service account](/concepts/service-accounts), there is no credential to store, distribute, or rotate.
 
+Managing OIDC federation requires **org admin** access.
+
 ## How it works
 
 1. A workload obtains its ambient OIDC token from its platform (for example, the ID token GitHub Actions issues to a job).
@@ -26,7 +28,7 @@ The exchange endpoint requires no Nuon credentials — trust is established enti
 | **Issuer URL** | The exact `iss` of the OIDC provider to trust, e.g. `https://token.actions.githubusercontent.com`. Nuon fetches this issuer's JWKS to verify signatures. Required. |
 | **Audience** | The expected `aud` claim on the presented token. Required. |
 | **Claim conditions** | Claims the token must satisfy. A `sub` condition is required. |
-| **Role** | The permissions granted to exchanged tokens — `org_admin` or `org_read_only`. Defaults to `org_read_only`. |
+| **Role** | The permissions granted to exchanged tokens. Defaults to `org_read_only`. See [Access control](/concepts/access-control) for the available roles. |
 | **Token duration** | Lifetime of the exchanged token, in seconds. Defaults to `3600`; maximum `86400`. |
 | **Enabled** | Whether the policy accepts exchanges. |
 

--- a/docs/concepts/service-accounts.mdx
+++ b/docs/concepts/service-accounts.mdx
@@ -13,14 +13,9 @@ Managing service accounts requires **org admin** access.
 
 ## Roles
 
-Every service account is assigned exactly one role, which determines its permissions. Roles are org-scoped. There are currently two roles, with more planned soon.
+Every service account is assigned exactly one role, which determines its permissions. Roles are org-scoped. See [Access control](/concepts/access-control) for the available roles and what each grants — **Admin** (`org_admin`) and **Read-only** (`org_read_only`).
 
-| Role | Title | Description |
-| --- | --- | --- |
-| `org_admin` | Admin | Full access to the org. |
-| `org_read_only` | Read-only | Read-only access to the org. |
-
-You can list available roles using the CLI.
+You can list the available roles at any time using the CLI:
 
 ```sh
 nuon roles list

--- a/docs/dashboard.mdx
+++ b/docs/dashboard.mdx
@@ -69,6 +69,6 @@ executing the action script.
 Manage API tokens for programmatic access to the [Nuon API](./nuon-api) from **Settings → API tokens**.
 Org admins can create, list, and delete tokens here. Each token is durable, scoped to the current
 org, and shown only once at creation — copy it somewhere safe before closing the dialog. When
-creating a token you choose its role (read-only, admin, or support; defaults to read-only), which
+creating a token you choose its [role](/concepts/access-control) (defaults to read-only), which
 controls what the token can do. Deleting a token revokes it immediately.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -128,6 +128,7 @@
               "concepts/policies",
               "concepts/operation-roles",
               "concepts/triggers",
+              "concepts/access-control",
               "concepts/api-tokens",
               "concepts/service-accounts",
               "concepts/oidc-federation"

--- a/docs/guides/team-management.mdx
+++ b/docs/guides/team-management.mdx
@@ -12,11 +12,25 @@ You can add users to your Nuon Org using our CLI.
 You can invite a user by email to your Nuon Org using our cli:
 
 ```sh
-nuon orgs invite --email=user@yourdomain.com
+nuon orgs invite --email=user@yourdomain.com --role=org_read_only
 ```
+
+Pass `--role` to set what the new member can do. See [Access control](/concepts/access-control) for the available
+roles and what each grants; run `nuon roles list` to see the current set. If you omit `--role`, the member is
+invited as an admin.
 
 The invited user will get a welcome email, and when they sign into the dashboard next will automatically be added to
 your Org.
+
+## Change a member's role
+
+To change the role of an existing member, use their user ID. This requires org admin access.
+
+```sh
+nuon orgs update-user-role --user-id=<user-id> --role=org_read_only
+```
+
+A member holds one role at a time, so this replaces their current role.
 
 ## View invites
 

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -20,6 +20,10 @@ All infrastructure in a customer's account is created by the customer themselves
 
 Runners use separate IAM roles for different operations (provisioning, maintenance, deprovisioning), each scoped to the minimum permissions required. Components and actions define their own roles and policies, so the Runner never holds more access than a single job needs. See [Permissions](/config-ref/permissions) for configuration details.
 
+## Control-Plane Access Control
+
+Access within your Nuon org is governed by roles. Every identity — a team member, service account, API token, or OIDC trust policy — is assigned a single role that determines what it can read and change, and roles are scoped to a single org. See [Access control](/concepts/access-control) for the full model.
+
 ## Customer Kill Switch
 
 The customer controls the Runner through the Stack. They can disable the Runner at any time to stop it from executing jobs, and re-enable it when ready. No action from the vendor or Nuon is required.

--- a/services/ctl-api/internal/app/role.go
+++ b/services/ctl-api/internal/app/role.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/indexes"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
 )
 
@@ -79,7 +80,12 @@ func (a *Role) AllowsContext(roleContext string) bool {
 }
 
 func (a *Role) Indexes(db *gorm.DB) []migrations.Index {
-	return []migrations.Index{}
+	return []migrations.Index{
+		{
+			Name:    indexes.Name(db, &Role{}, "org_id"),
+			Columns: []string{"org_id", "role_type"},
+		},
+	}
 }
 
 func (a *Role) BeforeCreate(tx *gorm.DB) error {

--- a/services/ctl-api/internal/pkg/authz/reconcile_org_roles.go
+++ b/services/ctl-api/internal/pkg/authz/reconcile_org_roles.go
@@ -2,8 +2,8 @@ package authz
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"slices"
 
 	"gorm.io/gorm"
 
@@ -17,38 +17,72 @@ import (
 // updated to match the definition. Existing rows' policies are deliberately
 // never modified.
 func ReconcileOrgRoles(ctx context.Context, db *gorm.DB, org app.Org) error {
+	var existingRoles []app.Role
+	if err := db.WithContext(ctx).
+		Where(app.Role{OrgID: generics.NewNullString(org.ID)}).
+		Find(&existingRoles).Error; err != nil {
+		return fmt.Errorf("unable to load roles for org %s: %w", org.ID, err)
+	}
+
+	byType := make(map[app.RoleType]app.Role, len(existingRoles))
+	for _, role := range existingRoles {
+		byType[role.RoleType] = role
+	}
+
+	var toCreate []app.Role
+	var toUpdate []app.Role
 	for _, want := range standardOrgRoles(org.ID) {
-		var existing app.Role
-		err := db.WithContext(ctx).
-			Where(app.Role{OrgID: generics.NewNullString(org.ID), RoleType: want.RoleType}).
-			First(&existing).Error
-		if errors.Is(err, gorm.ErrRecordNotFound) {
+		existing, ok := byType[want.RoleType]
+		if !ok {
 			want.CreatedByID = org.CreatedByID
 			for i := range want.Policies {
 				want.Policies[i].CreatedByID = org.CreatedByID
 			}
-			if err := db.WithContext(ctx).Create(&want).Error; err != nil {
-				return fmt.Errorf("unable to create %s role for org %s: %w", want.RoleType, org.ID, err)
-			}
+			toCreate = append(toCreate, want)
 			continue
 		}
-		if err != nil {
-			return fmt.Errorf("unable to check %s role for org %s: %w", want.RoleType, org.ID, err)
+		if roleMetadataMatches(existing, want) {
+			continue
 		}
-
-		res := db.WithContext(ctx).
-			Model(&existing).
-			Select("title", "description", "contexts", "managed").
-			Updates(app.Role{
-				Title:       want.Title,
-				Description: want.Description,
-				Contexts:    want.Contexts,
-				Managed:     want.Managed,
-			})
-		if res.Error != nil {
-			return fmt.Errorf("unable to update %s role metadata for org %s: %w", want.RoleType, org.ID, res.Error)
-		}
+		existing.Title = want.Title
+		existing.Description = want.Description
+		existing.Contexts = want.Contexts
+		existing.Managed = want.Managed
+		toUpdate = append(toUpdate, existing)
 	}
 
-	return nil
+	if len(toCreate) == 0 && len(toUpdate) == 0 {
+		return nil
+	}
+
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if len(toCreate) > 0 {
+			if err := tx.Create(&toCreate).Error; err != nil {
+				return fmt.Errorf("unable to create roles for org %s: %w", org.ID, err)
+			}
+		}
+		for i := range toUpdate {
+			role := &toUpdate[i]
+			if err := tx.Model(role).
+				Select("title", "description", "contexts", "managed").
+				Updates(app.Role{
+					Title:       role.Title,
+					Description: role.Description,
+					Contexts:    role.Contexts,
+					Managed:     role.Managed,
+				}).Error; err != nil {
+				return fmt.Errorf("unable to update %s role metadata for org %s: %w", role.RoleType, org.ID, err)
+			}
+		}
+		return nil
+	})
+}
+
+// roleMetadataMatches reports whether an existing role already carries the
+// metadata a definition specifies, so reconcile can skip a no-op update.
+func roleMetadataMatches(existing, want app.Role) bool {
+	return existing.Title == want.Title &&
+		existing.Description == want.Description &&
+		existing.Managed == want.Managed &&
+		slices.Equal(existing.Contexts, want.Contexts)
 }


### PR DESCRIPTION
### Summary

Follow-ups to the roles cleanup in #2123. We decided **not** to add the domain-scoped App developer / Install manager roles, so this PR no longer touches the role catalog or authorization — it's the surrounding polish that stands on its own.

**1. `nuon roles list` shows only assignable roles**

Held-only roles carry no assignment contexts, so the CLI now filters out roles with an empty `applies_to` — dropping the deprecated `org_support`/`installer` and the machine-only `runner` from the output. Matches the command's purpose of listing roles you can assign to members and service accounts. Filtered client-side so the unfiltered `GET /v1/roles` (used by the dashboard to show titles for already-held roles) is unaffected.

**2. Access control docs**

There was no single place documenting control-plane roles, and the scattered mentions were stale/inconsistent. This adds a dedicated **Access Control** concept page (Admin, Read-only; how roles are assigned across team invites, service accounts, API tokens, and OIDC trust policies; that tokens/trust-policies are backed by a service account carrying the role) and points the concept pages, CLI reference, dashboard, and security docs at it. Also fills the team-management guide's gap (assigning a role on invite, changing a member's role).

**3. Reconcile performance**

Independent improvements to `ReconcileOrgRoles` (called at org creation and by migration 126):
- Add a `roles(org_id, role_type)` index so the reconcile `SELECT` and the runtime `GET /v1/roles` use an index scan instead of a sequential scan.
- Load an org's roles in one query, skip metadata updates that already match, batch missing-role creates, and run writes in a single transaction.

### Testing

- `authz`, `authz/permissions`, `middlewares/org`, and `migrations` packages build and pass; CLI builds.
- Docs: no stale role references; `docs.json` valid.