### PR TITLE
feat(ui): custom byoc favicon

### DIFF
--- a/services/dashboard-ui/client/components/orgs/OrgStatusBar/OrgStatusBar.stories.tsx
+++ b/services/dashboard-ui/client/components/orgs/OrgStatusBar/OrgStatusBar.stories.tsx
@@ -13,3 +13,29 @@ export const Default = () => (
     workflowItems={[]}
   />
 )
+
+export const WithBYOCBadge = () => (
+  <OrgStatusBar
+    org={{ id: 'org-1', name: 'My Org' } as any}
+    approvals={[]}
+    activeWorkflows={[]}
+    approvalItems={[]}
+    workflowItems={[]}
+    byocName="acme payments"
+    byocColor="#1A6B4A"
+    byocTextColor="#FFFFFF"
+  />
+)
+
+export const WithBYOCBadgeLightColor = () => (
+  <OrgStatusBar
+    org={{ id: 'org-1', name: 'My Org' } as any}
+    approvals={[]}
+    activeWorkflows={[]}
+    approvalItems={[]}
+    workflowItems={[]}
+    byocName="acme"
+    byocColor="#F5D90A"
+    byocTextColor="#000000"
+  />
+)

--- a/services/dashboard-ui/client/components/orgs/OrgStatusBar/OrgStatusBar.tsx
+++ b/services/dashboard-ui/client/components/orgs/OrgStatusBar/OrgStatusBar.tsx
@@ -24,6 +24,9 @@ interface IOrgStatusBar {
   activeWorkflows: TWorkflow[]
   approvalItems: TContextTooltipItem[]
   workflowItems: TContextTooltipItem[]
+  byocName?: string
+  byocColor?: string
+  byocTextColor?: string
 }
 
 export const OrgStatusBar = ({
@@ -37,6 +40,9 @@ export const OrgStatusBar = ({
   activeWorkflows,
   approvalItems,
   workflowItems,
+  byocName,
+  byocColor,
+  byocTextColor,
 }: IOrgStatusBar) => {
   return (
     <div className="hidden md:flex border-t w-full px-4 py-1.5 items-center flex-none bg-code z-[1] gap-3">
@@ -168,6 +174,15 @@ export const OrgStatusBar = ({
             tooltipPosition="top"
           />
         </>
+      )}
+
+      {byocName && (
+        <span
+          className="ml-auto max-w-56 truncate rounded px-2 py-px font-mono text-xs font-strong tracking-widest uppercase"
+          style={{ backgroundColor: byocColor, color: byocTextColor }}
+        >
+          {byocName}
+        </span>
       )}
     </div>
   )

--- a/services/dashboard-ui/client/components/orgs/OrgStatusBar/OrgStatusBarContainer.tsx
+++ b/services/dashboard-ui/client/components/orgs/OrgStatusBar/OrgStatusBarContainer.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router'
 import { type TContextTooltipItem } from '@/components/common/ContextTooltip'
 import { Status } from '@/components/common/Status'
 import { useActiveWorkflows } from '@/hooks/use-active-workflows'
+import { useConfig } from '@/hooks/use-config'
 import { useOrg } from '@/hooks/use-org'
 import { useWorkflowApprovals } from '@/hooks/use-workflow-approvals'
 import {
@@ -17,6 +18,7 @@ import { OrgStatusBar } from './OrgStatusBar'
 
 export const OrgStatusBarContainer = () => {
   const { org } = useOrg()
+  const { byocName, byocColor, byocTextColor } = useConfig()
   const { approvals } = useWorkflowApprovals()
   const { activeWorkflows } = useActiveWorkflows()
   const { appId, branchId, installId } = useParams()
@@ -109,6 +111,9 @@ export const OrgStatusBarContainer = () => {
       activeWorkflows={activeWorkflows}
       approvalItems={approvalItems}
       workflowItems={workflowItems}
+      byocName={byocName}
+      byocColor={byocColor}
+      byocTextColor={byocTextColor}
     />
   )
 }

--- a/services/dashboard-ui/client/providers/config-provider.tsx
+++ b/services/dashboard-ui/client/providers/config-provider.tsx
@@ -16,6 +16,9 @@ export type TRuntimeConfig = {
   version?: string
   gitRef?: string
   isByoc: boolean
+  byocName?: string
+  byocColor?: string
+  byocTextColor?: string
   onboardingV2?: boolean
   adminDashboardUrl?: string
   isDev?: boolean

--- a/services/dashboard-ui/server/internal/config.go
+++ b/services/dashboard-ui/server/internal/config.go
@@ -55,6 +55,9 @@ type Config struct {
 	DisableMetrics        bool   `config:"disable_metrics"`
 	ServiceDeployment     string `config:"service_deployment"`
 	IsBYOC                bool   `config:"nuon_byoc"`
+	BYOCName              string `config:"nuon_byoc_name"`
+	BYOCIconText          string `config:"nuon_byoc_icon_text"`
+	BYOCColor             string `config:"nuon_byoc_color"`
 	OnboardingV2          bool   `config:"nuon_onboarding_v2"`
 	AdminDashboardUrl     string `config:"nuon_admin_dashboard_url"`
 }

--- a/services/dashboard-ui/server/internal/spa/favicon.go
+++ b/services/dashboard-ui/server/internal/spa/favicon.go
@@ -34,16 +34,10 @@ func generateBYOCFavicon(cfg *internal.Config, l *zap.Logger) []byte {
 		return nil
 	}
 
-	hasColor := false
-	background := byocDefaultBackground
-	if color != "" {
-		if hexColorPattern.MatchString(color) {
-			background = "#" + strings.TrimPrefix(color, "#")
-			hasColor = true
-		} else {
-			l.Warn("invalid NUON_BYOC_COLOR, falling back to default purple",
-				zap.String("color", cfg.BYOCColor))
-		}
+	background, hasColor := resolveBYOCBackground(color)
+	if color != "" && !hasColor {
+		l.Warn("invalid NUON_BYOC_COLOR, falling back to default purple",
+			zap.String("color", cfg.BYOCColor))
 	}
 
 	glyphs := ""
@@ -83,6 +77,14 @@ func generateBYOCFavicon(cfg *internal.Config, l *zap.Logger) []byte {
 		background, content)
 
 	return []byte(svg)
+}
+
+func resolveBYOCBackground(color string) (string, bool) {
+	c := strings.TrimSpace(color)
+	if c == "" || !hexColorPattern.MatchString(c) {
+		return byocDefaultBackground, false
+	}
+	return "#" + strings.TrimPrefix(c, "#"), true
 }
 
 func isValidIconText(s string) bool {

--- a/services/dashboard-ui/server/internal/spa/favicon.go
+++ b/services/dashboard-ui/server/internal/spa/favicon.go
@@ -1,0 +1,136 @@
+package spa
+
+import (
+	"fmt"
+	"html"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/dashboard-ui/server/internal"
+)
+
+const (
+	byocDefaultBackground = "#662F9D"
+	byocMarkDimOpacity    = "0.4"
+
+	nuonMark = `<g transform="translate(100.585 100.945) scale(1.42) translate(-100.585 -100.945)"><path d="M121.15 40.3118L97.9645 53.715V75.4151L79.1959 64.5597H79.1852L56.8232 77.492V148.651L79.1852 161.584H79.1959L103.205 147.699V126.951L121.161 137.325L144.346 123.922V53.715L121.161 40.3118H121.15ZM62.0528 80.5216L79.1745 70.6297H79.1852L97.9538 81.4744V117.862L62.0528 97.1151V80.5216ZM97.9538 144.669L79.1745 155.514L62.0528 145.622V103.174L97.9538 123.922V144.669ZM139.095 120.881L121.15 131.255L103.205 120.892V84.504L139.106 105.251V120.881H139.095ZM139.095 99.192L103.194 78.4447V56.7447L121.15 46.3711L139.095 56.7447V99.192Z" fill="%s"/></g>`
+)
+
+var hexColorPattern = regexp.MustCompile(`^#?(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$`)
+
+func generateBYOCFavicon(cfg *internal.Config, l *zap.Logger) []byte {
+	if !cfg.IsBYOC {
+		return nil
+	}
+
+	iconText := strings.TrimSpace(cfg.BYOCIconText)
+	color := strings.TrimSpace(cfg.BYOCColor)
+	if iconText == "" && color == "" {
+		return nil
+	}
+
+	hasColor := false
+	background := byocDefaultBackground
+	if color != "" {
+		if hexColorPattern.MatchString(color) {
+			background = "#" + strings.TrimPrefix(color, "#")
+			hasColor = true
+		} else {
+			l.Warn("invalid NUON_BYOC_COLOR, falling back to default purple",
+				zap.String("color", cfg.BYOCColor))
+		}
+	}
+
+	glyphs := ""
+	if iconText != "" {
+		runes := []rune(iconText)
+		if len(runes) > 2 {
+			runes = runes[:2]
+		}
+		if isValidIconText(string(runes)) {
+			glyphs = string(runes)
+		} else {
+			l.Warn("invalid NUON_BYOC_ICON_TEXT, must be printable characters",
+				zap.String("icon_text", cfg.BYOCIconText))
+		}
+	}
+
+	if glyphs == "" && !hasColor {
+		return nil
+	}
+
+	foreground := contrastingForeground(background)
+	mark := fmt.Sprintf(nuonMark, foreground)
+
+	content := mark
+	if glyphs != "" {
+		fit := ""
+		if len([]rune(glyphs)) == 2 {
+			fit = ` textLength="170" lengthAdjust="spacingAndGlyphs"`
+		}
+		content = fmt.Sprintf(
+			`<g opacity="%s">%s</g><text x="100.5" y="100.5" fill="%s" font-size="%d" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-weight="650" text-anchor="middle" dominant-baseline="central"%s>%s</text>`,
+			byocMarkDimOpacity, mark, foreground, glyphFontSize(glyphs), fit, html.EscapeString(glyphs))
+	}
+
+	svg := fmt.Sprintf(
+		`<svg width="201" height="201" viewBox="0 0 201 201" xmlns="http://www.w3.org/2000/svg"><rect x="0.5" y="0.5" width="200" height="200" rx="44" fill="%s"/>%s</svg>`,
+		background, content)
+
+	return []byte(svg)
+}
+
+func isValidIconText(s string) bool {
+	runes := []rune(s)
+	if len(runes) < 1 || len(runes) > 2 {
+		return false
+	}
+	for _, r := range runes {
+		if !unicode.IsPrint(r) || unicode.IsSpace(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func glyphFontSize(glyphs string) int {
+	if len([]rune(glyphs)) == 1 {
+		return 150
+	}
+	return 130
+}
+
+func contrastingForeground(hexColor string) string {
+	lum := relativeLuminance(hexColor)
+	contrastWithWhite := 1.05 / (lum + 0.05)
+	contrastWithBlack := (lum + 0.05) / 0.05
+	if contrastWithBlack > contrastWithWhite {
+		return "#000000"
+	}
+	return "#FFFFFF"
+}
+
+func relativeLuminance(hexColor string) float64 {
+	hexDigits := strings.TrimPrefix(hexColor, "#")
+	if len(hexDigits) == 3 {
+		hexDigits = strings.Repeat(string(hexDigits[0]), 2) +
+			strings.Repeat(string(hexDigits[1]), 2) +
+			strings.Repeat(string(hexDigits[2]), 2)
+	}
+
+	channel := func(offset int) float64 {
+		v, _ := strconv.ParseUint(hexDigits[offset:offset+2], 16, 8)
+		c := float64(v) / 255.0
+		if c <= 0.03928 {
+			return c / 12.92
+		}
+		return math.Pow((c+0.055)/1.055, 2.4)
+	}
+
+	return 0.2126*channel(0) + 0.7152*channel(2) + 0.0722*channel(4)
+}

--- a/services/dashboard-ui/server/internal/spa/favicon_test.go
+++ b/services/dashboard-ui/server/internal/spa/favicon_test.go
@@ -1,0 +1,146 @@
+package spa
+
+import (
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/services/dashboard-ui/server/internal"
+)
+
+func generate(t *testing.T, cfg internal.Config) string {
+	t.Helper()
+	return string(generateBYOCFavicon(&cfg, zap.NewNop()))
+}
+
+func TestGenerateBYOCFavicon_NotConfigured(t *testing.T) {
+	if got := generateBYOCFavicon(&internal.Config{IsBYOC: true}, zap.NewNop()); got != nil {
+		t.Fatalf("expected nil when no byoc favicon config set, got %q", got)
+	}
+	if got := generateBYOCFavicon(&internal.Config{BYOCIconText: "Rt"}, zap.NewNop()); got != nil {
+		t.Fatalf("expected nil when not BYOC, got %q", got)
+	}
+	if got := generateBYOCFavicon(&internal.Config{IsBYOC: true, BYOCName: "acme"}, zap.NewNop()); got != nil {
+		t.Fatalf("expected nil when only name is set (name does not drive the favicon), got %q", got)
+	}
+	if got := generateBYOCFavicon(&internal.Config{IsBYOC: true, BYOCIconText: "a\x01"}, zap.NewNop()); got != nil {
+		t.Fatalf("expected nil for invalid icon text with no color, got %q", got)
+	}
+	if got := generateBYOCFavicon(&internal.Config{IsBYOC: true, BYOCIconText: "   "}, zap.NewNop()); got != nil {
+		t.Fatalf("expected nil for whitespace-only icon text, got %q", got)
+	}
+}
+
+func TestGenerateBYOCFavicon_IconText(t *testing.T) {
+	tests := []struct {
+		text string
+		want string
+		size string
+	}{
+		{"R", "R", `font-size="150"`},
+		{"Rt", "Rt", `font-size="130"`},
+		{"xyz", "xy", `font-size="130"`},
+	}
+	for _, tt := range tests {
+		svg := generate(t, internal.Config{IsBYOC: true, BYOCIconText: tt.text})
+		if !strings.Contains(svg, ">"+tt.want+"</text>") {
+			t.Errorf("icon text %q: expected glyphs %q in %q", tt.text, tt.want, svg)
+		}
+		if !strings.Contains(svg, tt.size) {
+			t.Errorf("icon text %q: expected %s in %q", tt.text, tt.size, svg)
+		}
+		hasFit := strings.Contains(svg, `textLength="170"`)
+		if wantFit := len([]rune(tt.want)) == 2; hasFit != wantFit {
+			t.Errorf("icon text %q: textLength fit attr presence = %v, want %v", tt.text, hasFit, wantFit)
+		}
+	}
+}
+
+func TestGenerateBYOCFavicon_IconTextRendersDimmedMark(t *testing.T) {
+	svg := generate(t, internal.Config{IsBYOC: true, BYOCIconText: "Rt"})
+	if !strings.Contains(svg, `<g opacity="0.4"><g transform=`) {
+		t.Errorf("expected dimmed nuon mark behind glyphs, got %q", svg)
+	}
+	if !strings.Contains(svg, `<path d="M121.15`) {
+		t.Errorf("expected nuon mark path, got %q", svg)
+	}
+	if !strings.Contains(svg, "<text") {
+		t.Errorf("expected text element, got %q", svg)
+	}
+}
+
+func TestGenerateBYOCFavicon_ColorOnlyRendersFullMark(t *testing.T) {
+	svg := generate(t, internal.Config{IsBYOC: true, BYOCColor: "#0A3D62"})
+	if !strings.Contains(svg, `<path d="M121.15`) {
+		t.Errorf("expected nuon mark path, got %q", svg)
+	}
+	if strings.Contains(svg, "opacity") {
+		t.Errorf("expected full-strength mark for color-only favicon, got %q", svg)
+	}
+	if strings.Contains(svg, "<text") {
+		t.Errorf("expected no text element for color-only favicon, got %q", svg)
+	}
+	if !strings.Contains(svg, `fill="#0A3D62"`) {
+		t.Errorf("expected custom background, got %q", svg)
+	}
+	if !strings.Contains(svg, `fill="#FFFFFF"`) {
+		t.Errorf("expected white mark on dark background, got %q", svg)
+	}
+}
+
+func TestGenerateBYOCFavicon_InvalidIconTextWithColorFallsBackToMark(t *testing.T) {
+	svg := generate(t, internal.Config{IsBYOC: true, BYOCIconText: "a\x01", BYOCColor: "#0A3D62"})
+	if !strings.Contains(svg, `<path d="M121.15`) || strings.Contains(svg, "<text") {
+		t.Errorf("expected mark-only favicon when icon text is invalid, got %q", svg)
+	}
+}
+
+func TestGenerateBYOCFavicon_XMLEscaping(t *testing.T) {
+	svg := generate(t, internal.Config{IsBYOC: true, BYOCIconText: `<&`})
+	if strings.Contains(svg, "><&<") {
+		t.Fatalf("glyphs not escaped: %q", svg)
+	}
+	if !strings.Contains(svg, "&lt;&amp;") {
+		t.Errorf("expected escaped glyphs in %q", svg)
+	}
+}
+
+func TestGenerateBYOCFavicon_Background(t *testing.T) {
+	svg := generate(t, internal.Config{IsBYOC: true, BYOCIconText: "Rt"})
+	if !strings.Contains(svg, `fill="#662F9D"`) {
+		t.Errorf("expected default purple background, got %q", svg)
+	}
+
+	svg = generate(t, internal.Config{IsBYOC: true, BYOCIconText: "Rt", BYOCColor: "#1A6B4A"})
+	if !strings.Contains(svg, `fill="#1A6B4A"`) {
+		t.Errorf("expected custom background, got %q", svg)
+	}
+
+	svg = generate(t, internal.Config{IsBYOC: true, BYOCIconText: "Rt", BYOCColor: "1A6B4A"})
+	if !strings.Contains(svg, `fill="#1A6B4A"`) {
+		t.Errorf("expected bare hex to be accepted and normalized, got %q", svg)
+	}
+
+	svg = generate(t, internal.Config{IsBYOC: true, BYOCIconText: "Rt", BYOCColor: "not-a-color"})
+	if !strings.Contains(svg, `fill="#662F9D"`) {
+		t.Errorf("expected fallback to purple for invalid color, got %q", svg)
+	}
+}
+
+func TestGenerateBYOCFavicon_ForegroundContrast(t *testing.T) {
+	svg := generate(t, internal.Config{IsBYOC: true, BYOCIconText: "Rt", BYOCColor: "#F5D90A"})
+	if !strings.Contains(svg, `fill="#000000"`) {
+		t.Errorf("expected black foreground on light background, got %q", svg)
+	}
+
+	svg = generate(t, internal.Config{IsBYOC: true, BYOCIconText: "Rt", BYOCColor: "#1A1A2E"})
+	if !strings.Contains(svg, `fill="#FFFFFF"`) {
+		t.Errorf("expected white foreground on dark background, got %q", svg)
+	}
+
+	svg = generate(t, internal.Config{IsBYOC: true, BYOCIconText: "Rt", BYOCColor: "#fff"})
+	if !strings.Contains(svg, `fill="#000000"`) {
+		t.Errorf("expected black foreground on 3-digit white background, got %q", svg)
+	}
+}

--- a/services/dashboard-ui/server/internal/spa/favicon_test.go
+++ b/services/dashboard-ui/server/internal/spa/favicon_test.go
@@ -128,6 +128,33 @@ func TestGenerateBYOCFavicon_Background(t *testing.T) {
 	}
 }
 
+func TestBuildClientConfig_BYOCBadge(t *testing.T) {
+	cc := buildClientConfig(&internal.Config{IsBYOC: true, BYOCName: "acme", BYOCColor: "#F5D90A"})
+	if cc.BYOCName != "acme" || cc.BYOCColor != "#F5D90A" || cc.BYOCTextColor != "#000000" {
+		t.Errorf("expected badge fields with black text on light color, got %+v", cc)
+	}
+
+	cc = buildClientConfig(&internal.Config{IsBYOC: true, BYOCName: "acme"})
+	if cc.BYOCColor != "#662F9D" || cc.BYOCTextColor != "#FFFFFF" {
+		t.Errorf("expected purple badge with white text when no color set, got %+v", cc)
+	}
+
+	cc = buildClientConfig(&internal.Config{IsBYOC: true, BYOCName: "acme", BYOCColor: "nope"})
+	if cc.BYOCColor != "#662F9D" {
+		t.Errorf("expected purple badge for invalid color, got %+v", cc)
+	}
+
+	cc = buildClientConfig(&internal.Config{IsBYOC: true, BYOCColor: "#F5D90A"})
+	if cc.BYOCName != "" || cc.BYOCColor != "" || cc.BYOCTextColor != "" {
+		t.Errorf("expected no badge fields without a name, got %+v", cc)
+	}
+
+	cc = buildClientConfig(&internal.Config{BYOCName: "acme"})
+	if cc.BYOCName != "" {
+		t.Errorf("expected no badge fields when not BYOC, got %+v", cc)
+	}
+}
+
 func TestGenerateBYOCFavicon_ForegroundContrast(t *testing.T) {
 	svg := generate(t, internal.Config{IsBYOC: true, BYOCIconText: "Rt", BYOCColor: "#F5D90A"})
 	if !strings.Contains(svg, `fill="#000000"`) {

--- a/services/dashboard-ui/server/internal/spa/serve.go
+++ b/services/dashboard-ui/server/internal/spa/serve.go
@@ -49,12 +49,15 @@ type clientConfig struct {
 	Version               string `json:"version,omitempty"`
 	GitRef                string `json:"gitRef,omitempty"`
 	IsBYOC                bool   `json:"isByoc"`
+	BYOCName              string `json:"byocName,omitempty"`
+	BYOCColor             string `json:"byocColor,omitempty"`
+	BYOCTextColor         string `json:"byocTextColor,omitempty"`
 	OnboardingV2          bool   `json:"onboardingV2,omitempty"`
 	AdminDashboardUrl     string `json:"adminDashboardUrl,omitempty"`
 }
 
 func buildClientConfig(cfg *internal.Config) clientConfig {
-	return clientConfig{
+	cc := clientConfig{
 		APIUrl:                cfg.APIUrl,
 		TemporalUIUrl:         cfg.TemporalUIUrl,
 		AuthServiceUrl:        cfg.AuthServiceUrl,
@@ -72,6 +75,17 @@ func buildClientConfig(cfg *internal.Config) clientConfig {
 		OnboardingV2:          cfg.OnboardingV2,
 		AdminDashboardUrl:     cfg.AdminDashboardUrl,
 	}
+
+	if cfg.IsBYOC {
+		if name := strings.TrimSpace(cfg.BYOCName); name != "" {
+			background, _ := resolveBYOCBackground(cfg.BYOCColor)
+			cc.BYOCName = name
+			cc.BYOCColor = background
+			cc.BYOCTextColor = contrastingForeground(background)
+		}
+	}
+
+	return cc
 }
 
 type Handler struct {

--- a/services/dashboard-ui/server/internal/spa/serve.go
+++ b/services/dashboard-ui/server/internal/spa/serve.go
@@ -172,6 +172,7 @@ func (h *Handler) RegisterRoutes(e *gin.Engine) error {
 
 	publicFS := h.publicFS()
 	authHandler := authmw.New(h.cfg, h.l).Handler()
+	byocFavicon := generateBYOCFavicon(h.cfg, h.l)
 
 	e.NoRoute(func(c *gin.Context) {
 		if c.Request.Method != http.MethodGet {
@@ -184,6 +185,12 @@ func (h *Handler) RegisterRoutes(e *gin.Engine) error {
 		}
 
 		filePath := strings.TrimPrefix(c.Request.URL.Path, "/")
+
+		if byocFavicon != nil && !isLocalEnv && filePath == "favicon.svg" {
+			c.Header("Cache-Control", "public, max-age=3600")
+			c.Data(http.StatusOK, "image/svg+xml", byocFavicon)
+			return
+		}
 
 		if publicFS != nil {
 			rewrites := map[string]string(nil)


### PR DESCRIPTION
 Adds support to customize the favicon in byoc env using env vars `NUON_BYOC_NAME`, `NUON_BYOC_COLOR` and `NUON_BYOC_ICON_TEXT`. This will let you change the favicon color, the favicon glyph and add a byoc badge in the right side of the org status bar