### PR TITLE
fix: render config without html escaping

### DIFF
--- a/pkg/render/render_escaping_test.go
+++ b/pkg/render/render_escaping_test.go
@@ -1,0 +1,76 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pemPublicKey is the shape that first exposed the escaping bug: a PEM body is
+// standard base64, so it contains "+" roughly as often as any other character.
+const pemPublicKey = `-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAtC28SUqEM2D1AUBKuZyG
+kSht4TZkX6EdxMjPVO6X/ElGDeKxxBkMWEEGOOARWrcaeK13K3+mzLtIEWiX5QOQ
+SFTHTcRsDUoH1fuEodZmFGUCAwEAAQ==
+-----END PUBLIC KEY-----
+`
+
+// helmComponentConfig mirrors the shape of app.HelmComponentConfig: the values
+// files are carried as a []string of file contents tagged for templating.
+type helmComponentConfig struct {
+	ChartName   string            `features:"template"`
+	ValuesFiles []string          `features:"template"`
+	Values      map[string]string `features:"template"`
+}
+
+func escapingData() map[string]interface{} {
+	return map[string]interface{}{
+		"install": map[string]interface{}{
+			"inputs": map[string]interface{}{
+				"lovable_public_api_key": pemPublicKey,
+				"bootstrap_token":        "bst_ws-abc_dGVzdC10b2tlbg",
+				"connection":             `user=a&pass="b"<c>'d'`,
+			},
+		},
+	}
+}
+
+// A helm values file carrying a PEM through an input must survive byte for byte.
+// Through html/template the "+" became "&#43;" and the sandbox failed to parse
+// the key.
+func TestRenderStruct_HelmValuesFileKeepsPEMIntact(t *testing.T) {
+	cfg := &helmComponentConfig{
+		ChartName: "sandbox-cluster",
+		ValuesFiles: []string{
+			"sandboxAuth:\n  lovablePublicKey: |-{{ .nuon.install.inputs.lovable_public_api_key | nindent 4 }}\n",
+		},
+	}
+
+	require.NoError(t, RenderStruct(cfg, escapingData()))
+
+	assert.Contains(t, cfg.ValuesFiles[0], "eK13K3+mzLtIEWiX5QOQ")
+	assert.NotContains(t, cfg.ValuesFiles[0], "&#43;")
+}
+
+func TestRenderStruct_DoesNotEscapeStringFields(t *testing.T) {
+	cfg := &helmComponentConfig{
+		ChartName: "{{ .nuon.install.inputs.connection }}",
+	}
+
+	require.NoError(t, RenderStruct(cfg, escapingData()))
+
+	assert.Equal(t, `user=a&pass="b"<c>'d'`, cfg.ChartName)
+}
+
+func TestRenderMap_DoesNotEscapeValues(t *testing.T) {
+	vals := map[string]string{
+		"relay.bootstrapToken": "{{ .nuon.install.inputs.bootstrap_token }}",
+		"proxy.connection":     "{{ .nuon.install.inputs.connection }}",
+	}
+
+	require.NoError(t, RenderMap(&vals, escapingData()))
+
+	assert.Equal(t, "bst_ws-abc_dGVzdC10b2tlbg", vals["relay.bootstrapToken"])
+	assert.Equal(t, `user=a&pass="b"<c>'d'`, vals["proxy.connection"])
+}

--- a/pkg/render/render_map.go
+++ b/pkg/render/render_map.go
@@ -34,7 +34,7 @@ func RenderMap(obj any, data map[string]any) error {
 		switch mapValue.Kind() {
 		case reflect.String:
 			strValue := mapValue.String()
-			rendered, err := RenderV2(strValue, data)
+			rendered, err := renderStrField(strValue, data)
 			if err != nil {
 				return errors.Wrap(err, "unable to render string map value")
 			}
@@ -61,7 +61,7 @@ func RenderMap(obj any, data map[string]any) error {
 			}
 			elem := mapValue.Elem()
 			if elem.Kind() == reflect.String {
-				rendered, err := RenderV2(elem.String(), data)
+				rendered, err := renderStrField(elem.String(), data)
 				if err != nil {
 					return errors.Wrap(err, "unable to render *string map value")
 				}

--- a/pkg/render/render_struct.go
+++ b/pkg/render/render_struct.go
@@ -176,16 +176,21 @@ func walkFields(obj any, data map[string]any) error {
 	return nil
 }
 
+// Config fields walked by RenderStruct/RenderMap end up in infrastructure APIs --
+// helm values files, kubernetes manifests, terraform variables, env vars, nested
+// stack parameters -- never in a browser. They therefore render through
+// RenderTextV2: html/template escaping silently corrupts values, e.g. a PEM
+// public key inlined into a helm values file loses every "+" to "&#43;".
 func renderStrField(inputVal string, data map[string]any) (string, error) {
 	data = EnsurePrefix(data)
 
-	return RenderV2(inputVal, data)
+	return RenderTextV2(inputVal, data)
 }
 
 func renderByteField(inputVal []byte, data map[string]any) ([]byte, error) {
 	data = EnsurePrefix(data)
 
-	final, err := RenderV2(string(inputVal), data)
+	final, err := RenderTextV2(string(inputVal), data)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Config fields walked by `RenderStruct`/`RenderMap` were rendered with `html/template`, which escapes the rendered value. These fields all end up in infrastructure APIs — helm values files, kubernetes manifests, terraform variables, env vars — so escaping silently corrupts them.

Concretely: an app config that inlines a PEM public key into a helm values file from an install input loses every `+` to `&#43;`, and the consuming pod fails to parse the key. Same for any value containing `&`, `<`, `>`, `"` or `'`.

`RenderTextV2` already exists for exactly this reason (added when it bit CloudFormation nested-stack parameters). This routes the struct and map walkers through it too, so the fix covers every `features:"template"` field instead of one call site at a time.

`RenderV2` itself is unchanged.

Tests cover the PEM-through-a-helm-values-file case plus the general escaping set; all three fail on `main`.