### PR TITLE
feat: surface action preparation composite errors

### DIFF
--- a/services/ctl-api/internal/app/actions/actionerrors/preparation_failed.go
+++ b/services/ctl-api/internal/app/actions/actionerrors/preparation_failed.go
@@ -1,0 +1,33 @@
+package actionerrors
+
+import "github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+
+const PreparationFailedErrorType compositeerrors.Type = "action.preparation_failed"
+
+type PreparationFailedError struct {
+	Detail string `json:"detail"`
+}
+
+var _ compositeerrors.CompositeError = (*PreparationFailedError)(nil)
+
+func (*PreparationFailedError) Error() string {
+	return "Unable to prepare action run"
+}
+
+func (*PreparationFailedError) Type() compositeerrors.Type {
+	return PreparationFailedErrorType
+}
+
+func (*PreparationFailedError) Severity() compositeerrors.Severity {
+	return compositeerrors.SeverityError
+}
+
+func (e *PreparationFailedError) Sections() []compositeerrors.Section {
+	sections := []compositeerrors.Section{
+		compositeerrors.MarkdownSection("What happened", "The action failed before it could be sent to the runner."),
+	}
+	if e.Detail != "" {
+		sections = append(sections, compositeerrors.CodeSection("Error details", e.Detail))
+	}
+	return append(sections, compositeerrors.MarkdownSection("How to fix", "Resolve the reported install or action configuration issue, then retry the action."))
+}

--- a/services/ctl-api/internal/app/actions/actionerrors/preparation_failed_test.go
+++ b/services/ctl-api/internal/app/actions/actionerrors/preparation_failed_test.go
@@ -1,0 +1,23 @@
+package actionerrors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+func TestPreparationFailedError(t *testing.T) {
+	err := &PreparationFailedError{Detail: "stack outputs must have either AWS, Azure, or GCP outputs"}
+
+	data, freezeErr := compositeerrors.New(err)
+	require.NoError(t, freezeErr)
+	assert.Equal(t, PreparationFailedErrorType, data.Type)
+	assert.Equal(t, compositeerrors.SeverityError, data.Severity)
+	assert.Equal(t, "Unable to prepare action run", data.Message)
+	require.Len(t, data.Sections, 3)
+	assert.Equal(t, compositeerrors.SectionCode, data.Sections[1].Kind)
+	assert.Equal(t, err.Detail, data.Sections[1].Body)
+}

