### PR TITLE
refactor: use fx to manage dependency injection in the cli

### DIFF
--- a/bins/cli/cmd/actions.go
+++ b/bins/cli/cmd/actions.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/nuonco/nuon/bins/cli/internal/services/actions"
 )
 
 func (c *cli) actionsCmd() *cobra.Command {
@@ -26,7 +24,7 @@ func (c *cli) actionsCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all app actions",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := actions.New(c.v, c.apiClient, c.cfg)
+			svc := c.actions
 			return svc.List(cmd.Context(), appID, offset, limit, PrintJSON)
 		}),
 	}
@@ -44,7 +42,7 @@ func (c *cli) actionsCmd() *cobra.Command {
 		Short: "Get action's most recent runs",
 		Long:  "Get action's most recent runs for an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := actions.New(c.v, c.apiClient, c.cfg)
+			svc := c.actions
 			return svc.GetRecentRuns(cmd.Context(), installID, actionWorkflowID, offset, limit, PrintJSON)
 		}),
 	}
@@ -61,7 +59,7 @@ func (c *cli) actionsCmd() *cobra.Command {
 		Short: "Delete an action workflow",
 		Long:  "Delete an action workflow by ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := actions.New(c.v, c.apiClient, c.cfg)
+			svc := c.actions
 			return svc.DeleteWorkflow(cmd.Context(), actionWorkflowID)
 		}),
 	}
@@ -75,7 +73,7 @@ func (c *cli) actionsCmd() *cobra.Command {
 		Short: "Get an action run",
 		Long:  "Get an action run by ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := actions.New(c.v, c.apiClient, c.cfg)
+			svc := c.actions
 			return svc.GetRun(cmd.Context(), installID, runID, PrintJSON)
 		}),
 	}
@@ -90,7 +88,7 @@ func (c *cli) actionsCmd() *cobra.Command {
 		Short: "Run an action",
 		Long:  "Run an action by Install ID and Action Workflow ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := actions.New(c.v, c.apiClient, c.cfg)
+			svc := c.actions
 			return svc.CreateRun(cmd.Context(), installID, actionWorkflowID, roleName, PrintJSON)
 		}),
 	}

--- a/bins/cli/cmd/apps.go
+++ b/bins/cli/cmd/apps.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/nuonco/nuon/bins/cli/internal/services/apps"
-	"github.com/nuonco/nuon/bins/cli/internal/services/variables"
 	"github.com/nuonco/nuon/bins/cli/internal/services/version"
 )
 
@@ -32,7 +31,7 @@ func (c *cli) appsCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all your apps",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.List(cmd.Context(), offset, limit, PrintJSON)
 		}),
 	}
@@ -47,7 +46,7 @@ func (c *cli) appsCmd() *cobra.Command {
 		Short: "Get an app",
 		Long:  "Get either the current app or an app by name or ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.Get(cmd.Context(), appID, PrintJSON)
 		}),
 	}
@@ -62,7 +61,7 @@ func (c *cli) appsCmd() *cobra.Command {
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			printDeprecatedCommandWarning(cmd, "Use `nuon apps get` instead")
 
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.Get(cmd.Context(), c.cfg.GetString("app_id"), PrintJSON)
 		}),
 	}
@@ -73,7 +72,7 @@ func (c *cli) appsCmd() *cobra.Command {
 		Short: "View sandbox config",
 		Long:  "View apps latest sandbox config",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.GetSandboxConfig(cmd.Context(), appID, PrintJSON)
 		}),
 	}
@@ -86,7 +85,7 @@ func (c *cli) appsCmd() *cobra.Command {
 		Short: "List app configs",
 		Long:  "List app configs",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.ListConfigs(cmd.Context(), appID, offset, limit, PrintJSON)
 		}),
 	}
@@ -101,7 +100,7 @@ func (c *cli) appsCmd() *cobra.Command {
 		Short: "View app input config",
 		Long:  "View latest app input config",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.GetInputConfig(cmd.Context(), appID, PrintJSON)
 		}),
 	}
@@ -114,7 +113,7 @@ func (c *cli) appsCmd() *cobra.Command {
 		Short: "View app runner config",
 		Long:  "View latest app runner config",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.GetRunnerConfig(cmd.Context(), appID, PrintJSON)
 		}),
 	}
@@ -128,7 +127,7 @@ func (c *cli) appsCmd() *cobra.Command {
 		Long:        "Select your current app from a list or by app ID",
 		Annotations: tuiAnnotation(TUIContextual),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.Select(cmd.Context(), appID, PrintJSON)
 		}),
 	}
@@ -140,7 +139,7 @@ func (c *cli) appsCmd() *cobra.Command {
 		Short: "Deselect your current app",
 		Long:  "Deselect your current app",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.Deselect(cmd.Context())
 		}),
 	}
@@ -152,7 +151,7 @@ func (c *cli) appsCmd() *cobra.Command {
 		Short:      "Unset your current app (deprecated)",
 		Hidden:     true,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.Deselect(cmd.Context())
 		}),
 	}
@@ -188,7 +187,7 @@ func (c *cli) appsCmd() *cobra.Command {
 				PrintJSON: PrintJSON,
 				NoWait:    syncNoWait,
 			}
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			if syncCreate {
 				return svc.SyncDirWithCreate(cmd.Context(), dirName, version.Version, opts)
 			}
@@ -221,7 +220,7 @@ func (c *cli) appsCmd() *cobra.Command {
 			return nil
 		},
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.Build(cmd.Context(), buildAppID, buildConfigID)
 		}),
 	}
@@ -247,7 +246,7 @@ func (c *cli) appsCmd() *cobra.Command {
 				}
 			}
 
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.DeprecatedSyncDir(cmd.Context(), dirName, version.Version, apps.SyncOptions{})
 		}),
 	}
@@ -269,7 +268,7 @@ func (c *cli) appsCmd() *cobra.Command {
 				}
 			}
 
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.ValidateDir(cmd.Context(), dirName)
 		}),
 	}
@@ -281,7 +280,7 @@ func (c *cli) appsCmd() *cobra.Command {
 		Short:             "Create a new app",
 		PersistentPreRunE: c.persistentPreRunE,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.Create(cmd.Context(), name, PrintJSON, noSelect)
 		}),
 	}
@@ -298,7 +297,7 @@ func (c *cli) appsCmd() *cobra.Command {
 		Short:             "Delete an existing app",
 		PersistentPreRunE: c.persistentPreRunE,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.Delete(cmd.Context(), appID, PrintJSON)
 		}),
 	}
@@ -318,7 +317,7 @@ func (c *cli) appsCmd() *cobra.Command {
 		Short:             "Rename an app",
 		PersistentPreRunE: c.persistentPreRunE,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.Rename(cmd.Context(), appID, name, rename, PrintJSON)
 		}),
 	}
@@ -359,7 +358,7 @@ func (c *cli) branchesCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List branches for an app",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.ListBranches(cmd.Context(), appID, PrintJSON)
 		}),
 	}
@@ -370,7 +369,7 @@ func (c *cli) branchesCmd() *cobra.Command {
 		Use:   "get",
 		Short: "Get branch details",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.GetBranch(cmd.Context(), appID, branchID, PrintJSON)
 		}),
 	}
@@ -384,7 +383,7 @@ func (c *cli) branchesCmd() *cobra.Command {
 		Use:   "create",
 		Short: "Create a new branch",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.CreateBranch(cmd.Context(), appID, branchName, PrintJSON)
 		}),
 	}
@@ -407,7 +406,7 @@ func (c *cli) branchesCmd() *cobra.Command {
 		Short:       "Trigger a branch run",
 		Annotations: tuiAnnotation(TUIAltScreen),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			opts := apps.TriggerBranchRunOptions{
 				PlanOnly:   planOnly,
 				Force:      force,
@@ -436,7 +435,7 @@ func (c *cli) branchesCmd() *cobra.Command {
 		Use:   "delete",
 		Short: "Delete an app branch",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.DeleteBranch(cmd.Context(), appID, branchID, PrintJSON)
 		}),
 	}
@@ -453,7 +452,7 @@ func (c *cli) branchesCmd() *cobra.Command {
 		Short:       "List branch runs and monitor a selected workflow",
 		Annotations: tuiAnnotation(TUIAltScreen),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.ListBranchRuns(cmd.Context(), appID, branchID, PrintJSON)
 		}),
 	}
@@ -484,7 +483,7 @@ func (c *cli) variablesCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all app variables",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := variables.New(c.apiClient, c.cfg)
+			svc := c.variables
 			return svc.List(cmd.Context(), appID, offset, limit, PrintJSON)
 		}),
 	}
@@ -501,7 +500,7 @@ func (c *cli) variablesCmd() *cobra.Command {
 		Short: "Delete an app variable",
 		Long:  "Delete an app variable value",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := variables.New(c.apiClient, c.cfg)
+			svc := c.variables
 			return svc.Delete(cmd.Context(), appID, variableID, PrintJSON)
 		}),
 	}
@@ -524,7 +523,7 @@ func (c *cli) variablesCmd() *cobra.Command {
 		Short:             "Create a new app variable.",
 		PersistentPreRunE: c.persistentPreRunE,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := variables.New(c.apiClient, c.cfg)
+			svc := c.variables
 			return svc.Create(cmd.Context(), appID, name, value, PrintJSON)
 		}),
 	}

--- a/bins/cli/cmd/auth.go
+++ b/bins/cli/cmd/auth.go
@@ -8,7 +8,6 @@ import (
 	"github.com/nuonco/nuon/sdks/nuon-go"
 
 	"github.com/nuonco/nuon/bins/cli/internal/oidctoken"
-	"github.com/nuonco/nuon/bins/cli/internal/services/auth"
 	"github.com/nuonco/nuon/bins/cli/internal/ui"
 )
 
@@ -26,7 +25,7 @@ func (c *cli) authCmd() *cobra.Command {
 		Short:       "Login to Nuon",
 		Annotations: skipAuthAnnotation(),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := auth.New(c.apiClient, c.cfg)
+			svc := c.auth
 			return svc.Login(cmd.Context())
 		}),
 	}
