### PR TITLE
chore(ctl-api): the phone home init script is not strictly required

### DIFF
--- a/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
@@ -85,7 +85,7 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 	maps.Copy(tmpl.Parameters, customResult.params)
 
 	// Phone home Lambda + props — AFTER custom stacks so we have their output metadata
-	if err := validatePhoneHomeScriptSize(inp.PhonehomeScript); err != nil {
+	if err := validatePhoneHomeScript(inp.PhonehomeScript); err != nil {
 		return nil, err
 	}
 	tmpl.Resources["PhoneHomeProps"] = t.getRunnerPhoneHomeProps(inp, customResult)

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template_test.go
@@ -36,8 +36,9 @@ func TestGetAWSTemplate_RunnerResources(t *testing.T) {
 					RunnerNestedTemplateURL: server.URL + "/runner.yaml",
 				},
 			},
-			Runner:   &app.Runner{ID: "run123"},
-			Settings: &app.RunnerGroupSettings{},
+			Runner:          &app.Runner{ID: "run123"},
+			Settings:        &app.RunnerGroupSettings{},
+			PhonehomeScript: "print('phone home')",
 		}
 	}
 

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/resource_runner_phone_home_lambda.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/resource_runner_phone_home_lambda.go
@@ -126,11 +126,18 @@ func (a *Templates) getRunnerPhoneHomeProps(inp *stacks.TemplateInput, customSta
 // phone-home Lambda uses.
 const lambdaInlineCodeLimit = 4096
 
-// validatePhoneHomeScriptSize fails the render rather than letting an oversized
+// validatePhoneHomeScript fails the render rather than letting an empty or oversized
 // script fail at CreateStack inside the customer's account, where the error is far
 // harder to attribute. The escape hatch when the script legitimately outgrows this
 // is an S3-hosted zip (Code.S3Bucket/S3Key) in the existing template bucket.
-func validatePhoneHomeScriptSize(script string) error {
+//
+// Empty is checked here rather than as a `validate:"required"` tag on TemplateInput
+// because the Azure and GCP renderers share that struct and have no phone-home Lambda.
+func validatePhoneHomeScript(script string) error {
+	if script == "" {
+		return fmt.Errorf("phone home script is empty")
+	}
+
 	if len(script) > lambdaInlineCodeLimit {
 		return fmt.Errorf(
 			"phone home script is %d bytes, over the %d byte limit for inline lambda source",

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/resource_runner_phone_home_lambda_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/resource_runner_phone_home_lambda_test.go
@@ -173,14 +173,18 @@ func TestGetRunnerPhoneHomeLambda_TimeoutAndMemory(t *testing.T) {
 	}
 }
 
-// An oversized script otherwise fails at CreateStack inside the customer's account,
-// where the cause is far harder to attribute.
-func TestValidatePhoneHomeScriptSize(t *testing.T) {
-	assert.NoError(t, validatePhoneHomeScriptSize(strings.Repeat("x", lambdaInlineCodeLimit)))
+// An empty or oversized script otherwise fails at CreateStack inside the customer's
+// account, where the cause is far harder to attribute.
+func TestValidatePhoneHomeScript(t *testing.T) {
+	assert.NoError(t, validatePhoneHomeScript(strings.Repeat("x", lambdaInlineCodeLimit)))
 
-	err := validatePhoneHomeScriptSize(strings.Repeat("x", lambdaInlineCodeLimit+1))
+	err := validatePhoneHomeScript(strings.Repeat("x", lambdaInlineCodeLimit+1))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "inline lambda source")
+
+	err = validatePhoneHomeScript("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
 }
 
 // The role name is load-bearing: the secret's resource policy in the management account

--- a/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
+++ b/services/ctl-api/internal/pkg/stacks/gcp/render_test.go
@@ -36,7 +36,6 @@ func testInput() *stacks.TemplateInput {
 		Settings:                     &app.RunnerGroupSettings{RunnerAPIURL: "https://runner.nuon.co"},
 		APIToken:                     "test-token",
 		RunnerInitScriptURL:          "https://example.com/init.sh",
-		PhonehomeScript:              "echo done",
 		VPCNestedStackTemplateURL:    "https://example.com/vpc.yaml",
 		RunnerNestedStackTemplateURL: "https://example.com/runner.yaml",
 	}

--- a/services/ctl-api/internal/pkg/stacks/template_input.go
+++ b/services/ctl-api/internal/pkg/stacks/template_input.go
@@ -33,7 +33,12 @@ type TemplateInput struct {
 
 	// subscripts and embedded templates
 	RunnerInitScriptURL string `validate:"required"`
-	PhonehomeScript     string `validate:"required"`
+
+	// AWS-only: the inline source for the phone-home Lambda (Code.ZipFile). Unvalidated
+	// because the Azure and GCP paths share this struct — ARM builds its own phone-home
+	// script from PhoneHomeURL, and GCP has no equivalent resource. The AWS renderer
+	// enforces it instead.
+	PhonehomeScript string
 
 	// Custom template URLs for VPC/VNet and runner nested/linked deployments (AWS CloudFormation, Azure ARM)
 	VPCNestedStackTemplateURL    string


### PR DESCRIPTION
except for AWS. But for AWS, we have a baked in default. This PR removes
the strict requirement in the activity requests and moves the validation
into tha AWS branch.
