### PR TITLE
test: cover allow_all_users override; add identity providers story

### DIFF
--- a/sdks/nuon-go/models/app_install_stack_version.go
+++ b/sdks/nuon-go/models/app_install_stack_version.go
@@ -65,24 +65,21 @@ type AppInstallStackVersion struct {
 	// phone home url
 	PhoneHomeURL string `json:"phone_home_url,omitempty"`
 
-	// QuickLinkBucketKey is the Azure-only second S3 object behind QuickLinkURL: a
-	// wrapper template whose sole resource is a deployment stack pointing at
-	// AWSBucketKey's template. The portal cannot create a deployment stack
-	// directly, and the template cannot be inlined into the wrapper — see
-	// arm.QuickLinkWrapper. Empty on AWS, where the quick link addresses the
-	// template itself.
+	// QuickLinkBucketKey and QuickLinkUIDefBucketKey held the wrapper template and
+	// createUiDefinition that an earlier Azure quick link pointed at, so that the
+	// portal created a deployment stack rather than a plain deployment. Nothing
+	// writes them now: the quick link addresses the stack template directly on both
+	// platforms. Rows created while the wrapper shipped still carry their keys.
 	QuickLinkBucketKey string `json:"quick_link_bucket_key,omitempty"`
 
-	// QuickLinkUIDefBucketKey is the Azure-only createUiDefinition accompanying the
-	// wrapper. It constrains the portal's Basics step to the install's resource
-	// group and location, so that a reprovision updates the install's stack instead
-	// of silently creating a second one alongside it.
+	// quick link ui def bucket key
 	QuickLinkUIDefBucketKey string `json:"quick_link_ui_def_bucket_key,omitempty"`
 
 	// QuickLinkURL opens the cloud console pre-loaded with this version's stack:
-	// CloudFormation quick-create on AWS, the portal's Custom Deployment blade on
-	// Azure. Empty on GCP, and on any install whose template bucket is
-	// unconfigured.
+	// CloudFormation quick-create on AWS, Deploy to Azure on Azure. Empty on GCP,
+	// on any install whose template bucket is unconfigured, and on an Azure install
+	// at resource group scope — the portal cannot create the resource group the
+	// root template needs, so there is no link to offer.
 	QuickLinkURL string `json:"quick_link_url,omitempty"`
 
 	// runs

--- a/services/ctl-api/internal/app/auth/service/account_identity_test.go
+++ b/services/ctl-api/internal/app/auth/service/account_identity_test.go
@@ -174,3 +174,50 @@ func (s *AccountIdentityTestSuite) TestSameSubFromTwoProvidersResolvesToDifferen
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), secondAcct.ID, resolved.ID)
 }
+
+// The point of the per-provider override: with a deployment-wide flag alone, a contractor IdP
+// could not be invite-only while the staff IdP allowed self-signup.
+func (s *AccountIdentityTestSuite) TestInviteOnlyProviderRejectsUnknownUsers() {
+	ctx := context.Background()
+	inviteOnly := false
+
+	provider := s.seedOIDCProvider(ctx, "invite-only", "https://invite-only.example.com")
+	provider.AllowAllUsers = &inviteOnly
+	require.NoError(s.T(), s.service.DB.WithContext(ctx).Save(provider).Error)
+
+	stranger := &providers.UserInfo{
+		Subject: "invite-only|stranger",
+		Email:   fmt.Sprintf("%s@test.nuon.co", domains.NewAccountID()),
+	}
+
+	_, err := s.service.AuthService.resolveAccount(ctx, provider, stranger)
+	require.ErrorIs(s.T(), err, ErrAccountNotAuthorized)
+
+	var count int64
+	require.NoError(s.T(), s.service.DB.WithContext(ctx).
+		Model(&app.Account{}).
+		Where(&app.Account{Email: stranger.Email}).
+		Count(&count).Error)
+	require.Zero(s.T(), count, "an invite-only provider must not create an account")
+}
+
+// The same stranger on a provider that inherits an open deployment does get an account, so the
+// rejection above is the override doing its job rather than something else failing.
+func (s *AccountIdentityTestSuite) TestOpenProviderAdmitsUnknownUsers() {
+	ctx := context.Background()
+	if !s.service.Cfg.NuonAuthAllowAllUsers {
+		s.T().Skip("deployment is invite-only; nothing to inherit")
+	}
+
+	provider := s.seedOIDCProvider(ctx, "open", "https://open.example.com")
+	require.Nil(s.T(), provider.AllowAllUsers, "should inherit the deployment-wide flag")
+
+	stranger := &providers.UserInfo{
+		Subject: "open|stranger",
+		Email:   fmt.Sprintf("%s@test.nuon.co", domains.NewAccountID()),
+	}
+
+	account, err := s.service.AuthService.resolveAccount(ctx, provider, stranger)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), stranger.Email, account.Email)
+}

