### PR TITLE
feat: authenticate azure phone home with a managed identity token

### DIFF
--- a/bins/cli/cmd/installs.go
+++ b/bins/cli/cmd/installs.go
@@ -11,38 +11,40 @@ import (
 
 func (c *cli) installsCmd() *cobra.Command {
 	var (
-		id                 string
-		workflowID         string
-		actionWorkflowID   string
-		stepID             string
-		note               string
-		name               string
-		region             string
-		awsAccountID       string
-		appID              string
-		deployID           string
-		runID              string
-		installCompID      string
-		componentID        string
-		roleName           string
-		inputs             []string
-		labelArgs          []string
-		noSelect           bool
-		deployDeps         bool
-		deployDependents   bool
-		deployDependencies bool
-		stackOnly          bool
-		inputsOnly         bool
-		offset             int
-		limit              int
-		planOnly           bool
-		fileOrDir          string
-		confirm            bool
-		wait               bool
-		enable             bool
-		disable            bool
-		dryRun             bool
-		skipConfirm        bool
+		id                  string
+		workflowID          string
+		actionWorkflowID    string
+		stepID              string
+		note                string
+		name                string
+		region              string
+		awsAccountID        string
+		azureSubscriptionID string
+		gcpProjectID        string
+		appID               string
+		deployID            string
+		runID               string
+		installCompID       string
+		componentID         string
+		roleName            string
+		inputs              []string
+		labelArgs           []string
+		noSelect            bool
+		deployDeps          bool
+		deployDependents    bool
+		deployDependencies  bool
+		stackOnly           bool
+		inputsOnly          bool
+		offset              int
+		limit               int
+		planOnly            bool
+		fileOrDir           string
+		confirm             bool
+		wait                bool
+		enable              bool
+		disable             bool
+		dryRun              bool
+		skipConfirm         bool
 	)
 
 	installsCmds := &cobra.Command{
@@ -140,7 +142,11 @@ sandbox and components unprovisioned:
 		Annotations: tuiAnnotation(TUIAltScreen),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			svc := c.installs
-			return svc.Create(cmd.Context(), appID, name, region, awsAccountID, inputs, labelArgs, PrintJSON, noSelect, stackOnly)
+			return svc.Create(cmd.Context(), appID, name, region, installs.TargetAccount{
+				AWSAccountID:        awsAccountID,
+				AzureSubscriptionID: azureSubscriptionID,
+				GCPProjectID:        gcpProjectID,
+			}, inputs, labelArgs, PrintJSON, noSelect, stackOnly)
 		}),
 	}
 	createCmd.Flags().StringVarP(&appID, "app-id", "a", "", "The ID or name of the app to create this install for")
@@ -151,6 +157,8 @@ sandbox and components unprovisioned:
 	}
 	createCmd.Flags().StringVarP(&region, "region", "r", "", "The region to provision this install in (required for AWS installs)")
 	createCmd.Flags().StringVar(&awsAccountID, "aws-account-id", "", "The AWS account ID this install targets (required when phone home authentication is enabled for your org; immutable after creation)")
+	createCmd.Flags().StringVar(&azureSubscriptionID, "azure-subscription-id", "", "The Azure subscription ID this install targets (required when phone home authentication is enabled for your org; immutable after creation)")
+	createCmd.Flags().StringVar(&gcpProjectID, "gcp-project-id", "", "The GCP project ID this install targets (required when phone home authentication is enabled for your org; immutable after creation)")
 	createCmd.Flags().StringSliceVar(&inputs, "inputs", []string{}, "The app input values for the install")
 	createCmd.Flags().StringSliceVar(&labelArgs, "label", []string{}, "Labels to set on the install (repeatable, format: key=value). Example: --label env=prod --label team=platform")
 	createCmd.Flags().BoolVar(&noSelect, "no-select", false, "Do not automatically set the created install as the current install")

--- a/bins/cli/internal/services/installs/create.go
+++ b/bins/cli/internal/services/installs/create.go
@@ -23,7 +23,16 @@ const (
 	statusAccessError = "access_error"
 )
 
