### PR TITLE
fix: improve tail and API error handling

### DIFF
--- a/sdks/nuon-go/client/operations/log_stream_tail_logs_responses.go
+++ b/sdks/nuon-go/client/operations/log_stream_tail_logs_responses.go
@@ -61,6 +61,12 @@ func (o *LogStreamTailLogsReader) ReadResponse(response runtime.ClientResponse, 
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewLogStreamTailLogsServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("[GET /v1/log-streams/{log_stream_id}/logs/tail] LogStreamTailLogs", response, response.Code())
 	}
@@ -475,6 +481,76 @@ func (o *LogStreamTailLogsInternalServerError) GetPayload() *models.StderrErrRes
 }
 
 func (o *LogStreamTailLogsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.StderrErrResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && !stderrors.Is(err, io.EOF) {
+		return err
+	}
+
+	return nil
+}
+
+// NewLogStreamTailLogsServiceUnavailable creates a LogStreamTailLogsServiceUnavailable with default headers values
+func NewLogStreamTailLogsServiceUnavailable() *LogStreamTailLogsServiceUnavailable {
+	return &LogStreamTailLogsServiceUnavailable{}
+}
+
+/*
+LogStreamTailLogsServiceUnavailable describes a response with status code 503, with default header values.
+
+Service Unavailable
+*/
+type LogStreamTailLogsServiceUnavailable struct {
+	Payload *models.StderrErrResponse
+}
+
+// IsSuccess returns true when this log stream tail logs service unavailable response has a 2xx status code
+func (o *LogStreamTailLogsServiceUnavailable) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this log stream tail logs service unavailable response has a 3xx status code
+func (o *LogStreamTailLogsServiceUnavailable) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this log stream tail logs service unavailable response has a 4xx status code
+func (o *LogStreamTailLogsServiceUnavailable) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this log stream tail logs service unavailable response has a 5xx status code
+func (o *LogStreamTailLogsServiceUnavailable) IsServerError() bool {
+	return true
+}
+
+// IsCode returns true when this log stream tail logs service unavailable response a status code equal to that given
+func (o *LogStreamTailLogsServiceUnavailable) IsCode(code int) bool {
+	return code == 503
+}
+
+// Code gets the status code for the log stream tail logs service unavailable response
+func (o *LogStreamTailLogsServiceUnavailable) Code() int {
+	return 503
+}
+
+func (o *LogStreamTailLogsServiceUnavailable) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1/log-streams/{log_stream_id}/logs/tail][%d] logStreamTailLogsServiceUnavailable %s", 503, payload)
+}
+
+func (o *LogStreamTailLogsServiceUnavailable) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1/log-streams/{log_stream_id}/logs/tail][%d] logStreamTailLogsServiceUnavailable %s", 503, payload)
+}
+
+func (o *LogStreamTailLogsServiceUnavailable) GetPayload() *models.StderrErrResponse {
+	return o.Payload
+}
+
+func (o *LogStreamTailLogsServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.StderrErrResponse)
 

--- a/sdks/nuon-runner-go/client/operations/tail_runner_jobs_responses.go
+++ b/sdks/nuon-runner-go/client/operations/tail_runner_jobs_responses.go
@@ -61,6 +61,12 @@ func (o *TailRunnerJobsReader) ReadResponse(response runtime.ClientResponse, con
 			return nil, err
 		}
 		return nil, result
+	case 503:
+		result := NewTailRunnerJobsServiceUnavailable()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("[GET /v1/runners/{runner_id}/jobs/tail] TailRunnerJobs", response, response.Code())
 	}
