### PR TITLE
feat: add "disabled" runner status

### DIFF
--- a/sdks/nuon-go/models/app_a_w_s_stack_outputs.go
+++ b/sdks/nuon-go/models/app_a_w_s_stack_outputs.go
@@ -47,6 +47,10 @@ type AppAWSStackOutputs struct {
 	// region
 	Region string `json:"region,omitempty"`
 
+	// Nil when the stack predates the runner_enabled variable, which must read
+	// as enabled rather than disabled.
+	RunnerEnabled bool `json:"runner_enabled,omitempty"`
+
 	// runner iam role arn
 	RunnerIamRoleArn string `json:"runner_iam_role_arn,omitempty"`
 

--- a/sdks/nuon-go/models/app_g_c_p_stack_outputs.go
+++ b/sdks/nuon-go/models/app_g_c_p_stack_outputs.go
@@ -53,6 +53,10 @@ type AppGCPStackOutputs struct {
 	// region
 	Region string `json:"region,omitempty"`
 
+	// Nil when the stack predates the runner_enabled variable, which must read
+	// as enabled rather than disabled.
+	RunnerEnabled bool `json:"runner_enabled,omitempty"`
+
 	// runner service account email
 	RunnerServiceAccountEmail string `json:"runner_service_account_email,omitempty"`
 

--- a/sdks/nuon-go/models/app_runner_status.go
+++ b/sdks/nuon-go/models/app_runner_status.go
@@ -57,6 +57,9 @@ const (
 	// AppRunnerStatusAwaitingDashInstallDashStackDashRun captures enum value "awaiting-install-stack-run"
 	AppRunnerStatusAwaitingDashInstallDashStackDashRun AppRunnerStatus = "awaiting-install-stack-run"
 
+	// AppRunnerStatusDisabled captures enum value "disabled"
+	AppRunnerStatusDisabled AppRunnerStatus = "disabled"
+
 	// AppRunnerStatusUnknown captures enum value "unknown"
 	AppRunnerStatusUnknown AppRunnerStatus = "unknown"
 )
@@ -66,7 +69,7 @@ var appRunnerStatusEnum []any
 
 func init() {
 	var res []AppRunnerStatus
-	if err := json.Unmarshal([]byte(`["error","active","pending","provisioning","deprovisioning","deprovisioned","reprovisioning","offline","awaiting-install-stack-run","unknown"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["error","active","pending","provisioning","deprovisioning","deprovisioned","reprovisioning","offline","awaiting-install-stack-run","disabled","unknown"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/sdks/nuon-runner-go/models/app_runner_status.go
+++ b/sdks/nuon-runner-go/models/app_runner_status.go
@@ -57,6 +57,9 @@ const (
 	// AppRunnerStatusAwaitingDashInstallDashStackDashRun captures enum value "awaiting-install-stack-run"
 	AppRunnerStatusAwaitingDashInstallDashStackDashRun AppRunnerStatus = "awaiting-install-stack-run"
 
+	// AppRunnerStatusDisabled captures enum value "disabled"
+	AppRunnerStatusDisabled AppRunnerStatus = "disabled"
+
 	// AppRunnerStatusUnknown captures enum value "unknown"
 	AppRunnerStatusUnknown AppRunnerStatus = "unknown"
 )
@@ -66,7 +69,7 @@ var appRunnerStatusEnum []any
 
 func init() {
 	var res []AppRunnerStatus
-	if err := json.Unmarshal([]byte(`["error","active","pending","provisioning","deprovisioning","deprovisioned","reprovisioning","offline","awaiting-install-stack-run","unknown"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["error","active","pending","provisioning","deprovisioning","deprovisioned","reprovisioning","offline","awaiting-install-stack-run","disabled","unknown"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/sdks/stack/internal/core/outputs.go
+++ b/sdks/stack/internal/core/outputs.go
@@ -47,4 +47,9 @@ type AWSOutputs struct {
 
 	// SecretARNs is keyed by `<name>_arn` to match the phone-home contract.
 	SecretARNs map[string]string
+
+	// RunnerEnabled is false when the stack was applied with the runner module
+	// skipped, which ctl-api reads to mark the runner disabled rather than
+	// treating its silence as a failure.
+	RunnerEnabled bool
 }

--- a/sdks/stack/internal/core/outputs_gcp.go
+++ b/sdks/stack/internal/core/outputs_gcp.go
@@ -38,4 +38,9 @@ type GCPOutputs struct {
 	// SecretNames maps `<name>_secret_name` to the fully-qualified Secret
 	// Manager resource name.
 	SecretNames map[string]string
+
+	// RunnerEnabled is false when the stack was applied with the runner module
+	// skipped, which ctl-api reads to mark the runner disabled rather than
+	// treating its silence as a failure.
+	RunnerEnabled bool
 }

--- a/services/ctl-api/internal/app/install_stack_outputs.go
+++ b/services/ctl-api/internal/app/install_stack_outputs.go
@@ -67,6 +67,10 @@ type AWSStackOutputs struct {
 	BreakGlassRoleARNs    map[string]string `json:"break_glass_role_arns,omitzero" mapstructure:"break_glass_role_arns" temporaljson:"break_glass_role_arns,omitzero,omitempty"`
 	CustomRoleARNs        map[string]string `json:"custom_role_arns,omitzero" mapstructure:"custom_role_arns" temporaljson:"custom_role_arns,omitzero,omitempty"`
 	InstallInputs         map[string]string `json:"install_inputs,omitzero" mapstructure:"install_inputs" temporaljson:"install_inputs,omitzero,omitempty"`
+
+	// Nil when the stack predates the runner_enabled variable, which must read
+	// as enabled rather than disabled.
+	RunnerEnabled *bool `json:"runner_enabled,omitempty" mapstructure:"runner_enabled" temporaljson:"runner_enabled,omitzero,omitempty"`
 }
 
 func (a *AWSStackOutputs) ProvisionRoleID() (string, error)   { return a.ProvisionIAMRoleARN, nil }
@@ -201,6 +205,10 @@ type GCPStackOutputs struct {
 	BreakGlassSAEmails        map[string]string `json:"break_glass_sa_emails,omitzero" mapstructure:"break_glass_sa_emails" temporaljson:"break_glass_sa_emails,omitzero,omitempty"`
 	CustomSAEmails            map[string]string `json:"custom_sa_emails,omitzero" mapstructure:"custom_sa_emails" temporaljson:"custom_sa_emails,omitzero,omitempty"`
 	InstallInputs             map[string]string `json:"install_inputs,omitzero" mapstructure:"install_inputs" temporaljson:"install_inputs,omitzero,omitempty"`
+
+	// Nil when the stack predates the runner_enabled variable, which must read
+	// as enabled rather than disabled.
+	RunnerEnabled *bool `json:"runner_enabled,omitempty" mapstructure:"runner_enabled" temporaljson:"runner_enabled,omitzero,omitempty"`
 }
 
 func (a *GCPStackOutputs) ProvisionRoleID() (string, error)   { return a.ProvisionSAEmail, nil }
@@ -233,6 +241,18 @@ func (a *GCPStackOutputs) BreakGlassRoles() (map[string]string, error) {
 
 func (a *GCPStackOutputs) InstallInputValues() (map[string]string, error) {
 	return a.InstallInputs, nil
+}
+
+// RunnerDisabled reports whether the stack was applied with runner_enabled =
+// false. Azure stacks have no such variable, so they are never disabled.
+func (a *InstallStackOutputs) RunnerDisabled() bool {
+	switch {
+	case a.AWSStackOutputs != nil && a.AWSStackOutputs.RunnerEnabled != nil:
+		return !*a.AWSStackOutputs.RunnerEnabled
+	case a.GCPStackOutputs != nil && a.GCPStackOutputs.RunnerEnabled != nil:
+		return !*a.GCPStackOutputs.RunnerEnabled
+	}
+	return false
 }
 
 func (a *InstallStackOutputs) Indexes(db *gorm.DB) []migrations.Index {

--- a/services/ctl-api/internal/app/install_stack_outputs_test.go
+++ b/services/ctl-api/internal/app/install_stack_outputs_test.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/pkg/generics"
+)
+
+func TestInstallStackOutputsRunnerDisabled(t *testing.T) {
+	for name, tc := range map[string]struct {
+		data pgtype.Hstore
+		want bool
+	}{
+		"runner_enabled false": {pgtype.Hstore{"runner_enabled": generics.ToPtr("false")}, true},
+		"runner_enabled true":  {pgtype.Hstore{"runner_enabled": generics.ToPtr("true")}, false},
+		"key absent":           {pgtype.Hstore{"account_id": generics.ToPtr("123")}, false},
+		"key present but null": {pgtype.Hstore{"runner_enabled": nil}, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, platform := range []string{"aws", "gcp"} {
+				data := pgtype.Hstore{}
+				for k, v := range tc.data {
+					data[k] = v
+				}
+				if platform == "gcp" {
+					data["runner_service_account_email"] = generics.ToPtr("runner@example.com")
+				}
+
+				outputs := InstallStackOutputs{Data: data}
+				require.NoError(t, outputs.AfterQuery(nil))
+				require.Equal(t, tc.want, outputs.RunnerDisabled(), platform)
+			}
+		})
+	}
+}

--- a/services/ctl-api/internal/app/installs/helpers/create_install_workflow.go
+++ b/services/ctl-api/internal/app/installs/helpers/create_install_workflow.go
@@ -55,7 +55,7 @@ func (s *Helpers) createWorkflow(ctx context.Context,
 	planOnly bool,
 	role string,
 ) (*app.Workflow, error) {
-	if workflowType.RequiresRunner() {
+	if workflowType.RequiresInstallRunner() {
 		disabled, err := s.IsRunnerDisabled(ctx, installID)
 		if err != nil {
 			return nil, err

--- a/services/ctl-api/internal/app/installs/helpers/create_install_workflow.go
+++ b/services/ctl-api/internal/app/installs/helpers/create_install_workflow.go
@@ -55,6 +55,16 @@ func (s *Helpers) createWorkflow(ctx context.Context,
 	planOnly bool,
 	role string,
 ) (*app.Workflow, error) {
+	if workflowType.RequiresRunner() {
+		disabled, err := s.IsRunnerDisabled(ctx, installID)
+		if err != nil {
+			return nil, err
+		}
+		if disabled {
+			return nil, NewRunnerDisabledConflict()
+		}
+	}
+
 	approvalOption := app.InstallApprovalOptionPrompt
 	installConfig, err := s.GetLatestInstallConfig(ctx, installID)
 	if err != nil {

--- a/services/ctl-api/internal/app/installs/helpers/runner_disabled.go
+++ b/services/ctl-api/internal/app/installs/helpers/runner_disabled.go
@@ -1,0 +1,53 @@
+package helpers
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
+)
+
+// ErrRunnerDisabled is returned when a workflow that needs the install runner is
+// requested while the stack has the runner disabled.
+var ErrRunnerDisabled = errors.New("the install runner is disabled")
+
+const runnerDisabledDescription = "This install's runner is disabled, so it cannot run jobs. Re-enable it in the install stack, then try again."
+
+// NewRunnerDisabledConflict wraps ErrRunnerDisabled as a 409 with actionable
+// copy, so every surface reports the same reason and remedy.
+func NewRunnerDisabledConflict() error {
+	return stderr.ErrConflict{
+		Err:         ErrRunnerDisabled,
+		Description: runnerDisabledDescription,
+	}
+}
+
+// IsRunnerDisabled reports whether the install's runner was disabled by its
+// stack. A missing runner is not disabled — it has simply not been provisioned
+// yet, which the provisioning lifecycle already models.
+func (s *Helpers) IsRunnerDisabled(ctx context.Context, installID string) (bool, error) {
+	groupIDs := s.db.WithContext(ctx).
+		Model(&app.RunnerGroup{}).
+		Select("id").
+		Where(app.RunnerGroup{OwnerID: installID, OwnerType: "installs"})
+
+	var statuses []app.RunnerStatus
+	res := s.db.WithContext(ctx).
+		Model(&app.Runner{}).
+		Scopes(scopes.WithDisableViews).
+		Where("runner_group_id IN (?)", groupIDs).
+		Order("created_at DESC").
+		Limit(1).
+		Pluck("status", &statuses)
+	if res.Error != nil {
+		return false, errors.Wrap(res.Error, "unable to get install runner status")
+	}
+	if len(statuses) == 0 {
+		return false, nil
+	}
+
+	return statuses[0] == app.RunnerStatusDisabled, nil
+}

--- a/services/ctl-api/internal/app/installs/signals/awaitrunnerhealthy/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/awaitrunnerhealthy/signal.go
@@ -14,9 +14,14 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/poll"
+	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
 const SignalType signal.SignalType = "await-runner-healthy"
+
+// Existing await-runner-healthy histories already scheduled their poll
+// activities, so the disabled-runner short circuit must not apply on replay.
+const skipDisabledRunnerVersion = "await-runner-healthy-skip-disabled-runner-v1"
 
 type Signal struct {
 	InstallID      string `json:"install_id"`
@@ -74,6 +79,30 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 	runner, err := activities.AwaitGetRunnerByID(ctx, install.RunnerID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get runner")
+	}
+
+	// A runner disabled by the install stack will never report a healthy
+	// process, so waiting out the poll window would stall the workflow for an
+	// hour and then fail it. Nothing downstream can run without a runner
+	// either, but that is the deploy steps' problem to report, not this
+	// step's.
+	skipDisabled := workflow.GetVersion(ctx, skipDisabledRunnerVersion, workflow.DefaultVersion, 1) != workflow.DefaultVersion
+	if skipDisabled && runner.Status == app.RunnerStatusDisabled {
+		if s.WorkflowStepID != "" {
+			// The step executor only preserves a status it recognises as a skip,
+			// so write auto-skipped here rather than letting it default to
+			// success for a wait that never happened.
+			if err := statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
+				ID: s.WorkflowStepID,
+				Status: app.CompositeStatus{
+					Status:                 app.StatusAutoSkipped,
+					StatusHumanDescription: "runner is disabled by the install stack",
+				},
+			}); err != nil {
+				return errors.Wrap(err, "unable to mark step auto-skipped for disabled runner")
+			}
+		}
+		return nil
 	}
 
 	// Determine the process type to poll based on runner group type

--- a/services/ctl-api/internal/app/installs/signals/driftcheck/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/driftcheck/signal.go
@@ -55,6 +55,18 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 }
 
 func (s *Signal) Execute(ctx workflow.Context) error {
+	if disabled, err := activities.AwaitIsRunnerDisabled(ctx, activities.IsRunnerDisabledRequest{
+		InstallID: s.InstallID,
+	}); err != nil {
+		return fmt.Errorf("unable to check whether the install runner is disabled: %w", err)
+	} else if disabled.Disabled {
+		// Scheduled drift checks would otherwise pile up a graveyard of failed
+		// workflows for the whole time the runner stays disabled.
+		workflow.GetLogger(ctx).Info("install runner is disabled, skipping drift check",
+			"install_id", s.InstallID)
+		return nil
+	}
+
 	l := workflow.GetLogger(ctx)
 
 	// Resolve latest component build at execution time (not emitter creation time)

--- a/services/ctl-api/internal/app/installs/signals/driftchecksandbox/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/driftchecksandbox/signal.go
@@ -54,6 +54,18 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 }
 
 func (s *Signal) Execute(ctx workflow.Context) error {
+	if disabled, err := activities.AwaitIsRunnerDisabled(ctx, activities.IsRunnerDisabledRequest{
+		InstallID: s.InstallID,
+	}); err != nil {
+		return fmt.Errorf("unable to check whether the install runner is disabled: %w", err)
+	} else if disabled.Disabled {
+		// Scheduled drift checks would otherwise pile up a graveyard of failed
+		// workflows for the whole time the runner stays disabled.
+		workflow.GetLogger(ctx).Info("install runner is disabled, skipping drift check",
+			"install_id", s.InstallID)
+		return nil
+	}
+
 	wkflw, err := activities.AwaitCreateWorkflow(ctx, activities.CreateWorkflowRequest{
 		InstallID:    s.InstallID,
 		WorkflowType: app.WorkflowTypeDriftRunReprovisionSandbox,

--- a/services/ctl-api/internal/app/installs/signals/stackrun/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/stackrun/signal.go
@@ -387,6 +387,13 @@ func (s *Signal) processOutputs(ctx workflow.Context, install *app.Install, vers
 		l.Warn("unable to update install roles from stack outputs", zap.Error(err))
 	}
 
+	if err := activities.AwaitReconcileRunnerEnabled(ctx, &activities.ReconcileRunnerEnabled{
+		RunnerID: install.RunnerID,
+		Disabled: installStackOutputs.RunnerDisabled(),
+	}); err != nil {
+		return errors.Wrap(err, "unable to reconcile runner enabled status")
+	}
+
 	runnerIAMRoleARN := ""
 	if installStackOutputs.AWSStackOutputs != nil {
 		runnerIAMRoleARN = installStackOutputs.AWSStackOutputs.RunnerIAMRoleARN

--- a/services/ctl-api/internal/app/installs/signals/updateinstallstackoutputs/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/updateinstallstackoutputs/signal.go
@@ -144,6 +144,13 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		l.Warn("unable to update install roles from stack outputs", zap.Error(err))
 	}
 
+	if err := activities.AwaitReconcileRunnerEnabled(ctx, &activities.ReconcileRunnerEnabled{
+		RunnerID: install.RunnerID,
+		Disabled: installStackOutputs.RunnerDisabled(),
+	}); err != nil {
+		return errors.Wrap(err, "unable to reconcile runner enabled status")
+	}
+
 	// update the runner settings group
 	runnerIAMRoleARN := ""
 	if installStackOutputs.AWSStackOutputs != nil {

--- a/services/ctl-api/internal/app/installs/worker/activities/activities.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/activities.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/secretsmanager"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks/cloudformation"
+	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
 type Params struct {
@@ -46,6 +47,7 @@ type Params struct {
 	AccountsHelpers   *account.Client
 	TClient           temporalclient.Client
 	SecretsService    secretsmanager.Service
+	StatusActivities  *statusactivities.Activities
 }
 
 type Activities struct {
@@ -69,6 +71,7 @@ type Activities struct {
 	accountsHelpers   *account.Client
 	tClient           temporalclient.Client
 	secretsSvc        secretsmanager.Service
+	statusActivities  *statusactivities.Activities
 }
 
 func New(params Params) *Activities {
@@ -93,5 +96,6 @@ func New(params Params) *Activities {
 		accountsHelpers:   params.AccountsHelpers,
 		tClient:           params.TClient,
 		secretsSvc:        params.SecretsService,
+		statusActivities:  params.StatusActivities,
 	}
 }

--- a/services/ctl-api/internal/app/installs/worker/activities/is_runner_disabled.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/is_runner_disabled.go
@@ -1,0 +1,25 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+)
+
+type IsRunnerDisabledRequest struct {
+	InstallID string `validate:"required"`
+}
+
+type IsRunnerDisabledResponse struct {
+	Disabled bool `json:"disabled"`
+}
+
+// @temporal-gen-v2 activity
+// @max-retries 3
+func (a *Activities) IsRunnerDisabled(ctx context.Context, req IsRunnerDisabledRequest) (*IsRunnerDisabledResponse, error) {
+	disabled, err := a.helpers.IsRunnerDisabled(ctx, req.InstallID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine whether the install runner is disabled: %w", err)
+	}
+
+	return &IsRunnerDisabledResponse{Disabled: disabled}, nil
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/reconcile_runner_enabled.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/reconcile_runner_enabled.go
@@ -1,0 +1,74 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
+)
+
+type ReconcileRunnerEnabled struct {
+	RunnerID string `json:"runner_id" validate:"required"`
+	Disabled bool   `json:"disabled"`
+}
+
+// ReconcileRunnerEnabled aligns a runner's status with the runner_enabled value
+// from its install stack outputs. Re-enabling returns the runner to pending
+// rather than active: pending is skipped by the health machinery the same way
+// disabled is, so the runner only becomes active once it actually reports in.
+//
+// @temporal-gen-v2 activity
+// @max-retries 2
+// @local
+func (a *Activities) ReconcileRunnerEnabled(ctx context.Context, req *ReconcileRunnerEnabled) error {
+	var runner app.Runner
+	if res := a.db.WithContext(ctx).First(&runner, "id = ?", req.RunnerID); res.Error != nil {
+		return generics.TemporalGormError(res.Error, "unable to get runner")
+	}
+
+	target := app.RunnerStatusDisabled
+	description := "runner is disabled by the install stack"
+	switch {
+	case req.Disabled:
+		if runner.Status == app.RunnerStatusDisabled {
+			return nil
+		}
+	case runner.Status == app.RunnerStatusDisabled:
+		target = app.RunnerStatusPending
+		description = "runner was re-enabled by the install stack"
+	default:
+		return nil
+	}
+
+	if err := a.statusActivities.UpdateRunnerStatusV2Metadata(ctx, statusactivities.UpdateRunnerStatusV2MetadataRequest{
+		RunnerID: req.RunnerID,
+		Metadata: map[string]any{app.RunnerOfflineTSMetadataKey: nil},
+	}); err != nil {
+		return fmt.Errorf("unable to clear runner offline metadata: %w", err)
+	}
+
+	res := a.db.WithContext(ctx).Model(&app.Runner{ID: req.RunnerID}).Updates(app.Runner{
+		Status:            target,
+		StatusDescription: description,
+	})
+	if res.Error != nil {
+		return fmt.Errorf("unable to update runner status: %w", res.Error)
+	}
+	if res.RowsAffected < 1 {
+		return generics.TemporalGormError(gorm.ErrRecordNotFound, fmt.Sprintf("no runner found: %s", req.RunnerID))
+	}
+
+	if err := a.statusActivities.UpdateRunnerStatusV2(ctx, statusactivities.UpdateRunnerStatusV2Request{
+		RunnerID:          req.RunnerID,
+		Status:            target,
+		StatusDescription: description,
+	}); err != nil {
+		return fmt.Errorf("unable to update runner status v2: %w", err)
+	}
+
+	return nil
+}

--- a/services/ctl-api/internal/app/runner.go
+++ b/services/ctl-api/internal/app/runner.go
@@ -154,6 +154,13 @@ func (r *Runner) BeforeCreate(tx *gorm.DB) error {
 const missingMngProcessWarning = "The management process is not running. Remote restart, upgrade, and shutdown are unavailable until it recovers."
 
 func (r *Runner) AfterQuery(tx *gorm.DB) error {
+	// A disabled runner has no processes at all, so the missing-management
+	// warning is expected rather than actionable. The UI surfaces the disabled
+	// state itself.
+	if r.Status == RunnerStatusDisabled {
+		return nil
+	}
+
 	if missing, ok := r.StatusV2.Metadata["missing_mng_process"].(bool); ok && missing {
 		r.Warnings = append(r.Warnings, missingMngProcessWarning)
 	}

--- a/services/ctl-api/internal/app/runner.go
+++ b/services/ctl-api/internal/app/runner.go
@@ -25,6 +25,11 @@ const (
 	RunnerStatusOffline                 RunnerStatus = "offline"
 	RunnerStatusAwaitingInstallStackRun RunnerStatus = "awaiting-install-stack-run"
 
+	// RunnerStatusDisabled is set when the install stack was applied with
+	// runner_enabled = false. The runner does not exist, so it sends no
+	// heartbeats or health checks, but this is intentional and not an error.
+	RunnerStatusDisabled RunnerStatus = "disabled"
+
 	RunnerStatusUnknown RunnerStatus = "unknown"
 )
 
@@ -42,6 +47,8 @@ func (r RunnerStatus) Code() int {
 		return 200
 	case RunnerStatusProvisioning:
 		return 201
+	case RunnerStatusDisabled:
+		return 202
 
 		// 3xx statuses are for tear downs
 	case RunnerStatusDeprovisioning:

--- a/services/ctl-api/internal/app/runners/joberrors/lifecycle_failure.go
+++ b/services/ctl-api/internal/app/runners/joberrors/lifecycle_failure.go
@@ -53,6 +53,16 @@ func (*LifecycleFailureError) Type() compositeerrors.Type {
 	return LifecycleFailureErrorType
 }
 
+// Hints marks a disabled runner as terminal: nothing about the failure can
+// change until the customer re-applies their stack, so neither auto-retries nor
+// a manual retry can succeed.
+func (e *LifecycleFailureError) Hints() compositeerrors.Hints {
+	if e.Reason == LifecycleFailureReasonRunnerDisabled {
+		return compositeerrors.NewHints().WithTerminal()
+	}
+	return nil
+}
+
 func (*LifecycleFailureError) Severity() compositeerrors.Severity {
 	return compositeerrors.SeverityError
 }

--- a/services/ctl-api/internal/app/runners/joberrors/lifecycle_failure.go
+++ b/services/ctl-api/internal/app/runners/joberrors/lifecycle_failure.go
@@ -15,6 +15,7 @@ const (
 	LifecycleFailureReasonExecutionTimeout  LifecycleFailureReason = "execution_timeout"
 	LifecycleFailureReasonAttemptsExhausted LifecycleFailureReason = "attempts_exhausted"
 	LifecycleFailureReasonResultMissing     LifecycleFailureReason = "execution_result_missing"
+	LifecycleFailureReasonRunnerDisabled    LifecycleFailureReason = "runner_disabled"
 )
 
 type LifecycleFailureError struct {
@@ -27,6 +28,8 @@ func (e *LifecycleFailureError) Error() string {
 	switch e.Reason {
 	case LifecycleFailureReasonNoActiveRunner:
 		return "No active runner was available for this job"
+	case LifecycleFailureReasonRunnerDisabled:
+		return "The install runner is disabled"
 	case LifecycleFailureReasonQueueTimeout:
 		return "Runner job expired in the queue"
 	case LifecycleFailureReasonRunnerUnhealthy:
@@ -66,6 +69,8 @@ func (e *LifecycleFailureError) details() (string, string) {
 	switch e.Reason {
 	case LifecycleFailureReasonNoActiveRunner:
 		return "The job could not start because its assigned runner had no active process.", "Check that the runner is online and healthy, then retry the operation."
+	case LifecycleFailureReasonRunnerDisabled:
+		return "The install runner is disabled, so no runner exists to pick up this job.", "Re-enable the runner in the install stack, then retry the operation."
 	case LifecycleFailureReasonQueueTimeout:
 		return "The job waited in the queue longer than its configured queue timeout.", "Check the runner's health and workload, then retry the operation."
 	case LifecycleFailureReasonRunnerUnhealthy:

--- a/services/ctl-api/internal/app/runners/joberrors/lifecycle_failure_hints_test.go
+++ b/services/ctl-api/internal/app/runners/joberrors/lifecycle_failure_hints_test.go
@@ -1,0 +1,20 @@
+package joberrors
+
+import "testing"
+
+func TestLifecycleFailureHints(t *testing.T) {
+	if !(&LifecycleFailureError{Reason: LifecycleFailureReasonRunnerDisabled}).Hints().Terminal() {
+		t.Error("a disabled runner should be a terminal failure")
+	}
+
+	for _, reason := range []LifecycleFailureReason{
+		LifecycleFailureReasonNoActiveRunner,
+		LifecycleFailureReasonQueueTimeout,
+		LifecycleFailureReasonRunnerUnhealthy,
+		LifecycleFailureReasonPickupTimeout,
+	} {
+		if (&LifecycleFailureError{Reason: reason}).Hints().Terminal() {
+			t.Errorf("%s should stay retryable", reason)
+		}
+	}
+}

--- a/services/ctl-api/internal/app/runners/signals/installstackversionrun/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/installstackversionrun/signal.go
@@ -58,6 +58,21 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return nil
 	}
 
+	// A stack applied with runner_enabled = false provisions no runner, so it
+	// will never report health. Checking the run's outputs here rather than the
+	// runner's status is deliberate: this signal races
+	// update-install-stack-outputs off the same stack run, so the disabled
+	// status may not be written yet.
+	runnerDisabled, err := activities.AwaitGetStackRunRunnerDisabled(ctx, activities.GetStackRunRunnerDisabledRequest{
+		InstallStackVersionRunID: s.InstallStackVersionRunID,
+	})
+	if err != nil {
+		return errors.Wrap(err, "unable to determine whether stack run disabled the runner")
+	}
+	if runnerDisabled {
+		return nil
+	}
+
 	// Update runner status to Error state
 	// This indicates the install stack was run and is waiting for health check
 	if err := activities.AwaitUpdateStatus(ctx, activities.UpdateStatusRequest{

--- a/services/ctl-api/internal/app/runners/signals/offlinecheck/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/offlinecheck/signal.go
@@ -61,6 +61,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		app.RunnerStatusReprovisioning,
 		app.RunnerStatusDeprovisioned,
 		app.RunnerStatusOffline,
+		app.RunnerStatusDisabled,
 	})
 	if isNoop {
 		return nil

--- a/services/ctl-api/internal/app/runners/signals/processjob/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/processjob/signal.go
@@ -152,9 +152,18 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 			l.Info("job was already cancelled, not attempting")
 			return nil
 		}
-		l.Warn("runner has no active process, not attempting")
-		s.updateJobStatus(ctx, s.JobID, app.RunnerJobStatusNotAttempted, "no active runner process available")
-		s.recordJobLifecycleCompositeError(ctx, s.JobID, joberrors.LifecycleFailureReasonNoActiveRunner)
+		// A disabled runner has no processes by design, so report that rather
+		// than the generic unhealthy-runner reason.
+		reason := joberrors.LifecycleFailureReasonNoActiveRunner
+		description := "no active runner process available"
+		if runner != nil && runner.Status == app.RunnerStatusDisabled {
+			reason = joberrors.LifecycleFailureReasonRunnerDisabled
+			description = "install runner is disabled"
+		}
+
+		l.Warn("runner has no active process, not attempting", zap.String("reason", string(reason)))
+		s.updateJobStatus(ctx, s.JobID, app.RunnerJobStatusNotAttempted, description)
+		s.recordJobLifecycleCompositeError(ctx, s.JobID, reason)
 		return errors.New("runner has no active process")
 	}
 
@@ -307,6 +316,15 @@ func (s *Signal) startJobExecution(ctx workflow.Context, job *app.RunnerJob) (bo
 				break
 			}
 			etags["runner_status"] = string(runnerStatus)
+
+			// A disabled runner will never become active on its own, so fail
+			// now instead of burning the available timeout waiting for it.
+			if runnerStatus == app.RunnerStatusDisabled {
+				l.Warn("runner is disabled, not waiting for it to become active")
+				s.updateJobStatus(ctx, job.ID, app.RunnerJobStatusNotAttempted, "install runner is disabled")
+				tags["status"] = "runner_disabled"
+				return false, false, joberrors.LifecycleFailureReasonRunnerDisabled, nil
+			}
 
 			jobStatus, err := activities.AwaitGetJobStatusByID(ctx, job.ID)
 			if err != nil {

--- a/services/ctl-api/internal/app/runners/signals/processjob/signal_test.go
+++ b/services/ctl-api/internal/app/runners/signals/processjob/signal_test.go
@@ -54,6 +54,28 @@ func TestExecuteRecordsNoActiveRunnerCompositeError(t *testing.T) {
 	env.AssertExpectations(t)
 }
 
+func TestExecuteRecordsRunnerDisabledCompositeError(t *testing.T) {
+	env := newProcessJobTestEnvironment()
+	env.RegisterActivityWithOptions((&runneractivities.Activities{}).RecordJobLifecycleCompositeError,
+		activity.RegisterOptions{Name: "RecordJobLifecycleCompositeError"})
+	env.OnActivity((*runneractivities.Activities).GetRunnerJobForExecution, mock.Anything, mock.Anything, mock.Anything).
+		Return(&runneractivities.GetRunnerJobForExecutionResponse{
+			Runner: &app.Runner{ID: "runner-1", Status: app.RunnerStatusDisabled},
+			Job:    &app.RunnerJob{ID: "job-1", Status: app.RunnerJobStatusQueued},
+		}, nil).Once()
+	env.OnActivity((*runneractivities.Activities).UpdateJobStatus, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Once()
+	env.OnActivity((*statusactivities.Activities).UpdateRunnerJobStatusV2, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Once()
+	env.OnActivity("RecordJobLifecycleCompositeError", mock.Anything,
+		mock.MatchedBy(func(req runneractivities.RecordJobLifecycleCompositeErrorRequest) bool {
+			return req.JobID == "job-1" && req.Reason == joberrors.LifecycleFailureReasonRunnerDisabled
+		})).Return(nil).Once()
+
+	require.ErrorContains(t, executeProcessJobSignal(t, env), "runner has no active process")
+	env.AssertExpectations(t)
+}
+
 func TestExecuteDoesNotRecordLifecycleErrorForCancelledJob(t *testing.T) {
 	env := newProcessJobTestEnvironment()
 	env.OnActivity((*runneractivities.Activities).GetRunnerJobForExecution, mock.Anything, mock.Anything, mock.Anything).

--- a/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal.go
@@ -377,7 +377,8 @@ func isSkippableStatus(status app.RunnerStatus) bool {
 		app.RunnerStatusDeprovisioning,
 		app.RunnerStatusReprovisioning,
 		app.RunnerStatusDeprovisioned,
-		app.RunnerStatusPending:
+		app.RunnerStatusPending,
+		app.RunnerStatusDisabled:
 		return true
 	}
 	return false

--- a/services/ctl-api/internal/app/runners/worker/activities/batch_runner_healthchecks.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/batch_runner_healthchecks.go
@@ -212,12 +212,24 @@ func (a *Activities) applyRunnerHealthDecision(ectx context.Context, r *app.Runn
 	}
 
 	if d.UpdateLegacy {
-		if err := a.UpdateStatus(ectx, UpdateStatusRequest{
-			RunnerID:          r.ID,
-			Status:            d.TargetStatus,
-			StatusDescription: d.Reason,
-		}); err != nil {
-			return fmt.Errorf("unable to update runner status: %w", err)
+		// Guarded write: the decision was computed from a read that may predate
+		// a reconcile marking this runner disabled. Overwriting that would pin
+		// an intentionally-disabled runner to offline, and since the skip
+		// conditions match on status it would never recover.
+		res := a.db.WithContext(ectx).
+			Model(&app.Runner{ID: r.ID}).
+			Where("status <> ?", app.RunnerStatusDisabled).
+			Updates(app.Runner{
+				Status:            d.TargetStatus,
+				StatusDescription: d.Reason,
+			})
+		if res.Error != nil {
+			return fmt.Errorf("unable to update runner status: %w", res.Error)
+		}
+		if res.RowsAffected < 1 {
+			// Runner went disabled under us; leave its status v2 alone too so
+			// the two columns cannot disagree.
+			return nil
 		}
 	}
 	if d.UpdateV2 {

--- a/services/ctl-api/internal/app/runners/worker/activities/get_stack_run_runner_disabled.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_stack_run_runner_disabled.go
@@ -1,0 +1,38 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	dbgenerics "github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+)
+
+type GetStackRunRunnerDisabledRequest struct {
+	InstallStackVersionRunID string `validate:"required"`
+}
+
+// GetStackRunRunnerDisabled reports whether a stack run's outputs disabled the
+// runner. It reads the raw output key rather than the per-cloud structs so it
+// stays correct for any stack that grows the variable; a missing key means the
+// stack predates runner_enabled and the runner is enabled.
+//
+// @temporal-gen-v2 activity
+// @max-retries 1
+// @by-field InstallStackVersionRunID
+// @local
+func (a *Activities) GetStackRunRunnerDisabled(ctx context.Context, req GetStackRunRunnerDisabledRequest) (bool, error) {
+	run := app.InstallStackVersionRun{}
+	res := a.db.WithContext(ctx).
+		Select("id", "data").
+		First(&run, "id = ?", req.InstallStackVersionRunID)
+	if res.Error != nil {
+		return false, dbgenerics.TemporalGormError(res.Error, "unable to get install stack version run")
+	}
+
+	val, ok := run.Data["runner_enabled"]
+	if !ok || val == nil {
+		return false, nil
+	}
+
+	return *val == "false", nil
+}

--- a/services/ctl-api/internal/app/runners/worker/activities/healthcheck_cases_test.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/healthcheck_cases_test.go
@@ -180,12 +180,23 @@ func runnerHealthCases() []runnerHealthCase {
 		},
 	}
 
+	// A disabled runner has no processes at all, which must not arm offline_ts
+	// or raise an unhealthy alert the way a genuinely silent runner does.
+	cases = append(cases, runnerHealthCase{
+		name:      "disabled install runner with no processes is skipped",
+		groupType: app.RunnerGroupTypeInstall,
+		status:    app.RunnerStatusDisabled, v2Status: app.RunnerStatusDisabled,
+		mngChecked: true,
+		want:       runnerHealthWant{result: "skipped"},
+	})
+
 	for _, status := range []app.RunnerStatus{
 		app.RunnerStatusProvisioning,
 		app.RunnerStatusDeprovisioning,
 		app.RunnerStatusReprovisioning,
 		app.RunnerStatusDeprovisioned,
 		app.RunnerStatusPending,
+		app.RunnerStatusDisabled,
 	} {
 		cases = append(cases, runnerHealthCase{
 			name:      "skippable status " + string(status),

--- a/services/ctl-api/internal/app/runners/worker/activities/healthcheck_decisions.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/healthcheck_decisions.go
@@ -17,13 +17,15 @@ const (
 )
 
 // skippableRunnerStatuses mirrors the statuses the runner healthcheck never
-// acts on (provisioning lifecycle states).
+// acts on (provisioning lifecycle states, plus runners the install stack
+// disabled, which never report health by design).
 var skippableRunnerStatuses = []app.RunnerStatus{
 	app.RunnerStatusProvisioning,
 	app.RunnerStatusDeprovisioning,
 	app.RunnerStatusReprovisioning,
 	app.RunnerStatusDeprovisioned,
 	app.RunnerStatusPending,
+	app.RunnerStatusDisabled,
 }
 
 func isSkippableRunnerStatus(status app.RunnerStatus) bool {

--- a/services/ctl-api/internal/app/workflow.go
+++ b/services/ctl-api/internal/app/workflow.go
@@ -63,25 +63,19 @@ const (
 	WorkflowTypeRecoverHelmRelease WorkflowType = "recover_helm_release"
 )
 
-// RequiresRunner reports whether this workflow type dispatches runner jobs and
-// therefore cannot make progress while the install runner is disabled.
+// RequiresInstallRunner reports whether this workflow type dispatches jobs to
+// the install runner and therefore cannot make progress while that runner is
+// disabled. Callers must scope it to install-owned workflows: app-owned types
+// never reach it, and some of them (app config builds) use the org build
+// runner, which this says nothing about.
 //
-// The default is true: a new install workflow almost certainly needs the runner,
-// and defaulting to false would silently let it queue work that can never run.
-// WorkflowTypeReprovisionStack is deliberately exempt — applying the install
-// stack is the only way a customer flips runner_enabled back to true, so
-// blocking it would make disabling the runner a one-way door.
-func (i WorkflowType) RequiresRunner() bool {
-	switch i {
-	case WorkflowTypeReprovisionStack,
-		WorkflowTypeAppConfigBuild,
-		WorkflowTypeAppInstallSync,
-		WorkflowTypeAppBranchesRun,
-		WorkflowTypeAppBranchesConfigRepoUpdate,
-		WorkflowTypeAppBranchesComponentRepoUpdate:
-		return false
-	}
-	return true
+// The default is true: a new install workflow almost certainly needs the
+// runner, and defaulting to false would silently let it queue work that can
+// never run. WorkflowTypeReprovisionStack is deliberately exempt — applying the
+// install stack is the only way a customer flips runner_enabled back to true,
+// so blocking it would make disabling the runner a one-way door.
+func (i WorkflowType) RequiresInstallRunner() bool {
+	return i != WorkflowTypeReprovisionStack
 }
 
 type WorkflowMetadataKey string

--- a/services/ctl-api/internal/app/workflow.go
+++ b/services/ctl-api/internal/app/workflow.go
@@ -63,6 +63,27 @@ const (
 	WorkflowTypeRecoverHelmRelease WorkflowType = "recover_helm_release"
 )
 
+// RequiresRunner reports whether this workflow type dispatches runner jobs and
+// therefore cannot make progress while the install runner is disabled.
+//
+// The default is true: a new install workflow almost certainly needs the runner,
+// and defaulting to false would silently let it queue work that can never run.
+// WorkflowTypeReprovisionStack is deliberately exempt — applying the install
+// stack is the only way a customer flips runner_enabled back to true, so
+// blocking it would make disabling the runner a one-way door.
+func (i WorkflowType) RequiresRunner() bool {
+	switch i {
+	case WorkflowTypeReprovisionStack,
+		WorkflowTypeAppConfigBuild,
+		WorkflowTypeAppInstallSync,
+		WorkflowTypeAppBranchesRun,
+		WorkflowTypeAppBranchesConfigRepoUpdate,
+		WorkflowTypeAppBranchesComponentRepoUpdate:
+		return false
+	}
+	return true
+}
+
 type WorkflowMetadataKey string
 
 const (

--- a/services/ctl-api/internal/app/workflow_requires_runner_test.go
+++ b/services/ctl-api/internal/app/workflow_requires_runner_test.go
@@ -1,0 +1,44 @@
+package app
+
+import "testing"
+
+func TestWorkflowTypeRequiresInstallRunner(t *testing.T) {
+	// Applying the install stack is how runner_enabled gets set back to true,
+	// so it must stay runnable while the runner is disabled.
+	if WorkflowTypeReprovisionStack.RequiresInstallRunner() {
+		t.Error("reprovision_stack should not require the install runner")
+	}
+
+	needsRunner := []WorkflowType{
+		WorkflowTypeProvision,
+		WorkflowTypeReprovision,
+		WorkflowTypeReprovisionSandbox,
+		WorkflowTypeDriftRunReprovisionSandbox,
+		WorkflowTypeDeprovision,
+		WorkflowTypeDeprovisionSandbox,
+		WorkflowTypeManualDeploy,
+		WorkflowTypeDriftRun,
+		WorkflowTypeDeployComponents,
+		WorkflowTypeTeardownComponent,
+		WorkflowTypeTeardownComponents,
+		WorkflowTypeInputUpdate,
+		WorkflowTypeActionWorkflowRun,
+		WorkflowTypeSyncSecrets,
+		WorkflowTypeRunbookRun,
+		WorkflowTypeComponentEnabled,
+		WorkflowTypeComponentDisabled,
+		WorkflowTypeRecoverHelmRelease,
+		WorkflowTypeAppBranchConfigUpdate,
+	}
+	for _, wt := range needsRunner {
+		if !wt.RequiresInstallRunner() {
+			t.Errorf("%s should require the install runner", wt)
+		}
+	}
+
+	// An unrecognized type must default to requiring a runner: a new install
+	// workflow that silently skipped the gate would queue unrunnable jobs.
+	if !WorkflowType("some_future_workflow").RequiresInstallRunner() {
+		t.Error("unknown workflow types should require the install runner")
+	}
+}

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
@@ -441,6 +441,12 @@ func (s *Signal) handle(ctx workflow.Context, startFromGroupIdx int) error {
 
 		group := &groups[gi]
 
+		if stopped, err := s.stopIfRunnerDisabled(ctx, l, flw, groups, gi); err != nil {
+			return err
+		} else if stopped {
+			return flow.NewFlowStoppedErr("", "the install runner is disabled")
+		}
+
 		if s.Resident && !residentPending[group.GroupIdx] {
 			continue
 		}
@@ -975,4 +981,52 @@ func (s *Signal) checkGroupRetriesExhausted(ctx workflow.Context, group *app.Wor
 		}
 	}
 	return false
+}
+
+// runnerDisabledCheckVersion gates the pre-group runner check so in-flight
+// histories, which never scheduled the activity, still replay deterministically.
+const runnerDisabledCheckVersion = "execute-flow-runner-disabled-check-v1"
+
+// stopIfRunnerDisabled halts a workflow whose install runner was disabled after
+// it started. Creation already rejects these, so without this the workflow would
+// fail one runner-dependent group at a time and report each as its own error.
+func (s *Signal) stopIfRunnerDisabled(
+	ctx workflow.Context,
+	l *zap.Logger,
+	flw *app.Workflow,
+	groups []app.WorkflowStepGroup,
+	groupPosition int,
+) (bool, error) {
+	if workflow.GetVersion(ctx, runnerDisabledCheckVersion, workflow.DefaultVersion, 1) == workflow.DefaultVersion {
+		return false, nil
+	}
+
+	if flw.OwnerType != "installs" || !flw.Type.RequiresRunner() {
+		return false, nil
+	}
+
+	disabled, err := workflowactivities.AwaitCheckFlowRunnerDisabled(ctx, workflowactivities.CheckFlowRunnerDisabledRequest{
+		FlowID: s.WorkflowID,
+	})
+	if err != nil {
+		// A failed check must not take down a workflow that would otherwise run.
+		l.Warn("unable to check whether the install runner is disabled", zap.Error(err))
+		return false, nil
+	}
+	if !disabled {
+		return false, nil
+	}
+
+	l.Warn("install runner is disabled, stopping workflow",
+		zap.String("workflow_id", s.WorkflowID),
+		zap.Int("group_position", groupPosition))
+
+	s.markRemainingGroupStepsDiscarded(ctx, l, groups, groupPosition-1)
+	s.markRemainingStepsNotAttempted(ctx, l)
+
+	if err := workflowactivities.AwaitPkgWorkflowsFlowUpdateFlowFinishedAtByID(ctx, s.WorkflowID); err != nil {
+		l.Error("unable to update finished at", zap.Error(err))
+	}
+
+	return true, nil
 }

--- a/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeflow/execute.go
@@ -1001,7 +1001,7 @@ func (s *Signal) stopIfRunnerDisabled(
 		return false, nil
 	}
 
-	if flw.OwnerType != "installs" || !flw.Type.RequiresRunner() {
+	if flw.OwnerType != "installs" || !flw.Type.RequiresInstallRunner() {
 		return false, nil
 	}
 

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/execute_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/execute_step.go
@@ -139,13 +139,18 @@ func (s *Signal) Execute(ctx workflow.Context) (err error) {
 		l.Debug("step type non approval, step successful",
 			zap.String("step_id", step.ID),
 			zap.String("workflow_id", flw.ID))
-		if err := statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
-			ID: step.ID,
-			Status: app.CompositeStatus{
-				Status: app.StatusSuccess,
-			},
-		}); err != nil {
-			return errors.Wrap(err, "unable to mark step as success")
+		// A signal that skipped its own work marks the step skipped before
+		// returning. Overwriting that with success would report work as done
+		// that never ran, so leave an already-skipped status alone.
+		if !isSkippedStatus(step.Status.Status) {
+			if err := statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
+				ID: step.ID,
+				Status: app.CompositeStatus{
+					Status: app.StatusSuccess,
+				},
+			}); err != nil {
+				return errors.Wrap(err, "unable to mark step as success")
+			}
 		}
 
 		if err := statusactivities.AwaitPkgStatusUpdateFlowStatus(ctx, statusactivities.UpdateStatusRequest{
@@ -264,4 +269,10 @@ func (s *Signal) executeInnerSignal(ctx workflow.Context, step *app.WorkflowStep
 
 	logger.Info("queue signal completed successfully", "step_name", step.Name)
 	return nil
+}
+
+// isSkippedStatus reports whether a step status represents work that was
+// deliberately not performed, which the success write must not clobber.
+func isSkippedStatus(status app.Status) bool {
+	return status == app.StatusAutoSkipped || status == app.StatusUserSkipped
 }

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_errors.go
@@ -31,6 +31,7 @@ func (s *Signal) handleStepError(ctx workflow.Context, l *zap.Logger, step *app.
 	// by retrying) forces the await-retry branch so we park for manual retry
 	// instead of burning auto-retries.
 	skipAutoRetry := false
+	terminal := false
 	if targetSupportsCompositeErrorHints(step.StepTargetType) {
 		if hintsResp, herr := activities.AwaitGetStepErrorHints(ctx, activities.GetStepErrorHintsRequest{
 			StepID: step.ID,
@@ -40,7 +41,28 @@ func (s *Signal) handleStepError(ctx workflow.Context, l *zap.Logger, step *app.
 				zap.Error(herr))
 		} else if hintsResp != nil {
 			skipAutoRetry = hintsResp.Hints.SkipAutoRetry()
+			terminal = hintsResp.Hints.Terminal()
 		}
+	}
+
+	// A terminal failure cannot succeed on any retry, so parking for a manual
+	// one would offer the user an action guaranteed to fail. Stop instead, and
+	// let the reason on the step explain why.
+	if terminal {
+		l.Warn("step failed terminally, not retrying",
+			zap.String("step_id", step.ID))
+
+		metadata := map[string]any{"terminal": true}
+		directive := DirectiveStop
+		if step.SkipOnFailure {
+			metadata["skipped_on_failure"] = true
+			directive = DirectiveContinue
+		}
+
+		if err := setResultDirective(ctx, step.ID, directive); err != nil {
+			return errors.Wrap(err, "unable to set result directive")
+		}
+		return s.markStepFailed(ctx, step, stepErr, metadata)
 	}
 
 	// Determine max retries from the signal, falling back to default.

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/check_flow_runner_disabled.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/check_flow_runner_disabled.go
@@ -31,7 +31,7 @@ func (a *Activities) CheckFlowRunnerDisabled(ctx context.Context, req CheckFlowR
 		return false, errors.Wrap(res.Error, "unable to get workflow")
 	}
 
-	if flw.OwnerType != "installs" || !flw.Type.RequiresRunner() {
+	if flw.OwnerType != "installs" || !flw.Type.RequiresInstallRunner() {
 		return false, nil
 	}
 

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/check_flow_runner_disabled.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/check_flow_runner_disabled.go
@@ -1,0 +1,59 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
+)
+
+type CheckFlowRunnerDisabledRequest struct {
+	FlowID string `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+// @max-retries 3
+//
+// CheckFlowRunnerDisabled reports whether an install-owned workflow needs the
+// install runner but the stack has it disabled. Workflow creation already
+// rejects this, so a true result means the runner was disabled after the
+// workflow started.
+func (a *Activities) CheckFlowRunnerDisabled(ctx context.Context, req CheckFlowRunnerDisabledRequest) (bool, error) {
+	var flw app.Workflow
+	res := a.db.WithContext(ctx).
+		Scopes(scopes.WithDisableViews).
+		Select("id", "type", "owner_id", "owner_type").
+		Where(app.Workflow{ID: req.FlowID}).
+		Take(&flw)
+	if res.Error != nil {
+		return false, errors.Wrap(res.Error, "unable to get workflow")
+	}
+
+	if flw.OwnerType != "installs" || !flw.Type.RequiresRunner() {
+		return false, nil
+	}
+
+	groupIDs := a.db.WithContext(ctx).
+		Model(&app.RunnerGroup{}).
+		Select("id").
+		Where(app.RunnerGroup{OwnerID: flw.OwnerID, OwnerType: "installs"})
+
+	var statuses []app.RunnerStatus
+	res = a.db.WithContext(ctx).
+		Model(&app.Runner{}).
+		Scopes(scopes.WithDisableViews).
+		Where("runner_group_id IN (?)", groupIDs).
+		Order("created_at DESC").
+		Limit(1).
+		Pluck("status", &statuses)
+	if res.Error != nil {
+		return false, errors.Wrap(res.Error, "unable to get install runner status")
+	}
+	if len(statuses) == 0 {
+		return false, nil
+	}
+
+	return statuses[0] == app.RunnerStatusDisabled, nil
+}

--- a/services/dashboard-ui/client/components/runners/RunnerStatusBanner/RunnerStatusBanner.stories.tsx
+++ b/services/dashboard-ui/client/components/runners/RunnerStatusBanner/RunnerStatusBanner.stories.tsx
@@ -16,3 +16,5 @@ export const Multiple = () => (
 )
 
 export const Empty = () => <RunnerStatusBanner warnings={[]} />
+
+export const Disabled = () => <RunnerStatusBanner status="disabled" />

--- a/services/dashboard-ui/client/components/runners/RunnerStatusBanner/RunnerStatusBanner.tsx
+++ b/services/dashboard-ui/client/components/runners/RunnerStatusBanner/RunnerStatusBanner.tsx
@@ -1,6 +1,21 @@
 import { Banner } from '@/components/common/Banner'
 
-export const RunnerStatusBanner = ({ warnings }: { warnings?: string[] }) => {
+export const RunnerStatusBanner = ({
+  warnings,
+  status,
+}: {
+  warnings?: string[]
+  status?: string
+}) => {
+  if (status === 'disabled') {
+    return (
+      <Banner theme="neutral">
+        This runner is disabled, so it runs no jobs and reports no health.
+        Re-enable it in the install stack to start running jobs.
+      </Banner>
+    )
+  }
+
   if (!warnings?.length) return null
 
   return (

--- a/services/dashboard-ui/client/components/runners/RunnerStatusBanner/RunnerStatusBannerContainer.tsx
+++ b/services/dashboard-ui/client/components/runners/RunnerStatusBanner/RunnerStatusBannerContainer.tsx
@@ -4,5 +4,7 @@ import { RunnerStatusBanner } from './RunnerStatusBanner'
 export const RunnerStatusBannerContainer = () => {
   const { runner } = useRunner()
 
-  return <RunnerStatusBanner warnings={runner?.warnings} />
+  return (
+    <RunnerStatusBanner warnings={runner?.warnings} status={runner?.status} />
+  )
 }

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -6221,7 +6221,7 @@ export interface components {
     /** @enum {string} */
     "app.RunnerProcessType": "mng" | "install" | "build" | "org" | "";
     /** @enum {string} */
-    "app.RunnerStatus": "error" | "active" | "pending" | "provisioning" | "deprovisioning" | "deprovisioned" | "reprovisioning" | "offline" | "awaiting-install-stack-run" | "unknown";
+    "app.RunnerStatus": "error" | "active" | "pending" | "provisioning" | "deprovisioning" | "deprovisioned" | "reprovisioning" | "offline" | "awaiting-install-stack-run" | "disabled" | "unknown";
     /** @enum {string} */
     "app.SandboxRunType": "provision" | "reprovision" | "deprovision";
     "app.SlackChannelSubscription": {

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -3349,6 +3349,11 @@ export interface components {
       provision_iam_role_arn?: string;
       public_subnets?: string[];
       region?: string;
+      /**
+       * @description Nil when the stack predates the runner_enabled variable, which must read
+       * as enabled rather than disabled.
+       */
+      runner_enabled?: boolean;
       runner_iam_role_arn?: string;
       runner_subnet?: string;
       vpc_id?: string;
@@ -4455,6 +4460,11 @@ export interface components {
       provision_sa_email?: string;
       public_subnet_name?: string;
       region?: string;
+      /**
+       * @description Nil when the stack predates the runner_enabled variable, which must read
+       * as enabled rather than disabled.
+       */
+      runner_enabled?: boolean;
       runner_service_account_email?: string;
       runner_subnet_name?: string;
     };

--- a/services/dashboard-ui/client/utils/install-utils.test.ts
+++ b/services/dashboard-ui/client/utils/install-utils.test.ts
@@ -114,6 +114,9 @@ describe('install-utils', () => {
       expect(getInstallRunnerStatusTitle('deprovisioned')).toBe(
         'Runner is deprovisioned'
       )
+      expect(getInstallRunnerStatusTitle('disabled')).toBe(
+        'Runner is disabled'
+      )
       expect(getInstallRunnerStatusTitle('reprovisioning')).toBe(
         'Runner is reprovisioning'
       )

--- a/services/dashboard-ui/client/utils/install-utils.ts
+++ b/services/dashboard-ui/client/utils/install-utils.ts
@@ -147,6 +147,7 @@ const RUNNER_STATUS_TITLES: TTitleMap = {
   reprovisioning: 'Runner is reprovisioning',
   offline: 'Runner is offline',
   'awaiting-install-stack-run': 'Runner is awaiting install stack run',
+  disabled: 'Runner is disabled',
   unknown: 'Runner status is unknown',
 }
 


### PR DESCRIPTION
## Summary

Add a new "disabled" runner status. This allows the control-plane to understand when a runner has been intentionally disabled, rather than boing down unexpectedly.

A runner can be disabled by sending `"runner_enabled": false` in the phone home request. This is supported by the Terraform installs stacks through a variable.

```hcl inputs.auto.tfvars
runner_enabled = false
```

When a runner is disabled, it will behave in a similar way to a pending runner. It will not be considered unhealthy, but will not run jobs.

- Attempting to run any workflow besides a stack reprovision will fail with a "runner disabled" error.
- If a workflow is in progress when the runner is disabled, the next job to run will fail with a "runner disabled" error.
- Scheduled jobs like drift scans will be disabled.

<img width="1456" height="768" alt="Screenshot 2026-08-19 at 11 47 43" src="https://github.com/user-attachments/assets/e1bebf51-ddfe-40ea-a2a6-3ad4a8a31521" />
<img width="1060" height="602" alt="Screenshot 2026-08-19 at 11 25 32" src="https://github.com/user-attachments/assets/30feaf83-ba79-4f5a-baf8-07d39394f066" />
<img width="1932" height="1018" alt="Screenshot 2026-08-19 at 12 37 31" src="https://github.com/user-attachments/assets/4f56fd02-f00c-4037-aece-b46a976d1b2a" />
<img width="3024" height="1964" alt="Screenshot 2026-08-19 at 11 25 13" src="https://github.com/user-attachments/assets/0238fc6a-9463-48a6-830f-cc5df62da61e" />
<img width="1950" height="1362" alt="Screenshot 2026-08-19 at 15 19 43" src="https://github.com/user-attachments/assets/704a8f46-b7c0-4eb4-809b-c0755c460d6b" />