--- a/services/ctl-api/internal/app/actions/service/get_install_action_workflow_run.go
+++ b/services/ctl-api/internal/app/actions/service/get_install_action_workflow_run.go
@@ -84,6 +84,19 @@ func (s *service) findInstallActionWorkflowRun(ctx context.Context, runID string
 	if res.Error != nil {
 		return nil, fmt.Errorf("unable to get install action workflow runs: %w", res.Error)
 	}
+
+	switch run.Status {
+	case app.InstallActionRunStatusError:
+		if run.CompositeError != nil {
+			return run, nil
+		}
+	case app.InstallActionRunStatusCancelled, app.InstallActionRunStatusTimedOut:
+		run.CompositeError = nil
+	default:
+		run.CompositeError = nil
+		return run, nil
+	}
+
 	run.CompositeError, err = runnershelpers.GetLatestJobCompositeError(ctx, s.db, runnershelpers.GetLatestJobCompositeErrorRequest{
 		OwnerID:   run.ID,
 		OwnerType: "install_action_workflow_runs",

--- a/services/ctl-api/internal/app/actions/service/get_install_action_workflow_run_test.go
+++ b/services/ctl-api/internal/app/actions/service/get_install_action_workflow_run_test.go
@@ -27,6 +27,7 @@ import (
 	actionshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/actions/helpers"
 	comphelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
 	installhelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/joberrors"
 	vcshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/vcs/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
@@ -294,6 +295,126 @@ func (s *GetInstallActionWorkflowRunTestSuite) TestGetInstallActionRunIncludesLa
 		CompositeError:       expected,
 	}
 	require.NoError(s.T(), s.service.DB.WithContext(s.ctx).Create(result).Error)
+
+	path := fmt.Sprintf("/v1/installs/%s/actions/runs/%s", install.ID, run.ID)
+	rr := s.makeRequest(http.MethodGet, path, nil)
+	require.Equal(s.T(), http.StatusOK, rr.Code, rr.Body.String())
+
+	var response app.InstallActionWorkflowRun
+	require.NoError(s.T(), json.Unmarshal(rr.Body.Bytes(), &response))
+	assert.Equal(s.T(), expected, response.CompositeError)
+}
+
+func (s *GetInstallActionWorkflowRunTestSuite) TestGetInstallActionRunIncludesPreparationCompositeErrorWithoutRunnerJob() {
+	install := s.createInstall(s.testApp.ID)
+	action := s.createActionWorkflow(s.testApp.ID, "test-action-with-preparation-error")
+	installAction := s.createInstallActionWorkflow(install.ID, action.ID)
+	run := s.createInstallActionWorkflowRun(install.ID, installAction.ID, app.InstallActionRunStatusError)
+	expected := &compositeerrors.CompositeErrorData{
+		Version:  compositeerrors.SchemaVersion,
+		Type:     "action.preparation_failed",
+		Severity: compositeerrors.SeverityError,
+		Message:  "Unable to prepare action run",
+	}
+	require.NoError(s.T(), s.service.DB.WithContext(s.ctx).
+		Model(&app.InstallActionWorkflowRun{ID: run.ID}).
+		Select("composite_error").
+		Updates(app.InstallActionWorkflowRun{CompositeError: expected}).Error)
+
+	path := fmt.Sprintf("/v1/installs/%s/actions/runs/%s", install.ID, run.ID)
+	rr := s.makeRequest(http.MethodGet, path, nil)
+	require.Equal(s.T(), http.StatusOK, rr.Code, rr.Body.String())
+
+	var response app.InstallActionWorkflowRun
+	require.NoError(s.T(), json.Unmarshal(rr.Body.Bytes(), &response))
+	assert.Equal(s.T(), expected, response.CompositeError)
+}
+
+func (s *GetInstallActionWorkflowRunTestSuite) TestGetInstallActionRunPrefersPreparationCompositeError() {
+	install := s.createInstall(s.testApp.ID)
+	action := s.createActionWorkflow(s.testApp.ID, "test-action-with-retried-preparation-error")
+	installAction := s.createInstallActionWorkflow(install.ID, action.ID)
+	run := s.createInstallActionWorkflowRun(install.ID, installAction.ID, app.InstallActionRunStatusError)
+	job := s.service.Seeder.CreateRunnerJob(s.ctx, s.T(), run.ID, "install_action_workflow_runs")
+	runnerError := &compositeerrors.CompositeErrorData{
+		Version:  compositeerrors.SchemaVersion,
+		Type:     joberrors.CancellationErrorType,
+		Severity: compositeerrors.SeverityError,
+		Message:  "Runner job cancelled",
+	}
+	require.NoError(s.T(), s.service.DB.WithContext(s.ctx).
+		Model(&app.RunnerJob{ID: job.ID}).
+		Select("status", "composite_error").
+		Updates(app.RunnerJob{Status: app.RunnerJobStatusCancelled, CompositeError: runnerError}).Error)
+
+	expected := &compositeerrors.CompositeErrorData{
+		Version:  compositeerrors.SchemaVersion,
+		Type:     "action.preparation_failed",
+		Severity: compositeerrors.SeverityError,
+		Message:  "Unable to prepare action run",
+	}
+	require.NoError(s.T(), s.service.DB.WithContext(s.ctx).
+		Model(&app.InstallActionWorkflowRun{ID: run.ID}).
+		Select("composite_error").
+		Updates(app.InstallActionWorkflowRun{CompositeError: expected}).Error)
+
+	path := fmt.Sprintf("/v1/installs/%s/actions/runs/%s", install.ID, run.ID)
+	rr := s.makeRequest(http.MethodGet, path, nil)
+	require.Equal(s.T(), http.StatusOK, rr.Code, rr.Body.String())
+
+	var response app.InstallActionWorkflowRun
+	require.NoError(s.T(), json.Unmarshal(rr.Body.Bytes(), &response))
+	assert.Equal(s.T(), expected, response.CompositeError)
+}
+
+func (s *GetInstallActionWorkflowRunTestSuite) TestGetInstallActionRunSuppressesStalePreparationCompositeError() {
+	for _, status := range []app.InstallActionWorkflowRunStatus{
+		app.InstallActionRunStatusInProgress,
+		app.InstallActionRunStatusFinished,
+		app.InstallActionRunStatusRetried,
+	} {
+		s.Run(string(status), func() {
+			install := s.createInstall(s.testApp.ID)
+			action := s.createActionWorkflow(s.testApp.ID, "test-action-with-stale-preparation-error-"+string(status))
+			installAction := s.createInstallActionWorkflow(install.ID, action.ID)
+			run := s.createInstallActionWorkflowRun(install.ID, installAction.ID, status)
+			require.NoError(s.T(), s.service.DB.WithContext(s.ctx).
+				Model(&app.InstallActionWorkflowRun{ID: run.ID}).
+				Select("composite_error").
+				Updates(app.InstallActionWorkflowRun{CompositeError: &compositeerrors.CompositeErrorData{
+					Version:  compositeerrors.SchemaVersion,
+					Type:     "action.preparation_failed",
+					Severity: compositeerrors.SeverityError,
+					Message:  "Unable to prepare action run",
+				}}).Error)
+
+			path := fmt.Sprintf("/v1/installs/%s/actions/runs/%s", install.ID, run.ID)
+			rr := s.makeRequest(http.MethodGet, path, nil)
+			require.Equal(s.T(), http.StatusOK, rr.Code, rr.Body.String())
+
+			var response app.InstallActionWorkflowRun
+			require.NoError(s.T(), json.Unmarshal(rr.Body.Bytes(), &response))
+			assert.Nil(s.T(), response.CompositeError)
+		})
+	}
+}
+
+func (s *GetInstallActionWorkflowRunTestSuite) TestGetInstallActionRunPreservesCancellationCompositeError() {
+	install := s.createInstall(s.testApp.ID)
+	action := s.createActionWorkflow(s.testApp.ID, "test-cancelled-action")
+	installAction := s.createInstallActionWorkflow(install.ID, action.ID)
+	run := s.createInstallActionWorkflowRun(install.ID, installAction.ID, app.InstallActionRunStatusCancelled)
+	job := s.service.Seeder.CreateRunnerJob(s.ctx, s.T(), run.ID, "install_action_workflow_runs")
+	expected := &compositeerrors.CompositeErrorData{
+		Version:  compositeerrors.SchemaVersion,
+		Type:     joberrors.CancellationErrorType,
+		Severity: compositeerrors.SeverityError,
+		Message:  "Runner job cancelled",
+	}
+	require.NoError(s.T(), s.service.DB.WithContext(s.ctx).
+		Model(&app.RunnerJob{ID: job.ID}).
+		Select("status", "composite_error").
+		Updates(app.RunnerJob{Status: app.RunnerJobStatusCancelled, CompositeError: expected}).Error)
 
 	path := fmt.Sprintf("/v1/installs/%s/actions/runs/%s", install.ID, run.ID)
 	rr := s.makeRequest(http.MethodGet, path, nil)

--- a/services/ctl-api/internal/app/actions/service/get_install_action_workflow_runs.go
+++ b/services/ctl-api/internal/app/actions/service/get_install_action_workflow_runs.go
@@ -95,6 +95,11 @@ func (s *service) findInstallActionWorkflowRuns(ctx *gin.Context, orgID, install
 	if res.Error != nil {
 		return nil, fmt.Errorf("unable to get install action workflow runs: %w", res.Error)
 	}
+	for _, run := range runs {
+		if run.Status != app.InstallActionRunStatusError {
+			run.CompositeError = nil
+		}
+	}
 
 	runs, err := db.HandlePaginatedResponse(ctx, runs)
 	if err != nil {

--- a/services/ctl-api/internal/app/actions/service/get_install_action_workflow_runs_test.go
+++ b/services/ctl-api/internal/app/actions/service/get_install_action_workflow_runs_test.go
@@ -29,6 +29,7 @@ import (
 	installhelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	vcshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/vcs/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
 	"github.com/nuonco/nuon/services/ctl-api/tests"
 	"github.com/nuonco/nuon/services/ctl-api/tests/testseed"
 )
@@ -301,4 +302,29 @@ func (s *GetInstallActionWorkflowRunsTestSuite) TestGetInstallActionRuns() {
 			}
 		})
 	}
+}
+
+func (s *GetInstallActionWorkflowRunsTestSuite) TestGetInstallActionRunsSuppressesStalePreparationCompositeError() {
+	install := s.createInstall(s.testApp.ID)
+	action := s.createActionWorkflow(s.testApp.ID, "test-action-list-with-stale-error")
+	installAction := s.createInstallActionWorkflow(install.ID, action.ID)
+	run := s.createInstallActionWorkflowRun(install.ID, installAction.ID, app.InstallActionRunStatusFinished)
+	require.NoError(s.T(), s.service.DB.WithContext(s.ctx).
+		Model(&app.InstallActionWorkflowRun{ID: run.ID}).
+		Select("composite_error").
+		Updates(app.InstallActionWorkflowRun{CompositeError: &compositeerrors.CompositeErrorData{
+			Version:  compositeerrors.SchemaVersion,
+			Type:     "action.preparation_failed",
+			Severity: compositeerrors.SeverityError,
+			Message:  "Unable to prepare action run",
+		}}).Error)
+
+	path := fmt.Sprintf("/v1/installs/%s/actions/runs", install.ID)
+	rr := s.makeRequest(http.MethodGet, path, nil)
+	require.Equal(s.T(), http.StatusOK, rr.Code, rr.Body.String())
+
+	var response []*app.InstallActionWorkflowRun
+	require.NoError(s.T(), json.Unmarshal(rr.Body.Bytes(), &response))
+	require.Len(s.T(), response, 1)
+	assert.Nil(s.T(), response[0].CompositeError)
 }

--- a/services/ctl-api/internal/app/install_action_workflow_run.go
+++ b/services/ctl-api/internal/app/install_action_workflow_run.go
@@ -66,7 +66,7 @@ type InstallActionWorkflowRun struct {
 	Status            InstallActionWorkflowRunStatus      `json:"status,omitzero" gorm:"notnull" swaggertype:"string" temporaljson:"status,omitzero,omitempty"`
 	StatusDescription string                              `json:"status_description,omitzero" gorm:"notnull" temporaljson:"status_description,omitzero,omitempty"`
 	StatusV2          CompositeStatus                     `json:"status_v2,omitzero" gorm:"type:jsonb" temporaljson:"status_v2,omitzero,omitempty"`
-	CompositeError    *compositeerrors.CompositeErrorData `json:"composite_error,omitempty" gorm:"-" swaggertype:"object" temporaljson:"-"`
+	CompositeError    *compositeerrors.CompositeErrorData `json:"composite_error,omitempty" gorm:"type:jsonb" swaggertype:"object" temporaljson:"composite_error,omitzero,omitempty"`
 
 	TriggerType ActionWorkflowTriggerType `json:"trigger_type,omitzero" gorm:"notnull;default:''" temporaljson:"trigger_type,omitzero,omitempty"`
 

--- a/services/ctl-api/internal/app/installs/signals/actionworkflowrun/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/actionworkflowrun/signal.go
@@ -26,6 +26,7 @@ import (
 
 const SignalType signal.SignalType = "install-action-workflow-run"
 const runbookEventOutputsVersion = "runbook-event-outputs-v1"
+const preparationCompositeErrorVersion = "action-preparation-composite-error-v1"
 
 type Signal struct {
 	signal.LifecycleBase
@@ -251,6 +252,14 @@ func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, installID string
 	if err != nil {
 		return errors.Wrap(err, "unable to get action workflow run")
 	}
+	preparationCompositeErrorsEnabled := workflow.GetVersion(ctx, preparationCompositeErrorVersion, workflow.DefaultVersion, 1) != workflow.DefaultVersion
+	if preparationCompositeErrorsEnabled {
+		if err := activities.AwaitSetActionWorkflowRunPreparationCompositeError(ctx, activities.SetActionWorkflowRunPreparationCompositeErrorRequest{
+			RunID: run.ID,
+		}); err != nil {
+			l.Warn("unable to clear action workflow run preparation composite error", zap.Error(err))
+		}
+	}
 
 	parentLS, _ := cctx.GetLogStreamWorkflow(ctx)
 
@@ -292,6 +301,9 @@ func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, installID string
 		WorkflowID: fmt.Sprintf("%s-create-plan", workflow.GetInfo(ctx).WorkflowExecution.ID),
 	})
 	if err != nil {
+		if preparationCompositeErrorsEnabled {
+			s.recordPreparationCompositeError(ctx, run.ID, err)
+		}
 		s.updateActionRunStatus(ctx, run.ID, app.InstallActionRunStatusError, "unable to create plan")
 		return errors.Wrap(err, "unable to create plan")
 	}
@@ -310,6 +322,9 @@ func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, installID string
 		},
 	})
 	if err != nil {
+		if preparationCompositeErrorsEnabled {
+			s.recordPreparationCompositeError(ctx, run.ID, err)
+		}
 		s.updateActionRunStatus(ctx, run.ID, app.InstallActionRunStatusError, "unable to create job")
 		return errors.Wrap(err, "unable to create runner job")
 	}
