### PR TITLE
fix: harden policy evaluation and approval enforcement

### DIFF
--- a/bins/runner/internal/jobs/deploy/kubernetes_manifest/exec.go
+++ b/bins/runner/internal/jobs/deploy/kubernetes_manifest/exec.go
@@ -371,6 +371,12 @@ func (h *handler) handleCreateTeardownPlan(
 
 	manifestPlan.ContentDiff = formattedDiffs
 
+	dryRunYAML, err := kubernetesResourcesToMultiDocYAML(currentResources)
+	if err != nil {
+		return fmt.Errorf("failed to generate dry run delete YAML output: %w", err)
+	}
+	manifestPlan.DryRunOutput = dryRunYAML
+
 	jsonBytes, err := json.MarshalIndent(map[string]interface{}{
 		"diff": formattedDiffs,
 	}, "", "  ")

--- a/pkg/config/validate/validate_policies.go
+++ b/pkg/config/validate/validate_policies.go
@@ -13,6 +13,22 @@ func ValidatePolicies(a *config.AppConfig) error {
 	return ValidatePoliciesWithLogger(a, zap.NewNop())
 }
 
+func ValidateOPAPolicy(contents string) error {
+	module, err := ast.ParseModule("policy.rego", contents)
+	if err != nil {
+		return err
+	}
+	if module.Package.Path.String() != "data.nuon" {
+		return fmt.Errorf("OPA policy must use package nuon, got %s", module.Package.Path.String())
+	}
+	for _, rule := range module.Rules {
+		if rule.Head.Name == "deny" || rule.Head.Name == "warn" {
+			return nil
+		}
+	}
+	return fmt.Errorf("OPA policy must define at least one deny or warn rule")
+}
+
 func ValidatePoliciesWithLogger(a *config.AppConfig, l *zap.Logger) error {
 	if a.Policies == nil || len(a.Policies.Policies) < 1 {
 		l.Debug("no policies to validate")
@@ -29,7 +45,7 @@ func ValidatePoliciesWithLogger(a *config.AppConfig, l *zap.Logger) error {
 		)
 
 		if policy.Engine == config.AppPolicyEngineOPA {
-			if _, err := ast.ParseModule("policy.rego", policy.Contents); err != nil {
+			if err := ValidateOPAPolicy(policy.Contents); err != nil {
 				policyLogger.Error("invalid OPA rego policy", zap.Error(err))
 				return config.ErrConfig{
 					Description: fmt.Sprintf("policy %d (%s) was invalid rego", idx, policy.Type),

--- a/pkg/config/validate/validate_policies_test.go
+++ b/pkg/config/validate/validate_policies_test.go
@@ -5,7 +5,30 @@ import (
 
 	"github.com/nuonco/nuon/pkg/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestValidateOPAPolicy(t *testing.T) {
+	t.Run("accepts deny rule", func(t *testing.T) {
+		require.NoError(t, ValidateOPAPolicy("package nuon\ndeny := []"))
+	})
+
+	t.Run("accepts warn rule", func(t *testing.T) {
+		require.NoError(t, ValidateOPAPolicy("package nuon\nwarn := []"))
+	})
+
+	t.Run("rejects another package", func(t *testing.T) {
+		err := ValidateOPAPolicy("package other\ndeny := []")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must use package nuon")
+	})
+
+	t.Run("rejects policy without decisions", func(t *testing.T) {
+		err := ValidateOPAPolicy("package nuon\nallow := true")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must define at least one deny or warn rule")
+	})
+}
 
 func TestValidatePolicyType(t *testing.T) {
 	tests := map[string]struct {

--- a/pkg/plans/types/approval_plan/helm.go
+++ b/pkg/plans/types/approval_plan/helm.go
@@ -17,6 +17,9 @@ func NewHelmApprovalPlen(planJSON []byte) *HelmApprovalPlan {
 func (h *HelmApprovalPlan) IsNoop() (bool, error) {
 	result := gjson.GetBytes(h.PlanJSON, "helm_content_diff")
 	if !result.Exists() || result.IsArray() && len(result.Array()) == 0 {
+		if gjson.GetBytes(h.PlanJSON, "op").String() == "uninstall" {
+			return true, nil
+		}
 		return !h.releaseNeedsDeploy(), nil
 	}
 	return false, nil

--- a/pkg/plans/types/approval_plan/helm_test.go
+++ b/pkg/plans/types/approval_plan/helm_test.go
@@ -55,6 +55,11 @@ func TestHelmApprovalPlan_IsNoop(t *testing.T) {
 			planJSON: `{"helm_content_diff": [], "helm_release_status": ""}`,
 			want:     false,
 		},
+		{
+			name:     "uninstall with nothing to remove",
+			planJSON: `{"op": "uninstall", "helm_content_diff": []}`,
+			want:     true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/services/ctl-api/internal/app/apps/service/create_app_policies_config_test.go
+++ b/services/ctl-api/internal/app/apps/service/create_app_policies_config_test.go
@@ -25,11 +25,11 @@ func (s *AppConfigTypesTestSuite) TestCreateAppPoliciesConfig() {
 					AppConfigID: s.testAppConfig.ID,
 					Policies: []AppPolicyConfig{
 						{
-							Type:        config.AppPolicyTypeKubernetesCluster,
+							Type:        config.AppPolicyTypeSandbox,
 							Engine:      config.AppPolicyEngineOPA,
 							Name:        "test-policy",
 							Description: "Test policy description",
-							Contents:    "package test\n\ndefault allow = false",
+							Contents:    "package nuon\n\ndeny := []",
 						},
 					},
 				}

--- a/services/ctl-api/internal/app/components/signals/build/signal.go
+++ b/services/ctl-api/internal/app/components/signals/build/signal.go
@@ -1,7 +1,6 @@
 package build
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -9,22 +8,14 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
-	plantypes "github.com/nuonco/nuon/pkg/plans/types"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	createdsignal "github.com/nuonco/nuon/services/ctl-api/internal/app/components/signals/created"
+	componentsworker "github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/activities"
-	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/plan"
 	orgprovision "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/provision"
 	orgreprovision "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/signals/reprovision"
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/notifications"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
-	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/controlplanejob"
-	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job"
-	jobactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/job/activities"
 	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
 )
 
@@ -32,8 +23,6 @@ type Signal struct {
 	ComponentID string `json:"component_id" validate:"required"`
 	BuildID     string `json:"build_id" validate:"required"`
 	SandboxMode bool   `json:"sandbox_mode"`
-
-	runnerJobID string
 }
 
 var (
@@ -59,21 +48,7 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 func (s *Signal) Execute(ctx workflow.Context) error {
 	s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusPlanning, "creating build plan")
 
-	logStream, err := activities.AwaitCreateLogStreamByBuildID(ctx, s.BuildID)
-	if err != nil {
-		return errors.Wrap(err, "unable to create log stream")
-	}
-	defer func() {
-		closeCtx, cancel := workflow.NewDisconnectedContext(ctx)
-		defer cancel()
-		activities.AwaitCloseLogStreamByLogStreamID(closeCtx, logStream.ID)
-	}()
-	ctx = cctx.SetLogStreamWorkflowContext(ctx, logStream)
-	l, err := log.WorkflowLogger(ctx)
-	if err != nil {
-		return err
-	}
-
+	l := workflow.GetLogger(ctx)
 	l.Info("executing build")
 	preflightOptions := workflow.ActivityOptions{
 		RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1},
@@ -82,12 +57,6 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		l.Error(err.Error())
 		s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusError, err.Error())
 		return err
-	}
-
-	currentApp, err := activities.AwaitGetComponentAppByComponentID(ctx, s.ComponentID)
-	if err != nil {
-		s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusError, "unable to get component app")
-		return fmt.Errorf("unable to get component app: %w", err)
 	}
 
 	comp, err := activities.AwaitGetComponentByComponentID(ctx, s.ComponentID)
@@ -111,149 +80,17 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 
 	// A component is activated asynchronously by its `created` signal. During a
 	// sync burst the build can be enqueued before that signal commits the active
-	// status, so wait for the activation signal to finish before checking status
-	// rather than racing it and hard-failing.
+	// status, so wait for activation before the worker validates the status.
 	if err := queueclient.EnsureQueueSignal(ctx, comp.ID, "components", createdsignal.SignalType); err != nil {
 		s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusError, "component activation not ready")
 		return fmt.Errorf("component activation not ready: %w", err)
 	}
 
-	// Re-fetch to observe the status committed by the activation signal.
-	comp, err = activities.AwaitGetComponentByComponentID(ctx, s.ComponentID)
-	if err != nil {
-		s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusError, "unable to get component")
-		return fmt.Errorf("unable to get component: %w", err)
-	}
-
-	build, err := activities.AwaitGetComponentBuildByID(ctx, s.BuildID)
-	if err != nil {
-		s.updateBuildStatus(ctx, s.BuildID, app.ComponentBuildStatusError, "unable to get component build")
-		return fmt.Errorf("unable to get component build: %w", err)
-	}
-
-	notify := func(err error) error {
-		s.sendNotification(ctx, notifications.NotificationsTypeComponentBuildFailed, currentApp.ID, map[string]string{
-			"component_name": comp.Name,
-			"app_name":       currentApp.Name,
-			"created_by":     build.CreatedBy.Email,
-		})
-		return err
-	}
-
-	if err := s.execBuild(ctx, s.ComponentID, s.BuildID, currentApp, s.SandboxMode); err != nil {
-		return notify(err)
-	}
-
-	return nil
-}
-
-// execBuild executes the component build workflow
-func (s *Signal) execBuild(ctx workflow.Context, compID, buildID string, currentApp *app.App, sandboxMode bool) error {
-	comp, err := activities.AwaitGetComponent(ctx, activities.GetComponentRequest{
-		ComponentID: compID,
+	return componentsworker.AwaitBuild(ctx, componentsworker.BuildRequest{
+		ID:          s.ComponentID,
+		BuildID:     s.BuildID,
+		SandboxMode: s.SandboxMode,
 	})
-	if err != nil {
-		s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to get component")
-		return fmt.Errorf("unable to get component: %w", err)
-	}
-
-	// create the job
-	logStreamID, err := cctx.GetLogStreamIDWorkflow(ctx)
-	if err != nil {
-		return err
-	}
-	runnerJob, err := activities.AwaitCreateBuildJob(ctx, &activities.CreateBuildJobRequest{
-		BuildID:     buildID,
-		Op:          app.RunnerJobOperationTypeBuild,
-		Type:        comp.Type.BuildJobType(),
-		LogStreamID: logStreamID,
-		Metadata: map[string]string{
-			"component_id":       comp.ID,
-			"component_build_id": buildID,
-			"component_name":     comp.Name,
-			"app_id":             currentApp.ID,
-		},
-	})
-	if err != nil {
-		s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to create job")
-		return fmt.Errorf("unable to create job: %w", err)
-	}
-	s.runnerJobID = runnerJob.ID
-	if runnerJob.RunnerID == "" {
-		if runnerJob.Executor != app.RunnerJobExecutorControlPlane {
-			s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "no runners available in runner group")
-			_ = activities.AwaitUpdateJobStatus(ctx, &activities.UpdateJobStatusRequest{
-				JobID:             runnerJob.ID,
-				Status:            app.RunnerJobStatusFailed,
-				StatusDescription: "no runners available in runner group",
-			})
-			return fmt.Errorf("no runners available in runner group for org %s", comp.Org.ID)
-		}
-	}
-
-	cloudProvider, _ := activities.AwaitGetCloudProvider(ctx, &activities.GetCloudProviderRequest{})
-	managementIAMRoleARN, _ := activities.AwaitGetManagementIAMRoleARN(ctx, &activities.GetManagementIAMRoleARNRequest{})
-	runPlan, err := plan.AwaitCreateComponentBuildPlan(ctx, &plan.CreateComponentBuildPlanRequest{
-		ComponentID:          comp.ID,
-		ComponentBuildID:     buildID,
-		WorkflowID:           fmt.Sprintf("%s-create-build-plan", workflow.GetInfo(ctx).WorkflowExecution.ID),
-		CloudProvider:        cloudProvider,
-		ManagementIAMRoleARN: managementIAMRoleARN,
-		IsControlPlaneBuild:  runnerJob.Executor == app.RunnerJobExecutorControlPlane,
-	})
-	if err != nil {
-		s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to get component build plan")
-		return errors.Wrap(err, "unable to create plan")
-	}
-
-	if runPlan.ContainerImagePullPlan != nil {
-		if err := sharedactivities.EnsureGARAuth(ctx, runPlan.ContainerImagePullPlan.RepoCfg); err != nil {
-			s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to get GAR access token")
-			return errors.Wrap(err, "unable to get GAR access token")
-		}
-	}
-
-	planJSON, err := json.Marshal(runPlan)
-	if err != nil {
-		return errors.Wrap(err, "unable to create json")
-	}
-	if err != nil {
-		s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to get convert build plan to JSON")
-		return fmt.Errorf("unable to convert plan to json: %w", err)
-	}
-
-	if err := activities.AwaitSaveRunnerJobPlan(ctx, &activities.SaveRunnerJobPlanRequest{
-		JobID:    runnerJob.ID,
-		PlanJSON: string(planJSON),
-		CompositePlan: plantypes.CompositePlan{
-			BuildPlan: runPlan,
-		},
-	}); err != nil {
-		s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to save job plan")
-		return fmt.Errorf("unable to save runner job plan: %w", err)
-	}
-
-	// wait for the job
-	s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusBuilding, "building")
-	if runnerJob.Executor == app.RunnerJobExecutorControlPlane {
-		err = controlplanejob.AwaitExecuteControlPlaneJob(ctx, &controlplanejob.ExecuteRequest{JobID: runnerJob.ID}, &workflow.ChildWorkflowOptions{
-			WorkflowID: fmt.Sprintf("control-plane-%s-execute-job-%s", comp.ID, runnerJob.ID),
-		})
-	} else {
-		_, err = job.AwaitExecuteJob(ctx, &job.ExecuteJobRequest{
-			RunnerID: runnerJob.RunnerID,
-			JobID:    runnerJob.ID,
-		}, &workflow.ChildWorkflowOptions{
-			WorkflowID: fmt.Sprintf("queue-signal-%s-execute-job-%s", comp.ID, runnerJob.ID),
-		})
-	}
-	if err != nil {
-		s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, fmt.Sprintf("build failed: %s", signal.HumanError(err)))
-		return fmt.Errorf("build job failed: %w", err)
-	}
-
-	s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusActive, "build is active and ready to be deployed")
-	return nil
 }
 
 // updateBuildStatus updates the build status
@@ -288,22 +125,5 @@ func (s *Signal) Cancel(ctx workflow.Context) error {
 	cancelCtx, cancel := workflow.NewDisconnectedContext(ctx)
 	defer cancel()
 	s.updateBuildStatus(cancelCtx, s.BuildID, app.ComponentBuildStatus(app.StatusCancelled), "build cancelled")
-	if s.runnerJobID != "" {
-		jobactivities.AwaitPkgWorkflowsJobCancelJobByID(cancelCtx, s.runnerJobID)
-	}
 	return nil
-}
-
-func (s *Signal) sendNotification(ctx workflow.Context, typ notifications.Type, appID string, vars map[string]string) {
-	l := workflow.GetLogger(ctx)
-
-	if err := sharedactivities.AwaitSendEmail(ctx, sharedactivities.SendNotificationRequest{
-		AppID: appID,
-		Type:  typ,
-		Vars:  vars,
-	}); err != nil {
-		l.Error("unable to send email",
-			zap.Error(err),
-			zap.String("type", typ.String()))
-	}
 }

--- a/services/ctl-api/internal/app/components/worker/evaluate_external_image_policy.go
+++ b/services/ctl-api/internal/app/components/worker/evaluate_external_image_policy.go
@@ -9,8 +9,10 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 
+	"github.com/nuonco/nuon/pkg/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/components/worker/activities"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/policy_reports/policyerrors"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/controlplanejob"
@@ -148,14 +150,18 @@ func (w *Workflows) evaluateExternalImagePolicy(ctx workflow.Context, buildID, b
 
 	// Collect all violations from parallel evaluations
 	var allViolations []sharedactivities.PolicyViolation
+	evaluationFailed := false
 	for _, fut := range futures {
 		var result sharedactivities.EvaluateSinglePolicyResult
 		if err := fut.Get(ctx, &result); err != nil {
-			w.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, truncateErrorMessage("policy evaluation failed", err))
-			w.updateJobStatusForPolicyFailure(ctx, buildJobID, "policy evaluation failed")
-			return fmt.Errorf("policy evaluation failed: %w", err)
+			l.Error("policy evaluation failed; continuing with warning", zap.Error(err))
+			evaluationFailed = true
+			continue
 		}
 		allViolations = append(allViolations, result.Violations...)
+	}
+	if evaluationFailed {
+		w.recordComponentPolicyEvaluationFailure(ctx, l, metadataJob.ID)
 	}
 
 	var denyViolations []sharedactivities.PolicyViolation
@@ -169,31 +175,33 @@ func (w *Workflows) evaluateExternalImagePolicy(ctx workflow.Context, buildID, b
 		}
 	}
 
-	orgID, err := cctx.OrgIDFromContext(ctx)
-	if err != nil {
-		l.Warn("unable to get org id", zap.Error(err))
-	} else {
-		componentID := prepResult.ComponentID
-		policyInputCounts := make(map[string]int, len(prepResult.PolicyIDs))
-		for _, policyID := range prepResult.PolicyIDs {
-			policyInputCounts[policyID] = prepResult.InputCount
-		}
-		if _, err := sharedactivities.AwaitPersistPolicyReport(ctx, &sharedactivities.PersistPolicyReportRequest{
-			OrgID:             orgID,
-			AppID:             prepResult.AppID,
-			ComponentID:       &componentID,
-			InstallSandboxID:  nil,
-			OwnerID:           buildID,
-			OwnerType:         string(app.PolicyReportOwnerTypeComponentBuild),
-			RunnerJobID:       &buildJobID,
-			Violations:        allViolations,
-			PolicyIDs:         prepResult.PolicyIDs,
-			PolicyInputCounts: policyInputCounts,
-			OrgName:           prepResult.OrgName,
-			AppName:           prepResult.AppName,
-			ComponentName:     prepResult.ComponentName,
-		}); err != nil {
-			l.Warn("failed to persist policy report", zap.Error(err))
+	if !evaluationFailed {
+		orgID, err := cctx.OrgIDFromContext(ctx)
+		if err != nil {
+			l.Warn("unable to get org id", zap.Error(err))
+		} else {
+			componentID := prepResult.ComponentID
+			policyInputCounts := make(map[string]int, len(prepResult.PolicyIDs))
+			for _, policyID := range prepResult.PolicyIDs {
+				policyInputCounts[policyID] = prepResult.InputCount
+			}
+			if _, err := sharedactivities.AwaitPersistPolicyReport(ctx, &sharedactivities.PersistPolicyReportRequest{
+				OrgID:             orgID,
+				AppID:             prepResult.AppID,
+				ComponentID:       &componentID,
+				InstallSandboxID:  nil,
+				OwnerID:           buildID,
+				OwnerType:         string(app.PolicyReportOwnerTypeComponentBuild),
+				RunnerJobID:       &buildJobID,
+				Violations:        allViolations,
+				PolicyIDs:         prepResult.PolicyIDs,
+				PolicyInputCounts: policyInputCounts,
+				OrgName:           prepResult.OrgName,
+				AppName:           prepResult.AppName,
+				ComponentName:     prepResult.ComponentName,
+			}); err != nil {
+				l.Warn("failed to persist policy report", zap.Error(err))
+			}
 		}
 	}
 
@@ -218,6 +226,31 @@ func (w *Workflows) evaluateExternalImagePolicy(ctx workflow.Context, buildID, b
 
 	l.Info("policy evaluation completed", zap.Int("warn_count", len(warnViolations)))
 	return nil
+}
+
+func (w *Workflows) recordComponentPolicyEvaluationFailure(ctx workflow.Context, l *zap.Logger, runnerJobID string) {
+	if err := sharedactivities.AwaitRecordPolicyEvaluationCompositeError(ctx, sharedactivities.RecordPolicyEvaluationCompositeErrorRequest{
+		RunnerJobID: runnerJobID,
+		Stage:       policyerrors.EvaluationFailureStageEvaluation,
+	}); err != nil {
+		l.Warn("failed to record policy evaluation composite error", zap.Error(err))
+	}
+
+	if w.mw == nil {
+		return
+	}
+	orgID, err := cctx.OrgIDFromContext(ctx)
+	if err != nil {
+		l.Warn("unable to get org id for policy evaluation metric", zap.Error(err))
+		return
+	}
+	w.mw.Incr(ctx, "policy.evaluation", metrics.ToTags(map[string]string{
+		"org_id":           orgID,
+		"stage":            "evaluation",
+		"status":           "error",
+		"step_target_type": "component_builds",
+		"workflow_type":    "component_build",
+	})...)
 }
 
 func (w *Workflows) updateJobStatusForPolicyFailure(ctx workflow.Context, jobID, description string) {

--- a/services/ctl-api/internal/app/components/worker/evaluate_helm_build_policy.go
+++ b/services/ctl-api/internal/app/components/worker/evaluate_helm_build_policy.go
@@ -118,40 +118,46 @@ func (w *Workflows) evaluateHelmBuildPolicy(ctx workflow.Context, buildID, build
 	}
 
 	var allViolations []sharedactivities.PolicyViolation
+	evaluationFailed := false
 	for _, fut := range futures {
 		var result sharedactivities.EvaluateSinglePolicyResult
 		if err := fut.Get(ctx, &result); err != nil {
-			w.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, truncateErrorMessage("policy evaluation failed", err))
-			w.updateJobStatusForPolicyFailure(ctx, buildJobID, "policy evaluation failed")
-			return fmt.Errorf("policy evaluation failed: %w", err)
+			l.Error("policy evaluation failed; continuing with warning", zap.Error(err))
+			evaluationFailed = true
+			continue
 		}
 		allViolations = append(allViolations, result.Violations...)
 	}
+	if evaluationFailed {
+		w.recordComponentPolicyEvaluationFailure(ctx, l, buildJobID)
+	}
 
-	orgID, err := cctx.OrgIDFromContext(ctx)
-	if err != nil {
-		l.Warn("unable to get org id", zap.Error(err))
-	} else {
-		policyInputCounts := make(map[string]int, len(policyIDs))
-		for _, policyID := range policyIDs {
-			policyInputCounts[policyID] = len(payload.PolicyInput)
-		}
-		componentID := build.ComponentConfigConnection.ComponentID
-		if _, err := sharedactivities.AwaitPersistPolicyReport(ctx, &sharedactivities.PersistPolicyReportRequest{
-			OrgID:             orgID,
-			AppID:             build.ComponentConfigConnection.Component.AppID,
-			ComponentID:       &componentID,
-			OwnerID:           buildID,
-			OwnerType:         string(app.PolicyReportOwnerTypeComponentBuild),
-			RunnerJobID:       &buildJobID,
-			Violations:        allViolations,
-			PolicyIDs:         policyIDs,
-			PolicyInputCounts: policyInputCounts,
-			OrgName:           build.ComponentConfigConnection.Component.App.Org.Name,
-			AppName:           build.ComponentConfigConnection.Component.App.Name,
-			ComponentName:     build.ComponentConfigConnection.Component.Name,
-		}); err != nil {
-			l.Warn("failed to persist policy report", zap.Error(err))
+	if !evaluationFailed {
+		orgID, err := cctx.OrgIDFromContext(ctx)
+		if err != nil {
+			l.Warn("unable to get org id", zap.Error(err))
+		} else {
+			policyInputCounts := make(map[string]int, len(policyIDs))
+			for _, policyID := range policyIDs {
+				policyInputCounts[policyID] = len(payload.PolicyInput)
+			}
+			componentID := build.ComponentConfigConnection.ComponentID
+			if _, err := sharedactivities.AwaitPersistPolicyReport(ctx, &sharedactivities.PersistPolicyReportRequest{
+				OrgID:             orgID,
+				AppID:             build.ComponentConfigConnection.Component.AppID,
+				ComponentID:       &componentID,
+				OwnerID:           buildID,
+				OwnerType:         string(app.PolicyReportOwnerTypeComponentBuild),
+				RunnerJobID:       &buildJobID,
+				Violations:        allViolations,
+				PolicyIDs:         policyIDs,
+				PolicyInputCounts: policyInputCounts,
+				OrgName:           build.ComponentConfigConnection.Component.App.Org.Name,
+				AppName:           build.ComponentConfigConnection.Component.App.Name,
+				ComponentName:     build.ComponentConfigConnection.Component.Name,
+			}); err != nil {
+				l.Warn("failed to persist policy report", zap.Error(err))
+			}
 		}
 	}
 

--- a/services/ctl-api/internal/app/installs/service/create_workflow_step_approval_response.go
+++ b/services/ctl-api/internal/app/installs/service/create_workflow_step_approval_response.go
@@ -92,7 +92,7 @@ func (s *service) CreateWorkflowStepApprovalResponse(ctx *gin.Context) {
 		return
 	}
 
-	approval, err := s.getWorkflowStepApproval(ctx, org.ID, approvalID)
+	approval, err := s.getWorkflowStepApproval(ctx, org.ID, stepID, approvalID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			ctx.Error(stderr.ErrNotFound{

--- a/services/ctl-api/internal/app/installs/service/create_workflow_step_approval_response_test.go
+++ b/services/ctl-api/internal/app/installs/service/create_workflow_step_approval_response_test.go
@@ -78,3 +78,25 @@ func (s *InstallsServiceTestSuite) TestCreateApprovalResponseNotFound() {
 	rr := s.makeRequest(http.MethodPost, path, body)
 	assert.Equal(s.T(), http.StatusNotFound, rr.Code)
 }
+
+func (s *InstallsServiceTestSuite) TestCreateApprovalResponseRejectsApprovalFromAnotherStep() {
+	install := s.createTestInstall()
+	workflow := s.deps.Seeder.CreateWorkflow(s.ctx, s.T(), install.ID, app.WorkflowTypeReprovision)
+	requestedStep := s.deps.Seeder.CreateWorkflowStep(s.ctx, s.T(), workflow.ID)
+	approvalStep := s.deps.Seeder.CreateWorkflowStep(s.ctx, s.T(), workflow.ID)
+	approval := s.deps.Seeder.CreateWorkflowStepApproval(s.ctx, s.T(), approvalStep.ID, app.TerraformPlanApprovalType, "plan output")
+
+	body := CreateWorkflowStepApprovalResponseRequest{
+		ResponseType: app.WorkflowStepApprovalResponseTypeApprove,
+		Note:         "lgtm",
+	}
+	path := fmt.Sprintf("/v1/workflows/%s/steps/%s/approvals/%s/response", workflow.ID, requestedStep.ID, approval.ID)
+	rr := s.makeRequest(http.MethodPost, path, body)
+	require.Equal(s.T(), http.StatusNotFound, rr.Code, "body: %s", rr.Body.String())
+
+	var responseCount int64
+	require.NoError(s.T(), s.deps.DB.Model(&app.WorkflowStepApprovalResponse{}).
+		Where(app.WorkflowStepApprovalResponse{InstallWorkflowStepApprovalID: approval.ID}).
+		Count(&responseCount).Error)
+	assert.Zero(s.T(), responseCount)
+}

--- a/services/ctl-api/internal/app/installs/service/get_workflow_step_approval.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow_step_approval.go
@@ -45,7 +45,7 @@ func (s *service) GetWorkflowStepApproval(ctx *gin.Context) {
 		return
 	}
 
-	approval, err := s.getWorkflowStepApproval(ctx, org.ID, approvalID)
+	approval, err := s.getWorkflowStepApproval(ctx, org.ID, stepID, approvalID)
 	if err != nil {
 		ctx.Error(errors.Wrap(err, "unable to get workflow step approval"))
 		return
@@ -91,7 +91,7 @@ func (s *service) GetInstallWorkflowStepApproval(ctx *gin.Context) {
 		return
 	}
 
-	approval, err := s.getWorkflowStepApproval(ctx, org.ID, approvalID)
+	approval, err := s.getWorkflowStepApproval(ctx, org.ID, stepID, approvalID)
 	if err != nil {
 		ctx.Error(errors.Wrap(err, "unable to get install workflow step approval"))
 		return
@@ -100,12 +100,16 @@ func (s *service) GetInstallWorkflowStepApproval(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, approval)
 }
 
-func (s *service) getWorkflowStepApproval(ctx *gin.Context, OrgID, approvalID string) (*app.WorkflowStepApproval, error) {
+func (s *service) getWorkflowStepApproval(ctx *gin.Context, orgID, stepID, approvalID string) (*app.WorkflowStepApproval, error) {
 	var approval app.WorkflowStepApproval
 	// No Omit("contents") here: GetWorkflowStepApprovalContents reads
 	// approval.Contents through this getter.
 	res := s.db.WithContext(ctx).
-		Where("id = ? AND org_id = ?", approvalID, OrgID).
+		Where(app.WorkflowStepApproval{
+			ID:                    approvalID,
+			OrgID:                 orgID,
+			InstallWorkflowStepID: stepID,
+		}).
 		Preload("InstallWorkflowStep").
 		Preload("Response").
 		First(&approval)

--- a/services/ctl-api/internal/app/installs/service/get_workflow_step_approval_contents.go
+++ b/services/ctl-api/internal/app/installs/service/get_workflow_step_approval_contents.go
@@ -48,7 +48,7 @@ func (s *service) GetWorkflowStepApprovalContents(ctx *gin.Context) {
 		return
 	}
 
-	approval, err := s.getWorkflowStepApproval(ctx, org.ID, approvalID)
+	approval, err := s.getWorkflowStepApproval(ctx, org.ID, stepID, approvalID)
 	if err != nil {
 		ctx.Error(errors.Wrap(err, "unable to get workflow step approval"))
 		return

--- a/services/ctl-api/internal/app/policy_reports/helpers/context.go
+++ b/services/ctl-api/internal/app/policy_reports/helpers/context.go
@@ -27,5 +27,6 @@ type PolicyEvaluationContext struct {
 	// Fields used during policy preparation/resolution
 	AppConfigID   string
 	ComponentType app.ComponentType
+	SandboxType   string
 	IsSandbox     bool
 }

--- a/services/ctl-api/internal/app/policy_reports/policyerrors/evaluation_failed.go
+++ b/services/ctl-api/internal/app/policy_reports/policyerrors/evaluation_failed.go
@@ -9,6 +9,7 @@ type EvaluationFailureStage string
 const (
 	EvaluationFailureStagePreparation EvaluationFailureStage = "preparation"
 	EvaluationFailureStageEvaluation  EvaluationFailureStage = "evaluation"
+	EvaluationFailureStagePersistence EvaluationFailureStage = "persistence"
 )
 
 type EvaluationFailedError struct {
@@ -30,16 +31,18 @@ func (*EvaluationFailedError) Severity() compositeerrors.Severity {
 }
 
 func (e *EvaluationFailedError) Sections() []compositeerrors.Section {
-	whatHappened := "Nuon could not complete policy enforcement for this plan. The workflow continued without a policy result."
+	whatHappened := "Nuon could not complete policy enforcement. The operation continued without a policy result."
 	switch e.Stage {
 	case EvaluationFailureStagePreparation:
-		whatHappened = "Nuon could not prepare the plan and configured policies for evaluation. The workflow continued without a policy result."
+		whatHappened = "Nuon could not prepare the input and configured policies for evaluation. The operation continued without a policy result."
 	case EvaluationFailureStageEvaluation:
-		whatHappened = "Nuon prepared the policy inputs but could not finish evaluating the configured policies. The workflow continued without a policy result."
+		whatHappened = "Nuon prepared the policy inputs but could not finish evaluating the configured policies. The operation continued without a policy result."
+	case EvaluationFailureStagePersistence:
+		whatHappened = "Nuon evaluated the configured policies but could not save the policy report. The operation continued without a durable policy result."
 	}
 
 	return []compositeerrors.Section{
 		compositeerrors.MarkdownSection("What happened", whatHappened),
-		compositeerrors.MarkdownSection("How to continue", "Review the plan carefully before approving it. Retry the plan to attempt policy evaluation again, and contact support if this warning persists."),
+		compositeerrors.MarkdownSection("How to continue", "Review the resulting infrastructure or artifact carefully. Retry the operation to attempt policy evaluation again, and contact support if this warning persists."),
 	}
 }

--- a/services/ctl-api/internal/app/runners/helpers/get_latest_runner_job.go
+++ b/services/ctl-api/internal/app/runners/helpers/get_latest_runner_job.go
@@ -88,6 +88,11 @@ func ResolveJobCompositeError(job *app.RunnerJob) *compositeerrors.CompositeErro
 			return job.Executions[0].Result.CompositeError
 		}
 		return job.CompositeError
+	case app.RunnerJobStatusFinished:
+		if job.CompositeError != nil && job.CompositeError.Severity == compositeerrors.SeverityWarning {
+			return job.CompositeError
+		}
+		return nil
 	default:
 		return nil
 	}

--- a/services/ctl-api/internal/app/runners/helpers/get_latest_runner_job_test.go
+++ b/services/ctl-api/internal/app/runners/helpers/get_latest_runner_job_test.go
@@ -184,6 +184,7 @@ func TestResolveJobCompositeError(t *testing.T) {
 	executionError := &compositeerrors.CompositeErrorData{Type: "terraform.error"}
 	lifecycleError := &compositeerrors.CompositeErrorData{Type: "runner.job_lifecycle_failure"}
 	cancellationError := &compositeerrors.CompositeErrorData{Type: joberrors.CancellationErrorType}
+	policyWarning := &compositeerrors.CompositeErrorData{Type: "policy.evaluation_failed", Severity: compositeerrors.SeverityWarning}
 
 	tests := map[string]struct {
 		job      app.RunnerJob
@@ -234,6 +235,13 @@ func TestResolveJobCompositeError(t *testing.T) {
 				Status:         app.RunnerJobStatusFinished,
 				CompositeError: lifecycleError,
 			},
+		},
+		"finished job exposes policy warning": {
+			job: app.RunnerJob{
+				Status:         app.RunnerJobStatusFinished,
+				CompositeError: policyWarning,
+			},
+			expected: policyWarning,
 		},
 		"finished job hides stale execution error": {
 			job: app.RunnerJob{

--- a/services/ctl-api/internal/pkg/config/build/build_test.go
+++ b/services/ctl-api/internal/pkg/config/build/build_test.go
@@ -281,7 +281,7 @@ func TestStackConfigRejectsNestedStackWithoutContents(t *testing.T) {
 func TestPoliciesConfigKeepsName(t *testing.T) {
 	obj, err := PoliciesConfig(PolicyInputsFromConfig(&config.PoliciesConfig{
 		Policies: []config.AppPolicy{
-			{Type: config.AppPolicyTypeSandbox, Name: "no-public-buckets", Contents: "package x"},
+			{Type: config.AppPolicyTypeSandbox, Engine: config.AppPolicyEngineOPA, Name: "no-public-buckets", Contents: "package nuon\ndeny := []"},
 		},
 	}), "app1", "cfg1")
 	require.NoError(t, err)
@@ -294,6 +294,17 @@ func TestPoliciesConfigRejectsUnknownType(t *testing.T) {
 	_, err := PoliciesConfig([]PolicyInput{{Type: "nope", Contents: "package x"}}, "app1", "cfg1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid policy type")
+}
+
+func TestPoliciesConfigRejectsInvalidOPAPackage(t *testing.T) {
+	_, err := PoliciesConfig([]PolicyInput{{
+		Type:     config.AppPolicyTypeSandbox,
+		Engine:   config.AppPolicyEngineOPA,
+		Name:     "invalid-package",
+		Contents: "package other",
+	}}, "app1", "cfg1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must use package nuon")
 }
 
 func TestComponentConnectionKeepsToggles(t *testing.T) {

--- a/services/ctl-api/internal/pkg/config/build/policies.go
+++ b/services/ctl-api/internal/pkg/config/build/policies.go
@@ -48,6 +48,11 @@ func PoliciesConfig(policies []PolicyInput, appID, appConfigID string) (*app.App
 		if policyName == "" {
 			policyName = fmt.Sprintf("#%d", idx)
 		}
+		if policy.Engine == config.AppPolicyEngineOPA {
+			if err := validate.ValidateOPAPolicy(policy.Contents); err != nil {
+				return nil, fmt.Errorf("policy %q is invalid: %w", policyName, err)
+			}
+		}
 		if err := validate.ValidatePolicyComponents(policyName, policy.Type, policy.Components); err != nil {
 			return nil, err
 		}

--- a/services/ctl-api/internal/pkg/flow/checks/policy/check.go
+++ b/services/ctl-api/internal/pkg/flow/checks/policy/check.go
@@ -31,17 +31,21 @@ const (
 
 // Check implements directive.ApprovalCreateCheck for policy evaluation.
 type Check struct {
-	sig signal.Signal
-	tmw tmetrics.Writer
+	sig      signal.Signal
+	tmw      tmetrics.Writer
+	checkCtx *directive.CheckContext
 }
 
-func New(sig signal.Signal, tmw tmetrics.Writer) directive.ApprovalCreateCheck {
-	return &Check{sig: sig, tmw: tmw}
+func New(sig signal.Signal, tmw tmetrics.Writer, checkCtx *directive.CheckContext) directive.ApprovalCreateCheck {
+	return &Check{sig: sig, tmw: tmw, checkCtx: checkCtx}
 }
 
 func (c *Check) Name() string { return "policy" }
 
 func (c *Check) ShouldRun(step *app.WorkflowStep, flw *app.Workflow) bool {
+	if flw.PlanOnly || c.checkCtx.NoopPlan {
+		return false
+	}
 	pe, ok := c.sig.(signal.SignalWithPolicyEvaluation)
 	return ok && pe.RequiresPolicyEvaluation()
 }
@@ -72,8 +76,6 @@ func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workf
 		return directive.Pass(), nil
 	}
 
-	c.recordSuccess(ctx, step, flw, outcome)
-
 	policyInputCounts := make(map[string]int, len(policyContext.PolicyIDs))
 	for _, policyID := range policyContext.PolicyIDs {
 		policyInputCounts[policyID] = policyContext.InputCount
@@ -82,7 +84,7 @@ func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workf
 	if step.PolicyValidation != nil {
 		validationID = &step.PolicyValidation.ID
 	}
-	reportResult, err := activities.AwaitPersistPolicyReport(ctx, &activities.PersistPolicyReportRequest{
+	reportResult, reportErr := activities.AwaitPersistPolicyReport(ctx, &activities.PersistPolicyReportRequest{
 		OrgID:                          policyContext.OrgID,
 		AppID:                          policyContext.AppID,
 		InstallID:                      policyContext.InstallID,
@@ -100,8 +102,16 @@ func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workf
 		InstallName:                    policyContext.InstallName,
 		ComponentName:                  policyContext.ComponentName,
 	})
-	if err != nil {
-		l.Warn("failed to persist policy report", zap.Error(err))
+	if reportErr != nil {
+		policyErr := &policyEvaluationError{
+			stage: string(policyerrors.EvaluationFailureStagePersistence),
+			err:   errors.Wrap(reportErr, "unable to persist policy report"),
+		}
+		l.Error("failed to persist policy report; continuing with warning", zap.Error(reportErr))
+		c.recordFailure(ctx, step, flw, policyErr)
+		recordEvaluationCompositeError(ctx, l, step, policyErr)
+	} else {
+		c.recordSuccess(ctx, step, flw, outcome)
 	}
 
 	var passedPolicyIDs []string
@@ -118,7 +128,7 @@ func (c *Check) Run(ctx workflow.Context, step *app.WorkflowStep, flw *app.Workf
 
 	// If the signal opts into auto-approve on policies passing and there are
 	// no deny violations, short-circuit the pipeline with a continue directive.
-	if aa, ok := c.sig.(signal.SignalWithAutoApproveOnPoliciesPassing); ok && aa.AutoApproveOnPoliciesPassing(ctx) {
+	if aa, ok := c.sig.(signal.SignalWithAutoApproveOnPoliciesPassing); reportErr == nil && ok && aa.AutoApproveOnPoliciesPassing(ctx) {
 		l.Debug("auto-approving after policies passed",
 			zap.String("step_id", step.ID))
 		return directive.CheckResult{

--- a/services/ctl-api/internal/pkg/flow/checks/policy/check_test.go
+++ b/services/ctl-api/internal/pkg/flow/checks/policy/check_test.go
@@ -1,0 +1,96 @@
+package policy
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+
+	pkgdataconverter "github.com/nuonco/nuon/pkg/temporal/dataconverter"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/policy_reports/policyerrors"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/directive"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
+	statusactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/status/activities"
+	activities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/workflow/activities"
+)
+
+type policySignal struct{}
+
+func (*policySignal) Type() signal.SignalType         { return "test-policy" }
+func (*policySignal) Validate(workflow.Context) error { return nil }
+func (*policySignal) Execute(workflow.Context) error  { return nil }
+func (*policySignal) RequiresPolicyEvaluation() bool  { return true }
+func (*policySignal) AutoApproveOnPoliciesPassing(workflow.Context) bool {
+	return true
+}
+
+func TestCheckShouldRun(t *testing.T) {
+	checkCtx := &directive.CheckContext{}
+	check := New(&policySignal{}, nil, checkCtx)
+	step := &app.WorkflowStep{}
+
+	require.False(t, check.ShouldRun(step, &app.Workflow{PlanOnly: true}))
+	require.True(t, check.ShouldRun(step, &app.Workflow{}))
+
+	checkCtx.NoopPlan = true
+	require.False(t, check.ShouldRun(step, &app.Workflow{}))
+}
+
+func TestCheckDoesNotAutoApproveWhenPolicyReportPersistenceFails(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
+	env.SetDataConverter(converter.NewCompositeDataConverter(
+		converter.NewNilPayloadConverter(),
+		converter.NewByteSlicePayloadConverter(),
+		pkgdataconverter.NewJSONConverter(),
+	))
+	env.RegisterActivityWithOptions((&activities.Activities{}).RecordPolicyEvaluationCompositeError,
+		activity.RegisterOptions{Name: "RecordPolicyEvaluationCompositeError"})
+
+	env.OnActivity((*activities.Activities).PrepPolicyEvaluation, mock.Anything, mock.Anything, mock.Anything).
+		Return(&activities.PrepPolicyEvaluationResult{
+			HasPolicies: true,
+			OrgID:       "org-1",
+			AppID:       "app-1",
+			PolicyIDs:   []string{"policy-1"},
+			InputCount:  1,
+			Policies: []activities.PolicyToEvaluate{{
+				PolicyID:  "policy-1",
+				Contents:  "package nuon\ndeny := []",
+				InputJSON: []byte(`{}`),
+			}},
+		}, nil).Once()
+	env.OnActivity((*activities.Activities).EvaluateSinglePolicy, mock.Anything, mock.Anything, mock.Anything).
+		Return(&activities.EvaluateSinglePolicyResult{}, nil).Once()
+	env.OnActivity((*activities.Activities).PersistPolicyReport, mock.Anything, mock.Anything, mock.Anything).
+		Return((*activities.PersistPolicyReportResult)(nil), errors.New("write failed")).Times(3)
+	env.OnActivity("RecordPolicyEvaluationCompositeError", mock.Anything, mock.MatchedBy(func(req activities.RecordPolicyEvaluationCompositeErrorRequest) bool {
+		return req.Stage == policyerrors.EvaluationFailureStagePersistence
+	})).Return(nil).Once()
+	env.OnActivity((*statusactivities.Activities).PkgStatusUpdateFlowStepStatus, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Once()
+
+	check := New(&policySignal{}, nil, &directive.CheckContext{})
+	env.ExecuteWorkflow(func(ctx workflow.Context) (directive.CheckResult, error) {
+		return check.Run(ctx, &app.WorkflowStep{
+			ID:             "step-1",
+			StepTargetID:   "deploy-1",
+			StepTargetType: string(app.WorkflowStepTargetTypeInstallDeploy),
+		}, &app.Workflow{ID: "workflow-1", OrgID: "org-1"})
+	})
+
+	require.NoError(t, env.GetWorkflowError())
+	var result directive.CheckResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, directive.StepUnknown, result.Directive)
+	env.AssertExpectations(t)
+}

--- a/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_plan.go
+++ b/services/ctl-api/internal/pkg/flow/signals/executeworkflowstep/process_plan.go
@@ -128,9 +128,9 @@ func (s *Signal) approvalCreateChecks(ctx workflow.Context, sig qsignal.Signal, 
 		// Empty install groups have nothing to approve; skip before the approval wait.
 		emptygroup.New(sig, setResultDirective),
 		noop.New(sig, checkCtx, orgAutoSkipNoop, setResultDirective),
-		policy.New(sig, s.tmw),
-		autoapproval.New(stepSignal, setResultDirective),
 		planonly.New(s.OwnerID, checkCtx),
+		policy.New(sig, s.tmw, checkCtx),
+		autoapproval.New(stepSignal, setResultDirective),
 	}
 }
 

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/evaluate_single_policy.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/evaluate_single_policy.go
@@ -3,11 +3,13 @@ package activities
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
+	configvalidate "github.com/nuonco/nuon/pkg/config/validate"
 	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
 )
 
@@ -33,6 +35,11 @@ func (a *Activities) EvaluateSinglePolicy(ctx context.Context, req *EvaluateSing
 	l = l.With(zap.String("policy_id", req.PolicyID))
 
 	l.Info("evaluating policy")
+
+	if err := configvalidate.ValidateOPAPolicy(req.Contents); err != nil {
+		l.Error("invalid OPA policy", zap.Error(err))
+		return nil, errors.Wrap(err, "invalid OPA policy")
+	}
 
 	var input any
 	if err := json.Unmarshal(req.InputJSON, &input); err != nil {
@@ -107,8 +114,7 @@ func (a *Activities) evaluateRule(
 		for _, expr := range result.Expressions {
 			ruleResults, ok := expr.Value.([]interface{})
 			if !ok {
-				l.Warn("expression value is not a slice, skipping", zap.String("query", queryStr))
-				continue
+				return nil, fmt.Errorf("OPA rule %s must return a set or array of violation messages, got %T", queryStr, expr.Value)
 			}
 			for _, item := range ruleResults {
 				violation := PolicyViolation{
@@ -119,14 +125,19 @@ func (a *Activities) evaluateRule(
 				case string:
 					violation.Message = v
 				case map[string]interface{}:
-					if msg, ok := v["msg"].(string); ok {
-						violation.Message = msg
+					msg, ok := v["msg"].(string)
+					if !ok {
+						return nil, fmt.Errorf("OPA rule %s returned an object without a string msg field", queryStr)
 					}
+					violation.Message = msg
+				default:
+					return nil, fmt.Errorf("OPA rule %s returned unsupported violation type %T", queryStr, item)
 				}
 
-				if violation.Message != "" {
-					violations = append(violations, violation)
+				if violation.Message == "" {
+					return nil, fmt.Errorf("OPA rule %s returned an empty violation message", queryStr)
 				}
+				violations = append(violations, violation)
 			}
 		}
 	}

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/evaluate_single_policy_test.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/evaluate_single_policy_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
 	"go.uber.org/zap"
 )
 
@@ -94,6 +95,74 @@ deny contains msg if {
 
 	_, err := a.evaluateRule(ctx, l, invalidPolicy, input, "data.nuon.deny", "deny")
 	assert.Error(t, err, "expected error for invalid policy syntax")
+}
+
+func TestEvaluateSinglePolicyRejectsWrongPackage(t *testing.T) {
+	_, err := executeEvaluateSinglePolicy(t, &EvaluateSinglePolicyRequest{
+		PolicyID:  "policy-id",
+		Contents:  "package other\ndeny := []",
+		InputJSON: []byte("{}"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must use package nuon")
+}
+
+func TestEvaluateSinglePolicyRejectsMissingDecisions(t *testing.T) {
+	_, err := executeEvaluateSinglePolicy(t, &EvaluateSinglePolicyRequest{
+		PolicyID:  "policy-id",
+		Contents:  "package nuon\nallow := true",
+		InputJSON: []byte("{}"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must define at least one deny or warn rule")
+}
+
+func TestEvaluateSinglePolicyAllowsOneDecisionType(t *testing.T) {
+	result, err := executeEvaluateSinglePolicy(t, &EvaluateSinglePolicyRequest{
+		PolicyID:  "policy-id",
+		Contents:  "package nuon\ndeny := []",
+		InputJSON: []byte("{}"),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, result.Violations)
+}
+
+func executeEvaluateSinglePolicy(t *testing.T, req *EvaluateSinglePolicyRequest) (*EvaluateSinglePolicyResult, error) {
+	t.Helper()
+
+	activities := &Activities{}
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivity(activities.EvaluateSinglePolicy)
+
+	encoded, err := env.ExecuteActivity(activities.EvaluateSinglePolicy, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var result EvaluateSinglePolicyResult
+	require.NoError(t, encoded.Get(&result))
+	return &result, nil
+}
+
+func TestEvaluateRuleRejectsInvalidOutput(t *testing.T) {
+	tests := map[string]string{
+		"scalar rule": `package nuon
+deny := true`,
+		"unsupported violation type": `package nuon
+deny contains 42 if { true }`,
+		"object without message": `package nuon
+deny contains {"reason": "blocked"} if { true }`,
+		"empty message": `package nuon
+deny contains "" if { true }`,
+	}
+
+	for name, policy := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := (&Activities{}).evaluateRule(context.Background(), zap.NewNop(), policy, map[string]interface{}{}, "data.nuon.deny", "deny")
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestEvaluateRule_EmptyInput(t *testing.T) {

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/prep_policy_evaluation.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/prep_policy_evaluation.go
@@ -11,6 +11,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/pkg/config"
+	pulumiworkspace "github.com/nuonco/nuon/pkg/pulumi/workspace"
 	"github.com/nuonco/nuon/pkg/temporal/temporalzap"
 	plan "github.com/nuonco/nuon/pkg/types/approvals"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
@@ -209,6 +210,7 @@ func (a *Activities) resolveSandboxPolicyContext(ctx context.Context, sandboxRun
 	var sandboxRun app.InstallSandboxRun
 	res := a.db.WithContext(ctx).
 		Preload("Install.App.Org").
+		Preload("AppSandboxConfig").
 		First(&sandboxRun, "id = ?", sandboxRunID)
 	if res.Error != nil {
 		return nil, errors.Wrap(res.Error, "unable to get sandbox run")
@@ -222,6 +224,7 @@ func (a *Activities) resolveSandboxPolicyContext(ctx context.Context, sandboxRun
 		InstallSandboxID: sandboxRun.InstallSandboxID,
 		ComponentType:    "",
 		ComponentName:    "",
+		SandboxType:      sandboxRun.AppSandboxConfig.Type,
 		IsSandbox:        true,
 		OrgName:          sandboxRun.Install.App.Org.Name,
 		AppName:          sandboxRun.Install.App.Name,
@@ -296,7 +299,9 @@ func componentTypeToPolicyType(ct app.ComponentType) config.AppPolicyType {
 
 func (a *Activities) preparePolicyInputs(planContentsJSON []byte, pctx *policyContext) ([][]byte, []string, error) {
 	switch {
-	case pctx.IsSandbox, pctx.ComponentType == app.ComponentTypeTerraformModule, pctx.ComponentType == app.ComponentTypePulumi:
+	case pctx.IsSandbox && pctx.SandboxType == config.AppSandboxTypePulumi, pctx.ComponentType == app.ComponentTypePulumi:
+		return a.preparePulumiPolicyInputs(planContentsJSON, pctx)
+	case pctx.IsSandbox, pctx.ComponentType == app.ComponentTypeTerraformModule:
 		return a.prepareTerraformPolicyInputs(planContentsJSON, pctx)
 	case pctx.ComponentType == app.ComponentTypeHelmChart:
 		return a.prepareHelmPolicyInputs(planContentsJSON)
@@ -305,6 +310,26 @@ func (a *Activities) preparePolicyInputs(planContentsJSON []byte, pctx *policyCo
 	default:
 		return nil, nil, fmt.Errorf("unsupported component type for policy input preparation: %s", pctx.ComponentType)
 	}
+}
+
+func (a *Activities) preparePulumiPolicyInputs(planContentsJSON []byte, pctx *policyContext) ([][]byte, []string, error) {
+	var preview pulumiworkspace.PreviewResult
+	if err := json.Unmarshal(planContentsJSON, &preview); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to parse pulumi preview")
+	}
+	if preview.ChangeSummary == nil {
+		return nil, nil, fmt.Errorf("pulumi preview is missing change_summary")
+	}
+
+	identity := "pulumi-plan"
+	if pctx.ComponentID != nil {
+		identity = fmt.Sprintf("component:%s", *pctx.ComponentID)
+		if pctx.ComponentName != "" {
+			identity = fmt.Sprintf("component:%s (%s)", *pctx.ComponentID, pctx.ComponentName)
+		}
+	}
+
+	return [][]byte{planContentsJSON}, []string{identity}, nil
 }
 
 func (a *Activities) prepareTerraformPolicyInputs(planContentsJSON []byte, pctx *policyContext) ([][]byte, []string, error) {
@@ -350,7 +375,7 @@ func (a *Activities) prepareKubernetesManifestPolicyInputs(planContentsJSON []by
 		return nil, nil, errors.Wrap(err, "failed to unmarshal kubernetes manifest plan contents")
 	}
 
-	return a.yamlToAdmissionReviewInputs(planContents.DryRunOutput, planOpToAdmissionOperation(string(planContents.Op)), planContentsJSON)
+	return a.yamlToAdmissionReviewInputs(planContents.DryRunOutput, planOpToAdmissionOperation(string(planContents.Op)))
 }
 
 func (a *Activities) prepareHelmPolicyInputs(planContentsJSON []byte) ([][]byte, []string, error) {
@@ -362,7 +387,7 @@ func (a *Activities) prepareHelmPolicyInputs(planContentsJSON []byte) ([][]byte,
 		return nil, nil, errors.Wrap(err, "failed to unmarshal helm plan contents")
 	}
 
-	return a.yamlToAdmissionReviewInputs(planContents.TemplateOutput, planOpToAdmissionOperation(planContents.Op), planContentsJSON)
+	return a.yamlToAdmissionReviewInputs(planContents.TemplateOutput, planOpToAdmissionOperation(planContents.Op))
 }
 
 // planOpToAdmissionOperation maps a helm/kubernetes plan op to the admission
@@ -380,14 +405,14 @@ func planOpToAdmissionOperation(op string) string {
 	}
 }
 
-func (a *Activities) yamlToAdmissionReviewInputs(yamlManifests string, operation string, fallback []byte) ([][]byte, []string, error) {
+func (a *Activities) yamlToAdmissionReviewInputs(yamlManifests string, operation string) ([][]byte, []string, error) {
 	admissionReviews, err := plan.ParseMultiDocYAMLToAdmissionReviews(yamlManifests)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to parse manifests to admission reviews")
 	}
 
 	if len(admissionReviews) == 0 {
-		return [][]byte{fallback}, []string{"unknown"}, nil
+		return nil, nil, fmt.Errorf("rendered plan contains no Kubernetes manifests for policy evaluation")
 	}
 
 	inputs := make([][]byte, len(admissionReviews))

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/prep_policy_evaluation_test.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/prep_policy_evaluation_test.go
@@ -1,0 +1,111 @@
+package activities
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/pkg/config"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+func TestPreparePolicyInputsPulumi(t *testing.T) {
+	preview := []byte(`{
+		"stdout": "preview",
+		"change_summary": {"create": 1},
+		"resource_changes": [{
+			"urn": "urn:pulumi:dev::app::aws:s3/bucket:Bucket::assets",
+			"type": "aws:s3/bucket:Bucket",
+			"name": "assets",
+			"action": "create",
+			"new_inputs": {"acl": "private"}
+		}]
+	}`)
+
+	tests := map[string]*policyContext{
+		"component": {
+			ComponentType: app.ComponentTypePulumi,
+			ComponentID:   ptrString("component-id"),
+			ComponentName: "infrastructure",
+		},
+		"sandbox": {
+			IsSandbox:   true,
+			SandboxType: config.AppSandboxTypePulumi,
+		},
+	}
+
+	for name, pctx := range tests {
+		t.Run(name, func(t *testing.T) {
+			inputs, identities, err := (&Activities{}).preparePolicyInputs(preview, pctx)
+			require.NoError(t, err)
+			require.Len(t, inputs, 1)
+			require.Len(t, identities, 1)
+
+			var input map[string]any
+			require.NoError(t, json.Unmarshal(inputs[0], &input))
+			assert.Contains(t, input, "resource_changes")
+			assert.NotContains(t, input, "plan")
+		})
+	}
+}
+
+func TestPreparePolicyInputsTerraformSandbox(t *testing.T) {
+	inputs, _, err := (&Activities{}).preparePolicyInputs([]byte(fakeTerraformPlanDisplayContents), &policyContext{
+		IsSandbox:   true,
+		SandboxType: config.AppSandboxTypeTerraform,
+	})
+	require.NoError(t, err)
+	require.Len(t, inputs, 1)
+
+	var input map[string]any
+	require.NoError(t, json.Unmarshal(inputs[0], &input))
+	assert.Contains(t, input, "plan")
+}
+
+func TestPreparePulumiPolicyInputsRejectsWrongShape(t *testing.T) {
+	_, _, err := (&Activities{}).preparePulumiPolicyInputs([]byte(`{"resource_changes": []}`), &policyContext{})
+	require.ErrorContains(t, err, "missing change_summary")
+}
+
+func TestPrepareKubernetesPolicyInputsRejectEmptyRender(t *testing.T) {
+	tests := map[string]func() error{
+		"helm": func() error {
+			_, _, err := (&Activities{}).prepareHelmPolicyInputs([]byte(`{"op":"install","template_output":""}`))
+			return err
+		},
+		"kubernetes manifest": func() error {
+			_, _, err := (&Activities{}).prepareKubernetesManifestPolicyInputs([]byte(`{"op":"apply","dry_run_output":""}`))
+			return err
+		},
+	}
+
+	for name, evaluate := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorContains(t, evaluate(), "contains no Kubernetes manifests")
+		})
+	}
+}
+
+func TestPrepareKubernetesManifestDeletePolicyInputs(t *testing.T) {
+	planContents := []byte(`{
+		"op": "delete",
+		"dry_run_output": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: settings\n  namespace: default\n"
+	}`)
+
+	inputs, identities, err := (&Activities{}).prepareKubernetesManifestPolicyInputs(planContents)
+	require.NoError(t, err)
+	require.Len(t, inputs, 1)
+	assert.Equal(t, []string{"ConfigMap/default/settings"}, identities)
+
+	var input map[string]any
+	require.NoError(t, json.Unmarshal(inputs[0], &input))
+	review := input["review"].(map[string]any)
+	assert.Equal(t, "DELETE", review["operation"])
+	assert.Equal(t, "settings", review["object"].(map[string]any)["metadata"].(map[string]any)["name"])
+}
+
+func ptrString(value string) *string {
+	return &value
+}

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/record_policy_evaluation_composite_error.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/record_policy_evaluation_composite_error.go
@@ -11,13 +11,15 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/policy_reports/policyerrors"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/scopes"
 )
 
 type RecordPolicyEvaluationCompositeErrorRequest struct {
-	WorkflowStepID string `validate:"required"`
-	StepTargetID   string `validate:"required"`
-	StepTargetType string `validate:"required"`
-	Stage          policyerrors.EvaluationFailureStage
+	WorkflowStepID string                              `json:"workflow_step_id" temporaljson:"workflow_step_id,omitempty" validate:"required_without=RunnerJobID"`
+	StepTargetID   string                              `json:"step_target_id" temporaljson:"step_target_id,omitempty" validate:"required_without=RunnerJobID"`
+	StepTargetType string                              `json:"step_target_type" temporaljson:"step_target_type,omitempty" validate:"required_without=RunnerJobID"`
+	RunnerJobID    string                              `json:"runner_job_id" temporaljson:"runner_job_id,omitempty"`
+	Stage          policyerrors.EvaluationFailureStage `json:"stage" temporaljson:"stage,omitempty"`
 }
 
 // @temporal-gen-v2 activity
@@ -27,8 +29,16 @@ func (a *Activities) RecordPolicyEvaluationCompositeError(ctx context.Context, r
 		zap.String("workflow_step_id", req.WorkflowStepID),
 		zap.String("step_target_id", req.StepTargetID),
 		zap.String("step_target_type", req.StepTargetType),
+		zap.String("runner_job_id", req.RunnerJobID),
 		zap.String("stage", string(req.Stage)),
 	)
+
+	if req.RunnerJobID != "" {
+		return a.recordRunnerJobPolicyEvaluationCompositeError(ctx, l, req)
+	}
+	if req.WorkflowStepID == "" || req.StepTargetID == "" || req.StepTargetType == "" {
+		return fmt.Errorf("workflow step id, step target id, and step target type are required")
+	}
 
 	data, err := compositeerrors.New(
 		&policyerrors.EvaluationFailedError{Stage: req.Stage},
@@ -58,6 +68,31 @@ func (a *Activities) RecordPolicyEvaluationCompositeError(ctx context.Context, r
 	}
 	if res.RowsAffected < 1 {
 		return fmt.Errorf("no policy evaluation target found for id %s: %w", req.StepTargetID, gorm.ErrRecordNotFound)
+	}
+
+	l.Info("recorded policy evaluation composite error")
+	return nil
+}
+
+func (a *Activities) recordRunnerJobPolicyEvaluationCompositeError(ctx context.Context, l *zap.Logger, req RecordPolicyEvaluationCompositeErrorRequest) error {
+	data, err := compositeerrors.New(
+		&policyerrors.EvaluationFailedError{Stage: req.Stage},
+		compositeerrors.WithSource("runner_jobs", req.RunnerJobID),
+	)
+	if err != nil {
+		return fmt.Errorf("unable to build policy evaluation composite error: %w", err)
+	}
+
+	res := a.db.WithContext(ctx).
+		Scopes(scopes.WithDisableViews).
+		Model(&app.RunnerJob{ID: req.RunnerJobID}).
+		Select("composite_error").
+		Updates(app.RunnerJob{CompositeError: data})
+	if res.Error != nil {
+		return fmt.Errorf("unable to record policy evaluation composite error: %w", res.Error)
+	}
+	if res.RowsAffected < 1 {
+		return fmt.Errorf("no runner job found for id %s: %w", req.RunnerJobID, gorm.ErrRecordNotFound)
 	}
 
 	l.Info("recorded policy evaluation composite error")

--- a/services/ctl-api/internal/pkg/workflows/workflow/activities/record_policy_evaluation_composite_error_test.go
+++ b/services/ctl-api/internal/pkg/workflows/workflow/activities/record_policy_evaluation_composite_error_test.go
@@ -1,0 +1,48 @@
+package activities
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/policy_reports/policyerrors"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/compositeerrors"
+)
+
+func TestRecordPolicyEvaluationCompositeErrorForRunnerJob(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		CREATE TABLE runner_jobs (
+			id TEXT PRIMARY KEY,
+			updated_at DATETIME,
+			deleted_at INTEGER NOT NULL DEFAULT 0,
+			composite_error TEXT
+		);
+		INSERT INTO runner_jobs (id) VALUES ('job-1');
+	`).Error)
+
+	activities := &Activities{db: db}
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivity(activities.RecordPolicyEvaluationCompositeError)
+
+	_, err = env.ExecuteActivity(activities.RecordPolicyEvaluationCompositeError, RecordPolicyEvaluationCompositeErrorRequest{
+		RunnerJobID: "job-1",
+		Stage:       policyerrors.EvaluationFailureStageEvaluation,
+	})
+	require.NoError(t, err)
+
+	var raw string
+	require.NoError(t, db.Raw(`SELECT composite_error FROM runner_jobs WHERE id = 'job-1'`).Scan(&raw).Error)
+	var data compositeerrors.CompositeErrorData
+	require.NoError(t, json.Unmarshal([]byte(raw), &data))
+	require.Equal(t, policyerrors.EvaluationFailedErrorType, data.Type)
+	require.Equal(t, compositeerrors.SeverityWarning, data.Severity)
+	require.Equal(t, "runner_jobs", data.SourceType)
+	require.Equal(t, "job-1", data.SourceID)
+}


### PR DESCRIPTION
Validate OPA policies during config ingestion and evaluation, require the nuon package and deny or warn decisions, and reject malformed decision result shapes instead of silently ignoring them.

Prepare policy inputs consistently for Terraform, Pulumi, Helm, and Kubernetes plans. Preserve sandbox type context, include resources in Kubernetes delete plans, classify empty Helm uninstalls as no-ops, and report actionable plans that render no manifests as evaluation failures.

Route component build signals through the canonical policy-aware workflow so Helm and external-image checks run for normal app builds. Drain parallel evaluations, avoid persisting partial reports, keep evaluation and report persistence failures non-blocking, expose them as warning CompositeErrors, and emit outcome and failure-stage metrics. Prevent policy auto-approval when evaluation or persistence is incomplete and surface warning errors from otherwise successful runner jobs.

Run no-op and plan-only handling before policy auto-approval, and scope approval reads and responses to the workflow step that owns them.

### Summary

This PR makes multiple fixes around policy evaluation:
- Validate OPA package, decision, syntax, and result-shape contracts at sync and runtime.
- Prepare correct Terraform, Pulumi, Helm, and Kubernetes policy inputs for components and sandboxes.
- Include Kubernetes delete resources, handle empty Helm uninstalls, and warn on actionable empty renders.
- Route normal component builds through the canonical workflow so Helm and external-image policies execute.
- Drain evaluations, avoid partial reports, and surface evaluation or persistence failures as non-blocking warning CompositeErrors and metrics.
- Prevent incomplete policy checks from auto-approving and preserve no-op and plan-only behavior.
- Expose policy warnings from successful runner jobs and scope approvals to their owning workflow steps.