@@ -37,7 +36,7 @@ func (c *cli) authCmd() *cobra.Command {
 		Short:       "Logout from Nuon",
 		Annotations: skipAuthAnnotation(),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := auth.New(c.apiClient, c.cfg)
+			svc := c.auth
 			return svc.Logout(cmd.Context())
 		}),
 	}
@@ -72,7 +71,7 @@ With the default table output, only the token is printed so it can be captured d
 				token = detected
 			}
 
-			svc := auth.New(c.apiClient, c.cfg)
+			svc := c.auth
 			resp, err := svc.ExchangeOIDCToken(cmd.Context(), token, orgID)
 			if err != nil {
 				if _, ok := nuon.ToAPIError(err); ok {

--- a/bins/cli/cmd/builds.go
+++ b/bins/cli/cmd/builds.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/nuonco/nuon/bins/cli/internal/services/builds"
 )
 
 // newBuildsCmd constructs a new builds command
@@ -31,7 +29,7 @@ func (c *cli) buildsCmd() *cobra.Command {
 		Short:   "List builds",
 		Long:    "List your app's builds",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := builds.New(c.apiClient, c.cfg)
+			svc := c.builds
 			return svc.List(cmd.Context(), compID, appID, offset, limit, PrintJSON)
 		}),
 	}
@@ -47,7 +45,7 @@ func (c *cli) buildsCmd() *cobra.Command {
 		Short: "Get build",
 		Long:  "Get component build",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := builds.New(c.apiClient, c.cfg)
+			svc := c.builds
 			return svc.Get(cmd.Context(), appID, compID, buildID, PrintJSON)
 		}),
 	}
@@ -64,7 +62,7 @@ func (c *cli) buildsCmd() *cobra.Command {
 		Short: "Create a build",
 		Long:  "Create a build of an app component",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := builds.New(c.apiClient, c.cfg)
+			svc := c.builds
 			return svc.Create(cmd.Context(), appID, compID, PrintJSON)
 		}),
 	}
@@ -79,7 +77,7 @@ func (c *cli) buildsCmd() *cobra.Command {
 		Short: "View build logs",
 		Long:  "View build logs by components and build ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := builds.New(c.apiClient, c.cfg)
+			svc := c.builds
 			return svc.Logs(cmd.Context(), appID, compID, buildID, PrintJSON)
 		}),
 	}

--- a/bins/cli/cmd/cli.go
+++ b/bins/cli/cmd/cli.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nuonco/nuon/bins/cli/internal/services/components"
 	"github.com/nuonco/nuon/bins/cli/internal/services/docs"
 	"github.com/nuonco/nuon/bins/cli/internal/services/installs"
+	"github.com/nuonco/nuon/bins/cli/internal/services/mcpserver"
 	"github.com/nuonco/nuon/bins/cli/internal/services/orgs"
 	"github.com/nuonco/nuon/bins/cli/internal/services/roles"
 	"github.com/nuonco/nuon/bins/cli/internal/services/runbooks"
@@ -47,6 +48,7 @@ type cli struct {
 	components      *components.Service
 	docs            *docs.Service
 	installs        *installs.Service
+	mcpserver       *mcpserver.Service
 	orgs            *orgs.Service
 	roles           *roles.Service
 	runbooks        *runbooks.Service

--- a/bins/cli/cmd/cli.go
+++ b/bins/cli/cmd/cli.go
@@ -16,7 +16,21 @@ import (
 	"github.com/nuonco/nuon/bins/cli/internal/agentmode"
 	"github.com/nuonco/nuon/bins/cli/internal/config"
 	"github.com/nuonco/nuon/bins/cli/internal/oidctoken"
+	"github.com/nuonco/nuon/bins/cli/internal/services/actions"
+	"github.com/nuonco/nuon/bins/cli/internal/services/apps"
 	"github.com/nuonco/nuon/bins/cli/internal/services/auth"
+	"github.com/nuonco/nuon/bins/cli/internal/services/builds"
+	"github.com/nuonco/nuon/bins/cli/internal/services/components"
+	"github.com/nuonco/nuon/bins/cli/internal/services/docs"
+	"github.com/nuonco/nuon/bins/cli/internal/services/installs"
+	"github.com/nuonco/nuon/bins/cli/internal/services/orgs"
+	"github.com/nuonco/nuon/bins/cli/internal/services/roles"
+	"github.com/nuonco/nuon/bins/cli/internal/services/runbooks"
+	"github.com/nuonco/nuon/bins/cli/internal/services/secrets"
+	"github.com/nuonco/nuon/bins/cli/internal/services/serviceaccounts"
+	"github.com/nuonco/nuon/bins/cli/internal/services/triggers"
+	"github.com/nuonco/nuon/bins/cli/internal/services/variables"
+	"github.com/nuonco/nuon/bins/cli/internal/services/version"
 	"github.com/nuonco/nuon/bins/cli/internal/ui"
 )
 
@@ -25,6 +39,22 @@ type cli struct {
 	apiClient nuon.Client
 	ctx       context.Context
 	cfg       *config.Config
+
+	actions         *actions.Service
+	apps            *apps.Service
+	auth            *auth.Service
+	builds          *builds.Service
+	components      *components.Service
+	docs            *docs.Service
+	installs        *installs.Service
+	orgs            *orgs.Service
+	roles           *roles.Service
+	runbooks        *runbooks.Service
+	secrets         *secrets.Service
+	serviceAccounts *serviceaccounts.Service
+	triggers        *triggers.Service
+	variables       *variables.Service
+	version         *version.Service
 
 	currentUserOnce sync.Once
 	currentUser     *models.AppAccount
@@ -115,12 +145,11 @@ func (c *cli) doPersistentPreRunE(cmd *cobra.Command, args []string) error {
 		c.cfg.Interactive = false
 	}
 
-	if err := c.initAPIClient(); err != nil {
-		return errors.Wrap(err, "unable to initialize api client")
-	}
-
-	// Skip user initialization for auth commands (login, logout)
-	if !hasSkipAuthAnnotation(cmd) {
+	// The auth token must be resolved before the fx graph is built: services
+	// capture the API client at construction, so a client built with an empty
+	// token cannot be swapped out afterwards.
+	skipAuth := hasSkipAuthAnnotation(cmd)
+	if !skipAuth {
 		if c.cfg.APIToken == "" {
 			if err := c.tryAmbientOIDCExchange(cmd.Context()); err != nil {
 				return err
@@ -129,6 +158,13 @@ func (c *cli) doPersistentPreRunE(cmd *cobra.Command, args []string) error {
 		if c.cfg.APIToken == "" {
 			return errors.New("no API token configured; run `nuon login`, set api_token in config, or configure OIDC federation (NUON_OIDC_TOKEN or GitHub Actions with `permissions: id-token: write`)")
 		}
+	}
+
+	if err := c.populateDeps(); err != nil {
+		return errors.Wrap(err, "unable to initialize CLI dependencies")
+	}
+
+	if !skipAuth {
 		if err := c.initUser(); err != nil {
 			return errors.Wrap(err, "unable to initialize user")
 		}
@@ -153,17 +189,20 @@ func (c *cli) tryAmbientOIDCExchange(ctx context.Context) error {
 		return errors.Wrapf(err, "unable to get OIDC token from %s", source)
 	}
 
-	svc := auth.New(c.apiClient, c.cfg)
+	// The exchange runs before the fx graph exists, so it needs its own
+	// (tokenless) client: the exchange endpoint is unauthenticated.
+	exchangeClient, err := newAPIClient(c.v, c.cfg)
+	if err != nil {
+		return errors.Wrap(err, "unable to initialize api client for OIDC exchange")
+	}
+
+	svc := auth.New(exchangeClient, c.cfg)
 	resp, err := svc.ExchangeOIDCToken(ctx, oidcJWT, c.cfg.OrgID)
 	if err != nil {
 		return errors.Wrapf(err, "OIDC federation with token from %s failed", source)
 	}
 
 	c.cfg.APIToken = resp.Token
-	if err := c.initAPIClient(); err != nil {
-		return errors.Wrap(err, "unable to initialize api client with federated token")
-	}
-
 	ui.PrintLn(fmt.Sprintf("authenticated via OIDC federation (%s)", source))
 	return nil
 }

--- a/bins/cli/cmd/components.go
+++ b/bins/cli/cmd/components.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/nuonco/nuon/bins/cli/internal/services/components"
 )
 
 func (c *cli) componentsCmd() *cobra.Command {
@@ -28,7 +26,7 @@ func (c *cli) componentsCmd() *cobra.Command {
 		Short:   "List components",
 		Long:    "List your app's components",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := components.New(c.apiClient, c.cfg)
+			svc := c.components
 			return svc.List(cmd.Context(), appID, listOffset, listLimit, PrintJSON)
 		}),
 	}
@@ -42,7 +40,7 @@ func (c *cli) componentsCmd() *cobra.Command {
 		Short: "Get component",
 		Long:  "Get app component by ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := components.New(c.apiClient, c.cfg)
+			svc := c.components
 			return svc.Get(cmd.Context(), appID, id, PrintJSON)
 		}),
 	}
@@ -57,7 +55,7 @@ func (c *cli) componentsCmd() *cobra.Command {
 		Short: "Delete component",
 		Long:  "Delete app component by ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := components.New(c.apiClient, c.cfg)
+			svc := c.components
 			return svc.Delete(cmd.Context(), appID, id, PrintJSON)
 		}),
 	}
@@ -72,7 +70,7 @@ func (c *cli) componentsCmd() *cobra.Command {
 		Short: "Latest component config",
 		Long:  "Show latest component config",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := components.New(c.apiClient, c.cfg)
+			svc := c.components
 			return svc.LatestConfig(cmd.Context(), appID, id, PrintJSON)
 		}),
 	}
