### PR TITLE
fix: include runner_init_script_url in aws install tfvars

### DIFF
--- a/services/ctl-api/internal/pkg/stacks/aws/tmpl.go
+++ b/services/ctl-api/internal/pkg/stacks/aws/tmpl.go
@@ -10,6 +10,7 @@ aws_region               = "{{.Install.AWSAccount.Region}}"
 {{- end}}
 runner_api_url           = "{{.Settings.RunnerAPIURL}}"
 runner_id                = "{{.Runner.ID}}"
+runner_init_script_url   = "{{.RunnerInitScriptURL}}"
 phone_home_url           = "{{.CloudFormationStackVersion.PhoneHomeURL}}"
 nuon_support_iam_role_arns = {{.ControlPlaneAccountIDs}}
 provision_permissions              = {{.ProvisionPermissions}}


### PR DESCRIPTION
## Summary

This was missing from the tfvars for aws installs. Causing the runner to fall back to the tag `cloud`. Since `cloud` doesn't exist, it then falls back to the latest version.