### PR TITLE
fix(runner): preserve action output lines

### DIFF
--- a/bins/runner/internal/jobs/actions/workflow/exec_command.go
+++ b/bins/runner/internal/jobs/actions/workflow/exec_command.go
@@ -65,8 +65,8 @@ func (h *handler) execCommand(ctx context.Context, l *zap.Logger, cfg *models.Ap
 	// output and hide the runner's own job-lifecycle logs (which share the
 	// same oteljob scope and Info severity).
 	outL := l.With(zap.String("nuon.command_output", "true"))
-	lOut := zapwriter.New(outL, zapcore.InfoLevel, "")
-	lErr := zapwriter.New(outL, zapcore.ErrorLevel, "")
+	lOut := zapwriter.NewWithOpts(outL, zapwriter.WithLogLevel(zapcore.InfoLevel), zapwriter.WithLineBuffering())
+	lErr := zapwriter.NewWithOpts(outL, zapwriter.WithLogLevel(zapcore.ErrorLevel), zapwriter.WithLineBuffering())
 
 	dirName := git.Dir(src)
 	cwd := h.state.workspace.AbsPath(dirName)
@@ -93,10 +93,13 @@ func (h *handler) execCommand(ctx context.Context, l *zap.Logger, cfg *models.Ap
 	}
 
 	opCtx, end := op.Tool(ctx, "action", "command")
-	if err := cmdP.Exec(opCtx); err != nil {
-		end(err)
-		l.Error("error executing command "+err.Error(), zap.Error(err))
-		return fmt.Errorf("unable to execute command: %w", err)
+	execErr := cmdP.Exec(opCtx)
+	lOut.Flush()
+	lErr.Flush()
+	if execErr != nil {
+		end(execErr)
+		l.Error("error executing command "+execErr.Error(), zap.Error(execErr))
+		return fmt.Errorf("unable to execute command: %w", execErr)
 	}
 	end(nil)
 

--- a/bins/runner/internal/jobs/actions/workflow/exec_image.go
+++ b/bins/runner/internal/jobs/actions/workflow/exec_image.go
@@ -76,8 +76,8 @@ func (h *handler) execCommandInContainer(ctx context.Context, l *zap.Logger, cfg
 	}
 
 	outL := l.With(zap.String("nuon.command_output", "true"))
-	lOut := zapwriter.New(outL, zapcore.InfoLevel, "")
-	lErr := zapwriter.New(outL, zapcore.ErrorLevel, "")
+	lOut := zapwriter.NewWithOpts(outL, zapwriter.WithLogLevel(zapcore.InfoLevel), zapwriter.WithLineBuffering())
+	lErr := zapwriter.NewWithOpts(outL, zapwriter.WithLogLevel(zapcore.ErrorLevel), zapwriter.WithLineBuffering())
 
 	spec := launcher.RunSpec{
 		Image:         image,
@@ -109,9 +109,12 @@ func (h *handler) execCommandInContainer(ctx context.Context, l *zap.Logger, cfg
 	}
 
 	opCtx, end := op.Tool(ctx, "action", "image-command")
-	if err := h.launcher.Run(opCtx, spec); err != nil {
-		end(err)
-		return fmt.Errorf("unable to run action container: %w", err)
+	runErr := h.launcher.Run(opCtx, spec)
+	lOut.Flush()
+	lErr.Flush()
+	if runErr != nil {
+		end(runErr)
+		return fmt.Errorf("unable to run action container: %w", runErr)
 	}
 	end(nil)
 

--- a/pkg/zapwriter/writer.go
+++ b/pkg/zapwriter/writer.go
@@ -9,35 +9,73 @@ import (
 )
 
 func (z *zapWriter) Write(byts []byte) (int, error) {
+	if z.lineBuffered {
+		return z.writeBuffered(byts)
+	}
+
 	buf := bytes.NewBuffer(byts)
 
 	scanner := bufio.NewScanner(buf)
 	for scanner.Scan() {
-		inputLine := scanner.Text()
-		msg := inputLine
-		if z.lineFormatter != nil {
-			msg = z.lineFormatter(msg)
-		}
-
-		level := z.level
-		if z.lineLeveler != nil {
-			level = z.lineLeveler(inputLine)
-		}
-
-		switch level {
-		case zapcore.ErrorLevel:
-			z.l.Error(msg)
-		case zapcore.InfoLevel:
-			z.l.Info(msg)
-		case zapcore.DebugLevel:
-			z.l.Debug(msg)
-		default:
-			z.l.Info(msg)
-		}
+		z.logLine(scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
 		return 0, errors.Wrap(err, "unable to scan output")
 	}
 
 	return len(byts), nil
+}
+
+func (z *zapWriter) writeBuffered(byts []byte) (int, error) {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+
+	z.buffer = append(z.buffer, byts...)
+	for {
+		lineEnd := bytes.IndexByte(z.buffer, '\n')
+		if lineEnd < 0 {
+			break
+		}
+
+		line := z.buffer[:lineEnd]
+		line = bytes.TrimSuffix(line, []byte{'\r'})
+		z.logLine(string(line))
+		z.buffer = z.buffer[lineEnd+1:]
+	}
+
+	return len(byts), nil
+}
+
+func (z *zapWriter) Flush() {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+
+	if len(z.buffer) == 0 {
+		return
+	}
+	z.logLine(string(z.buffer))
+	z.buffer = nil
+}
+
+func (z *zapWriter) logLine(inputLine string) {
+	msg := inputLine
+	if z.lineFormatter != nil {
+		msg = z.lineFormatter(msg)
+	}
+
+	level := z.level
+	if z.lineLeveler != nil {
+		level = z.lineLeveler(inputLine)
+	}
+
+	switch level {
+	case zapcore.ErrorLevel:
+		z.l.Error(msg)
+	case zapcore.InfoLevel:
+		z.l.Info(msg)
+	case zapcore.DebugLevel:
+		z.l.Debug(msg)
+	default:
+		z.l.Info(msg)
+	}
 }

--- a/pkg/zapwriter/writer_test.go
+++ b/pkg/zapwriter/writer_test.go
@@ -1,0 +1,35 @@
+package zapwriter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestLineBufferedWriterPreservesLinesAcrossWrites(t *testing.T) {
+	core, logs := observer.New(zapcore.InfoLevel)
+	writer := NewWithOpts(zap.New(core), WithLineBuffering())
+
+	_, err := writer.Write([]byte("first line\npartial "))
+	require.NoError(t, err)
+	require.Equal(t, []string{"first line"}, observedMessages(logs))
+
+	_, err = writer.Write([]byte("line\r\nlast line"))
+	require.NoError(t, err)
+	require.Equal(t, []string{"first line", "partial line"}, observedMessages(logs))
+
+	writer.Flush()
+	require.Equal(t, []string{"first line", "partial line", "last line"}, observedMessages(logs))
+}
+
+func observedMessages(logs *observer.ObservedLogs) []string {
+	entries := logs.All()
+	messages := make([]string, len(entries))
+	for idx, entry := range entries {
+		messages[idx] = entry.Message
+	}
+	return messages
+}

--- a/pkg/zapwriter/zapwriter.go
+++ b/pkg/zapwriter/zapwriter.go
@@ -2,6 +2,7 @@ package zapwriter
 
 import (
 	"io"
+	"sync"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -36,6 +37,9 @@ type zapWriter struct {
 
 	lineFormatter func(string) string
 	lineLeveler   func(string) zapcore.Level
+	lineBuffered  bool
+	buffer        []byte
+	mu            sync.Mutex
 }
 
 type optFn func(*zapWriter)
@@ -63,5 +67,11 @@ func WithLineFormatter(fn func(string) string) optFn {
 func WithLineLeveler(fn func(string) zapcore.Level) optFn {
 	return func(r *zapWriter) {
 		r.lineLeveler = fn
+	}
+}
+
+func WithLineBuffering() optFn {
+	return func(r *zapWriter) {
+		r.lineBuffered = true
 	}
 }


### PR DESCRIPTION
## Summary

Action output now keeps each logical line intact when streamed to the CLI or notebook cells, so tabular command output no longer wraps at arbitrary pipe-read boundaries.

## What you can do after this PR

**Read action output in its original line structure.** Host and image-backed actions buffer partial writes until a newline arrives, then emit one log record per complete output line. Final output without a trailing newline is still emitted when the command exits.

## What stays the same

Action stdout and stderr keep their existing severity and command-output metadata, and other logger writers retain their current behavior.