### PR TITLE
fix: group runner health checks by install

### DIFF
--- a/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal.go
@@ -91,6 +91,12 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 
 	if runner.RunnerGroup.OwnerType == "installs" {
 		tags["install_id"] = runner.RunnerGroup.OwnerID
+		install, err := activities.LocalAwaitGetRunnerInstallByInstallID(ctx, runner.RunnerGroup.OwnerID)
+		if err != nil {
+			l.Warn("unable to add install name to runner health check metric", zap.Error(err))
+		} else {
+			tags["install_name"] = install.Name
+		}
 	}
 
 	if isSkippableStatus(runner.Status) {


### PR DESCRIPTION
## Summary

Runner health-check metrics now include the same `install_name` tag used by heartbeat and process-start metrics, allowing per-install monitors to group consistently.

## What stays the same

A failed install-name lookup does not block the health check or suppress its metric.
