### PR TITLE
fix: issue with deploy picking latest build rather than build on component config

### DIFF
--- a/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
@@ -39,12 +39,15 @@ type Signal struct {
 	// build instead of falling back to "latest build for component" at
 	// signal-run time. The workflow generator resolves this at step-gen
 	// so the build identity is captured up front.
-	BuildID        string
-	WorkflowStepID string
-	FlowStepID     string
-	FlowID         string
-	SandboxMode    bool
-	Role           string
+	BuildID string
+	// ComponentConfigConnectionID sets the ccc id for which we shuold lookup
+	// build for when build id is not passed in.
+	ComponentConfigConnectionID string
+	WorkflowStepID              string
+	FlowStepID                  string
+	FlowID                      string
+	SandboxMode                 bool
+	Role                        string
 
 	runnerJobID string
 }
@@ -215,11 +218,17 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	} else {
 		buildID := s.BuildID
 		if buildID == "" {
-			componentBuild, err := activities.AwaitGetComponentLatestBuildByComponentID(ctx, s.ComponentID)
-			if err != nil {
-				return fmt.Errorf("unable to get component build: %w", err)
+			if s.ComponentConfigConnectionID == "" {
+				return fmt.Errorf("unable to lookup build, component config connection id empty")
 			}
-			buildID = componentBuild.ID
+
+			pinned, err := activities.AwaitGetComponentBuildForConfigConnectionByComponentConfigConnectionID(ctx, s.ComponentConfigConnectionID)
+			if err != nil {
+				return fmt.Errorf("unable to get pinned component build: %w", err)
+			}
+			if pinned != nil {
+				buildID = pinned.ID
+			}
 		}
 
 		installDeploy, err = activities.AwaitCreateInstallDeploy(ctx, activities.CreateInstallDeployRequest{

--- a/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
@@ -226,9 +226,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 			if err != nil {
 				return fmt.Errorf("unable to get pinned component build: %w", err)
 			}
-			if pinned != nil {
-				buildID = pinned.ID
+			if pinned == nil {
+				return fmt.Errorf("no deployable build for component config connection %s", s.ComponentConfigConnectionID)
 			}
+			buildID = pinned.ID
 		}
 
 		installDeploy, err = activities.AwaitCreateInstallDeploy(ctx, activities.CreateInstallDeployRequest{

--- a/services/ctl-api/internal/app/installs/signals/componentsyncimage/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentsyncimage/signal.go
@@ -36,11 +36,14 @@ type Signal struct {
 	// build instead of falling back to "latest build for component" at
 	// signal-run time. The workflow generator resolves this at step-gen
 	// so the build identity is captured up front.
-	BuildID        string
-	WorkflowStepID string
-	FlowID         string
-	SandboxMode    bool
-	Role           string
+	BuildID string
+	// ComponentConfigConnectionID pins looking up build for specific ccc
+	// for that app config id, in case build id is not provided.
+	ComponentConfigConnectionID string
+	WorkflowStepID              string
+	FlowID                      string
+	SandboxMode                 bool
+	Role                        string
 
 	runnerJobID string
 }
@@ -54,10 +57,12 @@ func (s *Signal) SetStepContext(stepID, flowID string) {
 	s.FlowID = flowID
 }
 
-var _ signal.SignalWithStepContext = (*Signal)(nil)
-var _ signal.SignalWithAutoRetry = (*Signal)(nil)
-var _ signal.SignalWithCancel = (*Signal)(nil)
-var _ signal.SignalWithOnRetry = (*Signal)(nil)
+var (
+	_ signal.SignalWithStepContext = (*Signal)(nil)
+	_ signal.SignalWithAutoRetry   = (*Signal)(nil)
+	_ signal.SignalWithCancel      = (*Signal)(nil)
+	_ signal.SignalWithOnRetry     = (*Signal)(nil)
+)
 
 func (s *Signal) OnRetry(ctx workflow.Context) error {
 	if s.DeployID != "" {
@@ -89,7 +94,7 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 func (s *Signal) Execute(ctx workflow.Context) error {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "unable to create logger")
 	}
 
 	install, err := activities.AwaitGetInstallForInstallComponentByInstallComponentID(ctx, s.InstallComponentID)
@@ -108,11 +113,16 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	} else {
 		buildID := s.BuildID
 		if buildID == "" {
-			componentBuild, err := activities.AwaitGetComponentLatestBuildByComponentID(ctx, s.ComponentID)
-			if err != nil {
-				return fmt.Errorf("unable to get component build: %w", err)
+			if s.ComponentConfigConnectionID == "" {
+				return fmt.Errorf("unable to lookup builds, component config connection not provided")
 			}
-			buildID = componentBuild.ID
+			pinned, err := activities.AwaitGetComponentBuildForConfigConnectionByComponentConfigConnectionID(ctx, s.ComponentConfigConnectionID)
+			if err != nil {
+				return fmt.Errorf("unable to get pinned component build: %w", err)
+			}
+			if pinned != nil {
+				buildID = pinned.ID
+			}
 		}
 
 		typ := app.InstallDeployTypeSync
@@ -149,13 +159,9 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	}()
 
 	ctx = cctx.SetLogStreamWorkflowContext(ctx, logStream)
-	l, err = log.WorkflowLogger(ctx)
-	if err != nil {
-		return err
-	}
 
 	l.Info("syncing oci artifact")
-	if err := s.execSync(ctx, install, installDeploy, s.SandboxMode); err != nil {
+	if err := s.execSync(ctx, install, installDeploy); err != nil {
 		s.updateDeployStatus(ctx, installDeploy.ID, app.InstallDeployStatusError, "unable to sync")
 		return errors.Wrap(err, "unable to execute sync")
 	}
@@ -187,7 +193,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	return nil
 }
 
-func (s *Signal) execSync(ctx workflow.Context, install *app.Install, installDeploy *app.InstallDeploy, sandboxMode bool) error {
+func (s *Signal) execSync(ctx workflow.Context, install *app.Install, installDeploy *app.InstallDeploy) error {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
 		return err

--- a/services/ctl-api/internal/app/installs/signals/componentsyncimage/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentsyncimage/signal.go
@@ -120,9 +120,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 			if err != nil {
 				return fmt.Errorf("unable to get pinned component build: %w", err)
 			}
-			if pinned != nil {
-				buildID = pinned.ID
+			if pinned == nil {
+				return fmt.Errorf("no deployable build for component config connection %s", s.ComponentConfigConnectionID)
 			}
+			buildID = pinned.ID
 		}
 
 		typ := app.InstallDeployTypeSync

--- a/services/ctl-api/internal/app/installs/worker/activities/get_component_build_for_config_connection.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/get_component_build_for_config_connection.go
@@ -1,0 +1,69 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
+)
+
+type GetComponentBuildForConfigConnectionRequest struct {
+	ComponentConfigConnectionID string `validate:"required"`
+}
+
+// GetComponentBuildForConfigConnection resolves the build for a specific
+// config connection. Returns (nil, nil) when none exists yet.
+//
+// @temporal-gen-v2 activity
+// @by-field ComponentConfigConnectionID
+func (a *Activities) GetComponentBuildForConfigConnection(ctx context.Context, req GetComponentBuildForConfigConnectionRequest) (*app.ComponentBuild, error) {
+	var ccc app.ComponentConfigConnection
+	res := a.db.WithContext(ctx).
+		Select("id", "component_id", "checksum", "latest_build_id").
+		Where("id = ?", req.ComponentConfigConnectionID).
+		First(&ccc)
+	if res.Error != nil {
+		return nil, fmt.Errorf("unable to load component config connection: %w", res.Error)
+	}
+
+	if ccc.LatestBuildID.Valid {
+		var pinned app.ComponentBuild
+		res = a.db.WithContext(ctx).
+			Select("id", "status", "component_config_connection_id").
+			Where("id = ?", ccc.LatestBuildID.String).
+			First(&pinned)
+		if res.Error != nil && !errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("unable to load pinned component build: %w", res.Error)
+		}
+		if res.Error == nil && pinned.Status == app.ComponentBuildStatusActive {
+			return &pinned, nil
+		}
+	}
+
+	if ccc.Checksum == "" {
+		return nil, nil
+	}
+
+	var build app.ComponentBuild
+	viewOrTable := views.TableOrViewName(a.db, &app.ComponentConfigConnection{}, "")
+	res = a.db.WithContext(ctx).
+		Select("component_builds.id", "component_builds.status", "component_builds.component_config_connection_id").
+		Joins(fmt.Sprintf("JOIN %s ON %s.id = component_builds.component_config_connection_id", viewOrTable, viewOrTable)).
+		Where(fmt.Sprintf("%s.component_id = ?", viewOrTable), ccc.ComponentID).
+		Where(fmt.Sprintf("%s.checksum = ?", viewOrTable), ccc.Checksum).
+		Where("component_builds.status = ?", app.ComponentBuildStatusActive).
+		Order("component_builds.created_at DESC").
+		First(&build)
+	if res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unable to load active build for config checksum: %w", res.Error)
+	}
+
+	return &build, nil
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/get_component_build_for_config_connection_test.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/get_component_build_for_config_connection_test.go
@@ -1,0 +1,136 @@
+package activities
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupBuildForCCCDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`
+		CREATE TABLE component_config_connections (
+			id TEXT PRIMARY KEY,
+			component_id TEXT,
+			checksum TEXT,
+			latest_build_id TEXT,
+			created_at DATETIME,
+			updated_at DATETIME,
+			deleted_at INTEGER DEFAULT 0
+		)
+	`).Error)
+	require.NoError(t, db.Exec(`
+		CREATE VIEW component_config_connections_view_v1 AS
+		SELECT * FROM component_config_connections
+	`).Error)
+	require.NoError(t, db.Exec(`
+		CREATE TABLE component_builds (
+			id TEXT PRIMARY KEY,
+			component_config_connection_id TEXT,
+			status TEXT,
+			created_at DATETIME,
+			updated_at DATETIME,
+			deleted_at INTEGER DEFAULT 0
+		)
+	`).Error)
+
+	return db
+}
+
+func TestGetComponentBuildForConfigConnection(t *testing.T) {
+	const componentID = "cmp-1"
+
+	insertConn := func(t *testing.T, db *gorm.DB, id, checksum, latestBuildID string) {
+		t.Helper()
+		require.NoError(t, db.Exec(`
+			INSERT INTO component_config_connections (id, component_id, checksum, latest_build_id, created_at, updated_at)
+			VALUES (?, ?, ?, nullif(?, ''), datetime('now'), datetime('now'))
+		`, id, componentID, checksum, latestBuildID).Error)
+	}
+	insertBuild := func(t *testing.T, db *gorm.DB, id, connID, status, createdAt string) {
+		t.Helper()
+		require.NoError(t, db.Exec(`
+			INSERT INTO component_builds (id, component_config_connection_id, status, created_at, updated_at)
+			VALUES (?, ?, ?, ?, datetime('now'))
+		`, id, connID, status, createdAt).Error)
+	}
+
+	t.Run("returns pinned active build", func(t *testing.T) {
+		db := setupBuildForCCCDB(t)
+		insertConn(t, db, "conn-1", "sum", "bld-1")
+		insertBuild(t, db, "bld-1", "conn-1", "active", "2026-01-01 00:00:00")
+
+		a := &Activities{db: db}
+		out, err := a.GetComponentBuildForConfigConnection(context.Background(), GetComponentBuildForConfigConnectionRequest{
+			ComponentConfigConnectionID: "conn-1",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		require.Equal(t, "bld-1", out.ID)
+	})
+
+	t.Run("pinned build not active falls back to checksum match", func(t *testing.T) {
+		db := setupBuildForCCCDB(t)
+		insertConn(t, db, "conn-old", "sum", "")
+		insertBuild(t, db, "bld-old", "conn-old", "active", "2026-01-01 00:00:00")
+		insertConn(t, db, "conn-new", "sum", "bld-queued")
+		insertBuild(t, db, "bld-queued", "conn-new", "queued", "2026-01-02 00:00:00")
+
+		a := &Activities{db: db}
+		out, err := a.GetComponentBuildForConfigConnection(context.Background(), GetComponentBuildForConfigConnectionRequest{
+			ComponentConfigConnectionID: "conn-new",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		require.Equal(t, "bld-old", out.ID)
+	})
+
+	t.Run("checksum fallback ignores other checksums", func(t *testing.T) {
+		db := setupBuildForCCCDB(t)
+		insertConn(t, db, "conn-other", "other-sum", "")
+		insertBuild(t, db, "bld-other", "conn-other", "active", "2026-01-01 00:00:00")
+		insertConn(t, db, "conn-1", "sum", "")
+
+		a := &Activities{db: db}
+		out, err := a.GetComponentBuildForConfigConnection(context.Background(), GetComponentBuildForConfigConnectionRequest{
+			ComponentConfigConnectionID: "conn-1",
+		})
+		require.NoError(t, err)
+		require.Nil(t, out)
+	})
+
+	t.Run("empty checksum without pinned build returns nil", func(t *testing.T) {
+		db := setupBuildForCCCDB(t)
+		insertConn(t, db, "conn-1", "", "")
+
+		a := &Activities{db: db}
+		out, err := a.GetComponentBuildForConfigConnection(context.Background(), GetComponentBuildForConfigConnectionRequest{
+			ComponentConfigConnectionID: "conn-1",
+		})
+		require.NoError(t, err)
+		require.Nil(t, out)
+	})
+
+	t.Run("checksum fallback picks newest active", func(t *testing.T) {
+		db := setupBuildForCCCDB(t)
+		insertConn(t, db, "conn-a", "sum", "")
+		insertBuild(t, db, "bld-a", "conn-a", "active", "2026-01-01 00:00:00")
+		insertConn(t, db, "conn-b", "sum", "")
+		insertBuild(t, db, "bld-b", "conn-b", "active", "2026-01-02 00:00:00")
+
+		a := &Activities{db: db}
+		out, err := a.GetComponentBuildForConfigConnection(context.Background(), GetComponentBuildForConfigConnectionRequest{
+			ComponentConfigConnectionID: "conn-a",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		require.Equal(t, "bld-b", out.ID)
+	})
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/queue_component_deploy.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/queue_component_deploy.go
@@ -20,6 +20,10 @@ type CreateInstallDeployRequest struct {
 
 // @temporal-gen-v2 activity
 func (a *Activities) CreateInstallDeploy(ctx context.Context, req CreateInstallDeployRequest) (*app.InstallDeploy, error) {
+	if err := a.v.Struct(req); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
 	// create deploy
 	install, err := a.getInstall(ctx, req.InstallID)
 	if err != nil {

--- a/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/shared_helpers.go
@@ -107,9 +107,7 @@ func componentEnabledFromInputs(enabledInputs map[string]*string, ccc *app.Compo
 // trio used by the dep-aware deploy logic from an AppConfig's pinned
 // ComponentConfigConnections. cccByComp records membership of each component
 // in the install's pinned app config snapshot — used to skip deps that are
-// not part of this app config version. The build-to-push for each dep is
-// resolved at workflow generation time via the GetLatestActiveComponentBuild
-// activity (global heuristic — no cross-ACV pinning).
+// not part of this app config version and to pin build resolution.
 func buildComponentConfigMaps(appCfg *app.AppConfig) (
 	map[string]app.Component,
 	map[string][]string,
@@ -125,6 +123,21 @@ func buildComponentConfigMaps(appCfg *app.AppConfig) (
 		cccByComp[ccc.ComponentID] = ccc
 	}
 	return components, depIDsByComp, cccByComp
+}
+
+func resolvePinnedComponentBuild(ctx workflow.Context, dg *genCtx, compID string) (*app.ComponentBuild, error) {
+	ccc, ok := dg.cccByComp[compID]
+	if !ok || ccc == nil {
+		return nil, nil
+	}
+	return activities.AwaitGetComponentBuildForConfigConnectionByComponentConfigConnectionID(ctx, ccc.ID)
+}
+
+func pinnedCCCID(dg *genCtx, compID string) string {
+	if ccc, ok := dg.cccByComp[compID]; ok && ccc != nil {
+		return ccc.ID
+	}
+	return ""
 }
 
 // filterActionWorkflowsByTrigger filters pre-fetched install action workflows by trigger type,
@@ -335,30 +348,20 @@ func getComponentDeploySteps(ctx workflow.Context, dg *genCtx, componentIDs []st
 
 		// sync image
 		if comp.Type.IsImage() && !dg.flw.PlanOnly {
-			// Resolve the build to push using the global "latest active
-			// build for this component" heuristic. This does NOT enforce
-			// per-AppConfig-version pinning — a deploy of an install
-			// pinned to ACV vN may pick up a build created against vN+1
-			// or vN-1. Cross-ACV correctness is a deferred fix.
-			//
-			// When no Active build exists yet (e.g. the build is still
-			// in-flight), leave BuildID empty: the signal falls back to
-			// resolving the latest build at run time. This keeps a single
-			// component without an active build from aborting generation of
-			// the entire deploy workflow.
-			latestBuild, err := activities.AwaitGetLatestActiveComponentBuildByComponentID(ctx, comp.ID)
+			latestBuild, err := resolvePinnedComponentBuild(ctx, dg, compID)
 			if err != nil {
-				return nil, errors.Wrapf(err, "unable to resolve latest active build for image component %s", comp.Name)
+				return nil, errors.Wrapf(err, "unable to resolve pinned build for image component %s", comp.Name)
 			}
 			var buildID string
 			if latestBuild != nil {
 				buildID = latestBuild.ID
 			}
 			deployStep, err := dg.sg.installSignalStep(ctx, dg.installID, "sync "+comp.Name, pgtype.Hstore{}, &componentsyncimage.Signal{
-				InstallComponentID: installComponentID,
-				ComponentID:        comp.ID,
-				BuildID:            buildID,
-				Role:               dg.flw.Role,
+				InstallComponentID:          installComponentID,
+				ComponentID:                 comp.ID,
+				BuildID:                     buildID,
+				ComponentConfigConnectionID: pinnedCCCID(dg, compID),
+				Role:                        dg.flw.Role,
 			}, dg.flw.PlanOnly)
 			if err != nil {
 				return nil, errors.Wrap(err, "unable to create image sync")
@@ -370,25 +373,21 @@ func getComponentDeploySteps(ctx workflow.Context, dg *genCtx, componentIDs []st
 				continue
 			}
 
-			// Resolve the build to deploy using the global heuristic.
-			// Same caveat as the image-sync branch above — cross-ACV
-			// build leakage is possible. When no Active build exists yet,
-			// leave BuildID empty so the signal resolves the latest build
-			// at run time rather than aborting the whole workflow.
-			latestBuild, err := activities.AwaitGetLatestActiveComponentBuildByComponentID(ctx, comp.ID)
+			latestBuild, err := resolvePinnedComponentBuild(ctx, dg, compID)
 			if err != nil {
-				return nil, errors.Wrapf(err, "unable to resolve latest active build for component %s", comp.Name)
+				return nil, errors.Wrapf(err, "unable to resolve pinned build for component %s", comp.Name)
 			}
 			var buildID string
 			if latestBuild != nil {
 				buildID = latestBuild.ID
 			}
 			planStep, err := dg.sg.installSignalStep(ctx, dg.installID, "sync and plan "+comp.Name, pgtype.Hstore{}, &componentdeploysyncandplan.Signal{
-				InstallComponentID: installComponentID,
-				InstallID:          dg.installID,
-				ComponentID:        comp.ID,
-				BuildID:            buildID,
-				Role:               dg.flw.Role,
+				InstallComponentID:          installComponentID,
+				InstallID:                   dg.installID,
+				ComponentID:                 comp.ID,
+				BuildID:                     buildID,
+				ComponentConfigConnectionID: pinnedCCCID(dg, compID),
+				Role:                        dg.flw.Role,
 			}, dg.flw.PlanOnly, WithSkippable(false))
 			if err != nil {
 				return nil, errors.Wrap(err, "unable to create image sync")
@@ -558,22 +557,13 @@ func getImageDepSyncSteps(
 			continue
 		}
 
-		// Membership check only: skip deps that aren't part of this app
-		// config snapshot. We don't use the CCC for build resolution —
-		// see note below on cross-ACV leakage.
 		if depCCC, hasCCC := dg.cccByComp[depID]; !hasCCC || depCCC == nil {
 			continue
 		}
 
-		// Resolve the dep's latest Active build via the global heuristic
-		// (most recent Active build for this component across all CCCs).
-		// This can leak a build from a newer/older AppConfig version into
-		// the sync decision — cross-ACV correctness is a deferred fix.
-		// Skip silently when no Active build exists yet — the next deploy
-		// attempt will pick it up once the build lands.
-		latestActive, err := activities.AwaitGetLatestActiveComponentBuildByComponentID(ctx, depID)
+		latestActive, err := resolvePinnedComponentBuild(ctx, dg, depID)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to resolve latest active build for image dep %s", depID)
+			return nil, errors.Wrapf(err, "unable to resolve pinned build for image dep %s", depID)
 		}
 		if latestActive == nil {
 			continue


### PR DESCRIPTION
Currently while picking build for a component during deployment, we just pick the latest build for that componet rather than latest on that config connection, this causes weird issues where if multiple syncs and builds are going on, install on a particular app config id can pick builds which are on entirely different app config id, which causes weird runtime issues such as inconsistent deploy plan and outputs.

This pr picks the build associated with component against its component config connection which is a point in time config record for the install <> deployment when it was triggered.  