### PR TITLE
fix: add metrics context for kafka consumers

### DIFF
--- a/services/ctl-api/internal/pkg/consumer/consumer.go
+++ b/services/ctl-api/internal/pkg/consumer/consumer.go
@@ -27,6 +27,8 @@ import (
 	"github.com/nuonco/nuon/pkg/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/kafka"
 )
 
@@ -186,6 +188,18 @@ func NewSink(params Params, name Name, topic string) *Sink {
 func (s *Sink) instrument(handler pkgkafka.Handler) pkgkafka.Handler {
 	return func(ctx context.Context, partition int32, recs []*kgo.Record) error {
 		start := time.Now()
+
+		// Seed a MetricContext so the GORM metrics plugin tags this consumer's
+		// ClickHouse writes, the same way the Temporal activity interceptor does
+		// for worker activities. Without it the plugin has no request scope to
+		// attribute the write to and the per-table latency series is untagged.
+		ctx = context.WithValue(ctx, keys.MetricsKey, &cctx.MetricContext{
+			Endpoint:  string(s.name),
+			Method:    "kafka",
+			Context:   "consumer",
+			Namespace: s.topic,
+		})
+
 		err := handler(ctx, partition, recs)
 
 		tags := s.baseTags("status:ok")

--- a/services/ctl-api/internal/pkg/db/plugins/metrics/metrics_plugin.go
+++ b/services/ctl-api/internal/pkg/db/plugins/metrics/metrics_plugin.go
@@ -165,9 +165,16 @@ func (m *metricsWriterPlugin) afterAll(tx *gorm.DB, operationType OperationType)
 		tags = append(tags, "pool:"+string(routing.DecisionFromContext(ctx)))
 	}
 
+	// A MetricContext is seeded by the HTTP middleware and the Temporal activity
+	// interceptor, so anything driven by neither — the Kafka consumers, which
+	// write ClickHouse from a poll loop — has none. Fall back to an empty one and
+	// emit with the request-scoped tags blank: returning here instead meant every
+	// consumer-side write was silently unmeasured, which is how the otel ingest
+	// tables lost their gorm_operation_latency series when the writes moved off
+	// the api pods.
 	metricCtx, err := cctx.MetricsContextFromGinContext(ctx)
 	if err != nil {
-		return
+		metricCtx = &cctx.MetricContext{}
 	}
 
 	tags = append(tags,


### PR DESCRIPTION
Consumer metrics were shortcircuting because our metrics code assumes a gin context. Adds a safe default for that path. 