### PR TITLE
feat(ui): button tooltip support

### DIFF
--- a/.claude/commands/dashboard-ui/component.md
+++ b/.claude/commands/dashboard-ui/component.md
@@ -98,8 +98,23 @@ If you need a Phosphor icon that isn't already available, add it to `client/comp
 
 Never import directly from `@phosphor-icons/react`, `lucide-react`, or `heroicons` in component files.
 
+## Button tooltips (disabled reasons & nudges)
+
+The `Button` owns its tooltip via `tooltipProps` (`Omit<ITooltip, 'children'>`). **Never hand-wrap `<Tooltip>` around a `Button`, and never put `title=` on a button.** With `disabled` + `tooltipProps`, Button renders `aria-disabled` (not native `disabled`, which swallows pointer events) so the reason shows on hover and keyboard focus.
+
+```tsx
+<Button disabled tooltipProps={{ tipContent: 'Sync the app config first' }}>Trigger run</Button>
+```
+
+- **Every disabled button whose reason isn't obvious from context gets a `tooltipProps` reason.** Copy follows `COPY_STYLE.md`: sentence case, explains the unmet condition, fragment (no period). A plain-string `tipContent` auto-wraps in `Text subtext` — pass a string, don't wrap it.
+- "Obvious from context" (no tooltip needed): label already changes for async ops, form fields show their own errors, a type-to-confirm input is right above, or pagination/positional convention.
+- **Nudge** (controlled tooltip opened by app state): `useNudge(trigger)` → `{ isOpen, close }` + `tooltipProps={{ isOpen, disableHover: true, tipContent }}`. Don't re-implement the timer.
+- Tooltips on **non-Button** elements (text, icons, badges, toggles) keep the hand-wrapped `<Tooltip>` — `tooltipProps` is Button-only.
+
 ## Anti-Patterns
 
+- **Do not** hand-wrap `<Tooltip>` around a `Button` or put `title=` on a button — use `Button`'s `tooltipProps`
+- **Do not** leave a disabled button unexplained when its reason isn't obvious from context — add a `tooltipProps` reason
 - **Do not** create a component that duplicates an existing one — always check existing components first
 - **Do not** pass props to a component without reading its interface — wrong props cause runtime errors
 - **Do not** use `ModalBase` or `PanelBase` directly — always use the `Modal`/`Panel` wrappers from `surfaces/`

--- a/.claude/commands/dashboard-ui/user-flow.md
+++ b/.claude/commands/dashboard-ui/user-flow.md
@@ -50,6 +50,14 @@ This skill enforces the two-component (Button + Modal) pattern using useSurfaces
 
 7. For panel flows (sliding side panel): follow the same pattern with `addPanel`/`removePanel` and `Panel` from `client/components/surfaces/Panel`.
 
+8. If the trigger Button is **disabled** because an upstream condition isn't met (not just async pending), give it a reason via `tooltipProps` — never hand-wrap `<Tooltip>` and never use `title=`. Button renders `aria-disabled` internally so the reason shows on hover/focus even while disabled:
+   ```typescript
+   <Button disabled={!hasConfig} tooltipProps={!hasConfig ? { tipContent: 'Sync the app config first' } : undefined} onClick={() => addModal(modal)} {...props}>
+     Trigger run
+   </Button>
+   ```
+   Skip the tooltip when the reason is obvious from context (label already changes for async ops, form errors are shown, a type-to-confirm input is right above). Copy follows `COPY_STYLE.md` (sentence case, fragment, no period).
+
 Canonical source: `client/components/approvals/ApprovePlan.tsx`
 
 ## Anti-Patterns
@@ -58,3 +66,4 @@ Canonical source: `client/components/approvals/ApprovePlan.tsx`
 - **Do not** build a modal with `<div className="fixed inset-0 ...">` — use `Modal` from `client/components/surfaces/Modal`
 - **Do not** destructure `modalId` from props — always spread `{...props}` onto `<Modal>`, or `removeModal(props.modalId)` will fail
 - **Do not** use `useState(isOpen)` to control modal visibility — use `useSurfaces().addModal` / `removeModal`
+- **Do not** hand-wrap `<Tooltip>` around a trigger `Button` or use `title=` — a disabled trigger's reason goes in `tooltipProps`

