### PR TITLE
feat: additonal azure subscription scope UI updates

### DIFF
--- a/services/dashboard-ui/client/components/apps/config/AppStack.stories.tsx
+++ b/services/dashboard-ui/client/components/apps/config/AppStack.stories.tsx
@@ -6,47 +6,96 @@ import { AppStack } from './AppStack'
 
 export const Default = () => (
   <AppStack
-    appConfig={{
-      stack: {
-        type: 'eks',
-        name: 'production-stack',
-      },
-    } as any}
+    appConfig={
+      {
+        stack: {
+          type: 'aws-cloudformation',
+          name: 'production-stack',
+          description: 'Infrastructure stack for the payments app',
+        },
+      } as any
+    }
   />
 )
 
 export const WithTemplateUrls = () => (
   <AppStack
-    appConfig={{
-      stack: {
-        type: 'eks',
-        name: 'production-stack',
-        runner_nested_template_url: 'https://s3.amazonaws.com/my-bucket/runner.yaml',
-        vpc_nested_template_url: 'https://s3.amazonaws.com/my-bucket/vpc.yaml',
-      },
-    } as any}
+    appConfig={
+      {
+        stack: {
+          type: 'aws-cloudformation',
+          name: 'production-stack',
+          description: 'Infrastructure stack for the payments app',
+          runner_nested_template_url:
+            'https://s3.amazonaws.com/my-bucket/runner.yaml',
+          vpc_nested_template_url:
+            'https://s3.amazonaws.com/my-bucket/vpc.yaml',
+        },
+      } as any
+    }
+  />
+)
+
+export const AzureSubscriptionScope = () => (
+  <AppStack
+    appConfig={
+      {
+        stack: {
+          type: 'azure-bicep',
+          name: 'payments-{{.nuon.install.id}}',
+          description: 'Subscription-scoped install stack',
+          runner_nested_template_url:
+            'https://raw.githubusercontent.com/acme/install-stacks/main/azure/runner.json',
+          vpc_nested_template_url:
+            'https://raw.githubusercontent.com/acme/install-stacks/main/azure/vnet.json',
+          deployment_scope: 'subscription',
+        },
+      } as any
+    }
+  />
+)
+
+// deployment_scope is unset rather than 'resource_group', which is how the API
+// sends every config that has not opted into subscription scope.
+export const AzureDefaultScope = () => (
+  <AppStack
+    appConfig={
+      {
+        stack: {
+          type: 'azure-bicep',
+          name: 'payments-{{.nuon.install.id}}',
+          description: 'Resource-group-scoped install stack',
+        },
+      } as any
+    }
   />
 )
 
 export const WithCustomStacks = () => (
   <AppStack
-    appConfig={{
-      stack: {
-        type: 'eks',
-        name: 'production-stack',
-        custom_nested_stacks: [
-          {
-            name: 'monitoring',
-            template_url: 'https://s3.amazonaws.com/my-bucket/monitoring.yaml',
-            contents_hash: 'abc123',
-          },
-          {
-            name: 'logging',
-            template_url: 'https://s3.amazonaws.com/my-bucket/logging.yaml',
-            contents_hash: 'def456',
-          },
-        ],
-      },
-    } as any}
+    appConfig={
+      {
+        stack: {
+          type: 'aws-cloudformation',
+          name: 'production-stack',
+          description: 'Infrastructure stack for the payments app',
+          custom_nested_stacks: [
+            {
+              index: 0,
+              name: 'monitoring',
+              template_url:
+                'https://s3.amazonaws.com/my-bucket/monitoring.yaml',
+              contents_hash: 'abc123',
+            },
+            {
+              index: 1,
+              name: 'logging',
+              template_url: 'https://s3.amazonaws.com/my-bucket/logging.yaml',
+              contents_hash: 'def456',
+            },
+          ],
+        },
+      } as any
+    }
   />
 )

--- a/services/dashboard-ui/client/components/apps/config/AppStack.tsx
+++ b/services/dashboard-ui/client/components/apps/config/AppStack.tsx
@@ -1,48 +1,54 @@
-import { LabeledValue } from '@/components/common/LabeledValue'
+import { KeyValueList } from '@/components/common/KeyValueList'
 import { Link } from '@/components/common/Link'
 import { PropertyGrid } from '@/components/common/PropertyGrid'
 import { Text } from '@/components/common/Text'
-import type { TAppConfig } from '@/types'
+import type { TAppConfig, TAppStackConfig, TKeyValue } from '@/types'
 
 export interface IAppStack {
   appConfig: TAppConfig
 }
 
