### PR TITLE
fix: read runner heartbeat from the pre-aggregated view and allow retries

### DIFF
--- a/services/ctl-api/internal/app/runners/worker/activities/get_most_recent_heart_beat.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_most_recent_heart_beat.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
@@ -16,7 +15,7 @@ type GetMostRecentHeartBeatRequest struct {
 }
 
 // @temporal-gen-v2 activity
-// @max-retries 1
+// @max-retries 5
 // @by-field RunnerID
 func (a *Activities) GetMostRecentHeartBeatRequest(ctx context.Context, req GetMostRecentHeartBeatRequest) (*app.RunnerHeartBeat, error) {
 	hb, err := a.getMostRecentHeartBeat(ctx, req.RunnerID, req.Process)
@@ -45,23 +44,31 @@ func (a *Activities) getMostRecentHeartBeat(ctx context.Context, runnerID string
 }
 
 func (a *Activities) queryHeartBeat(ctx context.Context, runnerID string, process app.RunnerProcessType) (*app.RunnerHeartBeat, error) {
-	var hb app.RunnerHeartBeat
+	var latest []*app.LatestRunnerHeartBeat
 	db := a.chDB.WithContext(ctx).
 		Where("runner_id = ?", runnerID)
 	if process != "" {
 		db = db.Where("process = ?", process)
 	}
-	res := db.
-		Order("created_at desc").
-		Limit(1).
-		First(&hb)
-	if res.Error != nil {
-		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
 
+	res := db.
+		Order("created_at_latest desc").
+		Limit(1).
+		Find(&latest)
+	if res.Error != nil {
 		return nil, errors.Wrap(res.Error, "unable to get heart beats")
 	}
+	if len(latest) == 0 {
+		return nil, nil
+	}
 
-	return &hb, nil
+	return &app.RunnerHeartBeat{
+		RunnerID:  latest[0].RunnerID,
+		ProcessID: latest[0].ProcessID,
+		Process:   latest[0].Process,
+		Version:   latest[0].Version,
+		AliveTime: latest[0].AliveTime,
+		CreatedAt: latest[0].CreatedAt,
+		StartedAt: latest[0].StartedAt,
+	}, nil
 }

--- a/services/ctl-api/internal/app/runners/worker/activities/get_most_recent_heart_beat.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_most_recent_heart_beat.go
@@ -69,6 +69,6 @@ func (a *Activities) queryHeartBeat(ctx context.Context, runnerID string, proces
 		Version:   latest[0].Version,
 		AliveTime: latest[0].AliveTime,
 		CreatedAt: latest[0].CreatedAt,
-		StartedAt: latest[0].StartedAt,
+		StartedAt: latest[0].CreatedAt.Add(-1 * latest[0].AliveTime),
 	}, nil
 }


### PR DESCRIPTION
`GetMostRecentHeartBeatRequest` scanned the raw `runner_heart_beats` table with a runner-only filter, where `created_at` is the third key column so `ORDER BY created_at DESC LIMIT 1` cannot be served from key order. Measured on prod: 157,810 rows read vs 1,602 from the existing `latest_runner_heart_beats_mv_v3` view, which already backs `GET /v1/runners/:id/heart-beats/latest`. Also drops `@max-retries 1`, which made a single transient stall in this monitoring lookup non-retryable and reported a completed deploy as a failed job.

The timeout that prompted this is not explained by query cost — prod runs the old query in 45-73ms. Prod sets `CLICKHOUSE_DB_READ_TIMEOUT=600s` (code default is 10s) against a 60s activity StartToClose, so a stalled read can block 10x past the activity's own budget; that inversion needs a separate config decision.