### PR TITLE
fix: read runner heartbeats from the replicated table with a time floor

### DIFF
--- a/services/ctl-api/internal/app/runners/worker/activities/get_most_recent_heart_beat.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_most_recent_heart_beat.go
@@ -3,11 +3,17 @@ package activities
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 )
+
+// runner_heart_beats is ordered by (runner_id, process_id, created_at), so a created_at floor
+// keeps this to a granule read instead of scanning every beat the runner has sent. Live runners
+// beat every few seconds, so anything older than this means the runner is gone, not quiet.
+const heartBeatLookback = time.Hour
 
 type GetMostRecentHeartBeatRequest struct {
 	RunnerID string                `validate:"required"`
@@ -44,31 +50,27 @@ func (a *Activities) getMostRecentHeartBeat(ctx context.Context, runnerID string
 }
 
 func (a *Activities) queryHeartBeat(ctx context.Context, runnerID string, process app.RunnerProcessType) (*app.RunnerHeartBeat, error) {
-	var latest []*app.LatestRunnerHeartBeat
+	var beats []*app.RunnerHeartBeat
 	db := a.chDB.WithContext(ctx).
-		Where("runner_id = ?", runnerID)
+		Where("runner_id = ?", runnerID).
+		Where("created_at > ?", time.Now().Add(-heartBeatLookback))
 	if process != "" {
 		db = db.Where("process = ?", process)
 	}
 
 	res := db.
-		Order("created_at_latest desc").
+		Order("created_at desc").
 		Limit(1).
-		Find(&latest)
+		Find(&beats)
 	if res.Error != nil {
 		return nil, errors.Wrap(res.Error, "unable to get heart beats")
 	}
-	if len(latest) == 0 {
+	if len(beats) == 0 {
 		return nil, nil
 	}
 
-	return &app.RunnerHeartBeat{
-		RunnerID:  latest[0].RunnerID,
-		ProcessID: latest[0].ProcessID,
-		Process:   latest[0].Process,
-		Version:   latest[0].Version,
-		AliveTime: latest[0].AliveTime,
-		CreatedAt: latest[0].CreatedAt,
-		StartedAt: latest[0].CreatedAt.Add(-1 * latest[0].AliveTime),
-	}, nil
+	hb := beats[0]
+	hb.StartedAt = hb.CreatedAt.Add(-1 * hb.AliveTime)
+
+	return hb, nil
 }


### PR DESCRIPTION
Reverts the heartbeat read from #2228. `latest_runner_heart_beats` (the MV target) is a plain `ReplacingMergeTree`, not replicated. A ClickHouse MV is an INSERT trigger, and replication ships parts rather than INSERTs, so only the ingesting node's MV fires — the target is effectively node-local. On prod the two replicas disagree and the disagreement drifts: measured 5 min apart, replica 0-0-0 went from 0 rows for a live runner to current, while 0-1-0 went from current to 5 min stale. The source table is identical on both.

ctl-api pools a connection pinned to one replica, so this is deterministic per pod, not flaky — every job for an affected runner fails with `no heart beats found`. Stale (rather than missing) rows also feed the `hb.StartedAt` "runner restarted while job in flight → cancel" check.

Reads go back to `runner_heart_beats` (ReplicatedMergeTree, consistent), with a 1h `created_at` floor so it stays a granule read: EXPLAIN on prod goes from 16 parts/16 granules to 6/6, and is now bounded by the window rather than growing with runner lifetime. Verified the new query returns the runner on both replicas.

Note `GET /v1/runners/:runner_id/heart-beats/latest` still reads the MV and has the same divergence; it's display-only so I left it. Durable fix is making the target `ReplicatedReplacingMergeTree` and aligning its 5d TTL with the source's 2d.