### PR TITLE
fix: resolve azure managed identity principalId output instead of hardcoding it

### DIFF
--- a/docs/guides/custom-nested-stacks.mdx
+++ b/docs/guides/custom-nested-stacks.mdx
@@ -177,6 +177,30 @@ On `azure-bicep`, the reserved set follows ARM's camelCase convention and adds t
 Azure has no equivalent of the Role Enable parameters — per-operation access is granted through managed identities
 rather than template conditions.
 
+### Azure Managed Identities
+
+If an `azure-bicep` custom nested stack declares a `Microsoft.ManagedIdentity/userAssignedIdentities` resource, Nuon
+adds a subscription-level role assignment granting that identity `*/register/action`, so it can register Azure resource
+providers. ARM does not allow subscription-scoped deployments inside a linked deployment, so this has to live in the
+parent template — which means Nuon needs the identity's `principalId` as an **output**.
+
+Your template must expose an output named `identityPrincipalId`, or one ending in that suffix (for example
+`bauleiterIdentityPrincipalId`, useful when a stack has several identities' outputs to keep distinct). Matching is
+case-insensitive and an exact `identityPrincipalId` wins over a suffixed one.
+
+```json
+"outputs": {
+  "bauleiterIdentityPrincipalId": {
+    "type": "string",
+    "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'my-identity'), '2023-01-31').principalId]"
+  }
+}
+```
+
+If a stack declares a managed identity but exposes no matching output, install stack generation fails with an error
+listing the outputs it did find. This has no CloudFormation equivalent — IAM resources in an AWS nested stack are
+already account-scoped, so nothing needs hoisting to the parent.
+
 ## First-Class Output Wiring
 
 If a parameter in your custom template matches the name of an **output** from the VPC or runner nested stacks, Nuon

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/iancoleman/strcase"
 
@@ -25,6 +26,28 @@ func sanitizeDeploymentName(name string) string {
 // role assignment that the identity needs.
 type customDeploymentIdentity struct {
 	DeploymentName string
+	// output holding the identity's principalId, resolved from the template
+	PrincipalIDOutput string
+}
+
+// resolvePrincipalIDOutput finds the output carrying a managed identity's
+// principalId. An exact "identityPrincipalId" wins; otherwise any output with
+// that suffix matches, so a template may prefix it to keep outputs unique.
+func resolvePrincipalIDOutput(outputKeys []string) (string, bool) {
+	const want = "identityprincipalid"
+
+	for _, key := range outputKeys {
+		if strings.EqualFold(key, want) {
+			return key, true
+		}
+	}
+	for _, key := range outputKeys {
+		if strings.HasSuffix(strings.ToLower(key), want) {
+			return key, true
+		}
+	}
+
+	return "", false
 }
 
 // customDeploymentOutputs records a custom stack's deployment name and its
@@ -132,8 +155,19 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 		// Track custom nested stacks that declare managed identities so the
 		// parent template can create subscription-level role assignments.
 		if armTmpl.hasManagedIdentity() {
+			principalIDOutput, ok := resolvePrincipalIDOutput(outputKeys)
+			if !ok {
+				// Caught here rather than at deploy time, where ARM reports it
+				// as a missing output on a Nuon-generated resource.
+				return nil, nil, nil, nil, fmt.Errorf(
+					"custom_nested_stacks[%d] (%s): declares a managed identity but no output named %q (found: %v); add one so the subscription-level role assignment can read its principalId",
+					i, stack.Name, "identityPrincipalId", outputKeys,
+				)
+			}
+
 			identities = append(identities, customDeploymentIdentity{
-				DeploymentName: deploymentName,
+				DeploymentName:    deploymentName,
+				PrincipalIDOutput: principalIDOutput,
 			})
 		}
 

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_wiring_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_wiring_test.go
@@ -17,10 +17,11 @@ import (
 )
 
 type wiringStack struct {
-	name       string
-	params     map[string]any
-	outputs    []string
-	parameters map[string]string
+	name            string
+	params          map[string]any
+	outputs         []string
+	parameters      map[string]string
+	managedIdentity bool
 }
 
 func armWiringInput(t *testing.T, stacksIn ...wiringStack) *stacks.TemplateInput {
@@ -35,11 +36,20 @@ func armWiringInput(t *testing.T, stacksIn ...wiringStack) *stacks.TemplateInput
 			outputs[name] = map[string]any{"type": "string", "value": "x"}
 		}
 
+		resources := []any{}
+		if s.managedIdentity {
+			resources = append(resources, map[string]any{
+				"type":       "Microsoft.ManagedIdentity/userAssignedIdentities",
+				"apiVersion": "2023-01-31",
+				"name":       s.name + "-identity",
+			})
+		}
+
 		body, err := json.Marshal(map[string]any{
 			"$schema":        "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
 			"contentVersion": "1.0.0.0",
 			"parameters":     params,
-			"resources":      []any{},
+			"resources":      resources,
 			"outputs":        outputs,
 		})
 		require.NoError(t, err)
@@ -276,5 +286,81 @@ func TestGetCustomLinkedDeployments_OutputWiring(t *testing.T) {
 				fmt.Sprintf("stack %d", idx),
 			)
 		}
+	})
+}
+
+func TestGetCustomLinkedDeployments_PrincipalIDOutput(t *testing.T) {
+	t.Run("exact identityPrincipalId resolves", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t, wiringStack{
+			name:            "bauleiter",
+			managedIdentity: true,
+			outputs:         []string{"identityPrincipalId"},
+		})
+
+		_, _, identities, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+		require.Len(t, identities, 1)
+		assert.Equal(t, "identityPrincipalId", identities[0].PrincipalIDOutput)
+	})
+
+	t.Run("prefixed output resolves", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t, wiringStack{
+			name:            "bauleiter",
+			managedIdentity: true,
+			outputs: []string{
+				"bauleiterIdentityClientId", "bauleiterIdentityId",
+				"bauleiterIdentityName", "bauleiterIdentityPrincipalId",
+			},
+		})
+
+		_, _, identities, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+		require.Len(t, identities, 1)
+		assert.Equal(t, "bauleiterIdentityPrincipalId", identities[0].PrincipalIDOutput)
+
+		role := tmpl.getCustomDeploymentRoleAssignment(identities[0])
+		params := role["properties"].(map[string]any)["parameters"].(map[string]any)
+		assert.Equal(t,
+			"[reference('Bauleiter').outputs.bauleiterIdentityPrincipalId.value]",
+			params["principalID"].(map[string]any)["value"],
+		)
+	})
+
+	t.Run("exact match wins over a prefixed one", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t, wiringStack{
+			name:            "both",
+			managedIdentity: true,
+			outputs:         []string{"appIdentityPrincipalId", "identityPrincipalId"},
+		})
+
+		_, _, identities, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+		assert.Equal(t, "identityPrincipalId", identities[0].PrincipalIDOutput)
+	})
+
+	t.Run("managed identity without the output fails at generation", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t, wiringStack{
+			name:            "bauleiter",
+			managedIdentity: true,
+			outputs:         []string{"identityId", "identityName"},
+		})
+
+		_, _, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "declares a managed identity but no output named")
+		assert.Contains(t, err.Error(), "identityId")
+	})
+
+	t.Run("stack without a managed identity needs no such output", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		inp := armWiringInput(t, wiringStack{name: "storage", outputs: []string{"blobEndpoint"}})
+
+		_, _, identities, _, err := tmpl.getCustomLinkedDeployments(inp)
+		require.NoError(t, err)
+		assert.Empty(t, identities)
 	})
 }

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_custom_deployment_role.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_custom_deployment_role.go
@@ -6,9 +6,8 @@ import "fmt"
 // deployment that defines a custom role with */register/action and assigns it
 // to the managed identity created inside a custom linked deployment.
 //
