### PR TITLE
fix: gate sandbox OCI artifacts behind a flag, pass GAR credentials

### DIFF
--- a/services/ctl-api/internal/app/apps/signals/branches/builds/execute.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/builds/execute.go
@@ -84,26 +84,38 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return fmt.Errorf("component builds failed: %w", err)
 	}
 
-	sandboxEntry := buildEntry{
-		ComponentID:   "sandbox",
-		ComponentName: "Sandbox",
-		ComponentType: "sandbox",
-		Status:        "in-progress",
-		CacheStatus:   "no cache",
+	ociArtifacts, err := activities.AwaitOrgHasFeature(ctx, activities.OrgHasFeatureRequest{
+		OrgID:   run.OrgID,
+		Feature: string(app.OrgFeatureSandboxOCIArtifacts),
+	})
+	if err != nil {
+		return fmt.Errorf("unable to check sandbox-oci-artifacts feature flag: %w", err)
 	}
-	builds = append(builds, sandboxEntry)
-	s.updateBuildMetadata(ctx, builds)
 
-	if err := s.buildSandbox(ctx, l); err != nil {
-		s.setBuildStatus(builds, "sandbox", "error")
-		s.updateBuildMetadata(ctx, builds)
-		if isPreview && run.PRNumber != nil {
-			s.finalizePreview(ctx, l, run, err)
+	if ociArtifacts {
+		sandboxEntry := buildEntry{
+			ComponentID:   "sandbox",
+			ComponentName: "Sandbox",
+			ComponentType: "sandbox",
+			Status:        "in-progress",
+			CacheStatus:   "no cache",
 		}
-		return fmt.Errorf("sandbox build failed: %w", err)
+		builds = append(builds, sandboxEntry)
+		s.updateBuildMetadata(ctx, builds)
+
+		if err := s.buildSandbox(ctx, l); err != nil {
+			s.setBuildStatus(builds, "sandbox", "error")
+			s.updateBuildMetadata(ctx, builds)
+			if isPreview && run.PRNumber != nil {
+				s.finalizePreview(ctx, l, run, err)
+			}
+			return fmt.Errorf("sandbox build failed: %w", err)
+		}
+		s.setBuildStatus(builds, "sandbox", "success")
+		s.updateBuildMetadata(ctx, builds)
+	} else {
+		l.Info("sandbox-oci-artifacts disabled, skipping sandbox build")
 	}
-	s.setBuildStatus(builds, "sandbox", "success")
-	s.updateBuildMetadata(ctx, builds)
 
 	if isPreview && run.PRNumber != nil {
 		s.finalizePreview(ctx, l, run, nil)

--- a/services/ctl-api/internal/app/components/signals/build/signal.go
+++ b/services/ctl-api/internal/app/components/signals/build/signal.go
@@ -10,7 +10,6 @@ import (
 	"go.uber.org/zap"
 
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
-	"github.com/nuonco/nuon/pkg/plugins/configs"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	createdsignal "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/created"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/activities"
@@ -205,20 +204,10 @@ func (s *Signal) execBuild(ctx workflow.Context, compID, buildID string, current
 		return errors.Wrap(err, "unable to create plan")
 	}
 
-	if runPlan.ContainerImagePullPlan != nil &&
-		runPlan.ContainerImagePullPlan.RepoCfg != nil &&
-		runPlan.ContainerImagePullPlan.RepoCfg.RegistryType == configs.OCIRegistryTypeGAR {
-		garToken, err := activities.AwaitGetGARAccessToken(ctx, &activities.GetGARAccessTokenRequest{
-			ServiceAccountEmail:      runPlan.ContainerImagePullPlan.RepoCfg.ServiceAccountEmail,
-			WorkloadIdentityProvider: runPlan.ContainerImagePullPlan.RepoCfg.WorkloadIdentityProvider,
-		})
-		if err != nil {
+	if runPlan.ContainerImagePullPlan != nil {
+		if err := sharedactivities.EnsureGARAuth(ctx, runPlan.ContainerImagePullPlan.RepoCfg); err != nil {
 			s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to get GAR access token")
 			return errors.Wrap(err, "unable to get GAR access token")
-		}
-		runPlan.ContainerImagePullPlan.RepoCfg.OCIAuth = &configs.OCIRegistryAuth{
-			Username: garToken.Username,
-			Password: garToken.Password,
 		}
 	}
 

--- a/services/ctl-api/internal/app/components/signals/inlinebuild/signal.go
+++ b/services/ctl-api/internal/app/components/signals/inlinebuild/signal.go
@@ -10,7 +10,6 @@ import (
 	"go.uber.org/zap"
 
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
-	"github.com/nuonco/nuon/pkg/plugins/configs"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	created "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/created"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/activities"
@@ -218,20 +217,10 @@ func (s *Signal) execBuild(ctx workflow.Context, buildID string) error {
 		return notify(errors.Wrap(err, "unable to create plan"))
 	}
 
-	if runPlan.ContainerImagePullPlan != nil &&
-		runPlan.ContainerImagePullPlan.RepoCfg != nil &&
-		runPlan.ContainerImagePullPlan.RepoCfg.RegistryType == configs.OCIRegistryTypeGAR {
-		garToken, err := activities.AwaitGetGARAccessToken(ctx, &activities.GetGARAccessTokenRequest{
-			ServiceAccountEmail:      runPlan.ContainerImagePullPlan.RepoCfg.ServiceAccountEmail,
-			WorkloadIdentityProvider: runPlan.ContainerImagePullPlan.RepoCfg.WorkloadIdentityProvider,
-		})
-		if err != nil {
+	if runPlan.ContainerImagePullPlan != nil {
+		if err := sharedactivities.EnsureGARAuth(ctx, runPlan.ContainerImagePullPlan.RepoCfg); err != nil {
 			s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to get GAR access token")
 			return notify(errors.Wrap(err, "unable to get GAR access token"))
-		}
-		runPlan.ContainerImagePullPlan.RepoCfg.OCIAuth = &configs.OCIRegistryAuth{
-			Username: garToken.Username,
-			Password: garToken.Password,
 		}
 	}
 

--- a/services/ctl-api/internal/app/components/worker/activities/activities.go
+++ b/services/ctl-api/internal/app/components/worker/activities/activities.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/authz"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
+	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 )
 
 type Params struct {
@@ -26,6 +27,7 @@ type Params struct {
 	AuthzClient   *authz.Client
 	Cfg           *internal.Config
 	Features      *features.Features
+	SharedActs    *sharedactivities.Activities
 }
 
 type Activities struct {
@@ -38,6 +40,7 @@ type Activities struct {
 	authzClient    *authz.Client
 	cfg            *internal.Config
 	features       *features.Features
+	sharedActs     *sharedactivities.Activities
 }
 
 func New(params Params) *Activities {
@@ -51,5 +54,6 @@ func New(params Params) *Activities {
 		acctClient:     params.AcctClient,
 		authzClient:    params.AuthzClient,
 		features:       params.Features,
+		sharedActs:     params.SharedActs,
 	}
 }

--- a/services/ctl-api/internal/app/components/worker/activities/fetch_image_metadata.go
+++ b/services/ctl-api/internal/app/components/worker/activities/fetch_image_metadata.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
+	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 )
 
 type FetchImageMetadataRequest struct {
@@ -135,7 +136,7 @@ func (a *Activities) getACRAuth(ctx context.Context, acrCfg *app.AzureACRImageCo
 }
 
 func (a *Activities) getGARAuth(ctx context.Context, garCfg *app.GCPGARImageConfig) (*metadata.RegistryAuth, error) {
-	tok, err := a.GetGARAccessToken(ctx, &GetGARAccessTokenRequest{
+	tok, err := a.sharedActs.GetGARAccessToken(ctx, &sharedactivities.GetGARAccessTokenRequest{
 		ServiceAccountEmail:      garCfg.ServiceAccountEmail,
 		WorkloadIdentityProvider: garCfg.WorkloadIdentityProvider,
 	})

--- a/services/ctl-api/internal/app/components/worker/exec_build.go
+++ b/services/ctl-api/internal/app/components/worker/exec_build.go
@@ -9,11 +9,11 @@ import (
 	"github.com/pkg/errors"
 
 	plantypes "github.com/nuonco/nuon/pkg/plans/types"
-	"github.com/nuonco/nuon/pkg/plugins/configs"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/plan"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/controlplanejob"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
 )
@@ -76,19 +76,9 @@ func (w *Workflows) execBuild(ctx workflow.Context, compID, buildID string, curr
 		return errors.Wrap(err, "unable to create plan")
 	}
 
-	if runPlan.ContainerImagePullPlan != nil &&
-		runPlan.ContainerImagePullPlan.RepoCfg != nil &&
-		runPlan.ContainerImagePullPlan.RepoCfg.RegistryType == configs.OCIRegistryTypeGAR {
-		garToken, err := activities.AwaitGetGARAccessToken(ctx, &activities.GetGARAccessTokenRequest{
-			ServiceAccountEmail:      runPlan.ContainerImagePullPlan.RepoCfg.ServiceAccountEmail,
-			WorkloadIdentityProvider: runPlan.ContainerImagePullPlan.RepoCfg.WorkloadIdentityProvider,
-		})
-		if err != nil {
+	if runPlan.ContainerImagePullPlan != nil {
+		if err := sharedactivities.EnsureGARAuth(ctx, runPlan.ContainerImagePullPlan.RepoCfg); err != nil {
 			return errors.Wrap(err, "unable to get GAR access token")
-		}
-		runPlan.ContainerImagePullPlan.RepoCfg.OCIAuth = &configs.OCIRegistryAuth{
-			Username: garToken.Username,
-			Password: garToken.Password,
 		}
 	}
 

--- a/services/ctl-api/internal/app/installs/worker/activities/has_org_feature.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/has_org_feature.go
@@ -1,0 +1,24 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+type HasOrgFeatureRequest struct {
+	OrgID   string `validate:"required"`
+	Feature string `validate:"required"`
+}
+
+// HasOrgFeature resolves the org explicitly rather than from the context like
+// HasFeature does. Context propagation runs through optionalPropagator, which
+// swallows a failed inject, so a workflow missing org context reaches the
+// activity with no org ID and HasFeature errors — callers that hold the install
+// should pass its OrgID and get a deterministic answer.
+//
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 1m
+func (a *Activities) HasOrgFeature(ctx context.Context, req HasOrgFeatureRequest) (bool, error) {
+	return a.features.OrgHasFeature(ctx, req.OrgID, app.OrgFeature(req.Feature))
+}

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_sandbox_run.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_sandbox_run.go
@@ -183,6 +183,15 @@ func (p *Planner) createSandboxRunPlan(ctx workflow.Context, req *CreateSandboxR
 		}
 	}
 
+	// The install runner does not share the control plane's cloud, so a GAR
+	// artifact has to travel with its own credentials rather than relying on
+	// the runner finding GCP application default credentials.
+	if ociSource != nil {
+		if err := sharedactivities.EnsureGARAuth(ctx, ociSource.Registry); err != nil {
+			return nil, nil, errors.Wrap(err, "unable to get GAR access token for sandbox artifact")
+		}
+	}
+
 	l.Info("getting auth with role selection")
 	cloudAuth, roleSelection, err := p.getAuthForSandbox(ctx, stack.InstallStackOutputs, run, appCfg, stack, state)
 	if err != nil {

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_sandbox_run.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_sandbox_run.go
@@ -147,12 +147,23 @@ func (p *Planner) createSandboxRunPlan(ctx workflow.Context, req *CreateSandboxR
 		return nil, nil, errors.Wrap(err, "unable to get policies")
 	}
 
+	ociArtifacts, err := activities.AwaitHasOrgFeature(ctx, activities.HasOrgFeatureRequest{
+		OrgID:   install.OrgID,
+		Feature: string(app.OrgFeatureSandboxOCIArtifacts),
+	})
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "unable to check sandbox-oci-artifacts feature")
+	}
+
 	var gitSource *plantypes.GitSource
 	var ociSource *plantypes.OCISource
-	if req.OCISource != nil {
+	switch {
+	case !ociArtifacts:
+		l.Info("sandbox-oci-artifacts disabled, using git source")
+	case req.OCISource != nil:
 		l.Info("using OCI source from caller")
 		ociSource = req.OCISource
-	} else {
+	default:
 		l.Info("checking for active sandbox build OCI artifact")
 		sandboxBuild, sbErr := activities.AwaitGetLatestActiveSandboxBuildByAppConfigID(ctx, appCfg.ID)
 		if sbErr != nil {
@@ -173,13 +184,13 @@ func (p *Planner) createSandboxRunPlan(ctx workflow.Context, req *CreateSandboxR
 				}
 			}
 		}
+	}
 
-		if ociSource == nil {
-			l.Info("fetching sandbox git source")
-			gitSource, err = activities.AwaitGetSandboxRunGitSourceByAppConfigID(ctx, appCfg.ID)
-			if err != nil {
-				return nil, nil, errors.Wrap(err, "unable to get sandbox run git source")
-			}
+	if ociSource == nil {
+		l.Info("fetching sandbox git source")
+		gitSource, err = activities.AwaitGetSandboxRunGitSourceByAppConfigID(ctx, appCfg.ID)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "unable to get sandbox run git source")
 		}
 	}
 

--- a/services/ctl-api/internal/app/org.go
+++ b/services/ctl-api/internal/app/org.go
@@ -107,6 +107,11 @@ const (
 	// and /installs-configs endpoints, the VCS push fan-out, the installs config
 	// record written during app config sync, and the dashboard install syncs tab.
 	OrgFeatureAppInstallSyncing OrgFeature = "app-install-syncing"
+	// OrgFeatureSandboxOCIArtifacts builds the app sandbox into an OCI artifact
+	// during branch runs and resolves sandbox runs against that artifact instead
+	// of cloning the sandbox git source. With it off, sandbox runs always clone
+	// git — the path every install used before artifacts existed.
+	OrgFeatureSandboxOCIArtifacts OrgFeature = "sandbox-oci-artifacts"
 )
 
 type Org struct {
@@ -238,6 +243,7 @@ func (o *Org) BeforeCreate(tx *gorm.DB) error {
 		OrgFeatureNewAppIA:                false,
 		OrgFeatureOrgHealthcheckSweeps:    false,
 		OrgFeatureAppInstallSyncing:       false,
+		OrgFeatureSandboxOCIArtifacts:     false,
 
 		// Enabled by default
 		OrgFeatureAppBranches:   true,
@@ -299,6 +305,7 @@ func GetFeatures() []OrgFeature {
 		OrgFeatureNewAppIA,
 		OrgFeatureOrgHealthcheckSweeps,
 		OrgFeatureAppInstallSyncing,
+		OrgFeatureSandboxOCIArtifacts,
 	}
 }
 
@@ -338,6 +345,7 @@ func GetFeatureDescriptions() map[OrgFeature]string {
 		OrgFeatureNewAppIA:                 "Enable the branch-centric app information architecture in the dashboard: branches as the app landing page, grouped navigation, and the app source header. Requires app-branches-ui.",
 		OrgFeatureOrgHealthcheckSweeps:     "Replace per-runner and per-process healthcheck cron emitters with two per-org sweep emitters that check all runners/processes in paginated batches. Toggle via POST /v1/orgs/{org_id}/migrate-healthcheck-sweeps, which also migrates the emitters.",
 		OrgFeatureAppInstallSyncing:        "Enable app install config syncing: point an app at a git repo of per-install configs so pushes to that repo sync every install's config and create missing installs behind an approval step. Gates the install syncs API, the VCS push fan-out, and the dashboard install syncs tab.",
+		OrgFeatureSandboxOCIArtifacts:      "Build the app sandbox into an OCI artifact during branch runs and resolve sandbox runs against that artifact instead of cloning the sandbox git source. With it off, sandbox runs always clone git.",
 	}
 }
 

--- a/services/ctl-api/internal/pkg/workflows/activities/ensure_gar_auth.go
+++ b/services/ctl-api/internal/pkg/workflows/activities/ensure_gar_auth.go
@@ -1,0 +1,42 @@
+package activities
+
+import (
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/pkg/plugins/configs"
+)
+
+// EnsureGARAuth mints a GAR access token into cfg.OCIAuth so the runner can
+// authenticate without GCP application default credentials of its own.
+//
+// The runner only falls back to ADC when no token is supplied (see
+// pkg/runner/registry/gar.FetchAccessInfo), which holds solely for runners that
+// themselves run in GCP. A control plane in GCP can hand artifacts to a runner
+// in AWS or Azure, so every plan carrying a GAR repository has to embed
+// credentials minted here.
+//
+// Safe to call on any registry type; it is a no-op unless cfg is GAR without a
+// token already attached.
+func EnsureGARAuth(ctx workflow.Context, cfg *configs.OCIRegistryRepository) error {
+	if cfg == nil || cfg.RegistryType != configs.OCIRegistryTypeGAR {
+		return nil
+	}
+	if cfg.OCIAuth != nil && cfg.OCIAuth.Password != "" {
+		return nil
+	}
+
+	token, err := AwaitGetGARAccessToken(ctx, &GetGARAccessTokenRequest{
+		ServiceAccountEmail:      cfg.ServiceAccountEmail,
+		WorkloadIdentityProvider: cfg.WorkloadIdentityProvider,
+	})
+	if err != nil {
+		return err
+	}
+
+	cfg.OCIAuth = &configs.OCIRegistryAuth{
+		Username: token.Username,
+		Password: token.Password,
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/pkg/workflows/activities/get_gar_access_token.go
+++ b/services/ctl-api/internal/pkg/workflows/activities/get_gar_access_token.go
@@ -30,6 +30,11 @@ type GARAccessToken struct {
 	Password string
 }
 
+// GetGARAccessToken lives in the shared activity set because both the components
+// namespace (pulling a source image for a build) and the installs namespace
+// (resolving the sandbox artifact) schedule it. Activities are registered per
+// worker, so a components-only registration is invisible to installs.
+//
 // @temporal-gen-v2 activity
 // @max-retries 1
 func (a *Activities) GetGARAccessToken(ctx context.Context, req *GetGARAccessTokenRequest) (*GARAccessToken, error) {

--- a/services/ctl-api/internal/pkg/workflows/shared_activity_set_test.go
+++ b/services/ctl-api/internal/pkg/workflows/shared_activity_set_test.go
@@ -7,28 +7,42 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
 )
 
-// GetSandboxBuildOCIRegistry is scheduled from both the apps namespace (building
-// the sandbox artifact) and the installs namespace (resolving it when planning a
-// sandbox run). Activities are registered per worker, so it has to stay in the
-// shared set every worker registers — otherwise the installs worker fails the
-// call with ActivityNotRegisteredError and silently falls back to a git source.
-func TestGetSandboxBuildOCIRegistryIsInSharedActivitySet(t *testing.T) {
-	shared := &Activities{Activities: &activities.Activities{}}
-
-	const method = "GetSandboxBuildOCIRegistry"
-	for _, acts := range shared.AllActivities() {
-		if acts == nil {
-			continue
-		}
-		v := reflect.ValueOf(acts)
-		if v.Kind() == reflect.Ptr && v.IsNil() {
-			continue
-		}
-		if v.MethodByName(method).IsValid() {
-			return
-		}
+// Activities are registered per worker, so an activity scheduled from more than
+// one namespace has to stay in the shared set every worker registers. When it
+// does not, the caller fails with ActivityNotRegisteredError — which callers
+// here handle by falling back, so the breakage is silent.
+func TestSharedActivitySet(t *testing.T) {
+	// GetSandboxBuildOCIRegistry: scheduled from the apps namespace (building the
+	// sandbox artifact) and the installs namespace (resolving it when planning a
+	// sandbox run). Missing, the installs worker silently falls back to git.
+	//
+	// GetGARAccessToken: scheduled from the components namespace (pulling a
+	// source image) and the installs namespace (authenticating the sandbox
+	// artifact pull for a runner outside GCP).
+	methods := []string{
+		"GetSandboxBuildOCIRegistry",
+		"GetGARAccessToken",
 	}
 
-	t.Fatalf("%s is not reachable through Activities.AllActivities(); workers that "+
-		"do not register the apps branch activities cannot run it", method)
+	shared := &Activities{Activities: &activities.Activities{}}
+
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			for _, acts := range shared.AllActivities() {
+				if acts == nil {
+					continue
+				}
+				v := reflect.ValueOf(acts)
+				if v.Kind() == reflect.Ptr && v.IsNil() {
+					continue
+				}
+				if v.MethodByName(method).IsValid() {
+					return
+				}
+			}
+
+			t.Fatalf("%s is not reachable through Activities.AllActivities(); "+
+				"workers that do not register the owning namespace cannot run it", method)
+		})
+	}
 }


### PR DESCRIPTION
Sandbox OCI artifacts are new and were never actually exercised — #2153 turned the installs-side path on for the first time yesterday, and it immediately broke sandbox runs on a GCP control plane with an AWS install ("could not find default credentials"). Two changes:

**Flag it off.** New `sandbox-oci-artifacts` org feature, default false, gating both production (branch runs skip the sandbox build) and consumption (sandbox runs always clone git). `OrgHasFeature` returns false for a missing map key, so existing orgs fall back to git with no migration — which is exactly the path everything used before artifacts existed.

**Fix the GAR credentials** for when it is turned on. `GetSandboxBuildOCIRegistry`'s GAR branch shipped no credentials, relying on the runner having GCP ADC — only true when the runner is also in GCP. Sandbox run plans now mint a token into `OCIAuth`, the same pattern `getOrgRegistryRepositoryConfig` already uses for the component image sync against the same registry (`<ManagementGARRepositoryURL>/<orgID>/<appID>`), which proves the API pod's identity can read it.

`GetGARAccessToken` moves into the shared activity set so the installs worker can schedule it, and the four call sites collapse onto one `EnsureGARAuth` helper. The install-side gate uses a new `HasOrgFeature` activity taking an explicit OrgID — `optionalPropagator` swallows a failed context inject, so a context-based check would hard-fail every sandbox run if org context were ever absent.

Neither path has run against a live system; the flag makes that opt-in.