@@ -87,7 +85,7 @@ func (c *cli) componentsCmd() *cobra.Command {
 		Short: "List component configs",
 		Long:  "List component configs",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := components.New(c.apiClient, c.cfg)
+			svc := c.components
 			return svc.ListConfigs(cmd.Context(), appID, id, offset, limit, PrintJSON)
 		}),
 	}

--- a/bins/cli/cmd/config.go
+++ b/bins/cli/cmd/config.go
@@ -4,10 +4,6 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-
-	"github.com/nuonco/nuon/bins/cli/internal/services/apps"
-	"github.com/nuonco/nuon/bins/cli/internal/services/installs"
-	"github.com/nuonco/nuon/bins/cli/internal/services/orgs"
 )
 
 func (c *cli) configCmd() *cobra.Command {
@@ -33,7 +29,7 @@ func (c *cli) configCmd() *cobra.Command {
 		Long:        "Select your current org from a list or by org ID",
 		Annotations: tuiAnnotation(TUIContextual),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.Select(cmd.Context(), id, 0, 50, PrintJSON)
 		}),
 	}
@@ -47,7 +43,7 @@ func (c *cli) configCmd() *cobra.Command {
 		Long:        "Select your current app from a list or by app ID",
 		Annotations: tuiAnnotation(TUIContextual),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			return svc.Select(cmd.Context(), appID, PrintJSON)
 		}),
 	}
@@ -61,7 +57,7 @@ func (c *cli) configCmd() *cobra.Command {
 		Long:        "Select your current install from a list or by install ID",
 		Annotations: tuiAnnotation(TUIContextual),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Select(cmd.Context(), appID, installID, PrintJSON)
 		}),
 	}

--- a/bins/cli/cmd/docs.go
+++ b/bins/cli/cmd/docs.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/nuonco/nuon/bins/cli/internal/services/docs"
 )
 
 func (c *cli) docsCmd() *cobra.Command {
@@ -21,7 +19,7 @@ func (c *cli) docsCmd() *cobra.Command {
 		Long:        "Open up documentation at https://docs.nuon.co",
 		Annotations: skipAuthAnnotation(),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := docs.New(c.cfg)
+			svc := c.docs
 			return svc.Browse(cmd.Context(), PrintJSON)
 		}),
 	}
@@ -32,7 +30,7 @@ func (c *cli) docsCmd() *cobra.Command {
 		Short: "Open api-explorer",
 		Long:  "Open api explorer with preauthorized key and org-id.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := docs.New(c.cfg)
+			svc := c.docs
 			return svc.BrowseAPI(cmd.Context(), PrintJSON)
 		}),
 	}

--- a/bins/cli/cmd/fx.go
+++ b/bins/cli/cmd/fx.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nuonco/nuon/bins/cli/internal/services/components"
 	"github.com/nuonco/nuon/bins/cli/internal/services/docs"
 	"github.com/nuonco/nuon/bins/cli/internal/services/installs"
+	"github.com/nuonco/nuon/bins/cli/internal/services/mcpserver"
 	"github.com/nuonco/nuon/bins/cli/internal/services/orgs"
 	"github.com/nuonco/nuon/bins/cli/internal/services/roles"
 	"github.com/nuonco/nuon/bins/cli/internal/services/runbooks"
@@ -39,6 +40,7 @@ func (c *cli) populateDeps() error {
 			components.New,
 			docs.New,
 			installs.New,
+			mcpserver.New,
 			orgs.New,
 			roles.New,
 			runbooks.New,
@@ -57,6 +59,7 @@ func (c *cli) populateDeps() error {
 			&c.components,
 			&c.docs,
 			&c.installs,
+			&c.mcpserver,
 			&c.orgs,
 			&c.roles,
 			&c.runbooks,

--- a/bins/cli/cmd/fx.go
+++ b/bins/cli/cmd/fx.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"github.com/nuonco/nuon/sdks/nuon-go"
+	"go.uber.org/fx"
+
+	"github.com/nuonco/nuon/bins/cli/internal/services/actions"
+	"github.com/nuonco/nuon/bins/cli/internal/services/apps"
+	"github.com/nuonco/nuon/bins/cli/internal/services/auth"
+	"github.com/nuonco/nuon/bins/cli/internal/services/builds"
+	"github.com/nuonco/nuon/bins/cli/internal/services/components"
+	"github.com/nuonco/nuon/bins/cli/internal/services/docs"
+	"github.com/nuonco/nuon/bins/cli/internal/services/installs"
+	"github.com/nuonco/nuon/bins/cli/internal/services/orgs"
+	"github.com/nuonco/nuon/bins/cli/internal/services/roles"
+	"github.com/nuonco/nuon/bins/cli/internal/services/runbooks"
+	"github.com/nuonco/nuon/bins/cli/internal/services/secrets"
+	"github.com/nuonco/nuon/bins/cli/internal/services/serviceaccounts"
+	"github.com/nuonco/nuon/bins/cli/internal/services/triggers"
+	"github.com/nuonco/nuon/bins/cli/internal/services/variables"
+	"github.com/nuonco/nuon/bins/cli/internal/services/version"
+)
+
+// populateDeps wires the CLI's dependencies through fx and populates them onto
+// c. Unlike a daemon (see bins/runner), the CLI has no long-running lifecycle:
+// the graph is built once per invocation from the pre-run hook — after cobra
+// has parsed flags and the auth token has been resolved — and is never
+// started.
+func (c *cli) populateDeps() error {
+	app := fx.New(
+		fx.NopLogger,
+		fx.Supply(c.v, c.cfg),
+		fx.Provide(
+			newAPIClient,
+			actions.New,
+			apps.New,
+			auth.New,
+			builds.New,
+			components.New,
+			docs.New,
+			installs.New,
+			orgs.New,
+			roles.New,
+			runbooks.New,
+			secrets.New,
+			serviceaccounts.New,
+			variables.New,
+			version.New,
+			func(api nuon.Client) *triggers.Service { return triggers.New(api) },
+		),
+		fx.Populate(
+			&c.apiClient,
+			&c.actions,
+			&c.apps,
+			&c.auth,
+			&c.builds,
+			&c.components,
+			&c.docs,
+			&c.installs,
+			&c.orgs,
+			&c.roles,
+			&c.runbooks,
+			&c.secrets,
+			&c.serviceAccounts,
+			&c.triggers,
+			&c.variables,
+			&c.version,
+		),
+	)
+
+	return app.Err()
+}

--- a/bins/cli/cmd/generate.go
+++ b/bins/cli/cmd/generate.go
@@ -49,7 +49,7 @@ func (c *cli) initCmd() *cobra.Command {
 		Annotations:       tuiAnnotation(TUIContextual),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error { return nil }, // Skip auth for local init
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			params := apps.InitParams{
 				PrebuiltTemplate: prebuildTemplate,
 			}
@@ -135,7 +135,7 @@ func (c *cli) initCmd() *cobra.Command {
 	// 		Long:              fmt.Sprintf("Generate the %s configuration file", configFileName),
 	// 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error { return nil },
 	// 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-	// 			svc := apps.New(c.v, c.apiClient, c.cfg)
+	// 			svc := c.apps
 	// 			return svc.InitConfigFile(cmd.Context(), initPath, configFileName, initEnableDefaults, initEnableComments, initOverwrite)
 	// 		}),
 	// 	}
@@ -194,7 +194,7 @@ func (c *cli) initSandboxCmd() *cobra.Command {
 				VarFiles:         varFiles,
 			}
 
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			err := svc.InitSandboxConfig(cmd.Context(), genParams, params)
 			if err != nil {
 				return err
@@ -255,7 +255,7 @@ func (c *cli) initStackCmd() *cobra.Command {
 				RunnerNestedTemplateURL: runnerNestedTemplateURL,
 			}
 
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			err := svc.InitStackConfig(cmd.Context(), genParams, params)
 			if err != nil {
 				return err
@@ -304,7 +304,7 @@ func (c *cli) initRunnerCmd() *cobra.Command {
 				InitScriptURL: initScriptURL,
 			}
 
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			err := svc.InitRunnerConfig(cmd.Context(), genParams, params)
 			if err != nil {
 				return err
@@ -373,7 +373,7 @@ func (c *cli) initComponentTerraformModuleCmd() *cobra.Command {
 				DriftSchedule:    driftSchedule,
 			}
 
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			err := svc.InitTerraformModuleComponentConfig(cmd.Context(), genParams, params)
 			if err != nil {
 				return err
@@ -464,7 +464,7 @@ func (c *cli) initComponentHelmChartCmd() *cobra.Command {
 				DriftSchedule:    driftSchedule,
 			}
 
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			err := svc.InitHelmChartComponentConfig(cmd.Context(), genParams, params)
 			if err != nil {
 				return err
@@ -535,7 +535,7 @@ func (c *cli) initComponentKubernetesManifestCmd() *cobra.Command {
 				DriftSchedule: driftSchedule,
 			}
 
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			err := svc.InitKubernetesManifestComponentConfig(cmd.Context(), genParams, params)
 			if err != nil {
 				return err
@@ -629,7 +629,7 @@ func (c *cli) initActionCmd() *cobra.Command {
 				Dependencies:     dependencies,
 			}
 
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			err := svc.InitActionConfig(cmd.Context(), genParams, params)
 			if err != nil {
 				return err

--- a/bins/cli/cmd/init.go
+++ b/bins/cli/cmd/init.go
@@ -5,6 +5,7 @@ import (
 	stdhttp "net/http"
 
 	"github.com/cockroachdb/errors"
+	"github.com/go-playground/validator/v10"
 	"github.com/nuonco/nuon/sdks/nuon-go"
 
 	"github.com/nuonco/nuon/bins/cli/internal/config"
@@ -13,23 +14,32 @@ import (
 )
 
 // Construct an API client for the services to use.
-func (c *cli) initAPIClient() error {
+func newAPIClient(v *validator.Validate, cfg *config.Config) (nuon.Client, error) {
 	var transport stdhttp.RoundTripper
 	if Debug {
 		transport = httpdebug.NewTransport(nil)
 	}
 
 	api, err := nuon.New(
-		nuon.WithValidator(c.v),
-		nuon.WithAuthToken(c.cfg.APIToken),
-		nuon.WithOrgID(c.cfg.OrgID),
-		nuon.WithURL(c.cfg.APIURL),
+		nuon.WithValidator(v),
+		nuon.WithAuthToken(cfg.APIToken),
+		nuon.WithOrgID(cfg.OrgID),
+		nuon.WithURL(cfg.APIURL),
 		nuon.WithHTTPTransport(transport),
 	)
 	if err != nil {
-		return fmt.Errorf("unable to init API client: %w", err)
+		return nil, fmt.Errorf("unable to init API client: %w", err)
 	}
 	api.SetClientVersion(version.Version)
+
+	return api, nil
+}
+
+func (c *cli) initAPIClient() error {
+	api, err := newAPIClient(c.v, c.cfg)
+	if err != nil {
+		return err
+	}
 
 	c.apiClient = api
 	return nil

--- a/bins/cli/cmd/installs.go
+++ b/bins/cli/cmd/installs.go
@@ -67,7 +67,7 @@ provided labels must match (AND semantics):
 
   nuon installs list --labels env=prod --labels team=platform`,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.List(cmd.Context(), appID, offset, limit, labelArgs, PrintJSON)
 		}),
 	}
@@ -82,7 +82,7 @@ provided labels must match (AND semantics):
 		Short: "Get an install",
 		Long:  "Get an install by ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Get(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -97,7 +97,7 @@ provided labels must match (AND semantics):
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			printDeprecatedCommandWarning(cmd, "Use `nuon installs get` instead")
 
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Get(cmd.Context(), c.cfg.GetString("install_id"), PrintJSON)
 		}),
 	}
@@ -108,7 +108,7 @@ provided labels must match (AND semantics):
 		Short: "Generate config for an existing install",
 		Long:  "Generate config file for an existing install, to be used with a nuon app config",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.GenerateConfig(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -130,7 +130,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
     --label env=prod --label team=platform`,
 		Annotations: tuiAnnotation(TUIAltScreen),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Create(cmd.Context(), appID, name, region, awsAccountID, inputs, labelArgs, PrintJSON, noSelect)
 		}),
 	}
@@ -153,7 +153,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Delete install",
 		Long:  "Delete an install by ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Delete(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -169,7 +169,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Forget install",
 		Long:  "Forget an install by ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Forget(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -184,7 +184,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Sync install",
 		Long:  "Sync install(s) with the help of config files",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Sync(cmd.Context(), fileOrDir, appID, confirm, wait, dryRun, PrintJSON)
 		}),
 	}
@@ -202,7 +202,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Enable/disable install config sync",
 		Long:  "Toggle syncing of install using a config file",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ToggleSync(cmd.Context(), id, enable, disable, PrintJSON)
 		}),
 	}
@@ -221,7 +221,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 			"Intended for gating a rollout: poll this with --output agent and continue only once all_healthy is true.",
 		Args: cobra.NoArgs,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Health(cmd.Context(), healthAppID, healthLabels, PrintJSON)
 		}),
 	}
@@ -235,7 +235,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Manage install components",
 		Long:  "Manage the components on an install. With no subcommand, lists the components on an install.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Components(cmd.Context(), id, compOffset, compLimit, false, PrintJSON)
 		}),
 	}
