### PR TITLE
fix: skip policy evaluation when none apply

### DIFF
--- a/services/ctl-api/internal/app/policy_reports/policyerrors/evaluation_failed.go
+++ b/services/ctl-api/internal/app/policy_reports/policyerrors/evaluation_failed.go
@@ -1,0 +1,45 @@
+package policyerrors
+
+import "github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+
+const EvaluationFailedErrorType compositeerrors.Type = "policy.evaluation_failed"
+
+type EvaluationFailureStage string
+
+const (
+	EvaluationFailureStagePreparation EvaluationFailureStage = "preparation"
+	EvaluationFailureStageEvaluation  EvaluationFailureStage = "evaluation"
+)
+
+type EvaluationFailedError struct {
+	Stage EvaluationFailureStage `json:"stage"`
+}
+
+var _ compositeerrors.CompositeError = (*EvaluationFailedError)(nil)
+
+func (*EvaluationFailedError) Error() string {
+	return "Policy evaluation could not be completed"
+}
+
+func (*EvaluationFailedError) Type() compositeerrors.Type {
+	return EvaluationFailedErrorType
+}
+
+func (*EvaluationFailedError) Severity() compositeerrors.Severity {
+	return compositeerrors.SeverityWarning
+}
+
+func (e *EvaluationFailedError) Sections() []compositeerrors.Section {
+	whatHappened := "Nuon could not complete policy enforcement for this plan. The workflow continued without a policy result."
+	switch e.Stage {
+	case EvaluationFailureStagePreparation:
+		whatHappened = "Nuon could not prepare the plan and configured policies for evaluation. The workflow continued without a policy result."
+	case EvaluationFailureStageEvaluation:
+		whatHappened = "Nuon prepared the policy inputs but could not finish evaluating the configured policies. The workflow continued without a policy result."
+	}
+
+	return []compositeerrors.Section{
+		compositeerrors.MarkdownSection("What happened", whatHappened),
+		compositeerrors.MarkdownSection("How to continue", "Review the plan carefully before approving it. Retry the plan to attempt policy evaluation again, and contact support if this warning persists."),
+	}
+}

