### PR TITLE
fix: parse ARM templates using languageVersion 2.0 symbolic resources

### DIFF
--- a/services/ctl-api/internal/pkg/stacks/arm/fetch_template.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/fetch_template.go
@@ -1,9 +1,11 @@
 package arm
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"slices"
 	"strings"
@@ -21,24 +23,69 @@ type armTemplateResource struct {
 	DependsOn      json.RawMessage        `json:"dependsOn,omitempty"`
 	SubscriptionId string                 `json:"subscriptionId,omitempty"`
 	Properties     *armResourceProperties `json:"properties,omitempty"`
+
+	// symbolicName is the map key under languageVersion 2.0; empty under 1.0.
+	// In 2.0 dependsOn references these keys rather than resource names.
+	symbolicName string
+}
+
+// armResources accepts both resource declaration forms: the languageVersion 1.0
+// array and the 2.0 object keyed by symbolic name. Azure-authored templates
+// increasingly ship as 2.0, and a plain []armTemplateResource field fails the
+// whole unmarshal on them.
+type armResources []armTemplateResource
+
+func (r *armResources) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+
+	if trimmed[0] == '[' {
+		var arr []armTemplateResource
+		if err := json.Unmarshal(trimmed, &arr); err != nil {
+			return err
+		}
+		*r = arr
+		return nil
+	}
+
+	var obj map[string]armTemplateResource
+	if err := json.Unmarshal(trimmed, &obj); err != nil {
+		return err
+	}
+
+	// Sorted so validation errors are reported in a stable order.
+	out := make(armResources, 0, len(obj))
+	for _, key := range slices.Sorted(maps.Keys(obj)) {
+		res := obj[key]
+		res.symbolicName = key
+		out = append(out, res)
+	}
+	*r = out
+
+	return nil
 }
 
 type armResourceProperties struct {
-	Template *struct {
-		Resources []armTemplateResource `json:"resources,omitempty"`
-	} `json:"template,omitempty"`
+	Template *armInlineTemplate `json:"template,omitempty"`
+}
+
+type armInlineTemplate struct {
+	Resources armResources `json:"resources,omitempty"`
 }
 
 type armTemplateShape struct {
-	Parameters map[string]struct {
+	LanguageVersion string `json:"languageVersion,omitempty"`
+	Parameters      map[string]struct {
 		Type         string `json:"type"`
 		DefaultValue any    `json:"defaultValue,omitempty"`
 		Metadata     *struct {
 			Description string `json:"description,omitempty"`
 		} `json:"metadata,omitempty"`
 	} `json:"parameters"`
-	Resources []armTemplateResource `json:"resources"`
-	Outputs   map[string]struct{}   `json:"outputs"`
+	Resources armResources        `json:"resources"`
+	Outputs   map[string]struct{} `json:"outputs"`
 }
 
 // hasManagedIdentity returns true if the template declares a
@@ -119,13 +166,13 @@ func validateARMTemplate(tmpl *armTemplateShape) error {
 		if r.Name != "" {
 			resourceNames[r.Name] = true
 		}
+		if r.symbolicName != "" {
+			resourceNames[r.symbolicName] = true
+		}
 	}
 
 	for i, r := range tmpl.Resources {
-		resourceLabel := r.Name
-		if resourceLabel == "" {
-			resourceLabel = fmt.Sprintf("index %d", i)
-		}
+		label := resourceLabel(r, i)
 
 		// Subscription-level nested deployments are not supported inside linked
 		// deployments. ARM silently scopes them to resource-group level causing
@@ -135,14 +182,14 @@ func validateARMTemplate(tmpl *armTemplateShape) error {
 				"resource %q: subscription-level nested deployments (subscriptionId set) "+
 					"are not supported inside linked deployments; move the role assignment "+
 					"to the parent template or use a managed identity output pattern",
-				resourceLabel,
+				label,
 			))
 		}
 
 		// Validate dependsOn references point to resources declared in this template.
 		deps, err := parseDependsOn(r.DependsOn)
 		if err != nil {
-			errs = append(errs, fmt.Sprintf("resource %q: invalid dependsOn: %v", resourceLabel, err))
+			errs = append(errs, fmt.Sprintf("resource %q: invalid dependsOn: %v", label, err))
 			continue
 		}
 		for _, dep := range deps {
@@ -155,7 +202,7 @@ func validateARMTemplate(tmpl *armTemplateShape) error {
 			if !resourceNames[dep] {
 				errs = append(errs, fmt.Sprintf(
 					"resource %q: dependsOn references %q which is not defined in this template",
-					resourceLabel, dep,
+					label, dep,
 				))
 			}
 		}
@@ -167,14 +214,11 @@ func validateARMTemplate(tmpl *armTemplateShape) error {
 			r.Properties.Template != nil {
 			for j, nested := range r.Properties.Template.Resources {
 				if nested.Type == "Microsoft.Resources/deployments" && nested.SubscriptionId != "" {
-					nestedLabel := nested.Name
-					if nestedLabel == "" {
-						nestedLabel = fmt.Sprintf("index %d", j)
-					}
+					nestedLabel := resourceLabel(nested, j)
 					errs = append(errs, fmt.Sprintf(
 						"resource %q: inline template contains subscription-level nested deployment %q; "+
 							"this is not supported inside linked deployments",
-						resourceLabel, nestedLabel,
+						label, nestedLabel,
 					))
 				}
 			}
@@ -185,6 +229,19 @@ func validateARMTemplate(tmpl *armTemplateShape) error {
 		return fmt.Errorf("ARM template validation failed:\n  - %s", strings.Join(errs, "\n  - "))
 	}
 	return nil
+}
+
+// resourceLabel identifies a resource in validation messages, preferring its ARM
+// name, then its languageVersion 2.0 symbolic name, then its position.
+func resourceLabel(r armTemplateResource, i int) string {
+	if r.Name != "" {
+		return r.Name
+	}
+	if r.symbolicName != "" {
+		return r.symbolicName
+	}
+
+	return fmt.Sprintf("index %d", i)
 }
 
 // parseDependsOn extracts the dependency list from a raw JSON value.

--- a/services/ctl-api/internal/pkg/stacks/arm/fetch_template.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/fetch_template.go
@@ -24,6 +24,11 @@ type armTemplateResource struct {
 	SubscriptionId string                 `json:"subscriptionId,omitempty"`
 	Properties     *armResourceProperties `json:"properties,omitempty"`
 
+	// Existing marks a languageVersion 2.0 reference to a pre-existing resource.
+	// Such a resource is not declared by the template, so it must not count as
+	// one the parent template can read outputs off of.
+	Existing bool `json:"existing,omitempty"`
+
 	// symbolicName is the map key under languageVersion 2.0; empty under 1.0.
 	// In 2.0 dependsOn references these keys rather than resource names.
 	symbolicName string
@@ -92,6 +97,9 @@ type armTemplateShape struct {
 // Microsoft.ManagedIdentity/userAssignedIdentities resource.
 func (t *armTemplateShape) hasManagedIdentity() bool {
 	for _, r := range t.Resources {
+		if r.Existing {
+			continue
+		}
 		if r.Type == "Microsoft.ManagedIdentity/userAssignedIdentities" {
 			return true
 		}

--- a/services/ctl-api/internal/pkg/stacks/arm/fetch_template_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/fetch_template_test.go
@@ -2,6 +2,8 @@ package arm
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -408,5 +410,37 @@ func TestHasManagedIdentity_DeclaredIdentity(t *testing.T) {
 
 	if !tmpl.hasManagedIdentity() {
 		t.Error("expected a declared managed identity to be detected")
+	}
+}
+
+// testdata/vnet_languageversion_2.json is real `bicep build` output, not hand-written:
+// tool-generated ARM is what actually ships languageVersion 2.0, and it is what
+// regressed stack generation for an Azure install with a customer-supplied VNet.
+func TestParseGeneratedBicepTemplate(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("testdata", "vnet_languageversion_2.json"))
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+
+	var tmpl armTemplateShape
+	if err := json.Unmarshal(body, &tmpl); err != nil {
+		t.Fatalf("expected generated 2.0 template to parse, got: %v", err)
+	}
+
+	if tmpl.LanguageVersion != "2.0" {
+		t.Fatalf("fixture is no longer a 2.0 template: got %q", tmpl.LanguageVersion)
+	}
+
+	if err := validateARMTemplate(&tmpl); err != nil {
+		t.Fatalf("expected generated template to validate, got: %v", err)
+	}
+
+	if !tmpl.hasManagedIdentity() {
+		t.Error("expected the declared user-assigned identity to be detected")
+	}
+
+	params, _ := extractARMParameters(&tmpl, ReservedParamNames)
+	if _, ok := params["vnetAddressPrefix"]; !ok {
+		t.Error("expected vnetAddressPrefix parameter to be extracted")
 	}
 }

--- a/services/ctl-api/internal/pkg/stacks/arm/fetch_template_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/fetch_template_test.go
@@ -365,3 +365,48 @@ func TestUnmarshalTemplate_SymbolicInlineNestedResources(t *testing.T) {
 		t.Errorf("unexpected error message: %s", got)
 	}
 }
+
+func TestHasManagedIdentity_IgnoresExistingReference(t *testing.T) {
+	body := []byte(`{
+		"languageVersion": "2.0",
+		"resources": {
+			"sharedIdentity": {
+				"type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+				"apiVersion": "2023-01-31",
+				"name": "preExistingIdentity",
+				"existing": true
+			}
+		}
+	}`)
+
+	var tmpl armTemplateShape
+	if err := json.Unmarshal(body, &tmpl); err != nil {
+		t.Fatalf("failed to parse template: %v", err)
+	}
+
+	if tmpl.hasManagedIdentity() {
+		t.Error("an existing-resource reference is not a declared identity; gating on it forces the template to expose an identityPrincipalId output it does not own")
+	}
+}
+
+func TestHasManagedIdentity_DeclaredIdentity(t *testing.T) {
+	body := []byte(`{
+		"languageVersion": "2.0",
+		"resources": {
+			"identity": {
+				"type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+				"apiVersion": "2023-01-31",
+				"name": "myIdentity"
+			}
+		}
+	}`)
+
+	var tmpl armTemplateShape
+	if err := json.Unmarshal(body, &tmpl); err != nil {
+		t.Fatalf("failed to parse template: %v", err)
+	}
+
+	if !tmpl.hasManagedIdentity() {
+		t.Error("expected a declared managed identity to be detected")
+	}
+}

--- a/services/ctl-api/internal/pkg/stacks/arm/fetch_template_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/fetch_template_test.go
@@ -88,10 +88,8 @@ func TestValidateARMTemplate_InlineNestedSubscriptionDeployment(t *testing.T) {
 				Type: "Microsoft.Resources/deployments",
 				Name: "outerDeployment",
 				Properties: &armResourceProperties{
-					Template: &struct {
-						Resources []armTemplateResource `json:"resources,omitempty"`
-					}{
-						Resources: []armTemplateResource{
+					Template: &armInlineTemplate{
+						Resources: armResources{
 							{
 								Type:           "Microsoft.Resources/deployments",
 								Name:           "innerSubscriptionDeployment",
@@ -208,4 +206,162 @@ func searchString(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestUnmarshalTemplate_LanguageVersion2SymbolicResources(t *testing.T) {
+	body := []byte(`{
+		"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+		"languageVersion": "2.0",
+		"contentVersion": "1.0.0.0",
+		"parameters": {
+			"vnetAddressPrefix": {
+				"type": "string",
+				"defaultValue": "10.0.0.0/16",
+				"metadata": {"description": "VNet CIDR"}
+			}
+		},
+		"resources": {
+			"virtualNetwork": {
+				"type": "Microsoft.Network/virtualNetworks",
+				"apiVersion": "2023-05-01",
+				"name": "[parameters('vnetName')]"
+			},
+			"identity": {
+				"type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+				"apiVersion": "2023-01-31",
+				"name": "myIdentity"
+			}
+		}
+	}`)
+
+	var tmpl armTemplateShape
+	if err := json.Unmarshal(body, &tmpl); err != nil {
+		t.Fatalf("expected languageVersion 2.0 template to parse, got: %v", err)
+	}
+
+	if tmpl.LanguageVersion != "2.0" {
+		t.Errorf("expected languageVersion 2.0, got %q", tmpl.LanguageVersion)
+	}
+	if len(tmpl.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(tmpl.Resources))
+	}
+	if _, ok := tmpl.Parameters["vnetAddressPrefix"]; !ok {
+		t.Error("expected vnetAddressPrefix parameter to be parsed")
+	}
+	if !tmpl.hasManagedIdentity() {
+		t.Error("expected hasManagedIdentity to detect the symbolic-name identity resource")
+	}
+
+	// Sorted by symbolic name, so identity precedes virtualNetwork.
+	if got := tmpl.Resources[0].symbolicName; got != "identity" {
+		t.Errorf("expected first resource symbolicName 'identity', got %q", got)
+	}
+}
+
+func TestUnmarshalTemplate_LanguageVersion1ArrayResources(t *testing.T) {
+	body := []byte(`{
+		"resources": [
+			{"type": "Microsoft.Network/virtualNetworks", "name": "myVnet"}
+		]
+	}`)
+
+	var tmpl armTemplateShape
+	if err := json.Unmarshal(body, &tmpl); err != nil {
+		t.Fatalf("expected array-form template to parse, got: %v", err)
+	}
+
+	if len(tmpl.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(tmpl.Resources))
+	}
+	if tmpl.Resources[0].symbolicName != "" {
+		t.Errorf("expected no symbolicName in array form, got %q", tmpl.Resources[0].symbolicName)
+	}
+}
+
+func TestValidateARMTemplate_SymbolicDependsOn(t *testing.T) {
+	body := []byte(`{
+		"languageVersion": "2.0",
+		"resources": {
+			"identity": {
+				"type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+				"name": "myIdentity"
+			},
+			"enableApis": {
+				"type": "Microsoft.Resources/deploymentScripts",
+				"name": "enableApis",
+				"dependsOn": ["identity"]
+			}
+		}
+	}`)
+
+	var tmpl armTemplateShape
+	if err := json.Unmarshal(body, &tmpl); err != nil {
+		t.Fatalf("failed to parse template: %v", err)
+	}
+
+	if err := validateARMTemplate(&tmpl); err != nil {
+		t.Fatalf("expected symbolic-name dependsOn to validate, got: %v", err)
+	}
+}
+
+func TestValidateARMTemplate_SymbolicDependsOnUnknown(t *testing.T) {
+	body := []byte(`{
+		"languageVersion": "2.0",
+		"resources": {
+			"enableApis": {
+				"type": "Microsoft.Resources/deploymentScripts",
+				"name": "enableApis",
+				"dependsOn": ["doesNotExist"]
+			}
+		}
+	}`)
+
+	var tmpl armTemplateShape
+	if err := json.Unmarshal(body, &tmpl); err != nil {
+		t.Fatalf("failed to parse template: %v", err)
+	}
+
+	err := validateARMTemplate(&tmpl)
+	if err == nil {
+		t.Fatal("expected validation error for unknown symbolic dependsOn reference")
+	}
+	if got := err.Error(); !contains(got, "doesNotExist") {
+		t.Errorf("unexpected error message: %s", got)
+	}
+}
+
+func TestUnmarshalTemplate_SymbolicInlineNestedResources(t *testing.T) {
+	body := []byte(`{
+		"languageVersion": "2.0",
+		"resources": {
+			"outer": {
+				"type": "Microsoft.Resources/deployments",
+				"name": "outer",
+				"properties": {
+					"template": {
+						"resources": {
+							"roleAssignment": {
+								"type": "Microsoft.Resources/deployments",
+								"name": "roleAssignment",
+								"subscriptionId": "[subscription().subscriptionId]"
+							}
+						}
+					}
+				}
+			}
+		}
+	}`)
+
+	var tmpl armTemplateShape
+	if err := json.Unmarshal(body, &tmpl); err != nil {
+		t.Fatalf("failed to parse template: %v", err)
+	}
+
+	err := validateARMTemplate(&tmpl)
+	if err == nil {
+		t.Fatal("expected validation error for subscription-level deployment in symbolic inline template")
+	}
+	if got := err.Error(); !contains(got, "roleAssignment") {
+		t.Errorf("unexpected error message: %s", got)
+	}
 }

--- a/services/ctl-api/internal/pkg/stacks/arm/testdata/vnet_languageversion_2.json
+++ b/services/ctl-api/internal/pkg/stacks/arm/testdata/vnet_languageversion_2.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.46.1.21595",
+      "templateHash": "16230692149418818205"
+    }
+  },
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    },
+    "nuonInstallID": {
+      "type": "string"
+    },
+    "vnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16"
+    }
+  },
+  "resources": {
+    "identity": {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2023-01-31",
+      "name": "[format('{0}-identity', parameters('nuonInstallID'))]",
+      "location": "[parameters('location')]"
+    },
+    "virtualNetwork": {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2023-05-01",
+      "name": "[format('{0}-vnet', parameters('nuonInstallID'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('vnetAddressPrefix')]"
+          ]
+        }
+      },
+      "dependsOn": [
+        "identity"
+      ]
+    }
+  },
+  "outputs": {
+    "identityPrincipalId": {
+      "type": "string",
+      "value": "[reference('identity').principalId]"
+    },
+    "networkName": {
+      "type": "string",
+      "value": "[format('{0}-vnet', parameters('nuonInstallID'))]"
+    }
+  }
+}


### PR DESCRIPTION
Azure-authored ARM templates declare `resources` as an object keyed by symbolic name rather than an array, which failed the whole unmarshal with `json: cannot unmarshal object into Go struct field armTemplateShape.resources` at the generate-install-stack step. Accepts both shapes and registers symbolic names for dependsOn validation so 2.0 templates don't trip false positives.