### PR TITLE
fix: install audit logs view with indexes

### DIFF
--- a/services/ctl-api/internal/app/install_sandbox_run.go
+++ b/services/ctl-api/internal/app/install_sandbox_run.go
@@ -120,6 +120,14 @@ func (i *InstallSandboxRun) Indexes(db *gorm.DB) []migrations.Index {
 			},
 			Option: "WHERE status = 'drifted'",
 		},
+		// Without this the install_audit_logs_view arm seq scans the whole table.
+		{
+			Name: indexes.Name(db, &InstallSandboxRun{}, "install_created_at"),
+			Columns: []string{
+				"install_id",
+				"created_at",
+			},
+		},
 	}
 }
 

--- a/services/ctl-api/internal/app/policy_report.go
+++ b/services/ctl-api/internal/app/policy_report.go
@@ -134,6 +134,15 @@ func (r *PolicyReport) Indexes(db *gorm.DB) []migrations.Index {
 				"runner_job_id",
 			},
 		},
+		// install_audit_logs_view has no org_id predicate, so policy_reports_filter is unusable for it.
+		{
+			Name: indexes.Name(db, &PolicyReport{}, "install_evaluated_at"),
+			Columns: []string{
+				"install_id",
+				"evaluated_at",
+			},
+			Option: "WHERE install_id IS NOT NULL AND deleted_at = 0",
+		},
 	}
 }
 


### PR DESCRIPTION
## Problem

Page #6136 fired with `install_audit_logs | query | 900ms`. The only query path is
`GET /v1/installs/{install_id}/audit_logs`, which reads `install_audit_logs_view_v2`
filtered on `install_id` and a `time_stamp` range.

The view is a 4-way `UNION ALL`. Quals do push down into each arm, but two arms have no
index that can serve them:

- `install_sandbox_runs`: Seq Scan, no `install_id` index at all.
- `policy_reports`: its only index containing `install_id` leads with `org_id`, and the
  view has no `org_id` predicate (RLS is off here). So the planner walks every live row
  in the table across all orgs and post-filters, then `row_to_json` detoasts four jsonb
  columns per surviving row.

Not a fresh regression. The `policy_reports` arm landed in b791519cc (2026-02-07) and
its cost scales with a table that grows per policy validation and has no cleanup path.