@@ -262,7 +262,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 				return nil
 			}
 
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ComponentOutputs(cmd.Context(), id, componentID, PrintJSON)
 		}),
 	}
@@ -279,7 +279,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 			if enable && disable {
 				return fmt.Errorf("only one of --enable or --disable can be set")
 			}
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ToggleComponent(cmd.Context(), id, componentID, enable, disable, planOnly, PrintJSON)
 		}),
 	}
@@ -299,7 +299,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short:   "List install components",
 		Long:    "List all components on an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Components(cmd.Context(), id, compOffset, compLimit, compShowAll, PrintJSON)
 		}),
 	}
@@ -316,7 +316,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short:   "List deploys for an install component",
 		Long:    "List the deploys for a single component on an install (alias for `nuon installs deploys list`)",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ComponentDeploysList(cmd.Context(), id, componentID, offset, limit, PrintJSON)
 		}),
 	}
@@ -333,7 +333,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Deploy an install component",
 		Long:  "Deploy a single component on an install (alias for `nuon installs deploys create --type=deploy`). Uses the component's latest build unless --build-id is given.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ComponentDeployCreate(cmd.Context(), id, componentID, deployID, deployDeps, deployDependencies, PrintJSON)
 		}),
 	}
@@ -351,7 +351,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Deploy all components to an install",
 		Long:  "Deploy all components to an install.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.DeployComponents(cmd.Context(), id, roleName, planOnly, PrintJSON)
 		}),
 	}
@@ -366,7 +366,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Teardown a component on an install",
 		Long:  "Teardown a deployed component on an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.TeardownComponent(cmd.Context(), id, componentID, roleName, PrintJSON)
 		}),
 	}
@@ -382,7 +382,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Teardown all components on an install",
 		Long:  "Teardown all deployed components on an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.TeardownComponents(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -395,7 +395,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Forget a component on an install",
 		Long:  "Remove a component from Nuon's tracking without destroying its underlying infrastructure. The component must first be removed from the app config (via nuon apps sync). This is irreversible via the API.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ForgetComponent(cmd.Context(), id, componentID, skipConfirm, PrintJSON)
 		}),
 	}
@@ -421,7 +421,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short:   "List deploys for an install component",
 		Long:    "List the deploys for a single component on an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ComponentDeploysList(cmd.Context(), id, componentID, offset, limit, PrintJSON)
 		}),
 	}
@@ -438,7 +438,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Get an install deploy",
 		Long:  "Get an install deploy by ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.GetDeploy(cmd.Context(), id, deployID, PrintJSON)
 		}),
 	}
@@ -458,7 +458,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
   --type=deploy     deploy the component (uses its latest build unless --build-id is given)
   --type=teardown   teardown the component`,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			switch deployType {
 			case "deploy":
 				return svc.ComponentDeployCreate(cmd.Context(), id, componentID, deployID, deployDeps, deployDependencies, PrintJSON)
@@ -486,7 +486,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Cancel an install deploy",
 		Long:  "Cancel an in-flight install deploy by cancelling its workflow",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.DeployCancel(cmd.Context(), id, deployID, PrintJSON)
 		}),
 	}
@@ -503,7 +503,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Long:        "View deploy logs by install and deploy ID",
 		Annotations: tuiAnnotation(TUIAltScreen),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.DeployLogs(cmd.Context(), id, deployID, installCompID, PrintJSON)
 		}),
 	}
@@ -522,7 +522,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short:      "Get an install deploy",
 		Long:       "Get an install deploy by ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.GetDeploy(cmd.Context(), id, deployID, PrintJSON)
 		}),
 	}
@@ -538,7 +538,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short:      "Create an install deploy",
 		Long:       "Create an install deploy by install ID and build ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.CreateDeploy(cmd.Context(), id, deployID, deployDeps, deployDependencies, PrintJSON)
 		}),
 	}
@@ -558,7 +558,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Long:        "View deploy logs by install and deploy ID",
 		Annotations: tuiAnnotation(TUIAltScreen),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.DeployLogs(cmd.Context(), id, deployID, installCompID, PrintJSON)
 		}),
 	}
@@ -575,7 +575,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short:      "View all install deploys",
 		Long:       "View all install deploys by install ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ListDeploys(cmd.Context(), id, offset, limit, PrintJSON)
 		}),
 	}
@@ -601,7 +601,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short:   "List install sandbox runs",
 		Long:    "List the sandbox runs for an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.SandboxRuns(cmd.Context(), id, offset, limit, PrintJSON)
 		}),
 	}
@@ -616,7 +616,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Get an install sandbox run",
 		Long:  "Get an install sandbox run by ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.SandboxRunGet(cmd.Context(), id, runID, PrintJSON)
 		}),
 	}
@@ -635,7 +635,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
   --type=reprovision   reprovision the install sandbox
   --type=deprovision   deprovision the install sandbox`,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			switch sandboxRunType {
 			case "reprovision":
 				return svc.ReprovisionSandbox(cmd.Context(), id, sandboxSkipComponents, PrintJSON)
@@ -658,7 +658,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Cancel an install sandbox run",
 		Long:  "Cancel an in-flight install sandbox run by cancelling its workflow",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.SandboxRunCancel(cmd.Context(), id, runID, PrintJSON)
 		}),
 	}
@@ -673,7 +673,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "View sandbox run logs",
 		Long:  "View sandbox run logs by run & install IDs",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.SandboxRunLogs(cmd.Context(), id, runID, PrintJSON)
 		}),
 	}
@@ -698,7 +698,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short:   "List install sandbox runs",
 		Long:    "List the sandbox runs for an install (alias for `nuon installs sandbox-runs list`)",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.SandboxRuns(cmd.Context(), id, offset, limit, PrintJSON)
 		}),
 	}
@@ -713,7 +713,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Reprovision an install sandbox",
 		Long:  "Reprovision an install sandbox (alias for `nuon installs sandbox-runs create --type=reprovision`)",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ReprovisionSandbox(cmd.Context(), id, sandboxSkipComponents, PrintJSON)
 		}),
 	}
@@ -727,7 +727,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short: "Deprovision an install sandbox",
 		Long:  "Deprovision an install sandbox (alias for `nuon installs sandbox-runs create --type=deprovision`)",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.DeprovisionSandbox(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -744,7 +744,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Short:      "View sandbox run logs",
 		Long:       "View sandbox run logs by run & install IDs",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.SandboxRunLogs(cmd.Context(), id, runID, PrintJSON)
 		}),
 	}
@@ -761,7 +761,7 @@ Use --label (repeatable, format key=value) to attach labels at creation time:
 		Hidden:     true,
 		Short:      "View sandbox outputs (deprecated)",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Outputs(cmd.Context(), id, installs.OutputsOptions{SandboxOnly: true}, PrintJSON)
 		}),
 	}
