### PR TITLE
fix: close component build log streams on cancellation

### DIFF
--- a/services/ctl-api/internal/app/components/signals/build/signal.go
+++ b/services/ctl-api/internal/app/components/signals/build/signal.go
@@ -64,7 +64,9 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return errors.Wrap(err, "unable to create log stream")
 	}
 	defer func() {
-		activities.AwaitCloseLogStreamByLogStreamID(ctx, logStream.ID)
+		closeCtx, cancel := workflow.NewDisconnectedContext(ctx)
+		defer cancel()
+		activities.AwaitCloseLogStreamByLogStreamID(closeCtx, logStream.ID)
 	}()
 	ctx = cctx.SetLogStreamWorkflowContext(ctx, logStream)
 	l, err := log.WorkflowLogger(ctx)

--- a/services/ctl-api/internal/app/components/worker/build.go
+++ b/services/ctl-api/internal/app/components/worker/build.go
@@ -31,7 +31,9 @@ func (w *Workflows) Build(ctx workflow.Context, sreq BuildRequest) error {
 		return errors.Wrap(err, "unable to create log stream")
 	}
 	defer func() {
-		activities.AwaitCloseLogStreamByLogStreamID(ctx, logStream.ID)
+		closeCtx, cancel := workflow.NewDisconnectedContext(ctx)
+		defer cancel()
+		activities.AwaitCloseLogStreamByLogStreamID(closeCtx, logStream.ID)
 	}()
 	ctx = cctx.SetLogStreamWorkflowContext(ctx, logStream)
 	l, err := log.WorkflowLogger(ctx)


### PR DESCRIPTION
Run component build log-stream cleanup with a disconnected Temporal context in both the queue signal and canonical worker workflow.

This allows the close activity to execute after workflow cancellation instead of leaving the log stream open.