### PR TITLE
fix: provision deferred sync queues for both syncer.Run callers

### DIFF
--- a/services/ctl-api/internal/app/apps/signals/appconfigsync/activities.go
+++ b/services/ctl-api/internal/app/apps/signals/appconfigsync/activities.go
@@ -18,7 +18,6 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/apps/signals/syncappconfiginstalls"
 	componenthelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
 	configcreated "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/configcreated"
-	createdsignal "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/created"
 	updatecomponenttype "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/updatecomponenttype"
 	installhelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	runbookshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/runbooks/helpers"
@@ -111,16 +110,6 @@ func (a *Activities) applyAppConfig(ctx context.Context, req *ApplyAppConfigInpu
 		return nil, fmt.Errorf("unable to sync config: %w", err)
 	}
 
-	if err := a.provisionCreatedComponents(ctx, result.ComponentsCreated); err != nil {
-		return nil, err
-	}
-
-	for _, branchID := range result.AppBranchesCreated {
-		if err := a.deps.AppsHelpers.EnsureAppBranchQueues(ctx, branchID); err != nil {
-			return nil, fmt.Errorf("unable to create queues for app branch %s: %w", branchID, err)
-		}
-	}
-
 	toBuild := make([]ComponentToBuild, 0, len(result.ComponentsScheduled))
 	for _, cmp := range result.ComponentsScheduled {
 		toBuild = append(toBuild, ComponentToBuild{
@@ -136,36 +125,6 @@ func (a *Activities) applyAppConfig(ctx context.Context, req *ApplyAppConfigInpu
 		RunbookIDs:          result.RunbookIDs,
 		ComponentIDsToBuild: toBuild,
 	}, nil
-}
-
-// Runs post-commit: starting queue workflows inside the sync transaction would
-// leave them behind for components a rollback removed.
-func (a *Activities) provisionCreatedComponents(ctx context.Context, componentIDs []string) error {
-	for _, componentID := range componentIDs {
-		if _, err := a.deps.ComponentHelpers.EnsureComponentQueues(ctx, componentID); err != nil {
-			return fmt.Errorf("unable to create queues for component %s: %w", componentID, err)
-		}
-
-		q, err := a.queueClient.GetQueueByOwner(ctx, componentID, "components")
-		if err != nil {
-			return fmt.Errorf("unable to get queue for component %s: %w", componentID, err)
-		}
-
-		dedupeKey := fmt.Sprintf("component-created:%s", componentID)
-		if _, err := a.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
-			QueueID:   q.ID,
-			OwnerID:   componentID,
-			OwnerType: "components",
-			DedupeKey: &dedupeKey,
-			Signal: &createdsignal.Signal{
-				ComponentID: componentID,
-			},
-		}); err != nil {
-			return fmt.Errorf("unable to enqueue created signal for component %s: %w", componentID, err)
-		}
-	}
-
-	return nil
 }
 
 type FinalizeAppConfigSyncInput struct {

--- a/services/ctl-api/internal/pkg/config/syncer/run.go
+++ b/services/ctl-api/internal/pkg/config/syncer/run.go
@@ -16,10 +16,12 @@ import (
 	actionshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/actions/helpers"
 	appshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/helpers"
 	componenthelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/components/helpers"
+	createdsignal "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/created"
 	installhelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/helpers"
 	runbookshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/runbooks/helpers"
 	vcshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/vcs/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/config/syncer/triggers"
+	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/terraform"
 )
@@ -141,7 +143,49 @@ func Run(ctx context.Context, deps RunDeps, req RunRequest) (*RunResult, error) 
 		return nil, markSyncFailed(ctx, deps.DB, &appConfig, err)
 	}
 
+	if err := provisionDeferredQueues(ctx, deps, &result); err != nil {
+		return nil, markSyncFailed(ctx, deps.DB, &appConfig, err)
+	}
+
 	return &result, nil
+}
+
+// Queue creation starts Temporal workflows, so the sync transaction defers it to
+// here. It lives in Run rather than in each caller so no caller can skip it.
+func provisionDeferredQueues(ctx context.Context, deps RunDeps, result *RunResult) error {
+	queueClient := deps.ComponentHelpers.QueueClient()
+
+	for _, componentID := range result.ComponentsCreated {
+		if _, err := deps.ComponentHelpers.EnsureComponentQueues(ctx, componentID); err != nil {
+			return fmt.Errorf("unable to create queues for component %s: %w", componentID, err)
+		}
+
+		q, err := queueClient.GetQueueByOwner(ctx, componentID, "components")
+		if err != nil {
+			return fmt.Errorf("unable to get queue for component %s: %w", componentID, err)
+		}
+
+		dedupeKey := fmt.Sprintf("component-created:%s", componentID)
+		if _, err := queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID:   q.ID,
+			OwnerID:   componentID,
+			OwnerType: "components",
+			DedupeKey: &dedupeKey,
+			Signal: &createdsignal.Signal{
+				ComponentID: componentID,
+			},
+		}); err != nil {
+			return fmt.Errorf("unable to enqueue created signal for component %s: %w", componentID, err)
+		}
+	}
+
+	for _, branchID := range result.AppBranchesCreated {
+		if err := deps.AppsHelpers.EnsureAppBranchQueues(ctx, branchID); err != nil {
+			return fmt.Errorf("unable to create queues for app branch %s: %w", branchID, err)
+		}
+	}
+
+	return nil
 }
 
 func setStatus(ctx context.Context, db *gorm.DB, appConfig *app.AppConfig, status app.AppConfigStatus, description string) {


### PR DESCRIPTION
#2186 deferred component and app-branch queue creation out of the sync transaction, but only wired the post-commit provisioning into the appconfigsync caller. The app-branch sync path (`branches/activities/sync_app_config.go`) also calls `syncer.Run`, so components and branches it created got no queues and no created-signal. Moves provisioning into `Run` itself so neither caller can skip it.