@@ -787,7 +787,7 @@ a single section:
 
 The --stack, --sandbox, and --component-id flags are mutually exclusive.`,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Outputs(cmd.Context(), id, installs.OutputsOptions{
 				StackOnly:   outputsStack,
 				SandboxOnly: outputsSandbox,
@@ -810,7 +810,7 @@ The --stack, --sandbox, and --component-id flags are mutually exclusive.`,
 		Short:      "View current inputs",
 		Long:       "View current set app inputs",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.CurrentInputs(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -831,7 +831,7 @@ The --stack, --sandbox, and --component-id flags are mutually exclusive.`,
 		Short:   "View install inputs",
 		Long:    "View the install's current input values alongside their declared defaults",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.GetInputs(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -850,7 +850,7 @@ The current inputs are fetched first so changed values can be shown. Setting an
 input that is not declared on the app raises an error.`,
 		Args: cobra.MinimumNArgs(1),
 		Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.SetInputs(cmd.Context(), id, args, deployDependents, PrintJSON)
 		}),
 	}
@@ -865,7 +865,7 @@ input that is not declared on the app raises an error.`,
 			Long:        "Edit an install's inputs in an interactive TUI form pre-filled with the current values",
 			Annotations: annotations(tuiAnnotation(TUIAltScreen), outputsAnnotation(OutputTable)),
 			Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-				svc := installs.New(c.apiClient, c.cfg)
+				svc := c.installs
 				return svc.EditInputs(cmd.Context(), id, deployDependents)
 			}),
 		}
@@ -881,7 +881,7 @@ input that is not declared on the app raises an error.`,
 		Long:        "Select your current install from a list or by install ID",
 		Annotations: tuiAnnotation(TUIContextual),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Select(cmd.Context(), appID, id, PrintJSON)
 		}),
 	}
@@ -894,7 +894,7 @@ input that is not declared on the app raises an error.`,
 		Short: "Deselect your current install",
 		Long:  "Deselect your current install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Deselect(cmd.Context(), PrintJSON)
 		}),
 	}
@@ -906,7 +906,7 @@ input that is not declared on the app raises an error.`,
 		Short:      "Unset your current install selection (deprecated)",
 		Hidden:     true,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Deselect(cmd.Context(), PrintJSON)
 		}),
 	}
@@ -917,7 +917,7 @@ input that is not declared on the app raises an error.`,
 		Short: "Reprovision install",
 		Long:  "Reprovision an install sandbox",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Reprovision(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -930,7 +930,7 @@ input that is not declared on the app raises an error.`,
 		Short: "Deprovision install",
 		Long:  "Deprovision an install sandbox",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Deprovision(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -945,7 +945,7 @@ input that is not declared on the app raises an error.`,
 		Short:      "Teardown components on install.",
 		Long:       "Teardown all deployed components on an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.TeardownComponents(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -960,7 +960,7 @@ input that is not declared on the app raises an error.`,
 		Short:      "Teardown component on install.",
 		Long:       "Teardown a deployed component on an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.TeardownComponent(cmd.Context(), id, componentID, roleName, PrintJSON)
 		}),
 	}
@@ -978,7 +978,7 @@ input that is not declared on the app raises an error.`,
 		Short:      "Forget a component on an install.",
 		Long:       "Remove a component from Nuon's tracking without destroying its underlying infrastructure. The component must first be removed from the app config (via nuon apps sync). This is irreversible via the API.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ForgetComponent(cmd.Context(), id, componentID, skipConfirm, PrintJSON)
 		}),
 	}
@@ -996,7 +996,7 @@ input that is not declared on the app raises an error.`,
 		Short:      "Deploy all components to an install.",
 		Long:       "Deploy all components to an install.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.DeployComponents(cmd.Context(), id, roleName, planOnly, PrintJSON)
 		}),
 	}
@@ -1013,7 +1013,7 @@ input that is not declared on the app raises an error.`,
 		Short:      "Update install input",
 		Long:       "Update an install input value",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.UpdateInput(cmd.Context(), id, inputs, deployDependents, PrintJSON)
 		}),
 	}
@@ -1031,7 +1031,7 @@ input that is not declared on the app raises an error.`,
 		Short:      "Deprovision install sandbox",
 		Long:       "Deprovision an install sandbox",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.DeprovisionSandbox(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -1057,7 +1057,7 @@ input that is not declared on the app raises an error.`,
 			return nil
 		},
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ReprovisionSandbox(cmd.Context(), id, skipComponents, PrintJSON)
 		}),
 	}
@@ -1075,7 +1075,7 @@ By default, launches an interactive TUI to view workflows.`,
 		Args:        cobra.NoArgs,
 		Annotations: tuiAnnotation(TUIAltScreen),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.WorkflowsTUI(cmd.Context(), id, workflowID, PrintJSON, autoRetry)
 		}),
 	}
@@ -1090,7 +1090,7 @@ By default, launches an interactive TUI to view workflows.`,
 		Short:   "List workflows",
 		Long:    "List all workflows for an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.WorkflowsList(cmd.Context(), id, offset, limit, PrintJSON)
 		}),
 	}
@@ -1105,7 +1105,7 @@ By default, launches an interactive TUI to view workflows.`,
 		Short: "Get a workflow",
 		Long:  "Get workflow details including steps summary",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			wfID := workflowID
 			if wfID == "" {
 				wfID = svc.GetWorkflowID()
@@ -1125,7 +1125,7 @@ By default, launches an interactive TUI to view workflows.`,
 		Long:        "Select a workflow to use as default for subsequent commands",
 		Annotations: tuiAnnotation(TUIContextual),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.WorkflowsSelect(cmd.Context(), id, workflowID, offset, limit, PrintJSON)
 		}),
 	}
@@ -1140,7 +1140,7 @@ By default, launches an interactive TUI to view workflows.`,
 		Short: "Deselect the current workflow",
 		Long:  "Clear the currently selected workflow",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.WorkflowsDeselect(cmd.Context(), PrintJSON)
 		}),
 	}
@@ -1170,7 +1170,7 @@ Examples:
   nuon installs workflows watch`,
 		Annotations: tuiAnnotation(TUIAltScreen),
 		Run: c.wrapCmdWithExitCode(func(cmd *cobra.Command, _ []string) (int, error) {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 
 			// Try to get workflow ID from flag or config
 			wfID := workflowID
@@ -1210,7 +1210,7 @@ Examples:
 		Short:   "List workflow steps",
 		Long:    "List all steps for a workflow",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			wfID, err := getWorkflowID(svc)
 			if err != nil {
 				return err
@@ -1226,7 +1226,7 @@ Examples:
 		Short: "Get a workflow step",
 		Long:  "Get detailed information about a workflow step",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			wfID, err := getWorkflowID(svc)
 			if err != nil {
 				return err
@@ -1244,7 +1244,7 @@ Examples:
 		Short: "View step plan",
 		Long:  "View the deploy plan for a workflow step",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			wfID, err := getWorkflowID(svc)
 			if err != nil {
 				return err
@@ -1286,7 +1286,7 @@ Filtering examples:
 Available severity levels: Trace, Debug, Info, Warn, Error, Fatal
 Available service names: api, runner (or any service name present in the logs)`,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			wfID, err := getWorkflowID(svc)
 			if err != nil {
 				return err
@@ -1322,7 +1322,7 @@ Available service names: api, runner (or any service name present in the logs)`,
 		Short: "Approve a step",
 		Long:  "Approve a waiting workflow step. If step-id is not provided, uses the latest step and prompts for confirmation.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			wfID, err := getWorkflowID(svc)
 			if err != nil {
 				return err
@@ -1342,7 +1342,7 @@ Available service names: api, runner (or any service name present in the logs)`,
 		Short: "Reject a step",
 		Long:  "Reject a waiting workflow step. If step-id is not provided, uses the latest step and prompts for confirmation.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			wfID, err := getWorkflowID(svc)
 			if err != nil {
 				return err
@@ -1362,7 +1362,7 @@ Available service names: api, runner (or any service name present in the logs)`,
 		Short: "Retry a step",
 		Long:  "Retry a failed workflow step. If step-id is not provided, uses the latest step and prompts for confirmation.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			wfID, err := getWorkflowID(svc)
 			if err != nil {
 				return err
@@ -1383,7 +1383,7 @@ Available service names: api, runner (or any service name present in the logs)`,
 		Short: "Set workflow approval option",
 		Long:  "Set the approval option for a workflow (auto-approve all steps or prompt for each)",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			wfID, err := getWorkflowID(svc)
 			if err != nil {
 				return err
@@ -1410,7 +1410,7 @@ Available service names: api, runner (or any service name present in the logs)`,
 		Long:        "Get runner information for an install",
 		Annotations: tuiAnnotation(TUIContextual),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.RunnerGet(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -1422,7 +1422,7 @@ Available service names: api, runner (or any service name present in the logs)`,
 		Short: "Restart the install runner",
 		Long:  "Restart the runner process for an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.RunnerRestart(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -1435,7 +1435,7 @@ Available service names: api, runner (or any service name present in the logs)`,
 		Short: "Shut down the install runner VM",
 		Long:  "Shut down the VM running the install runner",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.RunnerVMShutDown(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -1449,7 +1449,7 @@ Available service names: api, runner (or any service name present in the logs)`,
 		Long:   "Shut down the mng process for an install runner (does not shut down the runner process)",
 		Hidden: true,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.RunnerShutDown(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -1470,7 +1470,7 @@ Available service names: api, runner (or any service name present in the logs)`,
 		Short:   "List install stack versions",
 		Long:    "List all stack versions for an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.StacksList(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -1484,7 +1484,7 @@ Available service names: api, runner (or any service name present in the logs)`,
 		Short: "Get an install stack",
 		Long:  "Get an install stack by stack ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.StacksGet(cmd.Context(), installStackID, PrintJSON)
 		}),
 	}
@@ -1497,7 +1497,7 @@ Available service names: api, runner (or any service name present in the logs)`,
 		Short: "Get the latest install stack version",
 		Long:  "Get the latest stack version for an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.StacksLatest(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -1511,7 +1511,7 @@ Available service names: api, runner (or any service name present in the logs)`,
 		Short: "Reprovision an install stack",
 		Long:  "Reprovision an install stack, recreating the runner and its infrastructure",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ReprovisionStack(cmd.Context(), id, stackSkipComponents, PrintJSON)
 		}),
 	}
