### PR TITLE
fix: remove infinite temporal activity retries from some places

### DIFF
--- a/pkg/gen/temporal-gen-v2/generate_test.go
+++ b/pkg/gen/temporal-gen-v2/generate_test.go
@@ -56,6 +56,12 @@ func TestGenerateExamples(t *testing.T) {
 	assert.Contains(t, string(content), "func AwaitComplexActivity(")
 	assert.Contains(t, string(content), "THIS FILE IS GENERATED. DO NOT EDIT.")
 
+	// SimpleActivity has no @max-retries and no @schedule-to-close-timeout, so it
+	// gets the default 24h total cap; ComplexActivity keeps its explicit 1h.
+	simpleAwait := string(content[strings.Index(string(content), "func AwaitSimpleActivity("):strings.Index(string(content), "func AwaitComplexActivity(")])
+	assert.Contains(t, simpleAwait, "options.ScheduleToCloseTimeout = time.Duration(86400000000000)")
+	assert.Contains(t, string(content), "options.ScheduleToCloseTimeout = time.Duration(3600000000000)")
+
 	// Verify workflow_gen.go
 	workflowGen := filepath.Join(examplesDir, "workflow_gen.go")
 	require.FileExists(t, workflowGen)

--- a/pkg/gen/temporal-gen-v2/internal/generator/file_generator.go
+++ b/pkg/gen/temporal-gen-v2/internal/generator/file_generator.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/nuonco/nuon/pkg/gen/temporal-gen-v2/config"
 	"github.com/nuonco/nuon/pkg/gen/temporal-gen-v2/internal/dir"
@@ -24,6 +25,10 @@ import (
 type GeneratorOptions struct {
 	ProcessImports bool
 }
+
+// Without @max-retries Temporal retries forever; without @schedule-to-close-timeout
+// nothing bounds that retry loop, so unannotated activities get a 24h total cap.
+const defaultScheduleToCloseTimeout = 24 * time.Hour
 
 func GenerateForFile(f *file.File, opts GeneratorOptions) error {
 	var body bytes.Buffer
@@ -51,6 +56,9 @@ func GenerateForFile(f *file.File, opts GeneratorOptions) error {
 		var code []byte
 		if fn.Annotation.Type == "activity" {
 			hasActivity = true
+			if !fn.Annotation.ActivityOpts.RetryPolicy && fn.Annotation.ActivityOpts.ScheduleToCloseTimeout == 0 {
+				fn.Annotation.ActivityOpts.ScheduleToCloseTimeout = defaultScheduleToCloseTimeout
+			}
 			if fn.Annotation.ActivityOpts.GenerateWrapper {
 				hasActivityWrapper = true
 			}

--- a/services/ctl-api/internal/app/runners/worker/activities/get_current_job_execution.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_current_job_execution.go
@@ -14,6 +14,7 @@ type GetCurrentJobExecutionRequest struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 1
 // @by-field JobID
 func (a *Activities) GetCurrentJobExecution(ctx context.Context, req GetCurrentJobExecutionRequest) (*app.RunnerJobExecution, error) {
 	jobExecution, err := a.getCurrentJobExecution(ctx, req.JobID)

--- a/services/ctl-api/internal/app/runners/worker/activities/get_heartbeat.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_heartbeat.go
@@ -13,6 +13,7 @@ type GetHeartBeatRequest struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 1
 // @by-field ID
 func (a *Activities) GetHeartBeat(ctx context.Context, req GetHeartBeatRequest) (*app.RunnerHeartBeat, error) {
 	runner := app.RunnerHeartBeat{}

--- a/services/ctl-api/internal/app/runners/worker/activities/get_job_execution.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_job_execution.go
@@ -14,6 +14,7 @@ type GetJobExecutionRequest struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 1
 func (a *Activities) GetJobExecution(ctx context.Context, req GetJobExecutionRequest) (*app.RunnerJobExecution, error) {
 	job, err := a.getRunnerJobExecution(ctx, req.JobExecutionID)
 	if err != nil {

--- a/services/ctl-api/internal/app/runners/worker/activities/get_job_execution_status.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_job_execution_status.go
@@ -12,6 +12,7 @@ type GetJobExecutionStatusRequest struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 1
 func (a *Activities) GetJobExecutionStatus(ctx context.Context, req GetJobExecutionStatusRequest) (app.RunnerJobExecutionStatus, error) {
 	jobExecution, err := a.getRunnerJobExecution(ctx, req.JobExecutionID)
 	if err != nil {

--- a/services/ctl-api/internal/app/runners/worker/activities/get_job_status.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_job_status.go
@@ -12,6 +12,7 @@ type GetJobStatusRequest struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 1
 // @by-field ID
 func (a *Activities) GetJobStatus(ctx context.Context, req GetJobStatusRequest) (app.RunnerJobStatus, error) {
 	job, err := a.getRunnerJob(ctx, req.ID)

--- a/services/ctl-api/internal/app/runners/worker/activities/get_latest_job_execution.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_latest_job_execution.go
@@ -22,6 +22,7 @@ type GetLatestJobExecutionResponse struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 1
 func (a *Activities) GetLatestJobExecution(ctx context.Context, req GetLatestJobExecutionRequest) (*GetLatestJobExecutionResponse, error) {
 	jobExecution, err := a.getLatestJobExecution(ctx, req.JobID, req.AvailableAt)
 	if err != nil {

--- a/services/ctl-api/internal/app/runners/worker/activities/get_most_recent_heart_beat.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_most_recent_heart_beat.go
@@ -16,6 +16,7 @@ type GetMostRecentHeartBeatRequest struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 1
 // @by-field RunnerID
 func (a *Activities) GetMostRecentHeartBeatRequest(ctx context.Context, req GetMostRecentHeartBeatRequest) (*app.RunnerHeartBeat, error) {
 	hb, err := a.getMostRecentHeartBeat(ctx, req.RunnerID, req.Process)

--- a/services/ctl-api/internal/app/runners/worker/activities/get_runner_job_for_execution.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_runner_job_for_execution.go
@@ -25,6 +25,7 @@ type GetRunnerJobForExecutionResponse struct {
 // shaves that latency for every job.
 //
 // @temporal-gen-v2 activity
+// @max-retries 1
 func (a *Activities) GetRunnerJobForExecution(ctx context.Context, req GetRunnerJobForExecutionRequest) (*GetRunnerJobForExecutionResponse, error) {
 	runner, err := a.getRunner(ctx, req.RunnerID)
 	if err != nil {

--- a/services/ctl-api/internal/app/runners/worker/activities/get_runner_status.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_runner_status.go
@@ -12,6 +12,7 @@ type GetRunnerStatusRequest struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 1
 // @by-field ID
 func (a *Activities) GetRunnerStatus(ctx context.Context, req GetRunnerStatusRequest) (app.RunnerStatus, error) {
 	runner, err := a.getRunner(ctx, req.ID)

--- a/services/ctl-api/internal/app/runners/worker/activities/has_active_runner_process.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/has_active_runner_process.go
@@ -15,6 +15,7 @@ type HasActiveRunnerProcessResponse struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 1
 // @by-field RunnerID
 func (a *Activities) HasActiveRunnerProcess(ctx context.Context, req HasActiveRunnerProcessRequest) (*HasActiveRunnerProcessResponse, error) {
 	var count int64

--- a/services/ctl-api/internal/app/runners/worker/activities/update_job_execution_status.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/update_job_execution_status.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 )
 
 type UpdateJobExecutionStatusRequest struct {
@@ -16,6 +17,7 @@ type UpdateJobExecutionStatusRequest struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 2
 func (a *Activities) UpdateJobExecutionStatus(ctx context.Context, req UpdateJobExecutionStatusRequest) error {
 	runner := app.RunnerJobExecution{
 		ID: req.JobExecutionID,
@@ -27,7 +29,10 @@ func (a *Activities) UpdateJobExecutionStatus(ctx context.Context, req UpdateJob
 		return fmt.Errorf("unable to update job execution status: %w", res.Error)
 	}
 	if res.RowsAffected < 1 {
-		return fmt.Errorf("no job execution found: %s %w", req.JobExecutionID, gorm.ErrRecordNotFound)
+		return generics.TemporalGormError(
+			gorm.ErrRecordNotFound,
+			fmt.Sprintf("no job execution found: %s", req.JobExecutionID),
+		)
 	}
 	helpers.AuditJobExecutionResult(ctx, a.db, a.mw, req.JobExecutionID, req.Status, "runner_workflow")
 

--- a/services/ctl-api/internal/app/runners/worker/activities/update_job_finished_at.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/update_job_finished_at.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/pkg/errors"
 )
 
@@ -17,6 +18,7 @@ type UpdateJobFinishedAtRequest struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 2
 // @by-field JobID
 func (a *Activities) UpdateJobFinishedAt(ctx context.Context, req UpdateJobFinishedAtRequest) error {
 	runner := app.RunnerJob{
@@ -29,7 +31,10 @@ func (a *Activities) UpdateJobFinishedAt(ctx context.Context, req UpdateJobFinis
 		return errors.Wrap(res.Error, "unable to update job started_at")
 	}
 	if res.RowsAffected < 1 {
-		return errors.Wrap(gorm.ErrRecordNotFound, fmt.Sprintf("no job found with id: %s", req.JobID))
+		return generics.TemporalGormError(
+			gorm.ErrRecordNotFound,
+			fmt.Sprintf("no job found with id: %s", req.JobID),
+		)
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/runners/worker/activities/update_job_started_at.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/update_job_started_at.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 	"github.com/pkg/errors"
 )
 
@@ -17,6 +18,7 @@ type UpdateJobStartedAtRequest struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 2
 // @by-field JobID
 func (a *Activities) UpdateJobStartedAt(ctx context.Context, req UpdateJobStartedAtRequest) error {
 	runner := app.RunnerJob{
@@ -29,7 +31,10 @@ func (a *Activities) UpdateJobStartedAt(ctx context.Context, req UpdateJobStarte
 		return errors.Wrap(res.Error, "unable to update job started_at")
 	}
 	if res.RowsAffected < 1 {
-		return errors.Wrap(gorm.ErrRecordNotFound, fmt.Sprintf("no job found with id: %s", req.JobID))
+		return generics.TemporalGormError(
+			gorm.ErrRecordNotFound,
+			fmt.Sprintf("no job found with id: %s", req.JobID),
+		)
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/runners/worker/activities/update_job_status.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/update_job_status.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 )
 
 type UpdateJobStatusRequest struct {
@@ -16,6 +17,7 @@ type UpdateJobStatusRequest struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 2
 func (a *Activities) UpdateJobStatus(ctx context.Context, req UpdateJobStatusRequest) error {
 	runner := app.RunnerJob{
 		ID: req.JobID,
@@ -28,7 +30,10 @@ func (a *Activities) UpdateJobStatus(ctx context.Context, req UpdateJobStatusReq
 		return fmt.Errorf("unable to update job status: %w", res.Error)
 	}
 	if res.RowsAffected < 1 {
-		return fmt.Errorf("no job found: %s %w", req.JobID, gorm.ErrRecordNotFound)
+		return generics.TemporalGormError(
+			gorm.ErrRecordNotFound,
+			fmt.Sprintf("no job found: %s", req.JobID),
+		)
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/runners/worker/activities/update_status.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/update_status.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 )
 
 type UpdateStatusRequest struct {
@@ -16,6 +17,7 @@ type UpdateStatusRequest struct {
 }
 
 // @temporal-gen-v2 activity
+// @max-retries 2
 // @local
 func (a *Activities) UpdateStatus(ctx context.Context, req UpdateStatusRequest) error {
 	runner := app.Runner{
@@ -29,7 +31,10 @@ func (a *Activities) UpdateStatus(ctx context.Context, req UpdateStatusRequest) 
 		return fmt.Errorf("unable to update runner status: %w", res.Error)
 	}
 	if res.RowsAffected < 1 {
-		return fmt.Errorf("no runner found: %s %w", req.RunnerID, gorm.ErrRecordNotFound)
+		return generics.TemporalGormError(
+			gorm.ErrRecordNotFound,
+			fmt.Sprintf("no runner found: %s", req.RunnerID),
+		)
 	}
 
 	return nil


### PR DESCRIPTION
Temporal codegen is missing configs which should eventually kill off an activity and not let it run indefinitely. 
Along with that this pr also adds some activity run boundaries to some of the most failed activities. 