### PR TITLE
chore: remove global f flag

### DIFF
--- a/bins/cli/cmd/extensions.go
+++ b/bins/cli/cmd/extensions.go
@@ -367,7 +367,7 @@ func (c *cli) extensionProxyCmd(ext extensions.InstalledExtension) *cobra.Comman
 		Annotations:        skipAuthAnnotation(),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// With DisableFlagParsing, Cobra skips all flag parsing
-			// including the root's persistent flags (e.g. -f ~/.stage).
+			// including the root's persistent flags (e.g. -C ~/.stage).
 			// Manually parse them so the config is loaded correctly.
 			if preArgs := argsBeforeCommand(ext.Name); len(preArgs) > 0 {
 				cmd.Root().PersistentFlags().Parse(preArgs)
@@ -377,7 +377,7 @@ func (c *cli) extensionProxyCmd(ext extensions.InstalledExtension) *cobra.Comman
 		Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
 			mgr := extensions.New(extensionsDir())
 			// When DisableFlagParsing is true, Cobra passes all unparsed
-			// args including parent persistent flags (e.g. -f ~/.stage)
+			// args including parent persistent flags (e.g. -C ~/.stage)
 			// that precede the extension name. Extract only the args that
 			// appear after the extension command name in os.Args.
 			extArgs := argsAfterCommand(ext.Name)
@@ -387,7 +387,7 @@ func (c *cli) extensionProxyCmd(ext extensions.InstalledExtension) *cobra.Comman
 }
 
 // argsBeforeCommand returns the slice of os.Args[1:] that precedes the first
-// occurrence of the given command name (i.e. parent flags like "-f ~/.stage").
+// occurrence of the given command name (i.e. parent flags like "-C ~/.stage").
 func argsBeforeCommand(name string) []string {
 	for i, arg := range os.Args[1:] {
 		if arg == name {
@@ -399,7 +399,7 @@ func argsBeforeCommand(name string) []string {
 
 // argsAfterCommand returns the slice of os.Args that follows the first
 // occurrence of the given command name. This ensures that parent flags
-// preceding the command (e.g. "-f ~/.stage") are not forwarded.
+// preceding the command (e.g. "-C ~/.stage") are not forwarded.
 func argsAfterCommand(name string) []string {
 	for i, arg := range os.Args {
 		if arg == name {

--- a/bins/cli/cmd/root.go
+++ b/bins/cli/cmd/root.go
@@ -53,9 +53,7 @@ nuon sync
 	rootCmd.PersistentFlags().StringVar(&Output, "output", "table", "output format: table, json, or agent. 'agent' is machine-friendly for LLM/agent use (non-interactive, results wrapped in a stable {ok,data,error} envelope on stdout). Can also be set with NUON_OUTPUT.")
 	rootCmd.PersistentFlags().BoolVar(&ReadOnly, "read-only", false, "block commands that modify state; safe default when driving the CLI with an agent. Can also be set with NUON_READ_ONLY=1.")
 	rootCmd.PersistentFlags().BoolVar(&Debug, "debug", false, "print per-request API timing (DNS, connect, TLS, server, transfer) to stderr")
-	rootCmd.PersistentFlags().StringVarP(&ConfigFile, "config", "f", DefaultConfigFilePath, "path to custom config file. Can also be set using the NUON_CONFIG_FILE env var.")
-	// alias so we can migrate from -f to -C
-	rootCmd.PersistentFlags().StringVarP(&ConfigFile, "config-file", "C", DefaultConfigFilePath, "path to custom config file. Can also be set using the NUON_CONFIG_FILE env var.")
+	rootCmd.PersistentFlags().StringVarP(&ConfigFile, "config", "C", DefaultConfigFilePath, "path to custom config file. Can also be set using the NUON_CONFIG_FILE env var.")
 
 	rootCmd.AddGroup(
 		&CoreGroup,

--- a/docs/cli-commands.mdx
+++ b/docs/cli-commands.mdx
@@ -7,6 +7,17 @@ keywords: ["nuon cli commands", "nuon auth login", "nuon orgs select", "nuon org
 
 The commands you'll use most. Run `nuon --help` (or `nuon <command> --help`) for the full set.
 
+## Global flags
+
+These work on every command.
+
+| Flag | What it does |
+|------|--------------|
+| `--config <path>`, `-C <path>` | Use a custom config file instead of `~/.nuon`. Can also be set with the `NUON_CONFIG_FILE` env var. |
+| `--output <format>` | Output format: `table` (default), `json`, or `agent`. Can also be set with `NUON_OUTPUT`. |
+| `--read-only` | Block any command that modifies state. Can also be set with `NUON_READ_ONLY=1`. |
+| `--debug` | Print per-request API timing to stderr. |
+
 ## Authenticate
 
 | Command | What it does |

--- a/docs/guides/cli-extensions.mdx
+++ b/docs/guides/cli-extensions.mdx
@@ -175,7 +175,7 @@ cases, you can run extensions directly as top-level commands (e.g. `nuon policie
 When the CLI starts, it scans the extensions directory and registers each installed extension as a top-level command.
 This means `nuon policies` works the same as `nuon ext exec policies`.
 
-When using top-level extension commands, Nuon root flags (for example `-f` / `--config`) are handled by the CLI, and
+When using top-level extension commands, Nuon root flags (for example `--config` / `-C`) are handled by the CLI, and
 only arguments after the extension command are forwarded to the extension process.
 
 ### Environment variables


### PR DESCRIPTION
## Why

`nuon --help` advertised two flags that did the exact same thing:

    -f --config       Path to custom config file. Can also be set using the NUON_CONFIG_FILE env var. (~/.nuon)
    -C --config-file  Path to custom config file. Can also be set using the NUON_CONFIG_FILE env var. (~/.nuon)

Both were bound to the same variable. The `--config-file`/`-C` pair was added in #9948 as a migration alias so we
could free `-f` up for other uses, but the migration was never finished, so both shipped side by side for a year.

## What

One flag now: `-C --config`.

    -C --config  Path to custom config file. Can also be set using the NUON_CONFIG_FILE env var. (~/.nuon)

- `bins/cli/cmd/root.go`: removed the `-f --config` and `-C --config-file` registrations, replaced with a single
  `-C --config`.
- `bins/cli/cmd/extensions.go`: the four flag-forwarding comments referencing `-f ~/.stage` now say `-C ~/.stage`.
- `docs/guides/cli-extensions.mdx`: "root flags (for example `-f` / `--config`)" is now "`--config` / `-C`".
- `docs/cli-commands.mdx`: added a **Global flags** section. The config flag had no public documentation at all, so
  this covers `--config`/`-C`, `--output`, `--read-only`, and `--debug` in one table.