@@ -1539,7 +1539,7 @@ By default, launches an interactive TUI to browse and execute actions.`,
 			return nil
 		},
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.Actions(cmd.Context(), id, offset, limit, PrintJSON)
 		}),
 	}
@@ -1557,7 +1557,7 @@ By default, launches an interactive TUI to browse and execute actions.`,
 		Args:        cobra.NoArgs,
 		Annotations: previewAnnotation(),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ActionsList(cmd.Context(), id, offset, limit, PrintJSON)
 		}),
 	}
@@ -1575,7 +1575,7 @@ By default, launches an interactive TUI to browse and execute actions.`,
 				return nil
 			}
 
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.ActionOutputs(cmd.Context(), id, actionWorkflowID, PrintJSON)
 		}),
 	}
@@ -1600,7 +1600,7 @@ Labels are key-value strings used to organize and filter installs.`,
 Examples:
   nuon installs labels list --install-id inst_abc`,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.LabelsList(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -1617,7 +1617,7 @@ Examples:
 Examples:
   nuon installs labels set --install-id inst_abc env=prod team=platform`,
 		Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.LabelsSet(cmd.Context(), id, args, PrintJSON)
 		}),
 	}
@@ -1634,7 +1634,7 @@ Examples:
 Examples:
   nuon installs labels unset --install-id inst_abc env team`,
 		Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
-			svc := installs.New(c.apiClient, c.cfg)
+			svc := c.installs
 			return svc.LabelsUnset(cmd.Context(), id, args, PrintJSON)
 		}),
 	}

--- a/bins/cli/cmd/login.go
+++ b/bins/cli/cmd/login.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/nuonco/nuon/bins/cli/internal/services/auth"
 )
 
 func (c *cli) loginCmd() *cobra.Command {
@@ -14,7 +12,7 @@ func (c *cli) loginCmd() *cobra.Command {
 		PersistentPreRunE: c.persistentPreRunE,
 		Annotations:       skipAuthAnnotation(),
 		Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
-			svc := auth.New(c.apiClient, c.cfg)
+			svc := c.auth
 			return svc.Login(cmd.Context())
 		}),
 		GroupID: AdditionalGroup.ID,

--- a/bins/cli/cmd/mcp.go
+++ b/bins/cli/cmd/mcp.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/nuonco/nuon/bins/cli/internal/services/mcpserver"
 )
 
 func (c *cli) mcpCmd() *cobra.Command {
@@ -28,11 +26,7 @@ Example Claude Code config (.mcp.json):
 			if ReadOnly || readOnlyFromEnv() {
 				allowWrites = false
 			}
-			// Constructed here rather than in the fx graph (see populateDeps):
-			// the service depends on allowWrites, which is only known after
-			// flag parsing and the read-only override above.
-			svc := mcpserver.New(c.apiClient, c.cfg, allowWrites)
-			return svc.Run(cmd.Context())
+			return c.mcpserver.Run(cmd.Context(), allowWrites)
 		}),
 	}
 	mcpCmd.Flags().BoolVar(&allowWrites, "allow-writes", false, "expose mutating tools (create_install, deploy_component)")

--- a/bins/cli/cmd/mcp.go
+++ b/bins/cli/cmd/mcp.go
@@ -28,6 +28,9 @@ Example Claude Code config (.mcp.json):
 			if ReadOnly || readOnlyFromEnv() {
 				allowWrites = false
 			}
+			// Constructed here rather than in the fx graph (see populateDeps):
+			// the service depends on allowWrites, which is only known after
+			// flag parsing and the read-only override above.
 			svc := mcpserver.New(c.apiClient, c.cfg, allowWrites)
 			return svc.Run(cmd.Context())
 		}),

--- a/bins/cli/cmd/orgs.go
+++ b/bins/cli/cmd/orgs.go
@@ -37,7 +37,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Short: "Get current org",
 		Long:  "Get the org you are currently authenticated with",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.Current(cmd.Context(), PrintJSON)
 		}),
 	}
@@ -49,7 +49,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			printDeprecatedCommandWarning(cmd, "Use `nuon orgs get` instead")
 
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.Current(cmd.Context(), PrintJSON)
 		}),
 	}
@@ -67,7 +67,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			printDeprecatedCommandWarning(cmd, "Use `nuon orgs api-tokens` instead")
 
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.APIToken(cmd.Context(), PrintJSON)
 		}),
 	}
@@ -78,7 +78,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Short: "Get current org id",
 		Long:  "Get id for current org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.ID(cmd.Context(), PrintJSON)
 		}),
 	}
@@ -90,7 +90,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Short:   "List orgs",
 		Long:    "List all your orgs",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.List(cmd.Context(), offset, limit, search, PrintJSON)
 		}),
 	}
@@ -104,7 +104,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Short: "List VCS connections",
 		Long:  "List all connected GitHub accounts",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.VCSConnections(cmd.Context(), offset, limit, PrintJSON)
 		}),
 	}
@@ -117,7 +117,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Short: "Delete VCS Connection",
 		Long:  "Delete a VCS connection from your Nuon org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.DeleteVCSConnection(cmd.Context(), connectionID, PrintJSON)
 		}),
 	}
@@ -131,7 +131,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Short: "Connect GitHub account",
 		Long:  "Connect GitHub account to your Nuon org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.ConnectGithub(cmd.Context())
 		}),
 	}
@@ -143,7 +143,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Short: "Create new org",
 		Long:  "Create a new org and set it as the current org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.Create(cmd.Context(), name, sandbox, noSelect, PrintJSON)
 		}),
 	}
@@ -159,7 +159,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Long:        "Select your current org from a list or by org ID",
 		Annotations: tuiAnnotation(TUIContextual),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.Select(cmd.Context(), id, offset, limit, PrintJSON)
 		}),
 	}
@@ -173,7 +173,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Short: "Deselect your current org",
 		Long:  "Deselect your current org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.Deselect(cmd.Context())
 		}),
 	}
@@ -184,7 +184,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Short: "Print the current cli config",
 		Long:  "Print the current cli config being used",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.PrintConfig(PrintJSON)
 		}),
 	})
@@ -194,7 +194,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Short: "Invite a user to org",
 		Long:  "Invite a user by email to org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.CreateInvite(cmd.Context(), email, role, PrintJSON)
 		}),
 	}
@@ -207,7 +207,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Short: "Change an org member's role",
 		Long:  "Change the role of an existing member of the current org. Requires org admin.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.UpdateUserRole(cmd.Context(), userID, role, PrintJSON)
 		}),
 	}
@@ -222,7 +222,7 @@ func (c *cli) orgsCmd() *cobra.Command {
 		Short: "List all org invites",
 		Long:  "List all org invites",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.ListInvites(cmd.Context(), offset, limit, PrintJSON)
 		}),
 	}
@@ -256,10 +256,7 @@ func (c *cli) apiTokensCmd() *cobra.Command {
 		Short: "Create a static API token for the current org",
 		Long:  "Create a static API token. By default the token is backed by a dedicated service account with the given role; use --personal to issue the token against your own account and its existing roles instead. The token is only shown once.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			if personal && cmd.Flags().Changed("role") {
-				return fmt.Errorf("--role cannot be used with --personal; personal tokens use your account's existing roles")
-			}
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.CreateStaticToken(cmd.Context(), name, duration, role, personal, PrintJSON)
 		}),
 	}
@@ -275,7 +272,7 @@ func (c *cli) apiTokensCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List static API tokens for the current org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.ListStaticTokens(cmd.Context(), PrintJSON)
 		}),
 	}
@@ -285,7 +282,7 @@ func (c *cli) apiTokensCmd() *cobra.Command {
 		Use:   "delete",
 		Short: "Delete a static API token for the current org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.DeleteStaticToken(cmd.Context(), tokenID, PrintJSON)
 		}),
 	}
@@ -335,7 +332,7 @@ Example (GitHub Actions, main branch of acme/app only):
 			if err != nil {
 				return err
 			}
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.CreateOIDCTrustPolicy(cmd.Context(), name, issuer, audience, role, ttl, conditions, PrintJSON)
 		}),
 	}
@@ -356,7 +353,7 @@ Example (GitHub Actions, main branch of acme/app only):
 		Aliases: []string{"ls"},
 		Short:   "List OIDC trust policies for the current org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.ListOIDCTrustPolicies(cmd.Context(), PrintJSON)
 		}),
 	}
@@ -366,7 +363,7 @@ Example (GitHub Actions, main branch of acme/app only):
 		Use:   "get",
 		Short: "Get an OIDC trust policy",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.GetOIDCTrustPolicy(cmd.Context(), policyID, PrintJSON)
 		}),
 	}
@@ -410,7 +407,7 @@ Example (GitHub Actions, main branch of acme/app only):
 				req.Enabled = &enable
 			}
 
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.UpdateOIDCTrustPolicy(cmd.Context(), policyID, req, PrintJSON)
 		}),
 	}
@@ -431,7 +428,7 @@ Example (GitHub Actions, main branch of acme/app only):
 		Short: "Delete an OIDC trust policy",
 		Long:  "Delete an OIDC trust policy and its service account. Tokens already exchanged under the policy stop working immediately.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.DeleteOIDCTrustPolicy(cmd.Context(), policyID, PrintJSON)
 		}),
 	}
@@ -596,7 +593,7 @@ func (c *cli) orgWebhooksCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List webhooks for the current org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.ListWebhooks(cmd.Context(), PrintJSON)
 		}),
 	}
@@ -620,7 +617,7 @@ path/to/subscription.json.
 ` + subscriptionJSONHelp,
 		Annotations: tuiAnnotation(TUIContextual),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.CreateWebhook(cmd.Context(), webhookURL, webhookSecret, createSubscription, PrintJSON)
 		}),
 	}
