### PR TITLE
feat: nuon app sync branch backfill

### DIFF
--- a/pkg/types/workflows/defaultappbranches/defaultappbranches.go
+++ b/pkg/types/workflows/defaultappbranches/defaultappbranches.go
@@ -1,0 +1,44 @@
+// Package defaultappbranches carries the input and progress types for the
+// fleet-wide default app branch backfill, which gives every app the `default`
+// branch and all-installs group that `nuon apps sync` otherwise creates lazily
+// on its first run under the default-app-branches flag.
+package defaultappbranches
+
+const (
+	WorkflowName = "BackfillDefaultAppBranches"
+	WorkflowID   = "general-default-app-branch-backfill"
+
+	ProgressQueryType = "progress"
+)
+
+// Request is the orchestrator input. Callers populate OrgIDs and DryRun; the
+// workflow fills in the rest and carries it across continue-as-new.
+type Request struct {
+	OrgIDs []string `json:"org_ids"`
+	DryRun bool     `json:"dry_run"`
+
+	Initialized       bool     `json:"initialized"`
+	Pending           []string `json:"pending"`
+	AppsTotal         int      `json:"apps_total"`
+	Created           int      `json:"created"`
+	Existing          int      `json:"existing"`
+	Claimed           int      `json:"claimed"`
+	Failed            int      `json:"failed"`
+	FailedAppIDs      []string `json:"failed_app_ids"`
+	InstallsConnected int      `json:"installs_connected"`
+}
+
+// Progress is the live snapshot returned by the progress query.
+type Progress struct {
+	DryRun            bool     `json:"dry_run"`
+	AppsTotal         int      `json:"apps_total"`
+	AppsDone          int      `json:"apps_done"`
+	Created           int      `json:"created"`
+	Existing          int      `json:"existing"`
+	Claimed           int      `json:"claimed"`
+	Failed            int      `json:"failed"`
+	FailedAppIDs      []string `json:"failed_app_ids,omitempty"`
+	InstallsConnected int      `json:"installs_connected"`
+	CurrentAppID      string   `json:"current_app_id,omitempty"`
+	Done              bool     `json:"done"`
+}

--- a/sdks/nuon-go/client/nuon_client.go
+++ b/sdks/nuon-go/client/nuon_client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+
 	"github.com/nuonco/nuon/sdks/nuon-go/client/operations"
 )
 

--- a/services/ctl-api/internal/app/apps/helpers/claim_strength_test.go
+++ b/services/ctl-api/internal/app/apps/helpers/claim_strength_test.go
@@ -1,0 +1,82 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/pkg/labels"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// A branch that took the install through an all-installs group claimed
+// everything unclaimed rather than this install, so it hands it over. Anything
+// naming the install keeps it.
+func TestClaimIsAllInstallsOnly(t *testing.T) {
+	t.Parallel()
+
+	install := &app.Install{
+		ID:      "install-1",
+		Labeled: labels.Labeled{Labels: labels.Labels{"env": "prod"}},
+	}
+
+	tests := []struct {
+		name   string
+		groups []app.AppBranchInstallGroup
+		weak   bool
+	}{
+		{
+			name:   "all installs group only",
+			groups: []app.AppBranchInstallGroup{{AllInstalls: true}},
+			weak:   true,
+		},
+		{
+			name: "explicit install id",
+			groups: []app.AppBranchInstallGroup{
+				{AllInstalls: true},
+				{InstallIDs: []string{"install-1"}},
+			},
+			weak: false,
+		},
+		{
+			name: "matching selector",
+			groups: []app.AppBranchInstallGroup{
+				{AllInstalls: true},
+				{LabelSelector: &labels.Selector{MatchLabels: labels.Labels{"env": "prod"}}},
+			},
+			weak: false,
+		},
+		{
+			name: "selector that does not match",
+			groups: []app.AppBranchInstallGroup{
+				{AllInstalls: true},
+				{LabelSelector: &labels.Selector{MatchLabels: labels.Labels{"env": "staging"}}},
+			},
+			weak: true,
+		},
+		{
+			name: "explicit id for another install",
+			groups: []app.AppBranchInstallGroup{
+				{AllInstalls: true},
+				{InstallIDs: []string{"install-2"}},
+			},
+			weak: true,
+		},
+		{
+			name:   "no groups at all",
+			groups: nil,
+			weak:   false,
+		},
+		{
+			name:   "groups but no all installs",
+			groups: []app.AppBranchInstallGroup{{InstallIDs: []string{"install-2"}}},
+			weak:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.weak, claimIsAllInstallsOnly(tt.groups, install))
+		})
+	}
+}

--- a/services/ctl-api/internal/app/apps/helpers/create_app_branch.go
+++ b/services/ctl-api/internal/app/apps/helpers/create_app_branch.go
@@ -11,6 +11,15 @@ import (
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 )
 