--- a/services/dashboard-ui/AGENTS.md
+++ b/services/dashboard-ui/AGENTS.md
@@ -622,6 +622,39 @@ import { Link } from 'react-router'
 <Link to={`/${org.id}/connections/vcs/${id}`}>View</Link>
 ```
 
+### Button tooltips (disabled reasons & nudges)
+
+**The `Button` owns its tooltip via the `tooltipProps` prop** (`tooltipProps?: Omit<ITooltip, 'children'>`). When present, Button renders itself wrapped in `Tooltip`. **Never hand-wrap `<Tooltip>` around a `Button`, and never put `title=` on a button** — both are review smells.
+
+Button solves the disabled-hover problem internally: when `disabled` + `tooltipProps`, it renders `aria-disabled` (not native `disabled`, which swallows pointer events) so the reason shows on hover **and** keyboard focus.
+
+```tsx
+// ✅ Disabled reason — shows on hover/focus even though disabled
+<Button disabled tooltipProps={{ tipContent: 'Sync the app config first' }}>
+  Trigger run
+</Button>
+
+// ❌ Wrong — native disabled swallows hover, tooltip never shows
+<Tooltip tipContent="Sync the app config first">
+  <Button disabled>Trigger run</Button>
+</Tooltip>
+```
+
+**Every disabled button whose reason isn't obvious from context gets a `tooltipProps` reason.** Reason copy follows [COPY_STYLE.md](./COPY_STYLE.md): sentence case, explains the unmet condition, fragment (no trailing period). A plain-string `tipContent` auto-wraps in `Text` `subtext` — pass a string, don't wrap it yourself.
+
+"Obvious from context" (→ **no** tooltip needed): the label already changes for an async op ("Saving…"), form fields show their own validation errors, a type-to-confirm input sits right above, or it's a pagination/positional convention.
+
+**Nudge** — a controlled tooltip opened by app state (not hover). Use `useNudge(trigger, durationMs?)` (`client/hooks/use-nudge.ts`) → `{ isOpen, close }`, wired to `tooltipProps`. Never re-implement the open/auto-close timer:
+
+```tsx
+const { isOpen, close } = useNudge(showNudge)
+<Button onClick={() => { close(); onRun() }} tooltipProps={{ isOpen, disableHover: true, position: 'bottom', tipContent: 'Trigger a run to deploy this branch' }}>
+  Trigger run
+</Button>
+```
+
+Tooltips on **non-Button** elements (text, icons, badges, toggles) keep the hand-wrapped `<Tooltip>` — `tooltipProps` is Button-only.
+
 ### Admin Tool Links
 
 **Never create ad-hoc links to admin tooling (admin dashboard, Temporal UI).** Always use the dedicated components in `client/components/admin/`. These components handle auth checks and demo mode internally — they render nothing for non-admin users, so consumers don't need any conditional logic.

--- a/services/dashboard-ui/DESIGN.md
+++ b/services/dashboard-ui/DESIGN.md
@@ -221,6 +221,23 @@ inside `labelProps`:
 - One **primary** action per surface — never two primary buttons on the same page (see §4.8);
   everything else `secondary`/`ghost`. `danger` only for destructive actions.
 
+### Button tooltips (disabled reasons + nudges)
+The `Button` owns its tooltip via `tooltipProps` — **never hand-wrap `<Tooltip>` around a `Button`,
+and never put `title=` on a button** (both are review smells). `Button` solves the disabled-hover
+problem internally: with `tooltipProps` + `disabled` it renders `aria-disabled` (not native
+`disabled`, which swallows pointer events), so the reason shows on hover **and** keyboard focus.
+```tsx
+<Button disabled tooltipProps={{ tipContent: 'Sync the app config first' }}>Trigger run</Button>
+```
+- **Every disabled button whose reason isn't obvious from context gets a `tooltipProps` reason.**
+  Reason copy follows [COPY_STYLE.md](./COPY_STYLE.md): sentence case, explains the unmet condition,
+  fragment (no trailing period). A plain-string `tipContent` auto-wraps in `Text` `subtext`.
+- "Obvious from context" (→ **no** tooltip needed): the label already changes for an async op
+  ("Saving…"), form fields show their own validation errors, a type-to-confirm input sits right
+  above, or it's a pagination/positional convention (first item can't move up).
+- **Nudge** (a controlled tooltip opened by app state, not hover) uses `useNudge(trigger)` +
+  `tooltipProps={{ isOpen, disableHover: true, tipContent }}` — don't re-implement the timer.
+
 ### Tables
 Prefer the Stratus `Table`. If you must hand-roll (e.g. inside a modal), mirror its styling:
 - Header row on the secondary surface: `bg-cool-grey-100 dark:bg-dark-grey-700`.

--- a/services/dashboard-ui/client/components/branches/BranchDetailActions/BranchDetailActions.stories.tsx
+++ b/services/dashboard-ui/client/components/branches/BranchDetailActions/BranchDetailActions.stories.tsx
@@ -50,3 +50,15 @@ export const TriggerPending = () => (
     onTriggerPreview={noop}
   />
 )
+
+export const WithNudge = () => (
+  <BranchDetailActions
+    editButton={<MockEditButton />}
+    deploymentPlanButton={<MockDeploymentPlanButton />}
+    deleteButton={<MockDeleteButton />}
+    isTriggerPending={false}
+    showTriggerNudge
+    onTriggerRun={noop}
+    onTriggerPreview={noop}
+  />
+)

--- a/services/dashboard-ui/client/components/branches/BranchDetailActions/BranchDetailActions.tsx
+++ b/services/dashboard-ui/client/components/branches/BranchDetailActions/BranchDetailActions.tsx
@@ -1,12 +1,9 @@
-import { type ReactNode, useEffect, useState } from 'react'
+import { type ReactNode } from 'react'
 import { Button } from '@/components/common/Button'
 import { Dropdown } from '@/components/common/Dropdown'
 import { Icon } from '@/components/common/Icon'
 import { Menu } from '@/components/common/Menu'
-import { Text } from '@/components/common/Text'
-import { Tooltip } from '@/components/common/Tooltip'
-
-const NUDGE_DURATION_MS = 8000
+import { useNudge } from '@/hooks/use-nudge'
 
 interface IBranchDetailActions {
   editButton: ReactNode
@@ -29,17 +26,7 @@ export const BranchDetailActions = ({
   onTriggerRun,
   onTriggerPreview,
 }: IBranchDetailActions) => {
-  const [nudgeOpen, setNudgeOpen] = useState(false)
-
-  useEffect(() => {
-    if (!showTriggerNudge) {
-      setNudgeOpen(false)
-      return
-    }
-    setNudgeOpen(true)
-    const timer = setTimeout(() => setNudgeOpen(false), NUDGE_DURATION_MS)
-    return () => clearTimeout(timer)
-  }, [showTriggerNudge])
+  const { isOpen: nudgeOpen, close: closeNudge } = useNudge(showTriggerNudge)
 
   return (
     <div className="flex items-center gap-3">
@@ -65,28 +52,24 @@ export const BranchDetailActions = ({
       ) : null}
 
       <div className="flex items-center">
-        <Tooltip
-          isOpen={nudgeOpen}
-          disableHover
-          position="bottom"
-          tipContent={
-            <Text variant="subtext">Trigger a run to deploy this branch</Text>
-          }
+        <Button
+          variant="primary"
+          disabled={isTriggerPending}
+          onClick={() => {
+            closeNudge()
+            onTriggerRun()
+          }}
+          className="!rounded-r-none"
+          tooltipProps={{
+            isOpen: nudgeOpen,
+            disableHover: true,
+            position: 'bottom',
+            tipContent: 'Trigger a run to deploy this branch',
+          }}
         >
-          <Button
-            variant="primary"
-            disabled={isTriggerPending}
-            onClick={() => {
-              setNudgeOpen(false)
-              onTriggerRun()
-            }}
-            className="!rounded-r-none"
-            title="Trigger a new run"
-          >
-            <Icon variant="PlayIcon" size={16} />
-            {isTriggerPending ? 'Triggering...' : 'Trigger run'}
-          </Button>
-        </Tooltip>
+          <Icon variant="PlayIcon" size={16} />
+          {isTriggerPending ? 'Triggering...' : 'Trigger run'}
+        </Button>
 
         <Dropdown
           id="trigger-run-options"

--- a/services/dashboard-ui/client/components/branches/management/BranchManagementDropdown/BranchManagementDropdown.tsx
+++ b/services/dashboard-ui/client/components/branches/management/BranchManagementDropdown/BranchManagementDropdown.tsx
@@ -52,6 +52,15 @@ export const BranchManagementDropdown = ({
           isMenuButton
           onClick={onTriggerRun}
           disabled={!hasConfig || isTriggerPending}
+          tooltipProps={
+            !hasConfig
+              ? {
+                  className: 'block !w-full',
+                  position: 'left',
+                  tipContent: 'Sync the app config first',
+                }
+              : undefined
+          }
         >
           Trigger run
           <Icon variant="PlayIcon" />

--- a/services/dashboard-ui/client/components/common/Button.stories.tsx
+++ b/services/dashboard-ui/client/components/common/Button.stories.tsx
@@ -141,6 +141,42 @@ export const Sizes = () => (
   </div>
 )
 
+export const Tooltips = () => (
+  <div className="space-y-6">
+    <div className="space-y-3">
+      <h3 className="text-lg font-semibold">Button Tooltips</h3>
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        Pass{' '}
+        <code className="px-2 py-0.5 bg-gray-100 dark:bg-gray-800 rounded text-xs">
+          tooltipProps
+        </code>{' '}
+        to let the Button own its tooltip. On a disabled button the reason still
+        shows on hover and keyboard focus — the Button renders itself{' '}
+        <code className="px-2 py-0.5 bg-gray-100 dark:bg-gray-800 rounded text-xs">
+          aria-disabled
+        </code>{' '}
+        instead of using the native attribute that swallows pointer events.
+      </p>
+    </div>
+
+    <div className="flex flex-wrap gap-4 items-center p-8 border rounded-lg">
+      <Button
+        variant="primary"
+        disabled
+        tooltipProps={{ tipContent: 'Sync the app config first' }}
+      >
+        Deploy
+      </Button>
+      <Button
+        variant="secondary"
+        tooltipProps={{ tipContent: 'Opens the docs in a new tab' }}
+      >
+        Docs
+      </Button>
+    </div>
+  </div>
+)
+
 export const Links = () => (
   <div className="space-y-6">
     <div className="space-y-3">

--- a/services/dashboard-ui/client/components/common/Button.stories.tsx
+++ b/services/dashboard-ui/client/components/common/Button.stories.tsx
@@ -2,6 +2,8 @@ export default {
   title: 'Common/Button',
 }
 
+import { useState } from 'react'
+import { useNudge } from '@/hooks/use-nudge'
 import { Button } from './Button'
 import { Icon } from './Icon'
 
@@ -176,6 +178,50 @@ export const Tooltips = () => (
     </div>
   </div>
 )
+
+export const Nudge = () => {
+  const [triggered, setTriggered] = useState(false)
+  const { isOpen, close } = useNudge(triggered, 4000)
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <h3 className="text-lg font-semibold">Nudge tooltip</h3>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          A one-time, programmatically opened tooltip. The{' '}
+          <code className="px-2 py-0.5 bg-gray-100 dark:bg-gray-800 rounded text-xs">
+            useNudge
+          </code>{' '}
+          hook opens the tooltip when a trigger flips true, auto-closes it after
+          the duration, and hands back a{' '}
+          <code className="px-2 py-0.5 bg-gray-100 dark:bg-gray-800 rounded text-xs">
+            close()
+          </code>{' '}
+          wired to the button&apos;s onClick.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-4 items-center p-8 border rounded-lg">
+        <Button variant="secondary" onClick={() => setTriggered(true)}>
+          Simulate app config synced
+        </Button>
+        <Button
+          variant="primary"
+          tooltipProps={{
+            isOpen,
+            disableHover: true,
+            position: 'bottom',
+            tipContent: 'Trigger a run to deploy this branch',
+          }}
+          onClick={close}
+        >
+          <Icon variant="PlayIcon" size={16} />
+          Trigger run
+        </Button>
+      </div>
+    </div>
+  )
+}
 
 export const Links = () => (
   <div className="space-y-6">

--- a/services/dashboard-ui/client/components/common/Button.tsx
+++ b/services/dashboard-ui/client/components/common/Button.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react'
 import { Link } from 'react-router'
 import { cn } from '@/utils/classnames'
+import { Tooltip, type ITooltip } from './Tooltip'
 
 export type TButtonSize = 'lg' | 'md' | 'sm' | 'xs'
 export type TButtonVariant =
@@ -17,6 +18,7 @@ interface IButtonBase {
   href?: string
   isActive?: boolean
   isMenuButton?: boolean
+  tooltipProps?: Omit<ITooltip, 'children'>
 }
 
 export interface IButtonAsButton
@@ -105,10 +107,15 @@ export const Button = forwardRef<
       isActive,
       isAnchorTag = false,
       isMenuButton,
+      tooltipProps,
       ...props
     },
     ref
   ) => {
+    const useTooltipDisabled =
+      tooltipProps != null &&
+      (props as React.ButtonHTMLAttributes<HTMLButtonElement>).disabled === true
+
     const classes = cn(
       `inline-flex items-center font-sans font-strong tracking-tight transition-colors whitespace-nowrap break-keep w-fit focus:outline-1 focus:outline-current cursor-pointer
       disabled:cursor-not-allowed`,
@@ -122,17 +129,56 @@ export const Button = forwardRef<
           isMenuButton && variant !== 'danger',
         '!p-2 text-sm !leading-none h-8 w-full flex justify-between !rounded-md !bg-transparent !border-0 !shadow-none !text-red-800 dark:!text-red-500 hover:!bg-red-50 dark:hover:!bg-[#1D0D10] focus:!bg-red-50 dark:focus:!bg-[#1D0D10] focus-visible:[--tw-outline-style:solid] focus-visible:outline-1 focus-visible:outline-offset-0 focus-visible:outline-red-400/80 dark:focus-visible:outline-red-500/50':
           isMenuButton && variant === 'danger',
+        'opacity-50 cursor-not-allowed pointer-events-none': useTooltipDisabled,
       },
       className
     )
 
-    if (href) {
-      if (isAnchorTag) {
+    const buttonProps = useTooltipDisabled
+      ? {
+          ...(props as React.ButtonHTMLAttributes<HTMLButtonElement>),
+          disabled: undefined,
+          'aria-disabled': true,
+          onClick: (e: React.MouseEvent<HTMLButtonElement>) =>
+            e.preventDefault(),
+        }
+      : (props as React.ButtonHTMLAttributes<HTMLButtonElement>)
+
+    const renderElement = () => {
+      if (href) {
+        if (isAnchorTag) {
+          return (
+            <a
+              ref={ref as React.Ref<HTMLAnchorElement>}
+              className={classes}
+              href={href}
+              {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+            >
+              {children}
+            </a>
+          )
+        }
+
+        const isInternal = href.startsWith('/')
+        if (isInternal) {
+          return (
+            <Link
+              to={href}
+              className={classes}
+              ref={ref as React.Ref<HTMLAnchorElement>}
+              {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+            >
+              {children}
+            </Link>
+          )
+        }
         return (
           <a
             ref={ref as React.Ref<HTMLAnchorElement>}
             className={classes}
             href={href}
+            target="_blank"
+            rel="noopener noreferrer"
             {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
           >
             {children}
@@ -140,42 +186,33 @@ export const Button = forwardRef<
         )
       }
 
-      const isInternal = href.startsWith('/')
-      if (isInternal) {
-        return (
-          <Link
-            to={href}
-            className={classes}
-            ref={ref as React.Ref<HTMLAnchorElement>}
-            {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
-          >
-            {children}
-          </Link>
-        )
-      }
       return (
-        <a
-          ref={ref as React.Ref<HTMLAnchorElement>}
+        <button
+          ref={ref as React.Ref<HTMLButtonElement>}
           className={classes}
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-          {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+          {...buttonProps}
         >
           {children}
-        </a>
+        </button>
       )
     }
 
-    return (
-      <button
-        ref={ref as React.Ref<HTMLButtonElement>}
-        className={classes}
-        {...(props as React.ButtonHTMLAttributes<HTMLButtonElement>)}
-      >
-        {children}
-      </button>
-    )
+    const element = renderElement()
+
+    if (tooltipProps) {
+      return (
+        <Tooltip
+          {...tooltipProps}
+          className={cn(tooltipProps.className, {
+            'cursor-not-allowed': useTooltipDisabled,
+          })}
+        >
+          {element}
+        </Tooltip>
+      )
+    }
+
+    return element
   }
 )
 

--- a/services/dashboard-ui/client/components/common/Tooltip.tsx
+++ b/services/dashboard-ui/client/components/common/Tooltip.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { cn } from '@/utils/classnames'
 import { Icon } from './Icon'
+import { Text } from './Text'
 import './Tooltip.css'
 
 export interface ITooltip extends React.HTMLAttributes<HTMLSpanElement> {
@@ -151,7 +152,7 @@ export const Tooltip = ({
     <span
       ref={tooltipRef}
       className={cn(
-        `tooltip-content bg-background text-foreground fixed block px-2 py-1 rounded-md drop-shadow-lg w-max whitespace-nowrap ${effPosition}`,
+        `tooltip-content bg-background text-foreground fixed flex items-center px-2 py-1 rounded-md drop-shadow-lg w-max whitespace-nowrap ${effPosition}`,
         {
           enter: isOpen,
           exit: !isOpen,
@@ -169,7 +170,11 @@ export const Tooltip = ({
           : undefined
       }
     >
-      {tipContent}
+      {typeof tipContent === 'string' ? (
+        <Text variant="subtext">{tipContent}</Text>
+      ) : (
+        tipContent
+      )}
     </span>
   )
 

--- a/services/dashboard-ui/client/components/common/Tooltip.tsx
+++ b/services/dashboard-ui/client/components/common/Tooltip.tsx
@@ -186,6 +186,15 @@ export const Tooltip = ({
         if (disableHover) return
         setOpen(false)
       }}
+      onFocus={() => {
+        if (disableHover) return
+        calculatePosition()
+        setOpen(true)
+      }}
+      onBlur={() => {
+        if (disableHover) return
+        setOpen(false)
+      }}
       {...props}
     >
       {showIcon ? (

--- a/services/dashboard-ui/client/components/install-components/management/ManagementDropdown.tsx
+++ b/services/dashboard-ui/client/components/install-components/management/ManagementDropdown.tsx
@@ -3,7 +3,6 @@ import { Dropdown } from '@/components/common/Dropdown'
 import { Icon } from '@/components/common/Icon'
 import { Menu } from '@/components/common/Menu'
 import { Text } from '@/components/common/Text'
-import { Tooltip } from '@/components/common/Tooltip'
 import { DeployComponentButton } from '@/components/install-components/management/DeployComponent'
 import { DriftScanComponentButton } from '@/components/install-components/management/DriftScanComponent'
 import { ForgetComponentButton } from '@/components/install-components/management/Forget'
@@ -21,12 +20,15 @@ const DisabledMenuItem = ({
   icon: 'CloudArrowDownIcon' | 'CloudArrowUpIcon' | 'TrashIcon'
   reason: string
 }) => (
-  <Tooltip className="block !w-full" position="left" tipContent={reason}>
-    <Button isMenuButton disabled className="pointer-events-none w-full">
-      {label}
-      <Icon variant={icon} />
-    </Button>
-  </Tooltip>
+  <Button
+    isMenuButton
+    disabled
+    className="w-full"
+    tooltipProps={{ className: 'block !w-full', position: 'left', tipContent: reason }}
+  >
+    {label}
+    <Icon variant={icon} />
+  </Button>
 )
 
 export const ManagementDropdown = ({

--- a/services/dashboard-ui/client/components/install-components/management/QuickComponentManagementDropdown.tsx
+++ b/services/dashboard-ui/client/components/install-components/management/QuickComponentManagementDropdown.tsx
@@ -3,7 +3,6 @@ import { Dropdown } from '@/components/common/Dropdown'
 import { Icon } from '@/components/common/Icon'
 import { Menu } from '@/components/common/Menu'
 import { Text } from '@/components/common/Text'
-import { Tooltip } from '@/components/common/Tooltip'
 import { DeployComponentButton } from '@/components/install-components/management/DeployComponent'
 import { DriftScanComponentButton } from '@/components/install-components/management/DriftScanComponent'
 import { SurfacesProvider } from '@/providers/surfaces-provider'
@@ -45,21 +44,20 @@ export const QuickComponentManagementDropdown = ({
             Controls
           </Text>
           {removed ? (
-            <Tooltip
-              className="block !w-full"
-              position="left"
-              tipContent={
-                <Text variant="subtext">
-                  This component is no longer in the install's app config
-                  version.
-                </Text>
-              }
+            <Button
+              isMenuButton
+              disabled
+              className="w-full"
+              tooltipProps={{
+                className: 'block !w-full',
+                position: 'left',
+                tipContent:
+                  "This component is no longer in the install's app config version.",
+              }}
             >
-              <Button isMenuButton disabled className="pointer-events-none w-full">
-                Deploy component
-                <Icon variant="CloudArrowUpIcon" />
-              </Button>
-            </Tooltip>
+              Deploy component
+              <Icon variant="CloudArrowUpIcon" />
+            </Button>
           ) : (
             <>
               <DriftScanComponentButton component={component} isMenuButton />

--- a/services/dashboard-ui/client/components/installs/management/EditInputs/EditInputsContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditInputs/EditInputsContainer.tsx
@@ -5,7 +5,6 @@ import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Text } from '@/components/common/Text'
-import { Tooltip } from '@/components/common/Tooltip'
 import { Modal, type IModal } from '@/components/surfaces/Modal'
 import { Toast } from '@/components/surfaces/Toast'
 import { useInstall } from '@/hooks/use-install'
@@ -185,18 +184,21 @@ export const EditInputsButton = ({
 
   if (isManagedByConfig) {
     return (
-      <Tooltip
-        tipContent={MANAGED_BY_CONFIG_TIP}
-        position="left"
-        tipContentClassName="!whitespace-normal !w-auto max-w-[200px] text-xs"
-        className="w-full"
+      <Button
+        disabled
+        tooltipProps={{
+          tipContent: MANAGED_BY_CONFIG_TIP,
+          position: 'left',
+          tipContentClassName:
+            '!whitespace-normal !w-auto max-w-[200px] text-xs',
+          className: 'w-full',
+        }}
+        {...props}
       >
-        <Button disabled className="pointer-events-none" {...props}>
-          {props?.isMenuButton ? null : <Icon variant="PencilSimpleLineIcon" />}
-          {showNameField ? 'Edit install' : 'Edit inputs'}
-          {props?.isMenuButton ? <Icon variant="PencilSimpleLineIcon" /> : null}
-        </Button>
-      </Tooltip>
+        {props?.isMenuButton ? null : <Icon variant="PencilSimpleLineIcon" />}
+        {showNameField ? 'Edit install' : 'Edit inputs'}
+        {props?.isMenuButton ? <Icon variant="PencilSimpleLineIcon" /> : null}
+      </Button>
     )
   }
 

--- a/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabelsContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditLabels/EditLabelsContainer.tsx
@@ -2,7 +2,6 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
-import { Tooltip } from '@/components/common/Tooltip'
 import { Toast } from '@/components/surfaces/Toast'
 import type { IModal } from '@/components/surfaces/Modal'
 import { useOrg } from '@/hooks/use-org'
@@ -91,12 +90,20 @@ export const EditLabelsButton = ({ ...props }: IButtonAsButton) => {
 
   if (isManagedByConfig) {
     return (
-      <Tooltip tipContent={MANAGED_BY_CONFIG_TIP} position="left" tipContentClassName="!whitespace-normal !w-auto max-w-[200px] text-xs" className="w-full">
-        <Button disabled className="pointer-events-none" {...props}>
-          Edit labels
-          <Icon variant="TagIcon" />
-        </Button>
-      </Tooltip>
+      <Button
+        disabled
+        tooltipProps={{
+          tipContent: MANAGED_BY_CONFIG_TIP,
+          position: 'left',
+          tipContentClassName:
+            '!whitespace-normal !w-auto max-w-[200px] text-xs',
+          className: 'w-full',
+        }}
+        {...props}
+      >
+        Edit labels
+        <Icon variant="TagIcon" />
+      </Button>
     )
   }
 

--- a/services/dashboard-ui/client/components/installs/management/EditStackOverrides/EditStackOverridesContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EditStackOverrides/EditStackOverridesContainer.tsx
@@ -2,7 +2,6 @@ import { useMutation } from '@tanstack/react-query'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
-import { Tooltip } from '@/components/common/Tooltip'
 import { Toast } from '@/components/surfaces/Toast'
 import type { IModal } from '@/components/surfaces/Modal'
 import { useOrg } from '@/hooks/use-org'
@@ -108,12 +107,20 @@ export const EditStackOverridesButton = ({
 
   if (isManagedByConfig) {
     return (
-      <Tooltip tipContent={MANAGED_BY_CONFIG_TIP} position="left" tipContentClassName="!whitespace-normal !w-auto max-w-[200px] text-xs" className="w-full">
-        <Button disabled className="pointer-events-none" {...props}>
-          <Icon variant="StackSimpleIcon" />
-          Edit stack overrides
-        </Button>
-      </Tooltip>
+      <Button
+        disabled
+        tooltipProps={{
+          tipContent: MANAGED_BY_CONFIG_TIP,
+          position: 'left',
+          tipContentClassName:
+            '!whitespace-normal !w-auto max-w-[200px] text-xs',
+          className: 'w-full',
+        }}
+        {...props}
+      >
+        <Icon variant="StackSimpleIcon" />
+        Edit stack overrides
+      </Button>
     )
   }
 

--- a/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/EnableAutoApproveContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/management/EnableAutoApprove/EnableAutoApproveContainer.tsx
@@ -2,7 +2,6 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Button, type IButtonAsButton } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
-import { Tooltip } from '@/components/common/Tooltip'
 import { Toast } from '@/components/surfaces/Toast'
 import type { IModal } from '@/components/surfaces/Modal'
 import { useOrg } from '@/hooks/use-org'
@@ -91,12 +90,20 @@ export const EnableAutoApproveButton = ({
 
   if (isManagedByConfig) {
     return (
-      <Tooltip tipContent={MANAGED_BY_CONFIG_TIP} position="left" tipContentClassName="!whitespace-normal !w-auto max-w-[200px] text-xs" className="w-full">
-        <Button disabled className="pointer-events-none" {...props}>
-          {buttonText}
-          <Icon variant={buttonIcon} />
-        </Button>
-      </Tooltip>
+      <Button
+        disabled
+        tooltipProps={{
+          tipContent: MANAGED_BY_CONFIG_TIP,
+          position: 'left',
+          tipContentClassName:
+            '!whitespace-normal !w-auto max-w-[200px] text-xs',
+          className: 'w-full',
+        }}
+        {...props}
+      >
+        {buttonText}
+        <Icon variant={buttonIcon} />
+      </Button>
     )
   }
 

--- a/services/dashboard-ui/client/components/notebooks/NotebookCellCard/NotebookCellCard.tsx
+++ b/services/dashboard-ui/client/components/notebooks/NotebookCellCard/NotebookCellCard.tsx
@@ -6,7 +6,6 @@ import { Input } from '@/components/common/form/Input'
 import { Status } from '@/components/common/Status'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
-import { Tooltip } from '@/components/common/Tooltip'
 
 interface INotebookCellCard {
   index: number
@@ -46,25 +45,16 @@ export const NotebookCellCard = ({
   return (
     <div className="flex flex-col gap-3 rounded-md border bg-background p-4">
       <div className="flex items-center gap-2">
-        <Tooltip
-          tipContentClassName="leading-none"
-          tipContent={
-            <Text variant="subtext">
-              {isRunning ? 'Running...' : 'Run cell'}
-            </Text>
-          }
-          position="top"
+        <Button
+          variant="ghost"
+          size="sm"
+          className="!p-1"
+          disabled={isRunning}
+          onClick={onRun}
+          tooltipProps={{ tipContent: isRunning ? 'Running...' : 'Run cell' }}
         >
-          <Button
-            variant="ghost"
-            size="sm"
-            className="!p-1"
-            disabled={isRunning}
-            onClick={onRun}
-          >
-            <Icon variant="PlayIcon" size={16} />
-          </Button>
-        </Tooltip>
+          <Icon variant="PlayIcon" size={16} />
+        </Button>
         {runStatus ? (
           <>
             <Status status={runStatus} />
@@ -93,41 +83,29 @@ export const NotebookCellCard = ({
         </div>
 
         <div className="flex items-center gap-1 shrink-0">
-          <Tooltip
-            tipContentClassName="leading-none"
-            tipContent={
-              <Text variant="subtext">
-                {isSaving ? 'Saving...' : 'Save changes'}
-              </Text>
-            }
-            position="top"
+          <Button
+            variant="ghost"
+            size="sm"
+            className="!p-1"
+            disabled={!isDirty || isSaving}
+            onClick={onSave}
+            tooltipProps={{
+              tipContent: isSaving ? 'Saving...' : 'Save changes',
+            }}
           >
-            <Button
-              variant="ghost"
-              size="sm"
-              className="!p-1"
-              disabled={!isDirty || isSaving}
-              onClick={onSave}
-            >
-              <Icon variant="FloppyDiskIcon" size={16} />
-            </Button>
-          </Tooltip>
+            <Icon variant="FloppyDiskIcon" size={16} />
+          </Button>
 
-          <Tooltip
-            tipContentClassName="leading-none"
-            tipContent={<Text variant="subtext">Delete cell</Text>}
-            position="top"
+          <Button
+            variant="ghost"
+            size="sm"
+            className="!p-1 !text-red-800 dark:!text-red-500"
+            disabled={isDeleting}
+            onClick={onDelete}
+            tooltipProps={{ tipContent: 'Delete cell' }}
           >
-            <Button
-              variant="ghost"
-              size="sm"
-              className="!p-1 !text-red-800 dark:!text-red-500"
-              disabled={isDeleting}
-              onClick={onDelete}
-            >
-              <Icon variant="TrashIcon" size={16} />
-            </Button>
-          </Tooltip>
+            <Icon variant="TrashIcon" size={16} />
+          </Button>
         </div>
       </div>
 

--- a/services/dashboard-ui/client/components/readme/ReadmeStudio/ReadmeStudio.tsx
+++ b/services/dashboard-ui/client/components/readme/ReadmeStudio/ReadmeStudio.tsx
@@ -144,7 +144,14 @@ function BlockMenuItems({ onAdd }: { onAdd: (type: TBlockType) => void }) {
       {blockGroups.flatMap((group) => [
         <Text key={group.label}>{group.label}</Text>,
         ...group.types.map((type) => (
-          <Button key={type} title={blockMeta[type].hint} onClick={() => onAdd(type)}>
+          <Button
+            key={type}
+            onClick={() => onAdd(type)}
+            tooltipProps={{
+              position: 'right',
+              tipContent: blockMeta[type].hint,
+            }}
+          >
             <span className="flex items-center gap-2">
               <Icon variant={blockMeta[type].icon} size="14" />
               {blockMeta[type].label}

--- a/services/dashboard-ui/client/components/runbooks/InstallRunbooksTable/InstallRunbooksTable.tsx
+++ b/services/dashboard-ui/client/components/runbooks/InstallRunbooksTable/InstallRunbooksTable.tsx
@@ -11,7 +11,6 @@ import { Table } from '@/components/common/Table'
 import { TableSkeleton } from '@/components/common/TableSkeleton'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
-import { Tooltip } from '@/components/common/Tooltip'
 import { RunRunbookButton } from '@/components/runbooks/RunRunbook'
 import { RemovedFromAppConfigBadge } from '@/components/installs/RemovedFromAppConfig'
 import type { TInstallRunbook } from '@/lib/ctl-api/installs/runbooks'
@@ -165,24 +164,20 @@ const columns: ColumnDef<TInstallRunbookRow>[] = [
       >
         <Menu>
           {info.row.original.removed ? (
-            <Tooltip
-              className="block !w-full"
-              position="left"
-              tipContent={
-                <Text variant="subtext">
-                  This runbook is no longer in the install's app config version.
-                </Text>
-              }
+            <Button
+              isMenuButton
+              disabled
+              className="w-full"
+              tooltipProps={{
+                className: 'block !w-full',
+                position: 'left',
+                tipContent:
+                  "This runbook is no longer in the install's app config version.",
+              }}
             >
-              <Button
-                isMenuButton
-                disabled
-                className="pointer-events-none w-full"
-              >
-                Run runbook
-                <Icon variant="PlayIcon" />
-              </Button>
-            </Tooltip>
+              Run runbook
+              <Icon variant="PlayIcon" />
+            </Button>
           ) : (
             <RunRunbookButton
               installRunbook={info.row.original.installRunbook}

--- a/services/dashboard-ui/client/components/triggers/event-ledger/EventDetails/EventDetails.tsx
+++ b/services/dashboard-ui/client/components/triggers/event-ledger/EventDetails/EventDetails.tsx
@@ -14,7 +14,6 @@ import { Status } from '@/components/common/Status'
 import { Table } from '@/components/common/Table'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
-import { Tooltip } from '@/components/common/Tooltip'
 import type {
   TTriggerEvent,
   TTriggerEventRaw,
@@ -373,6 +372,9 @@ export const EventDetails = ({
       variant="primary"
       disabled={cannotReplay || isReplaying}
       onClick={onReplay}
+      tooltipProps={
+        cannotReplay ? { tipContent: replayUnavailableReason } : undefined
+      }
     >
       {isReplaying ? 'Replaying event' : 'Replay event'}
     </Button>
@@ -427,11 +429,7 @@ export const EventDetails = ({
             </Text>
           </ClickToCopy>
         </div>
-        {cannotReplay ? (
-          <Tooltip tipContent={replayUnavailableReason}>{replayButton}</Tooltip>
-        ) : (
-          replayButton
-        )}
+        {replayButton}
       </div>
 
       <Card className="!p-4 !gap-4">

--- a/services/dashboard-ui/client/hooks/use-nudge.ts
+++ b/services/dashboard-ui/client/hooks/use-nudge.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const DEFAULT_NUDGE_DURATION_MS = 8000
+
+export function useNudge(
+  trigger: boolean,
+  durationMs = DEFAULT_NUDGE_DURATION_MS
+) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  useEffect(() => {
+    if (!trigger) {
+      setIsOpen(false)
+      return
+    }
+    setIsOpen(true)
+    const timer = setTimeout(() => setIsOpen(false), durationMs)
+    return () => clearTimeout(timer)
+  }, [trigger, durationMs])
+
+  const close = useCallback(() => setIsOpen(false), [])
+
+  return { isOpen, close }
+}

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -1764,34 +1764,6 @@ export interface paths {
      */
     get: operations["GetInstallComponentOutputs"];
   };
-  "/v1/installs/{install_id}/components/{component_id}/recover-helm-release": {
-    /**
-     * recover a stuck helm release for an install component
-     * @description Recover a Helm release that was left part-way through an operation.
-     *
-     * Helm records a `pending-install`, `pending-upgrade` or `pending-rollback` status before it
-     * starts changing the cluster and clears it once the operation finishes. A release left in one
-     * of those statuses is a rollout whose runner went away — a crash, a cancelled workflow, or a
-     * job that timed out. Helm then refuses every further operation on that release, and retrying
-     * the deploy cannot clear it.
-     *
-     * This endpoint starts a workflow that returns the release to a usable state:
-     *
-     * - when an earlier revision finished a rollout, the release is rolled back to it
-     * - when no revision ever rolled out, the stuck release is removed
-     *
-     * It deploys nothing and changes no desired state. Deploy the component afterwards to roll out
-     * the version you want.
-     *
-     * The recovery refuses to act on a release that is not pending, so it is safe to run when you
-     * are unsure and it is a no-op on a second run.
-     *
-     * Returns `409` when a job is already running for the component (recovering while Helm is
-     * genuinely mid-operation can corrupt the release) or when the component has never been
-     * deployed on this install. Returns `400` when the component is not a Helm chart.
-     */
-    post: operations["RecoverInstallComponentHelmRelease"];
-  };
   "/v1/installs/{install_id}/components/{component_id}/teardown": {
     /**
      * teardown an install component
@@ -4934,7 +4906,7 @@ export interface components {
       workflow_id?: string;
     };
     /** @enum {string} */
-    "app.InstallDeployType": "sync-image" | "apply" | "teardown" | "recover";
+    "app.InstallDeployType": "sync-image" | "apply" | "teardown";
     "app.InstallEvent": {
       created_at?: string;
       created_by_id?: string;
@@ -6696,7 +6668,7 @@ export interface components {
     /** @enum {string} */
     "app.WorkflowStepResponseType": "deny" | "approve" | "deny-skip-current" | "deny-skip-current-and-dependents" | "retry" | "auto-approve";
     /** @enum {string} */
-    "app.WorkflowType": "provision" | "deprovision" | "deprovision_sandbox" | "manual_deploy" | "input_update" | "deploy_components" | "teardown_component" | "teardown_components" | "reprovision_sandbox" | "drift_run_reprovision_sandbox" | "action_workflow_run" | "sync_secrets" | "drift_run" | "app_branches_manual_update" | "app_branches_config_repo_update" | "app_branches_component_repo_update" | "app_branch_config_update" | "app_install_sync" | "reprovision" | "reprovision_stack" | "app_config_build" | "runbook_run" | "component_enabled" | "component_disabled" | "recover_helm_release";
+    "app.WorkflowType": "provision" | "deprovision" | "deprovision_sandbox" | "manual_deploy" | "input_update" | "deploy_components" | "teardown_component" | "teardown_components" | "reprovision_sandbox" | "drift_run_reprovision_sandbox" | "action_workflow_run" | "sync_secrets" | "drift_run" | "app_branches_manual_update" | "app_branches_config_repo_update" | "app_branches_component_repo_update" | "app_branch_config_update" | "app_install_sync" | "reprovision" | "reprovision_stack" | "app_config_build" | "runbook_run" | "component_enabled" | "component_disabled";
     "blobstore.Blob": Record<string, never>;
     "callback.Ref": {
       namespace?: string;
@@ -7238,16 +7210,6 @@ export interface components {
        */
       name?: string;
       namespace?: string;
-      /**
-       * @description Recover, when set, makes this job unstick a release that helm left in a
-       * pending state instead of applying the chart. Nil is the normal deploy.
-       *
-       * A recovery reads the chart and values from the stored revision, so the
-       * runner skips fetching the OCI artifact entirely — requiring it would make
-       * recovery fail whenever the artifact is unreachable, which is exactly when
-       * an install is most likely to be wedged.
-       */
-      recover?: components["schemas"]["plantypes.HelmRecover"];
       skip_crds?: boolean;
       storage_driver?: string;
       take_ownership?: boolean;
@@ -7260,7 +7222,6 @@ export interface components {
        */
       values_override?: string;
     };
-    "plantypes.HelmRecover": Record<string, never>;
     "plantypes.HelmSandboxMode": {
       plan_contents?: string;
       plan_display_contents?: string;
@@ -8168,11 +8129,6 @@ export interface components {
       };
       metadata?: components["schemas"]["helpers.InstallMetadata"];
       name: string;
-      /**
-       * @description StackOnly provisions the install stack and runner, then stops. The sandbox
-       * and components stay unprovisioned until the install is provisioned again.
-       */
-      stack_only?: boolean;
     };
     "service.CreateInstallV2Request": {
       app_id: string;
@@ -8192,11 +8148,6 @@ export interface components {
       };
       metadata?: components["schemas"]["helpers.InstallMetadata"];
       name: string;
-      /**
-       * @description StackOnly provisions the install stack and runner, then stops. The sandbox
-       * and components stay unprovisioned until the install is provisioned again.
-       */
-      stack_only?: boolean;
     };
     "service.CreateJobComponentConfigRequest": {
       app_config_id?: string;
@@ -8772,9 +8723,6 @@ export interface components {
       readme?: string;
       warnings?: string[];
     };
-    "service.RecoverInstallComponentHelmReleaseRequest": {
-      role?: string;
-    };
     "service.RefreshInstallHealthClusterAccessRequest": {
       /**
        * @description RoleName is the identity health should read the cluster through. Empty
@@ -8987,11 +8935,6 @@ export interface components {
       inputs: {
         [key: string]: string;
       };
-      /**
-       * @description InputsOnly saves the new input values without deploying components,
-       * reprovisioning the sandbox, or running update-input lifecycle actions.
-       */
-      inputs_only?: boolean;
       role?: string;
     };
     "service.UpdateInstallRequest": {
@@ -22340,91 +22283,6 @@ export interface operations {
       };
       /** @description Not Found */
       404: {
-        content: {
-          "application/json": components["schemas"]["stderr.ErrResponse"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        content: {
-          "application/json": components["schemas"]["stderr.ErrResponse"];
-        };
-      };
-    };
-  };
-  /**
-   * recover a stuck helm release for an install component
-   * @description Recover a Helm release that was left part-way through an operation.
-   *
-   * Helm records a `pending-install`, `pending-upgrade` or `pending-rollback` status before it
-   * starts changing the cluster and clears it once the operation finishes. A release left in one
-   * of those statuses is a rollout whose runner went away — a crash, a cancelled workflow, or a
-   * job that timed out. Helm then refuses every further operation on that release, and retrying
-   * the deploy cannot clear it.
-   *
-   * This endpoint starts a workflow that returns the release to a usable state:
-   *
-   * - when an earlier revision finished a rollout, the release is rolled back to it
-   * - when no revision ever rolled out, the stuck release is removed
-   *
-   * It deploys nothing and changes no desired state. Deploy the component afterwards to roll out
-   * the version you want.
-   *
-   * The recovery refuses to act on a release that is not pending, so it is safe to run when you
-   * are unsure and it is a no-op on a second run.
-   *
-   * Returns `409` when a job is already running for the component (recovering while Helm is
-   * genuinely mid-operation can corrupt the release) or when the component has never been
-   * deployed on this install. Returns `400` when the component is not a Helm chart.
-   */
-  RecoverInstallComponentHelmRelease: {
-    parameters: {
-      path: {
-        /** @description install ID */
-        install_id: string;
-        /** @description component ID */
-        component_id: string;
-      };
-    };
-    /** @description Input */
-    requestBody?: {
-      content: {
-        "application/json": components["schemas"]["service.RecoverInstallComponentHelmReleaseRequest"];
-      };
-    };
-    responses: {
-      /** @description Created */
-      201: {
-        content: {
-          "application/json": components["schemas"]["app.WorkflowResponse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["stderr.ErrResponse"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        content: {
-          "application/json": components["schemas"]["stderr.ErrResponse"];
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        content: {
-          "application/json": components["schemas"]["stderr.ErrResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["stderr.ErrResponse"];
-        };
-      };
-      /** @description Conflict */
-      409: {
         content: {
           "application/json": components["schemas"]["stderr.ErrResponse"];
         };

--- a/services/dashboard-ui/client/views/install/ActionDetail.tsx
+++ b/services/dashboard-ui/client/views/install/ActionDetail.tsx
@@ -20,7 +20,6 @@ import { InstallActionManualRunButton } from '@/components/actions/InstallAction
 import { AdminDashboardLink } from '@/components/admin/AdminDashboardLink'
 import { InstallActionRunTimeline } from '@/components/actions/InstallActionRunTimeline'
 import { RemovedFromAppConfigBanner } from '@/components/installs/RemovedFromAppConfig'
-import { Tooltip } from '@/components/common/Tooltip'
 import { PageSection } from '@/components/layout/PageSection'
 import { Breadcrumbs } from '@/components/navigation/Breadcrumb'
 import { PageTitle } from '@/components/navigation/PageTitle'
@@ -193,20 +192,18 @@ export const ActionDetail = () => {
                 (t) => t.type === 'manual'
               ) ? (
                 removed ? (
-                  <Tooltip
-                    position="left"
-                    tipContent={
-                      <Text variant="subtext">
-                        This action is no longer in the install's app config
-                        version.
-                      </Text>
-                    }
+                  <Button
+                    variant="primary"
+                    disabled
+                    tooltipProps={{
+                      position: 'left',
+                      tipContent:
+                        "This action is no longer in the install's app config version.",
+                    }}
                   >
-                    <Button variant="primary" disabled>
-                      Run action
-                      <Icon variant="PlayIcon" />
-                    </Button>
-                  </Tooltip>
+                    Run action
+                    <Icon variant="PlayIcon" />
+                  </Button>
                 ) : (
                   <InstallActionManualRunButton
                     action={action.action_workflow}

--- a/services/dashboard-ui/client/views/install/RunbookDetailLayout.tsx
+++ b/services/dashboard-ui/client/views/install/RunbookDetailLayout.tsx
@@ -7,7 +7,6 @@ import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { ID } from '@/components/common/ID'
 import { Skeleton } from '@/components/common/Skeleton'
 import { Text } from '@/components/common/Text'
-import { Tooltip } from '@/components/common/Tooltip'
 import { Button } from '@/components/common/Button'
 import { Icon } from '@/components/common/Icon'
 import { RunRunbookButton } from '@/components/runbooks/RunRunbook'
@@ -165,20 +164,18 @@ export const RunbookDetailLayout = () => {
 
             {installRunbook ? (
               removed ? (
-                <Tooltip
-                  position="left"
-                  tipContent={
-                    <Text variant="subtext">
-                      This runbook is no longer in the install's app config
-                      version.
-                    </Text>
-                  }
+                <Button
+                  variant="primary"
+                  disabled
+                  tooltipProps={{
+                    position: 'left',
+                    tipContent:
+                      "This runbook is no longer in the install's app config version.",
+                  }}
                 >
-                  <Button variant="primary" disabled>
-                    Run runbook
-                    <Icon variant="PlayIcon" />
-                  </Button>
-                </Tooltip>
+                  Run runbook
+                  <Icon variant="PlayIcon" />
+                </Button>
               ) : (
                 <RunRunbookButton
                   installRunbook={installRunbook}

--- a/services/dashboard-ui/e2e/specs-ladle/button-nudge.spec.ts
+++ b/services/dashboard-ui/e2e/specs-ladle/button-nudge.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+const STORY = "/?story=common--button--nudge&mode=preview";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(STORY, { waitUntil: "domcontentloaded" });
+  await expect(
+    page.getByRole("button", { name: "Simulate app config synced" }),
+  ).toBeVisible();
+});
+
+test("the nudge opens when triggered and closes on click", async ({ page }) => {
+  const nudge = page.getByRole("tooltip", {
+    name: "Trigger a run to deploy this branch",
+  });
+  await expect(nudge).toBeHidden();
+
+  await page.getByRole("button", { name: "Simulate app config synced" }).click();
+  await expect(nudge).toBeVisible();
+
+  await page.getByRole("button", { name: "Trigger run" }).click();
+  await expect(nudge).toBeHidden();
+});

--- a/services/dashboard-ui/e2e/specs-ladle/button-tooltip.spec.ts
+++ b/services/dashboard-ui/e2e/specs-ladle/button-tooltip.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+const STORY = "/?story=common--button--tooltips&mode=preview";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(STORY, { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("button", { name: "Deploy" })).toBeVisible();
+});
+
+test("disabled button still shows its reason tooltip on hover", async ({
+  page,
+}) => {
+  const deploy = page.getByRole("button", { name: "Deploy" });
+  await expect(deploy).toHaveAttribute("aria-disabled", "true");
+
+  await deploy.hover({ force: true });
+
+  await expect(
+    page.getByRole("tooltip", { name: "Sync the app config first" }),
+  ).toBeVisible();
+});
+
+test("enabled button shows its hint tooltip on hover", async ({ page }) => {
+  await page.getByRole("button", { name: "Docs" }).hover();
+
+  await expect(
+    page.getByRole("tooltip", { name: "Opens the docs in a new tab" }),
+  ).toBeVisible();
+});


### PR DESCRIPTION
This PR moves a tooltip primitive to the button component so we can show why a button is disabled or draw attention to a button with the new `useNudge` hook. This PR also updates usage across the dashboard and updates all the support material for agents to understand and use this new tooltip ux pattern. 