### PR TITLE
fix(runner): persist terraform helm-release ownership across restarts

### DIFF
--- a/bins/runner/internal/pkg/componenthealth/manifest_kinds.go
+++ b/bins/runner/internal/pkg/componenthealth/manifest_kinds.go
@@ -33,6 +33,11 @@ type ManifestKindsProvider struct {
 	// objects carry neither nuon labels nor helm annotations, so this is the only
 	// record of who owns them — and it has to outlive the process.
 	objects map[string]string
+	// releases maps a helm release name to the terraform component that installed
+	// it. Same reasoning as objects: a chart installed by terraform matches no
+	// chart component and carries no nuon labels, so losing this makes every one
+	// of its workloads unowned and the component reads not-applicable forever.
+	releases map[string]string
 }
 
 type ManifestKindsProviderParams struct {
@@ -44,16 +49,17 @@ type ManifestKindsProviderParams struct {
 
 func NewManifestKindsProvider(params ManifestKindsProviderParams) *ManifestKindsProvider {
 	return &ManifestKindsProvider{
-		l:       params.L,
-		cluster: params.Cluster,
-		gvks:    map[string][]schema.GroupVersionKind{},
-		objects: map[string]string{},
+		l:        params.L,
+		cluster:  params.Cluster,
+		gvks:     map[string][]schema.GroupVersionKind{},
+		objects:  map[string]string{},
+		releases: map[string]string{},
 	}
 }
 
 // SetKinds records kinds a caller already resolved (terraform state), plus the
-// object keys that component owns.
-func (p *ManifestKindsProvider) SetKinds(componentID string, gvks []schema.GroupVersionKind, objectKeys []string) {
+// object keys and helm releases that component owns.
+func (p *ManifestKindsProvider) SetKinds(componentID string, gvks []schema.GroupVersionKind, objectKeys, releases []string) {
 	if componentID == "" {
 		return
 	}
@@ -72,8 +78,25 @@ func (p *ManifestKindsProvider) SetKinds(componentID string, gvks []schema.Group
 	for _, key := range objectKeys {
 		p.objects[key] = componentID
 	}
+	for release, owner := range p.releases {
+		if owner == componentID {
+			delete(p.releases, release)
+		}
+	}
+	for _, release := range releases {
+		p.releases[release] = componentID
+	}
 	p.mu.Unlock()
 	p.persist()
+}
+
+// ComponentForRelease returns the component whose terraform installed a helm
+// release, keyed by release name.
+func (p *ManifestKindsProvider) ComponentForRelease(release string) (string, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	componentID, ok := p.releases[release]
+	return componentID, ok
 }
 
 // ComponentForObject returns the component that applied an object, keyed as
@@ -97,11 +120,19 @@ func (p *ManifestKindsProvider) Load() {
 
 	restored := map[string][]schema.GroupVersionKind{}
 	restoredObjects := map[string]string{}
+	restoredReleases := map[string]string{}
 	for _, entry := range p.cluster.ComponentKinds() {
 		if after, isObject := strings.CutPrefix(entry, objectEntryPrefix); isObject {
 			componentID, key, found := strings.Cut(after, "|")
 			if found && componentID != "" && key != "" {
 				restoredObjects[key] = componentID
+			}
+			continue
+		}
+		if after, isRelease := strings.CutPrefix(entry, releaseEntryPrefix); isRelease {
+			componentID, release, found := strings.Cut(after, "|")
+			if found && componentID != "" && release != "" {
+				restoredReleases[release] = componentID
 			}
 			continue
 		}
@@ -124,11 +155,19 @@ func (p *ManifestKindsProvider) Load() {
 			p.objects[key] = componentID
 		}
 	}
+	for release, componentID := range restoredReleases {
+		if _, live := p.releases[release]; !live {
+			p.releases[release] = componentID
+		}
+	}
 }
 
 // objectEntryPrefix marks a persisted entry as object ownership rather than a
 // kind, so both share one stored list.
 const objectEntryPrefix = "obj:"
+
+// releaseEntryPrefix marks a persisted entry as helm-release ownership.
+const releaseEntryPrefix = "rel:"
 
 // persist mirrors every recorded kind so a restart does not lose them. Encoded
 // flat as "componentID|group/version/Kind" to keep the stored shape a plain
@@ -157,6 +196,9 @@ func (p *ManifestKindsProvider) persist() {
 	}
 	for key, componentID := range p.objects {
 		out = append(out, objectEntryPrefix+componentID+"|"+key)
+	}
+	for release, componentID := range p.releases {
+		out = append(out, releaseEntryPrefix+componentID+"|"+release)
 	}
 	p.mu.RUnlock()
 

--- a/bins/runner/internal/pkg/componenthealth/manifest_kinds_test.go
+++ b/bins/runner/internal/pkg/componenthealth/manifest_kinds_test.go
@@ -111,3 +111,63 @@ func TestPersistDoesNotClobberOtherComponents(t *testing.T) {
 	assert.Len(t, store.ComponentKinds(), 2, "cmp-a's kind must survive cmp-b's deploy")
 	assert.Len(t, b.DiscoveredGVKs(), 2)
 }
+
+// A terraform module that installs a chart owns real workloads, but they carry
+// no nuon labels and match no chart component, so the release->component map is
+// the only record of who owns them. It used to live in memory only, so any
+// runner restart made every one of those workloads unowned and the component
+// reported "no observable runtime resources" until it was redeployed.
+func TestReleaseOwnershipSurvivesRestart(t *testing.T) {
+	store := &ClusterProvider{l: zap.NewNop(), sandboxReleases: map[string]struct{}{}}
+
+	first := NewManifestKindsProvider(ManifestKindsProviderParams{L: zap.NewNop(), Cluster: store})
+	first.SetKinds("cmp-datadog", nil, nil, []string{"datadog-agent"})
+
+	owner, ok := first.ComponentForRelease("datadog-agent")
+	assert.True(t, ok)
+	assert.Equal(t, "cmp-datadog", owner)
+
+	restarted := NewManifestKindsProvider(ManifestKindsProviderParams{L: zap.NewNop(), Cluster: store})
+	_, ok = restarted.ComponentForRelease("datadog-agent")
+	assert.False(t, ok, "nothing until it loads")
+
+	restarted.Load()
+	owner, ok = restarted.ComponentForRelease("datadog-agent")
+	assert.True(t, ok, "release ownership must outlive the process")
+	assert.Equal(t, "cmp-datadog", owner)
+}
+
+// Releases removed from the module stop being attributed to it.
+func TestReleaseOwnershipReplacedOnReapply(t *testing.T) {
+	store := &ClusterProvider{l: zap.NewNop(), sandboxReleases: map[string]struct{}{}}
+	p := NewManifestKindsProvider(ManifestKindsProviderParams{L: zap.NewNop(), Cluster: store})
+
+	p.SetKinds("cmp-a", nil, nil, []string{"gone", "kept"})
+	p.SetKinds("cmp-a", nil, nil, []string{"kept"})
+
+	_, ok := p.ComponentForRelease("gone")
+	assert.False(t, ok, "a release dropped from the module must not stay attributed")
+	owner, ok := p.ComponentForRelease("kept")
+	assert.True(t, ok)
+	assert.Equal(t, "cmp-a", owner)
+}
+
+// Kinds, objects and releases share one stored list; none may evict another.
+func TestReleaseOwnershipCoexistsWithKindsAndObjects(t *testing.T) {
+	store := &ClusterProvider{l: zap.NewNop(), sandboxReleases: map[string]struct{}{}}
+	p := NewManifestKindsProvider(ManifestKindsProviderParams{L: zap.NewNop(), Cluster: store})
+
+	p.Set("cmp-chart", nodePoolManifest)
+	p.SetKinds("cmp-tf", nil, []string{"ConfigMap//cm"}, []string{"rel"})
+
+	restarted := NewManifestKindsProvider(ManifestKindsProviderParams{L: zap.NewNop(), Cluster: store})
+	restarted.Load()
+
+	assert.Len(t, restarted.DiscoveredGVKs(), 3, "chart kinds survive")
+	obj, ok := restarted.ComponentForObject("ConfigMap//cm")
+	assert.True(t, ok)
+	assert.Equal(t, "cmp-tf", obj)
+	rel, ok := restarted.ComponentForRelease("rel")
+	assert.True(t, ok)
+	assert.Equal(t, "cmp-tf", rel)
+}

--- a/bins/runner/internal/pkg/componenthealth/terraform.go
+++ b/bins/runner/internal/pkg/componenthealth/terraform.go
@@ -116,7 +116,7 @@ func (p *TerraformProvider) Set(componentID string, state *tfjson.State) {
 	p.mu.Unlock()
 
 	if sink != nil {
-		sink.SetKinds(componentID, gvks, objects)
+		sink.SetKinds(componentID, gvks, objects, releases)
 	}
 }
 
@@ -220,14 +220,26 @@ func manifestFromBody(body string) (apiVersion, kind, namespace, name string) {
 }
 
 // ComponentForRelease returns the terraform component managing a helm release.
+//
+// Falls back to the persisted store: byRelease is only repopulated by an apply,
+// so after a restart the live map is empty and every workload of a
+// terraform-installed chart would be dropped as unowned — leaving the component
+// reporting nothing and reading not-applicable until someone redeployed it.
 func (p *TerraformProvider) ComponentForRelease(release string) (string, bool) {
 	if release == "" {
 		return "", false
 	}
 	p.mu.RLock()
-	defer p.mu.RUnlock()
 	componentID, ok := p.byRelease[release]
-	return componentID, ok
+	sink := p.kindsSink
+	p.mu.RUnlock()
+	if ok {
+		return componentID, true
+	}
+	if sink == nil {
+		return "", false
+	}
+	return sink.ComponentForRelease(release)
 }
 
 // terraformHelmReleases walks state for helm_release resources. A terraform


### PR DESCRIPTION
A terraform module that installs a Helm chart owns real workloads, but they carry no Nuon labels and match no chart component, so `TerraformProvider.byRelease` is the only record of who owns them. That map was in-memory only — `SetKinds` persisted kinds and object keys but not releases — so any runner restart made those workloads unowned and the component reported "no observable runtime resources" until it was redeployed.

Persists release ownership alongside kinds and objects using the existing prefix encoding (`rel:`), and falls back to the persisted store on lookup. Found on a prod install where a datadog terraform component last reported 2026-08-19T11:53:47Z and has been stuck `not-applicable` since, while its helm_chart siblings kept updating.