### PR TITLE
chore: change default `runner` AWS instance type to `t3.medium`

### DIFF
--- a/services/ctl-api/internal/app/runner_group_settings.go
+++ b/services/ctl-api/internal/app/runner_group_settings.go
@@ -20,7 +20,7 @@ import (
 
 // Default runner machine/instance types per cloud platform.
 const (
-	DefaultAWSInstanceType   = "t3a.medium"
+	DefaultAWSInstanceType   = "t3.medium"
 	DefaultGCPInstanceType   = "e2-medium"
 	DefaultAzureInstanceType = "Standard_B2s"
 )


### PR DESCRIPTION
We don't have those in certain regions.