### PR TITLE
feat(ctl-api): show runner registration latency by phase

### DIFF
--- a/pkg/temporal/client/namespace.go
+++ b/pkg/temporal/client/namespace.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	enumspb "go.temporal.io/api/enums/v1"
 
 	"go.temporal.io/api/workflowservice/v1"
@@ -13,6 +17,8 @@ import (
 
 	"github.com/pkg/errors"
 )
+
+var clientTracer = otel.Tracer("github.com/nuonco/nuon/pkg/temporal/client")
 
 func (t *temporal) GetNamespaceClient(namespace string) (tclient.Client, error) {
 	defaultClient, err := t.getClient()
@@ -37,12 +43,29 @@ func (t *temporal) ExecuteWorkflowInNamespace(ctx context.Context,
 	workflow interface{},
 	args ...interface{},
 ) (tclient.WorkflowRun, error) {
+	attrs := []attribute.KeyValue{attribute.String("temporal.namespace", namespace)}
+	if workflowType, ok := workflow.(string); ok {
+		attrs = append(attrs, attribute.String("temporal.workflow.type", workflowType))
+	}
+	ctx, span := clientTracer.Start(ctx, "temporal.workflow.start",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attrs...),
+	)
+	defer span.End()
+
 	client, err := t.GetNamespaceClient(namespace)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return nil, errors.Wrap(err, "unable to get namespace client")
 	}
 