-// The identity's principalId is read from the linked deployment's
-// "identityPrincipalId" output, so the custom nested stack template must
-// expose that output.
+// The identity's principalId is read from an output resolved by
+// resolvePrincipalIDOutput, which the generator requires the template to expose.
 func (t *Templates) getCustomDeploymentRoleAssignment(id customDeploymentIdentity) map[string]any {
 	deploymentName := fmt.Sprintf("%s-identity-role", id.DeploymentName)
 
@@ -26,7 +25,7 @@ func (t *Templates) getCustomDeploymentRoleAssignment(id customDeploymentIdentit
 			"mode": "Incremental",
 			"parameters": map[string]any{
 				"deploymentName": map[string]any{"value": id.DeploymentName},
-				"principalID":    map[string]any{"value": fmt.Sprintf("[reference('%s').outputs.identityPrincipalId.value]", id.DeploymentName)},
+				"principalID":    map[string]any{"value": fmt.Sprintf("[reference('%s').outputs.%s.value]", id.DeploymentName, id.PrincipalIDOutput)},
 			},
 			"template": map[string]any{
 				"$schema":        "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",


### PR DESCRIPTION
A custom nested stack declaring a managed identity got a Nuon-generated role assignment reading a hardcoded `identityPrincipalId` output. Templates naming it anything else — `bauleiterIdentityPrincipalId` in lovable-enterprise — passed generation and failed at ARM deploy time on a resource the vendor never wrote.

Resolves the output by convention (exact match, else that suffix, case-insensitive) and fails at generation with the outputs it did find when a managed-identity stack exposes none. Documents the contract, which previously lived only in a Go comment. CloudFormation needs no equivalent — IAM in a nested stack is already account-scoped.