-func (s *Service) Create(ctx context.Context, appID, name, region, awsAccountID string, inputs, labelArgs []string, asJSON, noSelect, stackOnly bool) error {
+// TargetAccount is the cloud account an install is pinned to. Only the field matching the
+// app's cloud platform is used, and the API requires it once the org has phone-home auth
+// enabled.
+type TargetAccount struct {
+	AWSAccountID        string
+	AzureSubscriptionID string
+	GCPProjectID        string
+}
+
+func (s *Service) Create(ctx context.Context, appID, name, region string, target TargetAccount, inputs, labelArgs []string, asJSON, noSelect, stackOnly bool) error {
 	if appID == "" {
 		selectedID, err := appselector.App(ctx, s.cfg, s.api)
 		if err != nil {
@@ -78,7 +87,7 @@ func (s *Service) Create(ctx context.Context, appID, name, region, awsAccountID 
 		inputsMap[kvT[0]] = kvT[1]
 	}
 
-	req, err := s.buildCreateInstallRequest(ctx, appID, name, region, awsAccountID, inputsMap, labelsMap)
+	req, err := s.buildCreateInstallRequest(ctx, appID, name, region, target, inputsMap, labelsMap)
 	if err != nil {
 		return ui.PrintError(err)
 	}
@@ -111,7 +120,7 @@ func (s *Service) Create(ctx context.Context, appID, name, region, awsAccountID 
 	return nil
 }
 
-func (s *Service) buildCreateInstallRequest(ctx context.Context, appID, name, region, awsAccountID string, inputs, labelsMap map[string]string) (*models.ServiceCreateInstallRequest, error) {
+func (s *Service) buildCreateInstallRequest(ctx context.Context, appID, name, region string, target TargetAccount, inputs, labelsMap map[string]string) (*models.ServiceCreateInstallRequest, error) {
 	req := &models.ServiceCreateInstallRequest{
 		Name:   &name,
 		Inputs: s.inputsWithDefaults(ctx, appID, inputs),
@@ -120,20 +129,26 @@ func (s *Service) buildCreateInstallRequest(ctx context.Context, appID, name, re
 
 	runnerCfg, err := s.api.GetAppRunnerLatestConfig(ctx, appID)
 	if err != nil || runnerCfg == nil {
-		req.AwsAccount = &models.HelpersCreateInstallAWSAccountParams{Region: region, AccountID: awsAccountID}
+		req.AwsAccount = &models.HelpersCreateInstallAWSAccountParams{Region: region, AccountID: target.AWSAccountID}
 		return req, nil
 	}
 
 	switch runnerCfg.CloudPlatform {
 	case models.AppCloudPlatformGcp:
-		req.GcpAccount = &models.HelpersCreateInstallGCPAccountParams{}
+		req.GcpAccount = &models.HelpersCreateInstallGCPAccountParams{
+			ProjectID: target.GCPProjectID,
+			Region:    region,
+		}
 	case models.AppCloudPlatformAzure:
-		req.AzureAccount = &models.HelpersCreateInstallAzureAccountParams{}
+		req.AzureAccount = &models.HelpersCreateInstallAzureAccountParams{
+			SubscriptionID: target.AzureSubscriptionID,
+			Location:       region,
+		}
 	default:
 		if region == "" {
 			return nil, fmt.Errorf("--region is required for AWS installs")
 		}
-		req.AwsAccount = &models.HelpersCreateInstallAWSAccountParams{Region: region, AccountID: awsAccountID}
+		req.AwsAccount = &models.HelpersCreateInstallAWSAccountParams{Region: region, AccountID: target.AWSAccountID}
 	}
 
 	return req, nil

--- a/bins/cli/internal/services/mcpserver/tools_write.go
+++ b/bins/cli/internal/services/mcpserver/tools_write.go
@@ -11,11 +11,13 @@ import (
 )
 
 type createInstallInput struct {
-	App          string            `json:"app,omitempty" jsonschema:"app name or ID to create the install for; defaults to the currently selected app"`
-	Name         string            `json:"name" jsonschema:"name for the new install"`
-	Region       string            `json:"region,omitempty" jsonschema:"cloud region to provision in"`
-	AWSAccountID string            `json:"aws_account_id,omitempty" jsonschema:"AWS account ID this install targets; required when phone home authentication is enabled for the org"`
-	Inputs       map[string]string `json:"inputs,omitempty" jsonschema:"app input values"`
+	App                 string            `json:"app,omitempty" jsonschema:"app name or ID to create the install for; defaults to the currently selected app"`
+	Name                string            `json:"name" jsonschema:"name for the new install"`
+	Region              string            `json:"region,omitempty" jsonschema:"cloud region to provision in"`
+	AWSAccountID        string            `json:"aws_account_id,omitempty" jsonschema:"AWS account ID this install targets; required when phone home authentication is enabled for the org"`
+	AzureSubscriptionID string            `json:"azure_subscription_id,omitempty" jsonschema:"Azure subscription ID this install targets; required when phone home authentication is enabled for the org"`
+	GCPProjectID        string            `json:"gcp_project_id,omitempty" jsonschema:"GCP project ID this install targets; required when phone home authentication is enabled for the org"`
+	Inputs              map[string]string `json:"inputs,omitempty" jsonschema:"app input values"`
 }
 
 type deployComponentInput struct {
@@ -33,14 +35,28 @@ func (s *Service) registerWriteTools(server *mcp.Server) {
 		if err != nil {
 			return nil, nil, err
 		}
-		install, err := s.api.CreateInstall(ctx, appID, &models.ServiceCreateInstallRequest{
-			Name: &in.Name,
-			AwsAccount: &models.HelpersCreateInstallAWSAccountParams{
+		req := &models.ServiceCreateInstallRequest{Name: &in.Name, Inputs: in.Inputs}
+		// Only one account block may be set, and sending the AWS one unconditionally made
+		// Azure and GCP apps impossible to install through this tool.
+		switch {
+		case in.AzureSubscriptionID != "":
+			req.AzureAccount = &models.HelpersCreateInstallAzureAccountParams{
+				SubscriptionID: in.AzureSubscriptionID,
+				Location:       in.Region,
+			}
+		case in.GCPProjectID != "":
+			req.GcpAccount = &models.HelpersCreateInstallGCPAccountParams{
+				ProjectID: in.GCPProjectID,
+				Region:    in.Region,
+			}
+		default:
+			req.AwsAccount = &models.HelpersCreateInstallAWSAccountParams{
 				Region:    in.Region,
 				AccountID: in.AWSAccountID,
-			},
-			Inputs: in.Inputs,
-		})
+			}
+		}
+
+		install, err := s.api.CreateInstall(ctx, appID, req)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/services/ctl-api/internal/app/install.go
+++ b/services/ctl-api/internal/app/install.go
@@ -473,6 +473,17 @@ type CloudPlatformMetadata struct {
 	TargetSubscriptionID   string `json:"target_subscription_id,omitempty"`
 	ObservedSubscriptionID string `json:"observed_subscription_id,omitempty"`
 
+	// Tenant is not collected at install creation, so the first verified phone home
+	// pins it and later ones are checked against the pin. Until then a subscription
+	// match carries the binding on its own: a subscription belongs to exactly one
+	// tenant, and xms_mirid naming it is signed by that tenant.
+	TargetTenantID   string `json:"target_tenant_id,omitempty"`
+	ObservedTenantID string `json:"observed_tenant_id,omitempty"`
+
+	// Pinned the same way, so a leaked token cannot be presented by a second identity
+	// that happens to satisfy the subscription and name checks.
+	ObservedPhoneHomePrincipalID string `json:"observed_phone_home_principal_id,omitempty"`
+
 	TargetSource string `json:"target_source,omitempty"`
 }
 

--- a/services/ctl-api/internal/app/install_stack_version.go
+++ b/services/ctl-api/internal/app/install_stack_version.go
@@ -52,6 +52,11 @@ type InstallStackVersion struct {
 	// credential on its next run.
 	PhoneHomeTokenRevokedAt *time.Time `json:"-" temporaljson:"-"`
 
+	// Set means the template was rendered to authenticate, so an unauthenticated phone
+	// home is rejected rather than skipped. Empty versions predate enforcement on their
+	// cloud and are skipped, which is what lets this roll out per cloud.
+	PhoneHomeIdentityName string `json:"-" temporaljson:"-"`
+
 	// aws configuration parameters
 	AWSBucketName string `json:"aws_bucket_name,omitzero" temporaljson:"aws_bucket_name,omitzero,omitempty"`
 	AWSBucketKey  string `json:"aws_bucket_key,omitzero" temporaljson:"aws_bucket_key,omitzero,omitempty"`

--- a/services/ctl-api/internal/app/installs/service/post_install_phone_home_auth.go
+++ b/services/ctl-api/internal/app/installs/service/post_install_phone_home_auth.go
@@ -87,7 +87,10 @@ func (s *service) authorizePhoneHome(
 			phoneHomeRejectRevokedVersion,
 			fmt.Errorf("phone home token for stack version %s was revoked", stackVersion.ID),
 		)
-	case stackVersion.PhoneHomeTokenID == "":
+	// A version carries whichever credential its cloud renders. Neither means it was
+	// rendered before enforcement reached that cloud, so it is skipped rather than
+	// rejected.
+	case stackVersion.PhoneHomeIdentityName == "" && stackVersion.PhoneHomeTokenID == "":
 		return phoneHomeAuthSkipped, nil
 	}
 
@@ -103,6 +106,10 @@ func (s *service) authorizePhoneHome(
 				Description: "this install stack version has expired and needs to be reprovisioned",
 			},
 		}
+	}
+
+	if stackVersion.PhoneHomeIdentityName != "" {
+		return s.authorizeAzurePhoneHome(ctx, install, stackVersion, authHeader)
 	}
 
 	raw := bearerToken(authHeader)
@@ -182,15 +189,27 @@ func bearerToken(header string) string {
 // install was created against the wrong account or a token escaped into a different
 // one, and neither should be allowed to overwrite stack outputs.
 func checkObservedCloudAccount(install *app.Install, props map[string]any) (string, error) {
-	observed, _ := props["account_id"].(string)
-	if observed == "" || install.ExpectedAccountID == "" || observed == install.ExpectedAccountID {
-		return phoneHomeAuthOK, nil
+	for _, field := range []struct {
+		payloadKey string
+		expected   string
+	}{
+		{"account_id", install.ExpectedAccountID},
+		{"subscription_id", install.ExpectedSubscriptionID},
+		{"project_id", install.ExpectedProjectID},
+	} {
+		observed, _ := props[field.payloadKey].(string)
+		if observed == "" || field.expected == "" || strings.EqualFold(observed, field.expected) {
+			continue
+		}
+
+		return phoneHomeRejectAccountMismatch, rejectPhoneHome(
+			phoneHomeRejectAccountMismatch,
+			fmt.Errorf("payload %s %s does not match the account expected for this install",
+				field.payloadKey, observed),
+		)
 	}
 
-	return phoneHomeRejectAccountMismatch, rejectPhoneHome(
-		phoneHomeRejectAccountMismatch,
-		fmt.Errorf("payload account %s does not match the account expected for this install", observed),
-	)
+	return phoneHomeAuthOK, nil
 }
 
 // recordPhoneHomeAuthResult stamps the install so the dashboard can say "stack outputs

--- a/services/ctl-api/internal/app/installs/service/post_install_phone_home_auth_azure.go
+++ b/services/ctl-api/internal/app/installs/service/post_install_phone_home_auth_azure.go
@@ -1,0 +1,196 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workloadjwt"
+)
+
+const (
+	phoneHomeRejectIdentityToken    = "invalid_identity_token"
+	phoneHomeRejectIdentityMismatch = "identity_mismatch"
+	phoneHomeRejectTenantMismatch   = "tenant_mismatch"
+	phoneHomeRejectPrincipalPinned  = "principal_mismatch"
+	phoneHomeRejectNoTargetAccount  = "no_target_account"
+)
+
+// authorizeAzurePhoneHome verifies that the caller is the managed identity this stack
+// version's template was rendered with.
+//
+// The verified signature only proves which Entra tenant minted the token, so it carries
+// no authorization on its own. The binding is subscription plus identity name: Azure
+// assigns the subscription in a resource id and signs it into xms_mirid, so a token
+// naming this install's subscription can only have come from an identity inside it.
+func (s *service) authorizeAzurePhoneHome(
+	ctx context.Context, install *app.Install, stackVersion *app.InstallStackVersion, authHeader string,
+) (string, error) {
+	raw := bearerToken(authHeader)
+	if raw == "" {
+		return phoneHomeRejectMissingToken, rejectPhoneHome(
+			phoneHomeRejectMissingToken, errors.New("no bearer token presented"),
+		)
+	}
+
+	// Without a pinned subscription there is nothing to bind to, and a token from any
+	// Entra tenant would pass. Fail closed: the template only carries an identity once
+	// the feature is on, and the feature requires a subscription at creation.
+	if install.CloudPlatformMetadata.TargetSubscriptionID == "" {
+		return phoneHomeRejectNoTargetAccount, rejectPhoneHome(
+			phoneHomeRejectNoTargetAccount,
+			fmt.Errorf("install %s has no target subscription to bind against", install.ID),
+		)
+	}
+
+	// A pinned tenant is authoritative. Before the first success there is none, so the
+	// token's own tenant selects the key set and the subscription check below is what
+	// rejects a token minted anywhere else.
+	tenantID := install.CloudPlatformMetadata.TargetTenantID
+	if tenantID == "" {
+		tenantID = install.CloudPlatformMetadata.ObservedTenantID
+	}
+	if tenantID == "" {
+		var err error
+		if tenantID, err = unverifiedAzureTenantID(raw); err != nil {
+			return s.rejectAzureIdentityToken(install, err)
+		}
+	}
+
+	issuer, err := workloadjwt.AzureIssuer(tenantID)
+	if err != nil {
+		return s.rejectAzureIdentityToken(install, err)
+	}
+
+	claims, err := s.workloadJWT.Verify(ctx, workloadjwt.Request{
+		Token:    raw,
+		Issuer:   issuer,
+		Audience: workloadjwt.AzureManagementAudience,
+	})
+	if err != nil {
+		return s.rejectAzureIdentityToken(install, err)
+	}
+
+	identity, err := workloadjwt.ParseAzureManagedIdentity(claims)
+	if err != nil {
+		return s.rejectAzureIdentityToken(install, err)
+	}
+
+	if reason, err := bindAzureIdentity(install, stackVersion, identity, tenantID); err != nil {
+		return reason, err
+	}
+
+	s.pinAzurePhoneHomeIdentity(ctx, install, identity)
+
+	return phoneHomeAuthOK, nil
+}
+
+// bindAzureIdentity is the authorization step: it decides whether a token Entra has
+// already vouched for belongs to this install. Kept free of IO so every rejection path is
+// directly testable.
+func bindAzureIdentity(
+	install *app.Install,
+	stackVersion *app.InstallStackVersion,
+	identity *workloadjwt.AzureManagedIdentity,
+	expectedTenantID string,
+) (string, error) {
+	// Guards against a pinned tenant being bypassed by a token whose own tid selected the
+	// key set it was verified against.
+	if !strings.EqualFold(identity.TenantID, expectedTenantID) {
+		return phoneHomeRejectTenantMismatch, rejectPhoneHome(
+			phoneHomeRejectTenantMismatch,
+			fmt.Errorf("token tenant %s is not the tenant expected for this install", identity.TenantID),
+		)
+	}
+
+	// The load-bearing check. Azure assigns the subscription in a resource id and signs it
+	// into xms_mirid, so a token naming this subscription came from inside it.
+	if !strings.EqualFold(identity.SubscriptionID, install.CloudPlatformMetadata.TargetSubscriptionID) {
+		return phoneHomeRejectAccountMismatch, rejectPhoneHome(
+			phoneHomeRejectAccountMismatch,
+			fmt.Errorf("token subscription %s does not match the subscription expected for this install",
+				identity.SubscriptionID),
+		)
+	}
+
+	// Scopes the credential to one install: every install in a subscription renders a
+	// differently named identity, so a neighbour's token cannot post here.
+	if stackVersion.PhoneHomeIdentityName == "" ||
+		!strings.EqualFold(identity.Name, stackVersion.PhoneHomeIdentityName) {
+		return phoneHomeRejectIdentityMismatch, rejectPhoneHome(
+			phoneHomeRejectIdentityMismatch,
+			fmt.Errorf("token identity %q is not %q", identity.Name, stackVersion.PhoneHomeIdentityName),
+		)
+	}
+
+	if pinned := install.CloudPlatformMetadata.ObservedPhoneHomePrincipalID; pinned != "" &&
+		!strings.EqualFold(pinned, identity.PrincipalID) {
+		return phoneHomeRejectPrincipalPinned, rejectPhoneHome(
+			phoneHomeRejectPrincipalPinned,
+			fmt.Errorf("token principal %s is not the principal pinned for this install", identity.PrincipalID),
+		)
+	}
+
+	return phoneHomeAuthOK, nil
+}
+
+// rejectAzureIdentityToken keeps verification detail out of the response. The underlying
+// error quotes the presented token's own claims and, for a discovery failure, Entra's reply
+// verbatim -- echoing either back to an unauthenticated caller tells them how far they got.
+func (s *service) rejectAzureIdentityToken(install *app.Install, err error) (string, error) {
+	s.l.Warn("rejected azure phone home identity token",
+		zap.String("install_id", install.ID), zap.Error(err))
+
+	return phoneHomeRejectIdentityToken, rejectPhoneHome(
+		phoneHomeRejectIdentityToken, errors.New("identity token verification failed"),
+	)
+}
+
+// pinAzurePhoneHomeIdentity records the tenant and principal the first verified call came
+// from. Best-effort: a failure here must not reject a call that already verified, and the
+// next success retries it.
+func (s *service) pinAzurePhoneHomeIdentity(
+	ctx context.Context, install *app.Install, identity *workloadjwt.AzureManagedIdentity,
+) {
+	cpm := install.CloudPlatformMetadata
+	if cpm.ObservedTenantID == identity.TenantID &&
+		cpm.ObservedSubscriptionID == identity.SubscriptionID &&
+		cpm.ObservedPhoneHomePrincipalID == identity.PrincipalID {
+		return
+	}
+
+	cpm.ObservedTenantID = identity.TenantID
+	cpm.ObservedSubscriptionID = identity.SubscriptionID
+	cpm.ObservedPhoneHomePrincipalID = identity.PrincipalID
+
+	if res := s.db.WithContext(ctx).
+		Model(&app.Install{ID: install.ID}).
+		Update("cloud_platform_metadata", cpm); res.Error != nil {
+		s.l.Warn("unable to pin azure phone home identity",
+			zap.String("install_id", install.ID), zap.Error(res.Error))
+
+		return
+	}
+	install.CloudPlatformMetadata = cpm
+}
+
+// unverifiedAzureTenantID reads tid from an unverified token, only to pick which tenant's
+// keys to check the signature with. The value is re-checked against the verified claims
+// afterwards, and authorization never rests on it.
+func unverifiedAzureTenantID(token string) (string, error) {
+	claims, err := workloadjwt.UnverifiedClaims(token)
+	if err != nil {
+		return "", err
+	}
+
+	tenantID, ok := workloadjwt.StringClaim(claims, "tid")
+	if !ok {
+		return "", errors.New("token is missing the tid claim")
+	}
+
+	return tenantID, nil
+}

--- a/services/ctl-api/internal/app/installs/service/post_install_phone_home_auth_azure_test.go
+++ b/services/ctl-api/internal/app/installs/service/post_install_phone_home_auth_azure_test.go
@@ -1,0 +1,164 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workloadjwt"
+)
+
+const (
+	boundTenantID    = "11111111-2222-3333-4444-555555555555"
+	boundSubID       = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	boundPrincipalID = "99999999-8888-7777-6666-555555555555"
+	boundIdentity    = "inst123-phone-home"
+)
+
+func boundInstall() *app.Install {
+	return &app.Install{
+		ID: "inst123",
+		CloudPlatformMetadata: app.CloudPlatformMetadata{
+			TargetSubscriptionID: boundSubID,
+		},
+	}
+}
+
+func boundStackVersion() *app.InstallStackVersion {
+	return &app.InstallStackVersion{PhoneHomeIdentityName: boundIdentity}
+}
+
+func boundVerifiedIdentity() *workloadjwt.AzureManagedIdentity {
+	return &workloadjwt.AzureManagedIdentity{
+		SubscriptionID: boundSubID,
+		ResourceGroup:  "rg-1",
+		Name:           boundIdentity,
+		PrincipalID:    boundPrincipalID,
+		TenantID:       boundTenantID,
+	}
+}
+
+func TestBindAzureIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		install    func(*app.Install)
+		version    func(*app.InstallStackVersion)
+		identity   func(*workloadjwt.AzureManagedIdentity)
+		wantReason string
+	}{
+		{
+			name:       "the identity the template rendered is accepted",
+			wantReason: phoneHomeAuthOK,
+		},
+		{
+			// Azure does not preserve casing in xms_mirid, and GUIDs are
+			// case-insensitive, so a casing difference is not a mismatch.
+			name: "casing differences are not mismatches",
+			identity: func(i *workloadjwt.AzureManagedIdentity) {
+				i.SubscriptionID = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+				i.Name = "INST123-PHONE-HOME"
+				i.TenantID = "11111111-2222-3333-4444-555555555555"
+			},
+			wantReason: phoneHomeAuthOK,
+		},
+		{
+			// An attacker with their own Azure tenant can mint a validly signed token;
+			// this is the check that stops it being usable here.
+			name: "a token from another subscription is rejected",
+			identity: func(i *workloadjwt.AzureManagedIdentity) {
+				i.SubscriptionID = "ffffffff-bbbb-cccc-dddd-eeeeeeeeeeee"
+			},
+			wantReason: phoneHomeRejectAccountMismatch,
+		},
+		{
+			// Two installs in one subscription must not be able to post for each other.
+			name: "a neighbouring install's identity is rejected",
+			identity: func(i *workloadjwt.AzureManagedIdentity) {
+				i.Name = "inst999-phone-home"
+			},
+			wantReason: phoneHomeRejectIdentityMismatch,
+		},
+		{
+			// Fail closed: an unnamed version must never match a token whose identity
+			// name happens to be empty.
+			name:       "a version with no rendered identity cannot be satisfied",
+			version:    func(v *app.InstallStackVersion) { v.PhoneHomeIdentityName = "" },
+			identity:   func(i *workloadjwt.AzureManagedIdentity) { i.Name = "" },
+			wantReason: phoneHomeRejectIdentityMismatch,
+		},
+		{
+			name: "a token from another tenant is rejected",
+			identity: func(i *workloadjwt.AzureManagedIdentity) {
+				i.TenantID = "ffffffff-2222-3333-4444-555555555555"
+			},
+			wantReason: phoneHomeRejectTenantMismatch,
+		},
+		{
+			// Nothing to bind against: rendering an identity without a target
+			// subscription would mean enforcing against nothing.
+			name:       "an install with no target subscription is rejected",
+			install:    func(i *app.Install) { i.CloudPlatformMetadata.TargetSubscriptionID = "" },
+			wantReason: phoneHomeRejectAccountMismatch,
+		},
+		{
+			name: "a principal other than the pinned one is rejected",
+			install: func(i *app.Install) {
+				i.CloudPlatformMetadata.ObservedPhoneHomePrincipalID = "00000000-8888-7777-6666-555555555555"
+			},
+			wantReason: phoneHomeRejectPrincipalPinned,
+		},
+		{
+			name: "the pinned principal is accepted",
+			install: func(i *app.Install) {
+				i.CloudPlatformMetadata.ObservedPhoneHomePrincipalID = boundPrincipalID
+			},
+			wantReason: phoneHomeAuthOK,
+		},
+		{
+			// Before the first verified call there is no pin, so it must not reject.
+			name:       "an unpinned install is accepted",
+			install:    func(i *app.Install) { i.CloudPlatformMetadata.ObservedPhoneHomePrincipalID = "" },
+			wantReason: phoneHomeAuthOK,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			install, version, identity := boundInstall(), boundStackVersion(), boundVerifiedIdentity()
+			if tc.install != nil {
+				tc.install(install)
+			}
+			if tc.version != nil {
+				tc.version(version)
+			}
+			if tc.identity != nil {
+				tc.identity(identity)
+			}
+
+			reason, err := bindAzureIdentity(install, version, identity, boundTenantID)
+
+			assert.Equal(t, tc.wantReason, reason)
+			if tc.wantReason == phoneHomeAuthOK {
+				assert.NoError(t, err)
+				return
+			}
+			assert.Error(t, err)
+
+			// Every rejection reaches the caller as the same opaque 401.
+			var authErr errPhoneHomeAuth
+			assert.ErrorAs(t, err, &authErr)
+			assert.Equal(t, tc.wantReason, authErr.reason)
+		})
+	}
+}
+
+// The subscription check is what makes a validly signed token from any other Azure tenant
+// useless, so it must not be reachable only when a tenant is already pinned.
+func TestBindAzureIdentity_SubscriptionCheckedWithoutAPinnedTenant(t *testing.T) {
+	identity := boundVerifiedIdentity()
+	identity.SubscriptionID = "ffffffff-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+	reason, err := bindAzureIdentity(boundInstall(), boundStackVersion(), identity, identity.TenantID)
+
+	assert.Equal(t, phoneHomeRejectAccountMismatch, reason)
+	assert.Error(t, err)
+}

--- a/services/ctl-api/internal/app/installs/service/post_install_phone_home_auth_test.go
+++ b/services/ctl-api/internal/app/installs/service/post_install_phone_home_auth_test.go
@@ -143,11 +143,35 @@ func TestCheckObservedCloudAccount(t *testing.T) {
 			wantReason: phoneHomeAuthOK,
 		},
 		{
-			// GCP and Azure stacks post no account_id; rejecting them here would break
-			// clouds this check does not cover.
+			// A stack that posts no identifier at all has nothing to contradict.
 			name:       "a payload without an account is not a rejection",
 			install:    &app.Install{ExpectedAccountID: expected},
 			props:      map[string]any{},
+			wantReason: phoneHomeAuthOK,
+		},
+		{
+			name:       "matching azure subscription passes",
+			install:    &app.Install{ExpectedSubscriptionID: "AAAAAAAA-bbbb-cccc-dddd-eeeeeeeeeeee"},
+			props:      map[string]any{"subscription_id": "aaaaaaaa-BBBB-cccc-dddd-eeeeeeeeeeee"},
+			wantReason: phoneHomeAuthOK,
+		},
+		{
+			name:       "differing azure subscription is rejected",
+			install:    &app.Install{ExpectedSubscriptionID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"},
+			props:      map[string]any{"subscription_id": "ffffffff-bbbb-cccc-dddd-eeeeeeeeeeee"},
+			wantReason: phoneHomeRejectAccountMismatch,
+		},
+		{
+			name:       "differing gcp project is rejected",
+			install:    &app.Install{ExpectedProjectID: "acme-prod"},
+			props:      map[string]any{"project_id": "acme-staging"},
+			wantReason: phoneHomeRejectAccountMismatch,
+		},
+		{
+			// An install carries one cloud's identifier; the others must not false-positive.
+			name:       "an unrelated cloud identifier is ignored",
+			install:    &app.Install{ExpectedAccountID: expected},
+			props:      map[string]any{"subscription_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"},
 			wantReason: phoneHomeAuthOK,
 		},
 		{
@@ -196,6 +220,11 @@ func TestPhoneHomeRejectionReasonsAreStable(t *testing.T) {
 	assert.Equal(t, "revoked_stack_version", phoneHomeRejectRevokedVersion)
 	assert.Equal(t, "version_expired", phoneHomeRejectVersionExpired)
 	assert.Equal(t, "account_mismatch", phoneHomeRejectAccountMismatch)
+	assert.Equal(t, "invalid_identity_token", phoneHomeRejectIdentityToken)
+	assert.Equal(t, "identity_mismatch", phoneHomeRejectIdentityMismatch)
+	assert.Equal(t, "tenant_mismatch", phoneHomeRejectTenantMismatch)
+	assert.Equal(t, "principal_mismatch", phoneHomeRejectPrincipalPinned)
+	assert.Equal(t, "no_target_account", phoneHomeRejectNoTargetAccount)
 	assert.Equal(t, "skipped", phoneHomeAuthSkipped)
 	assert.Equal(t, "", phoneHomeAuthOK, "an empty reason must mean verified")
 }

--- a/services/ctl-api/internal/app/installs/service/service.go
+++ b/services/ctl-api/internal/app/installs/service/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/features"
 	flowclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/client"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workloadjwt"
 
 	accountshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/accounts/helpers"
 	actionshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/actions/helpers"
@@ -69,6 +70,7 @@ type service struct {
 	flowsClient      *flowclient.Client
 	blobSvc          blobstore.Service
 	audit            *audit.Emitter
+	workloadJWT      *workloadjwt.Verifier
 }
 
 var _ api.Service = (*service)(nil)
@@ -403,6 +405,7 @@ func New(params Params) *service {
 		flowsClient:      params.FlowsClient,
 		blobSvc:          params.BlobService,
 		audit:            params.Audit,
+		workloadJWT:      workloadjwt.NewVerifier(),
 	}
 }
 

--- a/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
@@ -270,6 +270,7 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		RunnerEnvVars:                stacks.FormatRunnerEnvVars(&cfg.RunnerConfig, s.cfg.RunnerContainerImageTag),
 		PhoneHomeSecretARN:           phoneHome.SecretARN,
 		PhoneHomeSecretRegion:        phoneHome.SecretRegion,
+		PhoneHomeIdentityName:        phoneHome.IdentityName,
 	}
 
 	switch cfg.RunnerConfig.Type {

--- a/services/ctl-api/internal/app/installs/worker/activities/ensure_install_phone_home_identity_azure.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/ensure_install_phone_home_identity_azure.go
@@ -1,0 +1,107 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workloadjwt"
+)
+
+// ensureAzurePhoneHomeIdentity records which managed identity each of this install's live
+// stack versions should phone home as.
+//
+// Azure needs no credential published anywhere: the stack presents a token Entra already
+// signed. So unlike the AWS path there is nothing to mint, encrypt, or grant — only a name
+// that the rendered template and the verifier both derive the same way.
+//
+// Convergent like its AWS counterpart. The name is written to every eligible version and
+// cleared from the rest, so a re-run after a partial failure is a no-op and a retired
+// version cannot keep authenticating.
+func (a *Activities) ensureAzurePhoneHomeIdentity(
+	ctx context.Context, install *app.Install, ignoreFeatureGate bool,
+) (*EnsureInstallPhoneHomeSecretResponse, error) {
+	if skip, err := a.azurePhoneHomeSkipReason(ctx, install, ignoreFeatureGate); err != nil {
+		return nil, err
+	} else if skip != "" {
+		return &EnsureInstallPhoneHomeSecretResponse{Skipped: true, SkipReason: skip}, nil
+	}
+
+	name := workloadjwt.AzurePhoneHomeIdentityName(install.ID)
+	resp := &EnsureInstallPhoneHomeSecretResponse{IdentityName: name}
+
+	if install.InstallStack == nil {
+		return resp, nil
+	}
+
+	for i := range install.InstallStack.InstallStackVersions {
+		version := &install.InstallStack.InstallStackVersions[i]
+
+		want := name
+		if !version.PhoneHomeTokenEligible() {
+			want = ""
+		}
+		if version.PhoneHomeIdentityName == want {
+			continue
+		}
+
+		if res := a.db.WithContext(ctx).
+			Model(&app.InstallStackVersion{ID: version.ID}).
+			Update("phone_home_identity_name", want); res.Error != nil {
+			return nil, generics.TemporalGormError(res.Error)
+		}
+		version.PhoneHomeIdentityName = want
+
+		if want == "" {
+			resp.TokensRevoked++
+		} else {
+			resp.TokensMinted++
+		}
+	}
+
+	a.l.Info("reconciled azure install phone home identity",
+		zap.String("install_id", install.ID),
+		zap.String("identity_name", name),
+		zap.Int("versions_set", resp.TokensMinted),
+		zap.Int("versions_cleared", resp.TokensRevoked),
+	)
+
+	return resp, nil
+}
+
+// azurePhoneHomeSkipReason returns a non-empty reason when this install must be passed
+// over. Every one is a clean no-op: enforcement is opt-in per cloud and a miss must never
+// fail a provision.
+func (a *Activities) azurePhoneHomeSkipReason(
+	ctx context.Context, install *app.Install, ignoreFeatureGate bool,
+) (string, error) {
+	if !ignoreFeatureGate {
+		enabled, err := a.features.OrgHasFeature(ctx, install.OrgID, app.OrgFeaturePhoneHomeAuth)
+		if err != nil {
+			return "", fmt.Errorf("unable to check phone home auth feature: %w", err)
+		}
+		if !enabled {
+			return phoneHomeSkipFeatureDisabled, nil
+		}
+	}
+
+	// The org is checked too because AdminForceSandboxMode flips the org without
+	// updating installs.sandbox_mode.
+	if install.SandboxMode.Bool || install.Org.SandboxMode {
+		return phoneHomeSkipSandboxMode, nil
+	}
+
+	// The verifier binds the token's subscription to this value, so rendering an
+	// identity without it would mean enforcing against nothing.
+	if install.CloudPlatformMetadata.TargetSubscriptionID == "" {
+		a.l.Info("skipping azure phone home identity: no target subscription",
+			zap.String("install_id", install.ID), zap.String("org_id", install.OrgID))
+
+		return phoneHomeSkipNoSubscription, nil
+	}
+
+	return "", nil
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/ensure_install_phone_home_identity_azure_gate_test.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/ensure_install_phone_home_identity_azure_gate_test.go
@@ -1,0 +1,85 @@
+package activities
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// Waiving the org feature flags must waive those and nothing else. Every case runs with a
+// nil features client on purpose: consulting it would panic, so these also prove the
+// bypass never reaches for it.
+func TestAzurePhoneHomeSkipReasonIgnoringFeatureGate(t *testing.T) {
+	const targetSubscription = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+	for _, tc := range []struct {
+		name    string
+		install *app.Install
+		want    string
+	}{
+		{
+			// Without it the verifier would have nothing to bind the token's
+			// subscription against, so rendering an identity would enforce nothing.
+			name:    "an install with no target subscription is skipped",
+			install: &app.Install{ID: "inst", AzureAccount: &app.AzureAccount{}},
+			want:    phoneHomeSkipNoSubscription,
+		},
+		{
+			name: "a sandbox install is skipped",
+			install: &app.Install{
+				ID:                    "inst",
+				SandboxMode:           sql.NullBool{Bool: true, Valid: true},
+				AzureAccount:          &app.AzureAccount{},
+				CloudPlatformMetadata: app.CloudPlatformMetadata{TargetSubscriptionID: targetSubscription},
+			},
+			want: phoneHomeSkipSandboxMode,
+		},
+		{
+			// An install created before AdminForceSandboxMode flipped the org keeps an
+			// explicit false that Install.AfterQuery will not override.
+			name: "an install in a sandboxed org is skipped even when its own flag is false",
+			install: &app.Install{
+				ID:                    "inst",
+				SandboxMode:           sql.NullBool{Bool: false, Valid: true},
+				Org:                   app.Org{SandboxMode: true},
+				AzureAccount:          &app.AzureAccount{},
+				CloudPlatformMetadata: app.CloudPlatformMetadata{TargetSubscriptionID: targetSubscription},
+			},
+			want: phoneHomeSkipSandboxMode,
+		},
+		{
+			name: "an otherwise eligible install proceeds even with the flag off",
+			install: &app.Install{
+				ID:                    "inst",
+				AzureAccount:          &app.AzureAccount{},
+				CloudPlatformMetadata: app.CloudPlatformMetadata{TargetSubscriptionID: targetSubscription},
+			},
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Activities{l: zap.NewNop()}
+
+			got, err := a.azurePhoneHomeSkipReason(context.Background(), tc.install, true)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// Skip reasons are metric tags and the backfill's progress output, so drift is silent.
+func TestAzurePhoneHomeSkipReasonsAreStable(t *testing.T) {
+	assert.Equal(t, "install has no target subscription id", phoneHomeSkipNoSubscription)
+}
+
+// Azure is gated by the same org flag as AWS, so enabling phone-home auth for an org
+// covers every cloud its installs run on.
+func TestAzureUsesTheSharedPhoneHomeAuthFlag(t *testing.T) {
+	assert.Equal(t, app.OrgFeature("phone-home-auth"), app.OrgFeaturePhoneHomeAuth)
+}

--- a/services/ctl-api/internal/app/installs/worker/activities/ensure_install_phone_home_secret.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/ensure_install_phone_home_secret.go
@@ -31,6 +31,8 @@ const (
 	phoneHomeSkipNoTargetAccount = "install has no target account id"
 	phoneHomeSkipNoManagement    = "control plane cannot reach management secrets manager"
 	phoneHomeSkipSandboxMode     = "install is in sandbox mode"
+
+	phoneHomeSkipNoSubscription = "install has no target subscription id"
 )
 
 type EnsureInstallPhoneHomeSecretRequest struct {
@@ -59,6 +61,10 @@ type EnsureInstallPhoneHomeSecretResponse struct {
 	TokensMinted  int  `json:"tokens_minted"`
 	TokensRevoked int  `json:"tokens_revoked"`
 	SecretWritten bool `json:"secret_written"`
+
+	// Set on Azure instead of a secret: the stack presents a managed identity, so there
+	// is no credential to publish, only a name for the template and the verifier to agree on.
+	IdentityName string `json:"identity_name,omitempty"`
 }
 
 // EnsureInstallPhoneHomeSecret reconciles an install's phone-home credentials.
@@ -90,11 +96,16 @@ func (a *Activities) EnsureInstallPhoneHomeSecret(
 	var install app.Install
 	if res := a.db.WithContext(ctx).
 		Preload("AWSAccount").
+		Preload("AzureAccount").
 		Preload("Org").
 		Preload("InstallStack.InstallStackVersions").
 		Where(app.Install{ID: req.InstallID}).
 		First(&install); res.Error != nil {
 		return nil, generics.TemporalGormError(res.Error)
+	}
+
+	if install.AzureAccount != nil {
+		return a.ensureAzurePhoneHomeIdentity(ctx, &install, req.IgnoreOrgFeatureGate)
 	}
 
 	if skip, err := a.phoneHomeSecretSkipReason(ctx, &install, req.IgnoreOrgFeatureGate); err != nil {

--- a/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
+++ b/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
@@ -225,6 +225,7 @@ func (w *Workflows) GenerateInstallStackVersion(ctx workflow.Context, sreq Gener
 		RunnerEnvVars:                stacks.FormatRunnerEnvVars(&cfg.RunnerConfig, w.cfg.RunnerContainerImageTag),
 		PhoneHomeSecretARN:           phoneHome.SecretARN,
 		PhoneHomeSecretRegion:        phoneHome.SecretRegion,
+		PhoneHomeIdentityName:        phoneHome.IdentityName,
 	}
 
 	switch cfg.RunnerConfig.Type {

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home.go
@@ -130,8 +130,15 @@ func (t *Templates) getPhoneHomeResources(inp *stacks.TemplateInput, customOutpu
 
 	payloadJSON := "{\n" + strings.Join(payloadFields, ",\n") + "\n}"
 
-	scriptContent := `#!/bin/bash
+	authPreamble := ""
+	authFlag := ""
+	if inp.PhoneHomeIdentityName != "" {
+		authPreamble = phoneHomeAuthScript
+		authFlag = "  -K \"$CURL_CONFIG\" \\\n"
+	}
 
+	scriptContent := `#!/bin/bash
+` + authPreamble + `
 PAYLOAD=$(cat << EOF
 ` + payloadJSON + `
 EOF
@@ -139,7 +146,7 @@ EOF
 
 curl -X POST \
   "` + phoneHomeURL + `" \
-  -H "Content-Type: application/json" \
+` + authFlag + `  -H "Content-Type: application/json" \
   -H "Accept: application/json" \
   -d "$PAYLOAD" \
   --fail \
@@ -198,6 +205,12 @@ fi
 			"value": "[reference('runnerDeployment').outputs.vmssPrincipalId.value]",
 		})
 	}
+	if inp.PhoneHomeIdentityName != "" {
+		envVars = append(envVars, map[string]any{
+			"name":  "PHONE_HOME_IDENTITY_CLIENT_ID",
+			"value": phoneHomeIdentityClientID(inp.PhoneHomeIdentityName),
+		})
+	}
 	envVars = append(envVars, secretEnvVars...)
 	envVars = append(envVars, vnetExtraEnvVars...)
 	envVars = append(envVars, customEnvVars...)
@@ -248,9 +261,36 @@ fi
 		},
 	}
 
+	// deploymentScripts supports user-assigned identities only, so there is no
+	// system-assigned alternative. The identity travels with the script into whichever
+	// scope it lands in, so its resourceId always resolves where the script is declared.
+	var identity []any
+	identityID := ""
+	if inp.PhoneHomeIdentityName != "" {
+		identityID = phoneHomeIdentityResourceID(inp.PhoneHomeIdentityName)
+		script["identity"] = map[string]any{
+			"type": "UserAssigned",
+			"userAssignedIdentities": map[string]any{
+				identityID: map[string]any{},
+			},
+		}
+		identity = append(identity, getPhoneHomeIdentityResource(inp.PhoneHomeIdentityName, scope))
+	}
+
 	if !scope.subscription {
+		if identityID != "" {
+			dependsOn = append(dependsOn, identityID)
+		}
 		script["dependsOn"] = dependsOn
-		return []any{script}
+
+		return append(identity, script)
+	}
+
+	// A UAMI is not subscription-deployable, so it moves into the install resource
+	// group alongside the script. Only the identity dependency can be expressed
+	// inside; everything else is declared in the root and goes on the wrapper.
+	if identityID != "" {
+		script["dependsOn"] = []string{identityID}
 	}
 
 	resources := scope.wrapInInstallRG(phoneHomeDeploymentName, map[string]nestedParam{
@@ -259,7 +299,7 @@ fi
 		"commonTags":           {typ: "object", value: "[variables('commonTags')]"},
 		"deployTimestamp":      {typ: "string", value: "[parameters('deployTimestamp')]"},
 		"environmentVariables": {typ: "array", value: envVars},
-	}, []any{script}, nil)
+	}, append(identity, script), nil)
 
 	// Everything the script reports on has to exist first, and the script can no
 	// longer say so itself — inner evaluation hides the root.

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home.go
@@ -205,12 +205,6 @@ fi
 			"value": "[reference('runnerDeployment').outputs.vmssPrincipalId.value]",
 		})
 	}
-	if inp.PhoneHomeIdentityName != "" {
-		envVars = append(envVars, map[string]any{
-			"name":  "PHONE_HOME_IDENTITY_CLIENT_ID",
-			"value": phoneHomeIdentityClientID(inp.PhoneHomeIdentityName),
-		})
-	}
 	envVars = append(envVars, secretEnvVars...)
 	envVars = append(envVars, vnetExtraEnvVars...)
 	envVars = append(envVars, customEnvVars...)
@@ -280,6 +274,8 @@ fi
 	if !scope.subscription {
 		if identityID != "" {
 			dependsOn = append(dependsOn, identityID)
+			script["properties"].(map[string]any)["environmentVariables"] =
+				append(envVars, phoneHomeIdentityClientIDEnvVar(inp.PhoneHomeIdentityName))
 		}
 		script["dependsOn"] = dependsOn
 
@@ -291,6 +287,10 @@ fi
 	// inside; everything else is declared in the root and goes on the wrapper.
 	if identityID != "" {
 		script["dependsOn"] = []string{identityID}
+		// The outer array cannot name the identity: it is created inside this wrapper,
+		// so resourceId() in the root resolves against no resource group at all.
+		script["properties"].(map[string]any)["environmentVariables"] =
+			phoneHomeInnerEnvVarsExpr(inp.PhoneHomeIdentityName)
 	}
 
 	resources := scope.wrapInInstallRG(phoneHomeDeploymentName, map[string]nestedParam{

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_identity.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_identity.go
@@ -1,6 +1,9 @@
 package arm
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // getPhoneHomeIdentityResource creates the identity the phone-home script authenticates
 // as. Deliberately carries no role assignments: it never touches Azure, so a token minted
@@ -19,6 +22,27 @@ func phoneHomeIdentityResourceID(identityName string) string {
 	return fmt.Sprintf(
 		"[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', '%s')]", identityName)
 }
+
+// phoneHomeIdentityClientIDEnvVar is evaluated wherever the identity is declared.
+func phoneHomeIdentityClientIDEnvVar(identityName string) map[string]any {
+	return map[string]any{
+		"name":  phoneHomeIdentityClientIDEnvName,
+		"value": phoneHomeIdentityClientID(identityName),
+	}
+}
+
+// phoneHomeInnerEnvVarsExpr appends the identity's client ID to the environment array
+// the root passed in, resolving it inside the install resource group where the identity
+// actually exists.
+func phoneHomeInnerEnvVarsExpr(identityName string) string {
+	return fmt.Sprintf(
+		"[concat(parameters('environmentVariables'), createArray(createObject('name', '%s', 'value', %s)))]",
+		phoneHomeIdentityClientIDEnvName,
+		strings.TrimSuffix(strings.TrimPrefix(phoneHomeIdentityClientID(identityName), "["), "]"),
+	)
+}
+
+const phoneHomeIdentityClientIDEnvName = "PHONE_HOME_IDENTITY_CLIENT_ID"
 
 func phoneHomeIdentityClientID(identityName string) string {
 	return fmt.Sprintf(

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_identity.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_identity.go
@@ -1,0 +1,65 @@
+package arm
+
+import "fmt"
+
+// getPhoneHomeIdentityResource creates the identity the phone-home script authenticates
+// as. Deliberately carries no role assignments: it never touches Azure, so a token minted
+// for it is inert everywhere except the phone-home endpoint.
+func getPhoneHomeIdentityResource(identityName string, scope armScope) map[string]any {
+	return map[string]any{
+		"type":       "Microsoft.ManagedIdentity/userAssignedIdentities",
+		"apiVersion": "2023-01-31",
+		"name":       identityName,
+		"location":   "[parameters('location')]",
+		"tags":       scope.innerCommonTagsExpr(),
+	}
+}
+
+func phoneHomeIdentityResourceID(identityName string) string {
+	return fmt.Sprintf(
+		"[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', '%s')]", identityName)
+}
+
+func phoneHomeIdentityClientID(identityName string) string {
+	return fmt.Sprintf(
+		"[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', '%s'), '2023-01-31').clientId]",
+		identityName)
+}
+
+// phoneHomeAuthScript fetches a token straight from IMDS rather than going through
+// `az login --identity`, which enumerates subscriptions and fails for an identity holding
+// no role assignments.
+//
+// The token is written to a curl config file instead of an argv header so it stays out of
+// the process list, and nothing echoes it: deployment script logs are readable by any
+// reader on the resource group.
+const phoneHomeAuthScript = `
+IMDS_URL="http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F&client_id=${PHONE_HOME_IDENTITY_CLIENT_ID}"
+
+CURL_CONFIG=$(mktemp)
+chmod 600 "$CURL_CONFIG"
+trap 'rm -f "$CURL_CONFIG"' EXIT
+
+# A freshly created identity is not immediately usable, so this retries rather than
+# failing the deployment on a propagation delay.
+TOKEN=""
+for attempt in $(seq 1 12); do
+  # Whitespace around the colon is tolerated: the IMDS response is JSON, so its exact
+  # spacing is not part of the contract.
+  TOKEN=$(curl -s -f -H "Metadata: true" "$IMDS_URL" |
+    sed -n 's/.*"access_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  if [ -n "$TOKEN" ]; then
+    break
+  fi
+  echo "waiting for managed identity token (attempt $attempt)"
+  sleep 10
+done
+
+if [ -z "$TOKEN" ]; then
+  echo "failed to acquire managed identity token"
+  exit 1
+fi
+
+printf 'header = "Authorization: Bearer %s"\n' "$TOKEN" > "$CURL_CONFIG"
+unset TOKEN
+`

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_identity_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_identity_test.go
@@ -1,0 +1,168 @@
+package arm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+)
+
+// phoneHomeScriptFrom picks the deploymentScripts resource out of the returned set,
+// which also carries the identity when phone home auth is active.
+func phoneHomeScriptFrom(t *testing.T, res []any) map[string]any {
+	t.Helper()
+	for _, r := range res {
+		m := r.(map[string]any)
+		if m["type"] == "Microsoft.Resources/deploymentScripts" {
+			return m
+		}
+	}
+	t.Fatal("no deploymentScripts resource returned")
+
+	return nil
+}
+
+func phoneHomeIdentityFrom(res []any) map[string]any {
+	for _, r := range res {
+		m := r.(map[string]any)
+		if m["type"] == "Microsoft.ManagedIdentity/userAssignedIdentities" {
+			return m
+		}
+	}
+
+	return nil
+}
+
+func TestGetPhoneHomeResource_NoIdentityWhenUnset(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+	inp := minimalTemplateInput()
+
+	all := tmpl.getPhoneHomeResources(inp, nil, nil, armScope{})
+	res := phoneHomeScriptFrom(t, all)
+
+	if _, ok := res["identity"]; ok {
+		t.Fatal("expected no identity block when phone home auth is inactive")
+	}
+	if phoneHomeIdentityFrom(all) != nil {
+		t.Fatal("expected no identity resource when phone home auth is inactive")
+	}
+
+	script := res["properties"].(map[string]any)["scriptContent"].(string)
+	for _, unwanted := range []string{"169.254.169.254", "Authorization: Bearer", "-K "} {
+		if strings.Contains(script, unwanted) {
+			t.Errorf("script should not authenticate, but contains %q", unwanted)
+		}
+	}
+}
+
+func TestGetPhoneHomeResource_AttachesIdentity(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+	inp := minimalTemplateInput()
+	inp.PhoneHomeIdentityName = "inst123-phone-home"
+
+	all := tmpl.getPhoneHomeResources(inp, nil, nil, armScope{})
+	res := phoneHomeScriptFrom(t, all)
+
+	identity, ok := res["identity"].(map[string]any)
+	if !ok {
+		t.Fatal("expected an identity block")
+	}
+	if identity["type"] != "UserAssigned" {
+		t.Errorf("deploymentScripts supports user-assigned identities only, got %v", identity["type"])
+	}
+
+	wantResourceID := phoneHomeIdentityResourceID("inst123-phone-home")
+	assigned := identity["userAssignedIdentities"].(map[string]any)
+	if _, ok := assigned[wantResourceID]; !ok {
+		t.Errorf("identity %q not attached, got %v", wantResourceID, assigned)
+	}
+
+	// The script must not be able to run before the identity exists.
+	var dependsOnIdentity bool
+	for _, dep := range res["dependsOn"].([]string) {
+		if dep == wantResourceID {
+			dependsOnIdentity = true
+		}
+	}
+	if !dependsOnIdentity {
+		t.Errorf("phone home script does not depend on its identity: %v", res["dependsOn"])
+	}
+
+	// The identity has to be emitted with the script, not assumed to exist.
+	if phoneHomeIdentityFrom(all) == nil {
+		t.Error("identity resource not emitted alongside the script")
+	}
+}
+
+func TestGetPhoneHomeResource_AuthenticatesWithoutLeakingToken(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+	inp := minimalTemplateInput()
+	inp.PhoneHomeIdentityName = "inst123-phone-home"
+
+	all := tmpl.getPhoneHomeResources(inp, nil, nil, armScope{})
+	res := phoneHomeScriptFrom(t, all)
+	props := res["properties"].(map[string]any)
+	script := props["scriptContent"].(string)
+
+	for _, want := range []string{
+		"169.254.169.254",
+		"management.azure.com",
+		`-K "$CURL_CONFIG"`,
+		"chmod 600",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("script missing %q", want)
+		}
+	}
+
+	// az login enumerates subscriptions and fails for a role-less identity.
+	if strings.Contains(script, "az login") {
+		t.Error("script should fetch the token from IMDS, not via az login")
+	}
+
+	// Deployment script logs are readable by any reader on the resource group.
+	if strings.Contains(script, "echo $TOKEN") || strings.Contains(script, "set -x") {
+		t.Error("script must not echo the token")
+	}
+
+	// The IMDS response is JSON, so its spacing is not part of the contract. An
+	// extraction anchored on `"access_token":"` silently yields an empty token against a
+	// pretty-printed response, and the script then fails the deployment.
+	if !strings.Contains(script, `"access_token"[[:space:]]*:[[:space:]]*"`) {
+		t.Error("token extraction must tolerate whitespace around the colon")
+	}
+
+	// A token it could not fetch must fail the deployment, never phone home unauthenticated.
+	if !strings.Contains(script, "failed to acquire managed identity token") ||
+		!strings.Contains(script, "exit 1") {
+		t.Error("script must exit non-zero when no token could be acquired")
+	}
+
+	var found bool
+	for _, env := range props["environmentVariables"].([]map[string]any) {
+		if env["name"] == "PHONE_HOME_IDENTITY_CLIENT_ID" {
+			found = true
+			if env["value"] != phoneHomeIdentityClientID("inst123-phone-home") {
+				t.Errorf("unexpected client id expression: %v", env["value"])
+			}
+		}
+	}
+	if !found {
+		t.Error("PHONE_HOME_IDENTITY_CLIENT_ID not passed to the script")
+	}
+}
+
+func TestGetPhoneHomeIdentityResource_HasNoRoleAssignments(t *testing.T) {
+	res := getPhoneHomeIdentityResource("inst123-phone-home", armScope{})
+
+	if res["type"] != "Microsoft.ManagedIdentity/userAssignedIdentities" {
+		t.Errorf("unexpected type %v", res["type"])
+	}
+	if res["name"] != "inst123-phone-home" {
+		t.Errorf("unexpected name %v", res["name"])
+	}
+	// A role-less identity is what makes a stolen token inert.
+	if _, ok := res["properties"]; ok {
+		t.Error("phone home identity should carry no properties, and no roles")
+	}
+}

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_identity_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_identity_test.go
@@ -1,6 +1,7 @@
 package arm
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -164,5 +165,33 @@ func TestGetPhoneHomeIdentityResource_HasNoRoleAssignments(t *testing.T) {
 	// A role-less identity is what makes a stolen token inert.
 	if _, ok := res["properties"]; ok {
 		t.Error("phone home identity should carry no properties, and no roles")
+	}
+}
+
+// At subscription scope the environment array is built in the root, but the identity is
+// created inside the install resource group. Resolving its client ID outside fails the
+// deployment with ResourceNotFound against a null resource group, so it has to be
+// appended within the wrapper.
+func TestGetPhoneHomeResources_SubscriptionScopeResolvesClientIDInside(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+	inp := subscriptionTemplateInput()
+	inp.PhoneHomeIdentityName = "inst123-phone-home"
+
+	res := tmpl.getPhoneHomeResources(inp, nil, nil, armScope{subscription: true})
+	encoded, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := string(encoded)
+
+	root, _, found := strings.Cut(rendered, `"template"`)
+	if !found {
+		t.Fatal("expected a nested wrapper template at subscription scope")
+	}
+	if strings.Contains(root, phoneHomeIdentityClientID("inst123-phone-home")) {
+		t.Error("client id resolved in the root, where the identity does not exist")
+	}
+	if !strings.Contains(rendered, "concat(parameters('environmentVariables')") {
+		t.Error("wrapper does not append the client id to the environment it was passed")
 	}
 }

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 // phoneHomeScript returns the deploymentScripts resource itself. At resource-group
-// scope getPhoneHomeResources emits exactly one resource; the wrapped
-// subscription-scope shape has its own tests.
+// scope getPhoneHomeResources emits exactly one resource unless phone home auth is
+// active, which adds the identity; the wrapped subscription-scope shape has its own
+// tests.
 func phoneHomeScript(t *testing.T, tmpl *Templates, inp *stacks.TemplateInput, customOutputs []customDeploymentOutputs) map[string]any {
 	t.Helper()
 	res := tmpl.getPhoneHomeResources(inp, customOutputs, nil, armScope{})

--- a/services/ctl-api/internal/pkg/stacks/arm/template.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/template.go
@@ -164,7 +164,7 @@ func (t *Templates) getAzureTemplate(inp *stacks.TemplateInput) (*ARMTemplate, e
 		}
 	}
 
-	// Phone home deployment script
+	// Phone home deployment script, and the identity it authenticates as
 	tmpl.Resources = append(tmpl.Resources, t.getPhoneHomeResources(inp, customOutputs, vnetExtraOutputs, scope)...)
 
 	// Add standard outputs (VNet, subnets, key vault)

--- a/services/ctl-api/internal/pkg/stacks/template_input.go
+++ b/services/ctl-api/internal/pkg/stacks/template_input.go
@@ -60,6 +60,12 @@ type TemplateInput struct {
 	// them.
 	PhoneHomeSecretARN    string
 	PhoneHomeSecretRegion string
+
+	// Azure-only: the managed identity the phone-home script authenticates as. A name,
+	// not a credential, so unlike the fields above it is safe in a template anyone can
+	// fetch. Empty whenever Azure phone-home auth is not active for the install, which
+	// is what leaves the script unauthenticated for stacks that predate it.
+	PhoneHomeIdentityName string
 }
 
 // PhoneHomeRoleName is the deterministic IAM role name for an install's phone-home

--- a/services/ctl-api/internal/pkg/workloadjwt/azure.go
+++ b/services/ctl-api/internal/pkg/workloadjwt/azure.go
@@ -1,0 +1,102 @@
+package workloadjwt
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Graph looks like the safer audience -- a token for a role-less identity can do nothing
+// -- but Microsoft signs Graph access tokens with a key that is not in the tenant JWKS, so
+// a third party cannot verify them. ARM tokens are ordinary v1 tokens and verify against
+// the tenant keys, which is why runner auth already uses this audience.
+//
+// The identity is created with no role assignments, so an ARM token minted for it is
+// authorized for nothing either.
+const AzureManagementAudience = "https://management.azure.com/"
+
+// Applied before a tenant or subscription is interpolated into a URL or compared, so a
+// claim can never reshape the URL it lands in.
+var azureGUID = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// AzureIssuer builds the v1 Entra issuer for a tenant. IMDS mints v1 tokens, so the
+// issuer is sts.windows.net rather than the v2 login.microsoftonline.com form.
+func AzureIssuer(tenantID string) (string, error) {
+	if !azureGUID.MatchString(tenantID) {
+		return "", fmt.Errorf("tenant id %q is not a guid", tenantID)
+	}
+
+	return fmt.Sprintf("https://sts.windows.net/%s/", tenantID), nil
+}
+
+type AzureManagedIdentity struct {
+	SubscriptionID string
+	ResourceGroup  string
+	Name           string
+	PrincipalID    string
+	TenantID       string
+}
+
+// /subscriptions/{sub}/resourcegroups/{rg}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{name}
+const azureMIRIDSegments = 8
+
+// Only user-assigned identities are accepted. A system-assigned identity puts the compute
+// resource in xms_mirid -- the runner's VMSS is one -- so a loose shape check would let a
+// runner token pass as a phone-home identity.
+func ParseAzureManagedIdentity(claims map[string]any) (*AzureManagedIdentity, error) {
+	tenantID, ok := StringClaim(claims, "tid")
+	if !ok {
+		return nil, fmt.Errorf("token is missing the tid claim")
+	}
+	if !azureGUID.MatchString(tenantID) {
+		return nil, fmt.Errorf("tid claim %q is not a guid", tenantID)
+	}
+
+	principalID, ok := StringClaim(claims, "oid")
+	if !ok {
+		return nil, fmt.Errorf("token is missing the oid claim")
+	}
+
+	mirID, ok := StringClaim(claims, "xms_mirid")
+	if !ok {
+		return nil, fmt.Errorf("token is missing the xms_mirid claim")
+	}
+
+	parts := strings.Split(strings.TrimPrefix(mirID, "/"), "/")
+	if len(parts) != azureMIRIDSegments {
+		return nil, fmt.Errorf("xms_mirid is not a managed identity resource id")
+	}
+
+	for i, want := range map[int]string{
+		0: "subscriptions",
+		2: "resourcegroups",
+		4: "providers",
+		5: "Microsoft.ManagedIdentity",
+		6: "userAssignedIdentities",
+	} {
+		if !strings.EqualFold(parts[i], want) {
+			return nil, fmt.Errorf("xms_mirid is not a user-assigned managed identity resource id")
+		}
+	}
+
+	if !azureGUID.MatchString(parts[1]) {
+		return nil, fmt.Errorf("xms_mirid subscription %q is not a guid", parts[1])
+	}
+	if parts[3] == "" || parts[7] == "" {
+		return nil, fmt.Errorf("xms_mirid is missing a resource group or identity name")
+	}
+
+	return &AzureManagedIdentity{
+		SubscriptionID: parts[1],
+		ResourceGroup:  parts[3],
+		Name:           parts[7],
+		PrincipalID:    principalID,
+		TenantID:       tenantID,
+	}, nil
+}
+
+// Rendered into the ARM template and compared against the verified xms_mirid, so both
+// sides must stay in step.
+func AzurePhoneHomeIdentityName(installID string) string {
+	return installID + "-phone-home"
+}

--- a/services/ctl-api/internal/pkg/workloadjwt/azure_test.go
+++ b/services/ctl-api/internal/pkg/workloadjwt/azure_test.go
@@ -1,0 +1,152 @@
+package workloadjwt
+
+import "testing"
+
+const (
+	testTenantID = "11111111-2222-3333-4444-555555555555"
+	testSubID    = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+)
+
+func azureClaims(mirID string) map[string]any {
+	return map[string]any{
+		"tid":       testTenantID,
+		"oid":       "99999999-8888-7777-6666-555555555555",
+		"xms_mirid": mirID,
+	}
+}
+
+func uamiMIRID(sub, name string) string {
+	return "/subscriptions/" + sub +
+		"/resourcegroups/rg-1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/" + name
+}
+
+func TestAzureIssuer_RejectsNonGUIDTenant(t *testing.T) {
+	// A tenant is interpolated into the issuer URL, so anything but a GUID is refused
+	// before it can reshape the URL.
+	for _, tenant := range []string{
+		"",
+		"not-a-guid",
+		"../../evil.com",
+		"11111111-2222-3333-4444-555555555555/../..",
+		"11111111-2222-3333-4444-555555555555@evil.com",
+	} {
+		if _, err := AzureIssuer(tenant); err == nil {
+			t.Errorf("expected %q to be rejected as an issuer tenant", tenant)
+		}
+	}
+}
+
+func TestAzureIssuer_BuildsV1Issuer(t *testing.T) {
+	got, err := AzureIssuer(testTenantID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// IMDS mints v1 tokens, so the issuer must be sts.windows.net, not the v2 form.
+	if want := "https://sts.windows.net/" + testTenantID + "/"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestParseAzureManagedIdentity_UserAssigned(t *testing.T) {
+	identity, err := ParseAzureManagedIdentity(azureClaims(uamiMIRID(testSubID, "inst123-phone-home")))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if identity.SubscriptionID != testSubID {
+		t.Errorf("got subscription %q", identity.SubscriptionID)
+	}
+	if identity.Name != "inst123-phone-home" {
+		t.Errorf("got name %q", identity.Name)
+	}
+	if identity.ResourceGroup != "rg-1" {
+		t.Errorf("got resource group %q", identity.ResourceGroup)
+	}
+}
+
+func TestParseAzureManagedIdentity_RejectsSystemAssigned(t *testing.T) {
+	// The runner's VMSS identity is system-assigned: xms_mirid names the compute
+	// resource, and its trailing segment is a VM name rather than an identity name.
+	// Accepting it would let a runner token pass as a phone-home identity.
+	systemAssigned := "/subscriptions/" + testSubID +
+		"/resourcegroups/rg-1/providers/Microsoft.Compute/virtualMachineScaleSets/inst123-vmss"
+
+	if _, err := ParseAzureManagedIdentity(azureClaims(systemAssigned)); err == nil {
+		t.Fatal("expected a system-assigned identity to be rejected")
+	}
+}
+
+func TestParseAzureManagedIdentity_RejectsMalformed(t *testing.T) {
+	cases := map[string]string{
+		"empty":              "",
+		"too few segments":   "/subscriptions/" + testSubID + "/resourcegroups/rg-1",
+		"non guid sub":       uamiMIRID("not-a-guid", "inst123-phone-home"),
+		"wrong provider":     "/subscriptions/" + testSubID + "/resourcegroups/rg-1/providers/Microsoft.Storage/userAssignedIdentities/x",
+		"empty name":         uamiMIRID(testSubID, ""),
+		"trailing extra seg": uamiMIRID(testSubID, "inst123-phone-home") + "/extra",
+	}
+
+	for name, mirID := range cases {
+		if _, err := ParseAzureManagedIdentity(azureClaims(mirID)); err == nil {
+			t.Errorf("%s: expected rejection for %q", name, mirID)
+		}
+	}
+}
+
+func TestParseAzureManagedIdentity_RequiresClaims(t *testing.T) {
+	mirID := uamiMIRID(testSubID, "inst123-phone-home")
+
+	for _, missing := range []string{"tid", "oid", "xms_mirid"} {
+		claims := azureClaims(mirID)
+		delete(claims, missing)
+		if _, err := ParseAzureManagedIdentity(claims); err == nil {
+			t.Errorf("expected rejection when %s is missing", missing)
+		}
+	}
+
+	// A non-string claim is treated as absent rather than coerced.
+	claims := azureClaims(mirID)
+	claims["tid"] = 12345
+	if _, err := ParseAzureManagedIdentity(claims); err == nil {
+		t.Error("expected rejection for a non-string tid")
+	}
+}
+
+func TestParseAzureManagedIdentity_RejectsNonGUIDTenant(t *testing.T) {
+	claims := azureClaims(uamiMIRID(testSubID, "inst123-phone-home"))
+	claims["tid"] = "not-a-guid"
+
+	if _, err := ParseAzureManagedIdentity(claims); err == nil {
+		t.Fatal("expected a non-guid tid to be rejected")
+	}
+}
+
+func TestParseAzureManagedIdentity_CaseInsensitiveResourceSegments(t *testing.T) {
+	// Azure does not preserve casing consistently in xms_mirid.
+	mirID := "/SUBSCRIPTIONS/" + testSubID +
+		"/RESOURCEGROUPS/rg-1/PROVIDERS/microsoft.managedidentity/USERASSIGNEDIDENTITIES/inst123-phone-home"
+
+	identity, err := ParseAzureManagedIdentity(azureClaims(mirID))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if identity.Name != "inst123-phone-home" {
+		t.Errorf("got name %q", identity.Name)
+	}
+}
+
+func TestAzurePhoneHomeIdentityName(t *testing.T) {
+	// Both the ARM renderer and the verifier derive the name from this, so it is the
+	// single point of agreement between them.
+	if got := AzurePhoneHomeIdentityName("inst123"); got != "inst123-phone-home" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// Graph would be the lower-value audience, but Microsoft signs Graph access tokens with a
+// key outside the tenant JWKS, so we cannot verify them. Separation from runner auth rests
+// on the identity-name bind instead.
+func TestAzureManagementAudience_IsVerifiable(t *testing.T) {
+	if AzureManagementAudience != "https://management.azure.com/" {
+		t.Errorf("expected the ARM audience, got %q", AzureManagementAudience)
+	}
+}

--- a/services/ctl-api/internal/pkg/workloadjwt/verifier.go
+++ b/services/ctl-api/internal/pkg/workloadjwt/verifier.go
@@ -1,0 +1,168 @@
+// Package workloadjwt verifies cloud-issued workload identity JWTs.
+//
+// Callers supply the issuer and audience; they are never read out of the presented
+// token, so an unauthenticated caller cannot steer which key set is trusted.
+package workloadjwt
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/auth0/go-jwt-middleware/v2/jwks"
+	"github.com/auth0/go-jwt-middleware/v2/validator"
+)
+
+const (
+	jwksCacheTTL     = 5 * time.Minute
+	allowedClockSkew = time.Minute
+
+	// Bounds memory and outbound discovery if a caller ever passes an issuer it did
+	// not fully constrain.
+	maxCachedIssuers = 256
+)
+
+type Request struct {
+	Token    string
+	Issuer   string
+	Audience string
+}
+
+func (r Request) validate() error {
+	switch {
+	case strings.TrimSpace(r.Token) == "":
+		return errors.New("token is required")
+	case strings.TrimSpace(r.Issuer) == "":
+		return errors.New("issuer is required")
+	case strings.TrimSpace(r.Audience) == "":
+		return errors.New("audience is required")
+	}
+
+	return nil
+}
+
+type Verifier struct {
+	mu        sync.Mutex
+	providers map[string]*jwks.CachingProvider
+	inserted  []string
+}
+
+func NewVerifier() *Verifier {
+	return &Verifier{providers: map[string]*jwks.CachingProvider{}}
+}
+
+// Verify checks signature, issuer, audience and time claims.
+//
+// A valid signature only establishes which cloud tenant minted the token, not that it is
+// the right one, so callers must bind the returned claims to stored state.
+func (v *Verifier) Verify(ctx context.Context, req Request) (map[string]any, error) {
+	if err := req.validate(); err != nil {
+		return nil, err
+	}
+
+	provider, err := v.provider(req.Issuer)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenValidator, err := validator.New(
+		provider.KeyFunc,
+		validator.RS256,
+		req.Issuer,
+		[]string{req.Audience},
+		validator.WithAllowedClockSkew(allowedClockSkew),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to build token validator: %w", err)
+	}
+
+	if _, err := tokenValidator.ValidateToken(ctx, req.Token); err != nil {
+		return nil, fmt.Errorf("token validation failed: %w", err)
+	}
+
+	// Decoded rather than read off the validator, which only surfaces registered claims
+	// unless a concrete type is registered up front. Safe: the signature over this
+	// payload is already checked.
+	claims, err := decodeClaims(req.Token)
+	if err != nil {
+		return nil, err
+	}
+
+	return claims, nil
+}
+
+func (v *Verifier) provider(issuer string) (*jwks.CachingProvider, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if provider, ok := v.providers[issuer]; ok {
+		return provider, nil
+	}
+
+	issuerURL, err := url.Parse(issuer)
+	if err != nil {
+		return nil, fmt.Errorf("invalid issuer url: %w", err)
+	}
+	if issuerURL.Scheme != "https" || issuerURL.Host == "" {
+		return nil, fmt.Errorf("issuer %q must be an https url", issuer)
+	}
+
+	if len(v.inserted) >= maxCachedIssuers {
+		oldest := v.inserted[0]
+		v.inserted = v.inserted[1:]
+		delete(v.providers, oldest)
+	}
+
+	provider := jwks.NewCachingProvider(issuerURL, jwksCacheTTL)
+	v.providers[issuer] = provider
+	v.inserted = append(v.inserted, issuer)
+
+	return provider, nil
+}
+
+// UnverifiedClaims decodes claims without checking the signature. Only for selecting
+// which key set to verify against; never for authorization.
+func UnverifiedClaims(token string) (map[string]any, error) {
+	return decodeClaims(token)
+}
+
+func decodeClaims(token string) (map[string]any, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("malformed jwt")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode jwt payload: %w", err)
+	}
+
+	claims := map[string]any{}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("unable to parse jwt claims: %w", err)
+	}
+
+	return claims, nil
+}
+
+// StringClaim reads a string claim. A claim of any other type is treated as absent
+// rather than coerced.
+func StringClaim(claims map[string]any, name string) (string, bool) {
+	raw, ok := claims[name]
+	if !ok {
+		return "", false
+	}
+
+	value, ok := raw.(string)
+	if !ok || value == "" {
+		return "", false
+	}
+
+	return value, true
+}

--- a/services/ctl-api/internal/pkg/workloadjwt/verifier_test.go
+++ b/services/ctl-api/internal/pkg/workloadjwt/verifier_test.go
@@ -1,0 +1,145 @@
+package workloadjwt
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestVerify_RequiresIssuerAndAudience(t *testing.T) {
+	// An empty issuer or audience would make the validator accept anything the caller
+	// forgot to constrain, so they are refused rather than defaulted.
+	for _, tc := range []struct {
+		name string
+		req  Request
+	}{
+		{"no token", Request{Issuer: "https://sts.windows.net/x/", Audience: "aud"}},
+		{"no issuer", Request{Token: "a.b.c", Audience: "aud"}},
+		{"no audience", Request{Token: "a.b.c", Issuer: "https://sts.windows.net/x/"}},
+		{"blank issuer", Request{Token: "a.b.c", Issuer: "   ", Audience: "aud"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewVerifier().Verify(context.Background(), tc.req); err == nil {
+				t.Error("expected an error")
+			}
+		})
+	}
+}
+
+func TestProvider_RejectsNonHTTPSIssuer(t *testing.T) {
+	// A non-https issuer would let a caller point key discovery at plaintext, or at
+	// something that is not a URL at all.
+	v := NewVerifier()
+
+	for _, issuer := range []string{
+		"http://sts.windows.net/tenant/",
+		"file:///etc/passwd",
+		"sts.windows.net/tenant/",
+		"https://",
+		"://nope",
+	} {
+		if _, err := v.provider(issuer); err == nil {
+			t.Errorf("expected issuer %q to be rejected", issuer)
+		}
+	}
+
+	if len(v.providers) != 0 {
+		t.Errorf("a rejected issuer must not be cached, got %d entries", len(v.providers))
+	}
+}
+
+func TestProvider_CachesPerIssuer(t *testing.T) {
+	v := NewVerifier()
+	const issuer = "https://sts.windows.net/11111111-2222-3333-4444-555555555555/"
+
+	first, err := v.provider(issuer)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	second, err := v.provider(issuer)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if first != second {
+		t.Error("expected the same provider to be reused for one issuer")
+	}
+	if len(v.providers) != 1 {
+		t.Errorf("expected 1 cached provider, got %d", len(v.providers))
+	}
+}
+
+// Issuers come from stored state today, but an unbounded cache keyed on anything derived
+// from a request is a memory leak waiting to happen.
+func TestProvider_CacheIsBounded(t *testing.T) {
+	v := NewVerifier()
+
+	for i := range maxCachedIssuers + 50 {
+		issuer := fmt.Sprintf("https://sts.windows.net/tenant-%d/", i)
+		if _, err := v.provider(issuer); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	if len(v.providers) > maxCachedIssuers {
+		t.Errorf("cache grew to %d, above the %d ceiling", len(v.providers), maxCachedIssuers)
+	}
+	if len(v.inserted) != len(v.providers) {
+		t.Errorf("insertion order (%d) drifted from the cache (%d), so eviction leaks",
+			len(v.inserted), len(v.providers))
+	}
+
+	// The oldest entries are the ones evicted.
+	if _, ok := v.providers["https://sts.windows.net/tenant-0/"]; ok {
+		t.Error("expected the oldest issuer to have been evicted")
+	}
+}
+
+func TestUnverifiedClaims(t *testing.T) {
+	// {"tid":"abc","oid":"def"} base64url encoded, with throwaway header and signature.
+	token := "eyJhbGciOiJSUzI1NiJ9.eyJ0aWQiOiJhYmMiLCJvaWQiOiJkZWYifQ.sig"
+
+	claims, err := UnverifiedClaims(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, _ := StringClaim(claims, "tid"); got != "abc" {
+		t.Errorf("got tid %q", got)
+	}
+	if got, _ := StringClaim(claims, "oid"); got != "def" {
+		t.Errorf("got oid %q", got)
+	}
+}
+
+func TestUnverifiedClaims_RejectsMalformed(t *testing.T) {
+	for _, token := range []string{
+		"",
+		"not-a-jwt",
+		"only.two",
+		"a.b.c.d",
+		"a.!!!notbase64!!!.c",
+	} {
+		if _, err := UnverifiedClaims(token); err == nil {
+			t.Errorf("expected %q to be rejected", token)
+		}
+	}
+}
+
+func TestStringClaim(t *testing.T) {
+	claims := map[string]any{
+		"str":   "value",
+		"num":   12345,
+		"empty": "",
+		"null":  nil,
+	}
+
+	if got, ok := StringClaim(claims, "str"); !ok || got != "value" {
+		t.Errorf("got %q, %v", got, ok)
+	}
+	// A non-string, empty, or absent claim is treated as absent rather than coerced.
+	for _, name := range []string{"num", "empty", "null", "missing"} {
+		if _, ok := StringClaim(claims, name); ok {
+			t.Errorf("expected claim %q to read as absent", name)
+		}
+	}
+}


### PR DESCRIPTION
Re-lands #2229, reverted in #2238 so the subscription-scoped stacks work (#2237) could go first. Rebuilt on current main and reconciled with the new ARM scope handling: the phone-home identity now travels with the deployment script, so at subscription scope it lands inside the install resource group rather than at subscription scope where a UAMI is not deployable.