--- a/services/ctl-api/internal/pkg/flow/checks/policy/check.go
+++ b/services/ctl-api/internal/pkg/flow/checks/policy/check.go
@@ -13,6 +13,7 @@ import (
 	tmetrics "github.com/nuonco/nuon/pkg/temporal/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	policyhelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/policy_reports/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/policy_reports/policyerrors"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/directive"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
@@ -25,8 +26,7 @@ const (
 	WarnViolationsKey  = "warn_violations"
 	PassedPolicyIDsKey = "passed_policy_ids"
 
-	policyEvaluationMetric     = "policy.evaluation"
-	policyCheckBehaviorVersion = "policy-check-fail-closed-metrics-v1"
+	policyEvaluationMetric = "policy.evaluation"
 )
 
 // Check implements directive.ApprovalCreateCheck for policy evaluation.
@@ -47,7 +47,6 @@ func (c *Check) ShouldRun(step *app.WorkflowStep, flw *app.Workflow) bool {
 }
 
 func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workflow) (directive.CheckResult, error) {
-	version := workflow.GetVersion(ctx, policyCheckBehaviorVersion, workflow.DefaultVersion, 1)
 	l, _ := log.WorkflowLogger(ctx)
 
 	l.Debug("starting policy check",
@@ -58,23 +57,16 @@ func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workf
 
 	violations, policyContext, outcome, policyErr := checkPolicies(ctx, step.StepTargetID, step.StepTargetType)
 	if policyErr != nil {
-		if version == workflow.DefaultVersion {
-			l.Warn("failed to check policies",
-				zap.String("step_id", step.ID),
-				zap.Error(policyErr))
-		} else {
-			l.Error("failed to check policies",
-				zap.String("step_id", step.ID),
-				zap.Error(policyErr))
-			c.recordFailure(ctx, step, flw, policyErr)
-			return directive.Pass(), errors.Wrap(policyErr, "unable to check policies")
-		}
+		l.Error("failed to check policies; continuing with warning",
+			zap.String("step_id", step.ID),
+			zap.Error(policyErr))
+		c.recordFailure(ctx, step, flw, policyErr)
+		recordEvaluationCompositeError(ctx, l, step, policyErr)
+		return directive.Pass(), nil
 	}
 
 	if policyContext != nil {
-		if version != workflow.DefaultVersion {
-			c.recordSuccess(ctx, step, flw, outcome)
-		}
+		c.recordSuccess(ctx, step, flw, outcome)
 
 		policyInputCounts := make(map[string]int, len(policyContext.PolicyIDs))
 		for _, policyID := range policyContext.PolicyIDs {
@@ -234,19 +226,34 @@ func (c *Check) recordFailure(ctx workflow.Context, step *app.WorkflowStep, flw 
 		return
 	}
 
-	stage := "unknown"
-	var evaluationErr *policyEvaluationError
-	if errors.As(policyErr, &evaluationErr) {
-		stage = evaluationErr.stage
-	}
-
 	c.tmw.Incr(ctx, policyEvaluationMetric, metrics.ToTags(map[string]string{
 		"org_id":           flw.OrgID,
-		"stage":            stage,
+		"stage":            policyEvaluationErrorStage(policyErr),
 		"status":           "error",
 		"step_target_type": step.StepTargetType,
 		"workflow_type":    string(flw.Type),
 	})...)
+}
+
+func policyEvaluationErrorStage(policyErr error) string {
+	var evaluationErr *policyEvaluationError
+	if errors.As(policyErr, &evaluationErr) {
+		return evaluationErr.stage
+	}
+	return "unknown"
+}
+
+func recordEvaluationCompositeError(ctx workflow.Context, l *zap.Logger, step *app.WorkflowStep, policyErr error) {
+	if err := activities.AwaitRecordPolicyEvaluationCompositeError(ctx, activities.RecordPolicyEvaluationCompositeErrorRequest{
+		WorkflowStepID: step.ID,
+		StepTargetID:   step.StepTargetID,
+		StepTargetType: step.StepTargetType,
+		Stage:          policyerrors.EvaluationFailureStage(policyEvaluationErrorStage(policyErr)),
+	}); err != nil {
+		l.Warn("failed to record policy evaluation composite error",
+			zap.String("step_id", step.ID),
+			zap.Error(err))
+	}
 }
 
 func (c *Check) recordSuccess(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workflow, outcome policyEvaluationOutcome) {

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/prep_policy_evaluation.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/prep_policy_evaluation.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
@@ -80,14 +81,12 @@ func (a *Activities) PrepPolicyEvaluation(ctx context.Context, req *PrepPolicyEv
 
 	policiesConfig, err := a.appsHelpers.GetPoliciesConfigByAppConfigID(ctx, policyContext.AppConfigID)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			l.Info("no policies config found")
+			return newNoPoliciesPrepResult(policyContext), nil
+		}
 		l.Error("unable to get policies config", zap.Error(err))
 		return nil, errors.Wrap(err, "unable to get policies config")
-	}
-
-	approvalPlan, err := a.getApprovalPlan(ctx, req.StepTargetID)
-	if err != nil {
-		l.Error("unable to get plan contents", zap.Error(err))
-		return nil, errors.Wrap(err, "unable to get plan contents")
 	}
 
 	applicablePolicies := a.filterApplicablePolicies(
@@ -101,22 +100,13 @@ func (a *Activities) PrepPolicyEvaluation(ctx context.Context, req *PrepPolicyEv
 
 	if len(applicablePolicies) == 0 {
 		l.Info("no applicable policies found")
-		return &PrepPolicyEvaluationResult{
-			Policies:         []PolicyToEvaluate{},
-			HasPolicies:      false,
-			OrgID:            policyContext.OrgID,
-			AppID:            policyContext.AppID,
-			InstallID:        policyContext.InstallID,
-			InstallSandboxID: policyContext.InstallSandboxID,
-			ComponentID:      policyContext.ComponentID,
-			ComponentBuildID: policyContext.ComponentBuildID,
-			PolicyIDs:        []string{},
-			InputCount:       0,
-			OrgName:          policyContext.OrgName,
-			AppName:          policyContext.AppName,
-			InstallName:      policyContext.InstallName,
-			ComponentName:    policyContext.ComponentName,
-		}, nil
+		return newNoPoliciesPrepResult(policyContext), nil
+	}
+
+	approvalPlan, err := a.getApprovalPlan(ctx, req.StepTargetID)
+	if err != nil {
+		l.Error("unable to get plan contents", zap.Error(err))
+		return nil, errors.Wrap(err, "unable to get plan contents")
 	}
 
 	policyIDs := make([]string, 0, len(applicablePolicies))
@@ -154,6 +144,25 @@ func (a *Activities) PrepPolicyEvaluation(ctx context.Context, req *PrepPolicyEv
 		InstallName:      policyContext.InstallName,
 		ComponentName:    policyContext.ComponentName,
 	}, nil
+}
+
+func newNoPoliciesPrepResult(policyContext *policyContext) *PrepPolicyEvaluationResult {
+	return &PrepPolicyEvaluationResult{
+		Policies:         []PolicyToEvaluate{},
+		HasPolicies:      false,
+		OrgID:            policyContext.OrgID,
+		AppID:            policyContext.AppID,
+		InstallID:        policyContext.InstallID,
+		InstallSandboxID: policyContext.InstallSandboxID,
+		ComponentID:      policyContext.ComponentID,
+		ComponentBuildID: policyContext.ComponentBuildID,
+		PolicyIDs:        []string{},
+		InputCount:       0,
+		OrgName:          policyContext.OrgName,
+		AppName:          policyContext.AppName,
+		InstallName:      policyContext.InstallName,
+		ComponentName:    policyContext.ComponentName,
+	}
 }
 
 // policyContext is an alias for the shared PolicyEvaluationContext type.

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/record_policy_evaluation_composite_error.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/record_policy_evaluation_composite_error.go
@@ -1,0 +1,65 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/policy_reports/policyerrors"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+type RecordPolicyEvaluationCompositeErrorRequest struct {
+	WorkflowStepID string `validate:"required"`
+	StepTargetID   string `validate:"required"`
+	StepTargetType string `validate:"required"`
+	Stage          policyerrors.EvaluationFailureStage
+}
+
+// @temporal-gen-v2 activity
+// @max-retries 1
+func (a *Activities) RecordPolicyEvaluationCompositeError(ctx context.Context, req RecordPolicyEvaluationCompositeErrorRequest) error {
+	l := temporalzap.GetActivityLogger(ctx).With(
+		zap.String("workflow_step_id", req.WorkflowStepID),
+		zap.String("step_target_id", req.StepTargetID),
+		zap.String("step_target_type", req.StepTargetType),
+		zap.String("stage", string(req.Stage)),
+	)
+
+	data, err := compositeerrors.New(
+		&policyerrors.EvaluationFailedError{Stage: req.Stage},
+		compositeerrors.WithSource("workflow_steps", req.WorkflowStepID),
+	)
+	if err != nil {
+		return fmt.Errorf("unable to build policy evaluation composite error: %w", err)
+	}
+
+	var res *gorm.DB
+	switch app.WorkflowStepTargetType(req.StepTargetType) {
+	case app.WorkflowStepTargetTypeInstallDeploy, app.WorkflowStepTargetTypeInstallDeploys:
+		res = a.db.WithContext(ctx).
+			Model(&app.InstallDeploy{ID: req.StepTargetID}).
+			Select("composite_error").
+			Updates(app.InstallDeploy{CompositeError: data})
+	case app.WorkflowStepTargetTypeInstallSandboxRun, app.WorkflowStepTargetTypeInstallSandboxRuns:
+		res = a.db.WithContext(ctx).
+			Model(&app.InstallSandboxRun{ID: req.StepTargetID}).
+			Select("composite_error").
+			Updates(app.InstallSandboxRun{CompositeError: data})
+	default:
+		return fmt.Errorf("unsupported policy evaluation target type %q", req.StepTargetType)
+	}
+	if res.Error != nil {
+		return fmt.Errorf("unable to record policy evaluation composite error: %w", res.Error)
+	}
+	if res.RowsAffected < 1 {
+		return fmt.Errorf("no policy evaluation target found for id %s: %w", req.StepTargetID, gorm.ErrRecordNotFound)
+	}
+
+	l.Info("recorded policy evaluation composite error")
+	return nil
+}


### PR DESCRIPTION
Treat a missing policies configuration as an expected no-policy result while preserving failures for other database errors.

Filter policies before loading approval plan data so components without applicable policies bypass evaluation cleanly instead of failing on unnecessary plan preparation.