@@ -318,6 +333,9 @@ func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, installID string
 	// save runner job plan
 	planJSON, err := json.Marshal(planResponse.Plan)
 	if err != nil {
+		if preparationCompositeErrorsEnabled {
+			s.recordPreparationCompositeError(ctx, run.ID, err)
+		}
 		s.updateActionRunStatus(ctx, run.ID, app.InstallActionRunStatusError, "unable to create job")
 		return errors.Wrap(err, "unable to convert plan to json")
 	}
@@ -327,6 +345,9 @@ func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, installID string
 		PlanJSON:      string(planJSON),
 		CompositePlan: plantypes.CompositePlan{ActionWorkflowRunPlan: planResponse.Plan},
 	}); err != nil {
+		if preparationCompositeErrorsEnabled {
+			s.recordPreparationCompositeError(ctx, run.ID, err)
+		}
 		s.updateActionRunStatus(ctx, run.ID, app.InstallActionRunStatusError, "unable to save job plan")
 		return errors.Wrap(err, "unable to save runner job plan")
 	}
@@ -336,6 +357,9 @@ func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, installID string
 		RunnerJobID:   runnerJob.ID,
 		RoleSelection: planResponse.RoleSelection,
 	}); err != nil {
+		if preparationCompositeErrorsEnabled {
+			s.recordPreparationCompositeError(ctx, run.ID, err)
+		}
 		s.updateActionRunStatus(ctx, run.ID, app.InstallActionRunStatusError, "unable to record install role usage")
 		return errors.Wrap(err, "unable to record install role usage")
 	}
