### PR TITLE
fix: wire azure custom nested stack outputs and fix param conflict check

### DIFF
--- a/docs/guides/custom-nested-stacks.mdx
+++ b/docs/guides/custom-nested-stacks.mdx
@@ -11,11 +11,17 @@ or any components run. This feature is useful for setting up resources that must
 that require permissions the vendor does not need to retain throughout the remainder of an app's lifetime.
 
 <Warning>
-Custom nested stacks are **CloudFormation-only**. The Terraform Stack templates do not include them or reference them. If you
-rely on this feature and your customers want to deploy via Terraform, see
-[Customizing Terraform Stack Templates](/guides/customizing-terraform-stack-templates), to learn how make equivalent changes to
-the Terraform templates.
+Custom nested stacks are supported on **CloudFormation** and **`azure-bicep`** install stacks. The Terraform Stack
+templates do not include them or reference them. If you rely on this feature and your customers want to deploy via
+Terraform, see [Customizing Terraform Stack Templates](/guides/customizing-terraform-stack-templates), to learn how make
+equivalent changes to the Terraform templates.
 </Warning>
+
+<Note>
+On `azure-bicep`, templates must be compiled ARM JSON — a `.bicep` source file will not parse. Parameter resolution,
+output wiring, and hoisting behave identically to CloudFormation, with the Azure-specific reserved parameters and
+first-class outputs listed below.
+</Note>
 
 ## Use Cases
 
@@ -156,6 +162,21 @@ Resources:
       InstallId: !Ref NuonInstallID
 ```
 
+### Azure Reserved Parameters
+
+On `azure-bicep`, the reserved set follows ARM's camelCase convention and adds two more:
+
+| Parameter         | Value                                        |
+| ----------------- | -------------------------------------------- |
+| `nuonInstallID`   | The install ID                               |
+| `nuonAppID`       | The app ID                                   |
+| `nuonOrgID`       | The org ID                                   |
+| `location`        | The install's Azure region                   |
+| `deployTimestamp` | Deployment timestamp                         |
+
+Azure has no equivalent of the Role Enable parameters — per-operation access is granted through managed identities
+rather than template conditions.
+
 ## First-Class Output Wiring
 
 If a parameter in your custom template matches the name of an **output** from the VPC or runner nested stacks, Nuon
@@ -176,6 +197,10 @@ Parameters:
 ```
 
 These auto-wired parameters are not hoisted to the parent stack.
+
+On `azure-bicep`, the equivalent source is the built-in VNet deployment. A parameter named `vnetId`, `vnetName`,
+`runnerSubnetId`, `runnerSubnetName`, `publicSubnet1Id`, `privateSubnet1Name` (and the rest of the subnet outputs) is
+wired to `[reference('vnetDeployment').outputs.<name>.value]`.
 
 ## Inter-Stack Output Wiring
 
@@ -214,8 +239,9 @@ explicitly mapped via `parameters` are **hoisted** into the parent CloudFormatio
 - Default values from your template are preserved.
 - Parameter types (e.g., `AWS::EC2::VPC::Id`, `String`, `Number`) are preserved.
 
-**Important:** Parameter names must be unique across all nested stacks (including the VPC and runner stacks). If two
-stacks define a parameter with the same name, `nuon apps sync` will fail with a conflict error.
+**Important:** *Hoisted* parameter names must be unique across all nested stacks (including the VPC and runner stacks).
+If two stacks hoist a parameter with the same name, install stack generation fails with a conflict error. Names that are
+auto-wired or explicitly mapped never reach the parent, so any number of stacks may declare them.
 
 ## Parameter Mapping
 

