### PR TITLE
fix(api): backfill org email notifications disabled by the auth0-only check

### DIFF
--- a/services/ctl-api/internal/pkg/db/psql/migrations/127_backfill_org_email_notifications.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/127_backfill_org_email_notifications.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// Migration127BackfillOrgEmailNotifications enables email notifications on org
+// notifications configs that were created between AccountTypeAuth landing
+// (2026-01-10, #128) and create_org widening its check to accept it
+// (2026-06-03, #1573). Orgs created by an `auth` account in that window got
+// enable_email_notifications=false, which silently drops every org invite email
+// because notifications.SendEmail returns nil when the flag is off.
+func (m *Migrations) Migration127BackfillOrgEmailNotifications(ctx context.Context, db *gorm.DB) error {
+	res := db.WithContext(ctx).Exec(`
+		UPDATE notifications_configs AS nc
+		SET enable_email_notifications = true,
+		    updated_at = now()
+		FROM orgs AS o
+		JOIN accounts AS a ON a.id = o.created_by_id
+		WHERE nc.owner_id = o.id
+		  AND nc.owner_type = 'orgs'
+		  AND nc.deleted_at = 0
+		  AND nc.enable_email_notifications = false
+		  AND a.account_type IN ('auth', 'auth0');`)
+	if res.Error != nil {
+		return res.Error
+	}
+
+	m.l.Info("backfilled org email notifications", zap.Int64("rows", res.RowsAffected))
+	return nil
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/127_backfill_org_email_notifications_test.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/127_backfill_org_email_notifications_test.go
@@ -1,0 +1,139 @@
+package migrations_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	psqlmigrations "github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/psql/migrations"
+	"github.com/nuonco/nuon/services/ctl-api/tests"
+	"github.com/nuonco/nuon/services/ctl-api/tests/testseed"
+)
+
+type migration127TestSuite struct {
+	tests.BaseDBTestSuite
+
+	db     *gorm.DB
+	seeder *testseed.Seeder
+}
+
+func TestMigration127Suite(t *testing.T) {
+	if os.Getenv("INTEGRATION") != "true" {
+		t.Skip("INTEGRATION is not set, skipping")
+		return
+	}
+
+	suite.Run(t, new(migration127TestSuite))
+}
+
+func (s *migration127TestSuite) SetupSuite() {
+	s.BaseDBTestSuite.SetupSuite()
+
+	cfg, err := tests.LoadDBConfig()
+	require.NoError(s.T(), err)
+	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		cfg.DBHost, cfg.DBPort, cfg.DBUser, cfg.DBPassword, cfg.DBName, cfg.DBSSLMode)
+	s.db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	require.NoError(s.T(), err)
+	s.seeder = testseed.New(testseed.Params{DB: s.db})
+	s.SetDB(s.db)
+}
+
+func (s *migration127TestSuite) TearDownSuite() {
+	db, err := s.db.DB()
+	require.NoError(s.T(), err)
+	require.NoError(s.T(), db.Close())
+}
+
+func (s *migration127TestSuite) seedOrgWithNotificationsConfig(
+	ctx context.Context,
+	acctType app.AccountType,
+	ownerType string,
+	emailEnabled bool,
+) (*app.Org, *app.NotificationsConfig) {
+	acct := &app.Account{
+		ID:          domains.NewAccountID(),
+		Subject:     domains.NewAccountID(),
+		Email:       fmt.Sprintf("%s@test.nuon.co", domains.NewAccountID()),
+		AccountType: acctType,
+	}
+	require.NoError(s.T(), s.db.WithContext(ctx).Create(acct).Error)
+
+	org := &app.Org{
+		ID:          domains.NewOrgID(),
+		Name:        fmt.Sprintf("org-%s", domains.NewOrgID()),
+		OrgType:     app.OrgTypeSandbox,
+		Status:      app.OrgStatusActive,
+		CreatedByID: acct.ID,
+	}
+	require.NoError(s.T(), s.db.WithContext(ctx).Create(org).Error)
+
+	cfg := &app.NotificationsConfig{
+		CreatedByID:              acct.ID,
+		OrgID:                    org.ID,
+		OwnerID:                  org.ID,
+		OwnerType:                ownerType,
+		EnableEmailNotifications: emailEnabled,
+	}
+	require.NoError(s.T(), s.db.WithContext(ctx).Create(cfg).Error)
+
+	return org, cfg
+}
+
+func (s *migration127TestSuite) emailEnabled(ctx context.Context, id string) bool {
+	var cfg app.NotificationsConfig
+	require.NoError(s.T(), s.db.WithContext(ctx).First(&cfg, "id = ?", id).Error)
+	return cfg.EnableEmailNotifications
+}
+
+func (s *migration127TestSuite) TestBackfillsOnlyUserCreatedOrgConfigs() {
+	ctx := context.Background()
+
+	// the Restate Cloud case: org created by a new-auth-service user while
+	// create_org still gated the flag on auth0 only
+	_, authOrgCfg := s.seedOrgWithNotificationsConfig(ctx, app.AccountTypeAuth, "orgs", false)
+	_, auth0OrgCfg := s.seedOrgWithNotificationsConfig(ctx, app.AccountTypeAuth0, "orgs", false)
+	_, serviceOrgCfg := s.seedOrgWithNotificationsConfig(ctx, app.AccountTypeService, "orgs", false)
+	_, canaryOrgCfg := s.seedOrgWithNotificationsConfig(ctx, app.AccountTypeCanary, "orgs", false)
+	_, appCfg := s.seedOrgWithNotificationsConfig(ctx, app.AccountTypeAuth, "apps", false)
+
+	migrations := psqlmigrations.New(psqlmigrations.Params{L: zap.NewNop()})
+	require.NoError(s.T(), migrations.Migration127BackfillOrgEmailNotifications(ctx, s.db))
+
+	require.True(s.T(), s.emailEnabled(ctx, authOrgCfg.ID), "auth-created org should be backfilled")
+	require.True(s.T(), s.emailEnabled(ctx, auth0OrgCfg.ID), "auth0-created org should be backfilled")
+	require.False(s.T(), s.emailEnabled(ctx, serviceOrgCfg.ID), "service-account org must stay disabled")
+	require.False(s.T(), s.emailEnabled(ctx, canaryOrgCfg.ID), "canary org must stay disabled")
+	require.False(s.T(), s.emailEnabled(ctx, appCfg.ID), "app-owned config must be untouched")
+}
+
+func (s *migration127TestSuite) TestIsIdempotentAndLeavesEnabledRowsAlone() {
+	ctx := context.Background()
+
+	_, disabled := s.seedOrgWithNotificationsConfig(ctx, app.AccountTypeAuth, "orgs", false)
+	_, alreadyEnabled := s.seedOrgWithNotificationsConfig(ctx, app.AccountTypeAuth, "orgs", true)
+
+	var before app.NotificationsConfig
+	require.NoError(s.T(), s.db.WithContext(ctx).First(&before, "id = ?", alreadyEnabled.ID).Error)
+
+	migrations := psqlmigrations.New(psqlmigrations.Params{L: zap.NewNop()})
+	require.NoError(s.T(), migrations.Migration127BackfillOrgEmailNotifications(ctx, s.db))
+	require.NoError(s.T(), migrations.Migration127BackfillOrgEmailNotifications(ctx, s.db))
+
+	require.True(s.T(), s.emailEnabled(ctx, disabled.ID))
+
+	var after app.NotificationsConfig
+	require.NoError(s.T(), s.db.WithContext(ctx).First(&after, "id = ?", alreadyEnabled.ID).Error)
+	require.True(s.T(), after.EnableEmailNotifications)
+	require.Equal(s.T(), before.UpdatedAt.UnixNano(), after.UpdatedAt.UnixNano(),
+		"already-enabled rows must not be rewritten")
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/all.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/all.go
@@ -180,5 +180,9 @@ func (m *Migrations) All() []migrations.Migration {
 			Name: "126-backfill-role-metadata",
 			Fn:   m.Migration126BackfillRoleMetadata,
 		},
+		{
+			Name: "127-backfill-org-email-notifications",
+			Fn:   m.Migration127BackfillOrgEmailNotifications,
+		},
 	}
 }


### PR DESCRIPTION
Orgs created by an `auth` (new auth service) account between 2026-01-10 (#128, which added `AccountTypeAuth`) and 2026-06-03 (#1573, which widened `create_org` to accept it) got `enable_email_notifications = false`, so every org invite email from them is silently dropped — `notifications.SendEmail` returns nil and the invite signal swallows it. Confirmed live on a BYOC control plane: same deployment, the affected org's SendEmail activity completed in 13ms without calling Loops while a healthy org took 214ms and delivered.

Migration 127 flips the flag for org-owned configs whose creator is `auth`/`auth0`, so BYOC planes get fixed on deploy instead of needing a per-org admin call. Service/canary/integration orgs and app-owned configs are left alone.