+const scalarKeys = [
+  'type',
+  'name',
+  'description',
+  'vpc_nested_template_url',
+  'runner_nested_template_url',
+] as const satisfies readonly (keyof TAppStackConfig)[]
+
+// deployment_scope is omitted from the response whenever it is the default, and
+// is deliberately never normalized on write so that configs stored before the
+// field existed do not show a spurious diff on the next sync. Rendering the
+// absent case as an em dash would leave the scope unreadable for exactly the
+// configs where it is most often unstated.
+const defaultDeploymentScope = 'resource_group'
+
+const stackKeyValues = (stackConfig: TAppStackConfig): TKeyValue[] => {
+  const values: TKeyValue[] = scalarKeys.map((key) => ({
+    key,
+    value: stackConfig?.[key] ?? '',
+  }))
+
+  if (stackConfig?.type === 'azure-bicep') {
+    values.push({
+      key: 'deployment_scope',
+      value: stackConfig?.deployment_scope || defaultDeploymentScope,
+    })
+  }
+
+  return values
+}
+
 export const AppStack = ({ appConfig }: IAppStack) => {
   const stackConfig = appConfig?.stack
 
+  if (!stackConfig) {
+    return null
+  }
+
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex gap-6 items-start justify-start">
-        <LabeledValue label="Type">
-          <Text family="mono" variant="subtext">
-            {stackConfig?.type}
-          </Text>
-        </LabeledValue>
-        <LabeledValue label="Name">
-          <Text variant="subtext">{stackConfig?.name}</Text>
-        </LabeledValue>
-      </div>
-
-      {stackConfig?.runner_nested_template_url ? (
-        <LabeledValue label="Runner template URL">
-          <Text variant="subtext">
-            <Link href={stackConfig?.runner_nested_template_url} isExternal>
-              {stackConfig?.runner_nested_template_url}
-            </Link>
-          </Text>
-        </LabeledValue>
-      ) : null}
-
-      {stackConfig?.vpc_nested_template_url ? (
-        <LabeledValue label="VPC template URL">
-          <Text variant="subtext">
-            <Link href={stackConfig?.vpc_nested_template_url} isExternal>
-              {stackConfig?.vpc_nested_template_url}
-            </Link>
-          </Text>
-        </LabeledValue>
-      ) : null}
+      <KeyValueList values={stackKeyValues(stackConfig)} />
 
       {stackConfig?.custom_nested_stacks?.length ? (
         <div className="flex flex-col gap-2">

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.stories.tsx
@@ -85,6 +85,21 @@ export const WithApplicationSecrets = () => (
   </div>
 )
 
+// The stack declares the resource group, the Key Vault and the secrets itself,
+// so none of those prerequisites render and the deploy commands are sub-scoped.
+export const SubscriptionScopeHidesPrerequisites = () => (
+  <div className="max-w-2xl p-4">
+    <AwaitAzureDetails
+      stack={mockStackWithQuickLink}
+      step={mockStep}
+      installId="install-1"
+      azureLocation="eastus"
+      secrets={mockSecrets}
+      deploymentScope="subscription"
+    />
+  </div>
+)
+
 export const Loading = () => (
   <div className="max-w-2xl p-4">
     <AwaitAzureDetails

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.tsx
@@ -80,20 +80,38 @@ export const AwaitAzureDetails = ({
   // A resource-group-scoped root template cannot be deployed from the portal —
   // the customer has to create the resource group first — so the button is
   // shown for subscription scope only.
-  const quickLink =
-    deploymentScope === 'subscription'
-      ? stack?.versions?.at(0)?.quick_link_url
-      : undefined
+  // At subscription scope the root template declares the install resource group,
+  // the Key Vault and the customer's secrets itself — the secrets arrive as
+  // securestring parameters on the deployment form. Every prerequisite below
+  // therefore has no point at which the customer could carry it out: the group
+  // does not exist yet, so `az keyvault create` and `az keyvault secret set`
+  // would both fail.
+  const isSubscriptionScope = deploymentScope === 'subscription'
+
+  const quickLink = isSubscriptionScope
+    ? stack?.versions?.at(0)?.quick_link_url
+    : undefined
 
   const vaultName = installId.slice(0, 24)
   const customerSecrets = secrets?.filter((s) => !s.auto_generate)
-  const hasCustomerSecrets = (customerSecrets?.length ?? 0) > 0
+  const hasCustomerSecrets =
+    !isSubscriptionScope && (customerSecrets?.length ?? 0) > 0
   const requiredSecrets = customerSecrets?.filter(
     (s) => s.required || (!s.default && !s.required)
   )
   const overridableSecrets = customerSecrets?.filter(
     (s) => !s.required && !!s.default
   )
+  // A subscription-scoped root template cannot be deployed with the `group`
+  // commands: they target a resource group that the template itself declares.
+  const templateUrl = stack?.versions?.at(0)?.template_url
+  const whatIfCmd = isSubscriptionScope
+    ? `az deployment sub what-if --location ${azureLocation} --template-uri ${templateUrl}`
+    : `az deployment group what-if --resource-group ${installId}-rg --template-uri ${templateUrl}`
+  const deployCmd = isSubscriptionScope
+    ? `az stack sub create --name ${installId}-stack --location ${azureLocation} --template-uri ${templateUrl} --deny-settings-mode "denyDelete" --aou deleteAll`
+    : `az stack group create --name ${installId}-stack --resource-group ${installId}-rg --template-uri ${templateUrl} --deny-settings-mode "denyDelete" --aou deleteAll`
+
   const grantSecretsPermissionCmd = `az role assignment create --assignee "$(az ad signed-in-user show --query id -o tsv)" --role "Key Vault Secrets Officer" --scope "$(az keyvault show --name ${vaultName} --resource-group ${installId}-rg --query id -o tsv)"`
   const createTelemetryExportSecretCmd = `az keyvault secret set \\
   --vault-name "${vaultName}" \\
@@ -162,38 +180,42 @@ export const AwaitAzureDetails = ({
           <Code>az login</Code>
         </Card>
 
-        <Card>
-          <span className="flex justify-between items-center">
-            <Text>Create a resource group to deploy into</Text>
-            <ClickToCopyButton
-              className="w-fit self-end"
-              textToCopy={`az group create --name ${installId}-rg --location ${azureLocation}`}
-            />
-          </span>
-          <Code>{`
+        {!isSubscriptionScope && (
+          <Card>
+            <span className="flex justify-between items-center">
+              <Text>Create a resource group to deploy into</Text>
+              <ClickToCopyButton
+                className="w-fit self-end"
+                textToCopy={`az group create --name ${installId}-rg --location ${azureLocation}`}
+              />
+            </span>
+            <Code>{`
             az group create --name ${installId}-rg --location ${azureLocation}
           `}</Code>
-        </Card>
+          </Card>
+        )}
       </div>
 
-      <div className="flex flex-col gap-4">
-        <Text variant="base" weight="strong">
-          Create the Key Vault
-        </Text>
+      {!isSubscriptionScope && (
+        <div className="flex flex-col gap-4">
+          <Text variant="base" weight="strong">
+            Create the Key Vault
+          </Text>
 
-        <Card>
-          <span className="flex justify-between items-center">
-            <Text>Create a Key Vault in the resource group</Text>
-            <ClickToCopyButton
-              className="w-fit self-end"
-              textToCopy={`az keyvault create --name ${vaultName} --resource-group ${installId}-rg --location ${azureLocation} --enable-rbac-authorization`}
-            />
-          </span>
-          <Code>{`
+          <Card>
+            <span className="flex justify-between items-center">
+              <Text>Create a Key Vault in the resource group</Text>
+              <ClickToCopyButton
+                className="w-fit self-end"
+                textToCopy={`az keyvault create --name ${vaultName} --resource-group ${installId}-rg --location ${azureLocation} --enable-rbac-authorization`}
+              />
+            </span>
+            <Code>{`
             az keyvault create --name ${vaultName} --resource-group ${installId}-rg --location ${azureLocation} --enable-rbac-authorization
           `}</Code>
-        </Card>
-      </div>
+          </Card>
+        </div>
+      )}
 
       {hasCustomerSecrets && (
         <div className="flex flex-col gap-4">
@@ -248,25 +270,25 @@ export const AwaitAzureDetails = ({
             <Text>Preview changes (dry-run)</Text>
             <ClickToCopyButton
               className="w-fit self-end"
-              textToCopy={`az deployment group what-if --resource-group ${installId}-rg --template-uri ${stack?.versions?.at(0)?.template_url}`}
+              textToCopy={whatIfCmd}
             />
           </span>
-          <Code>{`
-            az deployment group what-if --resource-group ${installId}-rg --template-uri ${stack?.versions?.at(0)?.template_url}
-          `}</Code>
+          <Code>{whatIfCmd}</Code>
         </Card>
 
         <Card>
           <span className="flex justify-between items-center">
-            <Text>Deploy the stack to the resource group</Text>
+            <Text>
+              {isSubscriptionScope
+                ? 'Deploy the stack to the subscription'
+                : 'Deploy the stack to the resource group'}
+            </Text>
             <ClickToCopyButton
               className="w-fit self-end"
-              textToCopy={`az stack group create --name ${installId}-stack --resource-group ${installId}-rg --template-uri ${stack?.versions?.at(0)?.template_url} --deny-settings-mode "denyDelete" --aou deleteAll`}
+              textToCopy={deployCmd}
             />
           </span>
-          <Code>{`
-            az stack group create --name ${installId}-stack --resource-group ${installId}-rg --template-uri ${stack?.versions?.at(0)?.template_url} --deny-settings-mode "denyDelete" --aou deleteAll
-          `}</Code>
+          <Code>{deployCmd}</Code>
         </Card>
       </div>
 


### PR DESCRIPTION
## Summary

We needed a few more UI updates for Azure subscription-scoped stacks.

### Display stack config

We were not displaying the value of `deployment_scope` in the dashboard. This PR updates the stack card on the app overview to display more config values, including `deployment_scope`.

<img width="1608" height="782" alt="Screenshot 2026-08-20 at 15 33 01" src="https://github.com/user-attachments/assets/f2337ab4-9aab-45ca-8c47-f12094a8f422" />

### Subscription-scoped CLI commands

In addition to displaying the "Deploy to Azure" button, we also need to display different CLI steps.

<img width="2972" height="912" alt="Screenshot 2026-08-20 at 15 53 32" src="https://github.com/user-attachments/assets/ffc9afc8-2242-4a25-91c7-09d7f79ca060" />
