### PR TITLE
chore(ctl-api): use defaults from runner asg nested stack, if present

### DIFF
--- a/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
@@ -256,16 +256,17 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	tmplByts := []byte{}
 	checksum := ""
 	inp := &stacks.TemplateInput{
-		Install:                    install,
-		CloudFormationStackVersion: stackVersion,
-		InstallState:               installState,
-		AppCfg:                     cfg,
-		Runner:                     runner,
-		Settings:                   &runner.RunnerGroup.Settings,
-		APIToken:                   generics.FromPtrStr(token),
-		RunnerEnvVars:              stacks.FormatRunnerEnvVars(&cfg.RunnerConfig, s.cfg.RunnerContainerImageTag),
-		PhoneHomeSecretARN:         phoneHome.SecretARN,
-		PhoneHomeSecretRegion:      phoneHome.SecretRegion,
+		Install:                      install,
+		CloudFormationStackVersion:   stackVersion,
+		InstallState:                 installState,
+		AppCfg:                       cfg,
+		Runner:                       runner,
+		Settings:                     &runner.RunnerGroup.Settings,
+		APIToken:                     generics.FromPtrStr(token),
+		ConfiguredRunnerInstanceType: cfg.RunnerConfig.InstanceType,
+		RunnerEnvVars:                stacks.FormatRunnerEnvVars(&cfg.RunnerConfig, s.cfg.RunnerContainerImageTag),
+		PhoneHomeSecretARN:           phoneHome.SecretARN,
+		PhoneHomeSecretRegion:        phoneHome.SecretRegion,
 	}
 
 	switch cfg.RunnerConfig.Type {

--- a/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
+++ b/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
@@ -213,16 +213,17 @@ func (w *Workflows) GenerateInstallStackVersion(ctx workflow.Context, sreq Gener
 	tmplByts := []byte{}
 	checksum := ""
 	inp := &stacks.TemplateInput{
-		Install:                    install,
-		CloudFormationStackVersion: stackVersion,
-		InstallState:               installState,
-		AppCfg:                     cfg,
-		Runner:                     runner,
-		Settings:                   &runner.RunnerGroup.Settings,
-		APIToken:                   generics.FromPtrStr(token),
-		RunnerEnvVars:              stacks.FormatRunnerEnvVars(&cfg.RunnerConfig, w.cfg.RunnerContainerImageTag),
-		PhoneHomeSecretARN:         phoneHome.SecretARN,
-		PhoneHomeSecretRegion:      phoneHome.SecretRegion,
+		Install:                      install,
+		CloudFormationStackVersion:   stackVersion,
+		InstallState:                 installState,
+		AppCfg:                       cfg,
+		Runner:                       runner,
+		Settings:                     &runner.RunnerGroup.Settings,
+		APIToken:                     generics.FromPtrStr(token),
+		ConfiguredRunnerInstanceType: cfg.RunnerConfig.InstanceType,
+		RunnerEnvVars:                stacks.FormatRunnerEnvVars(&cfg.RunnerConfig, w.cfg.RunnerContainerImageTag),
+		PhoneHomeSecretARN:           phoneHome.SecretARN,
+		PhoneHomeSecretRegion:        phoneHome.SecretRegion,
 	}
 
 	switch cfg.RunnerConfig.Type {

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
@@ -16,6 +16,8 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 
 	tb := tagBuilder{
 		installID:  inp.Install.ID,
+		orgID:      inp.Install.OrgID,
+		appID:      inp.Install.AppID,
 		additional: generics.ToStringMap(inp.Settings.AWSTags),
 	}
 

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
@@ -2,7 +2,9 @@ package cloudformation
 
 import (
 	"fmt"
+	"math"
 	"slices"
+	"strconv"
 
 	"github.com/awslabs/goformation/v7/cloudformation"
 	nestedcloudformation "github.com/awslabs/goformation/v7/cloudformation/cloudformation"
@@ -83,12 +85,55 @@ func (a *Templates) runnerAPIURL(inp *stacks.TemplateInput) string {
 	return a.cfg.RunnerAPIURL
 }
 
+const (
+	defaultRunnerRootVolumeSize = 30.0
+	minRunnerRootVolumeSize     = 8.0
+	maxRunnerRootVolumeSize     = 100.0
+)
+
 // getRunnerParameters returns the user-overridable top-level parameters for
 // the runner. These are exposed at the parent stack so customers can override
 // the defaults when creating/updating the stack; the nested runner ASG stack
 // references them via Ref().
+//
+// Defaults come from the nested runner template when it declares the matching
+// parameter, so a customer template that ships its own sizing is not silently
+// overridden by the platform defaults.
 func (a *Templates) getRunnerParameters(inp *stacks.TemplateInput) map[string]cloudformation.Parameter {
-	instanceType := inp.Settings.AWSInstanceType
+	tmplParams := a.runnerTemplateParameters(inp)
+
+	return map[string]cloudformation.Parameter{
+		"RunnerInstanceType":   a.runnerInstanceTypeParameter(inp, tmplParams["InstanceType"]),
+		"RunnerRootVolumeSize": a.runnerRootVolumeSizeParameter(tmplParams["RootVolumeSize"]),
+	}
+}
+
+// runnerTemplateParameters returns the parameters declared by the runner nested
+// template. It yields nil when the template cannot be fetched or parsed so the
+// platform defaults apply; getRunnerASGNestedStack surfaces the fetch error for
+// every stack that actually deploys the runner ASG.
+func (a *Templates) runnerTemplateParameters(inp *stacks.TemplateInput) map[string]cfnParameterShape {
+	if inp.AppCfg == nil || inp.AppCfg.StackConfig.RunnerNestedTemplateURL == "" {
+		return nil
+	}
+
+	tmpl, err := a.fetchTemplate(inp.AppCfg.StackConfig.RunnerNestedTemplateURL)
+	if err != nil {
+		return nil
+	}
+
+	return tmpl.Parameters
+}
+
+// The app's own runner config wins, then the nested template's declared default, then the
+// platform default. Settings.AWSInstanceType is deliberately not consulted: the stack
+// generators resolve the platform default into it, so it is never empty and would mask the
+// template's default entirely.
+func (a *Templates) runnerInstanceTypeParameter(inp *stacks.TemplateInput, tmplParam cfnParameterShape) cloudformation.Parameter {
+	instanceType := inp.ConfiguredRunnerInstanceType
+	if instanceType == "" {
+		instanceType, _ = tmplParam.Default.(string)
+	}
 	if instanceType == "" {
 		instanceType = app.DefaultAWSInstanceType
 	}
@@ -107,19 +152,53 @@ func (a *Templates) getRunnerParameters(inp *stacks.TemplateInput) map[string]cl
 		allowedInstanceTypes = append(allowedInstanceTypes, instanceType)
 	}
 
-	return map[string]cloudformation.Parameter{
-		"RunnerInstanceType": {
-			Type:          "String",
-			Description:   generics.ToPtr("EC2 instance type for the runner"),
-			Default:       instanceType,
-			AllowedValues: allowedInstanceTypes,
-		},
-		"RunnerRootVolumeSize": {
-			Type:        "Number",
-			Description: generics.ToPtr("Root EBS volume size (GiB) for the runner"),
-			Default:     "30",
-			MinValue:    ptr(8.0),
-			MaxValue:    ptr(100.0),
-		},
+	return cloudformation.Parameter{
+		Type:          "String",
+		Description:   generics.ToPtr("EC2 instance type for the runner"),
+		Default:       instanceType,
+		AllowedValues: allowedInstanceTypes,
+	}
+}
+
+func (a *Templates) runnerRootVolumeSizeParameter(tmplParam cfnParameterShape) cloudformation.Parameter {
+	size := defaultRunnerRootVolumeSize
+	if tmplDefault, ok := numericParamValue(tmplParam.Default); ok {
+		size = tmplDefault
+	}
+
+	minSize, maxSize := minRunnerRootVolumeSize, maxRunnerRootVolumeSize
+	if tmplParam.MinValue != nil {
+		minSize = *tmplParam.MinValue
+	}
+	if tmplParam.MaxValue != nil {
+		maxSize = *tmplParam.MaxValue
+	}
+	// the default has to satisfy the bounds, otherwise CloudFormation rejects the
+	// parent template outright.
+	minSize = math.Min(minSize, size)
+	maxSize = math.Max(maxSize, size)
+
+	return cloudformation.Parameter{
+		Type:        "Number",
+		Description: generics.ToPtr("Root EBS volume size (GiB) for the runner"),
+		Default:     strconv.FormatFloat(size, 'f', -1, 64),
+		MinValue:    ptr(minSize),
+		MaxValue:    ptr(maxSize),
+	}
+}
+
+func numericParamValue(val interface{}) (float64, bool) {
+	switch v := val.(type) {
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case float64:
+		return v, true
+	case string:
+		parsed, err := strconv.ParseFloat(v, 64)
+		return parsed, err == nil
+	default:
+		return 0, false
 	}
 }

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg_test.go
@@ -1,6 +1,8 @@
 package cloudformation
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,11 +12,32 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
 )
 
+func runnerTemplateInput(t *testing.T, configuredInstanceType string, template string) *stacks.TemplateInput {
+	t.Helper()
+
+	inp := &stacks.TemplateInput{
+		Settings:                     &app.RunnerGroupSettings{},
+		AppCfg:                       &app.AppConfig{},
+		ConfiguredRunnerInstanceType: configuredInstanceType,
+	}
+	if template == "" {
+		return inp
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(template))
+	}))
+	t.Cleanup(srv.Close)
+
+	inp.AppCfg.StackConfig.RunnerNestedTemplateURL = srv.URL + "/stack.yaml"
+	return inp
+}
+
 func TestGetRunnerParameters_InstanceType(t *testing.T) {
 	tpl := &Templates{}
 
-	t.Run("defaults to t3a.medium when unset", func(t *testing.T) {
-		inp := &stacks.TemplateInput{Settings: &app.RunnerGroupSettings{}}
+	t.Run("falls back to the platform default when nothing declares one", func(t *testing.T) {
+		inp := runnerTemplateInput(t, "", "")
 		params := tpl.getRunnerParameters(inp)
 
 		p := params["RunnerInstanceType"]
@@ -23,7 +46,7 @@ func TestGetRunnerParameters_InstanceType(t *testing.T) {
 	})
 
 	t.Run("uses configured value already in the allowed list", func(t *testing.T) {
-		inp := &stacks.TemplateInput{Settings: &app.RunnerGroupSettings{AWSInstanceType: "t3.large"}}
+		inp := runnerTemplateInput(t, "t3.large", "")
 		params := tpl.getRunnerParameters(inp)
 
 		p := params["RunnerInstanceType"]
@@ -33,12 +56,94 @@ func TestGetRunnerParameters_InstanceType(t *testing.T) {
 	})
 
 	t.Run("auto-adds a custom value to allowed values", func(t *testing.T) {
-		inp := &stacks.TemplateInput{Settings: &app.RunnerGroupSettings{AWSInstanceType: "m5.xlarge"}}
+		inp := runnerTemplateInput(t, "m5.xlarge", "")
 		params := tpl.getRunnerParameters(inp)
 
 		p := params["RunnerInstanceType"]
 		assert.Equal(t, "m5.xlarge", p.Default)
 		require.Contains(t, p.AllowedValues, interface{}("m5.xlarge"))
 		assert.Len(t, p.AllowedValues, 7, "custom value should be appended once")
+	})
+}
+
+const runnerTemplateWithDefaults = `
+Parameters:
+  InstanceType:
+    Type: String
+    Description: EC2 instance type for the runner
+    Default: m6i.large
+  RootVolumeSize:
+    Type: Number
+    Description: Size of the root EBS volume in GB
+    Default: 100
+    MinValue: 8
+    MaxValue: 200
+`
+
+func TestGetRunnerParameters_NestedTemplateDefaults(t *testing.T) {
+	tpl := &Templates{}
+
+	t.Run("uses the nested template defaults when the runner config declares none", func(t *testing.T) {
+		inp := runnerTemplateInput(t, "", runnerTemplateWithDefaults)
+		params := tpl.getRunnerParameters(inp)
+
+		instanceType := params["RunnerInstanceType"]
+		assert.Equal(t, "m6i.large", instanceType.Default)
+		assert.Contains(t, instanceType.AllowedValues, interface{}("m6i.large"))
+
+		rootVolume := params["RunnerRootVolumeSize"]
+		assert.Equal(t, "100", rootVolume.Default)
+		assert.Equal(t, 8.0, *rootVolume.MinValue)
+		assert.Equal(t, 200.0, *rootVolume.MaxValue)
+	})
+
+	// The stack generators resolve the platform default into Settings.AWSInstanceType before
+	// rendering, which used to mask the template's own default and pin every install to
+	// t3.medium no matter what the runner template declared.
+	t.Run("a resolved settings value does not mask the template default", func(t *testing.T) {
+		inp := runnerTemplateInput(t, "", runnerTemplateWithDefaults)
+		inp.Settings.AWSInstanceType = app.DefaultAWSInstanceType
+
+		params := tpl.getRunnerParameters(inp)
+
+		assert.Equal(t, "m6i.large", params["RunnerInstanceType"].Default)
+	})
+
+	t.Run("the runner config wins over the nested template default", func(t *testing.T) {
+		inp := runnerTemplateInput(t, "t3.large", runnerTemplateWithDefaults)
+		params := tpl.getRunnerParameters(inp)
+
+		assert.Equal(t, "t3.large", params["RunnerInstanceType"].Default)
+	})
+
+	t.Run("falls back to platform defaults when the template declares none", func(t *testing.T) {
+		inp := runnerTemplateInput(t, "", "Parameters:\n  SubnetId:\n    Type: String\n")
+		params := tpl.getRunnerParameters(inp)
+
+		assert.Equal(t, app.DefaultAWSInstanceType, params["RunnerInstanceType"].Default)
+
+		rootVolume := params["RunnerRootVolumeSize"]
+		assert.Equal(t, "30", rootVolume.Default)
+		assert.Equal(t, 8.0, *rootVolume.MinValue)
+		assert.Equal(t, 100.0, *rootVolume.MaxValue)
+	})
+
+	t.Run("falls back to platform defaults when the template cannot be fetched", func(t *testing.T) {
+		inp := runnerTemplateInput(t, "", "")
+		inp.AppCfg.StackConfig.RunnerNestedTemplateURL = "http://127.0.0.1:1/stack.yaml"
+
+		params := tpl.getRunnerParameters(inp)
+
+		assert.Equal(t, app.DefaultAWSInstanceType, params["RunnerInstanceType"].Default)
+		assert.Equal(t, "30", params["RunnerRootVolumeSize"].Default)
+	})
+
+	t.Run("widens the volume bounds so the template default stays valid", func(t *testing.T) {
+		inp := runnerTemplateInput(t, "", "Parameters:\n  RootVolumeSize:\n    Type: Number\n    Default: 250\n")
+		params := tpl.getRunnerParameters(inp)
+
+		rootVolume := params["RunnerRootVolumeSize"]
+		assert.Equal(t, "250", rootVolume.Default)
+		assert.Equal(t, 250.0, *rootVolume.MaxValue)
 	})
 }

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc.go
@@ -75,13 +75,17 @@ func (tpl *Templates) getVPCNestedStack(inp *stacks.TemplateInput, t tagBuilder)
 	return stack, defaultParameters, nil
 }
 
+type cfnParameterShape struct {
+	Type        string      `yaml:"Type" json:"Type"`
+	Description string      `yaml:"Description" json:"Description,omitempty"`
+	Default     interface{} `yaml:"Default" json:"Default,omitempty"`
+	MinValue    *float64    `yaml:"MinValue" json:"MinValue,omitempty"`
+	MaxValue    *float64    `yaml:"MaxValue" json:"MaxValue,omitempty"`
+}
+
 type cfnTemplateShape struct {
-	Parameters map[string]struct {
-		Type        string      `yaml:"Type" json:"Type"`
-		Description string      `yaml:"Description" json:"Description,omitempty"`
-		Default     interface{} `yaml:"Default" json:"Default,omitempty"`
-	} `yaml:"Parameters"`
-	Outputs map[string]struct{} `yaml:"Outputs"`
+	Parameters map[string]cfnParameterShape `yaml:"Parameters"`
+	Outputs    map[string]struct{}          `yaml:"Outputs"`
 }
 
 var templateFetchClient = &http.Client{Timeout: 30 * time.Second}

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/resource_role.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/resource_role.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/awslabs/goformation/v7/cloudformation"
 	"github.com/awslabs/goformation/v7/cloudformation/iam"
+	"github.com/awslabs/goformation/v7/cloudformation/tags"
 
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/pkg/render"
@@ -94,7 +95,7 @@ func (a *Templates) getRoleResources(role app.AppAWSIAMRoleConfig, t tagBuilder)
 		AssumeRolePolicyDocument: map[string]any{
 			"Statement": trustPolicies,
 		},
-		Tags: t.apply(nil, fmt.Sprintf("%s-role", role.Type)),
+		Tags: t.apply([]tags.Tag{{Key: TagKeyRunnerAssumable, Value: "true"}}, fmt.Sprintf("%s-role", role.Type)),
 	}
 
 	if len(role.PermissionsBoundaryJSON) < 1 || bytes.Equal(role.PermissionsBoundaryJSON, []byte("{}")) {

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/resource_role_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/resource_role_test.go
@@ -1,0 +1,101 @@
+package cloudformation
+
+import (
+	"testing"
+
+	"github.com/awslabs/goformation/v7/cloudformation/iam"
+	"github.com/awslabs/goformation/v7/cloudformation/tags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
+)
+
+func roleConfig(stackName string, roleType app.AWSIAMRoleType) app.AppAWSIAMRoleConfig {
+	return app.AppAWSIAMRoleConfig{
+		Type:                         roleType,
+		Name:                         stackName,
+		CloudFormationStackName:      stackName,
+		CloudFormationStackParamName: stackName + "Enabled",
+	}
+}
+
+func rolesTestInput() *stacks.TemplateInput {
+	inp := &stacks.TemplateInput{
+		Install:  &app.Install{ID: "inl123"},
+		AppCfg:   &app.AppConfig{},
+		Runner:   &app.Runner{ID: "run123"},
+		Settings: &app.RunnerGroupSettings{},
+	}
+	inp.AppCfg.PermissionsConfig.Roles = []app.AppAWSIAMRoleConfig{
+		roleConfig("ProvisionRole", app.AWSIAMRoleTypeRunnerProvision),
+	}
+	inp.AppCfg.BreakGlassConfig.Roles = []app.AppAWSIAMRoleConfig{
+		roleConfig("BreakGlassRole", app.AWSIAMRoleTypeBreakGlass),
+	}
+	inp.AppCfg.PermissionsConfig.CustomRoles = []app.AppAWSIAMRoleConfig{
+		roleConfig("BucketCleanupRole", app.AWSIAMRoleTypeCustom),
+	}
+
+	return inp
+}
+
+// The runner instance role's identity policy scopes sts:AssumeRole with a condition on
+// this tag, so every role the runner is meant to assume has to carry it — including
+// break-glass roles, which share the trust policy that names the runner principal.
+func TestGetRolesResources_RunnerAssumableTag(t *testing.T) {
+	tpl := &Templates{cfg: &internal.Config{}}
+	assumable := tags.Tag{Key: TagKeyRunnerAssumable, Value: "true"}
+
+	t.Run("every role family carries the tag", func(t *testing.T) {
+		rsrcs := tpl.getRolesResources(rolesTestInput(), tagBuilder{installID: "inl123"})
+
+		for _, stackName := range []string{"ProvisionRole", "BreakGlassRole", "BucketCleanupRole"} {
+			role, ok := rsrcs[stackName].(*iam.Role)
+			require.True(t, ok, "expected an IAM role at %s", stackName)
+			assert.Contains(t, role.Tags, assumable)
+		}
+	})
+
+	t.Run("roles also carry the default entity tags", func(t *testing.T) {
+		tb := tagBuilder{installID: "inl123", orgID: "org123", appID: "app123"}
+
+		rsrcs := tpl.getRolesResources(rolesTestInput(), tb)
+
+		role, ok := rsrcs["ProvisionRole"].(*iam.Role)
+		require.True(t, ok)
+
+		applied := tagMap(role.Tags)
+		assert.Equal(t, "inl123", applied["install.nuon.co/id"])
+		assert.Equal(t, "org123", applied["org.nuon.co/id"])
+		assert.Equal(t, "app123", applied["app.nuon.co/id"])
+		assert.Equal(t, "true", applied[TagKeyRunnerAssumable])
+	})
+
+	t.Run("customer tags cannot clear the tag", func(t *testing.T) {
+		tb := tagBuilder{
+			installID:  "inl123",
+			additional: map[string]string{TagKeyRunnerAssumable: "false"},
+		}
+
+		rsrcs := tpl.getRolesResources(rolesTestInput(), tb)
+
+		role, ok := rsrcs["ProvisionRole"].(*iam.Role)
+		require.True(t, ok)
+		assert.Contains(t, role.Tags, assumable)
+		assert.NotContains(t, role.Tags, tags.Tag{Key: TagKeyRunnerAssumable, Value: "false"})
+	})
+}
+
+// The tag marks assume-role targets, so it must stay on the role resource rather than
+// moving into tagBuilder.apply, which every tagged resource in the stack goes through.
+func TestGetRunnerPhoneHomeLambdaRole_NotRunnerAssumable(t *testing.T) {
+	tpl := &Templates{cfg: &internal.Config{}}
+	inp := phoneHomeTestInput("instabcdefghijklmnopqrstuv")
+
+	role := tpl.getRunnerPhoneHomeLambdaRole(inp, tagBuilder{installID: inp.Install.ID})
+
+	assert.NotContains(t, role.Tags, tags.Tag{Key: TagKeyRunnerAssumable, Value: "true"})
+}

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/tagger.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/tagger.go
@@ -6,8 +6,16 @@ import (
 	"github.com/awslabs/goformation/v7/cloudformation/tags"
 )
 
+// TagKeyRunnerAssumable marks an IAM role that the runner is permitted to assume. The runner
+// instance role's identity policy scopes sts:AssumeRole with an iam:ResourceTag condition on this
+// key, so it is a cross-repo contract with nuonco/aws-cloudformation-templates: renaming it here
+// without releasing a matching runner template revokes the runner's access.
+const TagKeyRunnerAssumable = "runner.nuon.co/assumable"
+
 type tagBuilder struct {
 	installID  string
+	orgID      string
+	appID      string
 	additional map[string]string
 }
 
@@ -19,6 +27,18 @@ func (t tagBuilder) apply(existing []tags.Tag, name string) []tags.Tag {
 
 	existingMap["install.nuon.co/id"] = t.installID
 	existingMap["nuon_install_id"] = t.installID
+
+	// Org and app ids are emitted only in the domain-qualified form. The snake_case keys
+	// above are legacy duplicates kept for the consumers that already read them; nothing
+	// reads a snake_case org or app id off an AWS resource. Skipped when empty so a caller
+	// without org/app context emits no tag rather than a blank one, which would silently
+	// fail any iam:ResourceTag condition matching on it.
+	if t.orgID != "" {
+		existingMap["org.nuon.co/id"] = t.orgID
+	}
+	if t.appID != "" {
+		existingMap["app.nuon.co/id"] = t.appID
+	}
 	if _, has := existingMap[name]; !has {
 		if name != "" {
 			existingMap["Name"] = fmt.Sprintf("%s-%s", t.installID, name)

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/tagger_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/tagger_test.go
@@ -1,0 +1,61 @@
+package cloudformation
+
+import (
+	"testing"
+
+	"github.com/awslabs/goformation/v7/cloudformation/tags"
+	"github.com/stretchr/testify/assert"
+)
+
+func tagMap(applied []tags.Tag) map[string]string {
+	out := make(map[string]string, len(applied))
+	for _, tag := range applied {
+		out[tag.Key] = tag.Value
+	}
+
+	return out
+}
+
+func TestTagBuilderApply_EntityTags(t *testing.T) {
+	tb := tagBuilder{installID: "inl123", orgID: "org123", appID: "app123"}
+
+	applied := tagMap(tb.apply(nil, "vpc"))
+
+	assert.Equal(t, "inl123", applied["install.nuon.co/id"])
+	assert.Equal(t, "inl123", applied["nuon_install_id"])
+	assert.Equal(t, "org123", applied["org.nuon.co/id"])
+	assert.Equal(t, "app123", applied["app.nuon.co/id"])
+	assert.Equal(t, "inl123-vpc", applied["Name"])
+}
+
+// A blank id would silently fail any iam:ResourceTag condition matching on it, so an
+// absent org/app emits no tag at all.
+func TestTagBuilderApply_OmitsBlankEntityTags(t *testing.T) {
+	tb := tagBuilder{installID: "inl123"}
+
+	applied := tagMap(tb.apply(nil, "vpc"))
+
+	assert.NotContains(t, applied, "org.nuon.co/id")
+	assert.NotContains(t, applied, "app.nuon.co/id")
+}
+
+func TestTagBuilderApply_CustomerTagsCannotOverrideEntityTags(t *testing.T) {
+	tb := tagBuilder{
+		installID: "inl123",
+		orgID:     "org123",
+		appID:     "app123",
+		additional: map[string]string{
+			"install.nuon.co/id": "spoofed",
+			"org.nuon.co/id":     "spoofed",
+			"app.nuon.co/id":     "spoofed",
+			"team":               "platform",
+		},
+	}
+
+	applied := tagMap(tb.apply(nil, "vpc"))
+
+	assert.Equal(t, "inl123", applied["install.nuon.co/id"])
+	assert.Equal(t, "org123", applied["org.nuon.co/id"])
+	assert.Equal(t, "app123", applied["app.nuon.co/id"])
+	assert.Equal(t, "platform", applied["team"], "unreserved customer tags still pass through")
+}

--- a/services/ctl-api/internal/pkg/stacks/template_input.go
+++ b/services/ctl-api/internal/pkg/stacks/template_input.go
@@ -19,6 +19,14 @@ type TemplateInput struct {
 	Settings *app.RunnerGroupSettings `validate:"required"`
 	APIToken string                   `validate:"required"`
 
+	// ConfiguredRunnerInstanceType is the instance type the app's runner config declares,
+	// empty when it declares none. Settings.AWSInstanceType cannot express "unset" — the
+	// stack generators resolve the platform default into it before rendering, because the
+	// GCP tfvars and the persisted runner group settings both need a concrete value — and
+	// the CloudFormation renderer needs the distinction to know whether it may fall back to
+	// the nested runner template's own default.
+	ConfiguredRunnerInstanceType string
+
 	// runner env vars from runner.toml [env_vars] section, formatted as
 	// newline-delimited "export key=value" pairs for injection into user-data.
 	RunnerEnvVars string


### PR DESCRIPTION
### Description

1. Ensure the defaults for the runner asg are using the default values from the runner asg template, if they are provided. 
2. Add tags to the roles. Adds default and `runner.nuon.co/assumable` = `true`. This way we can scope down our permission assumption even more. 

<details><summary>Role Tags Example</summary>
<p>

```json
        "Tags": [
          {
            "Key": "runner.nuon.co/assumable",
            "Value": "true"
          },
          {
            "Key": "install.nuon.co/id",
            "Value": "inlvkq81sry2cd93vgxo3kmman"
          },
          {
            "Key": "nuon_install_id",
            "Value": "inlvkq81sry2cd93vgxo3kmman"
          },
          {
            "Key": "org.nuon.co/id",
            "Value": "orgqqhpu28udza5ntzaq3b4ilh"
          },
          {
            "Key": "app.nuon.co/id",
            "Value": "appb9vl8jraophhu15ii6f3t1p"
          },
          {
            "Key": "Name",
            "Value": "inlvkq81sry2cd93vgxo3kmman-runner_maintenance-role"
          }
        ]

```

</p>
</details> 