### PR TITLE
fix: (policies) decode K8s manifest correctly and harden policy evaluation handling

### DIFF
--- a/pkg/runner/jobs/build/helm/policy_input.go
+++ b/pkg/runner/jobs/build/helm/policy_input.go
@@ -3,13 +3,14 @@ package helm
 import (
 	"context"
 	"fmt"
+	"io"
 	"regexp"
 	"strings"
 
 	"go.uber.org/zap"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
-	"sigs.k8s.io/yaml"
+	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/pkg/errors"
 
@@ -72,17 +73,15 @@ func toPolicyAdmissionInputs(chart *chart.Chart, values map[string]interface{}) 
 		return nil, nil
 	}
 
-	docs := strings.Split(manifests, "---")
-	inputs := make([]AdmissionReviewInput, 0, len(docs))
-	for _, doc := range docs {
-		doc = strings.TrimSpace(doc)
-		if doc == "" {
-			continue
-		}
-
+	decoder := yaml.NewYAMLOrJSONDecoder(strings.NewReader(manifests), 4096)
+	inputs := make([]AdmissionReviewInput, 0)
+	for documentIndex := 1; ; documentIndex++ {
 		var obj map[string]interface{}
-		if err := yaml.Unmarshal([]byte(doc), &obj); err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal helm manifest")
+		if err := decoder.Decode(&obj); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, errors.Wrapf(err, "failed to unmarshal helm manifest document %d", documentIndex)
 		}
 
 		if len(obj) == 0 {

--- a/pkg/runner/jobs/build/helm/policy_input_test.go
+++ b/pkg/runner/jobs/build/helm/policy_input_test.go
@@ -83,6 +83,28 @@ spec: {}`)
 	}, second.Object)
 }
 
+func TestToPolicyAdmissionInputsPreservesDocumentSeparatorInBlockScalar(t *testing.T) {
+	ch := testChart(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+data:
+  config: |-
+    first
+    ---
+    second
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service`)
+
+	inputs, err := toPolicyAdmissionInputs(ch, nil)
+	require.NoError(t, err)
+	require.Len(t, inputs, 2)
+	require.Equal(t, "first\n---\nsecond", inputs[0].Review.Object["data"].(map[string]interface{})["config"])
+}
+
 func TestToPolicyAdmissionInputsSanitizesNuonValues(t *testing.T) {
 	ch := testChart(`apiVersion: v1
 kind: ConfigMap

--- a/pkg/types/approvals/admission.go
+++ b/pkg/types/approvals/admission.go
@@ -1,10 +1,11 @@
 package plan
 
 import (
+	"io"
 	"strings"
 
 	"github.com/pkg/errors"
-	"sigs.k8s.io/yaml"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // AdmissionReviewInput mimics Kubernetes AdmissionReview structure for OPA policy evaluation.
@@ -28,25 +29,22 @@ type AdmissionReviewKind struct {
 	Version string `json:"version,omitempty"`
 }
 
-// ParseMultiDocYAMLToAdmissionReviews parses a multi-document YAML string (separated by ---)
+// ParseMultiDocYAMLToAdmissionReviews parses a multi-document YAML stream
 // and converts each document into an AdmissionReviewInput structure suitable for OPA policy evaluation.
 func ParseMultiDocYAMLToAdmissionReviews(multiDocYAML string) ([]AdmissionReviewInput, error) {
 	if strings.TrimSpace(multiDocYAML) == "" {
 		return []AdmissionReviewInput{}, nil
 	}
 
-	docs := strings.Split(multiDocYAML, "---")
-	var results []AdmissionReviewInput
-
-	for _, doc := range docs {
-		doc = strings.TrimSpace(doc)
-		if doc == "" {
-			continue
-		}
-
+	decoder := yaml.NewYAMLOrJSONDecoder(strings.NewReader(multiDocYAML), 4096)
+	results := make([]AdmissionReviewInput, 0)
+	for documentIndex := 1; ; documentIndex++ {
 		var obj map[string]interface{}
-		if err := yaml.Unmarshal([]byte(doc), &obj); err != nil {
-			return nil, errors.Wrapf(err, "failed to unmarshal YAML document")
+		if err := decoder.Decode(&obj); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, errors.Wrapf(err, "failed to unmarshal YAML document %d", documentIndex)
 		}
 
 		if len(obj) == 0 {

--- a/pkg/types/approvals/admission_test.go
+++ b/pkg/types/approvals/admission_test.go
@@ -143,6 +143,60 @@ spec:
 			},
 		},
 		{
+			name: "document separator inside a block scalar",
+			input: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+data:
+  config: |-
+    first
+    ---
+    second
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service`,
+			expected: []AdmissionReviewInput{
+				{
+					Review: AdmissionReviewRequest{
+						Kind: AdmissionReviewKind{
+							Kind:    "ConfigMap",
+							Group:   "",
+							Version: "v1",
+						},
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata": map[string]interface{}{
+								"name": "config",
+							},
+							"data": map[string]interface{}{
+								"config": "first\n---\nsecond",
+							},
+						},
+					},
+				},
+				{
+					Review: AdmissionReviewRequest{
+						Kind: AdmissionReviewKind{
+							Kind:    "Service",
+							Group:   "",
+							Version: "v1",
+						},
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Service",
+							"metadata": map[string]interface{}{
+								"name": "my-service",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "multi-document with empty documents",
 			input: `---
 apiVersion: v1

--- a/services/ctl-api/internal/pkg/flow/checks/policy/check.go
+++ b/services/ctl-api/internal/pkg/flow/checks/policy/check.go
@@ -9,6 +9,8 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
+	"github.com/nuonco/nuon/pkg/metrics"
+	tmetrics "github.com/nuonco/nuon/pkg/temporal/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	policyhelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/policy_reports/helpers"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/directive"
@@ -22,15 +24,19 @@ const (
 	DenyViolationsKey  = "deny_violations"
 	WarnViolationsKey  = "warn_violations"
 	PassedPolicyIDsKey = "passed_policy_ids"
+
+	policyEvaluationMetric     = "policy.evaluation"
+	policyCheckBehaviorVersion = "policy-check-fail-closed-metrics-v1"
 )
 
 // Check implements directive.ApprovalCreateCheck for policy evaluation.
 type Check struct {
 	sig signal.Signal
+	tmw tmetrics.Writer
 }
 
-func New(sig signal.Signal) directive.ApprovalCreateCheck {
-	return &Check{sig: sig}
+func New(sig signal.Signal, tmw tmetrics.Writer) directive.ApprovalCreateCheck {
+	return &Check{sig: sig, tmw: tmw}
 }
 
 func (c *Check) Name() string { return "policy" }
@@ -41,6 +47,7 @@ func (c *Check) ShouldRun(step *app.WorkflowStep, flw *app.Workflow) bool {
 }
 
 func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workflow) (directive.CheckResult, error) {
+	version := workflow.GetVersion(ctx, policyCheckBehaviorVersion, workflow.DefaultVersion, 1)
 	l, _ := log.WorkflowLogger(ctx)
 
 	l.Debug("starting policy check",
@@ -49,14 +56,26 @@ func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workf
 		zap.String("step_target_type", step.StepTargetType),
 		zap.String("workflow_id", flw.ID))
 
-	violations, policyContext, policyErr := checkPolicies(ctx, step.StepTargetID, step.StepTargetType)
+	violations, policyContext, outcome, policyErr := checkPolicies(ctx, step.StepTargetID, step.StepTargetType)
 	if policyErr != nil {
-		l.Warn("failed to check policies",
-			zap.String("step_id", step.ID),
-			zap.Error(policyErr))
+		if version == workflow.DefaultVersion {
+			l.Warn("failed to check policies",
+				zap.String("step_id", step.ID),
+				zap.Error(policyErr))
+		} else {
+			l.Error("failed to check policies",
+				zap.String("step_id", step.ID),
+				zap.Error(policyErr))
+			c.recordFailure(ctx, step, flw, policyErr)
+			return directive.Pass(), errors.Wrap(policyErr, "unable to check policies")
+		}
 	}
 
 	if policyContext != nil {
+		if version != workflow.DefaultVersion {
+			c.recordSuccess(ctx, step, flw, outcome)
+		}
+
 		policyInputCounts := make(map[string]int, len(policyContext.PolicyIDs))
 		for _, policyID := range policyContext.PolicyIDs {
 			policyInputCounts[policyID] = policyContext.InputCount
@@ -122,17 +141,36 @@ func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workf
 	return directive.Pass(), nil
 }
 
-func checkPolicies(ctx workflow.Context, stepTargetID, stepTargetType string) ([]activities.PolicyViolation, *policyhelpers.PolicyEvaluationContext, error) {
+type policyEvaluationOutcome string
+
+const (
+	policyEvaluationOutcomePass policyEvaluationOutcome = "pass"
+	policyEvaluationOutcomeWarn policyEvaluationOutcome = "warn"
+	policyEvaluationOutcomeDeny policyEvaluationOutcome = "deny"
+)
+
+type policyEvaluationError struct {
+	stage string
+	err   error
+}
+
+func (e *policyEvaluationError) Error() string { return e.err.Error() }
+func (e *policyEvaluationError) Unwrap() error { return e.err }
+
+func checkPolicies(ctx workflow.Context, stepTargetID, stepTargetType string) ([]activities.PolicyViolation, *policyhelpers.PolicyEvaluationContext, policyEvaluationOutcome, error) {
 	prepResult, err := activities.AwaitPrepPolicyEvaluation(ctx, &activities.PrepPolicyEvaluationRequest{
 		StepTargetID:   stepTargetID,
 		StepTargetType: stepTargetType,
 	})
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "unable to prepare policy evaluation")
+		return nil, nil, "", &policyEvaluationError{
+			stage: "preparation",
+			err:   errors.Wrap(err, "unable to prepare policy evaluation"),
+		}
 	}
 
 	if !prepResult.HasPolicies {
-		return nil, nil, nil
+		return nil, nil, "", nil
 	}
 
 	ao := workflow.ActivityOptions{
@@ -156,10 +194,21 @@ func checkPolicies(ctx workflow.Context, stepTargetID, stepTargetType string) ([
 	}
 
 	var allViolations []activities.PolicyViolation
+	outcome := policyEvaluationOutcomePass
 	for _, fut := range futures {
 		var result activities.EvaluateSinglePolicyResult
 		if err := fut.Get(ctx, &result); err != nil {
-			return nil, nil, errors.Wrap(err, "policy evaluation failed")
+			return nil, nil, "", &policyEvaluationError{
+				stage: "evaluation",
+				err:   errors.Wrap(err, "policy evaluation failed"),
+			}
+		}
+		for _, violation := range result.Violations {
+			if violation.Severity == "deny" {
+				outcome = policyEvaluationOutcomeDeny
+			} else if outcome != policyEvaluationOutcomeDeny {
+				outcome = policyEvaluationOutcomeWarn
+			}
 		}
 		allViolations = append(allViolations, result.Violations...)
 	}
@@ -177,7 +226,41 @@ func checkPolicies(ctx workflow.Context, stepTargetID, stepTargetType string) ([
 		AppName:          prepResult.AppName,
 		InstallName:      prepResult.InstallName,
 		ComponentName:    prepResult.ComponentName,
-	}, nil
+	}, outcome, nil
+}
+
+func (c *Check) recordFailure(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workflow, policyErr error) {
+	if c.tmw == nil {
+		return
+	}
+
+	stage := "unknown"
+	var evaluationErr *policyEvaluationError
+	if errors.As(policyErr, &evaluationErr) {
+		stage = evaluationErr.stage
+	}
+
+	c.tmw.Incr(ctx, policyEvaluationMetric, metrics.ToTags(map[string]string{
+		"org_id":           flw.OrgID,
+		"stage":            stage,
+		"status":           "error",
+		"step_target_type": step.StepTargetType,
+		"workflow_type":    string(flw.Type),
+	})...)
+}
+
+func (c *Check) recordSuccess(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workflow, outcome policyEvaluationOutcome) {
+	if c.tmw == nil {
+		return
+	}
+
+	tags := map[string]string{
+		"org_id":           flw.OrgID,
+		"status":           "success",
+		"step_target_type": step.StepTargetType,
+		"workflow_type":    string(flw.Type),
+	}
+	c.tmw.Incr(ctx, policyEvaluationMetric, metrics.ToTags(tags, "outcome", string(outcome))...)
 }
 
 func processPolicyViolations(ctx workflow.Context, l *zap.Logger, step *app.WorkflowStep, flw *app.Workflow, violations []activities.PolicyViolation, passedPolicyIDs []string) error {

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/execute_step.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/execute_step.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/pkg/metrics"
+	tmetrics "github.com/nuonco/nuon/pkg/temporal/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/callback"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
@@ -22,6 +23,13 @@ import (
 // its own state from the database.
 func (s *Signal) Execute(ctx workflow.Context) (err error) {
 	defer func() { s.finished = true }()
+
+	if s.mw != nil && s.v != nil {
+		tmw, metricsErr := tmetrics.New(s.v, tmetrics.WithMetricsWriter(s.mw))
+		if metricsErr == nil {
+			s.tmw = tmw
+		}
+	}
 
 	start := workflow.Now(ctx)
 	var stepName, executionType string

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_plan.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_plan.go
@@ -60,19 +60,21 @@ func (s *Signal) processPlan(ctx workflow.Context, step *app.WorkflowStep, flw *
 
 		result, err := check.Run(ctx, step, flw)
 		if err != nil {
+			checkErr := errors.Wrapf(err, "%s check failed", check.Name())
 			if statusErr := statusactivities.AwaitPkgStatusUpdateFlowStepStatus(ctx, statusactivities.UpdateStatusRequest{
 				ID: step.ID,
 				Status: app.CompositeStatus{
 					Status: app.StatusError,
 					Metadata: map[string]any{
-						"reason": fmt.Sprintf("Step failed during %s.", check.Name()),
+						"check":  check.Name(),
+						"reason": checkErr.Error(),
 					},
-					StatusHumanDescription: "Step failed",
+					StatusHumanDescription: fmt.Sprintf("%s check failed", check.Name()),
 				},
 			}); statusErr != nil {
 				return errors.Wrap(statusErr, "unable to mark step as error")
 			}
-			return err
+			return checkErr
 		}
 
 		if result.Directive != directive.StepUnknown {
@@ -126,7 +128,7 @@ func (s *Signal) approvalCreateChecks(ctx workflow.Context, sig qsignal.Signal, 
 		// Empty install groups have nothing to approve; skip before the approval wait.
 		emptygroup.New(sig, setResultDirective),
 		noop.New(sig, checkCtx, orgAutoSkipNoop, setResultDirective),
-		policy.New(sig),
+		policy.New(sig, s.tmw),
 		autoapproval.New(stepSignal, setResultDirective),
 		planonly.New(s.OwnerID, checkCtx),
 	}

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/signal.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/signal.go
@@ -3,10 +3,12 @@ package executeworkflowstep
 import (
 	"time"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/nuonco/nuon/pkg/metrics"
+	tmetrics "github.com/nuonco/nuon/pkg/temporal/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 )
@@ -100,7 +102,9 @@ type Signal struct {
 	approvalResponseID   string
 	approvalResponseType string
 
-	mw metrics.Writer
+	mw  metrics.Writer
+	v   *validator.Validate
+	tmw tmetrics.Writer
 }
 
 var (
@@ -115,6 +119,7 @@ var (
 
 func (s *Signal) WithParams(params *signal.Params) {
 	s.mw = params.MW
+	s.v = params.V
 }
 
 func (s *Signal) Timeout() time.Duration {


### PR DESCRIPTION
Parse Terraform and Kubernetes policy inputs with Kubernetes YAML stream decoders so literal document separators inside block scalars remain part of the manifest instead of corrupting policy input.

Fail closed when policy preparation or OPA execution fails and propagate the underlying cause through workflow error reporting. Emit a replay-safe `policy.evaluation` metric for `pass`, `warn`, `deny`, and `error` outcomes while preserving legacy behavior for in-flight Temporal histories through workflow versioning.

Add regression coverage for YAML stream decoding, error propagation, legacy replay behavior, and evaluation outcome metrics.