### PR TITLE
fix: get app components empty on sync error

### DIFF
--- a/services/ctl-api/internal/app/admin-dashboard/service/org_detail.go
+++ b/services/ctl-api/internal/app/admin-dashboard/service/org_detail.go
@@ -163,7 +163,7 @@ func (s *service) getMostRecentApp(ctx context.Context, orgID string) (*app.App,
 
 func (s *service) getAppComponentGraph(ctx context.Context, appID string) (string, error) {
 	// 1. Get the latest app config
-	appConfig, err := s.appsHelpers.GetAppLatestConfig(ctx, appID)
+	appConfig, err := s.appsHelpers.GetLatestActiveAppConfig(ctx, appID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return "", nil // No config yet, not an error

--- a/services/ctl-api/internal/app/app_config.go
+++ b/services/ctl-api/internal/app/app_config.go
@@ -107,6 +107,14 @@ type AppConfig struct {
 func (a *AppConfig) Indexes(db *gorm.DB) []migrations.Index {
 	return []migrations.Index{
 		{
+			Name: indexes.Name(db, &AppConfig{}, "preload"),
+			Columns: []string{
+				"app_id",
+				"deleted_at",
+				"created_at DESC",
+			},
+		},
+		{
 			Name: indexes.Name(db, &AppConfig{}, "org_id"),
 			Columns: []string{
 				"org_id",

--- a/services/ctl-api/internal/app/apps/helpers/delete_app_component.go
+++ b/services/ctl-api/internal/app/apps/helpers/delete_app_component.go
@@ -26,13 +26,13 @@ func (s *Helpers) DeleteAppComponent(ctx context.Context, compID string) error {
 	}
 
 	appID := comp.AppID
-	appCfg, err := s.GetAppLatestConfig(ctx, appID)
-	if err != nil {
+	appCfg, err := s.GetLatestActiveAppConfig(ctx, appID)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return fmt.Errorf("unable to get app latest config: %w", err)
 	}
 
 	// Check if the component is part of the current app config, if so, do not allow deletion.
-	if slices.Contains(appCfg.ComponentIDs, compID) {
+	if appCfg != nil && slices.Contains(appCfg.ComponentIDs, compID) {
 		msg := fmt.Sprintf("unable to delete component %s as it's a part of current app config", compID)
 		return stderr.ErrUser{
 			Description: msg,

--- a/services/ctl-api/internal/app/apps/helpers/get_config.go
+++ b/services/ctl-api/internal/app/apps/helpers/get_config.go
@@ -4,22 +4,50 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 )
 
-func (h *Helpers) GetAppLatestConfig(ctx context.Context, appID string) (*app.AppConfig, error) {
+// GetLatestActiveAppConfig returns the app's newest active config with component config connections
+// preloaded.
+func (h *Helpers) GetLatestActiveAppConfig(ctx context.Context, appID string) (*app.AppConfig, error) {
 	var appConfig app.AppConfig
 
 	res := h.db.WithContext(ctx).
-		Order("created_at DESC").
 		Scopes(
+			LatestActiveAppConfig(appID),
 			PreloadAppConfigComponentConfigConnections,
 		).
-		First(&appConfig, "app_id = ?", appID)
+		First(&appConfig)
 	if res.Error != nil {
-		return nil, errors.Wrap(res.Error, "unable to get app config")
+		return nil, wrapAppConfigErr(res.Error)
 	}
 
 	return &appConfig, nil
+}
+
+// GetLatestActiveAppConfigBare returns the app's newest active config without preloading children.
+func (h *Helpers) GetLatestActiveAppConfigBare(ctx context.Context, appID string) (*app.AppConfig, error) {
+	var appConfig app.AppConfig
+
+	res := h.db.WithContext(ctx).
+		Scopes(LatestActiveAppConfig(appID)).
+		First(&appConfig)
+	if res.Error != nil {
+		return nil, wrapAppConfigErr(res.Error)
+	}
+
+	return &appConfig, nil
+}
+
+func wrapAppConfigErr(err error) error {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return stderr.ErrNotFound{
+			Err:         err,
+			Description: "App has no successfully synced config, please sync the app config first",
+		}
+	}
+	return errors.Wrap(err, "unable to get app config")
 }

--- a/services/ctl-api/internal/app/apps/helpers/scopes.go
+++ b/services/ctl-api/internal/app/apps/helpers/scopes.go
@@ -2,7 +2,25 @@ package helpers
 
 import (
 	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
 )
+
+// LatestActiveAppConfig restricts a query to the app's configs that finished syncing, newest first.
+// A pending, syncing or errored config has no component_ids and no config records, so it must never
+// stand in as the app's current config.
+func LatestActiveAppConfig(appID string) func(*gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.
+			Where(app.AppConfig{AppID: appID}).
+			Where(
+				views.TableOrViewName(db, &app.AppConfig{}, ".status_v2 ->> 'status' = ?"),
+				string(app.AppConfigStatusActive),
+			).
+			Order("created_at DESC")
+	}
+}
 
 // secrets config
 func PreloadAppSecretsConfig(db *gorm.DB) *gorm.DB {

--- a/services/ctl-api/internal/app/apps/helpers/validate_graph.go
+++ b/services/ctl-api/internal/app/apps/helpers/validate_graph.go
@@ -7,11 +7,15 @@ import (
 	"github.com/dominikbraun/graph"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/pkg/errors"
+	"gorm.io/gorm"
 )
 
 func (h *Helpers) ValidateGraph(ctx context.Context, appID string) error {
-	latestCfg, err := h.GetAppLatestConfig(ctx, appID)
+	latestCfg, err := h.GetLatestActiveAppConfig(ctx, appID)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
 		return errors.Wrap(err, "unable to get latest config")
 	}
 

--- a/services/ctl-api/internal/app/apps/service/delete_app.go
+++ b/services/ctl-api/internal/app/apps/service/delete_app.go
@@ -64,7 +64,7 @@ func (s *service) DeleteApp(ctx *gin.Context) {
 		}
 	}
 
-	appCfg, cfgErr := s.helpers.GetAppLatestConfig(ctx, appID)
+	appCfg, cfgErr := s.helpers.GetLatestActiveAppConfig(ctx, appID)
 	if cfgErr != nil && !errors.Is(cfgErr, gorm.ErrRecordNotFound) {
 		ctx.Error(cfgErr)
 		return

--- a/services/ctl-api/internal/app/apps/service/get_latest_app_config.go
+++ b/services/ctl-api/internal/app/apps/service/get_latest_app_config.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"gorm.io/gorm"
 )
 
@@ -27,36 +26,31 @@ import (
 // @Success				200	{object}	app.AppConfig
 // @Router					/v1/apps/{app_id}/latest-config [get]
 func (s *service) GetAppLatestConfig(ctx *gin.Context) {
-	org, err := cctx.OrgFromContext(ctx)
-	if err != nil {
-		ctx.Error(err)
-		return
-	}
-
 	appID := ctx.Param("app_id")
 	recurse := ctx.DefaultQuery("recurse", "false") == "true"
-	app, err := s.findApp(ctx, org.ID, appID)
+
+	currentApp, err := s.appByNameOrID(ctx, appID)
 	if err != nil {
 		ctx.Error(fmt.Errorf("unable to get app %s: %w", appID, err))
 		return
 	}
 
-	if len(app.AppConfigs) < 1 {
-		ctx.Error(fmt.Errorf("no configs found for app: %w", gorm.ErrRecordNotFound))
+	response, err := s.helpers.GetLatestActiveAppConfigBare(ctx, currentApp.ID)
+	if err != nil {
+		ctx.Error(err)
 		return
 	}
 
-	response := &app.AppConfigs[0]
 	if recurse {
-		response, err = s.helpers.GetFullAppConfig(ctx, app.AppConfigs[0].ID, true)
+		response, err = s.helpers.GetFullAppConfig(ctx, response.ID, true)
 		if err != nil {
-			ctx.Error(fmt.Errorf("unable to get app config %s: %w", app.AppConfigs[0].ID, err))
+			ctx.Error(fmt.Errorf("unable to get app config %s: %w", response.ID, err))
 			return
 		}
-	}
-	if response == nil {
-		ctx.Error(fmt.Errorf("no configs found for app: %w", gorm.ErrRecordNotFound))
-		return
+		if response == nil {
+			ctx.Error(fmt.Errorf("no configs found for app: %w", gorm.ErrRecordNotFound))
+			return
+		}
 	}
 
 	ctx.JSON(http.StatusOK, response)

--- a/services/ctl-api/internal/app/apps/service/get_latest_app_config_test.go
+++ b/services/ctl-api/internal/app/apps/service/get_latest_app_config_test.go
@@ -34,6 +34,7 @@ func (s *AppConfigsTestSuite) TestGetAppLatestConfigSuccess() {
 					OrgID:             s.testOrg.ID,
 					AppID:             s.testApp.ID,
 					Status:            app.AppConfigStatusPending,
+					StatusV2:          app.NewCompositeStatus(ctx, app.Status(app.AppConfigStatusPending)),
 					StatusDescription: "pending",
 					Readme:            "older config",
 					CLIVersion:        "1.0.0",
@@ -46,6 +47,7 @@ func (s *AppConfigsTestSuite) TestGetAppLatestConfigSuccess() {
 					OrgID:             s.testOrg.ID,
 					AppID:             s.testApp.ID,
 					Status:            app.AppConfigStatusActive,
+					StatusV2:          app.NewCompositeStatus(ctx, app.Status(app.AppConfigStatusActive)),
 					StatusDescription: "success",
 					Readme:            "latest config",
 					CLIVersion:        "1.1.0",
@@ -71,8 +73,9 @@ func (s *AppConfigsTestSuite) TestGetAppLatestConfigSuccess() {
 					ID:                domains.NewAppCfgID(),
 					OrgID:             s.testOrg.ID,
 					AppID:             s.testApp.ID,
-					Status:            app.AppConfigStatusPending,
-					StatusDescription: "pending",
+					Status:            app.AppConfigStatusActive,
+					StatusV2:          app.NewCompositeStatus(ctx, app.Status(app.AppConfigStatusActive)),
+					StatusDescription: "success",
 					Readme:            "only config",
 					CLIVersion:        "1.0.0",
 				}
@@ -82,6 +85,46 @@ func (s *AppConfigsTestSuite) TestGetAppLatestConfigSuccess() {
 			},
 			validateFunc: func(cfg *models.AppAppConfig) {
 				assert.Equal(s.T(), "only config", cfg.Readme)
+				assert.Equal(s.T(), "1.0.0", cfg.CliVersion)
+			},
+		},
+		{
+			name: "skips newer failed config and returns last synced one",
+			setupFunc: func() []string {
+				ctx := context.Background()
+				ctx = cctx.SetAccountContext(ctx, s.testAcc)
+				ctx = cctx.SetOrgContext(ctx, s.testOrg)
+
+				synced := &app.AppConfig{
+					ID:                domains.NewAppCfgID(),
+					OrgID:             s.testOrg.ID,
+					AppID:             s.testApp.ID,
+					Status:            app.AppConfigStatusActive,
+					StatusV2:          app.NewCompositeStatus(ctx, app.Status(app.AppConfigStatusActive)),
+					StatusDescription: "success",
+					Readme:            "last synced config",
+					CLIVersion:        "1.0.0",
+				}
+				err := s.service.DB.WithContext(ctx).Create(synced).Error
+				require.NoError(s.T(), err)
+
+				failed := &app.AppConfig{
+					ID:                domains.NewAppCfgID(),
+					OrgID:             s.testOrg.ID,
+					AppID:             s.testApp.ID,
+					Status:            app.AppConfigStatusError,
+					StatusV2:          app.NewCompositeStatus(ctx, app.Status(app.AppConfigStatusError)),
+					StatusDescription: "sync failed: invalid name",
+					Readme:            "failed config",
+					CLIVersion:        "1.1.0",
+				}
+				err = s.service.DB.WithContext(ctx).Create(failed).Error
+				require.NoError(s.T(), err)
+
+				return []string{synced.ID, failed.ID}
+			},
+			validateFunc: func(cfg *models.AppAppConfig) {
+				assert.Equal(s.T(), "last synced config", cfg.Readme)
 				assert.Equal(s.T(), "1.0.0", cfg.CliVersion)
 			},
 		},
@@ -119,6 +162,36 @@ func (s *AppConfigsTestSuite) TestGetAppLatestConfigSuccess() {
 }
 
 func (s *AppConfigsTestSuite) TestGetAppLatestConfigNotFound() {
+	path := fmt.Sprintf("/v1/apps/%s/latest-config", s.testApp.ID)
+	rr := s.makeGetRequest(http.MethodGet, path)
+
+	if rr.Code != http.StatusNotFound {
+		s.T().Logf("Status: %d, Body: %s", rr.Code, rr.Body.String())
+	}
+	require.Equal(s.T(), http.StatusNotFound, rr.Code)
+}
+
+// TestGetAppLatestConfigNeverSynced asserts a config that never finished syncing is not served as
+// the app's latest config.
+func (s *AppConfigsTestSuite) TestGetAppLatestConfigNeverSynced() {
+	ctx := context.Background()
+	ctx = cctx.SetAccountContext(ctx, s.testAcc)
+	ctx = cctx.SetOrgContext(ctx, s.testOrg)
+
+	cfg := &app.AppConfig{
+		ID:                domains.NewAppCfgID(),
+		OrgID:             s.testOrg.ID,
+		AppID:             s.testApp.ID,
+		Status:            app.AppConfigStatusPending,
+		StatusV2:          app.NewCompositeStatus(ctx, app.Status(app.AppConfigStatusPending)),
+		StatusDescription: "sync pending",
+		CLIVersion:        "1.0.0",
+	}
+	require.NoError(s.T(), s.service.DB.WithContext(ctx).Create(cfg).Error)
+	s.T().Cleanup(func() {
+		s.service.DB.Unscoped().Delete(&app.AppConfig{}, "id = ?", cfg.ID)
+	})
+
 	path := fmt.Sprintf("/v1/apps/%s/latest-config", s.testApp.ID)
 	rr := s.makeGetRequest(http.MethodGet, path)
 

--- a/services/ctl-api/internal/app/components/service/get_app_components.go
+++ b/services/ctl-api/internal/app/components/service/get_app_components.go
@@ -68,8 +68,11 @@ func (s *service) GetAppComponents(ctx *gin.Context) {
 }
 
 func (s *service) getAppComponents(ctx *gin.Context, appID, q string, types []string, componentIDs []string, lbls labels.Labels) ([]app.Component, error) {
-	appCfg, err := s.appsHelpers.GetAppLatestConfig(ctx, appID)
+	appCfg, err := s.appsHelpers.GetLatestActiveAppConfig(ctx, appID)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return []app.Component{}, nil
+		}
 		return nil, errors.Wrap(err, "unable to get latest app config")
 	}
 

--- a/services/ctl-api/internal/app/components/service/get_app_components_test.go
+++ b/services/ctl-api/internal/app/components/service/get_app_components_test.go
@@ -137,4 +137,57 @@ func (s *ComponentsServiceTestSuite) TestGetAppComponentsEmptyApp() {
 
 		assert.Len(s.T(), response, 0, "should return empty when component not in app config")
 	})
+
+	s.Run("returns empty when the app has never synced a config", func() {
+		unsyncedApp := s.deps.Seeder.CreateApp(s.ctx, s.T())
+		cfg := s.deps.Seeder.CreateBareAppConfig(s.ctx, s.T(), unsyncedApp.ID)
+		s.setAppConfigStatus(cfg.ID, app.AppConfigStatusPending)
+
+		path := fmt.Sprintf("/v1/apps/%s/components", unsyncedApp.ID)
+		rr := s.makeRequest(http.MethodGet, path, nil)
+
+		if rr.Code != http.StatusOK {
+			s.T().Logf("Status: %d, Body: %s", rr.Code, rr.Body.String())
+		}
+		require.Equal(s.T(), http.StatusOK, rr.Code)
+
+		var response []app.Component
+		err := json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(s.T(), err)
+		assert.Len(s.T(), response, 0)
+	})
+}
+
+// TestGetAppComponentsIgnoresFailedConfig covers the case where a failed sync creates a newer app
+// config: the components from the last successfully synced config must still be listed.
+func (s *ComponentsServiceTestSuite) TestGetAppComponentsIgnoresFailedConfig() {
+	failed := s.deps.Seeder.CreateBareAppConfig(s.ctx, s.T(), s.testApp.ID)
+	s.setAppConfigStatus(failed.ID, app.AppConfigStatusError)
+	s.T().Cleanup(func() {
+		s.deps.DB.Unscoped().Delete(&app.AppConfig{}, "id = ?", failed.ID)
+	})
+
+	path := fmt.Sprintf("/v1/apps/%s/components", s.testApp.ID)
+	rr := s.makeRequest(http.MethodGet, path, nil)
+
+	if rr.Code != http.StatusOK {
+		s.T().Logf("Status: %d, Body: %s", rr.Code, rr.Body.String())
+	}
+	require.Equal(s.T(), http.StatusOK, rr.Code)
+
+	var response []app.Component
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	require.NoError(s.T(), err)
+
+	assert.Len(s.T(), response, len(s.testAppConfig.ComponentIDs))
+}
+
+// setAppConfigStatus writes both status columns, matching how the syncer records a status.
+func (s *ComponentsServiceTestSuite) setAppConfigStatus(appConfigID string, status app.AppConfigStatus) {
+	require.NoError(s.T(), s.deps.DB.WithContext(s.ctx).
+		Model(&app.AppConfig{ID: appConfigID}).
+		Updates(map[string]any{
+			"status":    status,
+			"status_v2": app.NewCompositeStatus(s.ctx, app.Status(status)),
+		}).Error)
 }

--- a/services/ctl-api/internal/app/components/service/get_component_dependencies.go
+++ b/services/ctl-api/internal/app/components/service/get_component_dependencies.go
@@ -56,7 +56,7 @@ func (s *service) GetAppComponentDependencies(ctx *gin.Context) {
 		return
 	}
 
-	appCfg, err := s.appsHelpers.GetAppLatestConfig(ctx, component.AppID)
+	appCfg, err := s.appsHelpers.GetLatestActiveAppConfig(ctx, component.AppID)
 	if err != nil {
 		ctx.Error(errors.Wrap(err, "unable to get app config"))
 		return
@@ -103,7 +103,7 @@ func (s *service) GetComponentDependencies(ctx *gin.Context) {
 		return
 	}
 
-	appCfg, err := s.appsHelpers.GetAppLatestConfig(ctx, component.AppID)
+	appCfg, err := s.appsHelpers.GetLatestActiveAppConfig(ctx, component.AppID)
 	if err != nil {
 		ctx.Error(errors.Wrap(err, "unable to get app config"))
 		return

--- a/services/ctl-api/internal/app/components/service/get_component_dependents.go
+++ b/services/ctl-api/internal/app/components/service/get_component_dependents.go
@@ -57,7 +57,7 @@ func (s *service) GetAppComponentDependents(ctx *gin.Context) {
 		return
 	}
 
-	appCfg, err := s.appsHelpers.GetAppLatestConfig(ctx, appID)
+	appCfg, err := s.appsHelpers.GetLatestActiveAppConfig(ctx, appID)
 	if err != nil {
 		ctx.Error(errors.Wrap(err, "unable to get app latest config"))
 		return
@@ -119,7 +119,7 @@ func (s *service) GetComponentDependents(ctx *gin.Context) {
 	}
 
 	appID := component.AppID
-	appCfg, err := s.appsHelpers.GetAppLatestConfig(ctx, appID)
+	appCfg, err := s.appsHelpers.GetLatestActiveAppConfig(ctx, appID)
 	if err != nil {
 		ctx.Error(errors.Wrap(err, "unable to get app latest config"))
 		return

--- a/services/ctl-api/internal/app/components/worker/activities/check_container_image_policies_exist.go
+++ b/services/ctl-api/internal/app/components/worker/activities/check_container_image_policies_exist.go
@@ -29,7 +29,7 @@ func (a *Activities) CheckContainerImagePoliciesExist(ctx context.Context, req *
 
 	l.Info("checking if container image policies exist")
 
-	build, err := a.getBuildWithAppConfig(ctx, req.BuildID)
+	build, err := a.getBuildWithComponentApp(ctx, req.BuildID)
 	if err != nil {
 		l.Error("unable to get build with app config", zap.Error(err))
 		return nil, errors.Wrap(err, "unable to get build with app config")
@@ -37,15 +37,14 @@ func (a *Activities) CheckContainerImagePoliciesExist(ctx context.Context, req *
 
 	componentName := build.ComponentConfigConnection.Component.Name
 
-	appConfigs := build.ComponentConfigConnection.Component.App.AppConfigs
-	if len(appConfigs) == 0 {
+	appConfigID := build.ComponentConfigConnection.AppConfigID
+	if appConfigID == "" {
 		l.Info("no app config found, no policies to evaluate")
 		return &CheckContainerImagePoliciesExistResult{
 			HasPolicies:   false,
 			ComponentName: componentName,
 		}, nil
 	}
-	appConfigID := appConfigs[0].ID
 
 	l = l.With(zap.String("app_config_id", appConfigID))
 

--- a/services/ctl-api/internal/app/components/worker/activities/get_component_app_config.go
+++ b/services/ctl-api/internal/app/components/worker/activities/get_component_app_config.go
@@ -19,7 +19,7 @@ func (a *Activities) GetComponentAppConfig(ctx context.Context, req *GetComponen
 		return nil, fmt.Errorf("unable to get component: %w", err)
 	}
 
-	appCfg, err := a.appsHelpers.GetAppLatestConfig(ctx, cmp.AppID)
+	appCfg, err := a.appsHelpers.GetLatestActiveAppConfig(ctx, cmp.AppID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get app config for component: %w", err)
 	}

--- a/services/ctl-api/internal/app/components/worker/activities/prep_external_image_policy.go
+++ b/services/ctl-api/internal/app/components/worker/activities/prep_external_image_policy.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/pkg/oci/metadata"
@@ -55,15 +54,15 @@ func (a *Activities) PrepExternalImagePolicy(ctx context.Context, req *PrepExter
 
 	l.Info("preparing external image policy evaluation")
 
-	build, err := a.getBuildWithAppConfig(ctx, req.BuildID)
+	build, err := a.getBuildWithComponentApp(ctx, req.BuildID)
 	if err != nil {
 		l.Error("unable to get build with app config", zap.Error(err))
 		return nil, errors.Wrap(err, "unable to get build with app config")
 	}
 
 	component := build.ComponentConfigConnection.Component
-	appConfigs := component.App.AppConfigs
-	if len(appConfigs) == 0 {
+	appConfigID := build.ComponentConfigConnection.AppConfigID
+	if appConfigID == "" {
 		l.Info("no app config found, skipping policy evaluation")
 		return &PrepExternalImagePolicyResult{
 			Policies:      []ExternalImagePolicyToEvaluate{},
@@ -77,7 +76,6 @@ func (a *Activities) PrepExternalImagePolicy(ctx context.Context, req *PrepExter
 			ComponentName: component.Name,
 		}, nil
 	}
-	appConfigID := appConfigs[0].ID
 
 	l = l.With(zap.String("app_config_id", appConfigID))
 
@@ -161,13 +159,10 @@ func (a *Activities) PrepExternalImagePolicy(ctx context.Context, req *PrepExter
 	}, nil
 }
 
-func (a *Activities) getBuildWithAppConfig(ctx context.Context, buildID string) (*app.ComponentBuild, error) {
+func (a *Activities) getBuildWithComponentApp(ctx context.Context, buildID string) (*app.ComponentBuild, error) {
 	var bld app.ComponentBuild
 
 	res := a.db.WithContext(ctx).
-		Preload("ComponentConfigConnection.Component.App.AppConfigs", func(db *gorm.DB) *gorm.DB {
-			return db.Order("created_at DESC").Limit(1)
-		}).
 		Preload("ComponentConfigConnection.Component.App.Org").
 		First(&bld, "id = ?", buildID)
 	if res.Error != nil {

--- a/services/ctl-api/internal/app/installs/service/get_install_readme.go
+++ b/services/ctl-api/internal/app/installs/service/get_install_readme.go
@@ -60,7 +60,7 @@ func (s *service) GetInstallReadme(ctx *gin.Context) {
 	}
 
 	// get app readme template
-	appConfig, err := s.appsHelpers.GetAppLatestConfig(ctx, install.AppID)
+	appConfig, err := s.appsHelpers.GetLatestActiveAppConfig(ctx, install.AppID)
 	if err != nil {
 		ctx.Error(fmt.Errorf("unable to get latest app config: %w", err))
 		return


### PR DESCRIPTION
Problem

When an apps sync fails, the app reports zero components. nuon components list -a <app> returns an empty table and the dashboard components view goes blank, even though the components still exist.

Cause

GetAppLatestConfig returned the newest app config regardless of status. A failed sync leaves behind a newer config with component_ids empty (that column is only written when a sync succeeds), so it became the app's authoritative config. The components list filters on component_ids, which made it resolve to nothing and return 200 [] with no error anywhere.

Fix

GetAppLatestConfig now returns the newest config with status_v2 active, via a shared LatestActiveAppConfig scope. Renamed to GetLatestActiveAppConfig so the name states the contract. This fixes eight call sites at once, including the delete_app guard that read "no components" off a failed config and skipped its safety check.

Two other spots resolved the latest config independently and had the same bug: the latest-config endpoint, and container image policy evaluation (which silently skipped policies). Both now go through the same path, with policy checks using the build's pinned AppConfigID.

Also added the missing (app_id, deleted_at, created_at DESC) index on app_configs. There was no app_id index at all, so these lookups were seq scans. Note this migration takes a write lock on the table while building.