-	return client.ExecuteWorkflow(ctx, options, workflow, args...)
+	workflowRun, err := client.ExecuteWorkflow(ctx, options, workflow, args...)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	return workflowRun, err
 }
 
 func (t *temporal) GetWorkflowStatusInNamespace(ctx context.Context,

--- a/services/ctl-api/internal/app/runners/helpers/create_process_queues.go
+++ b/services/ctl-api/internal/app/runners/helpers/create_process_queues.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+
 	"github.com/nuonco/nuon/pkg/generics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cronutil"
@@ -21,29 +24,56 @@ const (
 	defaultBuildUptimeThreshold   = 8 * time.Hour
 )
 
+var processTracer = otel.Tracer("github.com/nuonco/nuon/services/ctl-api/internal/app/runners/helpers")
+
+func traceProcessOperation(ctx context.Context, name string, fn func(context.Context) error) error {
+	ctx, span := processTracer.Start(ctx, name)
+	defer span.End()
+
+	if err := fn(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	return nil
+}
+
 // CreateProcessQueues creates a queue for the given runner process with a
 // scheduled uptime TTL emitter, then enqueues the process_init signal. For
 // sweep-enabled orgs health checks arrive from the per-org sweep emitter;
 // otherwise a legacy per-process cron emitter is created.
 func (h *Helpers) CreateProcessQueues(ctx context.Context, runnerID string, process *app.RunnerProcess) (*app.Queue, error) {
-	q, err := h.queueClient.Create(ctx, &queueclient.CreateQueueRequest{
-		OwnerID:     runnerID,
-		OwnerType:   "runners",
-		Namespace:   "runners",
-		Name:        fmt.Sprintf("runner-process-%s", process.ID),
-		MaxInFlight: 1,
-		MaxDepth:    10,
+	var q *app.Queue
+	err := traceProcessOperation(ctx, "runner.process.queue.create", func(ctx context.Context) error {
+		var err error
+		q, err = h.queueClient.Create(ctx, &queueclient.CreateQueueRequest{
+			OwnerID:     runnerID,
+			OwnerType:   "runners",
+			Namespace:   "runners",
+			Name:        fmt.Sprintf("runner-process-%s", process.ID),
+			MaxInFlight: 1,
+			MaxDepth:    10,
+		})
+		return err
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to create process queue: %w", err)
 	}
 
-	sweeps, err := h.featuresClient.OrgHealthcheckSweepsEnabled(ctx, process.OrgID)
+	var sweeps bool
+	err = traceProcessOperation(ctx, "runner.process.healthcheck_sweeps.evaluate", func(ctx context.Context) error {
+		var err error
+		sweeps, err = h.featuresClient.OrgHealthcheckSweepsEnabled(ctx, process.OrgID)
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to evaluate org healthcheck sweeps flag: %w", err)
 	}
 	if !sweeps {
-		if err := h.createProcessHealthcheckEmitter(ctx, q.ID, runnerID, process.ID); err != nil {
+		if err := traceProcessOperation(ctx, "runner.process.healthcheck_emitter.create", func(ctx context.Context) error {
+			return h.createProcessHealthcheckEmitter(ctx, q.ID, runnerID, process.ID)
+		}); err != nil {
 			return nil, err
 		}
 	}
@@ -68,31 +98,39 @@ func (h *Helpers) CreateProcessQueues(ctx context.Context, runnerID string, proc
 		}
 	}
 
-	if _, err := h.emitterClient.CreateEmitter(ctx, &emitterclient.CreateEmitterRequest{
-		QueueID:     q.ID,
-		Name:        fmt.Sprintf("process-%s-trigger-shutdown", process.ID),
-		Description: "Trigger process shutdown after uptime threshold",
-		Mode:        app.QueueEmitterModeFireOnce,
-		ScheduledAt: generics.ToPtr(time.Now().Add(threshold)),
-		SignalType:  "trigger_shutdown",
-		SignalTemplate: queuesignal.NewRaw("trigger_shutdown", map[string]any{
-			"runner_id":    runnerID,
-			"process_type": string(process.Type),
-		}),
-	}); err != nil {
+	err = traceProcessOperation(ctx, "runner.process.shutdown_emitter.create", func(ctx context.Context) error {
+		_, err := h.emitterClient.CreateEmitter(ctx, &emitterclient.CreateEmitterRequest{
+			QueueID:     q.ID,
+			Name:        fmt.Sprintf("process-%s-trigger-shutdown", process.ID),
+			Description: "Trigger process shutdown after uptime threshold",
+			Mode:        app.QueueEmitterModeFireOnce,
+			ScheduledAt: generics.ToPtr(time.Now().Add(threshold)),
+			SignalType:  "trigger_shutdown",
+			SignalTemplate: queuesignal.NewRaw("trigger_shutdown", map[string]any{
+				"runner_id":    runnerID,
+				"process_type": string(process.Type),
+			}),
+		})
+		return err
+	})
+	if err != nil {
 		return nil, fmt.Errorf("unable to create trigger shutdown emitter: %w", err)
 	}
 
 	// Enqueue the process_init signal to transition process from pending to active
-	if _, err := h.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
-		QueueID:   q.ID,
-		OwnerID:   process.ID,
-		OwnerType: plugins.TableName(h.db, app.RunnerProcess{}),
-		Signal: queuesignal.NewRaw("process_init", map[string]any{
-			"runner_id":  runnerID,
-			"process_id": process.ID,
-		}),
-	}); err != nil {
+	err = traceProcessOperation(ctx, "runner.process.init_signal.enqueue", func(ctx context.Context) error {
+		_, err := h.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
+			QueueID:   q.ID,
+			OwnerID:   process.ID,
+			OwnerType: plugins.TableName(h.db, app.RunnerProcess{}),
+			Signal: queuesignal.NewRaw("process_init", map[string]any{
+				"runner_id":  runnerID,
+				"process_id": process.ID,
+			}),
+		})
+		return err
+	})
+	if err != nil {
 		return nil, fmt.Errorf("unable to enqueue process init signal: %w", err)
 	}
 

--- a/services/ctl-api/internal/app/runners/helpers/create_process_queues_test.go
+++ b/services/ctl-api/internal/app/runners/helpers/create_process_queues_test.go
@@ -1,0 +1,35 @@
+package helpers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestTraceProcessOperation(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	previousTracer := processTracer
+	processTracer = provider.Tracer("test")
+	t.Cleanup(func() {
+		processTracer = previousTracer
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+
+	expectedErr := errors.New("operation failed")
+	err := traceProcessOperation(context.Background(), "runner.process.test", func(context.Context) error {
+		return expectedErr
+	})
+	require.ErrorIs(t, err, expectedErr)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "runner.process.test", spans[0].Name())
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+	require.Len(t, spans[0].Events(), 1)
+}

--- a/services/ctl-api/internal/app/runners/service/create_runner_process.go
+++ b/services/ctl-api/internal/app/runners/service/create_runner_process.go
@@ -49,18 +49,30 @@ func (s *service) CreateRunnerProcess(ctx *gin.Context) {
 		return
 	}
 
-	process, err := s.createRunnerProcess(ctx, runnerID, req)
+	var process *app.RunnerProcess
+	err := traceRunnerRequestOperation(ctx, "runner.process.persist", func(ctx context.Context) error {
+		var err error
+		process, err = s.createRunnerProcess(ctx, runnerID, req)
+		return err
+	})
 	if err != nil {
 		ctx.Error(fmt.Errorf("unable to create runner process: %w", err))
 		return
 	}
 
-	if _, err := s.helpers.CreateProcessQueues(ctx, runnerID, process); err != nil {
+	err = traceRunnerRequestOperation(ctx, "runner.process.queues.initialize", func(ctx context.Context) error {
+		_, err := s.helpers.CreateProcessQueues(ctx, runnerID, process)
+		return err
+	})
+	if err != nil {
 		ctx.Error(fmt.Errorf("unable to create process queues: %w", err))
 		return
 	}
 
+	_, telemetrySpan := runnerTracer.Start(
+		ctx.Request.Context(), "runner.process.telemetry.emit")
 	s.emitProcessStart(ctx, runnerID, process)
+	telemetrySpan.End()
 
 	ctx.JSON(http.StatusCreated, process)
 }

--- a/services/ctl-api/internal/app/runners/service/runner_span.go
+++ b/services/ctl-api/internal/app/runners/service/runner_span.go
@@ -1,12 +1,37 @@
 package service
 
 import (
+	"context"
+
 	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
+
+var runnerTracer = otel.Tracer("github.com/nuonco/nuon/services/ctl-api/internal/app/runners/service")
+
+func traceRunnerRequestOperation(ctx *gin.Context, name string, fn func(context.Context) error) error {
+	request := ctx.Request
+	spanCtx, span := runnerTracer.Start(request.Context(), name)
+	ctx.Request = request.WithContext(spanCtx)
+	defer func() {
+		ctx.Request = request
+		span.End()
+	}()
+
+	operationCtx := trace.ContextWithSpan(ctx, span)
+	if err := fn(operationCtx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	return nil
+}
 
 func setRunnerSpanAttributes(ctx *gin.Context, runner *app.Runner, installID, installName string, extra ...attribute.KeyValue) {
 	span := trace.SpanFromContext(ctx.Request.Context())

--- a/services/ctl-api/internal/app/runners/service/runner_span_test.go
+++ b/services/ctl-api/internal/app/runners/service/runner_span_test.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestTraceRunnerRequestOperation(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	previousTracer := runnerTracer
+	runnerTracer = provider.Tracer("test")
+	t.Cleanup(func() {
+		runnerTracer = previousTracer
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+
+	rootCtx, rootSpan := provider.Tracer("test").Start(context.Background(), "request")
+	responseRecorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(responseRecorder)
+	ctx.Request = httptest.NewRequest("POST", "/v1/runners/id/processes", nil).WithContext(rootCtx)
+	originalRequest := ctx.Request
+
+	err := traceRunnerRequestOperation(ctx, "runner.process.test", func(operationCtx context.Context) error {
+		require.Equal(t, trace.SpanContextFromContext(ctx.Request.Context()), trace.SpanContextFromContext(operationCtx))
+		require.NotEqual(t, rootSpan.SpanContext(), trace.SpanContextFromContext(operationCtx))
+		return nil
+	})
+	require.NoError(t, err)
+	require.Same(t, originalRequest, ctx.Request)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, rootSpan.SpanContext().SpanID(), spans[0].Parent().SpanID())
+	rootSpan.End()
+}


### PR DESCRIPTION
## Summary

Runner process registration traces now show where ctl-api spends time instead of reporting most latency as unexplained self time.

## What you can do after this PR

**Attribute registration latency to individual phases.** Traces separate process persistence, queue setup, feature evaluation, emitter creation, initialization enqueue, and telemetry emission.

**See synchronous Temporal workflow startup time.** Temporal start spans include the namespace and workflow type without adding high-cardinality identifiers.


## Mechanics worth flagging for review

Request context is preserved across Gin, GORM, and Temporal boundaries so child spans remain attached to the original HTTP trace.
