### PR TITLE
fix: slow get list service account

### DIFF
--- a/services/ctl-api/internal/app/account_role.go
+++ b/services/ctl-api/internal/app/account_role.go
@@ -56,5 +56,13 @@ func (a *AccountRole) Indexes(db *gorm.DB) []migrations.Index {
 				"org_id",
 			},
 		},
+		{
+			Name: indexes.Name(db, &AccountRole{}, "org_id_deleted_at_account_id"),
+			Columns: []string{
+				"org_id",
+				"deleted_at",
+				"account_id",
+			},
+		},
 	}
 }

--- a/services/ctl-api/internal/app/accounts/service/service_account.go
+++ b/services/ctl-api/internal/app/accounts/service/service_account.go
@@ -110,6 +110,30 @@ func (s *service) getOrgServiceAccount(ctx context.Context, orgID, accountID str
 	return acct, nil
 }
 
+// orgServiceAccountIDs resolves the org's service accounts off the
+// account_roles org index. Joining accounts to account_roles in the list query
+// instead lets the planner walk the whole accounts table in email order to
+// satisfy the ORDER BY and LIMIT, which took tens of seconds on a cold cache.
+func (s *service) orgServiceAccountIDs(ctx context.Context, orgID string, includeRunners bool) ([]string, error) {
+	tx := s.db.WithContext(ctx).
+		Model(&app.AccountRole{}).
+		Joins("JOIN accounts ON accounts.id = account_roles.account_id AND accounts.deleted_at = 0 AND accounts.account_type = ?", app.AccountTypeService).
+		Where(app.AccountRole{OrgID: generics.NewNullString(orgID)})
+
+	if !includeRunners {
+		tx = tx.
+			Joins("JOIN roles ON roles.id = account_roles.role_id AND roles.deleted_at = 0").
+			Where("roles.role_type != ?", app.RoleTypeRunner)
+	}
+
+	accountIDs := []string{}
+	if err := tx.Distinct().Pluck("account_roles.account_id", &accountIDs).Error; err != nil {
+		return nil, fmt.Errorf("unable to list service account ids for org %s: %w", orgID, err)
+	}
+
+	return accountIDs, nil
+}
+
 // @ID						ListServiceAccounts
 // @Summary				List service accounts for the current org
 // @Description.markdown	list_service_accounts.md
@@ -136,30 +160,28 @@ func (s *service) ListServiceAccounts(ctx *gin.Context) {
 
 	includeRunners := ctx.Query("include_runners") == "true"
 
-	accounts := []app.Account{}
-	tx := s.db.WithContext(ctx).
-		Model(&app.Account{}).
-		Joins("JOIN account_roles ON account_roles.account_id = accounts.id AND account_roles.org_id = ? AND account_roles.deleted_at = 0", org.ID).
-		Where("accounts.account_type = ?", app.AccountTypeService)
-
-	if !includeRunners {
-		tx = tx.
-			Joins("JOIN roles ON roles.id = account_roles.role_id AND roles.deleted_at = 0").
-			Where("roles.role_type != ?", app.RoleTypeRunner)
+	accountIDs, err := s.orgServiceAccountIDs(ctx, org.ID, includeRunners)
+	if err != nil {
+		ctx.Error(err)
+		return
 	}
 
-	tx = tx.
-		Group("accounts.id").
-		Order("accounts.email").
-		Order("accounts.id").
-		Scopes(scopes.WithOffsetPagination).
-		Preload("Roles", "org_id = ?", org.ID).
-		Preload("Roles.Org").
-		Preload("Roles.Policies").
-		Find(&accounts)
-	if tx.Error != nil {
-		ctx.Error(fmt.Errorf("unable to list service accounts for org %s: %w", org.ID, tx.Error))
-		return
+	accounts := []app.Account{}
+	if len(accountIDs) > 0 {
+		res := s.db.WithContext(ctx).
+			Model(&app.Account{}).
+			Where("accounts.id IN ?", accountIDs).
+			Order("accounts.email").
+			Order("accounts.id").
+			Scopes(scopes.WithOffsetPagination).
+			Preload("Roles", "org_id = ?", org.ID).
+			Preload("Roles.Org").
+			Preload("Roles.Policies").
+			Find(&accounts)
+		if res.Error != nil {
+			ctx.Error(fmt.Errorf("unable to list service accounts for org %s: %w", org.ID, res.Error))
+			return
+		}
 	}
 
 	accounts, err = db.HandlePaginatedResponse(ctx, accounts)


### PR DESCRIPTION
## fix: slow GET /v1/service-accounts

`GET /v1/service-accounts` was p95 4.5s and max 43.4s in prod, tripping the
`ui.request.latency` monitor on `endpoint:/v1/service_accounts`.

The whole cost was one query. In the 43s trace, 13 of the 14 Postgres spans were
1-20ms and one `query accounts` span was 43,356ms. The same `query accounts`
resource on every other route is p95 5-43ms, so this was the query shape, not
the database.

`ORDER BY accounts.email` plus `LIMIT` let the planner walk `idx_accounts_email`
in sort order and nested-loop into `account_roles` per row, betting it would
fill the limit early. Almost no account in the table belongs to any one org, so
it walked nearly the whole table before it could stop. `GROUP BY accounts.id`
blocked the cheaper shapes. Warm cache that's ~240ms for 5 rows; cold it's tens
of seconds, which matches the "slow the first time, fine after" reports.