+const (
+	// DefaultAppBranchName is the branch `nuon apps sync` routes through when the org
+	// has default-app-branches on; the CLI holds the same value in sync_branch.go.
+	DefaultAppBranchName = "default"
+
+	// DefaultAppBranchInstallGroupName names that branch's single all-installs group.
+	DefaultAppBranchInstallGroupName = "all installs"
+)
+
 func (h *Helpers) CreateAppBranch(
 	ctx context.Context,
 	appID string,

--- a/services/ctl-api/internal/app/apps/helpers/validate_branch_labels.go
+++ b/services/ctl-api/internal/app/apps/helpers/validate_branch_labels.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -17,6 +18,97 @@ type BranchForLabels struct {
 	Group  *app.AppBranchInstallGroup
 }
 
+// LatestConfigInstallGroups returns the install groups on a branch's newest
+// config, or nothing when the branch has no config yet.
+func (h *Helpers) LatestConfigInstallGroups(ctx context.Context, branchID string) ([]app.AppBranchInstallGroup, error) {
+	var latestConfig app.AppBranchConfig
+	if err := h.db.WithContext(ctx).
+		Where(app.AppBranchConfig{AppBranchID: branchID}).
+		Order("created_at DESC").
+		First(&latestConfig).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unable to get latest config for branch %s: %w", branchID, err)
+	}
+
+	var groups []app.AppBranchInstallGroup
+	if err := h.db.WithContext(ctx).
+		Where(app.AppBranchInstallGroup{AppBranchConfigID: latestConfig.ID}).
+		Find(&groups).Error; err != nil {
+		return nil, fmt.Errorf("unable to get install groups for config %s: %w", latestConfig.ID, err)
+	}
+
+	return groups, nil
+}
+
+// InstallOwnedByOtherBranch reports whether an install is held by a branch other
+// than claimingBranchID with a claim strong enough to refuse a handover.
+//
+// A branch that picked the install up through an all-installs group is a weak
+// owner: it claimed whatever was unclaimed rather than this install in
+// particular, so a selector or an explicit ID naming the install takes it over.
+// Run-time resolution already works this way, since ResolveAllInstallsForBranch
+// drops installs another branch's selector matches.
+func (h *Helpers) InstallOwnedByOtherBranch(ctx context.Context, install *app.Install, claimingBranchID string) (bool, error) {
+	return h.installOwnedByOtherBranch(ctx, install, claimingBranchID, newOwnerGroupCache())
+}
+
+// ownerGroupCache keeps a caller that walks many installs from re-reading the
+// same owning branch's config for each one.
+type ownerGroupCache map[string][]app.AppBranchInstallGroup
+
+func newOwnerGroupCache() ownerGroupCache {
+	return ownerGroupCache{}
+}
+
+func (h *Helpers) installOwnedByOtherBranch(
+	ctx context.Context,
+	install *app.Install,
+	claimingBranchID string,
+	cache ownerGroupCache,
+) (bool, error) {
+	ownerID := install.AppBranchID.String
+	if !install.AppBranchID.Valid || ownerID == "" || ownerID == claimingBranchID {
+		return false, nil
+	}
+
+	groups, ok := cache[ownerID]
+	if !ok {
+		loaded, err := h.LatestConfigInstallGroups(ctx, ownerID)
+		if err != nil {
+			return false, err
+		}
+		groups = loaded
+		cache[ownerID] = groups
+	}
+
+	return !claimIsAllInstallsOnly(groups, install), nil
+}
+
+// claimIsAllInstallsOnly reports whether the owning branch holds the install
+// only because one of its groups takes everything unclaimed. An owner with no
+// all-installs group holds it for some reason this cannot see, so it keeps it.
+func claimIsAllInstallsOnly(groups []app.AppBranchInstallGroup, install *app.Install) bool {
+	allInstalls := false
+	for i := range groups {
+		group := &groups[i]
+		for _, id := range group.InstallIDs {
+			if id == install.ID {
+				return false
+			}
+		}
+		if group.LabelSelector != nil && group.LabelSelector.Matches(install.Labels) {
+			return false
+		}
+		if group.AllInstalls {
+			allInstalls = true
+		}
+	}
+
+	return allInstalls
+}
+
 // FindBranchesMatchingLabels returns all app branches whose latest config
 // has an install group with a label selector that matches the given labels.
 func (h *Helpers) FindBranchesMatchingLabels(ctx context.Context, appID string, lbls labels.Labels) ([]BranchForLabels, error) {
@@ -30,22 +122,9 @@ func (h *Helpers) FindBranchesMatchingLabels(ctx context.Context, appID string, 
 	var results []BranchForLabels
 	for i := range branches {
 		branch := &branches[i]
-		var latestConfig app.AppBranchConfig
-		if err := h.db.WithContext(ctx).
-			Where(app.AppBranchConfig{AppBranchID: branch.ID}).
-			Order("created_at DESC").
-			First(&latestConfig).Error; err != nil {
-			if err == gorm.ErrRecordNotFound {
-				continue
-			}
-			return nil, fmt.Errorf("unable to get latest config for branch %s: %w", branch.ID, err)
-		}
-
-		var groups []app.AppBranchInstallGroup
-		if err := h.db.WithContext(ctx).
-			Where(app.AppBranchInstallGroup{AppBranchConfigID: latestConfig.ID}).
-			Find(&groups).Error; err != nil {
-			return nil, fmt.Errorf("unable to get install groups for config %s: %w", latestConfig.ID, err)
+		groups, err := h.LatestConfigInstallGroups(ctx, branch.ID)
+		if err != nil {
+			return nil, err
 		}
 
 		for j := range groups {
@@ -72,7 +151,11 @@ func (h *Helpers) ValidateInstallBranchExclusivity(ctx context.Context, install 
 	}
 
 	for _, m := range matches {
-		if install.AppBranchID.Valid && install.AppBranchID.String != m.Branch.ID {
+		owned, err := h.InstallOwnedByOtherBranch(ctx, install, m.Branch.ID)
+		if err != nil {
+			return err
+		}
+		if owned {
 			return stderr.ErrUser{
 				Err: fmt.Errorf(
 					"install %s is on branch %q but labels also match branch %q",
@@ -273,8 +356,14 @@ func (h *Helpers) ValidateInstallIDsNotOnOtherBranch(ctx context.Context, branch
 		return fmt.Errorf("unable to get installs: %w", err)
 	}
 
-	for _, install := range installs {
-		if install.AppBranchID.Valid && install.AppBranchID.String != branchID {
+	cache := newOwnerGroupCache()
+	for i := range installs {
+		install := &installs[i]
+		owned, err := h.installOwnedByOtherBranch(ctx, install, branchID, cache)
+		if err != nil {
+			return err
+		}
+		if owned {
 			return stderr.ErrUser{
 				Err: fmt.Errorf(
 					"install %q (%s) is already on branch %s",
@@ -292,9 +381,48 @@ func (h *Helpers) ValidateInstallIDsNotOnOtherBranch(ctx context.Context, branch
 	return nil
 }
 
+// ClaimSelectorInstallsFromWeakOwners re-points installs a new config's
+// selectors match away from a branch that only held them through an
+// all-installs group. Without it the handover the validator now allows would
+// leave the install still recorded on the branch that let it go.
+func (h *Helpers) ClaimSelectorInstallsFromWeakOwners(ctx context.Context, appID, branchID string, selectors []*labels.Selector) error {
+	if len(selectors) == 0 {
+		return nil
+	}
+
+	var installs []app.Install
+	if err := h.db.WithContext(ctx).
+		Where(app.Install{AppID: appID}).
+		Where("app_branch_id IS NOT NULL AND app_branch_id != ?", branchID).
+		Find(&installs).Error; err != nil {
+		return fmt.Errorf("unable to get installs: %w", err)
+	}
+
+	cache := newOwnerGroupCache()
+	for i := range installs {
+		install := &installs[i]
+		if !matchesAny(selectors, install.Labels) {
+			continue
+		}
+
+		owned, err := h.installOwnedByOtherBranch(ctx, install, branchID, cache)
+		if err != nil {
+			return err
+		}
+		if owned {
+			continue
+		}
+
+		h.SyncInstallBranchConnection(ctx, install, branchID)
+	}
+
+	return nil
+}
+
 // ValidateBranchConfigInstallsNotOnOtherBranch resolves installs from
 // label selectors and checks none are already assigned to a different branch.
 func (h *Helpers) ValidateBranchConfigInstallsNotOnOtherBranch(ctx context.Context, appID, branchID string, selectors []*labels.Selector) error {
+	cache := newOwnerGroupCache()
 	for _, sel := range selectors {
 		if sel == nil {
 			continue
@@ -307,11 +435,16 @@ func (h *Helpers) ValidateBranchConfigInstallsNotOnOtherBranch(ctx context.Conte
 			return fmt.Errorf("unable to get installs: %w", err)
 		}
 
-		for _, install := range installs {
+		for i := range installs {
+			install := &installs[i]
 			if !sel.Matches(install.Labels) {
 				continue
 			}
-			if install.AppBranchID.Valid && install.AppBranchID.String != branchID {
+			owned, err := h.installOwnedByOtherBranch(ctx, install, branchID, cache)
+			if err != nil {
+				return err
+			}
+			if owned {
 				return stderr.ErrUser{
 					Err: fmt.Errorf(
 						"install %q (%s) is already on branch %s",

--- a/services/ctl-api/internal/app/apps/service/create_app_branch_config.go
+++ b/services/ctl-api/internal/app/apps/service/create_app_branch_config.go
@@ -263,6 +263,11 @@ func (s *service) CreateAppBranchConfig(ctx *gin.Context) {
 		}
 	}
 
+	if err := s.helpers.ClaimSelectorInstallsFromWeakOwners(ctx, appID, appBranchID, labelSelectors); err != nil {
+		ctx.Error(fmt.Errorf("unable to claim installs from weak owners: %w", err))
+		return
+	}
+
 	if err := s.helpers.ReconcileRemovedBranchInstalls(ctx, appBranchID, explicitInstallIDs, labelSelectors); err != nil {
 		ctx.Error(fmt.Errorf("unable to reconcile removed branch installs: %w", err))
 		return

--- a/services/ctl-api/internal/app/general/service/admin_backfill_default_app_branches.go
+++ b/services/ctl-api/internal/app/general/service/admin_backfill_default_app_branches.go
@@ -1,0 +1,165 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	enumsv1 "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	tclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/nuonco/nuon/pkg/types/workflows/defaultappbranches"
+	"github.com/nuonco/nuon/pkg/workflows"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+)
+
+const defaultAppBranchesNamespace = "general"
+
+// AdminBackfillDefaultAppBranchesRequest optionally narrows the backfill to a
+// subset of orgs, or previews the work without doing it.
+type AdminBackfillDefaultAppBranchesRequest struct {
+	OrgIDs []string `json:"org_ids"`
+	DryRun bool     `json:"dry_run"`
+}
+
+// @ID						AdminBackfillDefaultAppBranches
+// @Summary				backfill default app branches
+// @Description			Starts a workflow that gives every app a branch named `default` with a single all-installs group, which is what `nuon apps sync` creates lazily on its first run once the org has default-app-branches enabled. Running this first means flipping the flag does not turn the next sync of every app into a migration.
+// @Description
+// @Description			Existing installs are recorded as members of that branch: every install the all-installs group resolves to and that no branch owns gets an active branch connection and its `app_branch_id` set, so the install reads as part of the branch instead of belonging to nothing. A branch holding installs only through an all-installs group is a weak owner, so a dev branch created later can still claim them by label or by ID. An app whose latest config on another branch already claims all installs is skipped, since two branches claiming everything would deploy over each other.
+// @Description
+// @Description			This does not touch the flag and does not trigger runs. An app that already has a `default` branch is still visited so its installs get connected.
+// @Description
+// @Description			Leave `org_ids` empty (or omit the body) to cover every org. Set `dry_run` to count the apps that would be backfilled without creating anything. Re-running drains whatever is left; an already-running backfill is reused rather than duplicated.
+// @Tags					general/admin
+// @Accept					json
+// @Produce				json
+// @Param					request	body	AdminBackfillDefaultAppBranchesRequest	false	"optional org subset and dry run; empty processes every org"
+// @Success				201	{string}	ok
+// @Router					/v1/general/backfill-default-app-branches [post]
+func (s *service) AdminBackfillDefaultAppBranches(ctx *gin.Context) {
+	var req AdminBackfillDefaultAppBranchesRequest
+	if ctx.Request.ContentLength > 0 {
+		if err := ctx.ShouldBindJSON(&req); err != nil {
+			ctx.Error(fmt.Errorf("unable to parse request: %w", err))
+			return
+		}
+	}
+
+	if err := s.startDefaultAppBranchesBackfill(ctx, req); err != nil {
+		ctx.Error(fmt.Errorf("unable to start default app branch backfill: %w", err))
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, map[string]string{
+		"status": "ok",
+	})
+}
+
+func (s *service) startDefaultAppBranchesBackfill(ctx context.Context, req AdminBackfillDefaultAppBranchesRequest) error {
+	opts := tclient.StartWorkflowOptions{
+		ID:                       defaultappbranches.WorkflowID,
+		TaskQueue:                workflows.APITaskQueue,
+		WorkflowIDReusePolicy:    enumsv1.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+		WorkflowIDConflictPolicy: enumsv1.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 1,
+		},
+		Memo: map[string]interface{}{
+			"started-by": "ctl-api",
+		},
+	}
+
+	if _, err := s.temporalClient.ExecuteWorkflowInNamespace(ctx, defaultAppBranchesNamespace, opts, defaultappbranches.WorkflowName, defaultappbranches.Request{
+		OrgIDs: req.OrgIDs,
+		DryRun: req.DryRun,
+	}); err != nil {
+		return fmt.Errorf("unable to execute default app branch backfill workflow: %w", err)
+	}
+
+	return nil
+}
+
+type BackfillDefaultAppBranchesStatusResponse struct {
+	Running        bool                         `json:"running"`
+	Status         string                       `json:"status"`
+	RunID          string                       `json:"run_id,omitempty"`
+	StartedAt      *time.Time                   `json:"started_at,omitempty"`
+	ClosedAt       *time.Time                   `json:"closed_at,omitempty"`
+	ElapsedSeconds float64                      `json:"elapsed_seconds,omitempty"`
+	Elapsed        string                       `json:"elapsed,omitempty"`
+	Progress       *defaultappbranches.Progress `json:"progress,omitempty"`
+}
+
+// @ID						GetBackfillDefaultAppBranchesStatus
+// @Summary				get default app branch backfill progress
+// @Description			Reports whether the default app branch backfill is still running and, when available, how many apps were given a `default` branch, already had one, were skipped because another branch claims all installs, or failed, plus how many installs were connected to their branch.
+// @Tags					general/admin
+// @Accept					json
+// @Produce				json
+// @Success				200	{object}	BackfillDefaultAppBranchesStatusResponse
+// @Router					/v1/general/backfill-default-app-branches [get]
+func (s *service) GetBackfillDefaultAppBranchesStatus(ctx *gin.Context) {
+	resp, err := s.getDefaultAppBranchesBackfillStatus(ctx)
+	if err != nil {
+		var notFoundErr *serviceerror.NotFound
+		if errors.As(err, &notFoundErr) {
+			ctx.Error(stderr.ErrNotFound{Err: fmt.Errorf("default app branch backfill workflow has not been started")})
+			return
+		}
+		ctx.Error(fmt.Errorf("unable to get default app branch backfill status: %w", err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, resp)
+}
+
+func (s *service) getDefaultAppBranchesBackfillStatus(ctx context.Context) (*BackfillDefaultAppBranchesStatusResponse, error) {
+	exec, err := s.temporalClient.DescribeWorkflowExecutionInNamespace(ctx, defaultAppBranchesNamespace, defaultappbranches.WorkflowID, "")
+	if err != nil {
+		return nil, fmt.Errorf("unable to describe default app branch backfill workflow: %w", err)
+	}
+
+	info := exec.GetWorkflowExecutionInfo()
+	status := info.GetStatus()
+	resp := &BackfillDefaultAppBranchesStatusResponse{
+		Status:  status.String(),
+		Running: status == enumsv1.WORKFLOW_EXECUTION_STATUS_RUNNING,
+		RunID:   info.GetExecution().GetRunId(),
+	}
+
+	if startTS := info.GetStartTime(); startTS != nil {
+		startedAt := startTS.AsTime()
+		resp.StartedAt = &startedAt
+
+		end := time.Now()
+		if closeTS := info.GetCloseTime(); closeTS != nil {
+			closedAt := closeTS.AsTime()
+			resp.ClosedAt = &closedAt
+			end = closedAt
+		}
+
+		elapsed := end.Sub(startedAt)
+		resp.ElapsedSeconds = elapsed.Seconds()
+		resp.Elapsed = elapsed.Round(time.Second).String()
+	}
+
+	encoded, err := s.temporalClient.QueryWorkflowInNamespace(ctx, defaultAppBranchesNamespace, defaultappbranches.WorkflowID, "", defaultappbranches.ProgressQueryType)
+	if err != nil {
+		// progress query is best-effort: a completed run on a closed workflow may not answer queries.
+		return resp, nil
+	}
+
+	var progress defaultappbranches.Progress
+	if err := encoded.Get(&progress); err != nil {
+		return nil, fmt.Errorf("unable to decode default app branch backfill progress: %w", err)
+	}
+	resp.Progress = &progress
+
+	return resp, nil
+}

--- a/services/ctl-api/internal/app/general/service/service.go
+++ b/services/ctl-api/internal/app/general/service/service.go
@@ -83,6 +83,8 @@ func (s *service) RegisterInternalRoutes(api *gin.Engine) error {
 		general.GET("/backfill-blobs", s.GetBackfillBlobsStatus)
 		general.POST("/verify-blobs", s.AdminVerifyBlobs)
 		general.GET("/verify-blobs", s.GetVerifyBlobsStatus)
+		general.POST("/backfill-default-app-branches", s.AdminBackfillDefaultAppBranches)
+		general.GET("/backfill-default-app-branches", s.GetBackfillDefaultAppBranchesStatus)
 
 		// temporal codec
 		general.POST("/temporal-codec/decode", s.TemporalCodecDecode)

--- a/services/ctl-api/internal/app/general/worker/activities/ensure_default_app_branch.go
+++ b/services/ctl-api/internal/app/general/worker/activities/ensure_default_app_branch.go
@@ -1,0 +1,248 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	appshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/helpers"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+)
+
+const (
+	DefaultAppBranchOutcomeCreated = "created"
+	DefaultAppBranchOutcomeExists  = "exists"
+	DefaultAppBranchOutcomeClaimed = "claimed_by_other_branch"
+)
+
+type EnsureDefaultAppBranchRequest struct {
+	AppID string `json:"app_id"`
+}
+
+type EnsureDefaultAppBranchResponse struct {
+	AppID             string `json:"app_id"`
+	BranchID          string `json:"branch_id,omitempty"`
+	Outcome           string `json:"outcome"`
+	InstallsConnected int    `json:"installs_connected"`
+}
+
+// EnsureDefaultAppBranch gives one app the `default` branch and single
+// all-installs group that `nuon apps sync` creates on its first run once
+// default-app-branches is on, so the flag can be flipped without the first sync
+// of every app also being a migration, and connects the app's existing installs
+// to that branch.
+//
+// Idempotent in stages rather than transactionally: a retry after the branch
+// landed but its config did not finds the branch and only adds the config, and
+// queue creation starts Temporal workflows so it cannot share a transaction
+// with the branch insert anyway.
+//
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 2m
+func (a *Activities) EnsureDefaultAppBranch(ctx context.Context, req EnsureDefaultAppBranchRequest) (*EnsureDefaultAppBranchResponse, error) {
+	var ap app.App
+	if err := a.db.WithContext(ctx).
+		Select("id", "org_id", "created_by_id").
+		First(&ap, "id = ?", req.AppID).Error; err != nil {
+		return nil, fmt.Errorf("unable to get app %s: %w", req.AppID, err)
+	}
+
+	// The branch, its config and its install group all have NOT NULL org_id and
+	// created_by_id filled from context. An activity has no account, so attribute
+	// the rows to whoever created the app, the way the phone-home backfill
+	// attributes to the org's creator.
+	ctx = cctx.SetOrgIDContext(ctx, ap.OrgID)
+	ctx = cctx.SetAccountIDContext(ctx, ap.CreatedByID)
+
+	var branches []app.AppBranch
+	if err := a.db.WithContext(ctx).
+		Where(app.AppBranch{AppID: ap.ID}).
+		Find(&branches).Error; err != nil {
+		return nil, fmt.Errorf("unable to list branches for app %s: %w", ap.ID, err)
+	}
+
+	resp := &EnsureDefaultAppBranchResponse{AppID: ap.ID}
+
+	var defaultBranch *app.AppBranch
+	for i := range branches {
+		if branches[i].Name == appshelpers.DefaultAppBranchName {
+			defaultBranch = &branches[i]
+			break
+		}
+	}
+
+	if defaultBranch != nil {
+		resp.BranchID = defaultBranch.ID
+
+		hasConfig, err := a.branchHasConfig(ctx, defaultBranch.ID)
+		if err != nil {
+			return nil, err
+		}
+		if hasConfig {
+			resp.Outcome = DefaultAppBranchOutcomeExists
+			resp.InstallsConnected, err = a.connectInstallsToBranch(ctx, ap.ID, defaultBranch.ID)
+			if err != nil {
+				return nil, err
+			}
+			return resp, nil
+		}
+	}
+
+	// Two branches claiming all installs would both deploy to the same installs, so
+	// an app already routing everything through a differently-named branch is left
+	// alone rather than given a competing default.
+	claimed, err := a.branchClaimsAllInstalls(ctx, branches, appshelpers.DefaultAppBranchName)
+	if err != nil {
+		return nil, err
+	}
+	if claimed {
+		resp.Outcome = DefaultAppBranchOutcomeClaimed
+		return resp, nil
+	}
+
+	if defaultBranch == nil {
+		branch, err := a.appsHelpers.CreateAppBranch(ctx, ap.ID, appshelpers.DefaultAppBranchName)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create default branch for app %s: %w", ap.ID, err)
+		}
+		defaultBranch = branch
+		resp.BranchID = branch.ID
+	} else if err := a.appsHelpers.EnsureAppBranchQueues(ctx, defaultBranch.ID); err != nil {
+		return nil, fmt.Errorf("unable to ensure queues for branch %s: %w", defaultBranch.ID, err)
+	}
+
+	if _, err := a.appsHelpers.CreateAppBranchConfig(
+		ctx,
+		defaultBranch.ID,
+		nil,
+		nil,
+		[]app.AppBranchInstallGroup{{
+			Name:        appshelpers.DefaultAppBranchInstallGroupName,
+			Order:       0,
+			AllInstalls: true,
+		}},
+		&[]string{},
+	); err != nil {
+		return nil, fmt.Errorf("unable to configure default branch %s: %w", defaultBranch.ID, err)
+	}
+
+	connected, err := a.connectInstallsToBranch(ctx, ap.ID, defaultBranch.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp.Outcome = DefaultAppBranchOutcomeCreated
+	resp.InstallsConnected = connected
+	return resp, nil
+}
+
+// connectInstallsToBranch records the installs the branch's all-installs group
+// already deploys to as members of the branch, so an install shows the branch it
+// belongs to rather than none at all. It claims exactly what the group resolves,
+// which leaves installs owned by another branch alone.
+func (a *Activities) connectInstallsToBranch(ctx context.Context, appID, branchID string) (int, error) {
+	installIDs, err := a.appsHelpers.ResolveAllInstallsForBranch(ctx, appID, branchID)
+	if err != nil {
+		return 0, fmt.Errorf("unable to resolve installs for branch %s: %w", branchID, err)
+	}
+	if len(installIDs) == 0 {
+		return 0, nil
+	}
+
+	var unconnected []app.Install
+	if err := a.db.WithContext(ctx).
+		Where("id IN ?", installIDs).
+		Where("app_branch_id IS NULL").
+		Find(&unconnected).Error; err != nil {
+		return 0, fmt.Errorf("unable to load installs for branch %s: %w", branchID, err)
+	}
+
+	for i := range unconnected {
+		a.appsHelpers.SyncInstallBranchConnection(ctx, &unconnected[i], branchID)
+	}
+
+	if err := a.verifyInstallsConnected(ctx, installIDs, branchID); err != nil {
+		return 0, err
+	}
+
+	return len(unconnected), nil
+}
+
+// verifyInstallsConnected re-reads both halves of branch membership, because
+// SyncInstallBranchConnection drops its write errors on the floor and a
+// migration must not report a count that nothing wrote. The connection row is
+// what the dashboard reads; the pin is what the branch validators read.
+func (a *Activities) verifyInstallsConnected(ctx context.Context, installIDs []string, branchID string) error {
+	var pinned int64
+	if err := a.db.WithContext(ctx).
+		Model(&app.Install{}).
+		Where("id IN ?", installIDs).
+		Where("app_branch_id = ?", branchID).
+		Count(&pinned).Error; err != nil {
+		return fmt.Errorf("unable to verify install pins for branch %s: %w", branchID, err)
+	}
+	if int(pinned) < len(installIDs) {
+		return fmt.Errorf("pinned %d of %d installs to branch %s", pinned, len(installIDs), branchID)
+	}
+
+	var connected int64
+	if err := a.db.WithContext(ctx).
+		Model(&app.InstallAppBranchConnection{}).
+		Where(app.InstallAppBranchConnection{AppBranchID: branchID, Active: true}).
+		Where("install_id IN ?", installIDs).
+		Count(&connected).Error; err != nil {
+		return fmt.Errorf("unable to verify install connections for branch %s: %w", branchID, err)
+	}
+	if int(connected) < len(installIDs) {
+		return fmt.Errorf("connected %d of %d installs to branch %s", connected, len(installIDs), branchID)
+	}
+
+	return nil
+}
+
+func (a *Activities) branchClaimsAllInstalls(ctx context.Context, branches []app.AppBranch, excludeName string) (bool, error) {
+	for _, branch := range branches {
+		if branch.Name == excludeName {
+			continue
+		}
+
+		var latest app.AppBranchConfig
+		err := a.db.WithContext(ctx).
+			Where(app.AppBranchConfig{AppBranchID: branch.ID}).
+			Order("created_at DESC").
+			First(&latest).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("unable to load latest config for branch %s: %w", branch.ID, err)
+		}
+
+		var count int64
+		if err := a.db.WithContext(ctx).
+			Model(&app.AppBranchInstallGroup{}).
+			Where(app.AppBranchInstallGroup{AppBranchConfigID: latest.ID, AllInstalls: true}).
+			Count(&count).Error; err != nil {
+			return false, fmt.Errorf("unable to count all-installs groups for config %s: %w", latest.ID, err)
+		}
+		if count > 0 {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (a *Activities) branchHasConfig(ctx context.Context, branchID string) (bool, error) {
+	var count int64
+	if err := a.db.WithContext(ctx).
+		Model(&app.AppBranchConfig{}).
+		Where(app.AppBranchConfig{AppBranchID: branchID}).
+		Count(&count).Error; err != nil {
+		return false, fmt.Errorf("unable to count configs for branch %s: %w", branchID, err)
+	}
+	return count > 0, nil
+}

--- a/services/ctl-api/internal/app/general/worker/activities/list_apps_needing_default_branch.go
+++ b/services/ctl-api/internal/app/general/worker/activities/list_apps_needing_default_branch.go
@@ -1,0 +1,85 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	appshelpers "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/helpers"
+)
+
+type ListAppsNeedingDefaultBranchRequest struct {
+	// OrgIDs narrows the backfill to a subset of orgs. Empty covers every org.
+	OrgIDs []string `json:"org_ids"`
+}
+
+type ListAppsNeedingDefaultBranchResponse struct {
+	AppIDs []string `json:"app_ids"`
+}
+
+// ListAppsNeedingDefaultBranch returns the apps that have no branch named
+// `default`, plus the ones that have it but still hold installs on no branch at
+// all, oldest first. The second case covers an app whose branch the CLI created
+// before the backfill existed, whose installs were never recorded as members.
+// Apps on their way out are left alone: a branch and its queues would outlive
+// the app they were created for.
+//
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 2m
+func (a *Activities) ListAppsNeedingDefaultBranch(ctx context.Context, req ListAppsNeedingDefaultBranchRequest) (*ListAppsNeedingDefaultBranchResponse, error) {
+	query := a.db.WithContext(ctx).
+		Model(&app.App{}).
+		Select("id").
+		Where("status IS NULL OR status NOT IN ?", []app.AppStatus{
+			app.AppStatusDeprovisioning,
+			app.AppStatusDeleteQueued,
+		})
+	if len(req.OrgIDs) > 0 {
+		query = query.Where("org_id IN ?", req.OrgIDs)
+	}
+
+	var apps []app.App
+	if err := query.Order("created_at ASC").Find(&apps).Error; err != nil {
+		return nil, fmt.Errorf("unable to list apps: %w", err)
+	}
+
+	var branches []app.AppBranch
+	if err := a.db.WithContext(ctx).
+		Model(&app.AppBranch{}).
+		Select("app_id").
+		Where(app.AppBranch{Name: appshelpers.DefaultAppBranchName}).
+		Find(&branches).Error; err != nil {
+		return nil, fmt.Errorf("unable to list default app branches: %w", err)
+	}
+
+	haveDefault := make(map[string]struct{}, len(branches))
+	for _, branch := range branches {
+		haveDefault[branch.AppID] = struct{}{}
+	}
+
+	var appIDsWithLooseInstalls []string
+	if err := a.db.WithContext(ctx).
+		Model(&app.Install{}).
+		Distinct("app_id").
+		Where("app_branch_id IS NULL").
+		Pluck("app_id", &appIDsWithLooseInstalls).Error; err != nil {
+		return nil, fmt.Errorf("unable to list apps with unconnected installs: %w", err)
+	}
+
+	looseInstalls := make(map[string]struct{}, len(appIDsWithLooseInstalls))
+	for _, appID := range appIDsWithLooseInstalls {
+		looseInstalls[appID] = struct{}{}
+	}
+
+	resp := &ListAppsNeedingDefaultBranchResponse{AppIDs: make([]string, 0, len(apps))}
+	for _, ap := range apps {
+		_, hasBranch := haveDefault[ap.ID]
+		_, hasLooseInstalls := looseInstalls[ap.ID]
+		if hasBranch && !hasLooseInstalls {
+			continue
+		}
+		resp.AppIDs = append(resp.AppIDs, ap.ID)
+	}
+
+	return resp, nil
+}

--- a/services/ctl-api/internal/app/general/worker/backfill_default_app_branches_workflow.go
+++ b/services/ctl-api/internal/app/general/worker/backfill_default_app_branches_workflow.go
@@ -1,0 +1,137 @@
+package worker
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/pkg/types/workflows/defaultappbranches"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/general/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
+)
+
+const (
+	// caps apps per run so workflow history stays bounded across a fleet-wide backfill.
+	defaultAppBranchesPerRun = 200
+
+	// a permanently broken app must not hold the rest of the fleet for the
+	// activity's 24h schedule-to-close default.
+	defaultAppBranchAttempts = 3
+	defaultAppBranchTimeout  = 5 * time.Minute
+
+	// keeps the progress query readable when a whole class of apps fails.
+	defaultAppBranchMaxFailedIDs = 50
+)
+
+// BackfillDefaultAppBranches gives every app the `default` branch and
+// all-installs group that `nuon apps sync` otherwise creates lazily on its first
+// run under default-app-branches, so flipping the flag does not make the next
+// sync of each app a migration.
+//
+// One app failing is counted rather than fatal: a fleet-wide backfill that stops
+// at the first bad app leaves the rest unmigrated with nothing to show for it.
+func (w *Workflows) BackfillDefaultAppBranches(ctx workflow.Context, req defaultappbranches.Request) error {
+	l, err := log.WorkflowLogger(ctx)
+	if err != nil {
+		return err
+	}
+
+	progress := defaultappbranches.Progress{
+		DryRun:            req.DryRun,
+		AppsTotal:         req.AppsTotal,
+		AppsDone:          req.Created + req.Existing + req.Claimed + req.Failed,
+		Created:           req.Created,
+		Existing:          req.Existing,
+		Claimed:           req.Claimed,
+		Failed:            req.Failed,
+		FailedAppIDs:      req.FailedAppIDs,
+		InstallsConnected: req.InstallsConnected,
+	}
+	if err := workflow.SetQueryHandler(ctx, defaultappbranches.ProgressQueryType, func() (defaultappbranches.Progress, error) {
+		return progress, nil
+	}); err != nil {
+		return errors.Wrap(err, "unable to register default app branch backfill progress query handler")
+	}
+
+	if !req.Initialized {
+		l.Info("general workflow execution", zap.String("type", "default-app-branch-backfill"))
+
+		resp, err := activities.AwaitListAppsNeedingDefaultBranch(ctx, activities.ListAppsNeedingDefaultBranchRequest{
+			OrgIDs: req.OrgIDs,
+		})
+		if err != nil {
+			return errors.Wrap(err, "unable to list apps needing a default branch")
+		}
+
+		req.Pending = resp.AppIDs
+		req.AppsTotal = len(resp.AppIDs)
+		req.Initialized = true
+		progress.AppsTotal = req.AppsTotal
+	}
+
+	if req.DryRun {
+		progress.Done = true
+		l.Info("default app branch backfill dry run", zap.Int("apps_total", req.AppsTotal))
+		return nil
+	}
+
+	actCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToCloseTimeout: defaultAppBranchTimeout,
+		RetryPolicy:            &temporal.RetryPolicy{MaximumAttempts: defaultAppBranchAttempts},
+	})
+
+	processedThisRun := 0
+	for len(req.Pending) > 0 && processedThisRun < defaultAppBranchesPerRun {
+		appID := req.Pending[0]
+		req.Pending = req.Pending[1:]
+		processedThisRun++
+
+		progress.CurrentAppID = appID
+		resp, err := activities.AwaitEnsureDefaultAppBranch(actCtx, activities.EnsureDefaultAppBranchRequest{AppID: appID})
+		if err != nil {
+			req.Failed++
+			if len(req.FailedAppIDs) < defaultAppBranchMaxFailedIDs {
+				req.FailedAppIDs = append(req.FailedAppIDs, appID)
+			}
+			l.Warn("unable to ensure default app branch", zap.String("app_id", appID), zap.Error(err))
+		} else {
+			req.InstallsConnected += resp.InstallsConnected
+			switch resp.Outcome {
+			case activities.DefaultAppBranchOutcomeCreated:
+				req.Created++
+			case activities.DefaultAppBranchOutcomeClaimed:
+				req.Claimed++
+			default:
+				req.Existing++
+			}
+		}
+
+		progress.Created = req.Created
+		progress.Existing = req.Existing
+		progress.Claimed = req.Claimed
+		progress.Failed = req.Failed
+		progress.FailedAppIDs = req.FailedAppIDs
+		progress.InstallsConnected = req.InstallsConnected
+		progress.AppsDone = req.Created + req.Existing + req.Claimed + req.Failed
+	}
+
+	if len(req.Pending) > 0 {
+		l.Info("continuing default app branch backfill",
+			zap.Int("apps_done", progress.AppsDone),
+			zap.Int("apps_total", req.AppsTotal))
+		return workflow.NewContinueAsNewError(ctx, defaultappbranches.WorkflowName, req)
+	}
+
+	progress.CurrentAppID = ""
+	progress.Done = true
+	l.Info("backfilled default app branches",
+		zap.Int("created", req.Created),
+		zap.Int("existing", req.Existing),
+		zap.Int("claimed", req.Claimed),
+		zap.Int("failed", req.Failed),
+		zap.Int("installs_connected", req.InstallsConnected))
+	return nil
+}

--- a/services/ctl-api/internal/app/general/worker/backfill_default_app_branches_workflow_test.go
+++ b/services/ctl-api/internal/app/general/worker/backfill_default_app_branches_workflow_test.go
@@ -1,0 +1,129 @@
+package worker
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/pkg/types/workflows/defaultappbranches"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/general/worker/activities"
+)
+
+// Activities are registered by name before any mock is set up: the test
+// environment only deserializes an activity's input for mocks when the activity
+// itself is registered, and every registration has to precede the first
+// OnActivity call.
+func newBackfillDefaultAppBranchesEnv(t *testing.T, appIDs []string) *testsuite.TestWorkflowEnvironment {
+	t.Helper()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
+
+	acts := &activities.Activities{}
+	env.RegisterActivityWithOptions(acts.ListAppsNeedingDefaultBranch,
+		activity.RegisterOptions{Name: "ListAppsNeedingDefaultBranch"})
+	env.RegisterActivityWithOptions(acts.EnsureDefaultAppBranch,
+		activity.RegisterOptions{Name: "EnsureDefaultAppBranch"})
+
+	env.OnActivity("ListAppsNeedingDefaultBranch", mock.Anything, mock.Anything).
+		Return(&activities.ListAppsNeedingDefaultBranchResponse{AppIDs: appIDs}, nil).Once()
+
+	return env
+}
+
+func backfillProgress(t *testing.T, env *testsuite.TestWorkflowEnvironment) defaultappbranches.Progress {
+	t.Helper()
+
+	encoded, err := env.QueryWorkflow(defaultappbranches.ProgressQueryType)
+	require.NoError(t, err)
+
+	var progress defaultappbranches.Progress
+	require.NoError(t, encoded.Get(&progress))
+	return progress
+}
+
+func TestBackfillDefaultAppBranchesDryRunCreatesNothing(t *testing.T) {
+	env := newBackfillDefaultAppBranchesEnv(t, []string{"app-1", "app-2", "app-3"})
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		return (&Workflows{}).BackfillDefaultAppBranches(ctx, defaultappbranches.Request{DryRun: true})
+	})
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	progress := backfillProgress(t, env)
+	require.True(t, progress.DryRun)
+	require.True(t, progress.Done)
+	require.Equal(t, 3, progress.AppsTotal)
+	require.Equal(t, 0, progress.AppsDone, "a dry run must not ensure any branch")
+	env.AssertExpectations(t)
+}
+
+// A fleet-wide backfill that stops at the first bad app leaves the rest
+// unmigrated, so a failure is counted and the run carries on.
+func TestBackfillDefaultAppBranchesTalliesOutcomes(t *testing.T) {
+	env := newBackfillDefaultAppBranchesEnv(t, []string{"app-new", "app-existing", "app-claimed", "app-broken"})
+
+	outcomes := map[string]string{
+		"app-new":      activities.DefaultAppBranchOutcomeCreated,
+		"app-existing": activities.DefaultAppBranchOutcomeExists,
+		"app-claimed":  activities.DefaultAppBranchOutcomeClaimed,
+	}
+	for appID, outcome := range outcomes {
+		env.OnActivity("EnsureDefaultAppBranch", mock.Anything,
+			activities.EnsureDefaultAppBranchRequest{AppID: appID}).
+			Return(&activities.EnsureDefaultAppBranchResponse{AppID: appID, Outcome: outcome, InstallsConnected: 2}, nil).Once()
+	}
+	env.OnActivity("EnsureDefaultAppBranch", mock.Anything,
+		activities.EnsureDefaultAppBranchRequest{AppID: "app-broken"}).
+		Return(nil, errors.New("boom")).Times(defaultAppBranchAttempts)
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		return (&Workflows{}).BackfillDefaultAppBranches(ctx, defaultappbranches.Request{})
+	})
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	progress := backfillProgress(t, env)
+	require.True(t, progress.Done)
+	require.Equal(t, 4, progress.AppsTotal)
+	require.Equal(t, 4, progress.AppsDone)
+	require.Equal(t, 1, progress.Created)
+	require.Equal(t, 1, progress.Existing)
+	require.Equal(t, 1, progress.Claimed)
+	require.Equal(t, 1, progress.Failed)
+	require.Equal(t, []string{"app-broken"}, progress.FailedAppIDs)
+	require.Equal(t, 6, progress.InstallsConnected, "installs connected are summed across outcomes, not just new branches")
+	env.AssertExpectations(t)
+}
+
+func TestBackfillDefaultAppBranchesContinuesAsNewPastRunCap(t *testing.T) {
+	appIDs := make([]string, defaultAppBranchesPerRun+1)
+	for i := range appIDs {
+		appIDs[i] = fmt.Sprintf("app-%d", i)
+	}
+
+	env := newBackfillDefaultAppBranchesEnv(t, appIDs)
+	env.OnActivity("EnsureDefaultAppBranch", mock.Anything, mock.Anything).
+		Return(&activities.EnsureDefaultAppBranchResponse{Outcome: activities.DefaultAppBranchOutcomeCreated}, nil).
+		Times(defaultAppBranchesPerRun)
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		return (&Workflows{}).BackfillDefaultAppBranches(ctx, defaultappbranches.Request{})
+	})
+	require.True(t, env.IsWorkflowCompleted())
+
+	var continueErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &continueErr,
+		"the run cap must hand the remainder to a new run, not drop it")
+	env.AssertExpectations(t)
+}

--- a/services/ctl-api/internal/app/general/worker/workflows.go
+++ b/services/ctl-api/internal/app/general/worker/workflows.go
@@ -31,6 +31,7 @@ func (w Workflows) All() []any {
 		w.VerifyBlobs,
 		w.VerifyBlobsDay,
 		w.ComponentHealthSweep,
+		w.BackfillDefaultAppBranches,
 	}
 	return wkflows
 }
@@ -46,6 +47,7 @@ func (w *Workflows) ListWorkflowFns() []any {
 		w.VerifyBlobs,
 		w.VerifyBlobsDay,
 		w.ComponentHealthSweep,
+		w.BackfillDefaultAppBranches,
 	}
 }
 


### PR DESCRIPTION
Title: feat: backfill default app branches

## What

Adds a fleet-wide admin backfill that gives every app the `default` app branch
that `nuon apps sync` otherwise creates lazily on its first run under the
`default-app-branches` flag, and records existing installs as members of that
branch.

Running this before flipping the flag means the next sync of each app is a
normal sync instead of a migration.

## Endpoints

POST /v1/general/backfill-default-app-branches   {"org_ids": [...], "dry_run": false}
GET  /v1/general/backfill-default-app-branches   -> status + progress

Both fields are optional. Empty body covers every org; `dry_run` counts the apps
that would be touched without writing anything. Re-POSTing while a run is in
flight reuses it.

## What it does per app

1. Creates a branch named `default` with one `all installs` group, using the same
   helpers the CLI's create-branch and create-branch-config calls land on.
2. Connects the installs that group resolves to: active
   `install_app_branch_connections` row plus `install.app_branch_id`.
3. Skips apps where another branch already claims all installs, and apps being
   deprovisioned or deleted.

It does not touch the feature flag and does not trigger runs. Each app is a
separate Temporal activity, idempotent in stages, so a failed app is counted and
the run continues rather than aborting the fleet. Deleting the branch releases
its installs, so the backfill is reversible.