### PR TITLE
feat: nuon app sync branch

### DIFF
--- a/bins/cli/AGENTS.md
+++ b/bins/cli/AGENTS.md
@@ -395,6 +395,31 @@ All config-to-database conversion lives server-side in `services/ctl-api/interna
 config knowledge to the CLI beyond parsing and validation** — a client-side syncer (`pkg/config/sync/apisyncer`) is
 exactly what this replaced, after it silently drifted from the server's conversion for months.
 
+#### The app branch path (`app-branch-sync`)
+
+When the org has the `app-branch-sync` feature flag on, or the user passes `--branch` / `--app-branch`, the sync
+routes through an app branch run instead (`internal/services/apps/sync_branch.go`). This path adds **no** endpoints of
+its own:
+
+1. `GET /v1/orgs/current` for the flag, then `GET /v1/apps/:app_id/branches` for a branch named `sync-default`. On the first
+   sync it does not exist yet, so `POST /v1/apps/:app_id/branches` creates it and
+   `POST /v1/apps/:app_id/branches/:branch_id/configs` gives it a single `all_installs` install group. A name collision
+   on create means a concurrent sync won the race, so re-list and use theirs.
+2. `POST /v1/apps/:app_id/configs` with `intermediate_config_json` and `app_branch_id`. The config is left unsynced.
+   **Resolving the branch here as a side effect of an empty `app_branch_id` does not work**: an older CLI would get a
+   branch-linked config and then call `/configs/:id/sync`, whose `finalizeAppConfigSync` skips the install rollout for
+   branch-linked configs on the assumption a branch run owns it. No run exists, so installs silently never update.
+3. `POST /v1/apps/:app_id/branches/:branch_id/runs` with `app_config_id` and `sync_app_config: true`. The run's
+   `sync app config` step is what calls the syncer, so the config still moves `pending` to `syncing` to
+   `active`/`error` and the status poll above is unchanged.
+4. The run's builds step owns component builds. **Do not also call `POST /configs/:id/sync` on this path**: it
+   dispatches builds too, and the run would build every changed component twice.
+5. The CLI waits until the run's builds step reaches a terminal status, then returns. The install group plan and deploy
+   steps that follow keep running server-side.
+
+Exit codes are unchanged: 0 synced, 1 sync failed, 3 builds failed. `--auto-approve` sets `approve-all` on the run;
+without it the gate follows the targeted installs' own `approval_option`, which defaults to `prompt`.
+
 ### Output format (`--output table|json|agent`)
 
 The global `--output` flag selects the output format (default `table`). `--json`/`-j` is a **deprecated** shorthand for

--- a/bins/cli/cmd/apps.go
+++ b/bins/cli/cmd/apps.go
@@ -158,10 +158,14 @@ func (c *cli) appsCmd() *cobra.Command {
 	appsCmd.AddCommand(unsetCurrentAppCmd)
 
 	var (
-		syncCreate bool
-		syncForce  bool
-		syncAppID  string
-		syncNoWait bool
+		syncCreate      bool
+		syncForce       bool
+		syncAppID       string
+		syncBranch      string
+		syncAppBranch   bool
+		syncPreview     bool
+		syncAutoApprove bool
+		syncNoWait      bool
 	)
 	syncCmd := &cobra.Command{
 		Use:               "sync [dir]",
@@ -181,11 +185,15 @@ func (c *cli) appsCmd() *cobra.Command {
 			}
 
 			opts := apps.SyncOptions{
-				AppFlag:   syncAppID,
-				Force:     syncForce,
-				Create:    syncCreate,
-				PrintJSON: PrintJSON,
-				NoWait:    syncNoWait,
+				AppFlag:     syncAppID,
+				Force:       syncForce,
+				Create:      syncCreate,
+				Branch:      syncBranch,
+				AppBranch:   syncAppBranch,
+				Preview:     syncPreview,
+				AutoApprove: syncAutoApprove,
+				PrintJSON:   PrintJSON,
+				NoWait:      syncNoWait,
 			}
 			svc := c.apps
 			if syncCreate {
@@ -197,6 +205,10 @@ func (c *cli) appsCmd() *cobra.Command {
 	syncCmd.Flags().BoolVar(&syncCreate, "create", false, "Create the app if it doesn't exist")
 	syncCmd.Flags().BoolVar(&syncForce, "force", false, "Sync to the configured app even if the directory name does not match")
 	syncCmd.Flags().StringVarP(&syncAppID, "app-id", "a", "", "The ID or name of the app to sync this config with (defaults to the selected app)")
+	syncCmd.Flags().StringVar(&syncBranch, "branch", "", "Target a specific app branch for this sync")
+	syncCmd.Flags().BoolVar(&syncAppBranch, "app-branch", false, "Select an app branch interactively and trigger a branch run after sync")
+	syncCmd.Flags().BoolVar(&syncPreview, "preview", false, "Plan-only preview mode (no apply). Only used with --branch or --app-branch")
+	syncCmd.Flags().BoolVar(&syncAutoApprove, "auto-approve", false, "Skip the branch run's approval gate before each install group deploys")
 	syncCmd.Flags().BoolVar(&syncNoWait, "no-wait", false, "Do not wait for scheduled component builds to complete")
 	appsCmd.AddCommand(syncCmd)
 

--- a/bins/cli/cmd/sync.go
+++ b/bins/cli/cmd/sync.go
@@ -23,13 +23,14 @@ Exit codes:
 
 func (c *cli) syncCmd() *cobra.Command {
 	var (
-		create    bool
-		force     bool
-		appID     string
-		branch    string
-		appBranch bool
-		preview   bool
-		noWait    bool
+		create      bool
+		force       bool
+		appID       string
+		branch      string
+		appBranch   bool
+		preview     bool
+		autoApprove bool
+		noWait      bool
 	)
 	syncCmd := &cobra.Command{
 		Use:               "sync",
@@ -38,14 +39,15 @@ func (c *cli) syncCmd() *cobra.Command {
 		PersistentPreRunE: c.persistentPreRunE,
 		Run: c.wrapCmd(func(cmd *cobra.Command, args []string) error {
 			opts := apps.SyncOptions{
-				AppFlag:   appID,
-				Force:     force,
-				Create:    create,
-				Branch:    branch,
-				AppBranch: appBranch,
-				Preview:   preview,
-				PrintJSON: PrintJSON,
-				NoWait:    noWait,
+				AppFlag:     appID,
+				Force:       force,
+				Create:      create,
+				Branch:      branch,
+				AppBranch:   appBranch,
+				Preview:     preview,
+				AutoApprove: autoApprove,
+				PrintJSON:   PrintJSON,
+				NoWait:      noWait,
 			}
 			svc := c.apps
 			if create {
@@ -61,6 +63,7 @@ func (c *cli) syncCmd() *cobra.Command {
 	syncCmd.Flags().StringVar(&branch, "branch", "", "Target a specific app branch for this sync")
 	syncCmd.Flags().BoolVar(&appBranch, "app-branch", false, "Select an app branch interactively and trigger a branch run after sync")
 	syncCmd.Flags().BoolVar(&preview, "preview", false, "Plan-only preview mode (no apply). Only used with --branch or --app-branch")
+	syncCmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip the branch run's approval gate before each install group deploys")
 	syncCmd.Flags().BoolVar(&noWait, "no-wait", false, "Do not wait for scheduled component builds to complete")
 
 	return syncCmd

--- a/bins/cli/internal/services/apps/sync_branch.go
+++ b/bins/cli/internal/services/apps/sync_branch.go
@@ -1,0 +1,283 @@
+package apps
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nuonco/nuon/sdks/nuon-go"
+	"github.com/nuonco/nuon/sdks/nuon-go/models"
+
+	"github.com/nuonco/nuon/bins/cli/internal/ui"
+	"github.com/nuonco/nuon/bins/cli/internal/ui/bubbles"
+	"github.com/nuonco/nuon/pkg/errs"
+)
+
+const (
+	// buildsStepName must match the step the branch run workflow generator
+	// creates for builds
+	// (services/ctl-api/internal/app/apps/workflows/app_branch_run.go). The sync
+	// returns once that step finishes; the install group steps that follow keep
+	// running server-side.
+	buildsStepName = "building components and sandbox"
+
+	defaultBranchRunPoll = time.Second * 5
+
+	appBranchSyncFeature    = "app-branch-sync"
+	defaultAppBranchName    = "sync-default"
+	defaultInstallGroupName = "all installs"
+)
+
+// resolveDefaultBranchID returns the app's default branch when the org has
+// app-branch-sync enabled, creating it if this is the first sync, or "" to leave
+// the sync on the standalone path.
+//
+// The branch is created here rather than as a side effect of POST /configs so an
+// older CLI never ends up with a branch-linked config it will not run: the sync
+// endpoint skips the install rollout for branch-linked configs on the assumption a
+// branch run owns it.
+func (s *Service) resolveDefaultBranchID(ctx context.Context, appID string) (string, error) {
+	org, err := s.api.GetOrg(ctx)
+	if err != nil {
+		return "", fmt.Errorf("unable to read org features: %w", err)
+	}
+	if !org.Features[appBranchSyncFeature] {
+		return "", nil
+	}
+
+	branchID, err := s.findBranchIDByName(ctx, appID, defaultAppBranchName)
+	if err != nil {
+		return "", err
+	}
+	if branchID != "" {
+		return branchID, nil
+	}
+
+	ui.PrintLn("creating " + defaultAppBranchName + " app branch")
+	branch, err := s.api.CreateAppBranch(ctx, appID, &models.ServiceCreateAppBranchRequest{
+		Name: ptr(defaultAppBranchName),
+	})
+	if err != nil {
+		// A concurrent sync may have won the race; the branch name is unique per app.
+		branchID, lookupErr := s.findBranchIDByName(ctx, appID, defaultAppBranchName)
+		if lookupErr == nil && branchID != "" {
+			return branchID, nil
+		}
+		return "", fmt.Errorf("unable to create default app branch: %w", err)
+	}
+
+	if _, err := s.api.CreateAppBranchConfig(ctx, appID, branch.ID, &models.ServiceCreateAppBranchConfigRequest{
+		InstallGroups: []*models.ServiceInstallGroupRequest{{
+			Name:        ptr(defaultInstallGroupName),
+			Order:       ptr(int64(0)),
+			AllInstalls: true,
+		}},
+		PostDeployRunbookIds: []string{},
+	}); err != nil {
+		return "", fmt.Errorf("unable to configure default app branch: %w", err)
+	}
+
+	return branch.ID, nil
+}
+
+func (s *Service) findBranchIDByName(ctx context.Context, appID, name string) (string, error) {
+	branches, err := s.api.GetAppBranches(ctx, appID)
+	if err != nil {
+		return "", fmt.Errorf("unable to list app branches: %w", err)
+	}
+	for _, branch := range branches {
+		if branch.Name == name {
+			return branch.ID, nil
+		}
+	}
+	return "", nil
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// syncViaBranchRun hands an already-uploaded config to a branch run, which syncs
+// it, builds the changed components, and rolls it out to the branch's install
+// groups. Only the sync and build phases are waited on.
+func (s *Service) syncViaBranchRun(ctx context.Context, appID, branchID, dir string, appConfig *models.AppAppConfig, opts SyncOptions) (*syncResult, error) {
+	run, err := s.api.TriggerAppBranchRun(ctx, appID, branchID, &models.ServiceTriggerAppBranchRunRequest{
+		AppConfigID:   appConfig.ID,
+		SyncAppConfig: true,
+		PlanOnly:      opts.Preview,
+		AutoApprove:   opts.AutoApprove,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ui.PrintSuccess(fmt.Sprintf("triggered app branch run %s", run.ID))
+	result := &syncResult{AppID: appID, Dir: dir, BranchID: branchID, RunID: run.ID}
+
+	synced, err := s.waitForRunConfigSync(ctx, appID, appConfig.ID, run.WorkflowID, opts.PrintJSON)
+	if err != nil {
+		return result, err
+	}
+	s.notifySyncResult(parseSyncState(synced.State).Result)
+
+	if opts.NoWait || run.WorkflowID == "" {
+		return result, nil
+	}
+
+	outcomes, waited, err := s.waitForBranchRunBuilds(ctx, appID, branchID, run.ID, run.WorkflowID, opts.PrintJSON)
+	if waited {
+		result.Builds = &syncBuildsResult{
+			Scheduled:  len(outcomes),
+			Waited:     true,
+			Components: outcomes,
+		}
+	}
+	if err != nil {
+		return result, err
+	}
+
+	ui.PrintSuccess("successfully synced " + dir)
+	ui.PrintLn(fmt.Sprintf("app branch run %s is rolling the config out to installs", run.ID))
+	return result, nil
+}
+
+// branchRunSyncErr keeps the exit codes the standalone sync path documents:
+// a failure once the config is synced and the run is building components is a
+// build failure (exit 3), anything earlier is a sync failure (exit 1).
+func branchRunSyncErr(err error, result *syncResult) error {
+	if result == nil || result.Builds == nil {
+		return err
+	}
+
+	return &ui.ErrExitCode{
+		Err:  fmt.Errorf("app config synced, but component builds did not succeed: %w", err),
+		Code: "builds_failed",
+		Exit: buildsFailedExitCode,
+	}
+}
+
+// waitForBranchRunBuilds blocks until the run's builds step finishes. The
+// returned bool reports whether the step was reached at all, so a run that fails
+// earlier does not report an empty build list as "nothing to build".
+func (s *Service) waitForBranchRunBuilds(ctx context.Context, appID, branchID, runID, workflowID string, printJSON bool) ([]BuildOutcome, bool, error) {
+	spinner := bubbles.NewSpinnerView(printJSON, s.cfg.Interactive)
+	spinner.Start("building components")
+
+	pollCtx, cancel := context.WithTimeout(ctx, defaultSyncTimeout)
+	defer cancel()
+
+	lastDescription := ""
+	for {
+		steps, err := s.api.GetWorkflowSteps(pollCtx, workflowID)
+		if err != nil && !nuon.IsNotFound(err) && !nuon.IsServerError(err) {
+			spinner.Fail(err)
+			return nil, false, err
+		}
+
+		buildsStep := findStepByName(steps, buildsStepName)
+		if buildsStep != nil && buildsStep.Status != nil {
+			if desc := buildsStep.Status.StatusHumanDescription; desc != "" && desc != lastDescription {
+				lastDescription = desc
+				spinner.Update(desc)
+			}
+
+			if isTerminalStatus(buildsStep.Status.Status) {
+				outcomes := s.branchRunBuildOutcomes(pollCtx, appID, branchID, runID)
+				if buildsStep.Status.Status == models.AppStatusSuccess {
+					spinner.Success("all component builds completed")
+					return outcomes, true, nil
+				}
+				err := errs.NewUserFacing("component builds did not succeed: %s", stepFailureMessage(buildsStep))
+				spinner.Fail(err)
+				return outcomes, true, err
+			}
+		}
+
+		if err := s.checkRunFailed(pollCtx, workflowID); err != nil {
+			spinner.Fail(err)
+			return nil, false, err
+		}
+
+		select {
+		case <-pollCtx.Done():
+			err := errs.NewUserFacing("timed out after %s waiting for component builds", defaultSyncTimeout)
+			spinner.Fail(err)
+			return nil, true, err
+		case <-time.After(defaultBranchRunPoll):
+		}
+	}
+}
+
+// checkRunFailed reports a branch run that reached a terminal non-success state,
+// so a wait on one of its steps stops instead of running out its own timeout.
+func (s *Service) checkRunFailed(ctx context.Context, workflowID string) error {
+	wf, err := s.api.GetWorkflow(ctx, workflowID)
+	if err != nil || wf.Status == nil {
+		return nil
+	}
+	if !isTerminalStatus(wf.Status.Status) || wf.Status.Status == models.AppStatusSuccess {
+		return nil
+	}
+
+	return errs.NewUserFacing("app branch run did not succeed: %s", wf.Status.StatusHumanDescription)
+}
+
+func (s *Service) branchRunBuildOutcomes(ctx context.Context, appID, branchID, runID string) []BuildOutcome {
+	builds, err := s.api.GetAppBranchRunBuilds(ctx, appID, branchID, runID)
+	if err != nil {
+		return nil
+	}
+
+	outcomes := make([]BuildOutcome, 0, len(builds))
+	for _, build := range builds {
+		outcomes = append(outcomes, BuildOutcome{
+			ComponentID:   build.ComponentID,
+			ComponentName: build.ComponentName,
+			Status:        buildOutcomeForStatus(build.Status),
+		})
+	}
+	return outcomes
+}
+
+func buildOutcomeForStatus(status string) string {
+	switch status {
+	case componentBuildStatusActive:
+		return buildOutcomeBuilt
+	case componentBuildStatusError:
+		return buildOutcomeError
+	case componentBuildStatusPolicyFailed:
+		return buildOutcomePolicyFailed
+	default:
+		return status
+	}
+}
+
+func findStepByName(steps []*models.AppWorkflowStep, name string) *models.AppWorkflowStep {
+	for _, step := range steps {
+		if step.Name == name {
+			return step
+		}
+	}
+	return nil
+}
+
+func isTerminalStatus(status models.AppStatus) bool {
+	switch status {
+	case models.AppStatusSuccess,
+		models.AppStatusError,
+		models.AppStatusCancelled,
+		models.AppStatusDiscarded,
+		models.AppStatusUserDashSkipped,
+		models.AppStatusAutoDashSkipped:
+		return true
+	}
+	return false
+}
+
+func stepFailureMessage(step *models.AppWorkflowStep) string {
+	if step.Status == nil {
+		return "unknown"
+	}
+	if step.Status.StatusHumanDescription != "" {
+		return step.Status.StatusHumanDescription
+	}
+	return string(step.Status.Status)
+}

--- a/bins/cli/internal/services/apps/sync_dir.go
+++ b/bins/cli/internal/services/apps/sync_dir.go
@@ -8,8 +8,6 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/pkg/errors"
 
-	"github.com/nuonco/nuon/sdks/nuon-go/models"
-
 	"github.com/nuonco/nuon/bins/cli/internal/lookup"
 	"github.com/nuonco/nuon/bins/cli/internal/ui"
 	"github.com/nuonco/nuon/bins/cli/internal/ui/bubbles"
@@ -44,6 +42,9 @@ type SyncOptions struct {
 	AppBranch bool
 	// Preview creates a plan-only run (no apply). Only used with Branch or AppBranch.
 	Preview bool
+	// AutoApprove skips the branch run's approval gate before each install group
+	// deploys. Without it the gate follows the targeted installs' approval option.
+	AutoApprove bool
 	// PrintJSON emits a machine-readable result on success (--output json/agent).
 	PrintJSON bool
 	// NoWait skips waiting for scheduled component builds to complete; the
@@ -139,40 +140,47 @@ func (s *Service) syncDir(ctx context.Context, dir string, version string, opts 
 	}
 
 	var branchID string
-	if opts.Branch != "" {
+	switch {
+	case opts.Branch != "":
 		var branchErr error
 		branchID, branchErr = s.resolveAppBranchID(ctx, appID, opts.Branch)
 		if branchErr != nil {
 			return ui.PrintError(branchErr)
 		}
 		ui.PrintLn(fmt.Sprintf("targeting app branch %q", opts.Branch))
-	} else if opts.AppBranch {
+	case opts.AppBranch:
 		var branchErr error
 		branchID, branchErr = s.selectAppBranch(ctx, appID)
 		if branchErr != nil {
 			return ui.PrintError(branchErr)
 		}
+	default:
+		var branchErr error
+		branchID, branchErr = s.resolveDefaultBranchID(ctx, appID)
+		if branchErr != nil {
+			return ui.PrintError(branchErr)
+		}
 	}
 
-	appConfig, state, err := s.pushConfig(ctx, appID, version, cfg, opts, branchID)
+	appConfig, err := s.createConfig(ctx, appID, version, cfg, branchID, opts.Preview)
 	if err != nil {
 		return ui.PrintError(err)
 	}
 
-	// When targeting a branch, trigger a branch run with the synced app config
 	if branchID != "" {
-		run, triggerErr := s.api.TriggerAppBranchRun(ctx, appID, branchID, &models.ServiceTriggerAppBranchRunRequest{
-			AppConfigID: appConfig.ID,
-			PlanOnly:    opts.Preview,
-		})
-		if triggerErr != nil {
-			return ui.PrintError(triggerErr)
+		result, branchErr := s.syncViaBranchRun(ctx, appID, branchID, dir, appConfig, opts)
+		if branchErr != nil {
+			return ui.PrintError(branchRunSyncErr(branchErr, result))
 		}
-		ui.PrintSuccess(fmt.Sprintf("triggered app branch run %s", run.ID))
 		if opts.PrintJSON {
-			ui.PrintJSON(syncResult{AppID: appID, Dir: dir, BranchID: branchID, RunID: run.ID})
+			ui.PrintJSON(*result)
 		}
 		return nil
+	}
+
+	state, err := s.syncConfig(ctx, appID, appConfig, opts)
+	if err != nil {
+		return ui.PrintError(err)
 	}
 
 	ui.PrintSuccess("successfully synced " + dir)

--- a/bins/cli/internal/services/apps/sync_push.go
+++ b/bins/cli/internal/services/apps/sync_push.go
@@ -23,13 +23,13 @@ const (
 	defaultConfigSyncLimit = time.Minute * 15
 )
 
-// pushConfig creates an app config carrying the parsed config in intermediate
-// form, asks the API to apply it, and waits for the result. All conversion to
-// database records is server-side (internal/pkg/config/syncer).
-func (s *Service) pushConfig(ctx context.Context, appID, version string, cfg *config.AppConfig, opts SyncOptions, branchID string) (*models.AppAppConfig, *sync.State, error) {
+// createConfig uploads the parsed config in intermediate form. Nothing is
+// converted to database records until something syncs it, either
+// POST /configs/:id/sync or a branch run's sync app config step.
+func (s *Service) createConfig(ctx context.Context, appID, version string, cfg *config.AppConfig, branchID string, planOnly bool) (*models.AppAppConfig, error) {
 	intermediateJSON, err := json.Marshal(cfg)
 	if err != nil {
-		return nil, nil, errs.WithUserFacing(err, "unable to serialize config")
+		return nil, errs.WithUserFacing(err, "unable to serialize config")
 	}
 
 	appConfig, err := s.api.CreateAppConfig(ctx, appID, &models.ServiceCreateAppConfigRequest{
@@ -37,26 +37,41 @@ func (s *Service) pushConfig(ctx context.Context, appID, version string, cfg *co
 		CliVersion:             version,
 		IntermediateConfigJSON: string(intermediateJSON),
 		AppBranchID:            branchID,
-		PlanOnly:               opts.Preview,
+		PlanOnly:               planOnly,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
+	return appConfig, nil
+}
+
+// syncConfig asks the API to apply an already-uploaded app config and waits for
+// the result. All conversion to database records is server-side
+// (internal/pkg/config/syncer). This is the standalone path: it dispatches
+// component builds itself, which is why a branch run must not use it.
+func (s *Service) syncConfig(ctx context.Context, appID string, appConfig *models.AppAppConfig, opts SyncOptions) (*sync.State, error) {
 	if _, err := s.api.SyncAppConfig(ctx, appID, appConfig.ID); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	synced, err := s.waitForConfigSync(ctx, appID, appConfig.ID, opts.PrintJSON)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return synced, parseSyncState(synced.State), nil
+	return parseSyncState(synced.State), nil
 }
 
 // waitForConfigSync polls until the sync reaches a terminal state.
 func (s *Service) waitForConfigSync(ctx context.Context, appID, appConfigID string, printJSON bool) (*models.AppAppConfig, error) {
+	return s.waitForRunConfigSync(ctx, appID, appConfigID, "", printJSON)
+}
+
+// waitForRunConfigSync polls until the sync reaches a terminal state. When
+// workflowID is set the sync is a step of that workflow, so a workflow that dies
+// before reaching the step is reported instead of waiting out the full timeout.
+func (s *Service) waitForRunConfigSync(ctx context.Context, appID, appConfigID, workflowID string, printJSON bool) (*models.AppAppConfig, error) {
 	spinner := bubbles.NewSpinnerView(printJSON, s.cfg.Interactive)
 	spinner.Start("syncing config")
 
@@ -83,6 +98,13 @@ func (s *Service) waitForConfigSync(ctx context.Context, appID, appConfigID stri
 				return appConfig, nil
 			case appConfigStatusError:
 				err := errs.NewUserFacing("%s", syncFailureMessage(appConfig))
+				spinner.Fail(err)
+				return nil, err
+			}
+		}
+
+		if workflowID != "" {
+			if err := s.checkRunFailed(pollCtx, workflowID); err != nil {
 				spinner.Fail(err)
 				return nil, err
 			}

--- a/sdks/nuon-go/client/nuon_client.go
+++ b/sdks/nuon-go/client/nuon_client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-
 	"github.com/nuonco/nuon/sdks/nuon-go/client/operations"
 )
 

--- a/sdks/nuon-go/models/app_app_branch_install_group.go
+++ b/sdks/nuon-go/models/app_app_branch_install_group.go
@@ -19,6 +19,11 @@ import (
 // swagger:model app.AppBranchInstallGroup
 type AppAppBranchInstallGroup struct {
 
+	// AllInstalls claims every install on the app that no other branch owns.
+	// A nil LabelSelector already means "use InstallIDs", so there is no
+	// selector shape that expresses "everything" — hence the explicit flag.
+	AllInstalls bool `json:"all_installs,omitempty"`
+
 	// app branch config id
 	AppBranchConfigID string `json:"app_branch_config_id,omitempty"`
 

--- a/sdks/nuon-go/models/service_install_group_request.go
+++ b/sdks/nuon-go/models/service_install_group_request.go
@@ -19,6 +19,10 @@ import (
 // swagger:model service.InstallGroupRequest
 type ServiceInstallGroupRequest struct {
 
+	// AllInstalls targets every install on the app that no other branch owns.
+	// Mutually exclusive with InstallIDs and LabelSelector.
+	AllInstalls bool `json:"all_installs,omitempty"`
+
 	// install ids
 	InstallIds []string `json:"install_ids"`
 

--- a/sdks/nuon-go/models/service_trigger_app_branch_run_request.go
+++ b/sdks/nuon-go/models/service_trigger_app_branch_run_request.go
@@ -20,6 +20,10 @@ type ServiceTriggerAppBranchRunRequest struct {
 	// optional - use pre-existing app config (skips VCS fetch + config parse)
 	AppConfigID string `json:"app_config_id,omitempty"`
 
+	// AutoApprove skips the approval gate on the plan steps. Without it the
+	// approval option is derived from the installs the branch targets.
+	AutoApprove bool `json:"auto_approve,omitempty"`
+
 	// base branch
 	BaseBranch string `json:"base_branch,omitempty"`
 
@@ -41,6 +45,11 @@ type ServiceTriggerAppBranchRunRequest struct {
 
 	// skip builds step (e.g. rollback to existing config with existing builds)
 	SkipBuilds bool `json:"skip_builds,omitempty"`
+
+	// SyncAppConfig syncs AppConfigID inside the run rather than assuming it was
+	// already synced. Set by callers that compiled the config themselves, such
+	// as `nuon apps sync`.
+	SyncAppConfig bool `json:"sync_app_config,omitempty"`
 }
 
 // Validate validates this service trigger app branch run request

--- a/sdks/nuon-runner-go/models/app_app_branch_install_group.go
+++ b/sdks/nuon-runner-go/models/app_app_branch_install_group.go
@@ -19,6 +19,11 @@ import (
 // swagger:model app.AppBranchInstallGroup
 type AppAppBranchInstallGroup struct {
 
+	// AllInstalls claims every install on the app that no other branch owns.
+	// A nil LabelSelector already means "use InstallIDs", so there is no
+	// selector shape that expresses "everything" — hence the explicit flag.
+	AllInstalls bool `json:"all_installs,omitempty"`
+
 	// app branch config id
 	AppBranchConfigID string `json:"app_branch_config_id,omitempty"`
 

--- a/services/ctl-api/AGENTS.md
+++ b/services/ctl-api/AGENTS.md
@@ -972,16 +972,19 @@ entry points reach it through `syncer.Run`, which reads the intermediate config 
 | Entry point                                | Path                                                                                     |
 | ------------------------------------------ | ---------------------------------------------------------------------------------------- |
 | CLI (`nuon apps sync`)                     | `POST /configs` (intermediate config) → `POST /configs/:id/sync` → `appconfigsync` signal |
+| CLI with `app-branch-sync` on              | `POST /configs` with `app_branch_id` → branch run with `sync_app_config` → branch run's sync-app-config step |
 | App branch sync (VCS push / PR preview)    | branch run's fetch-app-config step → `branches/activities.syncAppConfig`                 |
 
 The CLI does not walk the per-resource `Create*Config` endpoints — it parses, validates, and pushes the whole config
 in one request. Those endpoints remain part of the public API surface, so they must keep working, but they are no
 longer how a sync happens.
 
-The one behavioural difference between the two entry points is build scheduling, and it is explicit:
-`syncer.RunRequest.DispatchBuilds` (CLI path) makes the syncer reuse an unchanged component's existing config
-connection and report the changed ones for the caller to enqueue `configcreated` signals for. The branch run leaves
-it off because its own builds step schedules builds. Turning it on in both places would double-build.
+The one behavioural difference between the entry points is build scheduling, and it is explicit:
+`syncer.RunRequest.DispatchBuilds` (standalone CLI path) makes the syncer reuse an unchanged component's existing config
+connection and report the changed ones for the caller to enqueue `configcreated` signals for. Every branch run leaves
+it off because its own builds step schedules builds. Turning it on in both places would double-build, which is why the
+`app-branch-sync` CLI path posts the config and lets the run sync it rather than calling `/configs/:id/sync`
+first.
 
 **Config MUST be converted into `app.*` models through `internal/pkg/config/build`.** The syncer and the per-type
 HTTP handlers previously had independent conversions and silently drifted, dropping custom roles, break-glass roles,

--- a/services/ctl-api/internal/app/app_branch_install_group.go
+++ b/services/ctl-api/internal/app/app_branch_install_group.go
@@ -37,6 +37,11 @@ type AppBranchInstallGroup struct {
 
 	LabelSelector *labels.Selector `json:"label_selector,omitempty" gorm:"type:jsonb;serializer:json;default:null" temporaljson:"label_selector,omitzero,omitempty"`
 
+	// AllInstalls claims every install on the app that no other branch owns.
+	// A nil LabelSelector already means "use InstallIDs", so there is no
+	// selector shape that expresses "everything" — hence the explicit flag.
+	AllInstalls bool `json:"all_installs,omitzero" gorm:"default:false" temporaljson:"all_installs,omitzero,omitempty"`
+
 	MaxParallel int `json:"max_parallel,omitzero" gorm:"default:0" temporaljson:"max_parallel,omitzero,omitempty"`
 
 	// UseForPreviews marks this group for plan-only preview runs (e.g., PR previews).

--- a/services/ctl-api/internal/app/apps/helpers/resolve_all_installs_for_branch.go
+++ b/services/ctl-api/internal/app/apps/helpers/resolve_all_installs_for_branch.go
@@ -1,0 +1,95 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/pkg/labels"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// ResolveAllInstallsForBranch returns the app's installs that no other branch
+// owns, which is what an install group with AllInstalls set targets.
+//
+// Ownership is checked two ways because the data model records it two ways: an
+// install pinned to a group or labelled into one carries app_branch_id, but an
+// install created with labels that a selector happens to match never gets it
+// written. Missing the second case would let the default branch deploy over a
+// VCS branch's installs.
+func (h *Helpers) ResolveAllInstallsForBranch(ctx context.Context, appID, branchID string) ([]string, error) {
+	var installs []app.Install
+	if err := h.db.WithContext(ctx).
+		Where(app.Install{AppID: appID}).
+		Where("app_branch_id IS NULL OR app_branch_id = ?", branchID).
+		Find(&installs).Error; err != nil {
+		return nil, fmt.Errorf("unable to load installs: %w", err)
+	}
+
+	claimed, err := h.otherBranchSelectors(ctx, appID, branchID)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, 0, len(installs))
+	for _, install := range installs {
+		if matchesAny(claimed, install.Labels) {
+			continue
+		}
+		ids = append(ids, install.ID)
+	}
+
+	return ids, nil
+}
+
+// otherBranchSelectors collects the label selectors on every other branch's
+// latest config.
+func (h *Helpers) otherBranchSelectors(ctx context.Context, appID, branchID string) ([]*labels.Selector, error) {
+	var branches []app.AppBranch
+	if err := h.db.WithContext(ctx).
+		Where(app.AppBranch{AppID: appID}).
+		Where("id != ?", branchID).
+		Find(&branches).Error; err != nil {
+		return nil, fmt.Errorf("unable to load app branches: %w", err)
+	}
+
+	var selectors []*labels.Selector
+	for _, branch := range branches {
+		var latest app.AppBranchConfig
+		err := h.db.WithContext(ctx).
+			Where(app.AppBranchConfig{AppBranchID: branch.ID}).
+			Order("created_at DESC").
+			First(&latest).Error
+		if err == gorm.ErrRecordNotFound {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("unable to load latest config for branch %s: %w", branch.ID, err)
+		}
+
+		var groups []app.AppBranchInstallGroup
+		if err := h.db.WithContext(ctx).
+			Where(app.AppBranchInstallGroup{AppBranchConfigID: latest.ID}).
+			Find(&groups).Error; err != nil {
+			return nil, fmt.Errorf("unable to load install groups for config %s: %w", latest.ID, err)
+		}
+
+		for i := range groups {
+			if groups[i].LabelSelector != nil {
+				selectors = append(selectors, groups[i].LabelSelector)
+			}
+		}
+	}
+
+	return selectors, nil
+}
+
+func matchesAny(selectors []*labels.Selector, lbls labels.Labels) bool {
+	for _, selector := range selectors {
+		if selector.Matches(lbls) {
+			return true
+		}
+	}
+	return false
+}

--- a/services/ctl-api/internal/app/apps/helpers/resolve_app_branch_approval_option.go
+++ b/services/ctl-api/internal/app/apps/helpers/resolve_app_branch_approval_option.go
@@ -1,0 +1,100 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nuonco/nuon/pkg/labels"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// ResolveAppBranchApprovalOption returns approve-all only when every install the
+// branch config targets is itself set to approve-all. A run has one approval
+// option but installs each carry their own, so a single install that prompts
+// holds the whole run at its plan step.
+func (h *Helpers) ResolveAppBranchApprovalOption(ctx context.Context, appID, branchID, branchConfigID string) (app.InstallApprovalOption, error) {
+	installIDs, err := h.resolveAppBranchConfigInstallIDs(ctx, appID, branchID, branchConfigID)
+	if err != nil {
+		return app.InstallApprovalOptionPrompt, err
+	}
+	if len(installIDs) == 0 {
+		return app.InstallApprovalOptionPrompt, nil
+	}
+
+	type installApproval struct {
+		InstallID      string
+		ApprovalOption app.InstallApprovalOption
+	}
+
+	var approvals []installApproval
+	if err := h.db.WithContext(ctx).
+		Raw(`SELECT DISTINCT ON (install_id) install_id, approval_option
+			FROM install_configs
+			WHERE install_id IN ? AND deleted_at = 0
+			ORDER BY install_id, created_at DESC`, installIDs).
+		Scan(&approvals).Error; err != nil {
+		return app.InstallApprovalOptionPrompt, fmt.Errorf("unable to load install approval options: %w", err)
+	}
+
+	if len(approvals) != len(installIDs) {
+		return app.InstallApprovalOptionPrompt, nil
+	}
+
+	for _, approval := range approvals {
+		if approval.ApprovalOption != app.InstallApprovalOptionApproveAll {
+			return app.InstallApprovalOptionPrompt, nil
+		}
+	}
+
+	return app.InstallApprovalOptionApproveAll, nil
+}
+
+// resolveAppBranchConfigInstallIDs mirrors what the run's install group steps
+// resolve at execution time, so the approval option is derived from the same set
+// of installs the run will actually touch.
+func (h *Helpers) resolveAppBranchConfigInstallIDs(ctx context.Context, appID, branchID, branchConfigID string) ([]string, error) {
+	var groups []app.AppBranchInstallGroup
+	if err := h.db.WithContext(ctx).
+		Where(app.AppBranchInstallGroup{AppBranchConfigID: branchConfigID}).
+		Find(&groups).Error; err != nil {
+		return nil, fmt.Errorf("unable to load install groups: %w", err)
+	}
+
+	seen := make(map[string]struct{})
+	var ids []string
+	add := func(installIDs []string) {
+		for _, id := range installIDs {
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
+
+	for _, group := range groups {
+		switch {
+		case group.AllInstalls:
+			installIDs, err := h.ResolveAllInstallsForBranch(ctx, appID, branchID)
+			if err != nil {
+				return nil, err
+			}
+			add(installIDs)
+		case group.LabelSelector != nil:
+			var installs []app.Install
+			if err := h.db.WithContext(ctx).
+				Where(app.Install{AppID: appID}).
+				Scopes(labels.WithLabels("labels", group.LabelSelector.MatchLabels)).
+				Find(&installs).Error; err != nil {
+				return nil, fmt.Errorf("unable to resolve install group labels: %w", err)
+			}
+			for _, install := range installs {
+				add([]string{install.ID})
+			}
+		default:
+			add(group.InstallIDs)
+		}
+	}
+
+	return ids, nil
+}

--- a/services/ctl-api/internal/app/apps/helpers/trigger_app_branch_run.go
+++ b/services/ctl-api/internal/app/apps/helpers/trigger_app_branch_run.go
@@ -33,6 +33,9 @@ type TriggerAppBranchRunRequest struct {
 	Metadata  map[string]string
 	Callback  callback.Ref
 	DedupeKey *string
+
+	// ApprovalOption gates the run's plan steps. Empty means prompt.
+	ApprovalOption app.InstallApprovalOption
 }
 
 type TriggerAppBranchRunResponse struct {
@@ -56,6 +59,10 @@ func (h *Helpers) ResumeAppBranchRun(ctx context.Context, run *app.AppBranchRun,
 	req.Metadata["run_id"] = run.ID
 	req.Metadata["app_branch_id"] = run.AppBranchID
 	req.Metadata["commit_sha"] = run.CommitSHA
+	approvalOption := req.ApprovalOption
+	if approvalOption == "" {
+		approvalOption = app.InstallApprovalOptionPrompt
+	}
 	var wf app.Workflow
 	err := h.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var locked app.AppBranchRun
@@ -63,7 +70,7 @@ func (h *Helpers) ResumeAppBranchRun(ctx context.Context, run *app.AppBranchRun,
 			return err
 		}
 		if locked.WorkflowID == nil {
-			created, err := h.createWorkflowWithDB(ctx, tx, locked.AppBranchID, plugins.TableName(h.db, app.AppBranch{}), app.WorkflowTypeAppBranchesRun, req.Metadata, locked.PlanOnly, app.InstallApprovalOptionPrompt, "")
+			created, err := h.createWorkflowWithDB(ctx, tx, locked.AppBranchID, plugins.TableName(h.db, app.AppBranch{}), app.WorkflowTypeAppBranchesRun, req.Metadata, locked.PlanOnly, approvalOption, "")
 			if err != nil {
 				return fmt.Errorf("unable to create workflow: %w", err)
 			}

--- a/services/ctl-api/internal/app/apps/service/create_app_branch_config.go
+++ b/services/ctl-api/internal/app/apps/service/create_app_branch_config.go
@@ -24,6 +24,10 @@ type InstallGroupRequest struct {
 	// LabelSelector dynamically resolves installs at deploy time.
 	// Mutually exclusive with InstallIDs.
 	LabelSelector *labels.Selector `json:"label_selector,omitempty"`
+
+	// AllInstalls targets every install on the app that no other branch owns.
+	// Mutually exclusive with InstallIDs and LabelSelector.
+	AllInstalls bool `json:"all_installs,omitempty"`
 }
 
 type CreateAppBranchConfigRequest struct {
@@ -56,19 +60,25 @@ func (c *CreateAppBranchConfigRequest) Validate(v *validator.Validate) error {
 		}
 		orders[group.Order] = true
 
-		// InstallIDs and LabelSelector are mutually exclusive
+		// A group targets installs exactly one way
 		hasIDs := len(group.InstallIDs) > 0
 		hasSelector := group.LabelSelector != nil && len(group.LabelSelector.MatchLabels) > 0
-		if hasIDs && hasSelector {
-			return stderr.ErrUser{
-				Err:         fmt.Errorf("install group %q has both install_ids and label_selector", group.Name),
-				Description: "install groups must use either install_ids or label_selector, not both",
+		targets := 0
+		for _, set := range []bool{hasIDs, hasSelector, group.AllInstalls} {
+			if set {
+				targets++
 			}
 		}
-		if !hasIDs && !hasSelector {
+		if targets > 1 {
 			return stderr.ErrUser{
-				Err:         fmt.Errorf("install group %q has neither install_ids nor label_selector", group.Name),
-				Description: "install groups must specify either install_ids or label_selector",
+				Err:         fmt.Errorf("install group %q sets more than one of install_ids, label_selector, all_installs", group.Name),
+				Description: "install groups must use exactly one of install_ids, label_selector, or all_installs",
+			}
+		}
+		if targets == 0 {
+			return stderr.ErrUser{
+				Err:         fmt.Errorf("install group %q has none of install_ids, label_selector, all_installs", group.Name),
+				Description: "install groups must specify install_ids, label_selector, or all_installs",
 			}
 		}
 		if hasSelector {
@@ -226,6 +236,7 @@ func (s *service) CreateAppBranchConfig(ctx *gin.Context) {
 			Order:          g.Order,
 			InstallIDs:     g.InstallIDs,
 			LabelSelector:  selector,
+			AllInstalls:    g.AllInstalls,
 			UseForPreviews: g.UseForPreviews,
 		}
 	}

--- a/services/ctl-api/internal/app/apps/service/trigger_app_branch_run.go
+++ b/services/ctl-api/internal/app/apps/service/trigger_app_branch_run.go
@@ -7,9 +7,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
+	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/apps/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
 )
@@ -21,6 +23,15 @@ type TriggerAppBranchRunRequest struct {
 	AppConfigID string `json:"app_config_id"` // optional - use pre-existing app config (skips VCS fetch + config parse)
 	SkipBuilds  bool   `json:"skip_builds"`   // skip builds step (e.g. rollback to existing config with existing builds)
 
+	// SyncAppConfig syncs AppConfigID inside the run rather than assuming it was
+	// already synced. Set by callers that compiled the config themselves, such
+	// as `nuon apps sync`.
+	SyncAppConfig bool `json:"sync_app_config"`
+
+	// AutoApprove skips the approval gate on the plan steps. Without it the
+	// approval option is derived from the installs the branch targets.
+	AutoApprove bool `json:"auto_approve"`
+
 	// PR context, for previews triggered from CI rather than a GitHub webhook.
 	// Supplying PRNumber is what lets the run report back onto the pull request.
 	PRNumber   *int   `json:"pr_number,omitempty"`
@@ -31,6 +42,12 @@ type TriggerAppBranchRunRequest struct {
 func (c *TriggerAppBranchRunRequest) Validate(v *validator.Validate) error {
 	if err := v.Struct(c); err != nil {
 		return err
+	}
+	if c.SyncAppConfig && c.AppConfigID == "" {
+		return fmt.Errorf("sync_app_config requires app_config_id")
+	}
+	if c.SyncAppConfig && c.SkipBuilds {
+		return fmt.Errorf("sync_app_config cannot be combined with skip_builds: a freshly synced config has no builds yet")
 	}
 	return nil
 }
@@ -79,7 +96,7 @@ func (s *service) TriggerAppBranchRun(ctx *gin.Context) {
 		return
 	}
 	if err := req.Validate(s.v); err != nil {
-		ctx.Error(fmt.Errorf("invalid request: %w", err))
+		ctx.Error(stderr.NewInvalidRequest(err))
 		return
 	}
 
@@ -147,6 +164,9 @@ func (s *service) TriggerAppBranchRun(ctx *gin.Context) {
 	if req.SkipBuilds {
 		workflowMeta["skip_builds"] = "true"
 	}
+	if req.SyncAppConfig {
+		workflowMeta["sync_app_config"] = "true"
+	}
 	if req.PRNumber != nil {
 		workflowMeta["pr_number"] = strconv.Itoa(*req.PRNumber)
 	}
@@ -155,6 +175,15 @@ func (s *service) TriggerAppBranchRun(ctx *gin.Context) {
 	}
 	if req.BaseBranch != "" {
 		workflowMeta["base_branch"] = req.BaseBranch
+	}
+
+	approvalOption := app.InstallApprovalOptionApproveAll
+	if !req.AutoApprove {
+		approvalOption, err = s.helpers.ResolveAppBranchApprovalOption(ctx, appID, appBranchID, config.ID)
+		if err != nil {
+			ctx.Error(fmt.Errorf("unable to resolve approval option: %w", err))
+			return
+		}
 	}
 
 	triggerResp, err := s.helpers.TriggerAppBranchRun(ctx, &helpers.TriggerAppBranchRunRequest{
@@ -169,14 +198,25 @@ func (s *service) TriggerAppBranchRun(ctx *gin.Context) {
 			HeadSHA:           req.HeadSHA,
 			BaseBranch:        req.BaseBranch,
 		},
-		QueueID:  branch.Queue.ID,
-		Metadata: workflowMeta,
+		QueueID:        branch.Queue.ID,
+		Metadata:       workflowMeta,
+		ApprovalOption: approvalOption,
 	})
 	if err != nil {
 		ctx.Error(fmt.Errorf("unable to trigger app branch run: %w", err))
 		return
 	}
 	run := triggerResp.Run
+
+	// The standalone sync path advanced this in appconfigsync's finalize step,
+	// which a branch-run sync never reaches.
+	if req.SyncAppConfig {
+		if acct, acctErr := cctx.AccountFromContext(ctx); acctErr == nil {
+			if journeyErr := s.accountsHelpers.UpdateUserJourneyStepForFirstAppSync(ctx, acct.ID, appID); journeyErr != nil {
+				s.l.Warn("unable to update app_synced journey step", zap.Error(journeyErr))
+			}
+		}
+	}
 
 	res = s.db.WithContext(ctx).
 		Preload("Workflow").

--- a/services/ctl-api/internal/app/apps/service/trigger_app_branch_run_test.go
+++ b/services/ctl-api/internal/app/apps/service/trigger_app_branch_run_test.go
@@ -1,0 +1,208 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/pkg/metrics"
+	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	accountshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/accounts/helpers"
+	appshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/helpers"
+	installshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
+	vcshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/vcs/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/tests"
+	"github.com/nuonco/nuon/services/ctl-api/tests/testseed"
+)
+
+// TriggerAppBranchRunTestService holds all fx-injected dependencies for
+// TriggerAppBranchRun endpoint tests.
+type TriggerAppBranchRunTestService struct {
+	fx.In
+
+	DB              *gorm.DB `name:"psql"`
+	CHDB            *gorm.DB `name:"ch"`
+	V               *validator.Validate
+	L               *zap.Logger
+	MW              metrics.Writer
+	VcsHelpers      *vcshelpers.Helpers
+	AppsHelpers     *appshelpers.Helpers
+	InstallsHelpers *installshelpers.Helpers
+	AccountsHelpers *accountshelpers.Helpers
+	AppsService     *service
+	Seeder          *testseed.Seeder
+}
+
+// TriggerAppBranchRunTestSuite is the testify suite for the TriggerAppBranchRun endpoint.
+//
+// Only the request-validation rejections are covered here: a full happy-path
+// run enqueues Temporal signals via the queue/workflow machinery, which is out
+// of scope for this suite.
+type TriggerAppBranchRunTestSuite struct {
+	tests.BaseDBTestSuite
+
+	fxApp      *fxtest.App
+	service    TriggerAppBranchRunTestService
+	router     *gin.Engine
+	ctx        context.Context
+	testOrg    *app.Org
+	testAcc    *app.Account
+	testApp    *app.App
+	testBranch *app.AppBranch
+}
+
+func TestTriggerAppBranchRunSuite(t *testing.T) {
+	if os.Getenv("INTEGRATION") != "true" {
+		t.Skip("INTEGRATION is not set, skipping")
+		return
+	}
+	suite.Run(t, new(TriggerAppBranchRunTestSuite))
+}
+
+func (s *TriggerAppBranchRunTestSuite) SetupSuite() {
+	s.BaseDBTestSuite.SetupSuite()
+	gin.SetMode(gin.TestMode)
+
+	options := append(
+		tests.CtlApiFXOptions(s.T()),
+		// service under test
+		fx.Provide(New),
+		fx.Populate(&s.service),
+	)
+
+	s.fxApp = fxtest.New(s.T(), options...)
+	s.fxApp.RequireStart()
+
+	// Store DB reference for automatic truncation
+	s.SetDB(s.service.DB)
+}
+
+func (s *TriggerAppBranchRunTestSuite) SetupTest() {
+	s.BaseDBTestSuite.SetupTest()
+	s.setupTestData()
+
+	s.router = tests.NewTestRouter(tests.RouterOptions{
+		L:       s.service.L,
+		DB:      s.service.DB,
+		TestOrg: s.testOrg,
+		TestAcc: s.testAcc,
+	})
+
+	err := s.service.AppsService.RegisterPublicRoutes(s.router)
+	require.NoError(s.T(), err)
+}
+
+func (s *TriggerAppBranchRunTestSuite) TearDownSuite() {
+	s.fxApp.RequireStop()
+}
+
+func (s *TriggerAppBranchRunTestSuite) setupTestData() {
+	s.ctx = context.Background()
+	s.ctx, s.testAcc = s.service.Seeder.EnsureAccount(s.ctx, s.T())
+	s.ctx, s.testOrg = s.service.Seeder.EnsureOrg(s.ctx, s.T())
+	s.testApp = s.service.Seeder.CreateApp(s.ctx, s.T())
+
+	s.testBranch = &app.AppBranch{
+		ID:          domains.NewAppBranchID(),
+		OrgID:       s.testOrg.ID,
+		AppID:       s.testApp.ID,
+		CreatedByID: s.testAcc.ID,
+		Name:        "test-branch",
+		ManagedBy:   app.AppBranchManagedByManually,
+	}
+	require.NoError(s.T(), s.service.DB.WithContext(s.ctx).Create(s.testBranch).Error)
+}
+
+func (s *TriggerAppBranchRunTestSuite) makeRequest(method, path string, body interface{}) *httptest.ResponseRecorder {
+	var reqBody *bytes.Buffer
+	if body != nil {
+		jsonBytes, err := json.Marshal(body)
+		require.NoError(s.T(), err)
+		reqBody = bytes.NewBuffer(jsonBytes)
+	} else {
+		reqBody = bytes.NewBuffer(nil)
+	}
+
+	req, err := http.NewRequest(method, path, reqBody)
+	require.NoError(s.T(), err)
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	s.router.ServeHTTP(rr, req)
+	return rr
+}
+
+func (s *TriggerAppBranchRunTestSuite) makeRawRequest(method, path, rawBody string) *httptest.ResponseRecorder {
+	req, err := http.NewRequest(method, path, bytes.NewBufferString(rawBody))
+	require.NoError(s.T(), err)
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	s.router.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestTriggerAppBranchRunRejectsInvalidSyncAppConfig covers the two new
+// cross-field rejections on TriggerAppBranchRunRequest.Validate. Neither case
+// reaches the branch/config lookups or the helper that enqueues the run, so
+// no Temporal/queue mocking is required.
+func (s *TriggerAppBranchRunTestSuite) TestTriggerAppBranchRunRejectsInvalidSyncAppConfig() {
+	testCases := []struct {
+		name          string
+		req           TriggerAppBranchRunRequest
+		expectContain string
+	}{
+		{
+			name: "sync_app_config without app_config_id",
+			req: TriggerAppBranchRunRequest{
+				SyncAppConfig: true,
+			},
+			expectContain: "sync_app_config requires app_config_id",
+		},
+		{
+			name: "sync_app_config combined with skip_builds",
+			req: TriggerAppBranchRunRequest{
+				SyncAppConfig: true,
+				AppConfigID:   "cfgplaceholder0000000000000",
+				SkipBuilds:    true,
+			},
+			expectContain: "sync_app_config cannot be combined with skip_builds",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			path := fmt.Sprintf("/v1/apps/%s/branches/%s/runs", s.testApp.ID, s.testBranch.ID)
+			rr := s.makeRequest(http.MethodPost, path, tc.req)
+
+			if rr.Code != http.StatusBadRequest {
+				s.T().Logf("Status: %d, Body: %s", rr.Code, rr.Body.String())
+			}
+			require.Equal(s.T(), http.StatusBadRequest, rr.Code)
+			assert.Contains(s.T(), rr.Body.String(), tc.expectContain)
+
+			var count int64
+			require.NoError(s.T(), s.service.DB.WithContext(s.ctx).
+				Model(&app.AppBranchRun{}).
+				Where(app.AppBranchRun{AppBranchID: s.testBranch.ID}).
+				Count(&count).Error)
+			assert.EqualValues(s.T(), 0, count, "expected no run to be created for an invalid request")
+		})
+	}
+}

--- a/services/ctl-api/internal/app/apps/signals/branches/activities/resolve_install_group_installs.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/activities/resolve_install_group_installs.go
@@ -13,6 +13,11 @@ type ResolveInstallGroupInstallsInput struct {
 	AppID    string           `json:"app_id"`
 	GroupID  string           `json:"group_id"`
 	Selector *labels.Selector `json:"selector"`
+
+	// AllInstalls resolves every install on the app that no other branch owns,
+	// ignoring Selector. AppBranchID is the owning branch.
+	AllInstalls bool   `json:"all_installs,omitempty"`
+	AppBranchID string `json:"app_branch_id,omitempty"`
 }
 
 type ResolveInstallGroupInstallsOutput struct {
@@ -22,14 +27,27 @@ type ResolveInstallGroupInstallsOutput struct {
 // @temporal-gen-v2 activity
 // @start-to-close-timeout 1m
 func (a *Activities) ResolveInstallGroupInstalls(ctx context.Context, input *ResolveInstallGroupInstallsInput) (*ResolveInstallGroupInstallsOutput, error) {
-	var installs []app.Install
+	if input.AllInstalls {
+		ids, err := a.helpers.ResolveAllInstallsForBranch(ctx, input.AppID, input.AppBranchID)
+		if err != nil {
+			return nil, err
+		}
 
-	query := a.db.WithContext(ctx).
+		a.l.Info("resolved install group",
+			zap.String("group_id", input.GroupID),
+			zap.String("resolved_via", "all_installs"),
+			zap.Int("resolved_count", len(ids)),
+		)
+
+		return &ResolveInstallGroupInstallsOutput{InstallIDs: ids}, nil
+	}
+
+	var installs []app.Install
+	if err := a.db.WithContext(ctx).
 		Where(app.Install{AppID: input.AppID}).
 		Scopes(labels.WithLabels("labels", input.Selector.MatchLabels)).
-		Find(&installs)
-	if query.Error != nil {
-		return nil, query.Error
+		Find(&installs).Error; err != nil {
+		return nil, err
 	}
 
 	ids := make([]string, len(installs))
@@ -37,8 +55,9 @@ func (a *Activities) ResolveInstallGroupInstalls(ctx context.Context, input *Res
 		ids[i] = inst.ID
 	}
 
-	a.l.Info("resolved install group via label selector",
+	a.l.Info("resolved install group",
 		zap.String("group_id", input.GroupID),
+		zap.String("resolved_via", "label_selector"),
 		zap.Int("resolved_count", len(ids)),
 	)
 

--- a/services/ctl-api/internal/app/apps/signals/branches/appconfig/execute.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/appconfig/execute.go
@@ -16,12 +16,25 @@ import (
 func (s *Signal) Execute(ctx workflow.Context) error {
 	l := workflow.GetLogger(ctx)
 
-	run, err := activities.AwaitGetAppBranchRunWithCommitByRunID(ctx, s.RunID)
-	if err != nil {
-		return fmt.Errorf("unable to get app branch run with commit: %w", err)
-	}
+	preCompiled := s.AppConfigID != ""
 
-	commitSHA := run.VCSConnectionCommit.SHA
+	var (
+		run       *app.AppBranchRun
+		commitSHA string
+		err       error
+	)
+	if preCompiled {
+		run, err = activities.AwaitGetAppBranchRunByIDByRunID(ctx, s.RunID)
+		if err != nil {
+			return fmt.Errorf("unable to get app branch run: %w", err)
+		}
+	} else {
+		run, err = activities.AwaitGetAppBranchRunWithCommitByRunID(ctx, s.RunID)
+		if err != nil {
+			return fmt.Errorf("unable to get app branch run with commit: %w", err)
+		}
+		commitSHA = run.VCSConnectionCommit.SHA
+	}
 
 	// Create log stream for this run
 	logStream, err := activities.AwaitCreateLogStream(ctx, activities.CreateLogStreamRequest{
@@ -70,9 +83,19 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		vcsConfigID = cfg.ID
 	} else if cfg := branch.Configs[0].PublicGitVCSConfig; cfg != nil {
 		vcsConfigID = cfg.ID
-	} else {
+	} else if !preCompiled {
 		closeLogStream()
 		return fmt.Errorf("app branch has no VCS config")
+	}
+
+	if preCompiled {
+		return s.syncAndFinalize(ctx, finalizeParams{
+			run:         run,
+			branch:      branch,
+			appConfigID: s.AppConfigID,
+			vcsConfigID: vcsConfigID,
+			isPreview:   run.IsPreview(),
+		}, closeLogStream)
 	}
 
 	cloneResult, err := activities.LocalAwaitCloneRepo(ctx, activities.CloneRepoRequest{
@@ -233,9 +256,37 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		"app_config_id", createResp.AppConfigID,
 		"app_branch_id", branch.ID)
 
+	return s.syncAndFinalize(ctx, finalizeParams{
+		run:                     run,
+		branch:                  branch,
+		appConfigID:             createResp.AppConfigID,
+		vcsConfigID:             vcsConfigID,
+		isPreview:               isPreview,
+		previewDiff:             previewDiff,
+		previewBaselineConfigID: previewBaselineConfigID,
+	}, closeLogStream)
+}
+
+type finalizeParams struct {
+	run                     *app.AppBranchRun
+	branch                  *app.AppBranch
+	appConfigID             string
+	vcsConfigID             string
+	isPreview               bool
+	previewDiff             *activities.ComputeAppConfigDiffOutput
+	previewBaselineConfigID string
+}
+
+// syncAndFinalize turns an app config into database records and reports the
+// result onto the step. Shared by the VCS path, which has just created the
+// config from a cloned repo, and the pre-compiled path, which was handed one.
+func (s *Signal) syncAndFinalize(ctx workflow.Context, p finalizeParams, closeLogStream func()) error {
+	l := workflow.GetLogger(ctx)
+	run, branch := p.run, p.branch
+
 	syncResp, err := activities.AwaitSyncAppConfig(ctx, activities.SyncAppConfigRequest{
 		Req: &activities.SyncAppConfigInput{
-			AppConfigID: createResp.AppConfigID,
+			AppConfigID: p.appConfigID,
 			AppID:       branch.AppID,
 			AppBranchID: branch.ID,
 		},
@@ -280,8 +331,8 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		}
 
 		var configDiff *activities.ComputeAppConfigDiffOutput
-		if previewDiff != nil {
-			configDiff = previewDiff
+		if p.previewDiff != nil {
+			configDiff = p.previewDiff
 		} else {
 			var oldConfigID string
 			if run.PreviousRunID != nil && *run.PreviousRunID != "" {
@@ -308,8 +359,8 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 			meta["diff_changed"] = configDiff.Changed
 			meta["diff_sections"] = configDiff.Sections
 		}
-		if previewBaselineConfigID != "" {
-			meta["baseline_app_config_id"] = previewBaselineConfigID
+		if p.previewBaselineConfigID != "" {
+			meta["baseline_app_config_id"] = p.previewBaselineConfigID
 		}
 
 		_ = statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
@@ -321,7 +372,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 			},
 		})
 
-		if isPreview && run.PRNumber != nil {
+		if p.isPreview && run.PRNumber != nil {
 			commentBody := activities.BuildPRCommentBody(&activities.PRCommentParams{
 				AppName: branch.Name,
 				RunID:   s.RunID,
@@ -329,7 +380,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 				Diff:    configDiff,
 			})
 			_, _ = activities.AwaitCreateOrUpdatePRComment(ctx, &activities.CreateOrUpdatePRCommentInput{
-				VcsConfigID:       vcsConfigID,
+				VcsConfigID:       p.vcsConfigID,
 				PRNumber:          *run.PRNumber,
 				ExistingCommentID: run.GithubCommentID,
 				Body:              commentBody,

--- a/services/ctl-api/internal/app/apps/signals/branches/appconfig/signal.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/appconfig/signal.go
@@ -15,6 +15,12 @@ type Signal struct {
 	AppBranchID string `json:"app_branch_id" validate:"required"`
 	RunID       string `json:"run_id" validate:"required"`
 
+	// AppConfigID carries a config that was already compiled elsewhere (the CLI
+	// parses it locally and posts the intermediate config). When set, the step
+	// syncs it instead of cloning the branch's repo, so the branch needs no VCS
+	// config and the run needs no commit.
+	AppConfigID string `json:"app_config_id,omitempty"`
+
 	FlowID string `json:"flow_id,omitempty"`
 	StepID string `json:"step_id,omitempty"`
 }

--- a/services/ctl-api/internal/app/apps/signals/branches/appconfig/signal_test.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/appconfig/signal_test.go
@@ -68,6 +68,71 @@ func (s *AppConfigSignalTestSuite) mockBranchAndRun() {
 		}, nil)
 }
 
+// mockPreCompiledBranchAndRun stands up a branch with no VCS config at all, the
+// shape the default app branch has.
+func (s *AppConfigSignalTestSuite) mockPreCompiledBranchAndRun() {
+	s.env.OnActivity((*activities.Activities).GetAppBranchRunByID, mock.Anything, mock.Anything, mock.Anything).Return(
+		&app.AppBranchRun{ID: "run-1"}, nil)
+
+	s.env.OnActivity((*activities.Activities).CreateLogStream, mock.Anything, mock.Anything, mock.Anything).Return(
+		(*app.LogStream)(nil), fmt.Errorf("no log stream"))
+
+	s.env.OnActivity((*activities.Activities).AppBranchesGetAppBranchByID, mock.Anything, mock.Anything, mock.Anything).Return(
+		&app.AppBranch{
+			ID:      "branch-1",
+			AppID:   "app-1",
+			OrgID:   "org-1",
+			Configs: []app.AppBranchConfig{{ID: "config-1"}},
+		}, nil)
+}
+
+// A pre-compiled config syncs without cloning: CloneRepo and
+// FetchIntermediateConfig are left unmocked, so the workflow fails if it reaches
+// them.
+func (s *AppConfigSignalTestSuite) TestPreCompiledConfigSyncsWithoutClone() {
+	sig := &Signal{
+		AppBranchID: "branch-1",
+		RunID:       "run-1",
+		AppConfigID: "cfg-1",
+	}
+
+	s.mockPreCompiledBranchAndRun()
+
+	s.env.OnActivity((*activities.Activities).SyncAppConfig, mock.Anything, mock.Anything, mock.Anything).Return(
+		&activities.SyncAppConfigOutput{
+			AppConfigID:  "cfg-1",
+			ComponentIDs: []string{"cmp-1"},
+		}, nil)
+
+	s.env.OnActivity((*activities.Activities).UpdateAppBranchConfigIDs, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	s.env.OnActivity((*activities.Activities).UpdateAppBranchRunAppConfig, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	s.env.ExecuteWorkflow(sig.Execute)
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+}
+
+func (s *AppConfigSignalTestSuite) TestPreCompiledConfigSyncError() {
+	sig := &Signal{
+		AppBranchID: "branch-1",
+		RunID:       "run-1",
+		AppConfigID: "cfg-1",
+	}
+
+	s.mockPreCompiledBranchAndRun()
+
+	s.env.OnActivity((*activities.Activities).SyncAppConfig, mock.Anything, mock.Anything, mock.Anything).Return(
+		(*activities.SyncAppConfigOutput)(nil), fmt.Errorf("component validation failed"))
+
+	s.env.ExecuteWorkflow(sig.Execute)
+
+	s.True(s.env.IsWorkflowCompleted())
+	err := s.env.GetWorkflowError()
+	s.Error(err)
+	s.Contains(err.Error(), "unable to sync app config")
+}
+
 func (s *AppConfigSignalTestSuite) TestFetchIntermediateConfigError() {
 	sig := &Signal{
 		AppBranchID: "branch-1",

--- a/services/ctl-api/internal/app/apps/signals/branches/installgroups/resolve.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/installgroups/resolve.go
@@ -23,7 +23,7 @@ func Resolve(ctx workflow.Context, installGroupID, appBranchID string) (*Resolve
 		return nil, fmt.Errorf("unable to get install group: %w", err)
 	}
 
-	if group.LabelSelector == nil {
+	if group.LabelSelector == nil && !group.AllInstalls {
 		logger.Info("resolved install group",
 			"install_group_id", group.ID,
 			"install_group_name", group.Name,
@@ -38,19 +38,26 @@ func Resolve(ctx workflow.Context, installGroupID, appBranchID string) (*Resolve
 	}
 
 	resolved, err := activities.AwaitResolveInstallGroupInstalls(ctx, &activities.ResolveInstallGroupInstallsInput{
-		AppID:    branch.AppID,
-		GroupID:  group.ID,
-		Selector: group.LabelSelector,
+		AppID:       branch.AppID,
+		GroupID:     group.ID,
+		Selector:    group.LabelSelector,
+		AllInstalls: group.AllInstalls,
+		AppBranchID: appBranchID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to resolve install group labels: %w", err)
+	}
+
+	resolvedVia := "label_selector"
+	if group.AllInstalls {
+		resolvedVia = "all_installs"
 	}
 
 	logger.Info("resolved install group",
 		"install_group_id", group.ID,
 		"install_group_name", group.Name,
 		"install_count", len(resolved.InstallIDs),
-		"resolved_via", "label_selector",
+		"resolved_via", resolvedVia,
 	)
 
 	return &Resolved{InstallIDs: resolved.InstallIDs, GroupName: group.Name}, nil

--- a/services/ctl-api/internal/app/apps/workflows/app_branch_run.go
+++ b/services/ctl-api/internal/app/apps/workflows/app_branch_run.go
@@ -43,6 +43,7 @@ func AppBranchRun(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRe
 
 	appConfigID := generics.FromPtrStr(flw.Metadata["app_config_id"])
 	skipBuilds := generics.FromPtrStr(flw.Metadata["skip_builds"]) == "true"
+	syncAppConfig := generics.FromPtrStr(flw.Metadata["sync_app_config"]) == "true"
 
 	// Read the run rather than the workflow metadata: only the VCS push path
 	// writes run_type into metadata, so a plan-only run triggered through the
@@ -68,7 +69,8 @@ func AppBranchRun(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRe
 		steps = append(steps, step)
 	}
 
-	if appConfigID == "" {
+	switch {
+	case appConfigID == "":
 		sg.nextGroup()
 		step, err := sg.appBranchSignalStep(ctx, appBranchID, "fetch commit", pgtype.Hstore{}, &fetchcommit.Signal{
 			RunID:       runID,
@@ -88,7 +90,29 @@ func AppBranchRun(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsRe
 			return nil, errors.Wrap(err, "unable to create app config step")
 		}
 		steps = append(steps, step)
-	} else {
+
+	case syncAppConfig:
+		// Config was compiled by the caller: nothing to fetch, but it still has
+		// to be synced into database records before the builds step can run.
+		sg.nextGroup()
+		step, err := sg.appBranchSignalStep(ctx, appBranchID, "fetch commit (skipped)", pgtype.Hstore{}, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to create skipped fetch commit step")
+		}
+		steps = append(steps, step)
+
+		sg.nextGroup()
+		step, err = sg.appBranchSignalStep(ctx, appBranchID, "sync app config", pgtype.Hstore{}, &appconfig.Signal{
+			AppBranchID: appBranchID,
+			RunID:       runID,
+			AppConfigID: appConfigID,
+		}, WithSkippable(false))
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to create sync app config step")
+		}
+		steps = append(steps, step)
+
+	default:
 		// Pre-existing app config: skip VCS fetch and config parse
 		sg.nextGroup()
 		step, err := sg.appBranchSignalStep(ctx, appBranchID, "fetch commit (skipped)", pgtype.Hstore{}, nil)

--- a/services/ctl-api/internal/app/apps/workflows/app_branch_run_test.go
+++ b/services/ctl-api/internal/app/apps/workflows/app_branch_run_test.go
@@ -1,0 +1,125 @@
+package workflows
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/apps/signals/branches/activities"
+)
+
+type AppBranchRunStepsTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+	env *testsuite.TestWorkflowEnvironment
+}
+
+func TestAppBranchRunStepsSuite(t *testing.T) {
+	suite.Run(t, new(AppBranchRunStepsTestSuite))
+}
+
+func (s *AppBranchRunStepsTestSuite) SetupTest() {
+	s.env = s.NewTestWorkflowEnvironment()
+	s.env.SetWorkerOptions(worker.Options{
+		DeadlockDetectionTimeout: time.Minute,
+	})
+}
+
+// The generator's activities are registered by method name off the Activities
+// struct, which needs a database. Stubs registered under the same names keep the
+// test to what it is about: the shape of the generated steps.
+func (s *AppBranchRunStepsTestSuite) stubActivities(runType app.AppBranchRunType) {
+	s.env.RegisterActivityWithOptions(
+		func(ctx context.Context, req activities.GetAppBranchRunByIDRequest) (*app.AppBranchRun, error) {
+			return &app.AppBranchRun{ID: req.RunID, RunType: runType}, nil
+		},
+		activity.RegisterOptions{Name: "GetAppBranchRunByID"},
+	)
+	s.env.RegisterActivityWithOptions(
+		func(ctx context.Context, configID string) ([]*app.AppBranchInstallGroup, error) {
+			return nil, nil
+		},
+		activity.RegisterOptions{Name: "GetInstallGroupsByConfigID"},
+	)
+	s.env.RegisterActivityWithOptions(
+		func(ctx context.Context, input *activities.GetAppBranchConfigByIDInput) (*activities.GetAppBranchConfigByIDOutput, error) {
+			return &activities.GetAppBranchConfigByIDOutput{}, nil
+		},
+		activity.RegisterOptions{Name: "GetAppBranchConfigByID"},
+	)
+}
+
+func (s *AppBranchRunStepsTestSuite) generate(metadata map[string]string) *app.GenerateStepsResult {
+	hstore := make(map[string]*string, len(metadata))
+	for k, v := range metadata {
+		val := v
+		hstore[k] = &val
+	}
+
+	s.env.ExecuteWorkflow(AppBranchRun, &app.Workflow{Metadata: hstore})
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+
+	var result *app.GenerateStepsResult
+	s.NoError(s.env.GetWorkflowResult(&result))
+	return result
+}
+
+func stepNames(result *app.GenerateStepsResult) []string {
+	names := make([]string, 0, len(result.Steps))
+	for _, step := range result.Steps {
+		names = append(names, step.Name)
+	}
+	return names
+}
+
+func (s *AppBranchRunStepsTestSuite) TestVCSPathFetchesConfig() {
+	s.stubActivities(app.AppBranchRunTypeGit)
+
+	result := s.generate(map[string]string{
+		"app_branch_id": "branch-1",
+		"run_id":        "run-1",
+		"config_id":     "config-1",
+	})
+
+	s.Equal([]string{"fetch commit", "fetch app config", "building components and sandbox"}, stepNames(result))
+}
+
+func (s *AppBranchRunStepsTestSuite) TestPreCompiledConfigSyncsInsteadOfFetching() {
+	s.stubActivities(app.AppBranchRunTypeManual)
+
+	result := s.generate(map[string]string{
+		"app_branch_id":   "branch-1",
+		"run_id":          "run-1",
+		"config_id":       "config-1",
+		"app_config_id":   "cfg-1",
+		"sync_app_config": "true",
+	})
+
+	s.Equal([]string{"fetch commit (skipped)", "sync app config", "building components and sandbox"}, stepNames(result))
+	s.Equal(app.WorkflowStepExecutionTypeSystem, result.Steps[1].ExecutionType)
+}
+
+func (s *AppBranchRunStepsTestSuite) TestAlreadySyncedConfigSkipsBothSteps() {
+	s.stubActivities(app.AppBranchRunTypeManual)
+
+	result := s.generate(map[string]string{
+		"app_branch_id": "branch-1",
+		"run_id":        "run-1",
+		"config_id":     "config-1",
+		"app_config_id": "cfg-1",
+		"skip_builds":   "true",
+	})
+
+	s.Equal([]string{
+		"fetch commit (skipped)",
+		"fetch app config (skipped)",
+		"building components and sandbox (skipped)",
+	}, stepNames(result))
+}

--- a/services/ctl-api/internal/app/org.go
+++ b/services/ctl-api/internal/app/org.go
@@ -117,6 +117,7 @@ const (
 	// registry and the mng process runs each step's inline_contents in the
 	// image via the mounted actions-supervisor. VM-based runners only.
 	OrgFeatureImageBackedActions OrgFeature = "image-backed-actions"
+	OrgFeatureAppBranchSync      OrgFeature = "app-branch-sync"
 )
 
 type Org struct {
@@ -250,6 +251,7 @@ func (o *Org) BeforeCreate(tx *gorm.DB) error {
 		OrgFeatureOrgHealthcheckSweeps:    false,
 		OrgFeatureAppInstallSyncing:       false,
 		OrgFeatureSandboxOCIArtifacts:     false,
+		OrgFeatureAppBranchSync:           false,
 
 		// Enabled by default
 		OrgFeatureAppBranches:   true,
@@ -313,6 +315,7 @@ func GetFeatures() []OrgFeature {
 		OrgFeatureAppInstallSyncing,
 		OrgFeatureSandboxOCIArtifacts,
 		OrgFeatureImageBackedActions,
+		OrgFeatureAppBranchSync,
 	}
 }
 
@@ -354,6 +357,7 @@ func GetFeatureDescriptions() map[OrgFeature]string {
 		OrgFeatureAppInstallSyncing:        "Enable app install config syncing: point an app at a git repo of per-install configs so pushes to that repo sync every install's config and create missing installs behind an approval step. Gates the install syncs API, the VCS push fan-out, and the dashboard install syncs tab.",
 		OrgFeatureSandboxOCIArtifacts:      "Build the app sandbox into an OCI artifact during branch runs and resolve sandbox runs against that artifact instead of cloning the sandbox git source. With it off, sandbox runs always clone git.",
 		OrgFeatureImageBackedActions:       "Allow actions to declare a container image their steps run inside. Nuon mirrors the image into the install registry and the mng process runs each step's inline_contents in the image via the mounted actions-supervisor. VM-based runners only.",
+		OrgFeatureAppBranchSync:            "Route `nuon apps sync` through an app branch run: every app gets a `sync-default` branch covering all of its installs, and the sync hands its config to a run on that branch instead of the standalone config sync plus install rollout. Requires app-branches.",
 	}
 }
 


### PR DESCRIPTION
## What

New default-off org feature flag, `app-branch-sync`. With it on, `nuon apps sync`
compiles the config locally and hands it to a run on the app's `default` app branch
instead of the standalone config sync plus install rollout.

Flag off, nothing changes.

## Why

First step toward deprecating the standalone sync path. Every app gets a `default`
branch covering all of its installs, and the CLI just builds the config and creates a
branch run with it.

## How

No new endpoints. The CLI checks for a branch named `default` with `GET /branches`,
creates it with `POST /branches` and `POST /branches/:id/configs` on the first sync,
then posts the config with `app_branch_id` and triggers the run.

Branch runs can now sync a pre-compiled config: `sync_app_config` swaps the
`fetch commit` + `fetch app config` steps for a single `sync app config` step.

New API surface is two request fields on the trigger endpoint (`sync_app_config`,
`auto_approve`), `all_installs` on install group requests, and the flag.

The default branch is deliberately created by the CLI rather than as a side effect of
`POST /configs`. If the API linked a config to the branch on its own, an older CLI
would then call `/configs/:id/sync`, which skips the install rollout for
branch-linked configs on the assumption a branch run owns it. No run would exist and
installs would silently never update.

## Also fixes

`nuon apps sync --branch X` built every changed component twice, once from
`POST /configs/:id/sync` and once from the run's builds step. The new path only
builds once.