### PR TITLE
fix(ui): declutter install resources and 90-day health

### DIFF
--- a/services/dashboard-ui/client/components/install-health/HealthTimeline/HealthTimeline.stories.tsx
+++ b/services/dashboard-ui/client/components/install-health/HealthTimeline/HealthTimeline.stories.tsx
@@ -78,7 +78,37 @@ const mockComponents: TInstallHealthTimelineComponent[] = [
   },
 ]
 
+const mockNoSignalComponents: TInstallHealthTimelineComponent[] = [
+  {
+    install_component_id: 'icmp4',
+    component_name: 'networking',
+    current_health: 'not-applicable',
+    uptime_percent: 0,
+  },
+  {
+    install_component_id: 'icmp5',
+    component_name: 'secrets',
+    current_health: 'unknown',
+    uptime_percent: 0,
+  },
+  {
+    install_component_id: 'icmp6',
+    component_name: 'dns',
+    current_health: 'not-applicable',
+    uptime_percent: 0,
+  },
+]
+
 const mockTransitions: TInstallComponentHealthTransition[] = [
+  {
+    from_health: 'unhealthy',
+    to_health: 'healthy',
+    message: 'Pod api-7d9f8 recovered',
+    root_resource_kind: 'Deployment',
+    root_resource_namespace: 'default',
+    root_resource_name: 'api',
+    observed_at: DateTime.now().minus({ hours: 1 }).toISO()!,
+  },
   {
     from_health: 'healthy',
     to_health: 'unhealthy',
@@ -89,15 +119,6 @@ const mockTransitions: TInstallComponentHealthTransition[] = [
     correlated_deploy_id: 'dep_9f8a3c',
     diagnosis: 'Container was OOMKilled after hitting its memory limit.',
     observed_at: DateTime.now().minus({ hours: 3 }).toISO()!,
-  },
-  {
-    from_health: 'unhealthy',
-    to_health: 'healthy',
-    message: 'Pod api-7d9f8 recovered',
-    root_resource_kind: 'Deployment',
-    root_resource_namespace: 'default',
-    root_resource_name: 'api',
-    observed_at: DateTime.now().minus({ hours: 1 }).toISO()!,
   },
   {
     from_health: 'healthy',
@@ -116,6 +137,32 @@ export const InstallScope = () => (
     observedSeconds={90 * 86400}
     currentHealth="healthy"
     components={mockComponents}
+    componentBasePath="/org123/installs/inst123/components"
+  />
+)
+
+export const InstallScopeWithNoSignalComponents = () => (
+  <HealthTimeline
+    scope="install"
+    days={90}
+    daily={buildDaily(90)}
+    uptimePercent={99.42}
+    observedSeconds={90 * 86400}
+    currentHealth="healthy"
+    components={[...mockComponents, ...mockNoSignalComponents]}
+    componentBasePath="/org123/installs/inst123/components"
+  />
+)
+
+export const InstallScopeAllNoSignalComponents = () => (
+  <HealthTimeline
+    scope="install"
+    days={90}
+    daily={buildDaily(90)}
+    uptimePercent={99.42}
+    observedSeconds={90 * 86400}
+    currentHealth="unknown"
+    components={mockNoSignalComponents}
     componentBasePath="/org123/installs/inst123/components"
   />
 )

--- a/services/dashboard-ui/client/components/install-health/HealthTimeline/HealthTimeline.tsx
+++ b/services/dashboard-ui/client/components/install-health/HealthTimeline/HealthTimeline.tsx
@@ -1,5 +1,6 @@
 import type React from 'react'
 import { Divider } from '@/components/common/Divider'
+import { Expand } from '@/components/common/Expand'
 import { EmptyState } from '@/components/common/EmptyState/EmptyState'
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Duration } from '@/components/common/Duration'
@@ -17,6 +18,10 @@ import type {
   TInstallHealthTimelineComponent,
 } from '@/types'
 import { cn } from '@/utils/classnames'
+import {
+  bearsHealthVerdict,
+  compareHealthSeverityDesc,
+} from '@/utils/health-utils'
 import { kebabToWords, toSentenceCase } from '@/utils/string-utils'
 import { formatToRelativeDay } from '@/utils/timeline-utils'
 
@@ -148,6 +153,43 @@ function dayAriaLabel(day: THealthTimelineDay): string {
   }`
 }
 
+function ComponentHealthRows({
+  components,
+  componentBasePath,
+  className,
+}: {
+  components: TInstallHealthTimelineComponent[]
+  componentBasePath?: string
+  className?: string
+}) {
+  return (
+    <div className={cn('flex flex-col gap-2', className)}>
+      {components.map((component) => (
+        <div
+          key={component.install_component_id}
+          className="flex items-center justify-between gap-3"
+        >
+          {/* Component routes are keyed by component_id; linking with the
+              install-component id dead-ends on an empty page. */}
+          {componentBasePath && component.component_id ? (
+            <Link href={`${componentBasePath}/${component.component_id}`}>
+              {component.component_name || component.component_id}
+            </Link>
+          ) : (
+            <Text>{component.component_name || component.install_component_id}</Text>
+          )}
+          <div className="flex items-center gap-3 shrink-0">
+            <Status status={component.current_health || 'unknown'} variant="badge" />
+            <Text variant="subtext" theme="neutral" className="w-16 text-right">
+              {formatUptime(component.uptime_percent, component.observed_seconds)}
+            </Text>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export interface IHealthTimeline {
   className?: string
   headerAction?: React.ReactNode
@@ -196,13 +238,31 @@ export const HealthTimeline = ({
   const hasOverallData = (observedSeconds ?? 0) > 0
   const hasDaily = !!daily?.length
 
+  const ranked = [...(components ?? [])].sort(
+    (a, b) =>
+      compareHealthSeverityDesc(a.current_health, b.current_health) ||
+      (a.uptime_percent ?? 100) - (b.uptime_percent ?? 100) ||
+      (a.component_name || '').localeCompare(b.component_name || '')
+  )
+  const assessed = ranked.filter((component) =>
+    bearsHealthVerdict(component.current_health)
+  )
+  const unassessed = ranked.filter(
+    (component) => !bearsHealthVerdict(component.current_health)
+  )
+
   return (
     <div className={cn('flex flex-col gap-4', className)}>
       <div className="flex items-center justify-between gap-4 flex-wrap">
         <HeadingGroup>
-          <Text variant="body" weight="strong">
-            {days}-day health
-          </Text>
+          <span className="flex items-center gap-2">
+            <Text variant="body" weight="strong">
+              {days}-day health
+            </Text>
+            {currentHealth ? (
+              <Status variant="badge" status={currentHealth} />
+            ) : null}
+          </span>
           <Text variant="subtext" theme="neutral">
             {hasOverallData
               ? `${formatUptime(uptimePercent, observedSeconds)} uptime over the last ${days} days`
@@ -219,17 +279,27 @@ export const HealthTimeline = ({
       ) : null}
 
       {hasDaily ? (
-        <HealthBars
-          animated
-          grow
-          barClassName="h-8 rounded-xs"
-          bars={daily!.map((day, idx) => ({
-            key: day?.date || idx,
-            colorClass: dayBarClass(day),
-            ariaLabel: dayAriaLabel(day),
-            tooltip: <DayTooltipContent day={day} />,
-          }))}
-        />
+        <div className="flex flex-col gap-1.5">
+          <HealthBars
+            animated
+            grow
+            barClassName="h-8 rounded-xs"
+            bars={daily!.map((day, idx) => ({
+              key: day?.date || idx,
+              colorClass: dayBarClass(day),
+              ariaLabel: dayAriaLabel(day),
+              tooltip: <DayTooltipContent day={day} />,
+            }))}
+          />
+          <div className="flex items-center justify-between">
+            <Text variant="label" theme="neutral">
+              {daily!.length} days ago
+            </Text>
+            <Text variant="label" theme="neutral">
+              Today
+            </Text>
+          </div>
+        </div>
       ) : (
         <EmptyState
           variant="history"
@@ -242,40 +312,32 @@ export const HealthTimeline = ({
       {components?.length ? (
         <>
           <Divider dividerWord="Components" />
-          <div className="flex flex-col gap-2">
-            {components.map((component) => (
-              <div
-                key={component.install_component_id}
-                className="flex items-center justify-between gap-3"
-              >
-                {/* Component routes are keyed by component_id; linking with the
-                    install-component id dead-ends on an empty page. */}
-                {componentBasePath && component.component_id ? (
-                  <Link href={`${componentBasePath}/${component.component_id}`}>
-                    {component.component_name || component.component_id}
-                  </Link>
-                ) : (
-                  <Text>{component.component_name || component.install_component_id}</Text>
-                )}
-                <div className="flex items-center gap-3 shrink-0">
-                  <Status
-                    status={component.current_health || 'unknown'}
-                    variant="badge"
-                  />
-                  <Text
-                    variant="subtext"
-                    theme="neutral"
-                    className="w-16 text-right"
-                  >
-                    {formatUptime(
-                      component.uptime_percent,
-                      component.observed_seconds
-                    )}
-                  </Text>
-                </div>
-              </div>
-            ))}
-          </div>
+          {assessed.length > 0 ? (
+            <ComponentHealthRows
+              components={assessed}
+              componentBasePath={componentBasePath}
+            />
+          ) : null}
+          {unassessed.length > 0 ? (
+            <Expand
+              id="health-timeline-unassessed-components"
+              isIconBeforeHeading
+              headerClassName="!px-0 !justify-start"
+              heading={
+                <Text variant="subtext" theme="neutral">
+                  {unassessed.length}{' '}
+                  {unassessed.length === 1 ? 'component' : 'components'} with no
+                  health signal
+                </Text>
+              }
+            >
+              <ComponentHealthRows
+                className="pt-2"
+                components={unassessed}
+                componentBasePath={componentBasePath}
+              />
+            </Expand>
+          ) : null}
         </>
       ) : null}
 

--- a/services/dashboard-ui/client/components/install-health/HealthTimeline/HealthTimeline.tsx
+++ b/services/dashboard-ui/client/components/install-health/HealthTimeline/HealthTimeline.tsx
@@ -322,6 +322,9 @@ export const HealthTimeline = ({
             <Expand
               id="health-timeline-unassessed-components"
               isIconBeforeHeading
+              // Most installs have no probed components at all; collapsing the
+              // only list there is would leave the card looking broken.
+              isOpen={assessed.length === 0}
               headerClassName="!px-0 !justify-start"
               heading={
                 <Text variant="subtext" theme="neutral">

--- a/services/dashboard-ui/client/components/install-resources/InstallResourcesTable/InstallResourcesTable.stories.tsx
+++ b/services/dashboard-ui/client/components/install-resources/InstallResourcesTable/InstallResourcesTable.stories.tsx
@@ -3,12 +3,16 @@ export default {
 }
 
 import { useState } from 'react'
+import { useSearchParams } from 'react-router'
 import { SurfacesProvider } from '@/providers/surfaces-provider'
 import type { TInstallResource } from '@/types'
 import {
   groupComponentResources,
   groupSandboxResources,
+  healthFacetCounts,
   InstallResourcesTable,
+  matchesHealthFilter,
+  matchesResourceSearch,
 } from './InstallResourcesTable'
 
 const mockResources: TInstallResource[] = [
@@ -93,7 +97,14 @@ const mockResources: TInstallResource[] = [
   },
 ]
 
-const componentNames = { 'instcmp-1': 'web', 'instcmp-2': 'database' }
+const componentNames = {
+  'instcmp-1': 'web',
+  'instcmp-2': 'database',
+  'instcmp-3': 'config',
+  'instcmp-4': 'iam',
+  'instcmp-5': 'workers',
+  'instcmp-6': 'payments',
+}
 
 const InstallResourcesTableStory = ({
   resources,
@@ -103,23 +114,27 @@ const InstallResourcesTableStory = ({
   const [kind, setKind] = useState('')
   const [namespace, setNamespace] = useState('')
   const [health, setHealth] = useState('')
+  const [searchParams] = useSearchParams()
+  const search = searchParams.get('q') ?? ''
 
-  const filtered = resources.filter((r) => {
+  const scoped = resources.filter((r) => {
     if (kind && r.kind !== kind) return false
     if (namespace && r.namespace !== namespace) return false
-    if (health && r.health !== health) return false
-    return true
+    return matchesResourceSearch(r, search)
   })
+  const filtered = scoped.filter((r) => matchesHealthFilter(r, health))
 
   return (
     <SurfacesProvider>
       <InstallResourcesTable
         componentGroups={groupComponentResources(filtered, componentNames)}
         sandboxGroups={groupSandboxResources(filtered)}
+        healthCounts={healthFacetCounts(scoped)}
         isLoading={false}
         kind={kind}
         namespace={namespace}
         health={health}
+        search={search}
         kindOptions={Array.from(
           new Set(resources.map((r) => r.kind).filter((v): v is string => !!v))
         ).sort()}
@@ -136,18 +151,131 @@ const InstallResourcesTableStory = ({
   )
 }
 
+const noSignalResources: TInstallResource[] = [
+  {
+    install_component_id: 'instcmp-3',
+    component_id: 'component-3',
+    source: 'component',
+    kind: 'ConfigMap',
+    namespace: 'default',
+    name: 'app-settings',
+    health: 'not-applicable',
+    message: '',
+    provider: 'kubernetes',
+    observed_at: new Date().toISOString(),
+  },
+  {
+    install_component_id: 'instcmp-3',
+    component_id: 'component-3',
+    source: 'component',
+    kind: 'Job',
+    namespace: 'default',
+    name: 'migrate',
+    health: 'unknown',
+    message: 'No probe could be run against this resource.',
+    provider: 'kubernetes',
+    observed_at: new Date().toISOString(),
+  },
+  {
+    install_component_id: 'instcmp-4',
+    component_id: 'component-4',
+    source: 'component',
+    kind: 'aws_iam_role',
+    namespace: '',
+    name: 'acme-app-role',
+    health: 'unknown',
+    message: '',
+    provider: 'aws',
+    observed_at: new Date().toISOString(),
+  },
+  {
+    install_component_id: 'instcmp-1',
+    component_id: 'component-1',
+    source: 'component',
+    kind: 'Secret',
+    namespace: 'default',
+    name: 'web-app-tls',
+    health: 'unknown',
+    message: '',
+    provider: 'kubernetes',
+    observed_at: new Date().toISOString(),
+    removed_from_config: true,
+  },
+]
+
+const largeHealthyGroup: TInstallResource[] = Array.from(
+  { length: 12 },
+  (_, idx) => ({
+    install_component_id: 'instcmp-5',
+    component_id: 'component-5',
+    source: 'component',
+    kind: 'Pod',
+    namespace: 'workers',
+    name: `worker-${idx}`,
+    health: 'healthy',
+    message: '',
+    provider: 'kubernetes',
+    observed_at: new Date().toISOString(),
+  })
+)
+
+const staleGroup: TInstallResource[] = [
+  {
+    install_component_id: 'instcmp-6',
+    component_id: 'component-6',
+    source: 'component',
+    kind: 'Deployment',
+    namespace: 'payments',
+    name: 'payments-api',
+    health: 'healthy',
+    message: '',
+    provider: 'kubernetes',
+    observed_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    install_component_id: 'instcmp-6',
+    component_id: 'component-6',
+    source: 'component',
+    kind: 'Service',
+    namespace: 'payments',
+    name: 'payments-api-svc',
+    health: 'healthy',
+    message: '',
+    provider: 'kubernetes',
+    observed_at: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+  },
+]
+
 export const Default = () => (
   <InstallResourcesTableStory resources={mockResources} />
+)
+
+export const WithStaleGroup = () => (
+  <InstallResourcesTableStory resources={[...mockResources, ...staleGroup]} />
+)
+
+export const WithNoSignalResources = () => (
+  <InstallResourcesTableStory
+    resources={[...mockResources, ...noSignalResources]}
+  />
+)
+
+export const WithLargeHealthyGroup = () => (
+  <InstallResourcesTableStory
+    resources={[...mockResources, ...noSignalResources, ...largeHealthyGroup]}
+  />
 )
 
 export const Loading = () => (
   <InstallResourcesTable
     componentGroups={[]}
     sandboxGroups={[]}
+    healthCounts={{}}
     isLoading
     kind=""
     namespace=""
     health=""
+    search=""
     kindOptions={[]}
     namespaceOptions={[]}
     onKindChange={() => {}}
@@ -160,10 +288,12 @@ export const Empty = () => (
   <InstallResourcesTable
     componentGroups={[]}
     sandboxGroups={[]}
+    healthCounts={{}}
     isLoading={false}
     kind=""
     namespace=""
     health=""
+    search=""
     kindOptions={[]}
     namespaceOptions={[]}
     onKindChange={() => {}}

--- a/services/dashboard-ui/client/components/install-resources/InstallResourcesTable/InstallResourcesTable.test.ts
+++ b/services/dashboard-ui/client/components/install-resources/InstallResourcesTable/InstallResourcesTable.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from 'bun:test'
+import type { TInstallResource } from '@/types'
+import { DateTime } from 'luxon'
+import {
+  groupComponentResources,
+  hasHealthSignal,
+  healthFacetCounts,
+  matchesHealthFilter,
+  matchesResourceSearch,
+  NO_SIGNAL_FILTER,
+  visibleRowCount,
+} from './InstallResourcesTable'
+
+const now = DateTime.now().toISO()
+const longAgo = DateTime.now().minus({ hours: 2 }).toISO()
+
+function resource(overrides: Partial<TInstallResource>): TInstallResource {
+  return {
+    install_component_id: 'instcmp-1',
+    source: 'component',
+    kind: 'Deployment',
+    namespace: 'default',
+    name: 'web',
+    health: 'healthy',
+    provider: 'kubernetes',
+    observed_at: now,
+    ...overrides,
+  } as TInstallResource
+}
+
+describe('hasHealthSignal', () => {
+  test('assessed kubernetes resources carry signal', () => {
+    expect(hasHealthSignal(resource({ health: 'degraded' }))).toBe(true)
+  })
+
+  test('unknown and not-applicable carry none', () => {
+    expect(hasHealthSignal(resource({ health: 'unknown' }))).toBe(false)
+    expect(hasHealthSignal(resource({ health: 'not-applicable' }))).toBe(false)
+  })
+
+  test('cloud identity rows never carry signal, even if assessed', () => {
+    expect(hasHealthSignal(resource({ provider: 'aws', health: 'healthy' }))).toBe(false)
+    expect(hasHealthSignal(resource({ provider: 'gcp', health: 'healthy' }))).toBe(false)
+    expect(hasHealthSignal(resource({ provider: 'azure', health: 'healthy' }))).toBe(false)
+  })
+
+  test('rows removed from config carry none', () => {
+    expect(hasHealthSignal(resource({ removed_from_config: true }))).toBe(false)
+  })
+})
+
+describe('matchesHealthFilter', () => {
+  test('an empty filter matches everything', () => {
+    expect(matchesHealthFilter(resource({ health: 'unknown' }), '')).toBe(true)
+  })
+
+  test('an exact status filter matches on status', () => {
+    expect(matchesHealthFilter(resource({ health: 'degraded' }), 'degraded')).toBe(true)
+    expect(matchesHealthFilter(resource({ health: 'healthy' }), 'degraded')).toBe(false)
+  })
+
+  test('the no-signal filter matches every unassessed row', () => {
+    expect(matchesHealthFilter(resource({ health: 'unknown' }), NO_SIGNAL_FILTER)).toBe(true)
+    expect(
+      matchesHealthFilter(resource({ provider: 'aws', health: 'healthy' }), NO_SIGNAL_FILTER)
+    ).toBe(true)
+    expect(matchesHealthFilter(resource({ health: 'healthy' }), NO_SIGNAL_FILTER)).toBe(false)
+  })
+})
+
+describe('healthFacetCounts', () => {
+  test('buckets every unassessed row under no-signal', () => {
+    const counts = healthFacetCounts([
+      resource({ health: 'healthy' }),
+      resource({ health: 'healthy' }),
+      resource({ health: 'unhealthy' }),
+      resource({ health: 'unknown' }),
+      resource({ health: 'not-applicable' }),
+      resource({ provider: 'aws', health: 'healthy' }),
+    ])
+    expect(counts).toEqual({ healthy: 2, unhealthy: 1, [NO_SIGNAL_FILTER]: 3 })
+  })
+})
+
+describe('groupComponentResources', () => {
+  const groups = groupComponentResources(
+    [
+      resource({ install_component_id: 'a', name: 'a-ok', health: 'healthy' }),
+      resource({ install_component_id: 'a', name: 'a-cm', health: 'not-applicable' }),
+      resource({ install_component_id: 'b', name: 'b-bad', health: 'unhealthy' }),
+      resource({ install_component_id: 'b', name: 'b-ok', health: 'healthy' }),
+      resource({ install_component_id: 'c', name: 'c-iam', provider: 'aws' }),
+    ],
+    { a: 'alpha', b: 'bravo', c: 'charlie' }
+  )
+
+  test('sorts groups worst-health-first, not alphabetically', () => {
+    expect(groups.map((g) => g.heading)).toEqual(['bravo', 'alpha', 'charlie'])
+  })
+
+  test('splits each group into signal and no-signal rows', () => {
+    const alpha = groups.find((g) => g.heading === 'alpha')!
+    expect(alpha.signalRows.map((r) => r.name)).toEqual(['a-ok'])
+    expect(alpha.noSignalRows.map((r) => r.name)).toEqual(['a-cm'])
+  })
+
+  test('a group of only identity rows has no signal rows at all', () => {
+    const charlie = groups.find((g) => g.heading === 'charlie')!
+    expect(charlie.signalRows).toHaveLength(0)
+    expect(charlie.noSignalRows).toHaveLength(1)
+  })
+
+  test('sorts rows within a group worst-first', () => {
+    const bravo = groups.find((g) => g.heading === 'bravo')!
+    expect(bravo.rows.map((r) => r.name)).toEqual(['b-bad', 'b-ok'])
+  })
+
+  test('counts failing live rows', () => {
+    const bravo = groups.find((g) => g.heading === 'bravo')!
+    expect(bravo.failing).toBe(1)
+    expect(bravo.live).toBe(2)
+    expect(bravo.worst).toBe('unhealthy')
+  })
+})
+
+describe('matchesResourceSearch', () => {
+  test('an empty search matches everything', () => {
+    expect(matchesResourceSearch(resource({}), '')).toBe(true)
+    expect(matchesResourceSearch(resource({}), '   ')).toBe(true)
+  })
+
+  test('matches name, kind, and namespace case-insensitively', () => {
+    const r = resource({ name: 'web-app', kind: 'Deployment', namespace: 'prod' })
+    expect(matchesResourceSearch(r, 'WEB')).toBe(true)
+    expect(matchesResourceSearch(r, 'deploy')).toBe(true)
+    expect(matchesResourceSearch(r, 'PROD')).toBe(true)
+    expect(matchesResourceSearch(r, 'postgres')).toBe(false)
+  })
+})
+
+describe('group staleness', () => {
+  test('a group is fully stale only when every reporting row is stale', () => {
+    const [group] = groupComponentResources(
+      [
+        resource({ install_component_id: 'a', name: 'one', observed_at: longAgo }),
+        resource({ install_component_id: 'a', name: 'two', observed_at: longAgo }),
+      ],
+      { a: 'alpha' }
+    )
+    expect(group.fullyStale).toBe(true)
+    expect(group.lastReportedAt).toBe(longAgo)
+  })
+
+  test('one fresh row keeps the group reporting', () => {
+    const [group] = groupComponentResources(
+      [
+        resource({ install_component_id: 'a', name: 'one', observed_at: longAgo }),
+        resource({ install_component_id: 'a', name: 'two', observed_at: now }),
+      ],
+      { a: 'alpha' }
+    )
+    expect(group.fullyStale).toBe(false)
+    expect(group.lastReportedAt).toBe(now)
+  })
+
+  test('identity and removed rows cannot make a group look stale', () => {
+    const [group] = groupComponentResources(
+      [
+        resource({ install_component_id: 'a', provider: 'aws', observed_at: longAgo }),
+        resource({ install_component_id: 'a', removed_from_config: true, observed_at: longAgo }),
+      ],
+      { a: 'alpha' }
+    )
+    expect(group.fullyStale).toBe(false)
+  })
+})
+
+describe('group ordering with staleness', () => {
+  test('a silent group outranks healthy and progressing, but not a live failure', () => {
+    const groups = groupComponentResources(
+      [
+        resource({ install_component_id: 'a', health: 'healthy' }),
+        resource({ install_component_id: 'b', health: 'progressing' }),
+        resource({ install_component_id: 'c', health: 'healthy', observed_at: longAgo }),
+        resource({ install_component_id: 'd', health: 'unhealthy' }),
+      ],
+      { a: 'alpha', b: 'bravo', c: 'silent', d: 'broken' }
+    )
+    expect(groups.map((g) => g.heading)).toEqual([
+      'broken',
+      'silent',
+      'bravo',
+      'alpha',
+    ])
+  })
+})
+
+describe('visibleRowCount', () => {
+  function rowsFor(healths: string[]) {
+    return groupComponentResources(
+      healths.map((health, idx) =>
+        resource({ install_component_id: 'a', name: `r-${idx}`, health })
+      ),
+      { a: 'alpha' }
+    )[0].signalRows
+  }
+
+  test('shows every row when the group is small', () => {
+    const rows = rowsFor(['healthy', 'healthy', 'degraded'])
+    expect(rows.length).toBeLessThanOrEqual(visibleRowCount(rows))
+  })
+
+  test('folds only the healthy tail of a large group', () => {
+    const rows = rowsFor([...Array(20).fill('healthy'), 'degraded'])
+    const hidden = rows.slice(visibleRowCount(rows))
+    expect(hidden.length).toBe(13)
+    expect(hidden.every((row) => row.health === 'healthy')).toBe(true)
+  })
+
+  test('never folds a row that needs attention, however many there are', () => {
+    const rows = rowsFor([
+      ...Array(15).fill('unhealthy'),
+      ...Array(15).fill('healthy'),
+    ])
+    const visible = rows.slice(0, visibleRowCount(rows))
+    expect(visible.filter((row) => row.health === 'unhealthy')).toHaveLength(15)
+    expect(rows.slice(visibleRowCount(rows)).every((r) => r.health === 'healthy')).toBe(true)
+  })
+
+  test('progressing rows are never folded either', () => {
+    const rows = rowsFor([...Array(30).fill('healthy'), ...Array(4).fill('progressing')])
+    const hidden = rows.slice(visibleRowCount(rows))
+    expect(hidden.every((row) => row.health === 'healthy')).toBe(true)
+  })
+})

--- a/services/dashboard-ui/client/components/install-resources/InstallResourcesTable/InstallResourcesTable.tsx
+++ b/services/dashboard-ui/client/components/install-resources/InstallResourcesTable/InstallResourcesTable.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react'
 import type { ColumnDef } from '@tanstack/react-table'
 import { Button } from '@/components/common/Button'
+import { DebouncedSearchInput } from '@/components/common/DeboundedSearch'
 import { Dropdown } from '@/components/common/Dropdown'
 import { EmptyState } from '@/components/common/EmptyState'
+import { Expand } from '@/components/common/Expand'
 import { Icon } from '@/components/common/Icon'
 import { Menu } from '@/components/common/Menu'
 import { RadioInput } from '@/components/common/form/RadioInput'
@@ -15,15 +18,101 @@ import { InstallResourceDetailPanelButton } from '@/components/install-resources
 import { RemovedFromAppConfigBadge } from '@/components/installs/RemovedFromAppConfig/RemovedFromAppConfig'
 import { Badge } from '@/components/common/Badge'
 import type { TInstallResource } from '@/types'
-import { isStaleObservation } from '@/utils/time-utils'
+import { cn } from '@/utils/classnames'
+import {
+  bearsHealthVerdict,
+  compareHealthSeverityDesc,
+  HEALTH_DEGRADED,
+  HEALTH_HEALTHY,
+  HEALTH_NOT_APPLICABLE,
+  HEALTH_PROGRESSING,
+  HEALTH_UNHEALTHY,
+  HEALTH_UNKNOWN,
+  isFailingHealth,
+  worstHealth,
+} from '@/utils/health-utils'
+import { kebabToWords, toSentenceCase } from '@/utils/string-utils'
+import { isStaleObservation, latestTimestamp } from '@/utils/time-utils'
+
+// Synthetic filter value covering everything that carries no verdict, so the
+// summary chips and the dropdown share one filter axis instead of two.
+export const NO_SIGNAL_FILTER = 'no-signal'
 
 export const HEALTH_FILTER_OPTIONS = [
-  'healthy',
-  'progressing',
-  'degraded',
-  'unhealthy',
-  'unknown',
+  HEALTH_UNHEALTHY,
+  HEALTH_DEGRADED,
+  HEALTH_PROGRESSING,
+  HEALTH_HEALTHY,
+  HEALTH_UNKNOWN,
+  HEALTH_NOT_APPLICABLE,
+  NO_SIGNAL_FILTER,
 ]
+
+export const HEALTH_SUMMARY_ORDER = [
+  HEALTH_UNHEALTHY,
+  HEALTH_DEGRADED,
+  HEALTH_PROGRESSING,
+  HEALTH_HEALTHY,
+  NO_SIGNAL_FILTER,
+]
+
+// How many rows a group shows before folding the tail away: a component with
+// 80 pods otherwise buries every other component on the page. Only the healthy
+// tail is ever folded — see visibleRowCount.
+const GROUP_PREVIEW_ROWS = 8
+
+function healthFilterLabel(value: string): string {
+  if (value === NO_SIGNAL_FILTER) return 'No signal'
+  return toSentenceCase(kebabToWords(value))
+}
+
+// Cloud identity rows (aws/gcp/azure) never bear a verdict — mirrors the
+// evaluator's bearsVerdict. Staleness is meaningless for them: they are a
+// snapshot of what terraform manages, refreshed at apply time.
+export function isIdentityOnlyResource(resource: TInstallResource): boolean {
+  return ['aws', 'gcp', 'azure'].includes(resource?.provider || '')
+}
+
+export function hasHealthSignal(resource: TInstallResource): boolean {
+  return (
+    bearsHealthVerdict(resource?.health) &&
+    !isIdentityOnlyResource(resource) &&
+    !resource?.removed_from_config
+  )
+}
+
+export function matchesHealthFilter(
+  resource: TInstallResource,
+  health: string
+): boolean {
+  if (!health) return true
+  if (health === NO_SIGNAL_FILTER) return !hasHealthSignal(resource)
+  return resource?.health === health
+}
+
+export function matchesResourceSearch(
+  resource: TInstallResource,
+  search: string
+): boolean {
+  const needle = search.trim().toLowerCase()
+  if (!needle) return true
+  return [resource?.name, resource?.kind, resource?.namespace].some((field) =>
+    field?.toLowerCase().includes(needle)
+  )
+}
+
+export function healthFacetCounts(
+  resources: TInstallResource[]
+): Record<string, number> {
+  const counts: Record<string, number> = {}
+  resources.forEach((resource) => {
+    const key = hasHealthSignal(resource)
+      ? resource?.health || HEALTH_UNKNOWN
+      : NO_SIGNAL_FILTER
+    counts[key] = (counts[key] ?? 0) + 1
+  })
+  return counts
+}
 
 export type TInstallResourceRow = {
   resource: TInstallResource
@@ -35,6 +124,7 @@ export type TInstallResourceRow = {
   observedAt?: string
   removed?: boolean
   identityOnly?: boolean
+  hasSignal: boolean
   staleAfterSeconds?: number
 }
 
@@ -42,8 +132,13 @@ export type TInstallResourceGroup = {
   key: string
   heading: string
   rows: TInstallResourceRow[]
+  signalRows: TInstallResourceRow[]
+  noSignalRows: TInstallResourceRow[]
+  worst: string
   failing: number
   live: number
+  fullyStale: boolean
+  lastReportedAt?: string
   downstreamOf?: string
 }
 
@@ -53,16 +148,56 @@ function toInstallResourceRow(resource: TInstallResource): TInstallResourceRow {
     kind: resource?.kind || '',
     namespace: resource?.namespace || '',
     name: resource?.name || '',
-    health: resource?.health || 'unknown',
+    health: resource?.health || HEALTH_UNKNOWN,
     message: resource?.message || '',
     observedAt: resource?.observed_at,
     staleAfterSeconds: resource?.stale_after_seconds || undefined,
     removed: !!resource?.removed_from_config,
-    // Cloud identity rows (aws/gcp/azure) never bear a verdict — mirrors the
-    // evaluator's bearsVerdict. Staleness is meaningless for them: they are a
-    // snapshot of what terraform manages, refreshed at apply time.
-    identityOnly: ['aws', 'gcp', 'azure'].includes(resource?.provider || ''),
+    identityOnly: isIdentityOnlyResource(resource),
+    hasSignal: hasHealthSignal(resource),
   }
+}
+
+// Identity rows have no staleness window and removed rows are historical, so
+// neither can tell you whether the component stopped reporting.
+function isStaleRow(row: TInstallResourceRow): boolean {
+  return (
+    !row.removed &&
+    !row.identityOnly &&
+    isStaleObservation(row.observedAt, row.staleAfterSeconds)
+  )
+}
+
+// A component whose every probe went quiet is a different failure from a few
+// stale rows: the badges below it are all last-known values, so the group says
+// so once instead of repeating a chip on every row.
+function staleSummary(rows: TInstallResourceRow[]): {
+  fullyStale: boolean
+  lastReportedAt?: string
+} {
+  const reporting = rows.filter((row) => !row.removed && !row.identityOnly)
+  const stale = reporting.filter(isStaleRow)
+  return {
+    fullyStale: reporting.length > 0 && stale.length === reporting.length,
+    lastReportedAt: latestTimestamp(reporting.map((row) => row.observedAt)),
+  }
+}
+
+// Rows are sorted worst-first, so keeping at least as many as there are
+// non-healthy ones guarantees the fold can only ever hide green rows.
+export function visibleRowCount(rows: TInstallResourceRow[]): number {
+  const needingAttention = rows.filter(
+    (row) => row.health !== HEALTH_HEALTHY
+  ).length
+  return Math.max(GROUP_PREVIEW_ROWS, needingAttention)
+}
+
+function compareRows(a: TInstallResourceRow, b: TInstallResourceRow): number {
+  return (
+    compareHealthSeverityDesc(a.health, b.health) ||
+    a.kind.localeCompare(b.kind) ||
+    a.name.localeCompare(b.name)
+  )
 }
 
 function buildInstallResourceGroups(
@@ -78,13 +213,34 @@ function buildInstallResourceGroups(
   })
 
   return Array.from(groups.entries())
-    .map(([key, rows]) => ({
-      key,
-      heading: headingFor(key),
-      rows,
-      ...failingCounts(rows),
-    }))
-    .sort((a, b) => a.heading.localeCompare(b.heading))
+    .map(([key, unsorted]) => {
+      const rows = [...unsorted].sort(compareRows)
+      const signalRows = rows.filter((row) => row.hasSignal)
+      return {
+        key,
+        heading: headingFor(key),
+        rows,
+        signalRows,
+        noSignalRows: rows.filter((row) => !row.hasSignal),
+        worst: worstHealth(signalRows.map((row) => row.health)),
+        ...failingCounts(rows),
+        ...staleSummary(rows),
+      }
+    })
+    .sort(
+      (a, b) =>
+        groupTier(b) - groupTier(a) ||
+        compareHealthSeverityDesc(a.worst, b.worst) ||
+        a.heading.localeCompare(b.heading)
+    )
+}
+
+// A group nobody has heard from outranks a healthy one: its badges are last
+// known values, so "we are blind here" needs attention before "all good".
+// A live failure still outranks both.
+function groupTier(group: { failing: number; fullyStale: boolean }): number {
+  if (group.failing > 0) return 2
+  return group.fullyStale ? 1 : 0
 }
 
 // failingCounts mirrors the server-side fold's exclusions: removed and stale
@@ -95,9 +251,7 @@ function failingCounts(rows: TInstallResourceRow[]): { failing: number; live: nu
   const live = rows.filter(
     (row) => !row.removed && !isStaleObservation(row.observedAt, row.staleAfterSeconds)
   )
-  const failing = live.filter(
-    (row) => row.health === 'unhealthy' || row.health === 'degraded'
-  ).length
+  const failing = live.filter((row) => isFailingHealth(row.health)).length
   return { failing, live: live.length }
 }
 
@@ -127,7 +281,10 @@ export function groupSandboxResources(
   )
 }
 
-const columns: ColumnDef<TInstallResourceRow>[] = [
+function buildColumns({
+  hideStaleBadge = false,
+}: { hideStaleBadge?: boolean } = {}): ColumnDef<TInstallResourceRow>[] {
+  return [
   {
     accessorKey: 'kind',
     header: 'Kind',
@@ -159,12 +316,7 @@ const columns: ColumnDef<TInstallResourceRow>[] = [
       if (info.row.original?.removed) {
         return <RemovedFromAppConfigBadge kind="probe" />
       }
-      const stale =
-        !info.row.original?.identityOnly &&
-        isStaleObservation(
-          info.row.original?.observedAt,
-          info.row.original?.staleAfterSeconds
-        )
+      const stale = !hideStaleBadge && isStaleRow(info.row.original)
       const badge = <Status variant="badge" status={info.getValue() as string} />
       if (!stale) return badge
 
@@ -224,7 +376,10 @@ const columns: ColumnDef<TInstallResourceRow>[] = [
       />
     ),
   },
-]
+  ]
+}
+
+const columns = buildColumns()
 
 interface ISingleSelectFilterDropdown {
   id: string
@@ -232,6 +387,7 @@ interface ISingleSelectFilterDropdown {
   options: string[]
   value: string
   onChange: (value: string) => void
+  formatOption?: (option: string) => string
 }
 
 const SingleSelectFilterDropdown = ({
@@ -240,6 +396,7 @@ const SingleSelectFilterDropdown = ({
   options,
   value,
   onChange,
+  formatOption = (option) => option,
 }: ISingleSelectFilterDropdown) => {
   if (options.length === 0) return null
 
@@ -251,7 +408,7 @@ const SingleSelectFilterDropdown = ({
         <>
           <Icon variant="FunnelIcon" size={14} />
           {label}
-          {value ? ` (${value})` : ''}
+          {value ? ` (${formatOption(value)})` : ''}
         </>
       }
     >
@@ -269,7 +426,7 @@ const SingleSelectFilterDropdown = ({
               <RadioInput
                 key={option}
                 checked={value === option}
-                labelProps={{ labelText: option }}
+                labelProps={{ labelText: formatOption(option) }}
                 name={id}
                 onChange={() => onChange(option)}
                 value={option}
@@ -289,59 +446,291 @@ const SingleSelectFilterDropdown = ({
   )
 }
 
-const InstallResourceGroupTable = ({ group }: { group: TInstallResourceGroup }) => (
-  <div className="flex flex-col gap-3">
-    <div className="flex items-center gap-2">
-      <Text variant="base" weight="strong">
-        {group.heading}
+const HealthSummaryChips = ({
+  counts,
+  active,
+  onChange,
+}: {
+  counts: Record<string, number>
+  active: string
+  onChange: (value: string) => void
+}) => {
+  const present = HEALTH_SUMMARY_ORDER.filter((value) => counts[value])
+  if (present.length === 0) return null
+
+  const total = present.reduce((sum, value) => sum + counts[value], 0)
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Text variant="subtext" theme="neutral" nowrap>
+        {total} {total === 1 ? 'resource' : 'resources'}
       </Text>
-      {group.downstreamOf ? (
-        <Tooltip
-          position="top"
-          tipContent={
-            <Text variant="subtext">
-              This component is failing because its dependency{' '}
-              {group.downstreamOf} is unhealthy. Its alert is suppressed —{' '}
-              {group.downstreamOf} is the one that notifies.
+      {present.map((value) => {
+        const isActive = active === value
+        return (
+          <button
+            key={value}
+            type="button"
+            aria-pressed={isActive}
+            onClick={() => onChange(isActive ? '' : value)}
+            className={cn(
+              'flex items-center gap-2 rounded-full border px-2.5 py-1 cursor-pointer transition-all',
+              isActive
+                ? 'border-primary-400 bg-primary-50 dark:border-primary-500/50 dark:bg-primary-950/40'
+                : 'border-cool-grey-300 dark:border-dark-grey-600 hover:bg-black/5 dark:hover:bg-white/5'
+            )}
+          >
+            <Status
+              variant="badge"
+              className="!border-0 !px-0 !py-0"
+              status={value === NO_SIGNAL_FILTER ? HEALTH_UNKNOWN : value}
+            >
+              {healthFilterLabel(value)}
+            </Status>
+            <Text variant="subtext" theme="neutral">
+              {counts[value]}
             </Text>
-          }
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+const NoSignalDisclosure = ({
+  id,
+  label,
+  isOpen,
+  variant = 'row',
+  children,
+}: {
+  id: string
+  label: string
+  isOpen: boolean
+  variant?: 'row' | 'section'
+  children: React.ReactNode
+}) => (
+  <Expand
+    id={id}
+    isOpen={isOpen}
+    isIconBeforeHeading
+    className={cn(
+      variant === 'row' && 'border-t border-cool-grey-200 dark:border-dark-grey-700'
+    )}
+    headerClassName="!px-0 !justify-start"
+    heading={
+      <span className="flex flex-1 items-center gap-3">
+        <Text variant="subtext" theme="neutral" nowrap>
+          {label}
+        </Text>
+        {variant === 'section' ? <hr className="flex-1" /> : null}
+      </span>
+    }
+  >
+    <div className="pt-2">{children}</div>
+  </Expand>
+)
+
+const InstallResourceGroupTable = ({
+  group,
+  forceExpanded,
+  showAllRows = false,
+}: {
+  group: TInstallResourceGroup
+  forceExpanded: boolean
+  showAllRows?: boolean
+}) => {
+  const [isTailExpanded, setIsTailExpanded] = useState(false)
+
+  const rows = showAllRows ? group.rows : group.signalRows
+  const previewCount = visibleRowCount(rows)
+  const hiddenCount = Math.max(0, rows.length - previewCount)
+  const canFoldTail = !showAllRows && !forceExpanded && hiddenCount > 0
+  const visibleRows =
+    canFoldTail && !isTailExpanded ? rows.slice(0, previewCount) : rows
+
+  const groupColumns = buildColumns({ hideStaleBadge: group.fullyStale })
+  const table = (
+    <Table<TInstallResourceRow>
+      columns={groupColumns}
+      data={visibleRows}
+      enableSearch={false}
+    />
+  )
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="sticky top-0 z-10 flex items-center gap-2 bg-background py-2">
+        <Text variant="base" weight="strong">
+          {group.heading}
+        </Text>
+        {group.downstreamOf ? (
+          <Tooltip
+            position="top"
+            tipContent={
+              <Text variant="subtext">
+                This component is failing because its dependency{' '}
+                {group.downstreamOf} is unhealthy. Its alert is suppressed —{' '}
+                {group.downstreamOf} is the one that notifies.
+              </Text>
+            }
+          >
+            <Badge size="sm" theme="warn">
+              Downstream of {group.downstreamOf}
+            </Badge>
+          </Tooltip>
+        ) : null}
+        {/* The component's own verdict lives on the components tab and is
+            debounced; what the header shows is the live roll-up of the rows
+            below, with a count once something is actually failing. */}
+        {group.fullyStale ? (
+          <Tooltip
+            position="top"
+            tipContent={
+              <Text variant="subtext">
+                Nothing in this group has reported inside its staleness window,
+                so none of it counts toward the component verdict. The badges
+                below are the last values seen, not current state.
+              </Text>
+            }
+          >
+            <Badge size="sm" theme="warn">
+              {group.lastReportedAt ? (
+                <>
+                  Last reported{' '}
+                  <Time
+                    as="span"
+                    variant="label"
+                    time={group.lastReportedAt}
+                    format="relative"
+                  />
+                </>
+              ) : (
+                'Not reporting'
+              )}
+            </Badge>
+          </Tooltip>
+        ) : group.failing > 0 ? (
+          <Tooltip
+            position="top"
+            tipContent={
+              <Text variant="subtext">
+                Live resources currently degraded or unhealthy in this group —
+                not the component's health verdict, which is debounced and can
+                lag the rows below.
+              </Text>
+            }
+          >
+            <Badge size="sm" theme="error">
+              {group.failing} of {group.live} failing
+            </Badge>
+          </Tooltip>
+        ) : (
+          <Status variant="badge" status={group.worst} />
+        )}
+      </div>
+
+      {rows.length > 0 ? table : null}
+
+      {canFoldTail ? (
+        <Button
+          className="self-start"
+          variant="ghost"
+          size="sm"
+          onClick={() => setIsTailExpanded((expanded) => !expanded)}
         >
-          <Badge size="sm" theme="warn">
-            Downstream of {group.downstreamOf}
-          </Badge>
-        </Tooltip>
+          {isTailExpanded
+            ? 'Show fewer'
+            : `Show ${hiddenCount} more healthy ${
+                hiddenCount === 1 ? 'resource' : 'resources'
+              }`}
+          <Icon variant={isTailExpanded ? 'CaretUpIcon' : 'CaretDownIcon'} />
+        </Button>
       ) : null}
-      {/* Rows carry their own health badges and the verdict lives on the
-          components tab — what the header adds is the count, shown only when
-          something is actually failing. */}
-      {group.failing > 0 ? (
-        <Tooltip
-          position="top"
-          tipContent={
-            <Text variant="subtext">
-              Live resources currently degraded or unhealthy in this group —
-              not the component's health verdict, which is debounced and can
-              lag the rows below.
-            </Text>
-          }
+
+      {!showAllRows && group.noSignalRows.length > 0 ? (
+        <NoSignalDisclosure
+          id={`resource-group-${group.key}-no-signal`}
+          isOpen={forceExpanded}
+          label={`${group.noSignalRows.length} ${
+            group.noSignalRows.length === 1 ? 'resource' : 'resources'
+          } with no health signal`}
         >
-          <Badge size="sm" theme="error">
-            {group.failing} of {group.live} failing
-          </Badge>
-        </Tooltip>
+          <Table<TInstallResourceRow>
+            columns={columns}
+            data={group.noSignalRows}
+            enableSearch={false}
+          />
+        </NoSignalDisclosure>
       ) : null}
     </div>
-    <Table<TInstallResourceRow> columns={columns} data={group.rows} enableSearch={false} />
-  </div>
-)
+  )
+}
+
+const ResourceGroupSection = ({
+  title,
+  groups,
+  forceExpanded,
+}: {
+  title: string
+  groups: TInstallResourceGroup[]
+  forceExpanded: boolean
+}) => {
+  const signalGroups = groups.filter((group) => group.signalRows.length > 0)
+  const noSignalGroups = groups.filter((group) => group.signalRows.length === 0)
+
+  if (groups.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Text variant="h3" weight="strong">
+        {title}
+      </Text>
+      {signalGroups.length > 0 ? (
+        <div className="flex flex-col gap-6 md:gap-8">
+          {signalGroups.map((group) => (
+            <InstallResourceGroupTable
+              key={group.key}
+              group={group}
+              forceExpanded={forceExpanded}
+            />
+          ))}
+        </div>
+      ) : null}
+      {noSignalGroups.length > 0 ? (
+        <NoSignalDisclosure
+          id={`resource-section-${title.toLowerCase()}-no-signal`}
+          variant="section"
+          isOpen={forceExpanded || signalGroups.length === 0}
+          label={`${noSignalGroups.length} ${
+            noSignalGroups.length === 1 ? 'group' : 'groups'
+          } with no health signal`}
+        >
+          <div className="flex flex-col gap-6 md:gap-8">
+            {noSignalGroups.map((group) => (
+              <InstallResourceGroupTable
+                key={group.key}
+                group={group}
+                forceExpanded={forceExpanded}
+                showAllRows
+              />
+            ))}
+          </div>
+        </NoSignalDisclosure>
+      ) : null}
+    </div>
+  )
+}
 
 interface IInstallResourcesTable {
   componentGroups: TInstallResourceGroup[]
   sandboxGroups: TInstallResourceGroup[]
+  healthCounts: Record<string, number>
   isLoading: boolean
   kind: string
   namespace: string
   health: string
+  search: string
   kindOptions: string[]
   namespaceOptions: string[]
   onKindChange: (value: string) => void
@@ -352,10 +741,12 @@ interface IInstallResourcesTable {
 export const InstallResourcesTable = ({
   componentGroups,
   sandboxGroups,
+  healthCounts,
   isLoading,
   kind,
   namespace,
   health,
+  search,
   kindOptions,
   namespaceOptions,
   onKindChange,
@@ -367,66 +758,72 @@ export const InstallResourcesTable = ({
   }
 
   const hasResources = componentGroups.length > 0 || sandboxGroups.length > 0
+  // A filter is an explicit request to see the matching rows, so it overrides
+  // every "tucked away by default" decision below — otherwise filtering to
+  // `unknown` renders a page of empty groups.
+  const forceExpanded = !!(kind || namespace || health || search)
 
   return (
     <div className="flex flex-col gap-6 md:gap-8">
-      <div className="flex flex-wrap items-center gap-3">
-        <SingleSelectFilterDropdown
-          id="resource-filter-kind"
-          label="Kind"
-          options={kindOptions}
-          value={kind}
-          onChange={onKindChange}
-        />
-        <SingleSelectFilterDropdown
-          id="resource-filter-namespace"
-          label="Namespace"
-          options={namespaceOptions}
-          value={namespace}
-          onChange={onNamespaceChange}
-        />
-        <SingleSelectFilterDropdown
-          id="resource-filter-health"
-          label="Health"
-          options={HEALTH_FILTER_OPTIONS}
-          value={health}
+      <div className="flex flex-col gap-3">
+        <HealthSummaryChips
+          counts={healthCounts}
+          active={health}
           onChange={onHealthChange}
         />
+        <div className="flex flex-wrap items-center gap-3">
+          <DebouncedSearchInput
+            className="w-full md:w-64"
+            labelClassName="w-full md:w-64"
+            placeholder="Search resources"
+          />
+          <SingleSelectFilterDropdown
+            id="resource-filter-kind"
+            label="Kind"
+            options={kindOptions}
+            value={kind}
+            onChange={onKindChange}
+          />
+          <SingleSelectFilterDropdown
+            id="resource-filter-namespace"
+            label="Namespace"
+            options={namespaceOptions}
+            value={namespace}
+            onChange={onNamespaceChange}
+          />
+          <SingleSelectFilterDropdown
+            id="resource-filter-health"
+            label="Health"
+            options={HEALTH_FILTER_OPTIONS}
+            value={health}
+            onChange={onHealthChange}
+            formatOption={healthFilterLabel}
+          />
+        </div>
       </div>
 
       {!hasResources ? (
         <EmptyState
           variant="table"
-          emptyTitle="No resources yet"
-          emptyMessage="Resources will appear here once the runner reports component health for this install."
+          emptyTitle={forceExpanded ? 'No matching resources' : 'No resources yet'}
+          emptyMessage={
+            forceExpanded
+              ? 'No resources match the current filters. Clear them to see everything this install manages.'
+              : 'Resources will appear here once the runner reports component health for this install.'
+          }
         />
       ) : (
         <>
-          {componentGroups.length > 0 ? (
-            <div className="flex flex-col gap-4">
-              <Text variant="h3" weight="strong">
-                Components
-              </Text>
-              <div className="flex flex-col gap-6 md:gap-8">
-                {componentGroups.map((group) => (
-                  <InstallResourceGroupTable key={group.key} group={group} />
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          {sandboxGroups.length > 0 ? (
-            <div className="flex flex-col gap-4">
-              <Text variant="h3" weight="strong">
-                Sandbox
-              </Text>
-              <div className="flex flex-col gap-6 md:gap-8">
-                {sandboxGroups.map((group) => (
-                  <InstallResourceGroupTable key={group.key} group={group} />
-                ))}
-              </div>
-            </div>
-          ) : null}
+          <ResourceGroupSection
+            title="Components"
+            groups={componentGroups}
+            forceExpanded={forceExpanded}
+          />
+          <ResourceGroupSection
+            title="Sandbox"
+            groups={sandboxGroups}
+            forceExpanded={forceExpanded}
+          />
         </>
       )}
     </div>

--- a/services/dashboard-ui/client/components/install-resources/InstallResourcesTable/InstallResourcesTable.tsx
+++ b/services/dashboard-ui/client/components/install-resources/InstallResourcesTable/InstallResourcesTable.tsx
@@ -61,6 +61,10 @@ export const HEALTH_SUMMARY_ORDER = [
 // tail is ever folded — see visibleRowCount.
 const GROUP_PREVIEW_ROWS = 8
 
+// Folding two rows behind a "show more" saves nothing and just adds a click;
+// real components cluster at either 1-3 rows or 10+.
+const MIN_FOLDED_ROWS = 3
+
 function healthFilterLabel(value: string): string {
   if (value === NO_SIGNAL_FILTER) return 'No signal'
   return toSentenceCase(kebabToWords(value))
@@ -545,7 +549,8 @@ const InstallResourceGroupTable = ({
   const rows = showAllRows ? group.rows : group.signalRows
   const previewCount = visibleRowCount(rows)
   const hiddenCount = Math.max(0, rows.length - previewCount)
-  const canFoldTail = !showAllRows && !forceExpanded && hiddenCount > 0
+  const canFoldTail =
+    !showAllRows && !forceExpanded && hiddenCount >= MIN_FOLDED_ROWS
   const visibleRows =
     canFoldTail && !isTailExpanded ? rows.slice(0, previewCount) : rows
 

--- a/services/dashboard-ui/client/components/install-resources/InstallResourcesTable/InstallResourcesTableContainer.tsx
+++ b/services/dashboard-ui/client/components/install-resources/InstallResourcesTable/InstallResourcesTableContainer.tsx
@@ -7,7 +7,10 @@ import { getInstallComponents, getInstallResources } from '@/lib'
 import {
   groupComponentResources,
   groupSandboxResources,
+  healthFacetCounts,
   InstallResourcesTable,
+  matchesHealthFilter,
+  matchesResourceSearch,
 } from './InstallResourcesTable'
 
 export const InstallResourcesTableContainer = ({
@@ -28,6 +31,7 @@ export const InstallResourcesTableContainer = ({
   const kind = searchParams.get('kind') ?? ''
   const namespace = searchParams.get('namespace') ?? ''
   const health = searchParams.get('health') ?? ''
+  const search = searchParams.get('q') ?? ''
 
   const setFilter = useCallback(
     (key: string) => (value: string) => {
@@ -107,15 +111,26 @@ export const InstallResourcesTableContainer = ({
     [allResources]
   )
 
-  const filteredResources = useMemo(
+  // The chips are facet counts for the health axis, so they stay stable while
+  // you toggle between them — only the other axes narrow them.
+  const scopedResources = useMemo(
     () =>
       allResources.filter((r) => {
         if (kind && r?.kind !== kind) return false
         if (namespace && r?.namespace !== namespace) return false
-        if (health && r?.health !== health) return false
-        return true
+        return matchesResourceSearch(r, search)
       }),
-    [allResources, kind, namespace, health]
+    [allResources, kind, namespace, search]
+  )
+
+  const healthCounts = useMemo(
+    () => healthFacetCounts(scopedResources),
+    [scopedResources]
+  )
+
+  const filteredResources = useMemo(
+    () => scopedResources.filter((r) => matchesHealthFilter(r, health)),
+    [scopedResources, health]
   )
 
   const componentGroups = useMemo(
@@ -131,10 +146,12 @@ export const InstallResourcesTableContainer = ({
     <InstallResourcesTable
       componentGroups={componentGroups}
       sandboxGroups={sandboxGroups}
+      healthCounts={healthCounts}
       isLoading={isLoading}
       kind={kind}
       namespace={namespace}
       health={health}
+      search={search}
       kindOptions={kindOptions}
       namespaceOptions={namespaceOptions}
       onKindChange={setFilter('kind')}

--- a/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.tsx
+++ b/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.tsx
@@ -372,7 +372,7 @@ export const InstallStatuses = ({
           subtitle:
             install?.composite_health_status_description ??
             toSentenceCase(healthStatus),
-          href: `/${install.org_id}/installs/${install.id}/components`,
+          href: `/${install.org_id}/installs/${install.id}/resources?health=${healthStatus}`,
           leftContent: (
             <Status
               status={healthStatus}
@@ -529,7 +529,7 @@ export const InstallStatuses = ({
             subtitle:
               install?.composite_health_status_description ??
               toSentenceCase(healthStatus),
-            href: `/${install.org_id}/installs/${install.id}/components`,
+            href: `/${install.org_id}/installs/${install.id}/resources?health=${healthStatus}`,
             leftContent: (
               <Status
                 status={healthStatus}

--- a/services/dashboard-ui/client/utils/health-utils.test.ts
+++ b/services/dashboard-ui/client/utils/health-utils.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  bearsHealthVerdict,
+  compareHealthSeverityDesc,
+  healthSeverity,
+  isFailingHealth,
+  worstHealth,
+} from './health-utils'
+
+describe('health-utils', () => {
+  describe('healthSeverity', () => {
+    test('ranks assessed statuses worst-first', () => {
+      expect(healthSeverity('unhealthy')).toBeGreaterThan(healthSeverity('degraded'))
+      expect(healthSeverity('degraded')).toBeGreaterThan(healthSeverity('progressing'))
+      expect(healthSeverity('progressing')).toBeGreaterThan(healthSeverity('healthy'))
+    })
+
+    test('unknown and not-applicable share zero severity', () => {
+      expect(healthSeverity('unknown')).toBe(0)
+      expect(healthSeverity('not-applicable')).toBe(0)
+      expect(healthSeverity('')).toBe(0)
+      expect(healthSeverity(undefined)).toBe(0)
+    })
+
+    test('an unrecognized status never outranks an assessed one', () => {
+      expect(healthSeverity('wat')).toBeLessThan(healthSeverity('healthy'))
+    })
+  })
+
+  describe('bearsHealthVerdict', () => {
+    test('only assessed statuses bear a verdict', () => {
+      expect(bearsHealthVerdict('healthy')).toBe(true)
+      expect(bearsHealthVerdict('progressing')).toBe(true)
+      expect(bearsHealthVerdict('degraded')).toBe(true)
+      expect(bearsHealthVerdict('unhealthy')).toBe(true)
+      expect(bearsHealthVerdict('unknown')).toBe(false)
+      expect(bearsHealthVerdict('not-applicable')).toBe(false)
+      expect(bearsHealthVerdict(undefined)).toBe(false)
+    })
+  })
+
+  describe('isFailingHealth', () => {
+    test('only unhealthy and degraded are failing', () => {
+      expect(isFailingHealth('unhealthy')).toBe(true)
+      expect(isFailingHealth('degraded')).toBe(true)
+      expect(isFailingHealth('progressing')).toBe(false)
+      expect(isFailingHealth('healthy')).toBe(false)
+      expect(isFailingHealth('unknown')).toBe(false)
+    })
+  })
+
+  describe('worstHealth', () => {
+    test('returns the worst assessed status', () => {
+      expect(worstHealth(['healthy', 'degraded', 'progressing'])).toBe('degraded')
+      expect(worstHealth(['degraded', 'unhealthy'])).toBe('unhealthy')
+    })
+
+    test('an assessed status always beats unknown and not-applicable', () => {
+      expect(worstHealth(['unknown', 'healthy', 'not-applicable'])).toBe('healthy')
+    })
+
+    test('falls back to unknown when nothing was assessed', () => {
+      expect(worstHealth(['unknown', 'not-applicable'])).toBe('unknown')
+      expect(worstHealth([])).toBe('unknown')
+    })
+
+    test('falls back to not-applicable only when nothing tried', () => {
+      expect(worstHealth(['not-applicable', 'not-applicable'])).toBe('not-applicable')
+    })
+  })
+
+  describe('compareHealthSeverityDesc', () => {
+    test('sorts worst-first', () => {
+      expect(
+        ['healthy', 'unhealthy', 'unknown', 'degraded'].sort(compareHealthSeverityDesc)
+      ).toEqual(['unhealthy', 'degraded', 'healthy', 'unknown'])
+    })
+  })
+})

--- a/services/dashboard-ui/client/utils/health-utils.ts
+++ b/services/dashboard-ui/client/utils/health-utils.ts
@@ -1,0 +1,50 @@
+export const HEALTH_UNHEALTHY = 'unhealthy'
+export const HEALTH_DEGRADED = 'degraded'
+export const HEALTH_PROGRESSING = 'progressing'
+export const HEALTH_HEALTHY = 'healthy'
+export const HEALTH_UNKNOWN = 'unknown'
+export const HEALTH_NOT_APPLICABLE = 'not-applicable'
+
+// Mirrors componentHealthSeverity in the evaluator: unknown and not-applicable
+// share zero severity because neither is a verdict — one is "tried and could
+// not tell", the other "nothing here exposes health".
+const HEALTH_SEVERITY: Record<string, number> = {
+  [HEALTH_UNHEALTHY]: 4,
+  [HEALTH_DEGRADED]: 3,
+  [HEALTH_PROGRESSING]: 2,
+  [HEALTH_HEALTHY]: 1,
+}
+
+export function healthSeverity(health?: string): number {
+  return HEALTH_SEVERITY[health ?? ''] ?? 0
+}
+
+export function isFailingHealth(health?: string): boolean {
+  return health === HEALTH_UNHEALTHY || health === HEALTH_DEGRADED
+}
+
+export function bearsHealthVerdict(health?: string): boolean {
+  return healthSeverity(health) > 0
+}
+
+// Falls back the way the evaluator does when nothing was assessed: unknown
+// outranks not-applicable, because "tried and could not tell" is more
+// informative than "nothing here exposes health".
+export function worstHealth(healths: (string | undefined)[]): string {
+  const assessed = healths.filter(bearsHealthVerdict)
+  if (assessed.length > 0) {
+    return assessed.reduce<string>(
+      (worst, health) =>
+        healthSeverity(health) > healthSeverity(worst) ? health! : worst,
+      assessed[0]!
+    )
+  }
+  return healths.includes(HEALTH_NOT_APPLICABLE) &&
+    !healths.includes(HEALTH_UNKNOWN)
+    ? HEALTH_NOT_APPLICABLE
+    : HEALTH_UNKNOWN
+}
+
+export function compareHealthSeverityDesc(a?: string, b?: string): number {
+  return healthSeverity(b) - healthSeverity(a)
+}

--- a/services/dashboard-ui/client/utils/status-utils.test.ts
+++ b/services/dashboard-ui/client/utils/status-utils.test.ts
@@ -87,6 +87,7 @@ describe('status-utils', () => {
       expect(getStatusIconVariant('error')).toBe('XCircleIcon')
       expect(getStatusIconVariant('bad')).toBe('XCircleIcon')
       expect(getStatusIconVariant('unhealthy')).toBe('XCircleIcon')
+      expect(getStatusIconVariant('not-applicable')).toBe('MinusCircleIcon')
     })
 
     test('should return Warning for warning statuses', () => {

--- a/services/dashboard-ui/client/utils/status-utils.ts
+++ b/services/dashboard-ui/client/utils/status-utils.ts
@@ -137,6 +137,8 @@ const STATUS_ICON_MAP: Record<string, TIconVariant> = {
   'No build': 'ClockCountdownIcon',
   deprovisioned: 'WarningIcon',
 
+  'not-applicable': 'MinusCircleIcon',
+
   'auto-skipped': 'MinusCircleIcon',
   'user-skipped': 'MinusCircleIcon',
   retried: 'RepeatIcon',

--- a/services/dashboard-ui/client/utils/time-utils.test.ts
+++ b/services/dashboard-ui/client/utils/time-utils.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 
 import { describe, expect, test, beforeAll, afterAll, spyOn } from 'bun:test'
-import { isRecentTimestamp } from './time-utils'
+import { isRecentTimestamp, latestTimestamp } from './time-utils'
 import { DateTime } from 'luxon'
 
 describe('time-utils', () => {
@@ -57,5 +57,21 @@ describe('time-utils', () => {
       const result = isRecentTimestamp('invalid-date')
       expect(typeof result).toBe('boolean')
     })
+  })
+})
+
+describe('latestTimestamp', () => {
+  test('returns the newest timestamp', () => {
+    const older = DateTime.now().minus({ hours: 2 }).toISO()!
+    const newer = DateTime.now().minus({ minutes: 5 }).toISO()!
+    expect(latestTimestamp([older, newer])).toBe(newer)
+    expect(latestTimestamp([newer, older])).toBe(newer)
+  })
+
+  test('ignores undefined entries and returns undefined when empty', () => {
+    const only = DateTime.now().toISO()!
+    expect(latestTimestamp([undefined, only, undefined])).toBe(only)
+    expect(latestTimestamp([])).toBeUndefined()
+    expect(latestTimestamp([undefined])).toBeUndefined()
   })
 })

--- a/services/dashboard-ui/client/utils/time-utils.ts
+++ b/services/dashboard-ui/client/utils/time-utils.ts
@@ -14,6 +14,18 @@ export function isStaleObservation(
   return seconds > maxAgeSeconds
 }
 
+export function latestTimestamp(
+  timestamps: (string | undefined)[]
+): string | undefined {
+  return timestamps.reduce<string | undefined>((latest, timestamp) => {
+    if (!timestamp) return latest
+    if (!latest) return timestamp
+    return DateTime.fromISO(timestamp) > DateTime.fromISO(latest)
+      ? timestamp
+      : latest
+  }, undefined)
+}
+
 export function isRecentTimestamp(
   timestampStr: string | undefined,
   maxAgeSeconds = 60,


### PR DESCRIPTION
Hides not-applicable/unknown resources behind per-group and section-level disclosures, sorts groups and rows worst-health-first, and folds only the healthy tail of large groups. Adds clickable health summary chips, page-level search, and a group-level "last reported" badge that replaces the misleading healthy badge when a component has gone silent. Also links the install health chip to the filtered resources page instead of the bare components tab.

Raising to get it on stage — the fold thresholds and the staleness badge need real resource volumes to validate.