--- a/sdks/nuon-go/models/app_workflow_step.go
+++ b/sdks/nuon-go/models/app_workflow_step.go
@@ -98,6 +98,10 @@ type AppWorkflowStep struct {
 	// retryable
 	Retryable bool `json:"retryable,omitempty"`
 
+	// SkipOnFailure lets the workflow continue past this step after its retry
+	// budget is exhausted. Skippable only gates user-initiated skips.
+	SkipOnFailure bool `json:"skip_on_failure,omitempty"`
+
 	// skippable
 	Skippable bool `json:"skippable,omitempty"`
 

--- a/sdks/nuon-runner-go/models/app_workflow_step.go
+++ b/sdks/nuon-runner-go/models/app_workflow_step.go
@@ -98,6 +98,10 @@ type AppWorkflowStep struct {
 	// retryable
 	Retryable bool `json:"retryable,omitempty"`
 
+	// SkipOnFailure lets the workflow continue past this step after its retry
+	// budget is exhausted. Skippable only gates user-initiated skips.
+	SkipOnFailure bool `json:"skip_on_failure,omitempty"`
+
 	// skippable
 	Skippable bool `json:"skippable,omitempty"`
 

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom.go
@@ -64,6 +64,23 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 	allParamNames := map[string]string{}
 	prevDeploymentName := ""
 
+	// param name -> producing deployment; seeded with vnet outputs so they win over custom ones
+	wiredOutputs := map[string]string{}
+	for _, name := range []string{
+		"vnetId", "vnetName",
+		"publicSubnet1Id", "publicSubnet1Name",
+		"publicSubnet2Id", "publicSubnet2Name",
+		"publicSubnet3Id", "publicSubnet3Name",
+		"privateSubnet1Id", "privateSubnet1Name",
+		"privateSubnet2Id", "privateSubnet2Name",
+		"privateSubnet3Id", "privateSubnet3Name",
+		"runnerSubnetId", "runnerSubnetName",
+		"publicSubnetIds", "publicSubnetNames",
+		"privateSubnetIds", "privateSubnetNames",
+	} {
+		wiredOutputs[name] = "vnetDeployment"
+	}
+
 	for i, stack := range sorted {
 		if stack.Name == "" {
 			return nil, nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d]: name is required", i)
@@ -120,14 +137,6 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 			})
 		}
 
-		// Check for parameter name conflicts
-		for paramName := range defaultParams {
-			if owner, exists := allParamNames[paramName]; exists {
-				return nil, nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): parameter %q conflicts with stack %q", i, stack.Name, paramName, owner)
-			}
-			allParamNames[paramName] = stack.Name
-		}
-
 		// Build deployment parameters
 		deploymentParams := map[string]any{}
 
@@ -164,26 +173,28 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 			delete(defaultParams, cfnParamName)
 		}
 
-		// Wire VNet outputs to matching parameter names
-		vnetOutputs := []string{
-			"vnetId", "vnetName",
-			"publicSubnet1Id", "publicSubnet1Name",
-			"publicSubnet2Id", "publicSubnet2Name",
-			"publicSubnet3Id", "publicSubnet3Name",
-			"privateSubnet1Id", "privateSubnet1Name",
-			"privateSubnet2Id", "privateSubnet2Name",
-			"privateSubnet3Id", "privateSubnet3Name",
-			"runnerSubnetId", "runnerSubnetName",
-			"publicSubnetIds", "publicSubnetNames",
-			"privateSubnetIds", "privateSubnetNames",
-		}
+		// Wire VNet and earlier custom stack outputs to matching parameter names
 		for paramName := range params {
-			if slices.Contains(vnetOutputs, paramName) {
-				deploymentParams[paramName] = map[string]any{
-					"value": fmt.Sprintf("[reference('vnetDeployment').outputs.%s.value]", paramName),
-				}
-				delete(defaultParams, paramName)
+			if _, alreadySet := deploymentParams[paramName]; alreadySet {
+				continue
 			}
+			sourceDeployment, ok := wiredOutputs[paramName]
+			if !ok {
+				continue
+			}
+
+			deploymentParams[paramName] = map[string]any{
+				"value": fmt.Sprintf("[reference('%s').outputs.%s.value]", sourceDeployment, paramName),
+			}
+			delete(defaultParams, paramName)
+		}
+
+		// Runs after pruning: only names that actually reach the parent can conflict
+		for paramName := range defaultParams {
+			if owner, exists := allParamNames[paramName]; exists {
+				return nil, nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): parameter %q conflicts with stack %q", i, stack.Name, paramName, owner)
+			}
+			allParamNames[paramName] = stack.Name
 		}
 
 		// Remaining params are hoisted into parent
@@ -198,7 +209,7 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 			hoistedParams[k] = v
 		}
 
-		// Build dependsOn chain
+		// Sequential: output wiring needs every earlier stack to be a transitive dependency
 		var dependsOn []string
 		if prevDeploymentName != "" {
 			dependsOn = append(dependsOn, prevDeploymentName)
@@ -224,6 +235,18 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 		}
 
 		resources = append(resources, deployment)