--- a/services/ctl-api/internal/app/auth/service/auth_state.go
+++ b/services/ctl-api/internal/app/auth/service/auth_state.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -104,12 +105,7 @@ func (s *service) AuthState(c *gin.Context) {
 	}
 
 	// Look up or create account by (identity_provider_id, sub)
-	var account *app.Account
-	if s.allowAllUsers(identityProvider) {
-		account, err = s.getOrCreateAccountByIdentity(c.Request.Context(), identityProvider, userInfo)
-	} else {
-		account, err = s.getOrCreateAccountByIdentityStrict(c.Request.Context(), identityProvider, userInfo)
-	}
+	account, err := s.resolveAccount(c.Request.Context(), identityProvider, userInfo)
 	if err != nil {
 		if err == ErrAccountNotAuthorized {
 			s.l.Warn("authentication denied: no account or pending invite",
@@ -183,6 +179,19 @@ func (s *service) verifyUser(userInfo *providers.UserInfo) error {
 		return fmt.Errorf("user has no email or username")
 	}
 	return nil
+}
+
+// resolveAccount maps an authenticated IdP user onto a Nuon account, creating one if this
+// provider admits new users.
+func (s *service) resolveAccount(
+	ctx context.Context,
+	identityProvider *app.IdentityProvider,
+	userInfo *providers.UserInfo,
+) (*app.Account, error) {
+	if s.allowAllUsers(identityProvider) {
+		return s.getOrCreateAccountByIdentity(ctx, identityProvider, userInfo)
+	}
+	return s.getOrCreateAccountByIdentityStrict(ctx, identityProvider, userInfo)
 }
 
 // allowAllUsers reports whether this provider admits any user with an allowed email domain, or

--- a/services/ctl-api/internal/app/auth/service/identity_providers_test.go
+++ b/services/ctl-api/internal/app/auth/service/identity_providers_test.go
@@ -121,3 +121,29 @@ func TestProviderHint(t *testing.T) {
 	require.Empty(t, providerHint(&app.IdentityProvider{ProviderType: app.ProviderTypeGoogle}))
 	require.Empty(t, providerHint(&app.IdentityProvider{ProviderType: app.ProviderTypeOIDC}))
 }
+
+func TestAllowAllUsers(t *testing.T) {
+	enabled, disabled := true, false
+
+	testCases := []struct {
+		name     string
+		global   bool
+		provider *bool
+		expected bool
+	}{
+		{name: "unset inherits the deployment-wide flag", global: true, provider: nil, expected: true},
+		{name: "unset inherits a disabled deployment-wide flag", global: false, provider: nil, expected: false},
+		{name: "provider opens up a closed deployment", global: false, provider: &enabled, expected: true},
+		{name: "provider stays invite-only in an open deployment", global: true, provider: &disabled, expected: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := oidcConfig()
+			cfg.NuonAuthAllowAllUsers = tc.global
+
+			allowed := testService(cfg).allowAllUsers(&app.IdentityProvider{AllowAllUsers: tc.provider})
+			require.Equal(t, tc.expected, allowed)
+		})
+	}
+}

--- a/services/dashboard-ui/client/components/admin/sections/AdminIdentityProvidersSection/AdminIdentityProvidersSection.stories.tsx
+++ b/services/dashboard-ui/client/components/admin/sections/AdminIdentityProvidersSection/AdminIdentityProvidersSection.stories.tsx
@@ -1,0 +1,77 @@
+export default {
+  title: 'Admin/AdminIdentityProvidersSection',
+}
+
+import type { TIdentityProvider } from '@/lib'
+import { AdminIdentityProvidersSection } from './AdminIdentityProvidersSection'
+
+const envProvider: TIdentityProvider = {
+  id: 'default-google',
+  provider_type: 'google',
+  client_id: '822035598858-example.apps.googleusercontent.com',
+  enabled: true,
+  source: 'env',
+}
+
+const providers: TIdentityProvider[] = [
+  envProvider,
+  {
+    id: 'idp0bh1hyq9woty9d7thm5afsc',
+    provider_type: 'oidc',
+    name: 'Staff SSO',
+    client_id: 'staff-client',
+    enabled: true,
+    source: 'database',
+  },
+  {
+    id: 'idpl08pd14q7g6th7dhtbgsj3t',
+    provider_type: 'oidc',
+    name: 'Contractor SSO',
+    client_id: 'contractor-client',
+    enabled: false,
+    allow_all_users: false,
+    source: 'database',
+  },
+]
+
+export const Default = () => (
+  <AdminIdentityProvidersSection
+    identityProviders={providers}
+    isLoading={false}
+    onToggle={() => {}}
+  />
+)
+
+export const Loading = () => (
+  <AdminIdentityProvidersSection
+    identityProviders={[]}
+    isLoading
+    onToggle={() => {}}
+  />
+)
+
+export const Empty = () => (
+  <AdminIdentityProvidersSection
+    identityProviders={[]}
+    isLoading={false}
+    onToggle={() => {}}
+  />
+)
+
+// the env provider has no database row to patch, so its toggle stays disabled
+export const OnlyEnvProvider = () => (
+  <AdminIdentityProvidersSection
+    identityProviders={[envProvider]}
+    isLoading={false}
+    onToggle={() => {}}
+  />
+)
+
+export const Saving = () => (
+  <AdminIdentityProvidersSection
+    identityProviders={providers}
+    isLoading={false}
+    pendingId="idp0bh1hyq9woty9d7thm5afsc"
+    onToggle={() => {}}
+  />
+)

--- a/services/dashboard-ui/client/components/admin/sections/AdminIdentityProvidersSection/AdminIdentityProvidersSection.tsx
+++ b/services/dashboard-ui/client/components/admin/sections/AdminIdentityProvidersSection/AdminIdentityProvidersSection.tsx
@@ -4,6 +4,18 @@ import { Toggle } from '@/components/common/form/Toggle'
 import type { TIdentityProvider } from '@/lib'
 import { AdminSection } from '../../shared/AdminSection'
 
+// mirrors providerDisplayName on the sign-in page, so an unnamed provider reads the same in both
+const PROVIDER_TYPE_LABELS: Record<string, string> = {
+  google: 'Google',
+  github: 'GitHub',
+  oidc: 'Single Sign-On',
+}
+
+const displayName = (identityProvider: TIdentityProvider) =>
+  identityProvider.name ||
+  PROVIDER_TYPE_LABELS[identityProvider.provider_type] ||
+  identityProvider.provider_type
+
 export interface IAdminIdentityProvidersSection {
   identityProviders: TIdentityProvider[]
   isLoading: boolean
@@ -36,7 +48,7 @@ export const AdminIdentityProvidersSection = ({
           <div className="flex flex-col gap-1">
             <div className="flex items-center gap-2">
               <Text variant="base" weight="strong">
-                {identityProvider.name || identityProvider.provider_type}
+                {displayName(identityProvider)}
               </Text>
               <Badge size="xs">{identityProvider.provider_type}</Badge>
               {identityProvider.source === 'env' && (
@@ -60,7 +72,7 @@ export const AdminIdentityProvidersSection = ({
               pendingId === identityProvider.id
             }
             onChange={(enabled) => onToggle(identityProvider, enabled)}
-            label={`Enable ${identityProvider.name || identityProvider.provider_type}`}
+            aria-label={`Enable ${displayName(identityProvider)}`}
           />
         </div>
       ))}

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -5211,26 +5211,20 @@ export interface components {
       phone_home_id?: string;
       phone_home_url?: string;
       /**
-       * @description QuickLinkBucketKey is the Azure-only second S3 object behind QuickLinkURL: a
-       * wrapper template whose sole resource is a deployment stack pointing at
-       * AWSBucketKey's template. The portal cannot create a deployment stack
-       * directly, and the template cannot be inlined into the wrapper — see
-       * arm.QuickLinkWrapper. Empty on AWS, where the quick link addresses the
-       * template itself.
+       * @description QuickLinkBucketKey and QuickLinkUIDefBucketKey held the wrapper template and
+       * createUiDefinition that an earlier Azure quick link pointed at, so that the
+       * portal created a deployment stack rather than a plain deployment. Nothing
+       * writes them now: the quick link addresses the stack template directly on both
+       * platforms. Rows created while the wrapper shipped still carry their keys.
        */
       quick_link_bucket_key?: string;
-      /**
-       * @description QuickLinkUIDefBucketKey is the Azure-only createUiDefinition accompanying the
-       * wrapper. It constrains the portal's Basics step to the install's resource
-       * group and location, so that a reprovision updates the install's stack instead
-       * of silently creating a second one alongside it.
-       */
       quick_link_ui_def_bucket_key?: string;
       /**
        * @description QuickLinkURL opens the cloud console pre-loaded with this version's stack:
-       * CloudFormation quick-create on AWS, the portal's Custom Deployment blade on
-       * Azure. Empty on GCP, and on any install whose template bucket is
-       * unconfigured.
+       * CloudFormation quick-create on AWS, Deploy to Azure on Azure. Empty on GCP,
+       * on any install whose template bucket is unconfigured, and on an Azure install
+       * at resource group scope — the portal cannot create the resource group the
+       * root template needs, so there is no link to offer.
        */
       quick_link_url?: string;
       runs?: components["schemas"]["app.InstallStackVersionRun"][];


### PR DESCRIPTION
Follow-up to #2239 — this commit missed the squash merge.

Adds the tests for the per-provider `allow_all_users` override (unit test for precedence, integration tests that an invite-only provider rejects an unknown user and an inheriting one admits them), extracts `resolveAccount` so that branch is testable, and adds the Ladle story every peer admin section has. Also fixes two label issues the story exposed: the env row read "google [google] [env]", and each toggle repeated the provider name beside it.