### PR TITLE
feat(cli): run ad hoc install actions

### DIFF
--- a/bins/cli/cmd/actions.go
+++ b/bins/cli/cmd/actions.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
+
+	"github.com/nuonco/nuon/bins/cli/internal/services/actions"
 )
 
 func (c *cli) actionsCmd() *cobra.Command {
@@ -99,6 +103,31 @@ func (c *cli) actionsCmd() *cobra.Command {
 	runCmd.MarkFlagRequired("action-workflow-id")
 	runCmd.Flags().StringVar(&roleName, "role-name", "", "IAM role name to use for action workflow")
 	actionsCmd.AddCommand(runCmd)
+
+	var adhocParams actions.AdHocParams
+	adhocCmd := &cobra.Command{
+		Use:         "adhoc",
+		Short:       "Run a one-time action on an install",
+		Args:        cobra.NoArgs,
+		Annotations: outputsAnnotation(OutputTable, OutputJSON, OutputAgent),
+		Example: `  nuon actions adhoc --command 'kubectl get pods'
+  nuon actions adhoc --script ./debug.sh --env-file .env --env DEBUG=true
+  nuon actions adhoc --command 'kubectl get pods' --wait`,
+		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
+			return c.actions.CreateAdHocRun(cmd.Context(), adhocParams, PrintJSON)
+		}),
+	}
+	adhocCmd.Flags().StringVarP(&adhocParams.InstallID, "install-id", "i", "", "The ID or name of the install (defaults to the selected install)")
+	adhocCmd.Flags().StringVar(&adhocParams.Command, "command", "", "Single-line shell command to execute")
+	adhocCmd.Flags().StringVar(&adhocParams.ScriptPath, "script", "", "Path to a script to execute")
+	adhocCmd.Flags().StringArrayVar(&adhocParams.Env, "env", nil, "Environment variable as KEY=VALUE (repeatable)")
+	adhocCmd.Flags().StringVar(&adhocParams.EnvFile, "env-file", "", "Path to a dotenv-style environment file")
+	adhocCmd.Flags().DurationVar(&adhocParams.Timeout, "timeout", 5*time.Minute, "Execution timeout between 1s and 1h")
+	adhocCmd.Flags().StringVar(&adhocParams.Name, "name", "", "Display name for the action")
+	adhocCmd.Flags().StringVar(&adhocParams.Role, "role", "", "IAM role to use for the action")
+	adhocCmd.Flags().BoolVar(&adhocParams.EnableKubeConfig, "enable-kube-config", true, "Provide Kubernetes configuration to the action")
+	adhocCmd.Flags().BoolVar(&adhocParams.Wait, "wait", false, "Wait for completion and print raw action logs")
+	actionsCmd.AddCommand(adhocCmd)
 
 	return actionsCmd
 }