+
+		// Registered after the deployment so a stack cannot wire to its own outputs
+		for _, key := range outputKeys {
+			// a custom output must not shadow a Nuon-injected param for later stacks
+			if slices.Contains(ReservedParamNames, key) {
+				continue
+			}
+			if _, exists := wiredOutputs[key]; !exists {
+				wiredOutputs[key] = deploymentName
+			}
+		}
+
 		prevDeploymentName = deploymentName
 	}
 

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_wiring_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_wiring_test.go
@@ -1,0 +1,280 @@
+package arm
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/pkg/config"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
+)
+
+type wiringStack struct {
+	name       string
+	params     map[string]any
+	outputs    []string
+	parameters map[string]string
+}
+
+func armWiringInput(t *testing.T, stacksIn ...wiringStack) *stacks.TemplateInput {
+	t.Helper()
+
+	templates := map[string]string{}
+	for _, s := range stacksIn {
+		params := map[string]any{}
+		maps.Copy(params, s.params)
+		outputs := map[string]any{}
+		for _, name := range s.outputs {
+			outputs[name] = map[string]any{"type": "string", "value": "x"}
+		}
+
+		body, err := json.Marshal(map[string]any{
+			"$schema":        "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+			"contentVersion": "1.0.0.0",
+			"parameters":     params,
+			"resources":      []any{},
+			"outputs":        outputs,
+		})
+		require.NoError(t, err)
+		templates["/"+s.name+".json"] = string(body)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := templates[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	inp := minimalTemplateInput()
+	for i, s := range stacksIn {
+		inp.AppCfg.StackConfig.CustomNestedStacks = append(inp.AppCfg.StackConfig.CustomNestedStacks, config.CustomNestedStack{
+			Name:        s.name,
+			TemplateURL: server.URL + "/" + s.name + ".json",
+			Index:       i,
+			Parameters:  s.parameters,
+		})
+	}
+
+	return inp
+}
+
+func stringParam() map[string]any {
+	return map[string]any{"type": "string"}
+}
+
+func TestGetCustomLinkedDeployments_OutputWiring(t *testing.T) {
+	t.Run("two stacks may consume the same vnet output", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t,
+			wiringStack{name: "db-subnet", params: map[string]any{"vnetName": stringParam()}},
+			wiringStack{name: "dns-zones", params: map[string]any{"vnetName": stringParam()}},
+		)
+
+		resources, hoisted, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+		require.Len(t, resources, 2)
+
+		want := "[reference('vnetDeployment').outputs.vnetName.value]"
+		assert.Equal(t, want, armDeploymentParamValue(t, resources[0], "vnetName"))
+		assert.Equal(t, want, armDeploymentParamValue(t, resources[1], "vnetName"))
+		assert.NotContains(t, hoisted, "vnetName")
+	})
+
+	t.Run("earlier stack output wires into a later stack parameter", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t,
+			wiringStack{name: "db-subnet", outputs: []string{"dbSubnetId"}},
+			wiringStack{name: "apps-postgres", params: map[string]any{"dbSubnetId": stringParam()}},
+		)
+
+		resources, hoisted, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			"[reference('DbSubnet').outputs.dbSubnetId.value]",
+			armDeploymentParamValue(t, resources[1], "dbSubnetId"),
+		)
+		assert.NotContains(t, hoisted, "dbSubnetId")
+	})
+
+	t.Run("genuine conflict on a hoisted param still errors", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t,
+			wiringStack{name: "one", params: map[string]any{"instanceSize": stringParam()}},
+			wiringStack{name: "two", params: map[string]any{"instanceSize": stringParam()}},
+		)
+
+		_, _, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `parameter "instanceSize" conflicts with stack "one"`)
+	})
+
+	t.Run("a stack cannot wire to its own output", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t,
+			wiringStack{name: "solo", params: map[string]any{"zoneId": stringParam()}, outputs: []string{"zoneId"}},
+		)
+
+		resources, hoisted, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+
+		assert.Equal(t, "[parameters('zoneId')]", armDeploymentParamValue(t, resources[0], "zoneId"))
+		assert.Contains(t, hoisted, "zoneId")
+	})
+
+	t.Run("vnet output beats a custom output of the same name", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t,
+			wiringStack{name: "shadow", outputs: []string{"vnetName"}},
+			wiringStack{name: "consumer", params: map[string]any{"vnetName": stringParam()}},
+		)
+
+		resources, _, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			"[reference('vnetDeployment').outputs.vnetName.value]",
+			armDeploymentParamValue(t, resources[1], "vnetName"),
+		)
+	})
+
+	t.Run("earliest custom producer wins", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t,
+			wiringStack{name: "first", outputs: []string{"sharedId"}},
+			wiringStack{name: "second", outputs: []string{"sharedId"}},
+			wiringStack{name: "consumer", params: map[string]any{"sharedId": stringParam()}},
+		)
+
+		resources, _, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			"[reference('First').outputs.sharedId.value]",
+			armDeploymentParamValue(t, resources[2], "sharedId"),
+		)
+	})
+
+	t.Run("explicit parameter beats wiring", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t,
+			wiringStack{
+				name:       "consumer",
+				params:     map[string]any{"vnetName": stringParam()},
+				parameters: map[string]string{"vnetName": "explicit-vnet"},
+			},
+		)
+
+		resources, hoisted, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+
+		assert.Equal(t, "explicit-vnet", armDeploymentParamValue(t, resources[0], "vnetName"))
+		assert.NotContains(t, hoisted, "vnetName")
+	})
+
+	t.Run("a custom output cannot shadow a reserved param", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t,
+			wiringStack{name: "shadow", outputs: []string{"location", "nuonInstallID"}},
+			wiringStack{name: "consumer", params: map[string]any{
+				"location":      stringParam(),
+				"nuonInstallID": stringParam(),
+			}},
+		)
+
+		resources, _, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+
+		assert.Equal(t, "[parameters('location')]", armDeploymentParamValue(t, resources[1], "location"))
+		assert.Equal(t, inp.Install.ID, armDeploymentParamValue(t, resources[1], "nuonInstallID"))
+	})
+
+	t.Run("documented SharedSubnetID example", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t,
+			wiringStack{name: "stack-a", outputs: []string{"SharedSubnetID"}},
+			wiringStack{name: "stack-b", params: map[string]any{"SharedSubnetID": stringParam()}},
+		)
+
+		resources, _, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			"[reference('StackA').outputs.SharedSubnetID.value]",
+			armDeploymentParamValue(t, resources[1], "SharedSubnetID"),
+		)
+	})
+
+	t.Run("wiring accumulates across a multi-hop chain", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t,
+			wiringStack{name: "hop-zero", outputs: []string{"zeroOut"}},
+			wiringStack{name: "hop-one", params: map[string]any{"zeroOut": stringParam()}, outputs: []string{"oneOut"}},
+			wiringStack{name: "hop-two", params: map[string]any{"zeroOut": stringParam(), "oneOut": stringParam()}},
+		)
+
+		resources, hoisted, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+
+		assert.Equal(t, "[reference('HopZero').outputs.zeroOut.value]", armDeploymentParamValue(t, resources[1], "zeroOut"))
+		assert.Equal(t, "[reference('HopZero').outputs.zeroOut.value]", armDeploymentParamValue(t, resources[2], "zeroOut"))
+		assert.Equal(t, "[reference('HopOne').outputs.oneOut.value]", armDeploymentParamValue(t, resources[2], "oneOut"))
+		assert.Empty(t, hoisted)
+	})
+
+	t.Run("lovable-enterprise-azure stack set generates", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t,
+			wiringStack{name: "storage", outputs: []string{"storageAccountName"}},
+			wiringStack{
+				name:    "db-subnet",
+				params:  map[string]any{"vnetName": stringParam()},
+				outputs: []string{"dbSubnetId", "privateDnsZoneId"},
+			},
+			wiringStack{
+				name:       "dns_zones",
+				params:     map[string]any{"vnetName": stringParam(), "rootDomain": stringParam()},
+				outputs:    []string{"publicZoneId", "internalZoneId"},
+				parameters: map[string]string{"rootDomain": "example.installs.lovable.dev"},
+			},
+			wiringStack{name: "apps_postgres", params: map[string]any{
+				"dbSubnetId": stringParam(), "privateDnsZoneId": stringParam(),
+			}},
+			wiringStack{name: "sandbox_proxy_postgres", params: map[string]any{
+				"dbSubnetId": stringParam(), "privateDnsZoneId": stringParam(),
+			}},
+			wiringStack{name: "bauleiter"},
+		)
+
+		resources, hoisted, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+		require.Len(t, resources, 6)
+
+		for _, name := range []string{"vnetName", "dbSubnetId", "privateDnsZoneId", "rootDomain"} {
+			assert.NotContains(t, hoisted, name)
+		}
+		for _, idx := range []int{3, 4} {
+			assert.Equal(t,
+				"[reference('DbSubnet').outputs.dbSubnetId.value]",
+				armDeploymentParamValue(t, resources[idx], "dbSubnetId"),
+				fmt.Sprintf("stack %d", idx),
+			)
+			assert.Equal(t,
+				"[reference('DbSubnet').outputs.privateDnsZoneId.value]",
+				armDeploymentParamValue(t, resources[idx], "privateDnsZoneId"),
+				fmt.Sprintf("stack %d", idx),
+			)
+		}
+	})
+}


### PR DESCRIPTION
The ARM path ran the cross-stack parameter conflict check before pruning wired and explicitly-set params, so two Azure custom stacks consuming `vnetName` failed install stack generation. It also never wired an earlier custom stack's outputs into a later stack's parameters, unlike the CloudFormation path.

Moves the conflict check after pruning and folds custom stack outputs into the same wiring map as the VNet outputs (first writer wins, reserved names can't be shadowed). Unblocks the lovable-enterprise Azure stack set.