### PR TITLE
feat: surface runner job lifecycle errors

### DIFF
--- a/sdks/nuon-go/models/app_runner_job.go
+++ b/sdks/nuon-go/models/app_runner_job.go
@@ -23,6 +23,9 @@ type AppRunnerJob struct {
 	// available timeout is how long a job can be marked as "available" before being requeued
 	AvailableTimeout int64 `json:"available_timeout,omitempty"`
 
+	// composite error
+	CompositeError any `json:"composite_error,omitempty"`
+
 	// created at
 	CreatedAt string `json:"created_at,omitempty"`
 

--- a/sdks/nuon-runner-go/models/app_runner_job.go
+++ b/sdks/nuon-runner-go/models/app_runner_job.go
@@ -23,6 +23,9 @@ type AppRunnerJob struct {
 	// available timeout is how long a job can be marked as "available" before being requeued
 	AvailableTimeout int64 `json:"available_timeout,omitempty"`
 
+	// composite error
+	CompositeError any `json:"composite_error,omitempty"`
+
 	// created at
 	CreatedAt string `json:"created_at,omitempty"`
 

--- a/services/ctl-api/internal/app/installs/service/get_install_deploy.go
+++ b/services/ctl-api/internal/app/installs/service/get_install_deploy.go
@@ -6,9 +6,11 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	runnershelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
 )
@@ -106,6 +108,25 @@ func (s *service) getInstallDeploy(ctx context.Context, installID, deployID stri
 		First(&installDeploy, "install_deploys.id = ?", deployID)
 	if res.Error != nil {
 		return nil, fmt.Errorf("unable to get install deploy: %w", res.Error)
+	}
+	if len(installDeploy.RunnerJobs) > 0 {
+		compositeError, err := runnershelpers.GetLatestJobCompositeError(ctx, s.db, runnershelpers.GetLatestJobCompositeErrorRequest{
+			OwnerID:   installDeploy.ID,
+			OwnerType: "install_deploys",
+		})
+		if err != nil {
+			s.l.Warn("unable to hydrate install deploy composite error",
+				zap.String("deploy_id", installDeploy.ID),
+				zap.Error(err))
+		} else {
+			// Keep orchestration-owned errors, but derive runner-owned mirrors from
+			// the latest job so retries can replace or clear stale values.
+			runnerErrorMirrored := installDeploy.CompositeError != nil &&
+				(installDeploy.CompositeError.SourceType == "install_deploys" || installDeploy.CompositeError.SourceType == "runner_jobs")
+			if compositeError != nil || runnerErrorMirrored {
+				installDeploy.CompositeError = compositeError
+			}
+		}
 	}
 
 	return &installDeploy, nil

--- a/services/ctl-api/internal/app/installs/service/get_install_sandbox_run.go
+++ b/services/ctl-api/internal/app/installs/service/get_install_sandbox_run.go
@@ -5,9 +5,11 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	runnershelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 )
 
@@ -85,6 +87,25 @@ func (s *service) getInstallSandboxRun(ctx *gin.Context, runID string) (*app.Ins
 		First(&installSandboxRun)
 	if res.Error != nil {
 		return nil, fmt.Errorf("unable to get install sandbox run: %w", res.Error)
+	}
+	if len(installSandboxRun.RunnerJobs) > 0 {
+		compositeError, err := runnershelpers.GetLatestJobCompositeError(ctx, s.db, runnershelpers.GetLatestJobCompositeErrorRequest{
+			OwnerID:   installSandboxRun.ID,
+			OwnerType: "install_sandbox_runs",
+		})
+		if err != nil {
+			s.l.Warn("unable to hydrate install sandbox run composite error",
+				zap.String("sandbox_run_id", installSandboxRun.ID),
+				zap.Error(err))
+		} else {
+			// Keep orchestration-owned errors, but derive runner-owned mirrors from
+			// the latest job so retries can replace or clear stale values.
+			runnerErrorMirrored := installSandboxRun.CompositeError != nil &&
+				(installSandboxRun.CompositeError.SourceType == "install_sandbox_runs" || installSandboxRun.CompositeError.SourceType == "runner_jobs")
+			if compositeError != nil || runnerErrorMirrored {
+				installSandboxRun.CompositeError = compositeError
+			}
+		}
 	}
 
 	return &installSandboxRun, nil

--- a/services/ctl-api/internal/app/runner_job.go
+++ b/services/ctl-api/internal/app/runner_job.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
 	dbgenerics "github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/indexes"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/migrations"
@@ -267,9 +268,10 @@ type RunnerJob struct {
 
 	MaxExecutions int `json:"max_executions,omitzero" gorm:"not null;default null" temporaljson:"max_executions,omitzero,omitempty"`
 
-	Status            RunnerJobStatus `json:"status,omitzero" gorm:"not null;default null;index:idx_runner_jobs_query,priority:3" temporaljson:"status,omitzero,omitempty"`
-	StatusDescription string          `json:"status_description,omitzero" gorm:"not null;default null" temporaljson:"status_description,omitzero,omitempty"`
-	StatusV2          CompositeStatus `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
+	Status            RunnerJobStatus                     `json:"status,omitzero" gorm:"not null;default null;index:idx_runner_jobs_query,priority:3" temporaljson:"status,omitzero,omitempty"`
+	StatusDescription string                              `json:"status_description,omitzero" gorm:"not null;default null" temporaljson:"status_description,omitzero,omitempty"`
+	StatusV2          CompositeStatus                     `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
+	CompositeError    *compositeerrors.CompositeErrorData `json:"composite_error,omitempty" gorm:"type:jsonb" swaggertype:"object" temporaljson:"composite_error,omitzero,omitempty"`
 
 	Type      RunnerJobType          `json:"type,omitzero" gorm:"default null;not null" temporaljson:"type,omitzero,omitempty"`
 	Group     RunnerJobGroup         `json:"group,omitzero" gorm:"default:null;not null;index:idx_runner_jobs_query,priority:2" temporaljson:"group,omitzero,omitempty"`

--- a/services/ctl-api/internal/app/runners/helpers/get_latest_runner_job.go
+++ b/services/ctl-api/internal/app/runners/helpers/get_latest_runner_job.go
@@ -69,9 +69,14 @@ func GetLatestJobCompositeError(ctx context.Context, db *gorm.DB, req GetLatestJ
 		}
 		return nil, fmt.Errorf("unable to get latest runner job composite error: %w", res.Error)
 	}
-	if len(job.Executions) == 0 || job.Executions[0].Result == nil {
-		return nil, nil
+	if len(job.Executions) > 0 && job.Executions[0].Result != nil && job.Executions[0].Result.CompositeError != nil {
+		return job.Executions[0].Result.CompositeError, nil
 	}
 
-	return job.Executions[0].Result.CompositeError, nil
+	switch job.Status {
+	case app.RunnerJobStatusFailed, app.RunnerJobStatusTimedOut, app.RunnerJobStatusNotAttempted:
+		return job.CompositeError, nil
+	default:
+		return nil, nil
+	}
 }

--- a/services/ctl-api/internal/app/runners/helpers/get_latest_runner_job_test.go
+++ b/services/ctl-api/internal/app/runners/helpers/get_latest_runner_job_test.go
@@ -21,6 +21,8 @@ func TestGetLatestJobCompositeError(t *testing.T) {
 			owner_id TEXT NOT NULL,
 			owner_type TEXT NOT NULL,
 			created_at DATETIME NOT NULL,
+			status TEXT NOT NULL,
+			composite_error TEXT,
 			deleted_at INTEGER NOT NULL DEFAULT 0
 		);
 		CREATE TABLE runner_job_executions (
@@ -39,14 +41,38 @@ func TestGetLatestJobCompositeError(t *testing.T) {
 
 	now := time.Now()
 	errorJSON := `{"version":1,"type":"aws_permission_error","severity":"error","message":"missing permission","data":{}}`
+	lifecycleErrorJSON := `{"version":1,"type":"runner.job_lifecycle_failure","severity":"error","message":"runner unavailable","data":{"reason":"runner_unhealthy"}}`
 	require.NoError(t, db.Exec(`
-		INSERT INTO runner_jobs (id, owner_id, owner_type, created_at) VALUES
-			('old-job', 'owner-with-new-success', 'component_builds', ?),
-			('new-job', 'owner-with-new-success', 'component_builds', ?),
-			('error-job', 'owner-with-error', 'component_builds', ?),
-			('pending-job', 'owner-with-pending-retry', 'component_builds', ?),
-			('execution-retry-job', 'owner-with-execution-retry', 'component_builds', ?),
-			('wrong-owner-type-job', 'owner-with-error', 'install_action_workflow_runs', ?);
+		INSERT INTO runner_jobs (id, owner_id, owner_type, created_at, status, composite_error) VALUES
+			('old-job', 'owner-with-new-success', 'component_builds', ?, 'failed', ?),
+			('new-job', 'owner-with-new-success', 'component_builds', ?, 'finished', NULL),
+			('error-job', 'owner-with-error', 'component_builds', ?, 'failed', ?),
+			('pending-job', 'owner-with-pending-retry', 'component_builds', ?, 'available', ?),
+			('execution-retry-job', 'owner-with-execution-retry', 'component_builds', ?, 'failed', NULL),
+			('lifecycle-failed-job', 'owner-with-lifecycle-failure', 'component_builds', ?, 'failed', ?),
+			('lifecycle-timed-out-job', 'owner-with-lifecycle-timeout', 'component_builds', ?, 'timed-out', ?),
+			('lifecycle-not-attempted-job', 'owner-with-lifecycle-not-attempted', 'component_builds', ?, 'not-attempted', ?),
+			('finished-lifecycle-job', 'owner-with-finished-lifecycle', 'component_builds', ?, 'finished', ?),
+			('cancelled-lifecycle-job', 'owner-with-cancelled-lifecycle', 'component_builds', ?, 'cancelled', ?),
+			('old-lifecycle-retry-job', 'owner-with-new-pending-job', 'component_builds', ?, 'failed', ?),
+			('new-pending-job', 'owner-with-new-pending-job', 'component_builds', ?, 'queued', NULL),
+			('wrong-owner-type-job', 'owner-with-error', 'install_action_workflow_runs', ?, 'finished', NULL);
+	`,
+		now.Add(-2*time.Hour), lifecycleErrorJSON,
+		now.Add(-time.Hour),
+		now, lifecycleErrorJSON,
+		now, lifecycleErrorJSON,
+		now,
+		now, lifecycleErrorJSON,
+		now, lifecycleErrorJSON,
+		now, lifecycleErrorJSON,
+		now, lifecycleErrorJSON,
+		now, lifecycleErrorJSON,
+		now.Add(-time.Hour), lifecycleErrorJSON,
+		now,
+		now.Add(time.Hour),
+	).Error)
+	require.NoError(t, db.Exec(`
 		INSERT INTO runner_job_executions (id, runner_job_id, created_at) VALUES
 			('old-failed-execution', 'old-job', ?),
 			('new-success-execution', 'new-job', ?),
@@ -55,7 +81,13 @@ func TestGetLatestJobCompositeError(t *testing.T) {
 			('pending-execution', 'pending-job', ?),
 			('retry-failed-execution', 'execution-retry-job', ?),
 			('retry-success-execution', 'execution-retry-job', ?),
+			('lifecycle-timeout-execution', 'lifecycle-timed-out-job', ?),
 			('wrong-owner-type-execution', 'wrong-owner-type-job', ?);
+	`,
+		now.Add(-2*time.Hour), now.Add(-time.Hour), now.Add(-time.Hour), now, now,
+		now.Add(-time.Hour), now, now, now.Add(time.Hour),
+	).Error)
+	require.NoError(t, db.Exec(`
 		INSERT INTO runner_job_execution_results (id, runner_job_execution_id, composite_error) VALUES
 			('old-failed-result', 'old-failed-execution', ?),
 			('new-success-result', 'new-success-execution', NULL),
@@ -63,12 +95,9 @@ func TestGetLatestJobCompositeError(t *testing.T) {
 			('newer-error-result', 'newer-error-execution', ?),
 			('retry-failed-result', 'retry-failed-execution', ?),
 			('retry-success-result', 'retry-success-execution', NULL),
+			('lifecycle-timeout-result', 'lifecycle-timeout-execution', NULL),
 			('wrong-owner-type-result', 'wrong-owner-type-execution', NULL);
-	`,
-		now.Add(-2*time.Hour), now.Add(-time.Hour), now, now, now, now.Add(time.Hour),
-		now.Add(-2*time.Hour), now.Add(-time.Hour), now.Add(-time.Hour), now, now,
-		now.Add(-time.Hour), now, now.Add(time.Hour),
-		errorJSON, errorJSON, errorJSON,
+	`, errorJSON, errorJSON, errorJSON,
 	).Error)
 
 	ctx := context.Background()
@@ -85,6 +114,33 @@ func TestGetLatestJobCompositeError(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Nil(t, compositeError)
+
+	for _, ownerID := range []string{
+		"owner-with-lifecycle-failure",
+		"owner-with-lifecycle-timeout",
+		"owner-with-lifecycle-not-attempted",
+	} {
+		compositeError, err = GetLatestJobCompositeError(ctx, db, GetLatestJobCompositeErrorRequest{
+			OwnerID:   ownerID,
+			OwnerType: "component_builds",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, compositeError)
+		require.Equal(t, compositeerrors.Type("runner.job_lifecycle_failure"), compositeError.Type)
+	}
+
+	for _, ownerID := range []string{
+		"owner-with-finished-lifecycle",
+		"owner-with-cancelled-lifecycle",
+		"owner-with-new-pending-job",
+	} {
+		compositeError, err = GetLatestJobCompositeError(ctx, db, GetLatestJobCompositeErrorRequest{
+			OwnerID:   ownerID,
+			OwnerType: "component_builds",
+		})
+		require.NoError(t, err)
+		require.Nil(t, compositeError)
+	}
 
 	compositeError, err = GetLatestJobCompositeError(ctx, db, GetLatestJobCompositeErrorRequest{
 		OwnerID:   "owner-with-pending-retry",

--- a/services/ctl-api/internal/app/runners/joberrors/lifecycle_failure.go
+++ b/services/ctl-api/internal/app/runners/joberrors/lifecycle_failure.go
@@ -1,0 +1,86 @@
+package joberrors
+
+import "github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+
+const LifecycleFailureErrorType compositeerrors.Type = "runner.job_lifecycle_failure"
+
+type LifecycleFailureReason string
+
+const (
+	LifecycleFailureReasonNoActiveRunner    LifecycleFailureReason = "no_active_runner"
+	LifecycleFailureReasonQueueTimeout      LifecycleFailureReason = "queue_timeout"
+	LifecycleFailureReasonRunnerUnhealthy   LifecycleFailureReason = "runner_unhealthy"
+	LifecycleFailureReasonPickupTimeout     LifecycleFailureReason = "pickup_timeout"
+	LifecycleFailureReasonOverallTimeout    LifecycleFailureReason = "overall_timeout"
+	LifecycleFailureReasonExecutionTimeout  LifecycleFailureReason = "execution_timeout"
+	LifecycleFailureReasonAttemptsExhausted LifecycleFailureReason = "attempts_exhausted"
+	LifecycleFailureReasonResultMissing     LifecycleFailureReason = "execution_result_missing"
+)
+
+type LifecycleFailureError struct {
+	Reason LifecycleFailureReason `json:"reason"`
+}
+
+var _ compositeerrors.CompositeError = (*LifecycleFailureError)(nil)
+
+func (e *LifecycleFailureError) Error() string {
+	switch e.Reason {
+	case LifecycleFailureReasonNoActiveRunner:
+		return "No active runner was available for this job"
+	case LifecycleFailureReasonQueueTimeout:
+		return "Runner job expired in the queue"
+	case LifecycleFailureReasonRunnerUnhealthy:
+		return "Runner was unavailable while processing this job"
+	case LifecycleFailureReasonPickupTimeout:
+		return "Runner did not pick up the job in time"
+	case LifecycleFailureReasonOverallTimeout:
+		return "Runner job exceeded its overall timeout"
+	case LifecycleFailureReasonExecutionTimeout:
+		return "Runner job execution timed out"
+	case LifecycleFailureReasonAttemptsExhausted:
+		return "Runner job exhausted its execution attempts"
+	case LifecycleFailureReasonResultMissing:
+		return "Runner did not report a result for this job"
+	default:
+		return "Runner job could not be completed"
+	}
+}
+
+func (*LifecycleFailureError) Type() compositeerrors.Type {
+	return LifecycleFailureErrorType
+}
+
+func (*LifecycleFailureError) Severity() compositeerrors.Severity {
+	return compositeerrors.SeverityError
+}
+
+func (e *LifecycleFailureError) Sections() []compositeerrors.Section {
+	why, fix := e.details()
+	return []compositeerrors.Section{
+		compositeerrors.MarkdownSection("What happened", why),
+		compositeerrors.MarkdownSection("How to fix", fix),
+	}
+}
+
+func (e *LifecycleFailureError) details() (string, string) {
+	switch e.Reason {
+	case LifecycleFailureReasonNoActiveRunner:
+		return "The job could not start because its assigned runner had no active process.", "Check that the runner is online and healthy, then retry the operation."
+	case LifecycleFailureReasonQueueTimeout:
+		return "The job waited in the queue longer than its configured queue timeout.", "Check the runner's health and workload, then retry the operation."
+	case LifecycleFailureReasonRunnerUnhealthy:
+		return "The runner was not healthy long enough to start or continue the job.", "Restore the runner to a healthy state, then retry the operation."
+	case LifecycleFailureReasonPickupTimeout:
+		return "The job was made available, but the runner did not reserve it before the pickup timeout.", "Check the runner's connectivity and health, then retry the operation."
+	case LifecycleFailureReasonOverallTimeout:
+		return "The job did not complete before its overall timeout expired.", "Check the runner and the operation's progress, then retry once the underlying issue is resolved."
+	case LifecycleFailureReasonExecutionTimeout:
+		return "The runner reserved the job, but the execution did not finish before its timeout.", "Inspect the runner logs for the operation, address anything preventing completion, then retry."
+	case LifecycleFailureReasonAttemptsExhausted:
+		return "Every available execution attempt ended before the job completed.", "Check the runner's health and logs, then retry the operation."
+	case LifecycleFailureReasonResultMissing:
+		return "The execution ended, but the runner did not report its result details.", "Check the runner's health and logs, then retry the operation."
+	default:
+		return "The runner job ended before it could complete.", "Check the runner's health and logs, then retry the operation."
+	}
+}

--- a/services/ctl-api/internal/app/runners/joberrors/lifecycle_failure_test.go
+++ b/services/ctl-api/internal/app/runners/joberrors/lifecycle_failure_test.go
@@ -1,0 +1,46 @@
+package joberrors
+
+import (
+	"testing"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+func TestLifecycleFailureError(t *testing.T) {
+	reasons := []LifecycleFailureReason{
+		LifecycleFailureReasonNoActiveRunner,
+		LifecycleFailureReasonQueueTimeout,
+		LifecycleFailureReasonRunnerUnhealthy,
+		LifecycleFailureReasonPickupTimeout,
+		LifecycleFailureReasonOverallTimeout,
+		LifecycleFailureReasonExecutionTimeout,
+		LifecycleFailureReasonAttemptsExhausted,
+		LifecycleFailureReasonResultMissing,
+	}
+
+	for _, reason := range reasons {
+		t.Run(string(reason), func(t *testing.T) {
+			err := &LifecycleFailureError{Reason: reason}
+			if err.Error() == "" {
+				t.Fatal("Error() should not be empty")
+			}
+			if err.Type() != LifecycleFailureErrorType {
+				t.Fatalf("Type() = %q, want %q", err.Type(), LifecycleFailureErrorType)
+			}
+			if err.Severity() != compositeerrors.SeverityError {
+				t.Fatalf("Severity() = %q, want %q", err.Severity(), compositeerrors.SeverityError)
+			}
+			if sections := err.Sections(); len(sections) != 2 || sections[0].Body == "" || sections[1].Body == "" {
+				t.Fatalf("expected populated what-happened and how-to-fix sections, got %#v", sections)
+			}
+
+			data, newErr := compositeerrors.New(err)
+			if newErr != nil {
+				t.Fatalf("unexpected error freezing composite error: %v", newErr)
+			}
+			if data.Type != LifecycleFailureErrorType {
+				t.Fatalf("frozen type = %q, want %q", data.Type, LifecycleFailureErrorType)
+			}
+		})
+	}
+}

--- a/services/ctl-api/internal/app/runners/signals/processjob/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/processjob/signal.go
@@ -14,6 +14,7 @@ import (
 	tmetrics "github.com/nuonco/nuon/pkg/temporal/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/joberrors"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/callback"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
@@ -23,10 +24,19 @@ import (
 
 const SignalType signal.SignalType = "process_job"
 
+const lifecycleCompositeErrorVersion = "process-job-lifecycle-composite-error-v1"
+
 const (
 	minPollPeriod = time.Second
 	maxPollPeriod = 10 * time.Second
 )
+
+// Existing process_job histories did not schedule lifecycle-error activities
+// or stop retrying on cancellation. The version guard keeps their replay
+// deterministic during rollout.
+func lifecycleCompositeErrorsEnabled(ctx workflow.Context) bool {
+	return workflow.GetVersion(ctx, lifecycleCompositeErrorVersion, workflow.DefaultVersion, 1) != workflow.DefaultVersion
+}
 
 // pollPeriod backs off 1s→10s (1,2,4,8,10,...) so fast jobs are detected quickly
 // while long jobs stay cheap on workflow history.
@@ -138,8 +148,13 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 
 	// Check if runner has any active process
 	if !execData.HasActiveProcess {
+		if runnerJob.Status == app.RunnerJobStatusCancelled && lifecycleCompositeErrorsEnabled(ctx) {
+			l.Info("job was already cancelled, not attempting")
+			return nil
+		}
 		l.Warn("runner has no active process, not attempting")
 		s.updateJobStatus(ctx, s.JobID, app.RunnerJobStatusNotAttempted, "no active runner process available")
+		s.recordJobLifecycleCompositeError(ctx, s.JobID, joberrors.LifecycleFailureReasonNoActiveRunner)
 		return errors.New("runner has no active process")
 	}
 
@@ -179,27 +194,35 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	now := workflow.Now(ctx)
 	if runnerJob.CreatedAt.Add(runnerJob.QueueTimeout).Before(now) {
 		s.updateJobStatus(ctx, s.JobID, app.RunnerJobStatusNotAttempted, "queue timeout reached")
+		s.recordJobLifecycleCompositeError(ctx, s.JobID, joberrors.LifecycleFailureReasonQueueTimeout)
 		return nil
 	}
 
+	// Persist only the final retryable lifecycle failure so a later attempt
+	// cannot leave an obsolete reason on the job.
+	var lastLifecycleFailureReason joberrors.LifecycleFailureReason
 	for i := 0; i < runnerJob.MaxExecutions; i++ {
 		l.Info(fmt.Sprintf("attempting job execution %d of %d", i+1, runnerJob.MaxExecutions))
-		retry, started, err := s.startJobExecution(ctx, runnerJob)
+		retry, started, lifecycleFailureReason, err := s.startJobExecution(ctx, runnerJob)
 		if err != nil {
 			return err
 		}
+		lastLifecycleFailureReason = lifecycleFailureReason
 		if !started {
 			if !retry {
+				s.recordJobLifecycleCompositeError(ctx, s.JobID, lifecycleFailureReason)
 				return nil
 			}
 			continue
 		}
 
-		retry, err = s.monitorJobExecution(ctx, runnerJob)
+		retry, lifecycleFailureReason, err = s.monitorJobExecution(ctx, runnerJob)
 		if err != nil {
 			return err
 		}
+		lastLifecycleFailureReason = lifecycleFailureReason
 		if !retry {
+			s.recordJobLifecycleCompositeError(ctx, s.JobID, lifecycleFailureReason)
 			return nil
 		}
 	}
@@ -215,12 +238,21 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	}
 	if !finalStatus.IsTerminal() {
 		s.updateJobStatus(ctx, s.JobID, app.RunnerJobStatusFailed, "job execution attempts exhausted without completing")
+		finalStatus = app.RunnerJobStatusFailed
+		lastLifecycleFailureReason = joberrors.LifecycleFailureReasonAttemptsExhausted
+	}
+	switch finalStatus {
+	case app.RunnerJobStatusFailed, app.RunnerJobStatusTimedOut, app.RunnerJobStatusNotAttempted:
+		if lastLifecycleFailureReason == "" {
+			lastLifecycleFailureReason = joberrors.LifecycleFailureReasonResultMissing
+		}
+		s.recordJobLifecycleCompositeError(ctx, s.JobID, lastLifecycleFailureReason)
 	}
 
 	return nil
 }
 
-func (s *Signal) startJobExecution(ctx workflow.Context, job *app.RunnerJob) (bool, bool, error) {
+func (s *Signal) startJobExecution(ctx workflow.Context, job *app.RunnerJob) (bool, bool, joberrors.LifecycleFailureReason, error) {
 	startTS := workflow.Now(ctx)
 	tags := map[string]string{
 		"status":        "ok",
@@ -246,7 +278,7 @@ func (s *Signal) startJobExecution(ctx workflow.Context, job *app.RunnerJob) (bo
 
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
-		return false, false, err
+		return false, false, "", err
 	}
 
 	availableStart := workflow.Now(ctx)
@@ -269,7 +301,7 @@ func (s *Signal) startJobExecution(ctx workflow.Context, job *app.RunnerJob) (bo
 			runnerStatus, err = activities.AwaitGetRunnerStatusByID(ctx, job.RunnerID)
 			if err != nil {
 				l.Warn("unable to determine runner status", zap.Error(err))
-				return false, false, err
+				return false, false, "", err
 			}
 			if runnerStatus == app.RunnerStatusActive {
 				break
@@ -278,12 +310,12 @@ func (s *Signal) startJobExecution(ctx workflow.Context, job *app.RunnerJob) (bo
 
 			jobStatus, err := activities.AwaitGetJobStatusByID(ctx, job.ID)
 			if err != nil {
-				return false, false, nil
+				return false, false, "", nil
 			}
 			if jobStatus == app.RunnerJobStatusCancelled {
 				l.Error("job was cancelled")
 				tags["status"] = "job_cancelled"
-				return false, false, nil
+				return false, false, "", nil
 			}
 
 			now := workflow.Now(ctx)
@@ -301,7 +333,7 @@ func (s *Signal) startJobExecution(ctx workflow.Context, job *app.RunnerJob) (bo
 					AlertType:      statsd.Error,
 					AggregationKey: "runner-job-timeout-waiting-for-healthy-runner",
 				})
-				return false, false, nil
+				return false, false, joberrors.LifecycleFailureReasonRunnerUnhealthy, nil
 			}
 
 			if now.After(availableTimeout) {
@@ -318,7 +350,7 @@ func (s *Signal) startJobExecution(ctx workflow.Context, job *app.RunnerJob) (bo
 					AlertType:      statsd.Warning,
 					AggregationKey: "runner-job-timeout-waiting-for-healthy-runner",
 				})
-				return true, false, nil
+				return true, false, joberrors.LifecycleFailureReasonRunnerUnhealthy, nil
 			}
 
 			// Runner not yet healthy — wait out a poll tick before re-checking.
@@ -350,7 +382,7 @@ func (s *Signal) startJobExecution(ctx workflow.Context, job *app.RunnerJob) (bo
 				AlertType:      statsd.Error,
 				AggregationKey: "runner-job-timeout-awaiting-job-pickup",
 			})
-			return false, false, nil
+			return false, false, joberrors.LifecycleFailureReasonOverallTimeout, nil
 		}
 
 		if now.After(availableTimeout) {
@@ -368,17 +400,17 @@ func (s *Signal) startJobExecution(ctx workflow.Context, job *app.RunnerJob) (bo
 				AlertType:      statsd.Error,
 				AggregationKey: "runner-job-timeout-awaiting-job-pickup",
 			})
-			return true, false, nil
+			return true, false, joberrors.LifecycleFailureReasonPickupTimeout, nil
 		}
 
 		jobStatus, err := activities.AwaitGetJobStatusByID(ctx, job.ID)
 		if err != nil {
-			return false, false, nil
+			return false, false, "", nil
 		}
 		if jobStatus == app.RunnerJobStatusCancelled {
 			l.Error("job was cancelled")
 			tags["status"] = "job_cancelled"
-			return false, false, nil
+			return false, false, "", nil
 		}
 
 		jobExecutionResp, err := activities.AwaitGetLatestJobExecution(ctx, activities.GetLatestJobExecutionRequest{
@@ -386,13 +418,13 @@ func (s *Signal) startJobExecution(ctx workflow.Context, job *app.RunnerJob) (bo
 			AvailableAt: availableStart,
 		})
 		if err != nil {
-			return false, false, fmt.Errorf("error fetching latest job execution: %w", err)
+			return false, false, "", fmt.Errorf("error fetching latest job execution: %w", err)
 		}
 		jobExecutionFound = jobExecutionResp.Found
 	}
 
 	l.Info("job picked up by runner and is in progress")
-	return true, true, nil
+	return true, true, "", nil
 }
 
 // executionFailureDescription returns the runner-reported error from the
@@ -411,7 +443,7 @@ func executionFailureDescription(ctx workflow.Context, jobExecutionID, fallback 
 	return fallback
 }
 
-func (s *Signal) monitorJobExecution(ctx workflow.Context, job *app.RunnerJob) (bool, error) {
+func (s *Signal) monitorJobExecution(ctx workflow.Context, job *app.RunnerJob) (bool, joberrors.LifecycleFailureReason, error) {
 	startTS := workflow.Now(ctx)
 	tags := map[string]string{
 		"status":    "ok",
@@ -435,12 +467,12 @@ func (s *Signal) monitorJobExecution(ctx workflow.Context, job *app.RunnerJob) (
 
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	jobExecution, err := activities.AwaitGetCurrentJobExecutionByJobID(ctx, job.ID)
 	if err != nil {
-		return false, fmt.Errorf("error fetching latest job execution: %w", err)
+		return false, "", fmt.Errorf("error fetching latest job execution: %w", err)
 	}
 
 	// poll the job execution, until it's completed. The UpdateRunnerJobExecution
@@ -473,7 +505,7 @@ func (s *Signal) monitorJobExecution(ctx workflow.Context, job *app.RunnerJob) (
 				AlertType:      statsd.Error,
 				AggregationKey: "runner-job-timeout-while-executing",
 			})
-			return false, nil
+			return false, joberrors.LifecycleFailureReasonOverallTimeout, nil
 		}
 
 		// when the execution timeout is hit, we mark both the runner job and execution as timed out
@@ -495,17 +527,17 @@ func (s *Signal) monitorJobExecution(ctx workflow.Context, job *app.RunnerJob) (
 				AlertType:      statsd.Error,
 				AggregationKey: "runner-job-timeout-while-executing",
 			})
-			return true, nil
+			return true, joberrors.LifecycleFailureReasonExecutionTimeout, nil
 		}
 
 		// if the runner was started after this execution was created, we mark the execution as in error
 		// this is retryable
 		hb, err := activities.AwaitGetMostRecentHeartBeatRequestByRunnerID(ctx, job.RunnerID)
 		if err != nil {
-			return false, err
+			return false, "", err
 		}
 		if hb == nil {
-			return false, errors.New("no heart beats found")
+			return false, "", errors.New("no heart beats found")
 		}
 
 		// if the runner is restarted, we want to add a buffer before canceling any jobs in flight
@@ -532,13 +564,16 @@ func (s *Signal) monitorJobExecution(ctx workflow.Context, job *app.RunnerJob) (
 
 		jobStatus, err := activities.AwaitGetJobStatusByID(ctx, job.ID)
 		if err != nil {
-			return false, err
+			return false, "", err
 		}
 		if jobStatus == app.RunnerJobStatusCancelled {
 			l.Error("job was cancelled")
 			s.updateJobExecutionStatus(ctx, jobExecution.ID, app.RunnerJobExecutionStatusCancelled)
 			tags["status"] = "cancelled"
-			return true, nil
+			if lifecycleCompositeErrorsEnabled(ctx) {
+				return false, "", nil
+			}
+			return true, "", nil
 		}
 
 		// if the runner has no active process, the job execution is marked as failed.
@@ -561,14 +596,14 @@ func (s *Signal) monitorJobExecution(ctx workflow.Context, job *app.RunnerJob) (
 				AlertType:      statsd.Error,
 				AggregationKey: "runner-job-dropped",
 			})
-			return true, nil
+			return true, joberrors.LifecycleFailureReasonRunnerUnhealthy, nil
 		}
 
 		executionStatus, err := activities.AwaitGetJobExecutionStatus(ctx, activities.GetJobExecutionStatusRequest{
 			JobExecutionID: jobExecution.ID,
 		})
 		if err != nil {
-			return false, err
+			return false, "", err
 		}
 
 		switch executionStatus {
@@ -576,30 +611,49 @@ func (s *Signal) monitorJobExecution(ctx workflow.Context, job *app.RunnerJob) (
 			l.Info("job execution successfully finished")
 			s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusFinished, "finished")
 			tags["status"] = "ok"
-			return false, nil
+			return false, "", nil
 		case app.RunnerJobExecutionStatusCancelled:
 			l.Info("job cancelled")
 			tags["status"] = "execution_cancelled"
-			return true, nil
+			return true, "", nil
 		case app.RunnerJobExecutionStatusFailed:
 			l.Info("job execution failed")
 			s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusFailed, executionFailureDescription(ctx, jobExecution.ID, "failed"))
 			tags["status"] = "execution_failed"
-			return true, nil
+			return true, "", nil
 		case app.RunnerJobExecutionStatusTimedOut:
 			l.Info("job execution timed out")
 			s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusFailed, executionFailureDescription(ctx, jobExecution.ID, "execution timed out"))
 			tags["status"] = "execution_timed_out"
-			return true, nil
+			return true, "", nil
 		case app.RunnerJobExecutionStatusNotAttempted:
 			l.Info("job execution not attempted")
 			s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusFailed, executionFailureDescription(ctx, jobExecution.ID, "execution not attempted"))
 			tags["status"] = "execution_not_attempted"
-			return true, nil
+			return true, "", nil
 		default:
 			continue
 		}
 	}
+}
+
+func (s *Signal) recordJobLifecycleCompositeError(ctx workflow.Context, jobID string, reason joberrors.LifecycleFailureReason) {
+	if reason == "" || !lifecycleCompositeErrorsEnabled(ctx) {
+		return
+	}
+
+	err := activities.AwaitRecordJobLifecycleCompositeError(ctx, activities.RecordJobLifecycleCompositeErrorRequest{
+		JobID:  jobID,
+		Reason: reason,
+	})
+	if err == nil {
+		return
+	}
+
+	workflow.GetLogger(ctx).Warn("unable to record runner job lifecycle composite error",
+		zap.String("runner-job-id", jobID),
+		zap.String("reason", string(reason)),
+		zap.Error(err))
 }
 
 func (s *Signal) updateJobStatus(ctx workflow.Context, jobID string, status app.RunnerJobStatus, statusDescription string) {

--- a/services/ctl-api/internal/app/runners/signals/processjob/signal_test.go
+++ b/services/ctl-api/internal/app/runners/signals/processjob/signal_test.go
@@ -1,0 +1,68 @@
+package processjob
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/joberrors"
+	runneractivities "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/worker/activities"
+	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
+)
+
+func executeProcessJobSignal(t *testing.T, env *testsuite.TestWorkflowEnvironment) error {
+	t.Helper()
+	sig := &Signal{RunnerID: "runner-1", JobID: "job-1"}
+	env.ExecuteWorkflow(func(ctx workflow.Context) error { return sig.Execute(ctx) })
+	require.True(t, env.IsWorkflowCompleted())
+	return env.GetWorkflowError()
+}
+
+func newProcessJobTestEnvironment() *testsuite.TestWorkflowEnvironment {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
+	return env
+}
+
+func TestExecuteRecordsNoActiveRunnerCompositeError(t *testing.T) {
+	env := newProcessJobTestEnvironment()
+	env.RegisterActivityWithOptions((&runneractivities.Activities{}).RecordJobLifecycleCompositeError,
+		activity.RegisterOptions{Name: "RecordJobLifecycleCompositeError"})
+	env.OnActivity((*runneractivities.Activities).GetRunnerJobForExecution, mock.Anything, mock.Anything, mock.Anything).
+		Return(&runneractivities.GetRunnerJobForExecutionResponse{
+			Job: &app.RunnerJob{ID: "job-1", Status: app.RunnerJobStatusQueued},
+		}, nil).Once()
+	env.OnActivity((*runneractivities.Activities).UpdateJobStatus, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Once()
+	env.OnActivity((*statusactivities.Activities).UpdateRunnerJobStatusV2, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Once()
+	env.OnActivity("RecordJobLifecycleCompositeError", mock.Anything,
+		mock.MatchedBy(func(req runneractivities.RecordJobLifecycleCompositeErrorRequest) bool {
+			return req.JobID == "job-1" && req.Reason == joberrors.LifecycleFailureReasonNoActiveRunner
+		})).Return(errors.New("composite error write failed")).Once()
+
+	require.ErrorContains(t, executeProcessJobSignal(t, env), "runner has no active process")
+	env.AssertExpectations(t)
+}
+
+func TestExecuteDoesNotRecordLifecycleErrorForCancelledJob(t *testing.T) {
+	env := newProcessJobTestEnvironment()
+	env.OnActivity((*runneractivities.Activities).GetRunnerJobForExecution, mock.Anything, mock.Anything, mock.Anything).
+		Return(&runneractivities.GetRunnerJobForExecutionResponse{
+			Job: &app.RunnerJob{ID: "job-1", Status: app.RunnerJobStatusCancelled},
+		}, nil).Once()
+
+	require.NoError(t, executeProcessJobSignal(t, env))
+	env.AssertExpectations(t)
+	env.AssertNumberOfCalls(t, "UpdateJobStatus", 0)
+	env.AssertNumberOfCalls(t, "RecordJobLifecycleCompositeError", 0)
+}

--- a/services/ctl-api/internal/app/runners/worker/activities/record_job_lifecycle_composite_error.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/record_job_lifecycle_composite_error.go
@@ -1,0 +1,123 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	runnershelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/joberrors"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
+)
+
+type RecordJobLifecycleCompositeErrorRequest struct {
+	JobID  string                           `validate:"required"`
+	Reason joberrors.LifecycleFailureReason `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+// @max-retries 1
+func (a *Activities) RecordJobLifecycleCompositeError(ctx context.Context, req RecordJobLifecycleCompositeErrorRequest) error {
+	l := temporalzap.GetActivityLogger(ctx).With(
+		zap.String("job_id", req.JobID),
+		zap.String("reason", string(req.Reason)),
+	)
+
+	var job app.RunnerJob
+	res := a.db.WithContext(ctx).
+		Scopes(scopes.WithDisableViews).
+		Select("id", "owner_id", "owner_type").
+		Where(app.RunnerJob{ID: req.JobID}).
+		Take(&job)
+	if res.Error != nil {
+		return fmt.Errorf("unable to get runner job for lifecycle composite error: %w", res.Error)
+	}
+
+	if req.Reason == joberrors.LifecycleFailureReasonResultMissing {
+		var execution app.RunnerJobExecution
+		res = a.db.WithContext(ctx).
+			Select("id").
+			Where(app.RunnerJobExecution{RunnerJobID: req.JobID}).
+			Order("created_at DESC").
+			Order("id DESC").
+			Take(&execution)
+		if res.Error != nil && res.Error != gorm.ErrRecordNotFound {
+			return fmt.Errorf("unable to get latest runner job execution: %w", res.Error)
+		}
+		if res.Error == nil {
+			var result app.RunnerJobExecutionResult
+			res = a.db.WithContext(ctx).
+				Select("id").
+				Where(app.RunnerJobExecutionResult{RunnerJobExecutionID: execution.ID}).
+				Take(&result)
+			if res.Error == nil {
+				l.Info("runner job execution result exists, skipping missing-result composite error")
+				return nil
+			}
+			if res.Error != gorm.ErrRecordNotFound {
+				return fmt.Errorf("unable to check for runner job execution result: %w", res.Error)
+			}
+		}
+	}
+
+	data, err := compositeerrors.New(
+		&joberrors.LifecycleFailureError{Reason: req.Reason},
+		compositeerrors.WithSource("runner_jobs", req.JobID),
+	)
+	if err != nil {
+		return fmt.Errorf("unable to build runner job lifecycle composite error: %w", err)
+	}
+
+	res = a.db.WithContext(ctx).
+		Model(&job).
+		Select("composite_error").
+		Updates(app.RunnerJob{CompositeError: data})
+	if res.Error != nil {
+		return fmt.Errorf("unable to record runner job lifecycle composite error: %w", res.Error)
+	}
+	if res.RowsAffected < 1 {
+		return fmt.Errorf("no runner job found for id %s: %w", req.JobID, gorm.ErrRecordNotFound)
+	}
+
+	if job.OwnerType != "install_deploys" && job.OwnerType != "install_sandbox_runs" {
+		l.Info("recorded runner job lifecycle composite error")
+		return nil
+	}
+
+	ownerCompositeError, err := runnershelpers.GetLatestJobCompositeError(ctx, a.db, runnershelpers.GetLatestJobCompositeErrorRequest{
+		OwnerID:   job.OwnerID,
+		OwnerType: job.OwnerType,
+	})
+	if err != nil {
+		l.Warn("unable to resolve runner job lifecycle composite error for owner", zap.Error(err))
+		return nil
+	}
+
+	var mirrorRes *gorm.DB
+	switch job.OwnerType {
+	case "install_deploys":
+		mirrorRes = a.db.WithContext(ctx).
+			Model(&app.InstallDeploy{ID: job.OwnerID}).
+			Select("composite_error").
+			Updates(app.InstallDeploy{CompositeError: ownerCompositeError})
+	case "install_sandbox_runs":
+		mirrorRes = a.db.WithContext(ctx).
+			Model(&app.InstallSandboxRun{ID: job.OwnerID}).
+			Select("composite_error").
+			Updates(app.InstallSandboxRun{CompositeError: ownerCompositeError})
+	}
+	if mirrorRes != nil && (mirrorRes.Error != nil || mirrorRes.RowsAffected < 1) {
+		l.Warn("unable to mirror runner job lifecycle composite error to owner",
+			zap.String("owner_type", job.OwnerType),
+			zap.String("owner_id", job.OwnerID),
+			zap.Error(mirrorRes.Error))
+	}
+
+	l.Info("recorded runner job lifecycle composite error")
+	return nil
+}

--- a/services/ctl-api/internal/app/runners/worker/activities/record_job_lifecycle_composite_error_test.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/record_job_lifecycle_composite_error_test.go
@@ -1,0 +1,127 @@
+package activities
+
+import (
+	"database/sql"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/joberrors"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+func TestRecordJobLifecycleCompositeError(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		CREATE TABLE runner_jobs (
+			id TEXT PRIMARY KEY,
+			owner_id TEXT,
+			owner_type TEXT,
+			created_at DATETIME NOT NULL,
+			status TEXT NOT NULL,
+			updated_at DATETIME,
+			deleted_at INTEGER NOT NULL DEFAULT 0,
+			composite_error TEXT
+		);
+		CREATE TABLE runner_job_executions (
+			id TEXT PRIMARY KEY,
+			runner_job_id TEXT NOT NULL,
+			created_at DATETIME NOT NULL,
+			deleted_at INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE runner_job_execution_results (
+			id TEXT PRIMARY KEY,
+			runner_job_execution_id TEXT NOT NULL,
+			composite_error TEXT,
+			deleted_at INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE install_deploys (
+			id TEXT PRIMARY KEY,
+			updated_at DATETIME,
+			deleted_at INTEGER NOT NULL DEFAULT 0,
+			composite_error TEXT
+		);
+	`).Error)
+	require.NoError(t, db.Exec(`
+		INSERT INTO install_deploys (id) VALUES ('deploy-1'), ('deploy-with-result');
+		INSERT INTO runner_jobs (id, owner_id, owner_type, created_at, status) VALUES
+			('job-1', 'deploy-1', 'install_deploys', CURRENT_TIMESTAMP, 'timed-out'),
+			('job-with-owner-result', 'deploy-with-result', 'install_deploys', CURRENT_TIMESTAMP, 'failed'),
+			('job-with-result', NULL, NULL, CURRENT_TIMESTAMP, 'failed'),
+			('job-without-result', NULL, NULL, CURRENT_TIMESTAMP, 'failed');
+		INSERT INTO runner_job_executions (id, runner_job_id, created_at) VALUES
+			('execution-with-owner-result', 'job-with-owner-result', CURRENT_TIMESTAMP),
+			('execution-with-result', 'job-with-result', CURRENT_TIMESTAMP),
+			('execution-without-result', 'job-without-result', CURRENT_TIMESTAMP);
+		INSERT INTO runner_job_execution_results (id, runner_job_execution_id, composite_error) VALUES
+			('owner-result', 'execution-with-owner-result', ?),
+			('result-1', 'execution-with-result', NULL);
+	`, `{"version":1,"type":"terraform.aws_permission","severity":"error","message":"missing permission","data":{}}`).Error)
+
+	activities := &Activities{db: db}
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivity(activities.RecordJobLifecycleCompositeError)
+
+	_, err = env.ExecuteActivity(activities.RecordJobLifecycleCompositeError, RecordJobLifecycleCompositeErrorRequest{
+		JobID:  "job-1",
+		Reason: joberrors.LifecycleFailureReasonPickupTimeout,
+	})
+	require.NoError(t, err)
+
+	var raw sql.NullString
+	require.NoError(t, db.Raw(`SELECT composite_error FROM runner_jobs WHERE id = 'job-1'`).Scan(&raw).Error)
+	require.True(t, raw.Valid)
+
+	var data compositeerrors.CompositeErrorData
+	require.NoError(t, json.Unmarshal([]byte(raw.String), &data))
+	require.Equal(t, joberrors.LifecycleFailureErrorType, data.Type)
+	require.Equal(t, "runner_jobs", data.SourceType)
+	require.Equal(t, "job-1", data.SourceID)
+
+	require.NoError(t, db.Raw(`SELECT composite_error FROM install_deploys WHERE id = 'deploy-1'`).Scan(&raw).Error)
+	require.True(t, raw.Valid)
+	require.NoError(t, json.Unmarshal([]byte(raw.String), &data))
+	require.Equal(t, joberrors.LifecycleFailureErrorType, data.Type)
+
+	_, err = env.ExecuteActivity(activities.RecordJobLifecycleCompositeError, RecordJobLifecycleCompositeErrorRequest{
+		JobID:  "job-with-owner-result",
+		Reason: joberrors.LifecycleFailureReasonRunnerUnhealthy,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Raw(`SELECT composite_error FROM install_deploys WHERE id = 'deploy-with-result'`).Scan(&raw).Error)
+	require.True(t, raw.Valid)
+	require.NoError(t, json.Unmarshal([]byte(raw.String), &data))
+	require.Equal(t, compositeerrors.Type("terraform.aws_permission"), data.Type)
+
+	_, err = env.ExecuteActivity(activities.RecordJobLifecycleCompositeError, RecordJobLifecycleCompositeErrorRequest{
+		JobID:  "job-with-result",
+		Reason: joberrors.LifecycleFailureReasonResultMissing,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Raw(`SELECT composite_error FROM runner_jobs WHERE id = 'job-with-result'`).Scan(&raw).Error)
+	require.False(t, raw.Valid)
+
+	_, err = env.ExecuteActivity(activities.RecordJobLifecycleCompositeError, RecordJobLifecycleCompositeErrorRequest{
+		JobID:  "job-without-result",
+		Reason: joberrors.LifecycleFailureReasonResultMissing,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Raw(`SELECT composite_error FROM runner_jobs WHERE id = 'job-without-result'`).Scan(&raw).Error)
+	require.True(t, raw.Valid)
+	require.NoError(t, json.Unmarshal([]byte(raw.String), &data))
+	var lifecycleError joberrors.LifecycleFailureError
+	require.NoError(t, json.Unmarshal(data.Data, &lifecycleError))
+	require.Equal(t, joberrors.LifecycleFailureReasonResultMissing, lifecycleError.Reason)
+
+	_, err = env.ExecuteActivity(activities.RecordJobLifecycleCompositeError, RecordJobLifecycleCompositeErrorRequest{
+		JobID:  "missing-job",
+		Reason: joberrors.LifecycleFailureReasonQueueTimeout,
+	})
+	require.Error(t, err)
+}

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/get_step_error_hints.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/get_step_error_hints.go
@@ -50,8 +50,8 @@ func (a *Activities) GetStepErrorHints(ctx context.Context, req GetStepErrorHint
 }
 
 // stepTargetCompositeError reads the canonical composite error from the step
-// target's latest runner job execution result. A missing job, execution, or
-// result means no hint was recorded and yields nil.
+// target's latest runner job, preferring its execution result. A missing job
+// or composite error means no hint was recorded and yields nil.
 func (a *Activities) stepTargetCompositeError(ctx context.Context, step *app.WorkflowStep) (*compositeerrors.CompositeErrorData, error) {
 	if step.StepTargetID == "" {
 		return nil, nil


### PR DESCRIPTION
This PR adds new composite errors for failures that can happen in a job outside of it's own execution, like the runner being offline/unavailable etc.

- Adds typed composite errors for runner unavailability, queue/pickup timeouts, execution timeouts, exhausted attempts, and missing execution results.
- Persists lifecycle errors on runner jobs and exposes them through related deploy and sandbox-run APIs.
- Prevents missing-result errors from overwriting valid execution results and hides stale errors after successful retries.
- Adds comprehensive workflow, activity, and error-resolution tests, along with updated generated SDK models


These errors are rendered in both the Workflow Step details, as well as the Action Run details page.

<img width="1432" height="818" alt="Screenshot 2026-08-11 at 5 55 55 PM" src="https://github.com/user-attachments/assets/ffede232-1f84-4fb7-87bb-12a335792716" />

<img width="1401" height="706" alt="Screenshot 2026-08-11 at 5 30 41 PM" src="https://github.com/user-attachments/assets/7e487ca5-41f1-4bcd-9126-82319d8cc256" />
