### PR TITLE
fix: load config diff blobs correctly

### DIFF
--- a/services/ctl-api/internal/app/apps/service/get_app_config_diff.go
+++ b/services/ctl-api/internal/app/apps/service/get_app_config_diff.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/pkg/config/diff"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/blobstore"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 )
 
@@ -96,7 +97,8 @@ func (s *service) loadIntermediateConfig(ctx *gin.Context, orgID, appID, configI
 		return nil, gorm.ErrRecordNotFound
 	}
 
-	intermediateJSON, err := appCfg.IntermediateConfig.Get(ctx.Request.Context())
+	blobCtx := blobstore.WithBlobService(ctx.Request.Context(), s.blobSvc)
+	intermediateJSON, err := appCfg.IntermediateConfig.Get(blobCtx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load intermediate config: %w", err)
 	}

--- a/services/ctl-api/internal/app/apps/service/get_app_config_diff_test.go
+++ b/services/ctl-api/internal/app/apps/service/get_app_config_diff_test.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/pkg/config"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+)
+
+func (s *AppConfigsTestSuite) TestGetAppConfigDiffLoadsIntermediateConfigBlob() {
+	intermediate, err := json.Marshal(config.AppConfig{
+		Branch: &config.AppBranchConfig{Name: "main"},
+	})
+	require.NoError(s.T(), err)
+
+	ctx := cctx.SetAccountContext(context.Background(), s.testAcc)
+	ctx = cctx.SetOrgIDContext(ctx, s.testOrg.ID)
+	appConfig, err := s.service.AppsService.createAppConfig(ctx, s.testOrg.ID, s.testApp.ID, &CreateAppConfigRequest{
+		IntermediateConfigJSON: string(intermediate),
+	})
+	require.NoError(s.T(), err)
+
+	path := fmt.Sprintf("/v1/apps/%s/configs/%s/diff", s.testApp.ID, appConfig.ID)
+	rr := s.makeGetRequest(http.MethodGet, path)
+	require.Equal(s.T(), http.StatusOK, rr.Code, rr.Body.String())
+
+	var response AppConfigDiffResponse
+	require.NoError(s.T(), json.Unmarshal(rr.Body.Bytes(), &response))
+	require.Equal(s.T(), appConfig.ID, response.ConfigID)
+}


### PR DESCRIPTION
## Summary

Config diff requests can now load blob-backed intermediate configurations instead of returning an internal server error. Both the current and comparison configs use the ctl-api blob service when generating a diff.
