### PR TITLE
feat: expose azure runner identity principal id as a stack output

### DIFF
--- a/sdks/nuon-go/models/app_azure_stack_outputs.go
+++ b/sdks/nuon-go/models/app_azure_stack_outputs.go
@@ -68,6 +68,11 @@ type AppAzureStackOutputs struct {
 	// resource group name
 	ResourceGroupName string `json:"resource_group_name,omitempty"`
 
+	// Principal ID of the runner VMSS's system-assigned identity. Secret sync and
+	// image sync run as this identity, not a per-operation one, so sandboxes need
+	// it to grant cluster access.
+	RunnerIdentityPrincipalID string `json:"runner_identity_principal_id,omitempty"`
+
 	// subscription id
 	SubscriptionID string `json:"subscription_id,omitempty"`
 

--- a/services/ctl-api/internal/app/install_stack_outputs.go
+++ b/services/ctl-api/internal/app/install_stack_outputs.go
@@ -121,6 +121,11 @@ type AzureStackOutputs struct {
 	KeyVaultID   string `json:"key_vault_id,omitzero" mapstructure:"key_vault_id" temporaljson:"key_vault_id,omitzero,omitempty"`
 	KeyVaultName string `json:"key_vault_name,omitzero" mapstructure:"key_vault_name" temporaljson:"key_vault_name,omitzero,omitempty"`
 
+	// Principal ID of the runner VMSS's system-assigned identity. Secret sync and
+	// image sync run as this identity, not a per-operation one, so sandboxes need
+	// it to grant cluster access.
+	RunnerIdentityPrincipalID string `json:"runner_identity_principal_id,omitzero" mapstructure:"runner_identity_principal_id" temporaljson:"runner_identity_principal_id,omitzero,omitempty"`
+
 	ProvisionIdentityClientID   string            `json:"provision_identity_client_id,omitzero" mapstructure:"provision_identity_client_id" temporaljson:"provision_identity_client_id,omitzero,omitempty"`
 	MaintenanceIdentityClientID string            `json:"maintenance_identity_client_id,omitzero" mapstructure:"maintenance_identity_client_id" temporaljson:"maintenance_identity_client_id,omitzero,omitempty"`
 	DeprovisionIdentityClientID string            `json:"deprovision_identity_client_id,omitzero" mapstructure:"deprovision_identity_client_id" temporaljson:"deprovision_identity_client_id,omitzero,omitempty"`

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home.go
@@ -51,6 +51,10 @@ func (t *Templates) getPhoneHomeResource(inp *stacks.TemplateInput, customOutput
 		`  "subscription_id": "$SUBSCRIPTION_ID"`,
 		`  "subscription_tenant_id": "$SUBSCRIPTION_TENANT_ID"`,
 	}
+	// Local runners have no runnerDeployment to reference.
+	if !t.cfg.UseLocalRunners {
+		payloadFields = append(payloadFields, `  "runner_identity_principal_id": "$RUNNER_IDENTITY_PRINCIPAL_ID"`)
+	}
 	payloadFields = append(payloadFields, secretPayloadFields...)
 
 	// Custom nested stack outputs, mirroring the AWS phone-home shape:
@@ -130,6 +134,16 @@ fi
 		{"name": "PUBLIC_SUBNET_NAMES_CSV", "value": "[reference('vnetDeployment').outputs.publicSubnetNames.value]"},
 		{"name": "PRIVATE_SUBNET_IDS_CSV", "value": "[reference('vnetDeployment').outputs.privateSubnetIds.value]"},
 		{"name": "PRIVATE_SUBNET_NAMES_CSV", "value": "[reference('vnetDeployment').outputs.privateSubnetNames.value]"},
+	}
+	// The runner's system-assigned identity. Secret sync and image sync run as
+	// this identity rather than a per-operation one, so a sandbox has to be able
+	// to grant it cluster access -- the Azure counterpart of the runner role ARNs
+	// the AWS stack outputs.
+	if !t.cfg.UseLocalRunners {
+		envVars = append(envVars, map[string]any{
+			"name":  "RUNNER_IDENTITY_PRINCIPAL_ID",
+			"value": "[reference('runnerDeployment').outputs.vmssPrincipalId.value]",
+		})
 	}
 	envVars = append(envVars, secretEnvVars...)
 	envVars = append(envVars, customEnvVars...)

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_test.go
@@ -53,3 +53,36 @@ func TestGetPhoneHomeResource_CustomStackOutputs(t *testing.T) {
 	}
 	assertNoNestedBrackets(t, resBytes)
 }
+
+func TestGetPhoneHomeResource_RunnerIdentityPrincipalID(t *testing.T) {
+	t.Run("reported when a runner deployment exists", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{}}
+		res := tmpl.getPhoneHomeResource(minimalTemplateInput(), nil)
+
+		props := res["properties"].(map[string]any)
+		script := props["scriptContent"].(string)
+		if !strings.Contains(script, `"runner_identity_principal_id": "$RUNNER_IDENTITY_PRINCIPAL_ID"`) {
+			t.Error("payload missing runner_identity_principal_id")
+		}
+
+		var found string
+		for _, ev := range props["environmentVariables"].([]map[string]any) {
+			if ev["name"] == "RUNNER_IDENTITY_PRINCIPAL_ID" {
+				found = ev["value"].(string)
+			}
+		}
+		if want := "[reference('runnerDeployment').outputs.vmssPrincipalId.value]"; found != want {
+			t.Errorf("env var = %q, want %q", found, want)
+		}
+	})
+
+	t.Run("omitted for local runners", func(t *testing.T) {
+		tmpl := &Templates{cfg: &internal.Config{UseLocalRunners: true}}
+		res := tmpl.getPhoneHomeResource(minimalTemplateInput(), nil)
+
+		script := res["properties"].(map[string]any)["scriptContent"].(string)
+		if strings.Contains(script, "RUNNER_IDENTITY_PRINCIPAL_ID") {
+			t.Error("local runners have no runnerDeployment to reference")
+		}
+	})
+}


### PR DESCRIPTION
AWS hands sandboxes the runner role ARNs via `AWSStackOutputs`, which is how the aws-eks-karpenter sandbox creates its EKS access entries. Azure exposes the per-operation identity client IDs but nothing for the runner's system-assigned identity — the one secret sync and image sync actually run as. On a cluster using Azure RBAC with local accounts disabled, secret sync fails with `namespaces is forbidden` and the config has no way to grant access, because it cannot discover the principal.

Forwards the runner deployment's existing `vmssPrincipalId` output through phone home into `AzureStackOutputs.RunnerIdentityPrincipalID`, skipped for local runners where there is no runner deployment.