### PR TITLE
fix: route syncer helper writes through the sync transaction

### DIFF
--- a/services/ctl-api/internal/app/apps/helpers/create_app_branch_config.go
+++ b/services/ctl-api/internal/app/apps/helpers/create_app_branch_config.go
@@ -23,10 +23,7 @@ func (h *Helpers) CreateAppBranchConfig(
 	return h.CreateAppBranchConfigWithDB(ctx, h.db, appBranchID, connectedGithubVCSConfig, publicGitVCSConfig, installGroups, postDeployRunbookIDs)
 }
 
-// CreateAppBranchConfigWithDB is the transaction-aware form. Callers inside a
-// transaction must use it: the branch this config points at is often created in
-// the same transaction, and h.db cannot see it, so the insert fails the
-// app_branch_id foreign key.
+// Callers inside a transaction must use this, or the app_branch_id FK fails.
 func (h *Helpers) CreateAppBranchConfigWithDB(
 	ctx context.Context,
 	db *gorm.DB,

--- a/services/ctl-api/internal/app/apps/helpers/create_app_branch_config.go
+++ b/services/ctl-api/internal/app/apps/helpers/create_app_branch_config.go
@@ -20,8 +20,24 @@ func (h *Helpers) CreateAppBranchConfig(
 	installGroups []app.AppBranchInstallGroup,
 	postDeployRunbookIDs *[]string,
 ) (*app.AppBranchConfig, error) {
+	return h.CreateAppBranchConfigWithDB(ctx, h.db, appBranchID, connectedGithubVCSConfig, publicGitVCSConfig, installGroups, postDeployRunbookIDs)
+}
+
+// CreateAppBranchConfigWithDB is the transaction-aware form. Callers inside a
+// transaction must use it: the branch this config points at is often created in
+// the same transaction, and h.db cannot see it, so the insert fails the
+// app_branch_id foreign key.
+func (h *Helpers) CreateAppBranchConfigWithDB(
+	ctx context.Context,
+	db *gorm.DB,
+	appBranchID string,
+	connectedGithubVCSConfig *app.ConnectedGithubVCSConfig,
+	publicGitVCSConfig *app.PublicGitVCSConfig,
+	installGroups []app.AppBranchInstallGroup,
+	postDeployRunbookIDs *[]string,
+) (*app.AppBranchConfig, error) {
 	if postDeployRunbookIDs != nil && len(*postDeployRunbookIDs) > 0 {
-		if err := h.validatePostDeployRunbooks(ctx, appBranchID, *postDeployRunbookIDs); err != nil {
+		if err := h.validatePostDeployRunbooks(ctx, db, appBranchID, *postDeployRunbookIDs); err != nil {
 			return nil, err
 		}
 	}
@@ -34,7 +50,7 @@ func (h *Helpers) CreateAppBranchConfig(
 	}
 
 	var previous app.AppBranchConfig
-	res := h.db.WithContext(ctx).
+	res := db.WithContext(ctx).
 		Where(app.AppBranchConfig{AppBranchID: appBranchID}).
 		Order("created_at DESC").
 		First(&previous)
@@ -57,7 +73,7 @@ func (h *Helpers) CreateAppBranchConfig(
 		config.PostDeployRunbookIDs = previous.PostDeployRunbookIDs
 	}
 
-	if err := h.db.WithContext(ctx).Create(&config).Error; err != nil {
+	if err := db.WithContext(ctx).Create(&config).Error; err != nil {
 		return nil, fmt.Errorf("unable to create app branch config: %w", err)
 	}
 
@@ -67,14 +83,14 @@ func (h *Helpers) CreateAppBranchConfig(
 // validatePostDeployRunbooks rejects runbook IDs that don't belong to the branch's
 // app. Every caller passes through here, so a bad ID fails at config time rather
 // than mid-rollout.
-func (h *Helpers) validatePostDeployRunbooks(ctx context.Context, appBranchID string, runbookIDs []string) error {
+func (h *Helpers) validatePostDeployRunbooks(ctx context.Context, db *gorm.DB, appBranchID string, runbookIDs []string) error {
 	var branch app.AppBranch
-	if err := h.db.WithContext(ctx).First(&branch, "id = ?", appBranchID).Error; err != nil {
+	if err := db.WithContext(ctx).First(&branch, "id = ?", appBranchID).Error; err != nil {
 		return fmt.Errorf("unable to find app branch: %w", err)
 	}
 
 	var found []app.Runbook
-	if err := h.db.WithContext(ctx).
+	if err := db.WithContext(ctx).
 		Where(app.Runbook{AppID: branch.AppID}).
 		Where("id IN ?", runbookIDs).
 		Find(&found).Error; err != nil {

--- a/services/ctl-api/internal/app/apps/signals/appconfigsync/activities.go
+++ b/services/ctl-api/internal/app/apps/signals/appconfigsync/activities.go
@@ -89,8 +89,12 @@ type ComponentToBuild struct {
 	Type        app.ComponentType `json:"type"`
 }
 
+// Capped: the app sync queue runs one signal at a time, so an unbounded retry blocks every later sync.
+//
 // @temporal-gen-v2 activity
 // @start-to-close-timeout 10m
+// @schedule-to-close-timeout 30m
+// @max-retries 3
 // @as-wrapper
 func (a *Activities) applyAppConfig(ctx context.Context, req *ApplyAppConfigInput) (*ApplyAppConfigOutput, error) {
 	result, err := syncer.Run(ctx, a.deps, syncer.RunRequest{
@@ -139,6 +143,8 @@ type FinalizeAppConfigSyncInput struct {
 //
 // @temporal-gen-v2 activity
 // @start-to-close-timeout 1m
+// @schedule-to-close-timeout 5m
+// @max-retries 3
 // @as-wrapper
 func (a *Activities) finalizeAppConfigSync(ctx context.Context, req *FinalizeAppConfigSyncInput) error {
 	var appConfig app.AppConfig
@@ -189,6 +195,8 @@ type DispatchComponentBuildsInput struct {
 //
 // @temporal-gen-v2 activity
 // @start-to-close-timeout 5m
+// @schedule-to-close-timeout 15m
+// @max-retries 3
 // @as-wrapper
 func (a *Activities) dispatchComponentBuilds(ctx context.Context, req *DispatchComponentBuildsInput) error {
 	for _, cmp := range req.Components {

--- a/services/ctl-api/internal/app/components/helpers/component_dependencies.go
+++ b/services/ctl-api/internal/app/components/helpers/component_dependencies.go
@@ -32,10 +32,7 @@ func (h *Helpers) CreateComponentDependencies(ctx context.Context, compID string
 	return h.CreateComponentDependenciesWithDB(ctx, h.db, compID, dependencyIDs)
 }
 
-// CreateComponentDependenciesWithDB is the transaction-aware form. Callers inside
-// a transaction must use it: both sides of the dependency are often created in the
-// same transaction, and h.db cannot see them, so the insert fails the component
-// foreign keys.
+// Callers inside a transaction must use this, or the component FKs fail.
 func (h *Helpers) CreateComponentDependenciesWithDB(ctx context.Context, db *gorm.DB, compID string, dependencyIDs []string) error {
 	if len(dependencyIDs) < 1 {
 		return nil

--- a/services/ctl-api/internal/app/components/helpers/component_dependencies.go
+++ b/services/ctl-api/internal/app/components/helpers/component_dependencies.go
@@ -4,13 +4,19 @@ import (
 	"context"
 	"fmt"
 
+	"gorm.io/gorm"
+
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
 
 func (h *Helpers) ClearComponentDependencies(ctx context.Context, compID string) error {
+	return h.ClearComponentDependenciesWithDB(ctx, h.db, compID)
+}
+
+func (h *Helpers) ClearComponentDependenciesWithDB(ctx context.Context, db *gorm.DB, compID string) error {
 	// clear dependencies
 	compDep := app.ComponentDependency{}
-	res := h.db.WithContext(ctx).
+	res := db.WithContext(ctx).
 		Unscoped().
 		Delete(&compDep, "component_id = ?", compID)
 	if res.Error != nil {
@@ -23,6 +29,14 @@ func (h *Helpers) ClearComponentDependencies(ctx context.Context, compID string)
 // NOTE: GORM does not support callbacks when using a custom join table on many2many relationships + associations mode,
 // so this is a helper used to create component dependencies
 func (h *Helpers) CreateComponentDependencies(ctx context.Context, compID string, dependencyIDs []string) error {
+	return h.CreateComponentDependenciesWithDB(ctx, h.db, compID, dependencyIDs)
+}
+
+// CreateComponentDependenciesWithDB is the transaction-aware form. Callers inside
+// a transaction must use it: both sides of the dependency are often created in the
+// same transaction, and h.db cannot see them, so the insert fails the component
+// foreign keys.
+func (h *Helpers) CreateComponentDependenciesWithDB(ctx context.Context, db *gorm.DB, compID string, dependencyIDs []string) error {
 	if len(dependencyIDs) < 1 {
 		return nil
 	}
@@ -36,7 +50,7 @@ func (h *Helpers) CreateComponentDependencies(ctx context.Context, compID string
 		})
 	}
 
-	res := h.db.WithContext(ctx).
+	res := db.WithContext(ctx).
 		Create(&deps)
 	if res.Error != nil {
 		return res.Error

--- a/services/ctl-api/internal/app/components/helpers/get_component_by_name.go
+++ b/services/ctl-api/internal/app/components/helpers/get_component_by_name.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"gorm.io/gorm"
+
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -26,12 +28,19 @@ func (s *Helpers) GetComponentByName(ctx context.Context, appID, name string) (*
 }
 
 func (s *Helpers) GetComponentIDs(ctx context.Context, appID string, comps []string) ([]string, error) {
+	return s.GetComponentIDsWithDB(ctx, s.db, appID, comps)
+}
+
+// GetComponentIDsWithDB is the transaction-aware form. Callers inside a
+// transaction must use it, or components created earlier in that transaction
+// resolve as "not created yet".
+func (s *Helpers) GetComponentIDsWithDB(ctx context.Context, db *gorm.DB, appID string, comps []string) ([]string, error) {
 	if len(comps) == 0 {
 		return []string{}, nil
 	}
 
 	var components []app.Component
-	res := s.db.WithContext(ctx).
+	res := db.WithContext(ctx).
 		Select("id").
 		Where("app_id = ?", appID).
 		Where("name IN ? OR id IN ?", comps, comps).

--- a/services/ctl-api/internal/app/components/helpers/get_component_by_name.go
+++ b/services/ctl-api/internal/app/components/helpers/get_component_by_name.go
@@ -31,9 +31,7 @@ func (s *Helpers) GetComponentIDs(ctx context.Context, appID string, comps []str
 	return s.GetComponentIDsWithDB(ctx, s.db, appID, comps)
 }
 
-// GetComponentIDsWithDB is the transaction-aware form. Callers inside a
-// transaction must use it, or components created earlier in that transaction
-// resolve as "not created yet".
+// Callers inside a transaction must use this, or in-transaction components read as missing.
 func (s *Helpers) GetComponentIDsWithDB(ctx context.Context, db *gorm.DB, appID string, comps []string) ([]string, error) {
 	if len(comps) == 0 {
 		return []string{}, nil

--- a/services/ctl-api/internal/pkg/config/syncer/branches/sync.go
+++ b/services/ctl-api/internal/pkg/config/syncer/branches/sync.go
@@ -230,7 +230,7 @@ func syncSingleBranch(ctx context.Context, db *gorm.DB, appsHelper *appshelpers.
 
 	// Config-as-code is declarative: no post_deploy_runbooks in the TOML means
 	// none, so always pass a non-nil pointer rather than inheriting.
-	if _, err := appsHelper.CreateAppBranchConfig(ctx, branchID, connectedGithubVCSConfig, publicGitVCSConfig, installGroups, &postDeployRunbookIDs); err != nil {
+	if _, err := appsHelper.CreateAppBranchConfigWithDB(ctx, db, branchID, connectedGithubVCSConfig, publicGitVCSConfig, installGroups, &postDeployRunbookIDs); err != nil {
 		return sync.SyncInternalErr{
 			Description: fmt.Sprintf("unable to create config for branch %q", branchCfg.Name),
 			Err:         err,

--- a/services/ctl-api/internal/pkg/config/syncer/build_dispatch_test.go
+++ b/services/ctl-api/internal/pkg/config/syncer/build_dispatch_test.go
@@ -3,6 +3,8 @@ package syncer
 import (
 	"context"
 
+	"gorm.io/gorm"
+
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	testseedconfig "github.com/nuonco/nuon/services/ctl-api/tests/testseed/config"
@@ -13,22 +15,28 @@ import (
 func (s *SyncFieldsTestSuite) syncWithBuildDispatch(ctx context.Context, appID string, cfg *config.AppConfig) *app.AppConfig {
 	appCfg := s.deps.Seed.CreateBareAppConfig(ctx, s.T(), appID)
 
-	syncer := NewDBSyncer(
-		s.deps.DB,
-		s.deps.AppsHelpers,
-		s.deps.ComponentHelpers,
-		s.deps.ActionsHelpers,
-		s.deps.RunbooksHelpers,
-		s.deps.InstallHelpers,
-		s.deps.VCSHelpers,
-		s.deps.TFClient,
-		appID,
-		cfg,
-		appCfg.ID,
-		WithComponentBuildDispatch(),
-	)
-	s.Require().NoError(syncer.Sync(ctx), "sync should succeed")
-	s.scheduled = syncer.GetComponentsScheduled()
+	err := s.deps.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		syncer := NewDBSyncer(
+			tx,
+			s.deps.AppsHelpers,
+			s.deps.ComponentHelpers,
+			s.deps.ActionsHelpers,
+			s.deps.RunbooksHelpers,
+			s.deps.InstallHelpers,
+			s.deps.VCSHelpers,
+			s.deps.TFClient,
+			appID,
+			cfg,
+			appCfg.ID,
+			WithComponentBuildDispatch(),
+		)
+		if err := syncer.Sync(ctx); err != nil {
+			return err
+		}
+		s.scheduled = syncer.GetComponentsScheduled()
+		return nil
+	})
+	s.Require().NoError(err, "sync should succeed")
 
 	return appCfg
 }

--- a/services/ctl-api/internal/pkg/config/syncer/components/sync.go
+++ b/services/ctl-api/internal/pkg/config/syncer/components/sync.go
@@ -112,7 +112,7 @@ func SyncComponent(ctx context.Context, params SyncComponentParams) error {
 
 	depIDs := []string{}
 	if len(comp.Dependencies) > 0 {
-		depIDs, err = helpers.GetComponentIDs(ctx, appID, comp.Dependencies)
+		depIDs, err = helpers.GetComponentIDsWithDB(ctx, db, appID, comp.Dependencies)
 		if err != nil {
 			return sync.SyncInternalErr{
 				Description: fmt.Sprintf("unable to resolve dependencies for component %s", comp.Name),
@@ -416,7 +416,7 @@ func EnsureComponentDependencies(ctx context.Context, db *gorm.DB, helpers *comp
 		}
 	}
 
-	depIDs, err := helpers.GetComponentIDs(ctx, appID, comp.Dependencies)
+	depIDs, err := helpers.GetComponentIDsWithDB(ctx, db, appID, comp.Dependencies)
 	if err != nil {
 		return sync.SyncInternalErr{
 			Description: fmt.Sprintf("unable to resolve dependencies for component %s", comp.Name),
@@ -424,14 +424,14 @@ func EnsureComponentDependencies(ctx context.Context, db *gorm.DB, helpers *comp
 		}
 	}
 
-	if err := helpers.ClearComponentDependencies(ctx, apiComp.ID); err != nil {
+	if err := helpers.ClearComponentDependenciesWithDB(ctx, db, apiComp.ID); err != nil {
 		return sync.SyncInternalErr{
 			Description: fmt.Sprintf("unable to clear existing dependencies for component %s", comp.Name),
 			Err:         err,
 		}
 	}
 
-	if err := helpers.CreateComponentDependencies(ctx, apiComp.ID, depIDs); err != nil {
+	if err := helpers.CreateComponentDependenciesWithDB(ctx, db, apiComp.ID, depIDs); err != nil {
 		return sync.SyncInternalErr{
 			Description: fmt.Sprintf("unable to create dependencies for component %s", comp.Name),
 			Err:         err,

--- a/services/ctl-api/internal/pkg/config/syncer/sync_fields_test.go
+++ b/services/ctl-api/internal/pkg/config/syncer/sync_fields_test.go
@@ -123,10 +123,7 @@ func (s *SyncFieldsTestSuite) syncEmpty() (context.Context, *app.App, *app.AppCo
 
 // syncInto runs the branch-sync path — build dispatch off — into a fresh app
 // config on an existing app.
-//
-// The transaction mirrors Run: every step shares one handle, so a helper that
-// writes or reads through its own *gorm.DB instead fails here the way it fails
-// in production.
+// The transaction mirrors Run, so a helper that bypasses it fails here too.
 func (s *SyncFieldsTestSuite) syncInto(ctx context.Context, appID string, cfg *config.AppConfig) *app.AppConfig {
 	appCfg := s.deps.Seed.CreateBareAppConfig(ctx, s.T(), appID)
 

--- a/services/ctl-api/internal/pkg/config/syncer/sync_fields_test.go
+++ b/services/ctl-api/internal/pkg/config/syncer/sync_fields_test.go
@@ -123,23 +123,30 @@ func (s *SyncFieldsTestSuite) syncEmpty() (context.Context, *app.App, *app.AppCo
 
 // syncInto runs the branch-sync path — build dispatch off — into a fresh app
 // config on an existing app.
+//
+// The transaction mirrors Run: every step shares one handle, so a helper that
+// writes or reads through its own *gorm.DB instead fails here the way it fails
+// in production.
 func (s *SyncFieldsTestSuite) syncInto(ctx context.Context, appID string, cfg *config.AppConfig) *app.AppConfig {
 	appCfg := s.deps.Seed.CreateBareAppConfig(ctx, s.T(), appID)
 
-	syncer := NewDBSyncer(
-		s.deps.DB,
-		s.deps.AppsHelpers,
-		s.deps.ComponentHelpers,
-		s.deps.ActionsHelpers,
-		s.deps.RunbooksHelpers,
-		s.deps.InstallHelpers,
-		s.deps.VCSHelpers,
-		s.deps.TFClient,
-		appID,
-		cfg,
-		appCfg.ID,
-	)
-	s.Require().NoError(syncer.Sync(ctx), "sync should succeed")
+	err := s.deps.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		syncer := NewDBSyncer(
+			tx,
+			s.deps.AppsHelpers,
+			s.deps.ComponentHelpers,
+			s.deps.ActionsHelpers,
+			s.deps.RunbooksHelpers,
+			s.deps.InstallHelpers,
+			s.deps.VCSHelpers,
+			s.deps.TFClient,
+			appID,
+			cfg,
+			appCfg.ID,
+		)
+		return syncer.Sync(ctx)
+	})
+	s.Require().NoError(err, "sync should succeed")
 
 	return appCfg
 }

--- a/services/ctl-api/internal/pkg/config/syncer/tx_test.go
+++ b/services/ctl-api/internal/pkg/config/syncer/tx_test.go
@@ -1,0 +1,65 @@
+package syncer
+
+import (
+	"github.com/nuonco/nuon/pkg/config"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	testseedconfig "github.com/nuonco/nuon/services/ctl-api/tests/testseed/config"
+)
+
+// The sync steps run inside one transaction (see Run), so every write and every
+// read has to go through that handle. A helper that falls back to its own
+// *gorm.DB cannot see rows the sync just created, which surfaces as a foreign
+// key violation rather than as missing data.
+func (s *SyncFieldsTestSuite) TestNewBranchGetsAConfig() {
+	cfg := testseedconfig.BuildMinimalAppConfig()
+	cfg.Branches = []*config.AppBranchConfig{
+		{
+			Name: "main",
+			PublicRepo: &config.PublicRepoConfig{
+				Repo:      "https://github.com/nuonco/example",
+				Directory: "/",
+				Branch:    "main",
+			},
+		},
+	}
+
+	ctx, testApp, _ := s.sync(cfg)
+
+	var branch app.AppBranch
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.AppBranch{AppID: testApp.ID, Name: "main"}).
+		First(&branch).Error, "branch must be created")
+
+	var branchCfg app.AppBranchConfig
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Preload("PublicGitVCSConfig").
+		Where(app.AppBranchConfig{AppBranchID: branch.ID}).
+		First(&branchCfg).Error, "branch config must be created")
+
+	s.Require().NotNil(branchCfg.PublicGitVCSConfig)
+	s.Equal("https://github.com/nuonco/example", branchCfg.PublicGitVCSConfig.Repo)
+}
+
+func (s *SyncFieldsTestSuite) TestNewComponentDependenciesArePersisted() {
+	cfg := testseedconfig.BuildMinimalAppConfig()
+	base := testseedconfig.BuildJobComponent("base")
+	dependent := testseedconfig.BuildJobComponent("dependent")
+	dependent.Dependencies = []string{"base"}
+	cfg.Components = config.ComponentList{base, dependent}
+
+	ctx, testApp, _ := s.sync(cfg)
+
+	var baseComp, dependentComp app.Component
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.Component{AppID: testApp.ID, Name: "base"}).First(&baseComp).Error)
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.Component{AppID: testApp.ID, Name: "dependent"}).First(&dependentComp).Error)
+
+	var deps []app.ComponentDependency
+	s.Require().NoError(s.deps.DB.WithContext(ctx).
+		Where(app.ComponentDependency{ComponentID: dependentComp.ID}).
+		Find(&deps).Error)
+
+	s.Require().Len(deps, 1, "dependency on a component created in the same sync must be persisted")
+	s.Equal(baseComp.ID, deps[0].DependencyID)
+}

--- a/services/ctl-api/internal/pkg/config/syncer/tx_test.go
+++ b/services/ctl-api/internal/pkg/config/syncer/tx_test.go
@@ -6,10 +6,7 @@ import (
 	testseedconfig "github.com/nuonco/nuon/services/ctl-api/tests/testseed/config"
 )
 
-// The sync steps run inside one transaction (see Run), so every write and every
-// read has to go through that handle. A helper that falls back to its own
-// *gorm.DB cannot see rows the sync just created, which surfaces as a foreign
-// key violation rather than as missing data.
+// A helper that bypasses the sync transaction fails the foreign key instead of seeing the new rows.
 func (s *SyncFieldsTestSuite) TestNewBranchGetsAConfig() {
 	cfg := testseedconfig.BuildMinimalAppConfig()
 	cfg.Branches = []*config.AppBranchConfig{


### PR DESCRIPTION
#2186 wrapped the app config sync in one transaction, but `CreateAppBranchConfig`, `GetComponentIDs` and the component dependency helpers still used their own `*gorm.DB`, so they could not see rows the sync had just created. Adding a new app branch failed with `violates foreign key constraint` and adding a component with dependencies failed with `some components not created yet`; both now take the transaction, matching the existing `WithDB` helpers.

Also bounds the sync activity's retries. It was unlimited attempts over 24h, and since the app's sync queue runs one signal at a time, a failed sync held the only in-flight slot for a day and every later sync for that app hung instead of erroring.

Verified against the dev stack with a real config (branch with a public repo, a component with a dependency, an action): reproduced both errors on main, both sync clean on this branch, and a failed sync now releases the queue in ~8s so the next sync succeeds. The syncer test harness now runs the sync inside a transaction, which is why these were invisible to it before.