### PR TITLE
fix: resolve component config connection when the signal has no pin

### DIFF
--- a/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentdeploysyncandplan/signal.go
@@ -123,11 +123,13 @@ func (s *Signal) Clone(ctx workflow.Context, stepName string) ([]signal.CloneSte
 	return []signal.CloneStepDef{
 		{
 			Signal: &Signal{
-				InstallComponentID: s.InstallComponentID,
-				InstallID:          s.InstallID,
-				ComponentID:        s.ComponentID,
-				SandboxMode:        s.SandboxMode,
-				Role:               s.Role,
+				InstallComponentID:          s.InstallComponentID,
+				InstallID:                   s.InstallID,
+				ComponentID:                 s.ComponentID,
+				BuildID:                     s.BuildID,
+				ComponentConfigConnectionID: s.ComponentConfigConnectionID,
+				SandboxMode:                 s.SandboxMode,
+				Role:                        s.Role,
 			},
 			Name:          stepName,
 			ExecutionType: "approval",
@@ -201,6 +203,27 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 	return nil
 }
 
+// not every caller pins the connection on the signal, so fall back to the one
+// this install's app config resolves to rather than failing the step
+func (s *Signal) configConnectionID(ctx workflow.Context, install *app.Install) (string, error) {
+	if s.ComponentConfigConnectionID != "" {
+		return s.ComponentConfigConnectionID, nil
+	}
+
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to get app config")
+	}
+
+	for _, ccc := range appCfg.ComponentConfigConnections {
+		if ccc.ComponentID == s.ComponentID {
+			return ccc.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("no component config connection for component %s in app config %s", s.ComponentID, install.AppConfigID)
+}
+
 func (s *Signal) Execute(ctx workflow.Context) error {
 	install, err := activities.AwaitGetInstallForInstallComponentByInstallComponentID(ctx, s.InstallComponentID)
 	if err != nil {
@@ -218,16 +241,17 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	} else {
 		buildID := s.BuildID
 		if buildID == "" {
-			if s.ComponentConfigConnectionID == "" {
-				return fmt.Errorf("unable to lookup build, component config connection id empty")
+			cccID, err := s.configConnectionID(ctx, install)
+			if err != nil {
+				return err
 			}
 
-			pinned, err := activities.AwaitGetComponentBuildForConfigConnectionByComponentConfigConnectionID(ctx, s.ComponentConfigConnectionID)
+			pinned, err := activities.AwaitGetComponentBuildForConfigConnectionByComponentConfigConnectionID(ctx, cccID)
 			if err != nil {
 				return fmt.Errorf("unable to get pinned component build: %w", err)
 			}
 			if pinned == nil {
-				return fmt.Errorf("no deployable build for component config connection %s", s.ComponentConfigConnectionID)
+				return fmt.Errorf("no deployable build for component config connection %s", cccID)
 			}
 			buildID = pinned.ID
 		}

--- a/services/ctl-api/internal/app/installs/signals/componentsyncimage/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentsyncimage/signal.go
@@ -91,6 +91,27 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 	return nil
 }
 
+// not every caller pins the connection on the signal, so fall back to the one
+// this install's app config resolves to rather than failing the step
+func (s *Signal) configConnectionID(ctx workflow.Context, install *app.Install) (string, error) {
+	if s.ComponentConfigConnectionID != "" {
+		return s.ComponentConfigConnectionID, nil
+	}
+
+	appCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to get app config")
+	}
+
+	for _, ccc := range appCfg.ComponentConfigConnections {
+		if ccc.ComponentID == s.ComponentID {
+			return ccc.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("no component config connection for component %s in app config %s", s.ComponentID, install.AppConfigID)
+}
+
 func (s *Signal) Execute(ctx workflow.Context) error {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
@@ -113,15 +134,16 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	} else {
 		buildID := s.BuildID
 		if buildID == "" {
-			if s.ComponentConfigConnectionID == "" {
-				return fmt.Errorf("unable to lookup builds, component config connection not provided")
+			cccID, err := s.configConnectionID(ctx, install)
+			if err != nil {
+				return err
 			}
-			pinned, err := activities.AwaitGetComponentBuildForConfigConnectionByComponentConfigConnectionID(ctx, s.ComponentConfigConnectionID)
+			pinned, err := activities.AwaitGetComponentBuildForConfigConnectionByComponentConfigConnectionID(ctx, cccID)
 			if err != nil {
 				return fmt.Errorf("unable to get pinned component build: %w", err)
 			}
 			if pinned == nil {
-				return fmt.Errorf("no deployable build for component config connection %s", s.ComponentConfigConnectionID)
+				return fmt.Errorf("no deployable build for component config connection %s", cccID)
 			}
 			buildID = pinned.ID
 		}

--- a/services/ctl-api/internal/app/installs/workflows/v2/run_runbook.go
+++ b/services/ctl-api/internal/app/installs/workflows/v2/run_runbook.go
@@ -88,6 +88,18 @@ func RunRunbook(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResu
 		enabledInputs = install.CurrentInstallInputs.Values
 	}
 
+	// pin the build lookup to the config this run was generated against, not
+	// whatever the install points at by the time the step executes
+	rbAppCfg, err := activities.AwaitGetAppConfigByID(ctx, install.AppConfigID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get app config")
+	}
+	cccIDByComp := make(map[string]string, len(rbAppCfg.ComponentConfigConnections))
+	for i := range rbAppCfg.ComponentConfigConnections {
+		ccc := &rbAppCfg.ComponentConfigConnections[i]
+		cccIDByComp[ccc.ComponentID] = ccc.ID
+	}
+
 	// Generate state
 	orgEnabled, err := activities.AwaitHasFeatureByFeature(ctx, string(app.OrgFeatureStateGenV2))
 	if err != nil {
@@ -111,7 +123,7 @@ func RunRunbook(ctx workflow.Context, flw *app.Workflow) (*app.GenerateStepsResu
 		stepWorkflow := runbookStepWorkflow(flw, &stepCfg)
 		switch stepCfg.Type {
 		case app.RunbookStepTypeComponentDeploy:
-			deploySteps, err := runbookDeploySteps(ctx, installID, &stepCfg, sg, stepWorkflow, enabledInputs)
+			deploySteps, err := runbookDeploySteps(ctx, installID, &stepCfg, sg, stepWorkflow, enabledInputs, cccIDByComp)
 			if err != nil {
 				return nil, errors.Wrapf(err, "unable to generate deploy step %s", stepCfg.Name)
 			}
@@ -159,7 +171,7 @@ func runbookStepWorkflow(flw *app.Workflow, stepCfg *app.RunbookStepConfig) *app
 	return &effective
 }
 
-func runbookDeploySteps(ctx workflow.Context, installID string, stepCfg *app.RunbookStepConfig, sg *stepGroup, flw *app.Workflow, enabledInputs map[string]*string) ([]*app.WorkflowStep, error) {
+func runbookDeploySteps(ctx workflow.Context, installID string, stepCfg *app.RunbookStepConfig, sg *stepGroup, flw *app.Workflow, enabledInputs map[string]*string, cccIDByComp map[string]string) ([]*app.WorkflowStep, error) {
 	// Find the primary component by name
 	component, err := activities.AwaitGetComponentByName(ctx, activities.GetComponentByNameRequest{
 		InstallID:     installID,
@@ -183,14 +195,14 @@ func runbookDeploySteps(ctx workflow.Context, installID string, stepCfg *app.Run
 		}
 
 		for _, compID := range componentIDs {
-			depSteps, err := runbookDeploySingleComponent(ctx, installID, compID, stepCfg.Name, sg, flw, enabledInputs)
+			depSteps, err := runbookDeploySingleComponent(ctx, installID, compID, stepCfg.Name, sg, flw, enabledInputs, cccIDByComp)
 			if err != nil {
 				return nil, errors.Wrapf(err, "unable to deploy dependent %s", compID)
 			}
 			result = append(result, depSteps...)
 		}
 	} else {
-		steps, err := runbookDeploySingleComponent(ctx, installID, component.ID, stepCfg.Name, sg, flw, enabledInputs)
+		steps, err := runbookDeploySingleComponent(ctx, installID, component.ID, stepCfg.Name, sg, flw, enabledInputs, cccIDByComp)
 		if err != nil {
 			return nil, err
 		}
@@ -200,7 +212,7 @@ func runbookDeploySteps(ctx workflow.Context, installID string, stepCfg *app.Run
 	return result, nil
 }
 
-func runbookDeploySingleComponent(ctx workflow.Context, installID, componentID, stepName string, sg *stepGroup, flw *app.Workflow, enabledInputs map[string]*string) ([]*app.WorkflowStep, error) {
+func runbookDeploySingleComponent(ctx workflow.Context, installID, componentID, stepName string, sg *stepGroup, flw *app.Workflow, enabledInputs map[string]*string, cccIDByComp map[string]string) ([]*app.WorkflowStep, error) {
 	installComp, err := activities.AwaitGetInstallComponent(ctx, activities.GetInstallComponentRequest{
 		InstallID:   installID,
 		ComponentID: componentID,
@@ -253,9 +265,10 @@ func runbookDeploySingleComponent(ctx workflow.Context, installID, componentID, 
 		}
 		sg.nextGroupNamed(fmt.Sprintf("deploy: %s (sync)", name))
 		syncStep, err := sg.installSignalStep(ctx, installID, fmt.Sprintf("sync %s", name), pgtype.Hstore{}, &componentsyncimage.Signal{
-			InstallComponentID: installComponentID,
-			ComponentID:        componentID,
-			Role:               flw.Role,
+			InstallComponentID:          installComponentID,
+			ComponentID:                 componentID,
+			ComponentConfigConnectionID: cccIDByComp[componentID],
+			Role:                        flw.Role,
 		}, flw.PlanOnly)
 		if err != nil {
 			return nil, err
@@ -264,10 +277,11 @@ func runbookDeploySingleComponent(ctx workflow.Context, installID, componentID, 
 	} else {
 		sg.nextGroupNamed(fmt.Sprintf("deploy: %s", name))
 		planStep, err := sg.installSignalStep(ctx, installID, fmt.Sprintf("sync and plan %s", name), pgtype.Hstore{}, &componentdeploysyncandplan.Signal{
-			InstallComponentID: installComponentID,
-			InstallID:          installID,
-			ComponentID:        componentID,
-			Role:               flw.Role,
+			InstallComponentID:          installComponentID,
+			InstallID:                   installID,
+			ComponentID:                 componentID,
+			ComponentConfigConnectionID: cccIDByComp[componentID],
+			Role:                        flw.Role,
 		}, flw.PlanOnly, WithSkippable(false))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
#2217 made `ComponentConfigConnectionID` mandatory for build lookup but only set it at the two call sites in `shared_helpers.go`, so runbook image syncs and component deploys fail non-retryably with `component config connection not provided` — already hit in prod. Sets the pin at both `run_runbook.go` call sites and carries it through the sync-and-plan clone so retries keep it. Also falls back to the connection the install's app config resolves to instead of erroring, so a future unpinned caller degrades rather than wedging the workflow.