@@ -655,7 +652,7 @@ to preserve it.
 ` + subscriptionJSONHelp,
 		Annotations: tuiAnnotation(TUIContextual),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.UpdateWebhook(cmd.Context(), webhookID, webhookSecret, updateSubscription, PrintJSON)
 		}),
 	}
@@ -670,7 +667,7 @@ to preserve it.
 		Use:   "delete",
 		Short: "Delete a webhook for the current org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := orgs.New(c.apiClient, c.cfg)
+			svc := c.orgs
 			return svc.DeleteWebhook(cmd.Context(), webhookID, PrintJSON)
 		}),
 	}

--- a/bins/cli/cmd/roles.go
+++ b/bins/cli/cmd/roles.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/nuonco/nuon/bins/cli/internal/services/roles"
 )
 
 func (c *cli) rolesCmd() *cobra.Command {
@@ -19,7 +17,7 @@ func (c *cli) rolesCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List roles assignable to members and service accounts",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := roles.New(c.apiClient, c.cfg)
+			svc := c.roles
 			return svc.ListRoles(cmd.Context(), PrintJSON)
 		}),
 	}

--- a/bins/cli/cmd/runbooks.go
+++ b/bins/cli/cmd/runbooks.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/nuonco/nuon/bins/cli/internal/services/runbooks"
 )
 
 func (c *cli) runbooksCmd() *cobra.Command {
@@ -28,7 +26,7 @@ func (c *cli) runbooksCmd() *cobra.Command {
 		Short:   "List runbooks",
 		Long:    "List all runbooks for an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := runbooks.New(c.apiClient, c.cfg)
+			svc := c.runbooks
 			return svc.List(cmd.Context(), installID, PrintJSON)
 		}),
 	}
@@ -41,7 +39,7 @@ func (c *cli) runbooksCmd() *cobra.Command {
 		Short: "Get a runbook",
 		Long:  "Get a runbook by ID for an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := runbooks.New(c.apiClient, c.cfg)
+			svc := c.runbooks
 			return svc.Get(cmd.Context(), installID, runbookID, PrintJSON)
 		}),
 	}
@@ -56,7 +54,7 @@ func (c *cli) runbooksCmd() *cobra.Command {
 		Short: "Run a runbook",
 		Long:  "Trigger a runbook run by Install ID and Runbook ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := runbooks.New(c.apiClient, c.cfg)
+			svc := c.runbooks
 			return svc.CreateRun(cmd.Context(), installID, runbookID, PrintJSON)
 		}),
 	}
@@ -71,7 +69,7 @@ func (c *cli) runbooksCmd() *cobra.Command {
 		Short: "Get recent runbook runs",
 		Long:  "List recent runbook runs for an install",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := runbooks.New(c.apiClient, c.cfg)
+			svc := c.runbooks
 			return svc.GetRecentRuns(cmd.Context(), installID, runbookID, offset, limit, PrintJSON)
 		}),
 	}
@@ -87,7 +85,7 @@ func (c *cli) runbooksCmd() *cobra.Command {
 		Short: "Get a runbook run",
 		Long:  "Get a runbook run by ID",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := runbooks.New(c.apiClient, c.cfg)
+			svc := c.runbooks
 			return svc.GetRun(cmd.Context(), installID, runID, PrintJSON)
 		}),
 	}

--- a/bins/cli/cmd/secrets.go
+++ b/bins/cli/cmd/secrets.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/nuonco/nuon/bins/cli/internal/services/secrets"
 )
 
 func (c *cli) secretsCmd() *cobra.Command {
@@ -29,7 +27,7 @@ func (c *cli) secretsCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all secrets ",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := secrets.New(c.apiClient, c.cfg)
+			svc := c.secrets
 			return svc.List(cmd.Context(), appID, offset, limit, PrintJSON)
 		}),
 	}
@@ -46,7 +44,7 @@ func (c *cli) secretsCmd() *cobra.Command {
 		Short: "Delete secret",
 		Long:  "Delete an app secret",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := secrets.New(c.apiClient, c.cfg)
+			svc := c.secrets
 			return svc.Delete(cmd.Context(), appID, secretID, PrintJSON)
 		}),
 	}
@@ -69,7 +67,7 @@ func (c *cli) secretsCmd() *cobra.Command {
 		Short:             "Create a new secret.",
 		PersistentPreRunE: c.persistentPreRunE,
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := secrets.New(c.apiClient, c.cfg)
+			svc := c.secrets
 			return svc.Create(cmd.Context(), appID, name, value, PrintJSON)
 		}),
 	}

--- a/bins/cli/cmd/service_accounts.go
+++ b/bins/cli/cmd/service_accounts.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/nuonco/nuon/bins/cli/internal/services/serviceaccounts"
 )
 
 func (c *cli) serviceAccountsCmd() *cobra.Command {
@@ -32,7 +30,7 @@ func (c *cli) serviceAccountsCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List service accounts for the current org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := serviceaccounts.New(c.apiClient, c.cfg)
+			svc := c.serviceAccounts
 			return svc.ListServiceAccounts(cmd.Context(), includeRunners, offset, limit, PrintJSON)
 		}),
 	}
@@ -45,7 +43,7 @@ func (c *cli) serviceAccountsCmd() *cobra.Command {
 		Use:   "create",
 		Short: "Create a service account for the current org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := serviceaccounts.New(c.apiClient, c.cfg)
+			svc := c.serviceAccounts
 			return svc.CreateServiceAccount(cmd.Context(), name, role, PrintJSON)
 		}),
 	}
@@ -59,7 +57,7 @@ func (c *cli) serviceAccountsCmd() *cobra.Command {
 		Use:   "update-name",
 		Short: "Update the name of a service account",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := serviceaccounts.New(c.apiClient, c.cfg)
+			svc := c.serviceAccounts
 			return svc.UpdateServiceAccountName(cmd.Context(), id, name, PrintJSON)
 		}),
 	}
@@ -73,7 +71,7 @@ func (c *cli) serviceAccountsCmd() *cobra.Command {
 		Use:   "update-role",
 		Short: "Update the role of a service account",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := serviceaccounts.New(c.apiClient, c.cfg)
+			svc := c.serviceAccounts
 			return svc.UpdateServiceAccountRole(cmd.Context(), id, role, PrintJSON)
 		}),
 	}
@@ -87,7 +85,7 @@ func (c *cli) serviceAccountsCmd() *cobra.Command {
 		Use:   "delete",
 		Short: "Delete a service account for the current org",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := serviceaccounts.New(c.apiClient, c.cfg)
+			svc := c.serviceAccounts
 			return svc.DeleteServiceAccount(cmd.Context(), id, PrintJSON)
 		}),
 	}
@@ -106,7 +104,7 @@ func (c *cli) serviceAccountsCmd() *cobra.Command {
 		Short: "Create an API token for a service account",
 		Long:  "Create an API token for a service account. The token is only shown once.",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := serviceaccounts.New(c.apiClient, c.cfg)
+			svc := c.serviceAccounts
 			return svc.CreateServiceAccountToken(cmd.Context(), id, duration, invalidate, PrintJSON)
 		}),
 	}

--- a/bins/cli/cmd/sync.go
+++ b/bins/cli/cmd/sync.go
@@ -47,7 +47,7 @@ func (c *cli) syncCmd() *cobra.Command {
 				PrintJSON: PrintJSON,
 				NoWait:    noWait,
 			}
-			svc := apps.New(c.v, c.apiClient, c.cfg)
+			svc := c.apps
 			if create {
 				return svc.SyncDirWithCreate(cmd.Context(), ".", version.Version, opts)
 			}

--- a/bins/cli/cmd/triggers.go
+++ b/bins/cli/cmd/triggers.go
@@ -29,7 +29,7 @@ func (c *cli) triggerEventsCmd() *cobra.Command {
 		Args:        cobra.NoArgs,
 		Annotations: outputsAnnotation(OutputTable, OutputJSON, OutputAgent),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			return triggersservice.New(c.apiClient).List(cmd.Context(), models.TriggerEventListQuery{Limit: limit, Trigger: trigger, EventType: eventType, Outcome: outcome, Search: search, ReceivedAfter: receivedAfter, ReceivedBefore: receivedBefore, Cursor: cursor}, PrintJSON)
+			return c.triggers.List(cmd.Context(), models.TriggerEventListQuery{Limit: limit, Trigger: trigger, EventType: eventType, Outcome: outcome, Search: search, ReceivedAfter: receivedAfter, ReceivedBefore: receivedBefore, Cursor: cursor}, PrintJSON)
 		}),
 	}
 	listCmd.Flags().IntVarP(&limit, "limit", "l", 50, "Maximum events to return")
@@ -49,7 +49,7 @@ func (c *cli) triggerEventsCmd() *cobra.Command {
 			if len(args) != 1 {
 				return ui.PrintError(&ui.CLIUserError{Msg: "get requires exactly one event ID"})
 			}
-			return triggersservice.New(c.apiClient).Get(cmd.Context(), args[0], PrintJSON)
+			return c.triggers.Get(cmd.Context(), args[0], PrintJSON)
 		}),
 	}
 	replayCmd := &cobra.Command{
@@ -59,7 +59,7 @@ func (c *cli) triggerEventsCmd() *cobra.Command {
 			if len(args) != 1 {
 				return ui.PrintError(&ui.CLIUserError{Msg: "replay requires exactly one event ID"})
 			}
-			return triggersservice.New(c.apiClient).Replay(cmd.Context(), args[0], PrintJSON)
+			return c.triggers.Replay(cmd.Context(), args[0], PrintJSON)
 		}),
 	}
 	pathsCmd := &cobra.Command{
@@ -76,7 +76,7 @@ func (c *cli) triggerEventsCmd() *cobra.Command {
 			if len(args) == 1 {
 				id = args[0]
 			}
-			return triggersservice.New(c.apiClient).Paths(cmd.Context(), id, pathsLast, trigger, PrintJSON)
+			return c.triggers.Paths(cmd.Context(), id, pathsLast, trigger, PrintJSON)
 		}),
 	}
 	pathsCmd.Flags().BoolVar(&pathsLast, "last", false, "Inspect the most recent event")
@@ -95,7 +95,7 @@ func (c *cli) triggerEventsCmd() *cobra.Command {
 			if appConfig == "" {
 				return ui.PrintError(triggersservice.AppConfigError())
 			}
-			return triggersservice.New(c.apiClient).Test(cmd.Context(), eventID, last, trigger, appConfig, PrintJSON)
+			return c.triggers.Test(cmd.Context(), eventID, last, trigger, appConfig, PrintJSON)
 		}),
 	}
 	testCmd.Flags().StringVar(&eventID, "event", "", "Event ID to test")
@@ -106,7 +106,7 @@ func (c *cli) triggerEventsCmd() *cobra.Command {
 		Use: "tail", Short: "Continuously print newly received trigger events", Args: cobra.NoArgs,
 		Annotations: outputsAnnotation(OutputTable),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			return triggersservice.New(c.apiClient).Tail(cmd.Context(), trigger, pollInterval, tailRaw)
+			return c.triggers.Tail(cmd.Context(), trigger, pollInterval, tailRaw)
 		}),
 	}
 	tailCmd.Flags().StringVar(&trigger, "trigger", "", "Trigger ID or name")
@@ -124,15 +124,15 @@ func (c *cli) triggerDispatchesCmd() *cobra.Command {
 
 	dispatchesCmd := &cobra.Command{Use: "dispatches", Short: "Inspect and retry trigger dispatches"}
 	dispatchListCmd := &cobra.Command{Use: "list", Aliases: []string{"ls"}, Short: "List trigger dispatches", Args: cobra.NoArgs, Annotations: outputsAnnotation(OutputTable, OutputJSON, OutputAgent), Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-		return triggersservice.New(c.apiClient).ListDispatches(cmd.Context(), limit, eventID, cursor, PrintJSON)
+		return c.triggers.ListDispatches(cmd.Context(), limit, eventID, cursor, PrintJSON)
 	})}
 	dispatchListCmd.Flags().IntVarP(&limit, "limit", "l", 50, "Maximum dispatches to return")
 	dispatchListCmd.Flags().StringVar(&eventID, "event-id", "", "Filter by event ID")
 	dispatchListCmd.Flags().StringVar(&cursor, "cursor", "", "Continue listing from an opaque cursor")
 	dispatchesCmd.AddCommand(dispatchListCmd, &cobra.Command{Use: "get <dispatch-id>", Short: "Get a trigger dispatch", Args: cobra.ExactArgs(1), Annotations: outputsAnnotation(OutputTable, OutputJSON, OutputAgent), Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
-		return triggersservice.New(c.apiClient).GetDispatch(cmd.Context(), args[0], PrintJSON)
+		return c.triggers.GetDispatch(cmd.Context(), args[0], PrintJSON)
 	})}, &cobra.Command{Use: "retry <dispatch-id>", Short: "Retry a trigger dispatch", Args: cobra.ExactArgs(1), Annotations: outputsAnnotation(OutputTable, OutputJSON, OutputAgent), Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
-		return triggersservice.New(c.apiClient).RetryDispatch(cmd.Context(), args[0], PrintJSON)
+		return c.triggers.RetryDispatch(cmd.Context(), args[0], PrintJSON)
 	})})
 	return dispatchesCmd
 }
@@ -164,7 +164,7 @@ func (c *cli) triggersCmd() *cobra.Command {
 		if topicARN != "" {
 			req.AuthConfig.TopicARN = topicARN
 		}
-		return triggersservice.New(c.apiClient).CreateTrigger(cmd.Context(), req, PrintJSON)
+		return c.triggers.CreateTrigger(cmd.Context(), req, PrintJSON)
 	})}
 	createTriggerCmd.Flags().StringVar(&description, "description", "", "Trigger description")
 	createTriggerCmd.Flags().StringVar(&preset, "preset", "", "Provider preset: github, gitlab, bitbucket, gitea, forgejo, terraform-cloud, google-pubsub, azure-devops, aws-eventbridge, aws-sns, azure-event-grid, slack-events, or datadog")
@@ -182,11 +182,11 @@ func (c *cli) triggersCmd() *cobra.Command {
 	createTriggerCmd.Flags().StringVar(&idPayload, "id-payload", "", "Payload path containing the event ID")
 	triggerAction := func(use, short string, fn func(*triggersservice.Service, *cobra.Command, string) error) *cobra.Command {
 		return &cobra.Command{Use: use + " <trigger-id>", Short: short, Args: cobra.ExactArgs(1), Annotations: outputsAnnotation(OutputTable, OutputJSON, OutputAgent), Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
-			return fn(triggersservice.New(c.apiClient), cmd, args[0])
+			return fn(c.triggers, cmd, args[0])
 		})}
 	}
 	listTriggers := &cobra.Command{Use: "list", Aliases: []string{"ls"}, Short: "List event triggers", Args: cobra.NoArgs, Annotations: outputsAnnotation(OutputTable, OutputJSON, OutputAgent), Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-		return triggersservice.New(c.apiClient).ListTriggers(cmd.Context(), PrintJSON)
+		return c.triggers.ListTriggers(cmd.Context(), PrintJSON)
 	})}
 	getTrigger := triggerAction("get", "Get an event trigger", func(s *triggersservice.Service, cmd *cobra.Command, id string) error {
 		return s.GetTrigger(cmd.Context(), id, PrintJSON)
@@ -201,10 +201,10 @@ func (c *cli) triggersCmd() *cobra.Command {
 		return s.SetTrigger(cmd.Context(), id, false, PrintJSON)
 	})
 	revoke := &cobra.Command{Use: "revoke-secret <trigger-id> <secret-id>", Short: "Revoke a trigger secret", Args: cobra.ExactArgs(2), Annotations: outputsAnnotation(OutputTable, OutputJSON, OutputAgent), Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
-		return triggersservice.New(c.apiClient).RevokeTriggerSecret(cmd.Context(), args[0], args[1], PrintJSON)
+		return c.triggers.RevokeTriggerSecret(cmd.Context(), args[0], args[1], PrintJSON)
 	})}
 	revealSecret := &cobra.Command{Use: "reveal-secret <trigger-id> <secret-id>", Short: "Reveal an active trigger secret", Args: cobra.ExactArgs(2), Annotations: outputsAnnotation(OutputTable, OutputJSON, OutputAgent), Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
-		return triggersservice.New(c.apiClient).RevealTriggerSecret(cmd.Context(), args[0], args[1], PrintJSON)
+		return c.triggers.RevealTriggerSecret(cmd.Context(), args[0], args[1], PrintJSON)
 	})}
 	revealURL := triggerAction("reveal-ingress-url", "Reveal the current ingress URL", func(s *triggersservice.Service, cmd *cobra.Command, id string) error {
 		return s.RevealTriggerIngressURL(cmd.Context(), id, PrintJSON)

--- a/bins/cli/cmd/version.go
+++ b/bins/cli/cmd/version.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/nuonco/nuon/bins/cli/internal/services/version"
 )
 
 func (c *cli) versionCmd() *cobra.Command {
@@ -13,7 +11,7 @@ func (c *cli) versionCmd() *cobra.Command {
 		PersistentPreRunE: c.persistentPreRunE,
 		Annotations:       skipAuthAnnotation(),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			svc := version.New()
+			svc := c.version
 			return svc.Version(cmd.Context(), PrintJSON)
 		}),
 		GroupID: HelpGroup.ID,

--- a/bins/cli/internal/services/mcpserver/service.go
+++ b/bins/cli/internal/services/mcpserver/service.go
@@ -15,27 +15,26 @@ import (
 )
 
 type Service struct {
-	api         nuon.Client
-	cfg         *config.Config
-	allowWrites bool
+	api nuon.Client
+	cfg *config.Config
 }
 
-func New(api nuon.Client, cfg *config.Config, allowWrites bool) *Service {
-	return &Service{api: api, cfg: cfg, allowWrites: allowWrites}
+func New(api nuon.Client, cfg *config.Config) *Service {
+	return &Service{api: api, cfg: cfg}
 }
 
-func (s *Service) Run(ctx context.Context) error {
-	return s.buildServer().Run(ctx, &mcp.StdioTransport{})
+func (s *Service) Run(ctx context.Context, allowWrites bool) error {
+	return s.buildServer(allowWrites).Run(ctx, &mcp.StdioTransport{})
 }
 
-func (s *Service) buildServer() *mcp.Server {
+func (s *Service) buildServer(allowWrites bool) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "nuon",
 		Version: version.Version,
 	}, nil)
 
 	s.registerReadTools(server)
-	if s.allowWrites {
+	if allowWrites {
 		s.registerWriteTools(server)
 	}
 

--- a/bins/cli/internal/services/mcpserver/service_test.go
+++ b/bins/cli/internal/services/mcpserver/service_test.go
@@ -59,7 +59,7 @@ func connect(t *testing.T, api nuon.Client, allowWrites bool, cfg ...*config.Con
 	if len(cfg) > 0 {
 		c = cfg[0]
 	}
-	srv := New(api, c, allowWrites).buildServer()
+	srv := New(api, c).buildServer(allowWrites)
 	st, ct := mcp.NewInMemoryTransports()
 
 	_, err := srv.Connect(ctx, st, nil)


### PR DESCRIPTION
## Summary

This PR refactors the CLI to use `go.uber.org/fx`, bringing it in line with the runner binary and the services. This reduces a decent amount of duplication across the command files, where we construct services for the commands to use.

```go
// instead of
actions.New(c.v, c.apiClient, c.cfg)

// we can now do
svc := c.actions
```


