### PR TITLE
fix: map the AKS RBAC roles and reject unresolvable built-in roles at sync

### DIFF
--- a/services/ctl-api/internal/pkg/azureroles/builtin.go
+++ b/services/ctl-api/internal/pkg/azureroles/builtin.go
@@ -1,0 +1,65 @@
+// Package azureroles resolves Azure built-in role names to their definition
+// GUIDs. ARM role assignments reference a definition by GUID and have no name
+// lookup, so anything an app config expresses as a name has to be translated
+// before it reaches a template.
+package azureroles
+
+import (
+	"regexp"
+	"sort"
+)
+
+// builtInRoleGUIDs maps built-in role names to their definition GUIDs. These are
+// stable, well-known values assigned by Azure.
+var builtInRoleGUIDs = map[string]string{
+	"Owner":                     "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+	"Contributor":               "b24988ac-6180-42a0-ab88-20f7382dd24c",
+	"Reader":                    "acdd72a7-3385-48ef-bd42-f606fba81ae7",
+	"User Access Administrator": "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9",
+	"Role Based Access Control Administrator":     "f58310d9-a9f6-439a-9e8d-f62e7b41a168",
+	"Azure Kubernetes Service RBAC Cluster Admin": "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b",
+	"Azure Kubernetes Service RBAC Admin":         "3498e952-d568-435e-9b2c-8d77e338d7f7",
+	"Azure Kubernetes Service RBAC Writer":        "a7ffa36f-339b-4b5c-8bdf-e2c188b2c0eb",
+	"Azure Kubernetes Service RBAC Reader":        "7f6c6a51-bcf8-42ba-9220-52d62157d7db",
+	"Azure Kubernetes Service Cluster Admin Role": "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8",
+	"Azure Kubernetes Service Cluster User Role":  "4abbcc35-e782-43d8-92c5-2d3f1bd2253f",
+	"Key Vault Administrator":                     "00482a5a-887f-4fb3-b363-3b7fe8e74483",
+	"Key Vault Secrets User":                      "4633458b-17de-408a-b874-0445c86b69e6",
+	"Key Vault Secrets Officer":                   "b86a8fe4-44ce-4948-aee5-eccb2c155cd7",
+	"Storage Blob Data Contributor":               "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+	"Storage Blob Data Owner":                     "b7e6dc6d-f1e8-4753-8033-0f276bb0955b",
+	"Network Contributor":                         "4d97b98b-1d4f-4787-a291-c67834d212e7",
+}
+
+var guidRegexp = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// GUID resolves a role name to its definition GUID. A value that is already a
+// GUID is returned unchanged, so a config can name any role -- including one
+// absent from the map above -- by passing its GUID directly.
+func GUID(nameOrGUID string) string {
+	if guid, ok := builtInRoleGUIDs[nameOrGUID]; ok {
+		return guid
+	}
+	return nameOrGUID
+}
+
+// Resolvable reports whether GUID will produce something ARM can accept: either
+// a mapped name or a literal GUID. Anything else -- a typo, or a real role name
+// missing from the map -- would otherwise be forwarded to ARM verbatim and fail
+// the customer's stack deployment with InvalidRoleDefinitionId.
+func Resolvable(nameOrGUID string) bool {
+	if _, ok := builtInRoleGUIDs[nameOrGUID]; ok {
+		return true
+	}
+	return guidRegexp.MatchString(nameOrGUID)
+}
+
+// KnownNames returns the mapped role names, sorted, for error messages.
+func KnownNames() []string {
+	names := make([]string, 0, len(builtInRoleGUIDs))
+	for name := range builtInRoleGUIDs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/services/ctl-api/internal/pkg/azureroles/builtin_test.go
+++ b/services/ctl-api/internal/pkg/azureroles/builtin_test.go
@@ -1,0 +1,65 @@
+package azureroles
+
+import "testing"
+
+func TestGUID(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"Azure Kubernetes Service RBAC Reader", "7f6c6a51-bcf8-42ba-9220-52d62157d7db"},
+		{"Azure Kubernetes Service RBAC Cluster Admin", "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b"},
+		{"Network Contributor", "4d97b98b-1d4f-4787-a291-c67834d212e7"},
+		// Already a GUID: passed through so a config can name a role the map
+		// does not carry.
+		{"7f6c6a51-bcf8-42ba-9220-52d62157d7db", "7f6c6a51-bcf8-42ba-9220-52d62157d7db"},
+	}
+	for _, c := range cases {
+		if got := GUID(c.in); got != c.want {
+			t.Errorf("GUID(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestResolvable(t *testing.T) {
+	ok := []string{
+		"Azure Kubernetes Service RBAC Reader",
+		"Azure Kubernetes Service RBAC Writer",
+		"Azure Kubernetes Service RBAC Admin",
+		"Owner",
+		"7f6c6a51-bcf8-42ba-9220-52d62157d7db",
+		"7F6C6A51-BCF8-42BA-9220-52D62157D7DB",
+	}
+	for _, v := range ok {
+		if !Resolvable(v) {
+			t.Errorf("Resolvable(%q) = false, want true", v)
+		}
+	}
+
+	bad := []string{
+		"",
+		"Azure Kubernetes Service RBAC Readr", // typo
+		"Azure Kubernetes Service RBAC SuperAdmin", // not a real role
+		"7f6c6a51-bcf8-42ba-9220",                  // truncated GUID
+		"7f6c6a51bcf842ba922052d62157d7db",         // GUID without dashes
+	}
+	for _, v := range bad {
+		if Resolvable(v) {
+			t.Errorf("Resolvable(%q) = true, want false", v)
+		}
+	}
+}
+
+// The AKS data-plane roles are the ones an Azure app config reaches for, and
+// their absence is what let an invalid name reach a customer's stack deploy.
+func TestAKSDataPlaneRolesAreMapped(t *testing.T) {
+	for _, name := range []string{
+		"Azure Kubernetes Service RBAC Reader",
+		"Azure Kubernetes Service RBAC Writer",
+		"Azure Kubernetes Service RBAC Admin",
+		"Azure Kubernetes Service RBAC Cluster Admin",
+	} {
+		if GUID(name) == name {
+			t.Errorf("%q did not resolve to a GUID", name)
+		}
+	}
+}

--- a/services/ctl-api/internal/pkg/config/build/iam.go
+++ b/services/ctl-api/internal/pkg/config/build/iam.go
@@ -7,10 +7,12 @@ package build
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/azureroles"
 	dbgenerics "github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 )
 
@@ -68,6 +70,27 @@ func ValidatePolicyMutualExclusivity(roleName string, policies []config.AppAWSIA
 		}
 		if len(p.AzureActions) > 0 && len(p.AzureBuiltInRoles) > 0 {
 			return fmt.Errorf("role %q policy %q: azure_actions and azure_built_in_roles are mutually exclusive; use azure_actions for a fine-grained custom role or azure_built_in_roles for Azure-managed roles, not both", roleName, p.Name)
+		}
+	}
+	return nil
+}
+
+// ValidateAzureBuiltInRoles rejects a built-in role that cannot be resolved to a
+// definition GUID. ARM assignments reference a definition by GUID with no name
+// lookup, and the renderer forwards an unresolvable value verbatim -- so a typo,
+// or a real role absent from the name map, passes sync and generation and instead
+// fails the customer's stack deployment with InvalidRoleDefinitionId. Catch it
+// here, where the error can name the offending value.
+func ValidateAzureBuiltInRoles(roleName string, policies []config.AppAWSIAMPolicy) error {
+	for _, p := range policies {
+		for _, r := range p.AzureBuiltInRoles {
+			if azureroles.Resolvable(r) {
+				continue
+			}
+			return fmt.Errorf(
+				"role %q policy %q: azure_built_in_roles entry %q is neither a role definition GUID nor a known role name; pass the GUID or one of: %s",
+				roleName, p.Name, r, strings.Join(azureroles.KnownNames(), ", "),
+			)
 		}
 	}
 	return nil

--- a/services/ctl-api/internal/pkg/config/build/iam_test.go
+++ b/services/ctl-api/internal/pkg/config/build/iam_test.go
@@ -1,0 +1,57 @@
+package build
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nuonco/nuon/pkg/config"
+)
+
+func TestValidateAzureBuiltInRoles(t *testing.T) {
+	t.Run("mapped name is accepted", func(t *testing.T) {
+		err := ValidateAzureBuiltInRoles("install-preview-operations", []config.AppAWSIAMPolicy{
+			{Name: "k8s", AzureBuiltInRoles: []string{"Azure Kubernetes Service RBAC Reader"}},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("literal GUID is accepted", func(t *testing.T) {
+		err := ValidateAzureBuiltInRoles("install-preview-operations", []config.AppAWSIAMPolicy{
+			{Name: "k8s", AzureBuiltInRoles: []string{"7f6c6a51-bcf8-42ba-9220-52d62157d7db"}},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Without this the value is forwarded to ARM verbatim and the customer's
+	// stack deploy fails with InvalidRoleDefinitionId.
+	t.Run("unknown name is rejected at sync", func(t *testing.T) {
+		err := ValidateAzureBuiltInRoles("install-preview-operations", []config.AppAWSIAMPolicy{
+			{Name: "k8s", AzureBuiltInRoles: []string{"Azure Kubernetes Service RBAC Readr"}},
+		})
+		if err == nil {
+			t.Fatal("expected an error for an unmapped role name")
+		}
+		for _, want := range []string{"install-preview-operations", "k8s", "Azure Kubernetes Service RBAC Readr"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error should mention %q, got: %v", want, err)
+			}
+		}
+		if !strings.Contains(err.Error(), "Azure Kubernetes Service RBAC Reader") {
+			t.Errorf("error should list valid names, got: %v", err)
+		}
+	})
+
+	t.Run("policies without azure roles are untouched", func(t *testing.T) {
+		err := ValidateAzureBuiltInRoles("install-provision", []config.AppAWSIAMPolicy{
+			{Name: "aws", Contents: `{"Statement":[]}`},
+			{Name: "azure-actions", AzureActions: []string{"Microsoft.Network/dnsZones/read"}},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/services/ctl-api/internal/pkg/config/build/permissions.go
+++ b/services/ctl-api/internal/pkg/config/build/permissions.go
@@ -101,6 +101,9 @@ func validatePermissionRoles(in PermissionsInput) error {
 		if entry.role == nil {
 			continue
 		}
+		if err := ValidateAzureBuiltInRoles(entry.name, entry.role.Policies); err != nil {
+			return err
+		}
 		if err := ValidatePolicyMutualExclusivity(entry.name, entry.role.Policies); err != nil {
 			return err
 		}

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_operation_identities.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_operation_identities.go
@@ -9,28 +9,10 @@ import (
 	"strings"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/azureroles"
 )
 
 var azureIdentitySuffixRegexp = regexp.MustCompile(`[^A-Za-z0-9-]`)
-
-// azureBuiltInRoleGUIDs maps common built-in role names to their definition GUIDs;
-// role assignments reference the definition by GUID and ARM has no name lookup.
-var azureBuiltInRoleGUIDs = map[string]string{
-	"Owner":                     "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
-	"Contributor":               "b24988ac-6180-42a0-ab88-20f7382dd24c",
-	"Reader":                    "acdd72a7-3385-48ef-bd42-f606fba81ae7",
-	"User Access Administrator": "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9",
-	"Role Based Access Control Administrator":     "f58310d9-a9f6-439a-9e8d-f62e7b41a168",
-	"Azure Kubernetes Service RBAC Cluster Admin": "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b",
-	"Azure Kubernetes Service Cluster Admin Role": "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8",
-	"Azure Kubernetes Service Cluster User Role":  "4abbcc35-e782-43d8-92c5-2d3f1bd2253f",
-	"Key Vault Administrator":                     "00482a5a-887f-4fb3-b363-3b7fe8e74483",
-	"Key Vault Secrets User":                      "4633458b-17de-408a-b874-0445c86b69e6",
-	"Key Vault Secrets Officer":                   "b86a8fe4-44ce-4948-aee5-eccb2c155cd7",
-	"Storage Blob Data Contributor":               "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
-	"Storage Blob Data Owner":                     "b7e6dc6d-f1e8-4753-8033-0f276bb0955b",
-	"Network Contributor":                         "4d97b98b-1d4f-4787-a291-c67834d212e7",
-}
 
 type azureOperationIdentity struct {
 	// roleName is the rendered app-config role name; also the output map key for
@@ -52,10 +34,7 @@ func sanitizeAzureIdentitySuffix(name string) string {
 }
 
 func azureBuiltInRoleGUID(nameOrGUID string) string {
-	if guid, ok := azureBuiltInRoleGUIDs[nameOrGUID]; ok {
-		return guid
-	}
-	return nameOrGUID
+	return azureroles.GUID(nameOrGUID)
 }
 
 func azureOperationIdentities(appCfg *app.AppConfig) []azureOperationIdentity {


### PR DESCRIPTION
`azureBuiltInRoleGUIDs` had no entry for Azure Kubernetes Service RBAC Reader/Writer/Admin, and `azureBuiltInRoleGUID` returns an unmapped value unchanged. An app config naming one of those roles passed sync and stack generation, then failed the customer's `az stack group create` with `InvalidRoleDefinitionId` — the worst place to discover a config error.

Adds the three missing GUIDs, and validates at sync that every `azure_built_in_roles` entry is either a mapped name or a literal GUID, so a typo is rejected with the offending value and the list of valid names instead of reaching ARM.

The map moves to `internal/pkg/azureroles` so validation and rendering share one source; keeping a copy in each would drift.