@@ -473,6 +479,76 @@ func (o *TailRunnerJobsInternalServerError) GetPayload() *models.StderrErrRespon
 }
 
 func (o *TailRunnerJobsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.StderrErrResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && !stderrors.Is(err, io.EOF) {
+		return err
+	}
+
+	return nil
+}
+
+// NewTailRunnerJobsServiceUnavailable creates a TailRunnerJobsServiceUnavailable with default headers values
+func NewTailRunnerJobsServiceUnavailable() *TailRunnerJobsServiceUnavailable {
+	return &TailRunnerJobsServiceUnavailable{}
+}
+
+/*
+TailRunnerJobsServiceUnavailable describes a response with status code 503, with default header values.
+
+Service Unavailable
+*/
+type TailRunnerJobsServiceUnavailable struct {
+	Payload *models.StderrErrResponse
+}
+
+// IsSuccess returns true when this tail runner jobs service unavailable response has a 2xx status code
+func (o *TailRunnerJobsServiceUnavailable) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this tail runner jobs service unavailable response has a 3xx status code
+func (o *TailRunnerJobsServiceUnavailable) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this tail runner jobs service unavailable response has a 4xx status code
+func (o *TailRunnerJobsServiceUnavailable) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this tail runner jobs service unavailable response has a 5xx status code
+func (o *TailRunnerJobsServiceUnavailable) IsServerError() bool {
+	return true
+}
+
+// IsCode returns true when this tail runner jobs service unavailable response a status code equal to that given
+func (o *TailRunnerJobsServiceUnavailable) IsCode(code int) bool {
+	return code == 503
+}
+
+// Code gets the status code for the tail runner jobs service unavailable response
+func (o *TailRunnerJobsServiceUnavailable) Code() int {
+	return 503
+}
+
+func (o *TailRunnerJobsServiceUnavailable) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1/runners/{runner_id}/jobs/tail][%d] tailRunnerJobsServiceUnavailable %s", 503, payload)
+}
+
+func (o *TailRunnerJobsServiceUnavailable) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /v1/runners/{runner_id}/jobs/tail][%d] tailRunnerJobsServiceUnavailable %s", 503, payload)
+}
+
+func (o *TailRunnerJobsServiceUnavailable) GetPayload() *models.StderrErrResponse {
+	return o.Payload
+}
+
+func (o *TailRunnerJobsServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.StderrErrResponse)
 

--- a/services/ctl-api/internal/app/components/service/cancel_component_build.go
+++ b/services/ctl-api/internal/app/components/service/cancel_component_build.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 )
 
@@ -46,7 +47,10 @@ func (s *service) CancelAppComponentBuild(ctx *gin.Context) {
 	}
 
 	if bld.QueueSignal == nil {
-		ctx.Error(fmt.Errorf("build has no queue signal"))
+		ctx.Error(stderr.ErrConflict{
+			Err:         fmt.Errorf("build has no queue signal"),
+			Description: "this build cannot be cancelled because it is not queued",
+		})
 		return
 	}
 

--- a/services/ctl-api/internal/app/components/service/cancel_component_build_test.go
+++ b/services/ctl-api/internal/app/components/service/cancel_component_build_test.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+func (s *ComponentsServiceTestSuite) TestCancelAppComponentBuildWithoutQueueSignal() {
+	cmp := s.getSeededComponent(app.ComponentTypeHelmChart)
+	conn := s.getSeededConfigConnection(cmp.ID)
+	build := s.deps.Seeder.CreateComponentBuild(s.ctx, s.T(), conn.ID)
+
+	path := fmt.Sprintf("/v1/apps/%s/components/%s/builds/%s/cancel", s.testApp.ID, cmp.ID, build.ID)
+	rr := s.makeRequest(http.MethodPost, path, nil)
+
+	s.Require().Equal(http.StatusConflict, rr.Code, rr.Body.String())
+}

--- a/services/ctl-api/internal/app/orgs/service/admin_get_runner.go
+++ b/services/ctl-api/internal/app/orgs/service/admin_get_runner.go
@@ -1,9 +1,12 @@
 package service
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 )
 
 // @ID						AdminGetOrgRunner
