### PR TITLE
fix: apply install input defaults when the stored value is empty

### DIFF
--- a/services/ctl-api/internal/app/installs/helpers/get_install_state.go
+++ b/services/ctl-api/internal/app/installs/helpers/get_install_state.go
@@ -457,13 +457,18 @@ func ToInputState(inputs *app.InstallInputs, cfg *app.AppConfig, redacted bool) 
 	if redacted {
 		inputValues = inputs.ValuesRedacted
 	}
-	if len(inputValues) < 1 {
+	if len(inputValues) < 1 && len(cfg.InputConfig.AppInputs) < 1 {
 		return nil
 	}
 	is := state.NewInputsState()
 	for _, inp := range cfg.InputConfig.AppInputs {
+		// Fall back to the default when the input is unset, which covers both a
+		// missing key and a key materialized as "". ValuesRedacted carries every
+		// declared input, unset ones included, so keying off presence alone
+		// resolves those to "" and drops the default — a declared bool then
+		// reaches terraform as "" and fails plan with "a bool is required".
 		val, ok := inputValues[inp.Name]
-		if !ok {
+		if !ok || pkggenerics.FromPtrStr(val) == "" {
 			val = &inp.Default
 		}
 		is.Inputs[inp.Name] = pkggenerics.FromPtrStr(val)

--- a/services/ctl-api/internal/app/installs/helpers/to_input_state_test.go
+++ b/services/ctl-api/internal/app/installs/helpers/to_input_state_test.go
@@ -1,0 +1,77 @@
+package helpers_test
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+)
+
+func inputStateCfg() *app.AppConfig {
+	return &app.AppConfig{
+		InputConfig: app.AppInputConfig{
+			AppInputs: []app.AppInput{
+				{Name: "cluster_endpoint_public_access", Type: app.AppInputTypeBool, Default: "false"},
+				{Name: "cluster_version", Type: app.AppInputTypeString, Default: "1.36"},
+				{Name: "root_domain", Type: app.AppInputTypeString},
+			},
+		},
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
+// ValuesRedacted carries every declared input, unset ones included as "". Keying
+// the default fallback off presence alone resolved those to "" and dropped the
+// default, so a declared bool reached terraform as "" and failed plan with
+// "a bool is required".
+func TestToInputStateAppliesDefaultForEmptyValue(t *testing.T) {
+	inputs := &app.InstallInputs{
+		ValuesRedacted: pgtype.Hstore{
+			"cluster_endpoint_public_access": strPtr(""),
+			"cluster_version":                strPtr("1.36"),
+			"root_domain":                    strPtr(""),
+		},
+	}
+
+	is := helpers.ToInputState(inputs, inputStateCfg(), true)
+	require.NotNil(t, is)
+
+	assert.Equal(t, "false", is.Inputs["cluster_endpoint_public_access"])
+	assert.Equal(t, "1.36", is.Inputs["cluster_version"])
+	// No default declared, so an unset input stays empty rather than inventing one.
+	assert.Equal(t, "", is.Inputs["root_domain"])
+}
+
+func TestToInputStateAppliesDefaultForMissingKey(t *testing.T) {
+	inputs := &app.InstallInputs{
+		Values: pgtype.Hstore{
+			"cluster_version": strPtr("1.40"),
+		},
+	}
+
+	is := helpers.ToInputState(inputs, inputStateCfg(), false)
+	require.NotNil(t, is)
+
+	assert.Equal(t, "false", is.Inputs["cluster_endpoint_public_access"])
+	assert.Equal(t, "1.40", is.Inputs["cluster_version"], "an explicit value must win over the default")
+}
+
+// An install that sets no inputs at all still needs its declared defaults; the
+// previous empty-map short circuit returned nil and dropped every one of them.
+func TestToInputStateAppliesDefaultsWithNoValues(t *testing.T) {
+	is := helpers.ToInputState(&app.InstallInputs{}, inputStateCfg(), false)
+	require.NotNil(t, is)
+
+	assert.Equal(t, "false", is.Inputs["cluster_endpoint_public_access"])
+	assert.Equal(t, "1.36", is.Inputs["cluster_version"])
+}
+
+func TestToInputStateNilWhenNothingDeclared(t *testing.T) {
+	assert.Nil(t, helpers.ToInputState(&app.InstallInputs{}, &app.AppConfig{}, false))
+	assert.Nil(t, helpers.ToInputState(nil, inputStateCfg(), false))
+}


### PR DESCRIPTION
A declared bool with `default: false` reached terraform as `""` and failed plan with "The given value is not suitable for var.cluster_endpoint_public_access ... a bool is required". `ToInputState` fell back to the default only when the key was **absent**, but `ValuesRedacted` carries every declared input including unset ones as `""` — so present-but-empty resolved to `""` and dropped the default. Fall back when unset, covering both shapes.

Also fixes the empty-map short circuit: an install that sets no inputs at all returned nil state and dropped every declared default. Now returns nil only when nothing is declared either.

An input with no default stays empty rather than inventing a typed zero value — silently substituting `false` for an undeclared bool would hide a real misconfiguration; that belongs in input validation.

Verified the new test reproduces the production symptom (`expected "false", actual ""`) with the fix reverted.