### PR TITLE
fix: gorm traces should be scoped per statement

### DIFF
--- a/services/ctl-api/internal/pkg/db/plugins/tracing/tracing_plugin.go
+++ b/services/ctl-api/internal/pkg/db/plugins/tracing/tracing_plugin.go
@@ -19,7 +19,10 @@ import (
 
 type contextKey string
 
-const spanContextKey contextKey = "gorm_tracing_plugin_span"
+const (
+	spanContextKey          contextKey = "gorm_tracing_plugin_span"
+	statementSpanContextKey contextKey = "gorm_tracing_plugin_statement_span"
+)
 
 var _ gorm.Plugin = (*tracingPlugin)(nil)
 
@@ -27,6 +30,10 @@ var _ gorm.Plugin = (*tracingPlugin)(nil)
 // metrics plugin so high-cardinality dimensions (endpoint, table, org) live on traces instead of
 // metric tags. Preload queries re-enter the Query callback pipeline with the parent operation's
 // context, so they show up as child spans automatically.
+//
+// Each operation also gets a child statement span bracketing only the core SQL, using the same
+// callback positions as the metrics plugin so the span duration lines up with
+// gorm_operation.statement_latency rather than the preload-inclusive gorm_operation_latency.
 //
 // Spans only ever carry the prepared SQL with placeholders, never bound values.
 func NewTracingPlugin(dbType string) *tracingPlugin {
@@ -58,21 +65,33 @@ const (
 
 func (p *tracingPlugin) Initialize(db *gorm.DB) error {
 	db.Callback().Create().Before("*").Register("otel_before", func(tx *gorm.DB) { p.before(tx, createOperation) })
+	db.Callback().Create().After("gorm:save_before_associations").Before("gorm:create").Register("otel_before_statement", func(tx *gorm.DB) { p.beforeStatement(tx, createOperation) })
+	db.Callback().Create().After("gorm:create").Before("gorm:save_after_associations").Register("otel_after_statement", func(tx *gorm.DB) { p.afterStatement(tx, createOperation) })
 	db.Callback().Create().After("*").Register("otel_after", func(tx *gorm.DB) { p.after(tx, createOperation) })
 
 	db.Callback().Query().Before("*").Register("otel_before", func(tx *gorm.DB) { p.before(tx, queryOperation) })
+	db.Callback().Query().Before("gorm:query").Register("otel_before_statement", func(tx *gorm.DB) { p.beforeStatement(tx, queryOperation) })
+	db.Callback().Query().After("gorm:query").Before("gorm:preload").Register("otel_after_statement", func(tx *gorm.DB) { p.afterStatement(tx, queryOperation) })
 	db.Callback().Query().After("*").Register("otel_after", func(tx *gorm.DB) { p.after(tx, queryOperation) })
 
 	db.Callback().Update().Before("*").Register("otel_before", func(tx *gorm.DB) { p.before(tx, updateOperation) })
+	db.Callback().Update().After("gorm:save_before_associations").Before("gorm:update").Register("otel_before_statement", func(tx *gorm.DB) { p.beforeStatement(tx, updateOperation) })
+	db.Callback().Update().After("gorm:update").Before("gorm:save_after_associations").Register("otel_after_statement", func(tx *gorm.DB) { p.afterStatement(tx, updateOperation) })
 	db.Callback().Update().After("*").Register("otel_after", func(tx *gorm.DB) { p.after(tx, updateOperation) })
 
 	db.Callback().Delete().Before("*").Register("otel_before", func(tx *gorm.DB) { p.before(tx, deleteOperation) })
+	db.Callback().Delete().After("gorm:delete_before_associations").Before("gorm:delete").Register("otel_before_statement", func(tx *gorm.DB) { p.beforeStatement(tx, deleteOperation) })
+	db.Callback().Delete().After("gorm:delete").Register("otel_after_statement", func(tx *gorm.DB) { p.afterStatement(tx, deleteOperation) })
 	db.Callback().Delete().After("*").Register("otel_after", func(tx *gorm.DB) { p.after(tx, deleteOperation) })
 
 	db.Callback().Raw().Before("*").Register("otel_before", func(tx *gorm.DB) { p.before(tx, rawOperation) })
+	db.Callback().Raw().Before("gorm:raw").Register("otel_before_statement", func(tx *gorm.DB) { p.beforeStatement(tx, rawOperation) })
+	db.Callback().Raw().After("gorm:raw").Register("otel_after_statement", func(tx *gorm.DB) { p.afterStatement(tx, rawOperation) })
 	db.Callback().Raw().After("*").Register("otel_after", func(tx *gorm.DB) { p.after(tx, rawOperation) })
 
 	db.Callback().Row().Before("*").Register("otel_before", func(tx *gorm.DB) { p.before(tx, rowOperation) })
+	db.Callback().Row().Before("gorm:row").Register("otel_before_statement", func(tx *gorm.DB) { p.beforeStatement(tx, rowOperation) })
+	db.Callback().Row().After("gorm:row").Register("otel_after_statement", func(tx *gorm.DB) { p.afterStatement(tx, rowOperation) })
 	db.Callback().Row().After("*").Register("otel_after", func(tx *gorm.DB) { p.after(tx, rowOperation) })
 
 	return nil
@@ -99,6 +118,55 @@ func (p *tracingPlugin) before(tx *gorm.DB, op operationType) {
 	tx.Statement.Context = ctx
 }
 
+// beforeStatement/afterStatement bracket the core SQL only, so the child span excludes the preload
+// and association phases the parent span covers. The statement span is deliberately not pushed onto
+// the trace context: preload sub-queries must keep parenting under the operation span.
+func (p *tracingPlugin) beforeStatement(tx *gorm.DB, op operationType) {
+	ctx := tx.Statement.Context
+	if ctx.Value(spanContextKey) == nil {
+		return
+	}
+
+	_, span := p.tracer.Start(ctx, "gorm."+string(op)+".statement", trace.WithSpanKind(trace.SpanKindClient))
+	if !span.IsRecording() {
+		span.End()
+		return
+	}
+	tx.Statement.Context = context.WithValue(ctx, statementSpanContextKey, span)
+}
+
+func (p *tracingPlugin) afterStatement(tx *gorm.DB, op operationType) {
+	val := tx.Statement.Context.Value(statementSpanContextKey)
+	if val == nil {
+		return
+	}
+	span := val.(trace.Span)
+	defer span.End()
+
+	if !span.IsRecording() {
+		return
+	}
+
+	dbSystem := p.dbSystem()
+	table := tableName(tx)
+
+	// Distinct operation name from the parent span, otherwise the statement spans fold into the
+	// same Datadog APM stats family and double-count trace.<operation>.* for every query.
+	span.SetAttributes(
+		attribute.String("operation.name", dbSystem+".statement"),
+		attribute.String("resource.name", fmt.Sprintf("%s %s", op, table)),
+		attribute.String("db.system", dbSystem),
+		attribute.String("db.operation", string(op)),
+		attribute.String("db.sql.table", table),
+		attribute.String("db.statement", tx.Statement.SQL.String()),
+	)
+
+	if tx.Error != nil && !errors.Is(tx.Error, gorm.ErrRecordNotFound) {
+		span.RecordError(tx.Error)
+		span.SetStatus(codes.Error, tx.Error.Error())
+	}
+}
+
 func (p *tracingPlugin) after(tx *gorm.DB, op operationType) {
 	ctx := tx.Statement.Context
 
@@ -113,15 +181,8 @@ func (p *tracingPlugin) after(tx *gorm.DB, op operationType) {
 		return
 	}
 
-	tableName := "raw_sql"
-	if tx.Statement.Schema != nil {
-		tableName = tx.Statement.Schema.Table
-	}
-
-	dbSystem := "postgresql"
-	if p.dbType == "ch" {
-		dbSystem = "clickhouse"
-	}
+	table := tableName(tx)
+	dbSystem := p.dbSystem()
 
 	// The ddotel bridge turns the span name into the Datadog operation name, and Datadog
 	// creates one APM stats metric family per operation name (trace.<operation>.*). Keep the
@@ -130,10 +191,10 @@ func (p *tracingPlugin) after(tx *gorm.DB, op operationType) {
 	// resource_name tag on those metrics.
 	attrs := []attribute.KeyValue{
 		attribute.String("operation.name", dbSystem+".query"),
-		attribute.String("resource.name", fmt.Sprintf("%s %s", op, tableName)),
+		attribute.String("resource.name", fmt.Sprintf("%s %s", op, table)),
 		attribute.String("db.system", dbSystem),
 		attribute.String("db.operation", string(op)),
-		attribute.String("db.sql.table", tableName),
+		attribute.String("db.sql.table", table),
 		attribute.String("db.statement", tx.Statement.SQL.String()),
 		attribute.Int64("db.rows_affected", tx.RowsAffected),
 		attribute.Int("nuon.db.preload_count", len(tx.Statement.Preloads)),
@@ -159,6 +220,20 @@ func (p *tracingPlugin) after(tx *gorm.DB, op operationType) {
 		span.RecordError(tx.Error)
 		span.SetStatus(codes.Error, tx.Error.Error())
 	}
+}
+
+func (p *tracingPlugin) dbSystem() string {
+	if p.dbType == "ch" {
+		return "clickhouse"
+	}
+	return "postgresql"
+}
+
+func tableName(tx *gorm.DB) string {
+	if tx.Statement.Schema != nil {
+		return tx.Statement.Schema.Table
+	}
+	return "raw_sql"
 }
 
 func responseSize(tx *gorm.DB) int {

--- a/services/ctl-api/internal/pkg/db/plugins/tracing/tracing_plugin_test.go
+++ b/services/ctl-api/internal/pkg/db/plugins/tracing/tracing_plugin_test.go
@@ -159,6 +159,68 @@ func TestPreloadQueriesBecomeChildSpans(t *testing.T) {
 	require.Equal(t, int64(1), attrMap(root)["nuon.db.preload_count"].AsInt64())
 }
 
+func TestStatementSpanExcludesPreloads(t *testing.T) {
+	db, recorder := setupTest(t)
+
+	require.NoError(t, db.Create(&testAuthor{
+		Name:  "amy",
+		Books: []testBook{{Title: "one"}, {Title: "two"}},
+	}).Error)
+
+	var operation, statement, preload sdktrace.ReadOnlySpan
+	var authors []testAuthor
+	require.NoError(t, db.Preload("Books").Find(&authors).Error)
+
+	for _, s := range recorder.Ended() {
+		table := attrMap(s)["db.sql.table"].AsString()
+		switch {
+		case s.Name() == "gorm.query" && table == "test_authors" && !s.Parent().IsValid():
+			operation = s
+		case s.Name() == "gorm.query.statement" && table == "test_authors":
+			statement = s
+		case s.Name() == "gorm.query" && table == "test_books":
+			preload = s
+		}
+	}
+	require.NotNil(t, operation, "operation span not found")
+	require.NotNil(t, statement, "statement span not found")
+	require.NotNil(t, preload, "preload span not found")
+
+	require.Equal(t, operation.SpanContext().SpanID(), statement.Parent().SpanID())
+	require.Equal(t, operation.SpanContext().TraceID(), statement.SpanContext().TraceID())
+
+	// The statement span must close before the preload runs, and the operation span after it:
+	// that difference is what separates statement_latency from gorm_operation_latency.
+	require.False(t, statement.EndTime().After(preload.StartTime()))
+	require.False(t, operation.EndTime().Before(preload.EndTime()))
+
+	attrs := attrMap(statement)
+	require.Equal(t, "postgresql.statement", attrs["operation.name"].AsString())
+	require.Equal(t, "query test_authors", attrs["resource.name"].AsString())
+	require.Contains(t, attrs["db.statement"].AsString(), "SELECT")
+	require.NotContains(t, attrs["db.statement"].AsString(), "amy")
+}
+
+func TestStatementSpanEmittedForEachOperation(t *testing.T) {
+	db, recorder := setupTest(t)
+
+	author := testAuthor{Name: "amy"}
+	require.NoError(t, db.Create(&author).Error)
+	require.NoError(t, db.Model(&author).Update("name", "amy2").Error)
+	require.NoError(t, db.Delete(&author).Error)
+
+	got := map[string]bool{}
+	for _, s := range recorder.Ended() {
+		if attrMap(s)["operation.name"].AsString() == "postgresql.statement" {
+			got[attrMap(s)["db.operation"].AsString()] = true
+		}
+	}
+
+	for _, op := range []string{"create", "update", "delete"} {
+		require.True(t, got[op], "no statement span for %s", op)
+	}
+}
+
 func TestErrorsAreRecorded(t *testing.T) {
 	db, recorder := setupTest(t)
 


### PR DESCRIPTION
  ### Problem

  The gorm tracing plugin (#2114) registers only `Before("*")` / `After("*")`, so its span
  covers the entire ORM operation including the preload and association phases. That makes
  the span duration the trace analogue of `gorm_operation_latency`, not
  `gorm_operation.statement_latency` (#1644), which brackets just the root SQL.

  There is currently no span corresponding to statement latency at all. When a slow-query
  monitor fires on `gorm_operation.statement_latency` and you open the trace to investigate,
  the numbers don't correspond. On preload-heavy paths the gap is large: measured locally,
  the operation span runs 2x to 10x the actual root query.

  ### Change

  Registers `beforeStatement` / `afterStatement` at the same six callback positions the
  metrics plugin uses, emitting a child `gorm.<op>.statement` span around the core SQL only.