@@ -22,6 +25,13 @@ func (s *service) AdminGetOrgRunner(ctx *gin.Context) {
 	org, err := s.adminGetOrg(ctx, nameOrID)
 	if err != nil {
 		ctx.Error(err)
+		return
+	}
+	if len(org.RunnerGroup.Runners) == 0 {
+		ctx.Error(stderr.ErrNotFound{
+			Err:         fmt.Errorf("org has no runner"),
+			Description: "no runner was found for this org",
+		})
 		return
 	}
 

--- a/services/ctl-api/internal/app/orgs/service/admin_get_runner_test.go
+++ b/services/ctl-api/internal/app/orgs/service/admin_get_runner_test.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+)
+
+func (s *AdminGetOrgTestSuite) TestAdminGetOrgRunnerWithoutRunner() {
+	ctx := cctx.SetAccountContext(context.Background(), s.testAcc)
+	org := &app.Org{
+		ID:          domains.NewOrgID(),
+		Name:        "org-without-runner",
+		SandboxMode: true,
+	}
+	s.Require().NoError(s.service.DB.WithContext(ctx).Create(org).Error)
+	s.Require().NoError(s.service.DB.WithContext(ctx).Create(&app.RunnerGroup{
+		ID:        domains.NewRunnerGroupID(),
+		OwnerID:   org.ID,
+		OwnerType: "orgs",
+	}).Error)
+
+	rr := s.makeRequest(http.MethodGet, "/v1/orgs/"+org.ID+"/admin-get-runner")
+
+	s.Require().Equal(http.StatusNotFound, rr.Code, rr.Body.String())
+}

--- a/services/ctl-api/internal/app/runners/service/get_runner_jobs_tail.go
+++ b/services/ctl-api/internal/app/runners/service/get_runner_jobs_tail.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -26,6 +27,8 @@ const (
 	jobTailBackstopInterval    = 5 * time.Second
 	jobTailMaxConcurrentProbes = 50
 	jobTailProbeQueryTimeout   = 2 * time.Second
+	jobTailErrorMinBackoff     = 250 * time.Millisecond
+	jobTailErrorMaxBackoff     = 1 * time.Second
 )
 
 var jobTailProbeSem = make(chan struct{}, jobTailMaxConcurrentProbes)