--- a/bins/cli/internal/services/actions/adhoc.go
+++ b/bins/cli/internal/services/actions/adhoc.go
@@ -1,0 +1,303 @@
+package actions
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/nuonco/nuon/bins/cli/internal/lookup"
+	"github.com/nuonco/nuon/bins/cli/internal/ui"
+	"github.com/nuonco/nuon/sdks/nuon-go/models"
+)
+
+type AdHocParams struct {
+	InstallID        string
+	Command          string
+	ScriptPath       string
+	Env              []string
+	EnvFile          string
+	Timeout          time.Duration
+	Name             string
+	Role             string
+	EnableKubeConfig bool
+	Wait             bool
+}
+
+// Kafka-backed log ingestion can trail stream closure by up to five seconds.
+const adHocClosedLogDrainPolls = 4
+
+func (s *Service) CreateAdHocRun(ctx context.Context, params AdHocParams, asJSON bool) error {
+	view := ui.NewGetView()
+
+	if params.InstallID == "" {
+		params.InstallID = s.cfg.GetString("install_id")
+	}
+	installID, err := lookup.InstallID(ctx, s.api, params.InstallID)
+	if err != nil {
+		return view.Error(err)
+	}
+
+	inlineContents, err := readAdHocInput(params.Command, params.ScriptPath)
+	if err != nil {
+		return view.Error(err)
+	}
+
+	envVars, err := parseAdHocEnv(params.EnvFile, params.Env)
+	if err != nil {
+		return view.Error(err)
+	}
+
+	if params.Timeout < time.Second || params.Timeout > time.Hour || params.Timeout%time.Second != 0 {
+		return view.Error(fmt.Errorf("timeout must be a whole number of seconds between 1s and 1h"))
+	}
+
+	req := &models.ServiceCreateAdHocActionRequest{
+		Command:          params.Command,
+		InlineContents:   inlineContents,
+		EnvVars:          envVars,
+		Timeout:          int64(params.Timeout / time.Second),
+		Name:             params.Name,
+		Role:             params.Role,
+		EnableKubeConfig: &params.EnableKubeConfig,
+	}
+
+	run, err := s.api.CreateAdHocAction(ctx, installID, req)
+	if err != nil {
+		return view.Error(err)
+	}
+	if params.Wait {
+		logWriter := io.Writer(os.Stdout)
+		if asJSON {
+			logWriter = os.Stderr
+		}
+		completedRun, err := s.waitForAdHocRun(ctx, installID, run.ID, logWriter)
+		if err != nil {
+			return printAdHocWaitError(err, asJSON)
+		}
+
+		run.Status = models.AppInstallActionWorkflowRunStatus(completedRun.Status)
+		run.StatusDescription = completedRun.StatusDescription
+		if completedRun.Status != string(models.AppInstallActionWorkflowRunStatusFinished) {
+			message := fmt.Sprintf("ad-hoc action %s ended with status %s", completedRun.ID, completedRun.Status)
+			if completedRun.StatusDescription != "" {
+				message += ": " + completedRun.StatusDescription
+			}
+			return printAdHocWaitError(&ui.CLIUserError{
+				Msg: message,
+			}, asJSON)
+		}
+		if asJSON {
+			ui.PrintJSON(run)
+		}
+		return nil
+	}
+
+	if asJSON {
+		ui.PrintJSON(run)
+		return nil
+	}
+
+	ui.PrintSuccess("ad-hoc action queued")
+	view.Render([][]string{
+		{"run id", run.ID},
+		{"workflow id", run.WorkflowID},
+		{"install id", run.InstallID},
+		{"status", string(run.Status)},
+		{"status description", run.StatusDescription},
+	})
+
+	return nil
+}
+
+func (s *Service) waitForAdHocRun(ctx context.Context, installID, runID string, writer io.Writer) (*models.AppInstallActionWorkflowRun, error) {
+	streamedLogs := false
+	for {
+		run, err := s.api.GetInstallActionWorkflowRun(ctx, installID, runID)
+		if err != nil {
+			return nil, fmt.Errorf("get ad-hoc action run: %w", err)
+		}
+
+		if !streamedLogs && run.RunnerJob != nil && run.RunnerJob.LogStreamID != "" {
+			if err := s.streamRawAdHocLogs(ctx, run.RunnerJob.LogStreamID, writer); err != nil {
+				return nil, err
+			}
+			streamedLogs = true
+		}
+
+		if isTerminalAdHocStatus(run.Status) {
+			return run, nil
+		}
+		if err := waitForAdHocPoll(ctx); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func (s *Service) streamRawAdHocLogs(ctx context.Context, logStreamID string, writer io.Writer) error {
+	cursor := ""
+	closedEmptyPolls := 0
+	for {
+		response, err := s.api.LogStreamTailLogs(ctx, logStreamID, cursor, "2s")
+		if err != nil {
+			return fmt.Errorf("read ad-hoc action logs: %w", err)
+		}
+		for _, record := range response.Logs {
+			if record.LogAttributes["nuon.command_output"] != "true" {
+				continue
+			}
+			if _, err := io.WriteString(writer, record.Body); err != nil {
+				return fmt.Errorf("write ad-hoc action logs: %w", err)
+			}
+			if !strings.HasSuffix(record.Body, "\n") {
+				if _, err := io.WriteString(writer, "\n"); err != nil {
+					return fmt.Errorf("write ad-hoc action logs: %w", err)
+				}
+			}
+		}
+		if response.Next != "" {
+			cursor = response.Next
+		}
+		if response.HasMore {
+			continue
+		}
+
+		logStream, err := s.api.GetLogStream(ctx, logStreamID)
+		if err != nil {
+			return fmt.Errorf("get ad-hoc action log stream: %w", err)
+		}
+		if logStream.Open || len(response.Logs) > 0 {
+			closedEmptyPolls = 0
+			continue
+		}
+
+		closedEmptyPolls++
+		if closedEmptyPolls >= adHocClosedLogDrainPolls {
+			return nil
+		}
+	}
+}
+
+func isTerminalAdHocStatus(status string) bool {
+	switch models.AppInstallActionWorkflowRunStatus(status) {
+	case models.AppInstallActionWorkflowRunStatusFinished,
+		models.AppInstallActionWorkflowRunStatusError,
+		models.AppInstallActionWorkflowRunStatusTimedDashOut,
+		models.AppInstallActionWorkflowRunStatusCancelled,
+		models.AppInstallActionWorkflowRunStatusRetried:
+		return true
+	default:
+		return false
+	}
+}
+
+func waitForAdHocPoll(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(time.Second):
+		return nil
+	}
+}
+
+func printAdHocWaitError(err error, asJSON bool) error {
+	if asJSON {
+		return ui.PrintError(err)
+	}
+	fmt.Fprintln(os.Stderr, err)
+	return err
+}
+
+func readAdHocInput(command, scriptPath string) (string, error) {
+	if command != "" && scriptPath != "" {
+		return "", fmt.Errorf("provide either --command or --script, not both")
+	}
+	if command == "" && scriptPath == "" {
+		return "", fmt.Errorf("either --command or --script is required")
+	}
+	if scriptPath == "" {
+		return "", nil
+	}
+
+	contents, err := os.ReadFile(scriptPath)
+	if err != nil {
+		return "", fmt.Errorf("read script %q: %w", scriptPath, err)
+	}
+	if len(contents) == 0 {
+		return "", fmt.Errorf("script %q is empty", scriptPath)
+	}
+	return string(contents), nil
+}
+
+func parseAdHocEnv(envFile string, values []string) (map[string]string, error) {
+	env := make(map[string]string)
+	if envFile != "" {
+		file, err := os.Open(envFile)
+		if err != nil {
+			return nil, fmt.Errorf("open env file %q: %w", envFile, err)
+		}
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		for lineNumber := 1; scanner.Scan(); lineNumber++ {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+			key, value, err := parseEnvAssignment(line)
+			if err != nil {
+				return nil, fmt.Errorf("parse env file %q line %d: %w", envFile, lineNumber, err)
+			}
+			env[key] = trimMatchingQuotes(strings.TrimSpace(value))
+		}
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("read env file %q: %w", envFile, err)
+		}
+	}
+
+	for _, value := range values {
+		key, envValue, err := parseEnvAssignment(value)
+		if err != nil {
+			return nil, fmt.Errorf("parse --env %q: %w", value, err)
+		}
+		env[key] = envValue
+	}
+
+	return env, nil
+}
+
+func parseEnvAssignment(value string) (string, string, error) {
+	key, envValue, ok := strings.Cut(value, "=")
+	key = strings.TrimSpace(key)
+	if !ok || !validEnvKey(key) {
+		return "", "", fmt.Errorf("expected KEY=VALUE")
+	}
+	return key, envValue, nil
+}
+
+func validEnvKey(key string) bool {
+	if key == "" || !(key[0] == '_' || key[0] >= 'A' && key[0] <= 'Z' || key[0] >= 'a' && key[0] <= 'z') {
+		return false
+	}
+	for i := 1; i < len(key); i++ {
+		char := key[i]
+		if char != '_' && !(char >= 'A' && char <= 'Z') && !(char >= 'a' && char <= 'z') && !(char >= '0' && char <= '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func trimMatchingQuotes(value string) string {
+	if len(value) < 2 {
+		return value
+	}
+	if value[0] == value[len(value)-1] && (value[0] == '\'' || value[0] == '"') {
+		return value[1 : len(value)-1]
+	}
+	return value
+}

--- a/bins/cli/internal/services/actions/adhoc_test.go
+++ b/bins/cli/internal/services/actions/adhoc_test.go
@@ -1,0 +1,198 @@
+package actions
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/bins/cli/internal/config"
+	"github.com/nuonco/nuon/sdks/nuon-go"
+	"github.com/nuonco/nuon/sdks/nuon-go/models"
+)
+
+type adHocAPI struct {
+	nuon.Client
+	installID     string
+	request       *models.ServiceCreateAdHocActionRequest
+	runs          []*models.AppInstallActionWorkflowRun
+	runIndex      int
+	logPages      []adHocLogPage
+	logPageIndex  int
+	logCursors    []string
+	logStreamOpen bool
+}
+
+type adHocLogPage struct {
+	records []*models.AppOtelLogRecord
+	next    string
+	hasMore bool
+}
+
+func (a *adHocAPI) GetInstall(_ context.Context, installID string) (*models.AppInstall, error) {
+	a.installID = installID
+	return &models.AppInstall{ID: "inst_resolved"}, nil
+}
+
+func (a *adHocAPI) CreateAdHocAction(_ context.Context, installID string, req *models.ServiceCreateAdHocActionRequest) (*models.ServiceCreateAdHocActionResponse, error) {
+	a.installID = installID
+	a.request = req
+	return &models.ServiceCreateAdHocActionResponse{
+		ID:         "run_123",
+		InstallID:  installID,
+		WorkflowID: "workflow_123",
+		Status:     models.AppInstallActionWorkflowRunStatusQueued,
+	}, nil
+}
+
+func (a *adHocAPI) GetInstallActionWorkflowRun(_ context.Context, _, _ string) (*models.AppInstallActionWorkflowRun, error) {
+	run := a.runs[a.runIndex]
+	if a.runIndex < len(a.runs)-1 {
+		a.runIndex++
+	}
+	return run, nil
+}
+
+func (a *adHocAPI) LogStreamTailLogs(_ context.Context, _ string, cursor string, _ string) (*models.ServiceLogStreamTailLogsResponse, error) {
+	a.logCursors = append(a.logCursors, cursor)
+	page := a.logPages[a.logPageIndex]
+	if a.logPageIndex < len(a.logPages)-1 {
+		a.logPageIndex++
+	}
+	return &models.ServiceLogStreamTailLogsResponse{
+		Logs:    page.records,
+		Next:    page.next,
+		HasMore: page.hasMore,
+	}, nil
+}
+
+func (a *adHocAPI) GetLogStream(_ context.Context, _ string) (*models.AppLogStream, error) {
+	return &models.AppLogStream{Open: a.logStreamOpen}, nil
+}
+
+func TestCreateAdHocRunUsesSelectedInstallAndBuildsRequest(t *testing.T) {
+	scriptPath := filepath.Join(t.TempDir(), "debug.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("echo hello\n"), 0o600))
+
+	v := viper.New()
+	v.Set("install_id", "selected-install")
+	cfg := &config.Config{Viper: v}
+	api := &adHocAPI{}
+	service := New(validator.New(), api, cfg)
+
+	err := service.CreateAdHocRun(context.Background(), AdHocParams{
+		ScriptPath:       scriptPath,
+		Env:              []string{"DEBUG=true"},
+		Timeout:          10 * time.Minute,
+		Name:             "debug script",
+		Role:             "maintenance",
+		EnableKubeConfig: false,
+	}, true)
+	require.NoError(t, err)
+	require.Equal(t, "inst_resolved", api.installID)
+	require.Equal(t, "echo hello\n", api.request.InlineContents)
+	require.Empty(t, api.request.Command)
+	require.Equal(t, map[string]string{"DEBUG": "true"}, api.request.EnvVars)
+	require.Equal(t, int64(600), api.request.Timeout)
+	require.Equal(t, "debug script", api.request.Name)
+	require.Equal(t, "maintenance", api.request.Role)
+	require.NotNil(t, api.request.EnableKubeConfig)
+	require.False(t, *api.request.EnableKubeConfig)
+}
+
+func TestParseAdHocEnvMergesFileAndFlags(t *testing.T) {
+	envPath := filepath.Join(t.TempDir(), ".env")
+	require.NoError(t, os.WriteFile(envPath, []byte("# defaults\nFROM_FILE='value'\nexport SHARED=file\nEMPTY=\n"), 0o600))
+
+	env, err := parseAdHocEnv(envPath, []string{"SHARED=flag", "WITH_EQUALS=one=two"})
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"FROM_FILE":   "value",
+		"SHARED":      "flag",
+		"EMPTY":       "",
+		"WITH_EQUALS": "one=two",
+	}, env)
+}
+
+func TestReadAdHocInputRequiresOneSource(t *testing.T) {
+	_, err := readAdHocInput("echo hello", "script.sh")
+	require.EqualError(t, err, "provide either --command or --script, not both")
+
+	_, err = readAdHocInput("", "")
+	require.EqualError(t, err, "either --command or --script is required")
+}
+
+func TestWaitForAdHocRunStreamsRawPaginatedLogs(t *testing.T) {
+	api := &adHocAPI{
+		runs: []*models.AppInstallActionWorkflowRun{{
+			ID:     "run_123",
+			Status: string(models.AppInstallActionWorkflowRunStatusFinished),
+			RunnerJob: &models.AppRunnerJob{
+				ID:          "job_123",
+				LogStreamID: "logs_123",
+			},
+		}},
+		logPages: []adHocLogPage{
+			{
+				records: []*models.AppOtelLogRecord{
+					{ID: "plan_log", Body: "creating plan"},
+					{ID: "lifecycle_log", RunnerJobID: "job_123", ScopeName: "oteljob", Body: "executing job"},
+					{ID: "log_1", RunnerJobID: "job_123", Body: "first line", LogAttributes: map[string]string{"nuon.command_output": "true"}},
+					{ID: "log_2", RunnerJobID: "job_123", Body: "second line\n", LogAttributes: map[string]string{"nuon.command_output": "true"}},
+				},
+				next:    "next-page",
+				hasMore: true,
+			},
+			{
+				records: []*models.AppOtelLogRecord{{ID: "log_3", RunnerJobID: "job_123", Body: "third line", LogAttributes: map[string]string{"nuon.command_output": "true"}}},
+			},
+			{},
+		},
+	}
+	service := New(validator.New(), api, &config.Config{Viper: viper.New()})
+	var output bytes.Buffer
+
+	run, err := service.waitForAdHocRun(context.Background(), "inst_123", "run_123", &output)
+	require.NoError(t, err)
+	require.Equal(t, string(models.AppInstallActionWorkflowRunStatusFinished), run.Status)
+	require.Equal(t, "first line\nsecond line\nthird line\n", output.String())
+	require.Equal(t, []string{"", "next-page", "next-page", "next-page", "next-page", "next-page"}, api.logCursors)
+}
+
+func TestWaitForAdHocRunReturnsFailedTerminalStatus(t *testing.T) {
+	api := &adHocAPI{runs: []*models.AppInstallActionWorkflowRun{{
+		ID:                "run_123",
+		Status:            string(models.AppInstallActionWorkflowRunStatusError),
+		StatusDescription: "command failed",
+	}}}
+	service := New(validator.New(), api, &config.Config{Viper: viper.New()})
+
+	run, err := service.waitForAdHocRun(context.Background(), "inst_123", "run_123", &bytes.Buffer{})
+	require.NoError(t, err)
+	require.Equal(t, string(models.AppInstallActionWorkflowRunStatusError), run.Status)
+	require.Equal(t, "command failed", run.StatusDescription)
+}
+
+func TestWaitForAdHocRunHonorsCancellation(t *testing.T) {
+	api := &adHocAPI{runs: []*models.AppInstallActionWorkflowRun{{
+		ID:     "run_123",
+		Status: string(models.AppInstallActionWorkflowRunStatusQueued),
+	}}}
+	service := New(validator.New(), api, &config.Config{Viper: viper.New()})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := service.waitForAdHocRun(ctx, "inst_123", "run_123", &bytes.Buffer{})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestUnknownAdHocStatusIsNotTerminal(t *testing.T) {
+	require.False(t, isTerminalAdHocStatus(string(models.AppInstallActionWorkflowRunStatusUnknown)))
+	require.True(t, isTerminalAdHocStatus(string(models.AppInstallActionWorkflowRunStatusTimedDashOut)))
+}

--- a/sdks/nuon-go/actions.go
+++ b/sdks/nuon-go/actions.go
@@ -169,6 +169,19 @@ func (c *client) CreateInstallActionWorkflowRun(ctx context.Context, installID s
 	return err
 }
 
+func (c *client) CreateAdHocAction(ctx context.Context, installID string, req *models.ServiceCreateAdHocActionRequest) (*models.ServiceCreateAdHocActionResponse, error) {
+	resp, err := c.genClient.Operations.CreateAdHocAction(&operations.CreateAdHocActionParams{
+		InstallID: installID,
+		Req:       req,
+		Context:   ctx,
+	}, c.getOrgIDAuthInfo())
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Payload, nil
+}
+
 func (c *client) GetInstallActionWorkflowRun(ctx context.Context, installID, runID string) (*models.AppInstallActionWorkflowRun, error) {
 	resp, err := c.genClient.Operations.GetInstallActionWorkflowRun(&operations.GetInstallActionWorkflowRunParams{
 		InstallID: installID,

--- a/sdks/nuon-go/client.go
+++ b/sdks/nuon-go/client.go
@@ -338,6 +338,7 @@ type Client interface {
 	GetInstallActionWorkflows(ctx context.Context, installID string, query *models.GetPaginatedQuery) ([]*models.AppInstallActionWorkflow, bool, error)
 	GetInstallActionWorkflowRecentRuns(ctx context.Context, installID, actionWorkflowID string, query *models.GetPaginatedQuery) (*models.AppInstallActionWorkflow, bool, error)
 	CreateInstallActionWorkflowRun(ctx context.Context, installID string, req *models.ServiceCreateInstallActionWorkflowRunRequest) error
+	CreateAdHocAction(ctx context.Context, installID string, req *models.ServiceCreateAdHocActionRequest) (*models.ServiceCreateAdHocActionResponse, error)
 	GetInstallActionWorkflowRun(ctx context.Context, installID, runID string) (*models.AppInstallActionWorkflowRun, error)
 	GetInstallActionWorkflowOutputs(ctx context.Context, installID, actionID string) (any, error)
 	GetActionWorkflowLatestConfig(ctx context.Context, actionWorkflowID string) (*models.AppActionWorkflowConfig, error)


### PR DESCRIPTION
## Summary

Run one-time commands or scripts against an install from the CLI, with optional raw output streaming until completion.

## What you can do after this PR

**Run an ad hoc command or local script.** The command uses the install selected with `nuon installs select`, with `--install-id` available as an override.

**Configure the action.** Set environment variables directly or from a dotenv file, and control the timeout, name, IAM role, and Kubernetes configuration.

**Wait for command output.** `--wait` follows the same command-output log contract as notebook cells, drains delayed logs, and exits nonzero for unsuccessful runs. JSON and agent output keep structured results on stdout and send logs to stderr.

## What stays the same

Without `--wait`, the command returns queued action metadata immediately. Existing action workflow commands are unchanged.