@@ -376,6 +400,15 @@ func (s *Signal) executeActionWorkflowRun(ctx workflow.Context, installID string
 	}
 
 	return nil
+}
+
+func (s *Signal) recordPreparationCompositeError(ctx workflow.Context, runID string, runErr error) {
+	if err := activities.AwaitSetActionWorkflowRunPreparationCompositeError(ctx, activities.SetActionWorkflowRunPreparationCompositeErrorRequest{
+		RunID:  runID,
+		Detail: signal.HumanError(runErr),
+	}); err != nil {
+		workflow.GetLogger(ctx).Warn("unable to record action workflow run preparation composite error", zap.Error(err))
+	}
 }
 
 func (s *Signal) updateActionRunStatus(ctx workflow.Context, runID string, status app.InstallActionWorkflowRunStatus, msg string) {

--- a/services/ctl-api/internal/app/installs/worker/activities/set_action_workflow_run_preparation_composite_error.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/set_action_workflow_run_preparation_composite_error.go
@@ -1,0 +1,51 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/actions/actionerrors"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+type SetActionWorkflowRunPreparationCompositeErrorRequest struct {
+	RunID  string `validate:"required"`
+	Detail string
+}
+
+// @temporal-gen-v2 activity
+// @max-retries 3
+func (a *Activities) SetActionWorkflowRunPreparationCompositeError(ctx context.Context, req SetActionWorkflowRunPreparationCompositeErrorRequest) error {
+	l := temporalzap.GetActivityLogger(ctx).With(zap.String("action_workflow_run_id", req.RunID))
+
+	var data *compositeerrors.CompositeErrorData
+	if req.Detail != "" {
+		var err error
+		data, err = compositeerrors.New(
+			&actionerrors.PreparationFailedError{Detail: req.Detail},
+			compositeerrors.WithSource("install_action_workflow_runs", req.RunID),
+		)
+		if err != nil {
+			return fmt.Errorf("unable to build action workflow run preparation composite error: %w", err)
+		}
+	}
+
+	res := a.db.WithContext(ctx).
+		Model(&app.InstallActionWorkflowRun{ID: req.RunID}).
+		Select("composite_error").
+		Updates(app.InstallActionWorkflowRun{CompositeError: data})
+	if res.Error != nil {
+		return fmt.Errorf("unable to set action workflow run preparation composite error: %w", res.Error)
+	}
+	if res.RowsAffected < 1 {
+		return fmt.Errorf("no action workflow run found for id %s: %w", req.RunID, gorm.ErrRecordNotFound)
+	}
+
+	l.Info("updated action workflow run preparation composite error")
+	return nil
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/set_action_workflow_run_preparation_composite_error_test.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/set_action_workflow_run_preparation_composite_error_test.go
@@ -1,0 +1,62 @@
+package activities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/actions/actionerrors"
+)
+
+func TestSetActionWorkflowRunPreparationCompositeError(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		CREATE TABLE install_action_workflow_runs (
+			id TEXT PRIMARY KEY,
+			updated_at DATETIME,
+			deleted_at INTEGER NOT NULL DEFAULT 0,
+			composite_error TEXT
+		);
+		INSERT INTO install_action_workflow_runs (id) VALUES ('run-1');
+	`).Error)
+
+	activities := &Activities{db: db}
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivity(activities.SetActionWorkflowRunPreparationCompositeError)
+
+	_, err = env.ExecuteActivity(activities.SetActionWorkflowRunPreparationCompositeError, SetActionWorkflowRunPreparationCompositeErrorRequest{
+		RunID:  "run-1",
+		Detail: "api_token=secret-value could not be resolved",
+	})
+	require.NoError(t, err)
+
+	var run app.InstallActionWorkflowRun
+	require.NoError(t, db.Where(app.InstallActionWorkflowRun{ID: "run-1"}).First(&run).Error)
+	require.NotNil(t, run.CompositeError)
+	require.Equal(t, actionerrors.PreparationFailedErrorType, run.CompositeError.Type)
+	require.Equal(t, "install_action_workflow_runs", run.CompositeError.SourceType)
+	require.Equal(t, "run-1", run.CompositeError.SourceID)
+	require.Contains(t, run.CompositeError.Sections[1].Body, "api_token=[REDACTED]")
+	require.NotContains(t, run.CompositeError.Sections[1].Body, "secret-value")
+
+	_, err = env.ExecuteActivity(activities.SetActionWorkflowRunPreparationCompositeError, SetActionWorkflowRunPreparationCompositeErrorRequest{
+		RunID: "run-1",
+	})
+	require.NoError(t, err)
+
+	run = app.InstallActionWorkflowRun{}
+	require.NoError(t, db.Where(app.InstallActionWorkflowRun{ID: "run-1"}).First(&run).Error)
+	require.Nil(t, run.CompositeError)
+
+	_, err = env.ExecuteActivity(activities.SetActionWorkflowRunPreparationCompositeError, SetActionWorkflowRunPreparationCompositeErrorRequest{
+		RunID:  "missing-run",
+		Detail: "preparation failed",
+	})
+	require.ErrorContains(t, err, gorm.ErrRecordNotFound.Error())
+}


### PR DESCRIPTION
Surfaces rich composite errors when an action run fails during preparation, before its job is dispatched to the runner.

- Adds the `action.preparation_failed` composite error with redacted diagnostic details and remediation guidance.
- Persists preparation errors on action runs and clears stale errors when a new attempt begins.
- Prefers current preparation errors over errors from previous runner jobs while preserving valid cancellation and timeout errors.
- Suppresses stale composite errors for in-progress, retried, and successful action runs.
- Adds coverage for persistence, clearing, redaction, precedence, missing runner jobs, retries, and cancellation behavior.

<img width="1299" height="853" alt="Screenshot 2026-08-11 at 9 18 58 PM" src="https://github.com/user-attachments/assets/70449ce3-fc0b-4382-a7b2-b63a461666e9" />