@@ -34,6 +37,7 @@ const (
 	metricJobTailHotProbeMs = "runner_job_tail.hot_probe_ms"
 	metricJobTailOutcome    = "runner_job_tail.outcome"
 	metricJobTailNotifyWake = "runner_job_tail.notify_wake_probe"
+	metricJobTailProbeError = "runner_job_tail.probe_error"
 )
 
 const (
@@ -60,6 +64,7 @@ const (
 // @Failure				403	{object}	stderr.ErrResponse
 // @Failure				404	{object}	stderr.ErrResponse
 // @Failure				500	{object}	stderr.ErrResponse
+// @Failure				503	{object}	stderr.ErrResponse
 // @Success				200	{array}		app.RunnerJob
 // @Router					/v1/runners/{runner_id}/jobs/tail [get]
 func (s *service) TailRunnerJobs(ctx *gin.Context) {
@@ -88,6 +93,7 @@ func (s *service) TailRunnerJobs(ctx *gin.Context) {
 	startedAt := time.Now()
 	deadline := startedAt.Add(wait)
 	firstIter := true
+	errorBackoff := jobTailErrorMinBackoff
 	// Subscribe BEFORE the first probe so a NOTIFY that fires between our probe
 	// and entering the select isn't missed — the buffered wake channel holds it
 	// and the next select drains it immediately.
@@ -98,10 +104,49 @@ func (s *service) TailRunnerJobs(ctx *gin.Context) {
 		probeStart := time.Now()
 		job, qerr := s.tailJobProbe(ctx.Request.Context(), runnerID, grp)
 		if qerr != nil {
-			s.emitJobTailExit(jobTailOutcomeError)
-			ctx.Error(errors.Wrap(qerr, "unable to probe runner job tail"))
-			return
+			s.mw.Count(metricJobTailProbeError, 1, nil)
+			if ctx.Request.Context().Err() != nil {
+				s.emitJobTailExit(jobTailOutcomeClientCancel)
+				return
+			}
+			if !isTransientTailProbeError(qerr) {
+				s.emitJobTailExit(jobTailOutcomeError)
+				ctx.Error(errors.Wrap(qerr, "unable to probe runner job tail"))
+				return
+			}
+
+			firstIter = false
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				s.emitJobTailExit(jobTailOutcomeError)
+				s.l.Warn("runner job tail probe retries exhausted", zap.Error(qerr))
+				writeTailUnavailable(ctx)
+				return
+			}
+
+			sleep := errorBackoff + jitter(errorBackoff)
+			if sleep > remaining {
+				sleep = remaining
+			}
+			select {
+			case <-ctx.Request.Context().Done():
+				s.emitJobTailExit(jobTailOutcomeClientCancel)
+				return
+			case <-time.After(sleep):
+			}
+			if time.Until(deadline) <= 0 {
+				s.emitJobTailExit(jobTailOutcomeError)
+				s.l.Warn("runner job tail probe retries exhausted", zap.Error(qerr))
+				writeTailUnavailable(ctx)
+				return
+			}
+			errorBackoff *= 2
+			if errorBackoff > jobTailErrorMaxBackoff {
+				errorBackoff = jobTailErrorMaxBackoff
+			}
+			continue
 		}
+		errorBackoff = jobTailErrorMinBackoff
 
 		if job != nil {
 			outcome := jobTailOutcomeIdleThenHit

--- a/services/ctl-api/internal/app/runners/service/log_stream_read_logs.go
+++ b/services/ctl-api/internal/app/runners/service/log_stream_read_logs.go
@@ -247,7 +247,7 @@ func (s *service) LogStreamReadLogs(ctx *gin.Context) {
 	if cursorStr != "" {
 		cursorVal, err := strconv.ParseInt(cursorStr, 10, 64)
 		if err != nil {
-			ctx.Error(errors.Wrap(err, "unable to parse pagination cursor"))
+			ctx.Error(stderr.NewInvalidRequest(errors.Wrap(err, "unable to parse pagination cursor")))
 			return
 		}
 		cursor = cursorVal

--- a/services/ctl-api/internal/app/runners/service/log_stream_read_logs_test.go
+++ b/services/ctl-api/internal/app/runners/service/log_stream_read_logs_test.go
@@ -382,6 +382,19 @@ func (s *LogStreamReadLogsTestSuite) TestLogStreamReadLogs() {
 			},
 		},
 		{
+			name: "invalid pagination cursor returns error",
+			setupFunc: func() string {
+				return s.testLogStream.ID
+			},
+			headers: map[string]string{
+				"X-Nuon-API-Offset": "not-an-offset",
+			},
+			expectedCode: http.StatusBadRequest,
+			validateFunc: func(logs []app.OtelLogRecord, headers http.Header) {
+				// Error response
+			},
+		},
+		{
 			name: "pagination with X-Nuon-API-Next header (ascending)",
 			setupFunc: func() string {
 				ctx := context.Background()

--- a/services/ctl-api/internal/app/runners/service/log_stream_tail_logs.go
+++ b/services/ctl-api/internal/app/runners/service/log_stream_tail_logs.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
@@ -53,7 +54,8 @@ const (
 	// run materially hotter (e.g. rows trickle in just often enough to
 	// keep resetting the backoff) this is where it shows before CH
 	// does.
-	metricTailProbe = "log_tail.probe"
+	metricTailProbe      = "log_tail.probe"
+	metricTailProbeError = "log_tail.probe_error"
 	// metricTailEmptyProbeMs — when CH had nothing to return, how
 	// long did the round-trip cost? Health of the idle path. Should
 	// sit in single-digit ms; a creeping p95 means CH is doing real
@@ -135,6 +137,7 @@ type LogStreamTailLogsResponse struct {
 // @Failure				403	{object}	stderr.ErrResponse
 // @Failure				404	{object}	stderr.ErrResponse
 // @Failure				500	{object}	stderr.ErrResponse
+// @Failure				503	{object}	stderr.ErrResponse
 // @Success				200	{object}	LogStreamTailLogsResponse
 // @Router					/v1/log-streams/{log_stream_id}/logs/tail [GET]
 func (s *service) LogStreamTailLogs(ctx *gin.Context) {
@@ -181,9 +184,47 @@ func (s *service) LogStreamTailLogs(ctx *gin.Context) {
 		probes++
 		s.mw.Count(metricTailProbe, 1, nil)
 		if qerr != nil {
-			s.emitTailExit(tailOutcomeError, startedAt, probes)
-			ctx.Error(errors.Wrap(qerr, "unable to probe log tail"))
-			return
+			s.mw.Count(metricTailProbeError, 1, nil)
+			if ctx.Request.Context().Err() != nil {
+				s.emitTailExit(tailOutcomeClientCancel, startedAt, probes)
+				return
+			}
+			if !isTransientTailProbeError(qerr) {
+				s.emitTailExit(tailOutcomeError, startedAt, probes)
+				ctx.Error(errors.Wrap(qerr, "unable to probe log tail"))
+				return
+			}
+
+			firstIter = false
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				s.emitTailExit(tailOutcomeError, startedAt, probes)
+				s.l.Warn("log tail probe retries exhausted", zap.Error(qerr))
+				writeTailUnavailable(ctx)
+				return
+			}
+
+			sleep := backoff + jitter(backoff)
+			if sleep > remaining {
+				sleep = remaining
+			}
+			select {
+			case <-ctx.Request.Context().Done():
+				s.emitTailExit(tailOutcomeClientCancel, startedAt, probes)
+				return
+			case <-time.After(sleep):
+			}
+			if time.Until(deadline) <= 0 {
+				s.emitTailExit(tailOutcomeError, startedAt, probes)
+				s.l.Warn("log tail probe retries exhausted", zap.Error(qerr))
+				writeTailUnavailable(ctx)
+				return
+			}
+			backoff *= 2
+			if backoff > tailMaxBackoff {
+				backoff = tailMaxBackoff
+			}
+			continue
 		}
 
 		if len(logs) > 0 {

--- a/services/ctl-api/internal/app/runners/service/log_stream_write_logs.go
+++ b/services/ctl-api/internal/app/runners/service/log_stream_write_logs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nuonco/nuon/pkg/metrics"
 	"github.com/nuonco/nuon/pkg/shortid/domains"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/kafka"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/otel"
@@ -53,7 +54,7 @@ func (s *service) LogStreamWriteLogs(ctx *gin.Context) {
 	// NOTE(fd): this is essentially our validation step. we do not use this object directly otherwise.
 	expreq := plogotlp.NewExportRequest()
 	if err := expreq.UnmarshalProto(byts); err != nil {
-		ctx.Error(fmt.Errorf("unable to unmarshal request: %w", err))
+		ctx.Error(stderr.NewInvalidRequest(fmt.Errorf("unable to unmarshal request: %w", err)))
 		return
 	}
 

--- a/services/ctl-api/internal/app/runners/service/log_stream_write_logs_test.go
+++ b/services/ctl-api/internal/app/runners/service/log_stream_write_logs_test.go
@@ -340,7 +340,7 @@ func (s *LogStreamWriteLogsTestSuite) TestLogStreamWriteLogs() {
 				body := s.buildInvalidOTLPRequest()
 				return s.testLogStream.ID, body
 			},
-			expectedCode: http.StatusInternalServerError,
+			expectedCode: http.StatusBadRequest,
 			validateFunc: func(logStreamID string) {
 				// No logs should be written
 				count := s.countLogsInCH(logStreamID)
@@ -445,7 +445,7 @@ func (s *LogStreamWriteLogsTestSuite) TestLogStreamWriteLogs() {
 			setupFunc: func() (string, []byte) {
 				return s.testLogStream.ID, []byte{}
 			},
-			expectedCode: http.StatusInternalServerError,
+			expectedCode: http.StatusBadRequest,
 			validateFunc: func(logStreamID string) {
 				// No logs should be written
 				count := s.countLogsInCH(logStreamID)

--- a/services/ctl-api/internal/app/runners/service/tail_errors.go
+++ b/services/ctl-api/internal/app/runners/service/tail_errors.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+)
+
+func writeTailUnavailable(ctx *gin.Context) {
+	ctx.Header("Retry-After", "1")
+	ctx.JSON(http.StatusServiceUnavailable, stderr.ErrResponse{
+		Error:       "service unavailable",
+		Description: "the backing store did not respond before the long-poll deadline; retry the request",
+	})
+}
+
+func isTransientTailProbeError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, driver.ErrBadConn) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && (netErr.Timeout() || netErr.Temporary()) {
+		return true
+	}
+
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return strings.HasPrefix(pgErr.Code, "08") ||
+		strings.HasPrefix(pgErr.Code, "53") ||
+		pgErr.Code == "57P01" ||
+		pgErr.Code == "57P02" ||
+		pgErr.Code == "57P03"
+}

--- a/services/ctl-api/internal/app/runners/service/tail_errors_test.go
+++ b/services/ctl-api/internal/app/runners/service/tail_errors_test.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsTransientTailProbeError(t *testing.T) {
+	tests := map[string]struct {
+		err       error
+		transient bool
+	}{
+		"deadline":             {err: context.DeadlineExceeded, transient: true},
+		"wrapped deadline":     {err: fmt.Errorf("query: %w", context.DeadlineExceeded), transient: true},
+		"bad connection":       {err: driver.ErrBadConn, transient: true},
+		"EOF":                  {err: io.EOF, transient: true},
+		"unexpected EOF":       {err: io.ErrUnexpectedEOF, transient: true},
+		"network timeout":      {err: &net.DNSError{IsTimeout: true}, transient: true},
+		"connection exception": {err: &pgconn.PgError{Code: "08006"}, transient: true},
+		"resource exhausted":   {err: &pgconn.PgError{Code: "53300"}, transient: true},
+		"database shutdown":    {err: &pgconn.PgError{Code: "57P01"}, transient: true},
+		"canceled":             {err: context.Canceled},
+		"query error":          {err: errors.New("column does not exist")},
+		"invalid SQL":          {err: &pgconn.PgError{Code: "42601"}},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.transient, isTransientTailProbeError(tt.err))
+		})
+	}
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/128_runner_job_available_tail_indexes.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/128_runner_job_available_tail_indexes.go
@@ -1,0 +1,25 @@
+package migrations
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+func (m *Migrations) Migration128RunnerJobAvailableTailIndexes(ctx context.Context, db *gorm.DB) error {
+	statements := []string{
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_runner_jobs_available_tail
+ON runner_jobs (runner_id, created_at DESC)
+WHERE deleted_at = 0 AND status = 'available'`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_runner_jobs_available_group_tail
+ON runner_jobs (runner_id, "group", created_at DESC)
+WHERE deleted_at = 0 AND status = 'available'`,
+	}
+
+	for _, statement := range statements {
+		if err := db.WithContext(ctx).Exec(statement).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/services/ctl-api/internal/pkg/db/psql/migrations/all.go
+++ b/services/ctl-api/internal/pkg/db/psql/migrations/all.go
@@ -184,5 +184,9 @@ func (m *Migrations) All() []migrations.Migration {
 			Name: "127-backfill-org-email-notifications",
 			Fn:   m.Migration127BackfillOrgEmailNotifications,
 		},
+		{
+			Name: "128-runner-job-available-tail-indexes",
+			Fn:   m.Migration128RunnerJobAvailableTailIndexes,
+		},
 	}
 }


### PR DESCRIPTION
## Summary

Runner tail requests now tolerate transient database failures. Known invalid or non-actionable API states return accurate HTTP statuses instead of false 500s.

## What you can do after this PR

**Keep log tailing and job pickup running through brief database interruptions.** Transient failures retry with jitter. Client disconnects exit silently, while exhausted retries return 503 with `Retry-After`.

**Receive actionable API errors.** Malformed log payloads and pagination cursors return 400, missing org runners return 404, and uncancellable builds return 409.

**Poll available runner jobs efficiently.** Partial indexes support both grouped and ungrouped job lookups.

## What stays the same

Permanent query errors still return 500. Successful and empty long polls retain their existing 200 responses.
