### PR TITLE
docs: note GitHub Action alternative to org webhook permission

### DIFF
--- a/docs/guides/byoc/requirements.mdx
+++ b/docs/guides/byoc/requirements.mdx
@@ -71,6 +71,10 @@ Organization permissions:
 | ---------- | -------------- |
 | Webhooks   | Read and write |
 
+<Note>
+The **Webhooks** permission lets Nuon register a webhook to trigger [app branch runs](/concepts/app-branches). If you do not want grant this access, you can instead trigger runs from your own CI using the [Nuon GitHub Action](/guides/github-actions).
+</Note>
+
 4. Under "Where can this GitHub App be installed?", select **Only on this account** (unless you need to access repos in other GitHub organizations).
 
 5. Click **Create GitHub App**.


### PR DESCRIPTION
## Summary

On the BYOC setup requirements page, add a note under the GitHub App **Webhooks** permission: if a customer doesn't want to grant org-wide webhook access, they can trigger [app branch runs](https://docs.nuon.co/concepts/app-branches) from their own CI using the [Nuon GitHub Action](https://docs.nuon.co/guides/github-actions) instead.