### PR TITLE
feat: nuon app sync branch

### DIFF
--- a/bins/cli/AGENTS.md
+++ b/bins/cli/AGENTS.md
@@ -395,13 +395,13 @@ All config-to-database conversion lives server-side in `services/ctl-api/interna
 config knowledge to the CLI beyond parsing and validation** — a client-side syncer (`pkg/config/sync/apisyncer`) is
 exactly what this replaced, after it silently drifted from the server's conversion for months.
 
-#### The app branch path (`app-branch-sync`)
+#### The app branch path (`default-app-branches`)
 
-When the org has the `app-branch-sync` feature flag on, or the user passes `--branch` / `--app-branch`, the sync
+When the org has the `default-app-branches` feature flag on, or the user passes `--branch` / `--app-branch`, the sync
 routes through an app branch run instead (`internal/services/apps/sync_branch.go`). This path adds **no** endpoints of
 its own:
 
-1. `GET /v1/orgs/current` for the flag, then `GET /v1/apps/:app_id/branches` for a branch named `sync-default`. On the first
+1. `GET /v1/orgs/current` for the flag, then `GET /v1/apps/:app_id/branches` for a branch named `default`. On the first
    sync it does not exist yet, so `POST /v1/apps/:app_id/branches` creates it and
    `POST /v1/apps/:app_id/branches/:branch_id/configs` gives it a single `all_installs` install group. A name collision
    on create means a concurrent sync won the race, so re-list and use theirs.

--- a/bins/cli/internal/services/apps/sync_branch.go
+++ b/bins/cli/internal/services/apps/sync_branch.go
@@ -23,13 +23,13 @@ const (
 
 	defaultBranchRunPoll = time.Second * 5
 
-	appBranchSyncFeature    = "app-branch-sync"
-	defaultAppBranchName    = "sync-default"
-	defaultInstallGroupName = "all installs"
+	defaultAppBranchesFeature = "default-app-branches"
+	defaultAppBranchName      = "default"
+	defaultInstallGroupName   = "all installs"
 )
 
 // resolveDefaultBranchID returns the app's default branch when the org has
-// app-branch-sync enabled, creating it if this is the first sync, or "" to leave
+// default-app-branches enabled, creating it if this is the first sync, or "" to leave
 // the sync on the standalone path.
 //
 // The branch is created here rather than as a side effect of POST /configs so an
@@ -41,7 +41,7 @@ func (s *Service) resolveDefaultBranchID(ctx context.Context, appID string) (str
 	if err != nil {
 		return "", fmt.Errorf("unable to read org features: %w", err)
 	}
-	if !org.Features[appBranchSyncFeature] {
+	if !org.Features[defaultAppBranchesFeature] {
 		return "", nil
 	}
 

--- a/services/ctl-api/AGENTS.md
+++ b/services/ctl-api/AGENTS.md
@@ -972,7 +972,7 @@ entry points reach it through `syncer.Run`, which reads the intermediate config 
 | Entry point                                | Path                                                                                     |
 | ------------------------------------------ | ---------------------------------------------------------------------------------------- |
 | CLI (`nuon apps sync`)                     | `POST /configs` (intermediate config) → `POST /configs/:id/sync` → `appconfigsync` signal |
-| CLI with `app-branch-sync` on              | `POST /configs` with `app_branch_id` → branch run with `sync_app_config` → branch run's sync-app-config step |
+| CLI with `default-app-branches` on              | `POST /configs` with `app_branch_id` → branch run with `sync_app_config` → branch run's sync-app-config step |
 | App branch sync (VCS push / PR preview)    | branch run's fetch-app-config step → `branches/activities.syncAppConfig`                 |
 
 The CLI does not walk the per-resource `Create*Config` endpoints — it parses, validates, and pushes the whole config
@@ -983,7 +983,7 @@ The one behavioural difference between the entry points is build scheduling, and
 `syncer.RunRequest.DispatchBuilds` (standalone CLI path) makes the syncer reuse an unchanged component's existing config
 connection and report the changed ones for the caller to enqueue `configcreated` signals for. Every branch run leaves
 it off because its own builds step schedules builds. Turning it on in both places would double-build, which is why the
-`app-branch-sync` CLI path posts the config and lets the run sync it rather than calling `/configs/:id/sync`
+`default-app-branches` CLI path posts the config and lets the run sync it rather than calling `/configs/:id/sync`
 first.
 
 **Config MUST be converted into `app.*` models through `internal/pkg/config/build`.** The syncer and the per-type

--- a/services/ctl-api/internal/app/org.go
+++ b/services/ctl-api/internal/app/org.go
@@ -117,7 +117,7 @@ const (
 	// registry and the mng process runs each step's inline_contents in the
 	// image via the mounted actions-supervisor. VM-based runners only.
 	OrgFeatureImageBackedActions OrgFeature = "image-backed-actions"
-	OrgFeatureAppBranchSync      OrgFeature = "app-branch-sync"
+	OrgFeatureDefaultAppBranches OrgFeature = "default-app-branches"
 )
 
 type Org struct {
@@ -251,7 +251,7 @@ func (o *Org) BeforeCreate(tx *gorm.DB) error {
 		OrgFeatureOrgHealthcheckSweeps:    false,
 		OrgFeatureAppInstallSyncing:       false,
 		OrgFeatureSandboxOCIArtifacts:     false,
-		OrgFeatureAppBranchSync:           false,
+		OrgFeatureDefaultAppBranches:      false,
 
 		// Enabled by default
 		OrgFeatureAppBranches:   true,
@@ -315,7 +315,7 @@ func GetFeatures() []OrgFeature {
 		OrgFeatureAppInstallSyncing,
 		OrgFeatureSandboxOCIArtifacts,
 		OrgFeatureImageBackedActions,
-		OrgFeatureAppBranchSync,
+		OrgFeatureDefaultAppBranches,
 	}
 }
 
@@ -357,7 +357,7 @@ func GetFeatureDescriptions() map[OrgFeature]string {
 		OrgFeatureAppInstallSyncing:        "Enable app install config syncing: point an app at a git repo of per-install configs so pushes to that repo sync every install's config and create missing installs behind an approval step. Gates the install syncs API, the VCS push fan-out, and the dashboard install syncs tab.",
 		OrgFeatureSandboxOCIArtifacts:      "Build the app sandbox into an OCI artifact during branch runs and resolve sandbox runs against that artifact instead of cloning the sandbox git source. With it off, sandbox runs always clone git.",
 		OrgFeatureImageBackedActions:       "Allow actions to declare a container image their steps run inside. Nuon mirrors the image into the install registry and the mng process runs each step's inline_contents in the image via the mounted actions-supervisor. VM-based runners only.",
-		OrgFeatureAppBranchSync:            "Route `nuon apps sync` through an app branch run: every app gets a `sync-default` branch covering all of its installs, and the sync hands its config to a run on that branch instead of the standalone config sync plus install rollout. Requires app-branches.",
+		OrgFeatureDefaultAppBranches:       "Route `nuon apps sync` through an app branch run: every app gets a `default` branch covering all of its installs, and the sync hands its config to a run on that branch instead of the standalone config sync plus install rollout. Requires app-branches.",
 	}
 }
 


### PR DESCRIPTION
# Rename app-branch-sync to default-app-branches

Follow-up to #2207. Renames the org feature flag and the branch it creates:

- flag `app-branch-sync` → `default-app-branches` (`OrgFeatureAppBranchSync` → `OrgFeatureDefaultAppBranches`)
- default branch name `sync-default` → `default`

The flag is still default-off, so nothing changes for any org. Also updates both