### PR TITLE
feat(dashboard): prototype install operation queues

### DIFF
--- a/services/dashboard-ui/client/components/operation-queues/InstallOperationRules/InstallOperationRules.stories.tsx
+++ b/services/dashboard-ui/client/components/operation-queues/InstallOperationRules/InstallOperationRules.stories.tsx
@@ -1,0 +1,151 @@
+import { InstallOperationRules } from './InstallOperationRules'
+import { makeOperationRules } from './schema'
+
+export default {
+  title: 'Operation queues/Install operation rules',
+}
+
+const noop = () => {}
+
+export const Default = () => (
+  <InstallOperationRules
+    installName="production-us-west"
+    timezone="America/Los_Angeles"
+    rules={makeOperationRules({
+      deployments: {
+        enabled: true,
+        cadence: 'weekly',
+        daysOfWeek: ['tue', 'thu'],
+        startTime: '10:00',
+        endTime: '16:00',
+        outsideWindowPolicy: 'queue',
+      },
+      'break-glass': {
+        enabled: true,
+        cadence: 'weekly',
+        daysOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri'],
+        startTime: '08:00',
+        endTime: '18:00',
+        outsideWindowPolicy: 'approval',
+      },
+    })}
+    onCancel={noop}
+    onSave={noop}
+  />
+)
+
+export const AllDisabled = () => (
+  <InstallOperationRules
+    installName="production-us-west"
+    timezone="UTC"
+    rules={makeOperationRules()}
+    onCancel={noop}
+    onSave={noop}
+  />
+)
+
+export const AllEnabled = () => (
+  <InstallOperationRules
+    installName="production-us-west"
+    timezone="UTC"
+    rules={makeOperationRules({
+      actions: {
+        enabled: true,
+        cadence: 'weekly',
+        daysOfWeek: ['mon', 'wed', 'fri'],
+        outsideWindowPolicy: 'queue',
+      },
+      runbooks: {
+        enabled: true,
+        cadence: 'monthly',
+        dayOfMonth: '15',
+        startTime: '01:00',
+        endTime: '05:00',
+        outsideWindowPolicy: 'approval',
+      },
+      'sandbox-updates': {
+        enabled: true,
+        cadence: 'monthly',
+        dayOfMonth: 'last',
+        startTime: '22:00',
+        endTime: '23:30',
+        outsideWindowPolicy: 'reject',
+      },
+      deployments: {
+        enabled: true,
+        cadence: 'weekly',
+        daysOfWeek: ['tue', 'thu'],
+        outsideWindowPolicy: 'queue',
+      },
+      'break-glass': {
+        enabled: true,
+        cadence: 'anytime',
+      },
+    })}
+    onCancel={noop}
+    onSave={noop}
+  />
+)
+
+export const WeeklyChangeWindow = () => (
+  <InstallOperationRules
+    installName="production-eu-central"
+    timezone="Europe/Berlin"
+    rules={makeOperationRules({
+      deployments: {
+        enabled: true,
+        cadence: 'weekly',
+        daysOfWeek: ['wed'],
+        startTime: '02:00',
+        endTime: '06:00',
+        outsideWindowPolicy: 'queue',
+      },
+      'sandbox-updates': {
+        enabled: true,
+        cadence: 'weekly',
+        daysOfWeek: ['wed'],
+        startTime: '02:00',
+        endTime: '06:00',
+        outsideWindowPolicy: 'reject',
+      },
+    })}
+    onCancel={noop}
+    onSave={noop}
+  />
+)
+
+export const BreakGlassApproval = () => (
+  <InstallOperationRules
+    installName="production-us-east"
+    timezone="America/New_York"
+    rules={makeOperationRules({
+      'break-glass': {
+        enabled: true,
+        cadence: 'monthly',
+        dayOfMonth: '1',
+        startTime: '00:00',
+        endTime: '23:59',
+        outsideWindowPolicy: 'approval',
+      },
+    })}
+    onCancel={noop}
+    onSave={noop}
+  />
+)
+
+export const IncompleteWindow = () => (
+  <InstallOperationRules
+    installName="production-us-west"
+    timezone="UTC"
+    rules={makeOperationRules({
+      actions: {
+        enabled: true,
+        cadence: 'weekly',
+        daysOfWeek: [],
+        outsideWindowPolicy: 'reject',
+      },
+    })}
+    onCancel={noop}
+    onSave={noop}
+  />
+)

--- a/services/dashboard-ui/client/components/operation-queues/InstallOperationRules/InstallOperationRules.tsx
+++ b/services/dashboard-ui/client/components/operation-queues/InstallOperationRules/InstallOperationRules.tsx
@@ -1,0 +1,535 @@
+import { useForm, useStore } from '@tanstack/react-form'
+import { Badge } from '@/components/common/Badge'
+import { Button } from '@/components/common/Button'
+import { Card } from '@/components/common/Card'
+import { Divider } from '@/components/common/Divider'
+import { Icon, type TIconVariant } from '@/components/common/Icon'
+import { Text } from '@/components/common/Text'
+import { ToggleButton } from '@/components/common/ToggleButton'
+import { FormCheckbox } from '@/components/common/form/FormCheckbox'
+import { FormInput } from '@/components/common/form/FormInput'
+import { FormRadioGroup } from '@/components/common/form/FormRadioGroup'
+import { FormSelect } from '@/components/common/form/FormSelect'
+import { Label } from '@/components/common/form/Label'
+import { Toggle } from '@/components/common/form/Toggle'
+import {
+  installOperationRulesSchema,
+  isRuleWindowValid,
+  type InstallOperationRuleValues,
+  type InstallOperationRulesValues,
+  type TOperationRuleId,
+  type TOperationWindowCadence,
+  type TOutsideWindowPolicy,
+} from './schema'
+
+export interface IInstallOperationRules {
+  installName: string
+  timezone: string
+  rules: InstallOperationRuleValues[]
+  onCancel: () => void
+  onSave: (values: InstallOperationRulesValues) => void
+}
+
+interface IOperationRuleMeta {
+  label: string
+  description: string
+  icon: TIconVariant
+}
+
+const ruleMeta: Record<TOperationRuleId, IOperationRuleMeta> = {
+  actions: {
+    label: 'Actions',
+    description:
+      'One-off action runs triggered manually, on a schedule, or through the API.',
+    icon: 'LightningIcon',
+  },
+  runbooks: {
+    label: 'Runbooks',
+    description: 'Ordered release procedures that combine deploys and actions.',
+    icon: 'BookOpenTextIcon',
+  },
+  'sandbox-updates': {
+    label: 'Sandbox updates',
+    description:
+      'Changes to the install sandbox — IAM, networking, and cluster infrastructure.',
+    icon: 'FlaskIcon',
+  },
+  deployments: {
+    label: 'Deployments',
+    description: 'Component deploys and redeploys to this install.',
+    icon: 'RocketIcon',
+  },
+  'break-glass': {
+    label: 'Break glass',
+    description: 'Emergency runs that bypass the normal operation path.',
+    icon: 'LockKeyOpenIcon',
+  },
+}
+
+const cadenceOptions: {
+  value: TOperationWindowCadence
+  label: string
+}[] = [
+  { value: 'anytime', label: 'Anytime' },
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'monthly', label: 'Monthly' },
+]
+
+const weekdays = [
+  { value: 'mon', label: 'Mon' },
+  { value: 'tue', label: 'Tue' },
+  { value: 'wed', label: 'Wed' },
+  { value: 'thu', label: 'Thu' },
+  { value: 'fri', label: 'Fri' },
+  { value: 'sat', label: 'Sat' },
+  { value: 'sun', label: 'Sun' },
+]
+
+const dayOfMonthOptions = [
+  ...Array.from({ length: 28 }, (_, i) => ({
+    value: `${i + 1}`,
+    label: `Day ${i + 1}`,
+  })),
+  { value: 'last', label: 'Last day of the month' },
+]
+
+const timezoneOptions = [
+  { value: 'UTC', label: 'UTC' },
+  { value: 'America/Los_Angeles', label: 'America/Los_Angeles' },
+  { value: 'America/Denver', label: 'America/Denver' },
+  { value: 'America/Chicago', label: 'America/Chicago' },
+  { value: 'America/New_York', label: 'America/New_York' },
+  { value: 'Europe/London', label: 'Europe/London' },
+  { value: 'Europe/Berlin', label: 'Europe/Berlin' },
+  { value: 'Asia/Tokyo', label: 'Asia/Tokyo' },
+  { value: 'Australia/Sydney', label: 'Australia/Sydney' },
+]
+
+const policyMeta: Record<
+  TOutsideWindowPolicy,
+  { label: string; description: string; icon: TIconVariant }
+> = {
+  reject: {
+    label: 'Reject',
+    description: 'Block the operation and notify whoever triggered it.',
+    icon: 'ProhibitIcon',
+  },
+  approval: {
+    label: 'Ask for permission',
+    description: 'Hold the operation until an approver responds.',
+    icon: 'ShieldCheckIcon',
+  },
+  queue: {
+    label: 'Queue',
+    description: 'Run automatically once the next window opens.',
+    icon: 'ClockIcon',
+  },
+}
+
+const policyOptions = (['reject', 'approval', 'queue'] as const).map(
+  (value) => ({
+    value,
+    label: (
+      <span className="flex flex-col gap-0.5">
+        <Text flex weight="strong">
+          <Icon variant={policyMeta[value].icon} size={14} />
+          {policyMeta[value].label}
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          {policyMeta[value].description}
+        </Text>
+      </span>
+    ),
+  })
+)
+
+const windowSummary = (rule: InstallOperationRuleValues) => {
+  if (rule.cadence === 'anytime') return 'anytime'
+  const when =
+    rule.cadence === 'weekly'
+      ? rule.daysOfWeek.length
+        ? rule.daysOfWeek
+            .map(
+              (day) => weekdays.find((weekday) => weekday.value === day)?.label
+            )
+            .join(', ')
+        : 'no days selected'
+      : rule.dayOfMonth === 'last'
+        ? 'the last day of the month'
+        : `day ${rule.dayOfMonth} of the month`
+  return `${when}, ${rule.startTime}–${rule.endTime}`
+}
+
+const policyPhrases: Record<TOutsideWindowPolicy, [string, string]> = {
+  reject: ['is rejected', 'are rejected'],
+  approval: ['asks for permission', 'ask for permission'],
+  queue: ['is queued', 'are queued'],
+}
+
+const policySummary = (counts: Record<TOutsideWindowPolicy, number>) => {
+  const parts = (['reject', 'approval', 'queue'] as const)
+    .filter((policy) => counts[policy])
+    .map((policy) => {
+      const count = counts[policy]
+      const [singular, plural] = policyPhrases[policy]
+      return `${count} ${count === 1 ? 'operation type' : 'operation types'} ${count === 1 ? singular : plural}`
+    })
+  if (parts.length < 2) return parts.join('')
+  return `${parts.slice(0, -1).join(', ')} and ${parts.at(-1)}`
+}
+
+export const InstallOperationRules = ({
+  installName,
+  timezone,
+  rules,
+  onCancel,
+  onSave,
+}: IInstallOperationRules) => {
+  const form = useForm({
+    defaultValues: { timezone, rules } as InstallOperationRulesValues,
+    validators: {
+      onMount: installOperationRulesSchema,
+      onChange: installOperationRulesSchema,
+    },
+    onSubmit: ({ value }) => onSave(value),
+  })
+  const values = useStore(form.store, (state) => state.values)
+  const canSubmit = useStore(form.store, (state) => state.canSubmit)
+
+  const enabledRules = values.rules.filter((rule) => rule.enabled)
+  const allEnabled = values.rules.every((rule) => rule.enabled)
+  const invalidRules = values.rules.filter((rule) => !isRuleWindowValid(rule))
+  const restrictedRules = enabledRules.filter(
+    (rule) => rule.cadence !== 'anytime' && rule.enforceOutsideWindow
+  )
+  const policyCounts = restrictedRules.reduce(
+    (counts, rule) => ({
+      ...counts,
+      [rule.outsideWindowPolicy]: (counts[rule.outsideWindowPolicy] ?? 0) + 1,
+    }),
+    {} as Record<TOutsideWindowPolicy, number>
+  )
+
+  const setAllEnabled = (enabled: boolean) =>
+    values.rules.forEach((_, index) =>
+      form.setFieldValue(`rules[${index}].enabled`, enabled)
+    )
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-6">
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+        <div className="flex items-start gap-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Back to install"
+            onClick={onCancel}
+          >
+            <Icon variant="ArrowLeftIcon" />
+          </Button>
+          <div className="flex flex-col items-start gap-1">
+            <Text as="h1" variant="h2" weight="stronger">
+              Install operation rules
+            </Text>
+            <Text theme="neutral">
+              Control when operations may run on {installName}, and what happens
+              when one is triggered outside its window.
+            </Text>
+            <Badge size="sm" theme="neutral">
+              <Icon variant="CubeIcon" size={13} />
+              {installName}
+            </Badge>
+          </div>
+        </div>
+        <Button
+          variant="primary"
+          disabled={!canSubmit || !!invalidRules.length}
+          tooltipProps={
+            invalidRules.length
+              ? { tipContent: 'Finish the highlighted windows first' }
+              : undefined
+          }
+          onClick={() => form.handleSubmit()}
+        >
+          <Icon variant="CheckIcon" />
+          Save rules
+        </Button>
+      </div>
+
+      <form
+        autoComplete="off"
+        noValidate
+        onSubmit={(event) => event.preventDefault()}
+        className="flex flex-col gap-6"
+      >
+        <Card className="!gap-4 !p-4">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="flex flex-col gap-2">
+              <Toggle
+                checked={allEnabled}
+                onChange={setAllEnabled}
+                label="Enable all"
+                description={`${enabledRules.length} of ${values.rules.length} operation types are governed by a rule.`}
+              />
+            </div>
+            <form.Field name="timezone">
+              {(field) => (
+                <FormSelect
+                  field={field}
+                  size="sm"
+                  options={timezoneOptions}
+                  className="min-w-[16rem]"
+                  labelProps={{ labelText: 'Window timezone' }}
+                />
+              )}
+            </form.Field>
+          </div>
+        </Card>
+
+        <Card className="!gap-4 !p-4">
+          <div className="flex flex-col gap-1">
+            <Text variant="base" weight="strong">
+              Operation rules
+            </Text>
+            <Text variant="subtext" theme="neutral">
+              Give each operation type a repeating window, then choose what to
+              do with operations triggered outside it.
+            </Text>
+          </div>
+
+          <div className="-mx-4">
+            <Divider />
+          </div>
+
+          <div className="divide-y">
+            {values.rules.map((rule, index) => {
+              const meta = ruleMeta[rule.id]
+              const isAnytime = rule.cadence === 'anytime'
+              const isValid = isRuleWindowValid(rule)
+
+              return (
+                <div
+                  key={rule.id}
+                  className="grid gap-4 py-5 first:pt-0 last:pb-0 sm:grid-cols-[minmax(0,1fr)_minmax(22rem,1fr)]"
+                >
+                  <div className="flex flex-col gap-2">
+                    <Text flex weight="strong">
+                      <Icon variant={meta.icon} size={16} />
+                      {meta.label}
+                    </Text>
+                    <Text variant="subtext" theme="neutral">
+                      {meta.description}
+                    </Text>
+                    <form.Field name={`rules[${index}].enabled`}>
+                      {(field) => (
+                        <Toggle
+                          checked={!!field.state.value}
+                          onChange={(checked) => field.handleChange(checked)}
+                          label={
+                            field.state.value ? 'Rule enabled' : 'Not enforced'
+                          }
+                          aria-label={`${meta.label} rule`}
+                        />
+                      )}
+                    </form.Field>
+                  </div>
+
+                  {!rule.enabled ? (
+                    <Text variant="subtext" theme="neutral">
+                      {meta.label} may run at any time.
+                    </Text>
+                  ) : (
+                    <div className="flex flex-col gap-4">
+                      <div className="flex flex-col gap-2">
+                        <Label>Window</Label>
+                        <form.Field name={`rules[${index}].cadence`}>
+                          {(field) => (
+                            <ToggleButton<TOperationWindowCadence>
+                              options={cadenceOptions}
+                              value={
+                                field.state.value as TOperationWindowCadence
+                              }
+                              onChange={(value) => field.handleChange(value)}
+                              className="self-start"
+                            />
+                          )}
+                        </form.Field>
+                      </div>
+
+                      {isAnytime ? (
+                        <Text flex variant="subtext" theme="neutral">
+                          <Icon variant="CheckCircleIcon" size={14} />
+                          {meta.label} may run at any time — nothing falls
+                          outside this window.
+                        </Text>
+                      ) : (
+                        <>
+                          {rule.cadence === 'weekly' ? (
+                            <form.Field name={`rules[${index}].daysOfWeek`}>
+                              {(field) => {
+                                const selected =
+                                  (field.state.value as string[]) ?? []
+                                return (
+                                  <div className="flex flex-col gap-2">
+                                    <Label>Days</Label>
+                                    <div className="flex flex-wrap gap-1">
+                                      {weekdays.map((day) => (
+                                        <Button
+                                          key={day.value}
+                                          size="xs"
+                                          variant={
+                                            selected.includes(day.value)
+                                              ? 'primary'
+                                              : 'secondary'
+                                          }
+                                          aria-pressed={selected.includes(
+                                            day.value
+                                          )}
+                                          className="min-w-[3rem] justify-center"
+                                          onClick={() =>
+                                            field.handleChange(
+                                              selected.includes(day.value)
+                                                ? selected.filter(
+                                                    (value) =>
+                                                      value !== day.value
+                                                  )
+                                                : [...selected, day.value]
+                                            )
+                                          }
+                                        >
+                                          {day.label}
+                                        </Button>
+                                      ))}
+                                    </div>
+                                  </div>
+                                )
+                              }}
+                            </form.Field>
+                          ) : (
+                            <form.Field name={`rules[${index}].dayOfMonth`}>
+                              {(field) => (
+                                <FormSelect
+                                  field={field}
+                                  size="sm"
+                                  options={dayOfMonthOptions}
+                                  labelProps={{ labelText: 'Day' }}
+                                />
+                              )}
+                            </form.Field>
+                          )}
+
+                          <div className="grid gap-3 sm:grid-cols-2">
+                            <form.Field name={`rules[${index}].startTime`}>
+                              {(field) => (
+                                <FormInput
+                                  field={field}
+                                  type="time"
+                                  size="sm"
+                                  labelProps={{ labelText: 'Opens' }}
+                                />
+                              )}
+                            </form.Field>
+                            <form.Field name={`rules[${index}].endTime`}>
+                              {(field) => (
+                                <FormInput
+                                  field={field}
+                                  type="time"
+                                  size="sm"
+                                  labelProps={{ labelText: 'Closes' }}
+                                />
+                              )}
+                            </form.Field>
+                          </div>
+
+                          <form.Field
+                            name={`rules[${index}].enforceOutsideWindow`}
+                          >
+                            {(field) => (
+                              <FormCheckbox
+                                field={field}
+                                labelProps={{
+                                  className: '-ml-2',
+                                  labelText:
+                                    'When triggered outside of this window, do the following',
+                                }}
+                              />
+                            )}
+                          </form.Field>
+
+                          {rule.enforceOutsideWindow ? (
+                            <form.Field
+                              name={`rules[${index}].outsideWindowPolicy`}
+                            >
+                              {(field) => (
+                                <FormRadioGroup
+                                  field={field}
+                                  options={policyOptions}
+                                />
+                              )}
+                            </form.Field>
+                          ) : (
+                            <Text variant="subtext" theme="neutral">
+                              Operations triggered outside the window run
+                              normally.
+                            </Text>
+                          )}
+
+                          {!isValid ? (
+                            <Text flex variant="subtext" theme="error">
+                              <Icon variant="WarningIcon" size={14} />
+                              {rule.cadence === 'weekly' &&
+                              !rule.daysOfWeek.length
+                                ? 'Pick at least one day.'
+                                : 'Set an opening and closing time that differ.'}
+                            </Text>
+                          ) : null}
+                        </>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </Card>
+      </form>
+
+      <Card className="!gap-4 !p-4 bg-cool-grey-50 dark:bg-dark-grey-700">
+        <div className="flex items-center gap-2">
+          <Icon variant="InfoIcon" size={18} theme="brand" />
+          <Text variant="base" weight="strong">
+            Impact
+          </Text>
+        </div>
+        <div className="flex flex-col gap-2">
+          {enabledRules.length ? (
+            <>
+              {enabledRules.map((rule) => (
+                <Text key={rule.id} flex variant="subtext">
+                  <Icon variant={ruleMeta[rule.id].icon} size={15} />
+                  {ruleMeta[rule.id].label}: {windowSummary(rule)}
+                  {rule.cadence === 'anytime' ? '.' : ` (${values.timezone}).`}
+                </Text>
+              ))}
+              <Text flex variant="subtext" theme="neutral">
+                <Icon variant="ClockIcon" size={15} />
+                {restrictedRules.length
+                  ? `Outside their window, ${policySummary(policyCounts)}.`
+                  : 'No operation type blocks work outside its window.'}
+              </Text>
+            </>
+          ) : (
+            <Text flex variant="subtext" theme="neutral">
+              <Icon variant="CheckCircleIcon" size={15} />
+              No rules are enforced — every operation may run at any time.
+            </Text>
+          )}
+          <Text flex variant="subtext" theme="neutral">
+            <Icon variant="ShieldIcon" size={15} />
+            Break glass runs are permissioned and audited separately.
+          </Text>
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/services/dashboard-ui/client/components/operation-queues/InstallOperationRules/index.ts
+++ b/services/dashboard-ui/client/components/operation-queues/InstallOperationRules/index.ts
@@ -1,0 +1,19 @@
+export {
+  InstallOperationRules,
+  type IInstallOperationRules,
+} from './InstallOperationRules'
+export {
+  installOperationRuleSchema,
+  installOperationRulesSchema,
+  isRuleWindowValid,
+  makeOperationRule,
+  makeOperationRules,
+  operationRuleIds,
+  operationWindowCadences,
+  outsideWindowPolicies,
+  type InstallOperationRuleValues,
+  type InstallOperationRulesValues,
+  type TOperationRuleId,
+  type TOperationWindowCadence,
+  type TOutsideWindowPolicy,
+} from './schema'

--- a/services/dashboard-ui/client/components/operation-queues/InstallOperationRules/schema.ts
+++ b/services/dashboard-ui/client/components/operation-queues/InstallOperationRules/schema.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod'
+
+export const operationWindowCadences = ['anytime', 'weekly', 'monthly'] as const
+export const outsideWindowPolicies = ['reject', 'approval', 'queue'] as const
+export const operationRuleIds = [
+  'actions',
+  'runbooks',
+  'sandbox-updates',
+  'deployments',
+  'break-glass',
+] as const
+
+export const installOperationRuleSchema = z.object({
+  id: z.enum(operationRuleIds),
+  enabled: z.boolean(),
+  cadence: z.enum(operationWindowCadences),
+  daysOfWeek: z.array(z.string()),
+  dayOfMonth: z.string(),
+  startTime: z.string(),
+  endTime: z.string(),
+  enforceOutsideWindow: z.boolean(),
+  outsideWindowPolicy: z.enum(outsideWindowPolicies),
+})
+
+export const installOperationRulesSchema = z.object({
+  timezone: z.string().min(1, 'Select a timezone'),
+  rules: z.array(installOperationRuleSchema),
+})
+
+export type TOperationWindowCadence = (typeof operationWindowCadences)[number]
+export type TOutsideWindowPolicy = (typeof outsideWindowPolicies)[number]
+export type TOperationRuleId = (typeof operationRuleIds)[number]
+export type InstallOperationRuleValues = z.infer<
+  typeof installOperationRuleSchema
+>
+export type InstallOperationRulesValues = z.infer<
+  typeof installOperationRulesSchema
+>
+
+export const makeOperationRule = (
+  id: TOperationRuleId,
+  overrides: Partial<InstallOperationRuleValues> = {}
+): InstallOperationRuleValues => ({
+  id,
+  enabled: false,
+  cadence: 'anytime',
+  daysOfWeek: [],
+  dayOfMonth: '1',
+  startTime: '09:00',
+  endTime: '17:00',
+  enforceOutsideWindow: true,
+  outsideWindowPolicy: 'queue',
+  ...overrides,
+})
+
+export const makeOperationRules = (
+  overrides: Partial<
+    Record<TOperationRuleId, Partial<InstallOperationRuleValues>>
+  > = {}
+): InstallOperationRuleValues[] =>
+  operationRuleIds.map((id) => makeOperationRule(id, overrides[id]))
+
+export const isRuleWindowValid = (rule: InstallOperationRuleValues) => {
+  if (!rule.enabled || rule.cadence === 'anytime') return true
+  if (!rule.startTime || !rule.endTime || rule.startTime === rule.endTime)
+    return false
+  if (rule.cadence === 'weekly') return rule.daysOfWeek.length > 0
+  return !!rule.dayOfMonth
+}

--- a/services/dashboard-ui/client/components/operation-queues/InstallOperationsQueue/InstallOperationsQueue.stories.tsx
+++ b/services/dashboard-ui/client/components/operation-queues/InstallOperationsQueue/InstallOperationsQueue.stories.tsx
@@ -1,0 +1,1093 @@
+export default {
+  title: 'Operation queues/Install operations queue',
+}
+
+import { useState } from 'react'
+import { useForm, useStore } from '@tanstack/react-form'
+import type { ColumnDef } from '@tanstack/react-table'
+import { Badge } from '@/components/common/Badge'
+import { Banner } from '@/components/common/Banner'
+import { Button } from '@/components/common/Button'
+import { Card } from '@/components/common/Card'
+import { Divider } from '@/components/common/Divider'
+import { HeadingGroup } from '@/components/common/HeadingGroup'
+import { Icon } from '@/components/common/Icon'
+import { Link } from '@/components/common/Link'
+import { Status } from '@/components/common/Status'
+import { Table } from '@/components/common/Table'
+import { Text } from '@/components/common/Text'
+import { PageSection } from '@/components/layout/PageSection'
+import {
+  InstallRunbooksTableComponent,
+  type TInstallRunbookRow,
+} from '@/components/runbooks/InstallRunbooksTable'
+import {
+  AddQueueOperationStudio,
+  InstallOperationsQueue,
+  QueueAdmissionRulesStudio,
+  type IOperationQueueEntry,
+  type IQueueAdmissionExemptionOption,
+  type IQueueOperationOption,
+  type TQueueAdmissionPolicy,
+  type TScheduledOperationsPolicy,
+  type TOperationQueueStatus,
+} from './InstallOperationsQueue'
+import {
+  installQueueReorderSchema,
+  type InstallQueueReorderValues,
+} from './schema'
+
+const initialEntries: IOperationQueueEntry[] = [
+  {
+    id: 'operation-backup',
+    name: 'Back up database',
+    type: 'runbook',
+    status: 'success',
+    detail: 'Runbook · Completed 8 minutes ago',
+    required: true,
+  },
+  {
+    id: 'operation-rotate',
+    name: 'Rotate database credentials',
+    type: 'runbook',
+    status: 'in-progress',
+    detail: 'Runbook · Started by an operator',
+    required: true,
+  },
+  {
+    id: 'operation-deploy',
+    name: 'Deploy application',
+    type: 'deploy',
+    status: 'blocked',
+    detail: 'Deploy all components from the approved build',
+    blockedBy: 'Rotate database credentials',
+  },
+  {
+    id: 'operation-verify',
+    name: 'Verify service health',
+    type: 'action',
+    status: 'queued',
+    detail: 'Action · Run health and connectivity checks',
+  },
+]
+
+const rules = [
+  {
+    id: 'rule-admission',
+    name: 'Mutations use this queue',
+    description: 'Runbooks, deploys, and actions must be submitted here.',
+  },
+  {
+    id: 'rule-deploy',
+    name: 'Credentials before deploy',
+    description: 'The deploy remains blocked until credential rotation passes.',
+  },
+  {
+    id: 'rule-concurrency',
+    name: 'One operation at a time',
+    description:
+      'The next eligible operation starts after the current one finishes.',
+  },
+]
+
+const operationOptions: IQueueOperationOption[] = [
+  {
+    id: 'restart-workers',
+    name: 'Restart workers',
+    type: 'runbook',
+    detail: 'Runbook · Restart workers and verify queue processing',
+  },
+  {
+    id: 'deploy-approved-build',
+    name: 'Deploy approved build',
+    type: 'deploy',
+    detail: 'Deploy · Roll out the approved build to all components',
+  },
+  {
+    id: 'verify-connectivity',
+    name: 'Verify connectivity',
+    type: 'action',
+    detail: 'Action · Check service and dependency connectivity',
+  },
+]
+
+const exemptionOptions: IQueueAdmissionExemptionOption[] = [
+  {
+    id: 'runbook-independent',
+    operationType: 'runbook',
+    labelKey: 'operations',
+    labelValue: 'independent',
+    matchingOperations: ['Restart stateless workers', 'Verify service health'],
+  },
+  {
+    id: 'component-deploy-canary',
+    operationType: 'component deploy',
+    labelKey: 'environment',
+    labelValue: 'canary',
+    matchingOperations: ['Deploy metrics collector'],
+  },
+  {
+    id: 'sandbox-read-only',
+    operationType: 'sandbox operation',
+    labelKey: 'risk',
+    labelValue: 'read-only',
+    matchingOperations: ['Check sandbox drift'],
+  },
+  {
+    id: 'action-routine',
+    operationType: 'action',
+    labelKey: 'operations',
+    labelValue: 'routine',
+    matchingOperations: ['Verify connectivity', 'Flush cache'],
+  },
+]
+
+export const Interactive = () => {
+  const [status, setStatus] = useState<TOperationQueueStatus>('running')
+  const [entries, setEntries] = useState(initialEntries)
+  const [addingOperation, setAddingOperation] = useState(false)
+  const [configuringRules, setConfiguringRules] = useState(false)
+  const [selectedOptionId, setSelectedOptionId] = useState('')
+  const [required, setRequired] = useState(false)
+  const [admissionPolicy, setAdmissionPolicy] =
+    useState<TQueueAdmissionPolicy>('enqueue')
+  const [scheduledOperationsPolicy, setScheduledOperationsPolicy] =
+    useState<TScheduledOperationsPolicy>('enqueue')
+  const [selectedExemptionIds, setSelectedExemptionIds] = useState<string[]>([])
+
+  const addOperation = () => {
+    const selectedOption = operationOptions.find(
+      (option) => option.id === selectedOptionId
+    )
+    if (!selectedOption) return
+
+    setEntries((current) =>
+      current.some((entry) => entry.id === `operation-${selectedOption.id}`)
+        ? current
+        : [
+            ...current,
+            {
+              ...selectedOption,
+              id: `operation-${selectedOption.id}`,
+              status: 'queued',
+              required,
+            },
+          ]
+    )
+    setAddingOperation(false)
+    setSelectedOptionId('')
+    setRequired(false)
+  }
+
+  if (addingOperation) {
+    return (
+      <AddQueueOperationStudio
+        installName="production-us-west"
+        queueName="August maintenance"
+        entries={entries}
+        options={operationOptions}
+        selectedOptionId={selectedOptionId}
+        required={required}
+        onSelectOption={setSelectedOptionId}
+        onRequiredChange={setRequired}
+        onCancel={() => {
+          setAddingOperation(false)
+          setSelectedOptionId('')
+          setRequired(false)
+        }}
+        onAdd={addOperation}
+      />
+    )
+  }
+
+  if (configuringRules) {
+    return (
+      <QueueAdmissionRulesStudio
+        installName="production-us-west"
+        queueName="August maintenance"
+        admissionPolicy={admissionPolicy}
+        scheduledOperationsPolicy={scheduledOperationsPolicy}
+        exemptionOptions={exemptionOptions}
+        selectedExemptionIds={selectedExemptionIds}
+        onCancel={() => setConfiguringRules(false)}
+        onSave={(nextRules) => {
+          setAdmissionPolicy(nextRules.admissionPolicy)
+          setScheduledOperationsPolicy(nextRules.scheduledOperationsPolicy)
+          setSelectedExemptionIds(nextRules.selectedExemptionIds)
+          setConfiguringRules(false)
+        }}
+      />
+    )
+  }
+
+  const configuredRules =
+    admissionPolicy === 'strict'
+      ? [
+          {
+            id: 'rule-strict-admission',
+            name: 'Strict queue admission',
+            description:
+              'Blocks every operation that was not submitted through this queue.',
+          },
+          rules[2],
+        ]
+      : [
+          rules[0],
+          {
+            id: 'rule-scheduled',
+            name: 'Scheduled operations',
+            description:
+              scheduledOperationsPolicy === 'direct'
+                ? 'Cron-triggered operations run directly.'
+                : 'Cron-triggered operations join this queue.',
+          },
+          ...exemptionOptions
+            .filter((exemption) => selectedExemptionIds.includes(exemption.id))
+            .map((exemption) => ({
+              id: `rule-operation-exemption-${exemption.id}`,
+              name: 'Operation exemption',
+              description: `Allows ${exemption.operationType} operations labeled ${exemption.labelKey}=${exemption.labelValue} to run directly.`,
+            })),
+          rules[2],
+        ]
+
+  return (
+    <InstallOperationsQueue
+      installName="production-us-west"
+      queueName="August maintenance"
+      status={status}
+      entries={entries}
+      rules={configuredRules}
+      onAddOperation={() => setAddingOperation(true)}
+      onConfigureRules={() => setConfiguringRules(true)}
+      onStart={() => setStatus('running')}
+      onRunOutsideQueue={() => setStatus('out-of-band')}
+      onFinishOutsideOperation={() => setStatus('running')}
+    />
+  )
+}
+
+export const AdmissionRules = () => {
+  return (
+    <QueueAdmissionRulesStudio
+      installName="production-us-west"
+      queueName="August maintenance"
+      admissionPolicy="enqueue"
+      scheduledOperationsPolicy="enqueue"
+      exemptionOptions={exemptionOptions}
+      selectedExemptionIds={exemptionOptions.map((exemption) => exemption.id)}
+      onCancel={() => {}}
+      onSave={() => {}}
+    />
+  )
+}
+
+export const AdmissionRulesWithoutExemptions = () => {
+  return (
+    <QueueAdmissionRulesStudio
+      installName="production-us-west"
+      queueName="August maintenance"
+      admissionPolicy="enqueue"
+      scheduledOperationsPolicy="enqueue"
+      exemptionOptions={exemptionOptions}
+      selectedExemptionIds={[]}
+      onCancel={() => {}}
+      onSave={() => {}}
+    />
+  )
+}
+
+export const AdmissionRulesStrictQueue = () => {
+  return (
+    <QueueAdmissionRulesStudio
+      installName="production-us-west"
+      queueName="August maintenance"
+      admissionPolicy="strict"
+      scheduledOperationsPolicy="direct"
+      exemptionOptions={exemptionOptions}
+      selectedExemptionIds={exemptionOptions.map((exemption) => exemption.id)}
+      onCancel={() => {}}
+      onSave={() => {}}
+    />
+  )
+}
+
+export const Draft = () => (
+  <InstallOperationsQueue
+    installName="production-us-west"
+    queueName="August maintenance"
+    status="draft"
+    entries={initialEntries.map((entry) => ({
+      ...entry,
+      status: 'queued',
+      blockedBy: undefined,
+    }))}
+    rules={rules}
+  />
+)
+
+export const OutsideOperationActive = () => (
+  <InstallOperationsQueue
+    installName="production-us-west"
+    queueName="August maintenance"
+    status="out-of-band"
+    entries={initialEntries}
+    rules={rules}
+  />
+)
+
+export const DirectRunBlocked = () => {
+  const [attempted, setAttempted] = useState(false)
+  const runbookNames = [
+    'Back up database',
+    'Rotate database credentials',
+    'Deploy application',
+  ]
+  const runbookRows: TInstallRunbookRow[] = runbookNames.map((name, index) => {
+    const managedByQueue = name === 'Deploy application'
+    return {
+      runbookId: `runbook-${index + 1}`,
+      runbookName: name,
+      description: (
+        <Text variant="subtext" theme="neutral">
+          {managedByQueue
+            ? 'Deploy the approved application build and verify its services.'
+            : 'Run an operational procedure for this install.'}
+        </Text>
+      ),
+      labels: (
+        <Badge size="sm" theme={managedByQueue ? 'warn' : 'neutral'}>
+          {managedByQueue ? 'In operations queue' : 'production'}
+        </Badge>
+      ),
+      lastUpdated: (
+        <Text variant="subtext" theme="neutral">
+          3 days ago
+        </Text>
+      ),
+      lastRun: (
+        <Text variant="subtext" theme="neutral">
+          {index === 0 ? '8 minutes ago' : '2 days ago'}
+        </Text>
+      ),
+      href: `/org-1/installs/install-1/runbooks/runbook-${index + 1}`,
+      latestRunHref: `/org-1/installs/install-1/workflows/workflow-${index + 1}`,
+      installRunbook: {
+        id: `install-runbook-${index + 1}`,
+        runbook_id: `runbook-${index + 1}`,
+      } as TInstallRunbookRow['installRunbook'],
+      runAction: (
+        <Button
+          isMenuButton
+          disabled={managedByQueue && attempted}
+          tooltipProps={
+            managedByQueue && attempted
+              ? {
+                  className: 'block !w-full',
+                  position: 'left',
+                  tipContent:
+                    'Cannot run — this runbook is managed by August maintenance',
+                }
+              : undefined
+          }
+          onClick={() => managedByQueue && setAttempted(true)}
+        >
+          Run runbook
+          <Icon
+            variant={managedByQueue && attempted ? 'LockIcon' : 'PlayIcon'}
+          />
+        </Button>
+      ),
+    }
+  })
+
+  return (
+    <PageSection>
+      <HeadingGroup>
+        <Text variant="base" weight="strong">
+          Runbooks
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          View and run operational procedures for this install.
+        </Text>
+      </HeadingGroup>
+
+      {attempted && (
+        <Banner theme="warn">
+          <div className="flex flex-col gap-1">
+            <Text weight="strong">Run blocked by operations queue</Text>
+            <Text variant="subtext">
+              Deploy application is already queued in August maintenance. It can
+              run only after Rotate database credentials completes.
+            </Text>
+          </div>
+        </Banner>
+      )}
+
+      <InstallRunbooksTableComponent
+        key={attempted ? 'blocked' : 'ready'}
+        data={runbookRows}
+        isLoading={false}
+        pagination={{ hasNext: false, offset: 0, limit: 20 }}
+      />
+    </PageSection>
+  )
+}
+
+type TInstallGroupQueueTarget = {
+  id: string
+  installName: string
+  queueName: string
+  queueState: string
+  queuePosition: number
+  alreadyQueued?: boolean
+  reordered?: boolean
+}
+
+const installGroupTargets: TInstallGroupQueueTarget[] = [
+  {
+    id: 'install-west',
+    installName: 'production-us-west',
+    queueName: 'August maintenance',
+    queueState: '2 operations ahead',
+    queuePosition: 3,
+  },
+  {
+    id: 'install-east',
+    installName: 'production-us-east',
+    queueName: 'Routine operations',
+    queueState: '1 operation running',
+    queuePosition: 2,
+  },
+  {
+    id: 'install-eu-west',
+    installName: 'production-eu-west',
+    queueName: 'No active queue',
+    queueState: 'No operations ahead',
+    queuePosition: 1,
+  },
+  {
+    id: 'install-eu-central',
+    installName: 'production-eu-central',
+    queueName: 'August maintenance',
+    queueState: 'Already queued at position 2',
+    queuePosition: 2,
+    alreadyQueued: true,
+  },
+  {
+    id: 'install-ap-southeast',
+    installName: 'production-ap-southeast',
+    queueName: 'Patch window',
+    queueState: '3 operations ahead',
+    queuePosition: 4,
+  },
+  {
+    id: 'install-ap-northeast',
+    installName: 'production-ap-northeast',
+    queueName: 'No active queue',
+    queueState: 'No operations ahead',
+    queuePosition: 1,
+  },
+]
+
+const installGroupInstallColumn: ColumnDef<TInstallGroupQueueTarget> = {
+  accessorKey: 'installName',
+  header: 'Install',
+  cell: ({ row }) => (
+    <div className="flex flex-col items-start gap-0.5">
+      <Link href={`/org-1/installs/${row.original.id}`}>
+        {row.original.installName}
+      </Link>
+      <Text variant="subtext" theme="neutral">
+        {row.original.queueName}
+      </Text>
+    </div>
+  ),
+}
+
+const getInstallGroupColumns = (
+  onReorder: (target: TInstallGroupQueueTarget) => void
+): ColumnDef<TInstallGroupQueueTarget>[] => [
+  installGroupInstallColumn,
+  {
+    accessorKey: 'queueState',
+    header: 'Current queue',
+    cell: ({ row }) => (
+      <Text variant="subtext" theme="neutral">
+        {row.original.queueState}
+      </Text>
+    ),
+  },
+  {
+    accessorKey: 'queuePosition',
+    header: 'Result',
+    cell: ({ row }) =>
+      row.original.reordered ? (
+        <div className="flex flex-col items-start gap-1">
+          <Badge size="sm" theme="brand">
+            Reordered · Position {row.original.queuePosition}
+          </Badge>
+          <Text variant="subtext" theme="neutral">
+            {row.original.alreadyQueued
+              ? 'Existing required entry'
+              : 'New required entry'}
+          </Text>
+        </div>
+      ) : row.original.alreadyQueued ? (
+        <div className="flex flex-col items-start gap-1">
+          <Badge size="sm" theme="info">
+            Existing entry reused
+          </Badge>
+          <Text variant="subtext" theme="neutral">
+            Marked required
+          </Text>
+        </div>
+      ) : (
+        <div className="flex flex-col items-start gap-1">
+          <Badge size="sm" theme="brand">
+            Position {row.original.queuePosition}
+          </Badge>
+          <Text variant="subtext" theme="neutral">
+            New required entry
+          </Text>
+        </div>
+      ),
+  },
+  {
+    id: 'actions',
+    header: '',
+    cell: ({ row }) => (
+      <Button variant="ghost" size="xs" onClick={() => onReorder(row.original)}>
+        <Icon variant="ListIcon" />
+        Reorder
+      </Button>
+    ),
+  },
+]
+
+const trackedInstallGroupColumns: ColumnDef<TInstallGroupQueueTarget>[] = [
+  installGroupInstallColumn,
+  {
+    accessorKey: 'queuePosition',
+    header: 'Queue position',
+    cell: ({ row }) => <Text family="mono">{row.original.queuePosition}</Text>,
+  },
+  {
+    id: 'status',
+    header: 'Status',
+    cell: ({ row }) => (
+      <Status status={row.original.queuePosition === 1 ? 'info' : 'default'}>
+        {row.original.queuePosition === 1
+          ? 'Next to run'
+          : `Waiting for ${row.original.queuePosition - 1} operation${row.original.queuePosition === 2 ? '' : 's'}`}
+      </Status>
+    ),
+  },
+]
+
+const InstallQueueReorder = ({
+  target,
+  reorder,
+  onCancel,
+  onSave,
+}: {
+  target: TInstallGroupQueueTarget
+  reorder?: InstallQueueReorderValues
+  onCancel: () => void
+  onSave: (values: InstallQueueReorderValues) => void
+}) => {
+  const hasRunningOperation = target.queueName !== 'No active queue'
+  const otherOperations = [
+    ...(hasRunningOperation
+      ? [
+          {
+            id: 'apply-config',
+            name: 'Apply approved configuration',
+            detail: 'Action · Running now',
+            running: true,
+          },
+        ]
+      : []),
+    {
+      id: 'verify-health',
+      name: 'Verify service health',
+      detail: 'Action · Queued',
+      running: false,
+    },
+    {
+      id: 'deploy-application',
+      name: 'Deploy application',
+      detail: 'Deploy · Queued',
+      running: false,
+    },
+  ]
+  const minimumPosition = hasRunningOperation ? 2 : 1
+  const maximumPosition = otherOperations.length + 1
+  const form = useForm({
+    defaultValues: {
+      queuePosition: reorder?.queuePosition ?? target.queuePosition,
+    } as InstallQueueReorderValues,
+    validators: {
+      onMount: installQueueReorderSchema,
+      onChange: installQueueReorderSchema,
+    },
+    onSubmit: ({ value }) => onSave(value),
+  })
+  const canSubmit = useStore(form.store, (state) => state.canSubmit)
+  const queuePosition = useStore(
+    form.store,
+    (state) => state.values.queuePosition
+  )
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-6">
+      <div className="flex items-start gap-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="Back to queue preview"
+          onClick={onCancel}
+        >
+          <Icon variant="ArrowLeftIcon" />
+        </Button>
+        <HeadingGroup className="gap-1">
+          <Text as="h1" variant="h2" weight="stronger">
+            Reorder install queue
+          </Text>
+          <Text theme="neutral">
+            Choose where the required runbook should run on{' '}
+            <Link href={`/org-1/installs/${target.id}`}>
+              {target.installName}
+            </Link>
+            .
+          </Text>
+        </HeadingGroup>
+      </div>
+
+      <Card className="!gap-4 !p-4">
+        <div className="flex items-start gap-3">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-cool-grey-100 dark:bg-dark-grey-700">
+            <Icon variant="BookOpenTextIcon" size={18} theme="neutral" />
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <Text weight="strong">Rotate database credentials</Text>
+              <Badge size="sm" theme="brand">
+                <Icon variant="LockIcon" size={11} />
+                Required
+              </Badge>
+            </div>
+            <Text variant="subtext" theme="neutral">
+              {target.queueName} · Reordering affects only {target.installName}
+            </Text>
+          </div>
+        </div>
+      </Card>
+
+      <form
+        autoComplete="off"
+        noValidate
+        onSubmit={(event) => event.preventDefault()}
+        className="flex flex-col gap-3"
+      >
+        <div className="flex flex-col gap-1">
+          <Text variant="base" weight="strong">
+            Queue order
+          </Text>
+          <Text variant="subtext" theme="neutral">
+            Move the runbook within this install queue. A running operation
+            cannot be moved.
+          </Text>
+        </div>
+        <form.Field name="queuePosition">
+          {(field) => {
+            const operations = [...otherOperations]
+            operations.splice(
+              Math.min(field.state.value - 1, operations.length),
+              0,
+              {
+                id: 'rotate-credentials',
+                name: 'Rotate database credentials',
+                detail: 'Runbook · Required group operation',
+                running: false,
+              }
+            )
+
+            return (
+              <div className="overflow-hidden rounded-lg border">
+                {operations.map((operation, index) => {
+                  const position = index + 1
+                  const isTarget = operation.id === 'rotate-credentials'
+                  return (
+                    <div
+                      key={operation.id}
+                      className={`flex items-center gap-3 border-t p-4 first:border-t-0 ${
+                        isTarget ? 'bg-primary-50 dark:bg-primary-950/20' : ''
+                      }`}
+                    >
+                      <Icon
+                        variant={
+                          operation.running
+                            ? 'LockIcon'
+                            : operation.id === 'deploy-application'
+                              ? 'RocketIcon'
+                              : operation.id === 'rotate-credentials'
+                                ? 'BookOpenTextIcon'
+                                : 'LightningIcon'
+                        }
+                        size={16}
+                        theme="neutral"
+                      />
+                      <Text family="mono" variant="subtext" theme="neutral">
+                        {position.toString().padStart(2, '0')}
+                      </Text>
+                      <div className="flex min-w-0 flex-1 flex-col gap-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Text weight="strong">{operation.name}</Text>
+                          {isTarget && (
+                            <Badge size="sm" theme="brand">
+                              <Icon variant="LockIcon" size={11} />
+                              Required
+                            </Badge>
+                          )}
+                        </div>
+                        <Text variant="subtext" theme="neutral">
+                          {operation.detail}
+                        </Text>
+                      </div>
+                      {operation.running ? (
+                        <Status status="info">Running</Status>
+                      ) : isTarget ? (
+                        <div className="flex items-center gap-1">
+                          {field.state.value > minimumPosition && (
+                            <Button
+                              variant="ghost"
+                              size="xs"
+                              aria-label="Move runbook up"
+                              onClick={() =>
+                                field.handleChange(field.state.value - 1)
+                              }
+                            >
+                              <Icon variant="ArrowUpIcon" />
+                            </Button>
+                          )}
+                          {field.state.value < maximumPosition && (
+                            <Button
+                              variant="ghost"
+                              size="xs"
+                              aria-label="Move runbook down"
+                              onClick={() =>
+                                field.handleChange(field.state.value + 1)
+                              }
+                            >
+                              <Icon variant="ArrowDownIcon" />
+                            </Button>
+                          )}
+                        </div>
+                      ) : (
+                        <Status status="default">Queued</Status>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            )
+          }}
+        </form.Field>
+      </form>
+
+      <div className="flex items-start gap-2">
+        <Icon variant="LockIcon" size={15} />
+        <Text variant="subtext">
+          The runbook remains required regardless of its queue position.
+        </Text>
+      </div>
+
+      <div className="flex justify-end gap-2 border-t pt-4">
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          disabled={!canSubmit || queuePosition === target.queuePosition}
+          tooltipProps={
+            queuePosition === target.queuePosition
+              ? { tipContent: 'Move the runbook to save a new order' }
+              : undefined
+          }
+          onClick={() => form.handleSubmit()}
+        >
+          <Icon variant="CheckIcon" />
+          Save order
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export const QueueRunbookForInstallGroup = () => {
+  const [queued, setQueued] = useState(false)
+  const [reorderingInstallId, setReorderingInstallId] = useState<string>()
+  const [reorders, setReorders] = useState<
+    Record<string, InstallQueueReorderValues>
+  >({})
+  const effectiveTargets = installGroupTargets.map((target) => {
+    const reorder = reorders[target.id]
+    return reorder
+      ? {
+          ...target,
+          reordered: true,
+          queuePosition: reorder.queuePosition,
+        }
+      : target
+  })
+  const reorderingTarget = installGroupTargets.find(
+    (target) => target.id === reorderingInstallId
+  )
+
+  if (reorderingTarget) {
+    return (
+      <InstallQueueReorder
+        target={reorderingTarget}
+        reorder={reorders[reorderingTarget.id]}
+        onCancel={() => setReorderingInstallId(undefined)}
+        onSave={(values) => {
+          setReorders((current) => ({
+            ...current,
+            [reorderingTarget.id]: values,
+          }))
+          setReorderingInstallId(undefined)
+        }}
+      />
+    )
+  }
+
+  if (queued) {
+    return (
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-6">
+        <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+          <div className="flex items-start gap-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label="Back to install group"
+              onClick={() => setQueued(false)}
+            >
+              <Icon variant="ArrowLeftIcon" />
+            </Button>
+            <HeadingGroup className="gap-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <Text as="h1" variant="h2" weight="stronger">
+                  Rotate database credentials
+                </Text>
+                <Status status="info" variant="badge">
+                  Queued
+                </Status>
+              </div>
+              <Text theme="neutral">Group operation for Production fleet</Text>
+            </HeadingGroup>
+          </div>
+          <Button variant="secondary" onClick={() => setQueued(false)}>
+            View install group
+          </Button>
+        </div>
+
+        <Banner theme="success">
+          <div className="flex flex-col gap-1">
+            <Text weight="strong">Runbook queued for 6 installs</Text>
+            <Text>
+              Added 5 required entries and linked 1 existing entry. Each install
+              keeps its own queue ordering.
+            </Text>
+          </div>
+        </Banner>
+
+        <Card className="!gap-4 !p-4">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <div className="flex size-9 items-center justify-center rounded-md bg-cool-grey-100 dark:bg-dark-grey-700">
+                <Icon variant="TreeStructureIcon" size={18} theme="neutral" />
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <Text weight="strong">Group progress</Text>
+                <Text variant="subtext" theme="neutral">
+                  Membership snapshot · 6 installs
+                </Text>
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <Text variant="subtext" theme="neutral">
+                0 of 6 complete
+              </Text>
+              <Badge size="sm" theme="brand">
+                <Icon variant="LockIcon" size={11} />
+                Required
+              </Badge>
+            </div>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-cool-grey-100 dark:bg-dark-grey-700" />
+        </Card>
+
+        <div className="flex flex-col gap-2">
+          <Text variant="base" weight="strong">
+            Install entries
+          </Text>
+          <Text variant="subtext" theme="neutral">
+            Entries run independently when they reach the front of each install
+            queue.
+          </Text>
+        </div>
+        <Table
+          columns={trackedInstallGroupColumns}
+          data={effectiveTargets}
+          enableSearch={false}
+          enableSorting={false}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-6">
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+        <div className="flex items-start gap-3">
+          <Button variant="ghost" size="sm" aria-label="Back to install group">
+            <Icon variant="ArrowLeftIcon" />
+          </Button>
+          <HeadingGroup className="gap-1">
+            <Text as="h1" variant="h2" weight="stronger">
+              Queue runbook for install group
+            </Text>
+            <Text theme="neutral">
+              Add one required operation to every install queue in Production
+              fleet.
+            </Text>
+          </HeadingGroup>
+        </div>
+        <Button variant="primary" onClick={() => setQueued(true)}>
+          <Icon variant="StackPlusIcon" />
+          Queue for 6 installs
+        </Button>
+      </div>
+
+      <Banner theme="info">
+        <div className="flex flex-col gap-1">
+          <Text weight="strong">Membership is captured on submission</Text>
+          <Text variant="subtext">
+            These 6 installs form the operation snapshot. Installs added to the
+            group later are not included.
+          </Text>
+        </div>
+      </Banner>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <div className="flex min-w-0 flex-col gap-6">
+          <Card className="!gap-4 !p-4">
+            <div className="flex items-start gap-3">
+              <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-cool-grey-100 dark:bg-dark-grey-700">
+                <Icon variant="BookOpenTextIcon" size={18} theme="neutral" />
+              </div>
+              <div className="flex min-w-0 flex-1 flex-col gap-1">
+                <Text variant="subtext" theme="neutral">
+                  Runbook
+                </Text>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Text variant="base" weight="strong">
+                    Rotate database credentials
+                  </Text>
+                  <Badge size="sm" theme="brand">
+                    <Icon variant="LockIcon" size={11} />
+                    Required
+                  </Badge>
+                </div>
+                <Text variant="subtext" theme="neutral">
+                  Rotate credentials and verify dependent services.
+                </Text>
+              </div>
+            </div>
+            <div className="-mx-4">
+              <Divider />
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-cool-grey-100 dark:bg-dark-grey-700">
+                <Icon variant="TreeStructureIcon" size={18} theme="neutral" />
+              </div>
+              <div className="flex flex-col gap-1">
+                <Text variant="subtext" theme="neutral">
+                  Install group
+                </Text>
+                <Text weight="strong">Production fleet</Text>
+                <Text variant="subtext" theme="neutral">
+                  6 matching installs · Snapshot taken when queued
+                </Text>
+              </div>
+            </div>
+          </Card>
+        </div>
+
+        <Card className="h-fit !gap-4 !p-4">
+          <Text weight="strong">Submission summary</Text>
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between gap-3">
+              <Text variant="subtext" theme="neutral">
+                Group members
+              </Text>
+              <Text weight="strong">6</Text>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <Text variant="subtext" theme="neutral">
+                New queue entries
+              </Text>
+              <Text weight="strong">5</Text>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <Text variant="subtext" theme="neutral">
+                Existing entry reused
+              </Text>
+              <Text weight="strong">1</Text>
+            </div>
+          </div>
+          <div className="-mx-4">
+            <Divider />
+          </div>
+          <div className="flex items-start gap-2">
+            <Icon variant="LockIcon" size={15} theme="brand" />
+            <Text variant="subtext" theme="neutral">
+              All 6 entries are required and cannot be removed from their
+              install queues.
+            </Text>
+          </div>
+          <div className="flex items-start gap-2">
+            <Icon
+              variant="ArrowsInLineVerticalIcon"
+              size={15}
+              theme="neutral"
+            />
+            <Text variant="subtext" theme="neutral">
+              Each entry waits for the operations already ahead of it.
+            </Text>
+          </div>
+        </Card>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Text variant="base" weight="strong">
+          Queue preview
+        </Text>
+        <Text variant="subtext" theme="neutral">
+          Existing operations keep their positions. Duplicate entries are reused
+          instead of added twice. Reorder an install to change where the
+          required entry lands.
+        </Text>
+      </div>
+      <Table
+        columns={getInstallGroupColumns((target) =>
+          setReorderingInstallId(target.id)
+        )}
+        data={effectiveTargets}
+        enableSearch={false}
+        enableSorting={false}
+      />
+    </div>
+  )
+}

--- a/services/dashboard-ui/client/components/operation-queues/InstallOperationsQueue/InstallOperationsQueue.tsx
+++ b/services/dashboard-ui/client/components/operation-queues/InstallOperationsQueue/InstallOperationsQueue.tsx
@@ -1,0 +1,1066 @@
+import { useState } from 'react'
+import { useForm, useStore } from '@tanstack/react-form'
+import { Badge, type TBadgeTheme } from '@/components/common/Badge'
+import { Banner } from '@/components/common/Banner'
+import { Button } from '@/components/common/Button'
+import { Card } from '@/components/common/Card'
+import { Divider } from '@/components/common/Divider'
+import { Dropdown } from '@/components/common/Dropdown'
+import { Icon, type TIconVariant } from '@/components/common/Icon'
+import { Menu } from '@/components/common/Menu'
+import { Status } from '@/components/common/Status'
+import { Text } from '@/components/common/Text'
+import { FormRadioGroup } from '@/components/common/form/FormRadioGroup'
+import { cn } from '@/utils/classnames'
+import { admissionRulesSchema, type AdmissionRulesValues } from './schema'
+
+export type TOperationQueueStatus =
+  | 'completed'
+  | 'draft'
+  | 'out-of-band'
+  | 'running'
+
+export type TOperationQueueEntryStatus =
+  | 'blocked'
+  | 'failed'
+  | 'in-progress'
+  | 'queued'
+  | 'success'
+
+export interface IOperationQueueEntry {
+  id: string
+  name: string
+  type: 'action' | 'deploy' | 'runbook'
+  status: TOperationQueueEntryStatus
+  detail: string
+  required?: boolean
+  blockedBy?: string
+}
+
+export interface IQueueOperationOption {
+  id: string
+  name: string
+  type: IOperationQueueEntry['type']
+  detail: string
+}
+
+export interface IOperationQueueRule {
+  id: string
+  name: string
+  description: string
+}
+
+export interface IInstallOperationsQueue {
+  installName: string
+  queueName: string
+  status: TOperationQueueStatus
+  entries: IOperationQueueEntry[]
+  rules: IOperationQueueRule[]
+  onAddOperation?: () => void
+  onConfigureRules?: () => void
+  onFinishOutsideOperation?: () => void
+  onRunOutsideQueue?: () => void
+  onStart?: () => void
+}
+
+export interface IAddQueueOperationStudio {
+  installName: string
+  queueName: string
+  entries: IOperationQueueEntry[]
+  options: IQueueOperationOption[]
+  selectedOptionId?: string
+  required: boolean
+  onAdd: () => void
+  onCancel: () => void
+  onRequiredChange: (required: boolean) => void
+  onSelectOption: (optionId: string) => void
+}
+
+export type TScheduledOperationsPolicy =
+  AdmissionRulesValues['scheduledOperationsPolicy']
+export type TQueueAdmissionPolicy = AdmissionRulesValues['admissionPolicy']
+
+export type TQueueExemptionOperationType =
+  | 'action'
+  | 'component deploy'
+  | 'runbook'
+  | 'sandbox operation'
+
+export interface IQueueAdmissionExemptionOption {
+  id: string
+  operationType: TQueueExemptionOperationType
+  labelKey: string
+  labelValue: string
+  matchingOperations: string[]
+}
+
+export interface IQueueAdmissionRulesStudio {
+  installName: string
+  queueName: string
+  admissionPolicy: TQueueAdmissionPolicy
+  scheduledOperationsPolicy: TScheduledOperationsPolicy
+  exemptionOptions: IQueueAdmissionExemptionOption[]
+  selectedExemptionIds: string[]
+  onCancel: () => void
+  onSave: (rules: {
+    admissionPolicy: TQueueAdmissionPolicy
+    scheduledOperationsPolicy: TScheduledOperationsPolicy
+    selectedExemptionIds: string[]
+  }) => void
+}
+
+const statusTheme: Record<TOperationQueueStatus, TBadgeTheme> = {
+  completed: 'success',
+  draft: 'neutral',
+  'out-of-band': 'warn',
+  running: 'info',
+}
+
+const entryIcons: Record<IOperationQueueEntry['type'], TIconVariant> = {
+  action: 'LightningIcon',
+  deploy: 'RocketIcon',
+  runbook: 'BookOpenTextIcon',
+}
+
+const entryStatusLabels: Record<TOperationQueueEntryStatus, string> = {
+  blocked: 'Blocked',
+  failed: 'Failed',
+  'in-progress': 'Running',
+  queued: 'Queued',
+  success: 'Complete',
+}
+
+const queueStatusLabels: Record<TOperationQueueStatus, string> = {
+  completed: 'Completed',
+  draft: 'Draft',
+  'out-of-band': 'Outside operation active',
+  running: 'Running',
+}
+
+const OperationRow = ({
+  entry,
+  position,
+}: {
+  entry: IOperationQueueEntry
+  position: number
+}) => (
+  <div className="flex items-start gap-4 py-4 first:pt-0 last:pb-0">
+    <div className="flex w-6 shrink-0 justify-center pt-2">
+      <Text family="mono" variant="subtext" theme="neutral">
+        {position.toString().padStart(2, '0')}
+      </Text>
+    </div>
+    <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-cool-grey-100 dark:bg-dark-grey-700">
+      <Icon variant={entryIcons[entry.type]} size={18} theme="neutral" />
+    </div>
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <div className="flex flex-wrap items-center gap-2">
+        <Text weight="strong">{entry.name}</Text>
+        <Badge size="xs" variant="code" theme="default">
+          {entry.type}
+        </Badge>
+        {entry.required && (
+          <Badge size="xs" theme="brand">
+            <Icon variant="LockIcon" size={11} />
+            Required
+          </Badge>
+        )}
+      </div>
+      <Text variant="subtext" theme="neutral">
+        {entry.detail}
+      </Text>
+      {entry.blockedBy && (
+        <Text flex variant="subtext" theme="warn">
+          <Icon variant="LockIcon" size={13} />
+          Waiting for {entry.blockedBy}
+        </Text>
+      )}
+    </div>
+    <Status status={entry.status}>{entryStatusLabels[entry.status]}</Status>
+  </div>
+)
+
+const QueueActions = ({
+  status,
+  onAddOperation,
+  onFinishOutsideOperation,
+  onRunOutsideQueue,
+  onStart,
+}: Pick<
+  IInstallOperationsQueue,
+  | 'status'
+  | 'onAddOperation'
+  | 'onFinishOutsideOperation'
+  | 'onRunOutsideQueue'
+  | 'onStart'
+>) => {
+  if (status === 'out-of-band') {
+    return (
+      <Button variant="primary" onClick={onFinishOutsideOperation}>
+        <Icon variant="ShieldCheckIcon" />
+        Finish outside operation
+      </Button>
+    )
+  }
+
+  if (status === 'completed') return null
+
+  return (
+    <div className="flex flex-wrap items-center justify-end gap-2">
+      {status === 'draft' && (
+        <Button variant="primary" onClick={onStart}>
+          <Icon variant="PlayIcon" />
+          Start queue
+        </Button>
+      )}
+      <Button
+        variant={status === 'running' ? 'primary' : 'secondary'}
+        onClick={onAddOperation}
+      >
+        <Icon variant="PlusIcon" />
+        Add operation
+      </Button>
+      {status === 'running' && (
+        <Button variant="secondary" onClick={onRunOutsideQueue}>
+          <Icon variant="ShieldIcon" />
+          Run outside queue
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export const QueueAdmissionRulesStudio = ({
+  installName,
+  queueName,
+  admissionPolicy,
+  scheduledOperationsPolicy,
+  exemptionOptions,
+  selectedExemptionIds,
+  onCancel,
+  onSave,
+}: IQueueAdmissionRulesStudio) => {
+  const [currentExemptionIds, setCurrentExemptionIds] =
+    useState(selectedExemptionIds)
+  const form = useForm({
+    defaultValues: {
+      admissionPolicy,
+      scheduledOperationsPolicy,
+    } as AdmissionRulesValues,
+    validators: {
+      onMount: admissionRulesSchema,
+      onChange: admissionRulesSchema,
+    },
+    onSubmit: ({ value }) =>
+      onSave({
+        admissionPolicy: value.admissionPolicy,
+        scheduledOperationsPolicy: value.scheduledOperationsPolicy,
+        selectedExemptionIds: currentExemptionIds,
+      }),
+  })
+  const currentScheduledPolicy = useStore(
+    form.store,
+    (state) => state.values.scheduledOperationsPolicy
+  )
+  const currentAdmissionPolicy = useStore(
+    form.store,
+    (state) => state.values.admissionPolicy
+  )
+  const isStrict = currentAdmissionPolicy === 'strict'
+  const canSubmit = useStore(form.store, (state) => state.canSubmit)
+  const selectedExemptions = exemptionOptions.filter((exemption) =>
+    currentExemptionIds.includes(exemption.id)
+  )
+  const availableExemptions = exemptionOptions.filter(
+    (exemption) => !currentExemptionIds.includes(exemption.id)
+  )
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-6">
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+        <div className="flex items-start gap-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Back to operations queue"
+            onClick={onCancel}
+          >
+            <Icon variant="ArrowLeftIcon" />
+          </Button>
+          <div className="flex flex-col gap-1">
+            <Text as="h1" variant="h2" weight="stronger">
+              Admission rules
+            </Text>
+            <Text theme="neutral">
+              Control which operations may start outside {queueName} on{' '}
+              {installName}.
+            </Text>
+            <Badge size="sm" theme="neutral">
+              <Icon variant="ArrowsInLineVerticalIcon" size={13} />
+              {queueName}
+            </Badge>
+          </div>
+        </div>
+        <Button
+          variant="primary"
+          disabled={!canSubmit}
+          onClick={() => form.handleSubmit()}
+        >
+          <Icon variant="CheckIcon" />
+          Save rules
+        </Button>
+      </div>
+
+      <Card className="!gap-4 !p-4">
+        <div className="flex flex-col gap-1">
+          <Text variant="base" weight="strong">
+            Default behavior
+          </Text>
+          <Text variant="subtext" theme="neutral">
+            Choose how operations that were not submitted through this queue are
+            handled.
+          </Text>
+        </div>
+
+        <div className="-mx-4">
+          <Divider />
+        </div>
+
+        <form
+          autoComplete="off"
+          noValidate
+          onSubmit={(event) => event.preventDefault()}
+          className="flex flex-col gap-4"
+        >
+          <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_minmax(18rem,1fr)]">
+            <div className="flex flex-col gap-1">
+              <Text weight="strong">Operations outside the queue</Text>
+              <Text variant="subtext" theme="neutral">
+                Manual, scheduled, and API-triggered workflows.
+              </Text>
+            </div>
+            <form.Field name="admissionPolicy">
+              {(field) => (
+                <FormRadioGroup
+                  field={field}
+                  options={[
+                    {
+                      value: 'enqueue',
+                      label: (
+                        <span className="flex flex-col gap-0.5">
+                          <Text weight="strong">Add to queue</Text>
+                          <Text variant="subtext" theme="neutral">
+                            Admit the operation at the end of the queue.
+                          </Text>
+                        </span>
+                      ),
+                    },
+                    {
+                      value: 'strict',
+                      label: (
+                        <span className="flex flex-col gap-0.5">
+                          <Text flex weight="strong">
+                            <Icon variant="LockIcon" size={14} />
+                            Block all
+                          </Text>
+                          <Text variant="subtext" theme="neutral">
+                            Only operations already in this queue may start.
+                          </Text>
+                        </span>
+                      ),
+                    },
+                  ]}
+                />
+              )}
+            </form.Field>
+          </div>
+
+          <div className="-mx-4">
+            <Divider />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_minmax(18rem,1fr)]">
+            <div className="flex flex-col gap-1">
+              <Text weight="strong">Scheduled operations</Text>
+              <Text variant="subtext" theme="neutral">
+                Cron-triggered drifts, actions, and runbooks.
+              </Text>
+            </div>
+            {isStrict ? (
+              <div className="flex flex-col items-start gap-1 sm:items-end">
+                <Text flex weight="strong" theme="warn">
+                  <Icon variant="LockIcon" size={14} />
+                  Blocked
+                </Text>
+                <Text
+                  variant="subtext"
+                  theme="neutral"
+                  className="sm:text-right"
+                >
+                  Scheduled workflows cannot start outside this queue.
+                </Text>
+              </div>
+            ) : (
+              <form.Field name="scheduledOperationsPolicy">
+                {(field) => (
+                  <FormRadioGroup
+                    field={field}
+                    options={[
+                      {
+                        value: 'enqueue',
+                        label: (
+                          <span className="flex flex-col gap-0.5">
+                            <Text weight="strong">Add to queue</Text>
+                            <Text variant="subtext" theme="neutral">
+                              Wait for its queue position.
+                            </Text>
+                          </span>
+                        ),
+                      },
+                      {
+                        value: 'direct',
+                        label: (
+                          <span className="flex flex-col gap-0.5">
+                            <Text weight="strong">Run directly</Text>
+                            <Text variant="subtext" theme="neutral">
+                              Skip queue admission unless a required entry
+                              exists.
+                            </Text>
+                          </span>
+                        ),
+                      },
+                    ]}
+                  />
+                )}
+              </form.Field>
+            )}
+          </div>
+        </form>
+      </Card>
+
+      <Card className="!gap-4 !p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <Text variant="base" weight="strong">
+              Operation exemptions
+            </Text>
+            <Text variant="subtext" theme="neutral">
+              {isStrict
+                ? 'Strict queue mode disables every operation exemption.'
+                : 'Operations matching any exemption can run directly from manual, scheduled, or API requests.'}
+            </Text>
+          </div>
+          <Dropdown
+            key={availableExemptions.map((exemption) => exemption.id).join('-')}
+            id="add-operation-exemption"
+            alignment="right"
+            variant="secondary"
+            buttonText="Add exemption"
+            disabled={isStrict || !availableExemptions.length}
+            tooltipProps={
+              isStrict
+                ? { tipContent: 'Exemptions are disabled in strict queue mode' }
+                : availableExemptions.length
+                  ? undefined
+                  : { tipContent: 'All available exemptions are in use' }
+            }
+          >
+            <Menu className="w-80">
+              <Text>Available exemptions</Text>
+              {availableExemptions.map((exemption) => (
+                <Button
+                  key={exemption.id}
+                  isMenuButton
+                  onClick={() =>
+                    setCurrentExemptionIds((current) => [
+                      ...current,
+                      exemption.id,
+                    ])
+                  }
+                >
+                  <span className="flex min-w-0 items-center gap-2">
+                    <Badge size="xs" theme="neutral">
+                      {exemption.operationType}
+                    </Badge>
+                    <Badge variant="code" size="sm" theme="default">
+                      {exemption.labelKey}={exemption.labelValue}
+                    </Badge>
+                  </span>
+                  <Icon variant="PlusIcon" size={14} />
+                </Button>
+              ))}
+            </Menu>
+          </Dropdown>
+        </div>
+
+        <div className="-mx-4">
+          <Divider />
+        </div>
+
+        {isStrict ? (
+          <div className="flex flex-col items-center gap-1 py-4 text-center">
+            <Icon variant="LockIcon" size={20} theme="warn" />
+            <Text weight="strong">All exemptions blocked</Text>
+            <Text variant="subtext" theme="neutral">
+              Manual, scheduled, and API operations must already be in this
+              queue.
+            </Text>
+          </div>
+        ) : selectedExemptions.length ? (
+          <div className="divide-y">
+            {selectedExemptions.map((exemption) => (
+              <div
+                key={exemption.id}
+                className="grid gap-3 py-4 first:pt-0 last:pb-0 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center"
+              >
+                <div className="flex min-w-0 flex-col gap-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge size="xs" theme="neutral">
+                      {exemption.operationType}
+                    </Badge>
+                    <Badge variant="code" size="sm" theme="default">
+                      {exemption.labelKey}={exemption.labelValue}
+                    </Badge>
+                  </div>
+                  <Text variant="subtext" theme="neutral">
+                    Matches {exemption.matchingOperations.length}{' '}
+                    {exemption.matchingOperations.length === 1
+                      ? 'operation'
+                      : 'operations'}
+                    : {exemption.matchingOperations.join(', ')}
+                  </Text>
+                </div>
+                <div className="flex flex-wrap items-center gap-1">
+                  <Text variant="subtext" theme="neutral" className="mr-1">
+                    Sources
+                  </Text>
+                  {['Manual', 'Scheduled', 'API'].map((source) => (
+                    <Badge key={source} size="xs" theme="neutral">
+                      {source}
+                    </Badge>
+                  ))}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  aria-label={`Remove ${exemption.operationType} ${exemption.labelKey}=${exemption.labelValue} exemption`}
+                  onClick={() =>
+                    setCurrentExemptionIds((current) =>
+                      current.filter((id) => id !== exemption.id)
+                    )
+                  }
+                >
+                  <Icon variant="TrashIcon" size={14} />
+                </Button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-1 py-4 text-center">
+            <Text weight="strong">No operation exemptions</Text>
+            <Text variant="subtext" theme="neutral">
+              Operations follow the default behavior above.
+            </Text>
+          </div>
+        )}
+      </Card>
+
+      <Card className="!gap-4 !p-4 bg-cool-grey-50 dark:bg-dark-grey-700">
+        <div className="flex items-center gap-2">
+          <Icon variant="InfoIcon" size={18} theme="brand" />
+          <Text variant="base" weight="strong">
+            Impact
+          </Text>
+        </div>
+        <div className="flex flex-col gap-2">
+          {isStrict ? (
+            <Text flex variant="subtext" weight="strong">
+              <Icon variant="LockIcon" theme="warn" size={15} />
+              Direct, scheduled, API, and label-exempt operations are blocked
+              unless they are already in this queue.
+            </Text>
+          ) : (
+            <>
+              <Text flex variant="subtext">
+                <Icon variant="CheckCircleIcon" theme="success" size={15} />
+                Scheduled operations{' '}
+                {currentScheduledPolicy === 'direct'
+                  ? 'run directly.'
+                  : 'are added to the queue.'}
+              </Text>
+              <Text flex variant="subtext">
+                <Icon variant="TagIcon" theme="neutral" size={15} />
+                {selectedExemptions.length}{' '}
+                {selectedExemptions.length === 1
+                  ? 'operation exemption may'
+                  : 'operation exemptions may'}{' '}
+                run directly.
+              </Text>
+            </>
+          )}
+          <Text flex variant="subtext" weight="strong">
+            <Icon variant="LockIcon" theme="warn" size={15} />
+            Required queue entries always use the queue and override these
+            settings.
+          </Text>
+          <Text flex variant="subtext" theme="neutral">
+            <Icon variant="ShieldIcon" size={15} />
+            Authorized outside-queue runs are permissioned and audited
+            separately.
+          </Text>
+        </div>
+      </Card>
+    </div>
+  )
+}
+
+export const AddQueueOperationStudio = ({
+  installName,
+  queueName,
+  entries,
+  options,
+  selectedOptionId,
+  required,
+  onAdd,
+  onCancel,
+  onRequiredChange,
+  onSelectOption,
+}: IAddQueueOperationStudio) => {
+  const selectedOption = options.find(
+    (option) => option.id === selectedOptionId
+  )
+  const predecessor = entries.at(-1)
+  const position = entries.length + 1
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-6">
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+        <div className="flex items-start gap-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Back to operations queue"
+            onClick={onCancel}
+          >
+            <Icon variant="ArrowLeftIcon" />
+          </Button>
+          <div className="flex flex-col gap-1">
+            <Text as="h1" variant="h2" weight="stronger">
+              Add operation
+            </Text>
+            <Text theme="neutral">
+              {queueName} for {installName}
+            </Text>
+          </div>
+        </div>
+        <Button
+          variant="primary"
+          disabled={!selectedOption}
+          tooltipProps={
+            selectedOption
+              ? undefined
+              : { tipContent: 'Cannot add — choose an operation first' }
+          }
+          onClick={onAdd}
+        >
+          <Icon variant="PlusIcon" />
+          Add to queue
+        </Button>
+      </div>
+
+      <Banner theme="neutral">
+        Adding an operation does not run it immediately. It joins the end of the
+        queue and waits for the operations before it.
+      </Banner>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(19rem,2fr)]">
+        <Card className="!gap-4 !p-4">
+          <div className="flex items-center justify-between gap-3 pl-5">
+            <div className="flex flex-col gap-1">
+              <Text variant="base" weight="strong">
+                Queue notebook
+              </Text>
+              <Text variant="subtext" theme="neutral">
+                Choose and configure the next operation.
+              </Text>
+            </div>
+            <Badge size="sm" theme="neutral">
+              {position} operations
+            </Badge>
+          </div>
+
+          <div className="flex flex-col gap-2 pl-5">
+            {entries.map((entry, index) => (
+              <div
+                key={entry.id}
+                className="flex items-center gap-3 rounded-lg border bg-cool-grey-50/70 px-3 py-2.5 dark:bg-dark-grey-800"
+              >
+                <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-blue-500/10 text-xs font-semibold text-blue-700 dark:text-blue-400">
+                  {index + 1}
+                </span>
+                <Icon
+                  variant={entryIcons[entry.type]}
+                  size={16}
+                  className="shrink-0 text-cool-grey-500 dark:text-cool-grey-400"
+                />
+                <div className="flex min-w-0 flex-col">
+                  <Text weight="strong" className="truncate">
+                    {entry.name}
+                  </Text>
+                  <Text variant="subtext" theme="neutral" className="truncate">
+                    {entry.type}
+                  </Text>
+                </div>
+                <Status className="ml-auto" status={entry.status}>
+                  {entryStatusLabels[entry.status]}
+                </Status>
+              </div>
+            ))}
+
+            <div className="rounded-lg border bg-white shadow-sm ring-1 ring-blue-500/30 dark:bg-dark-grey-800">
+              <div className="flex items-center gap-2 border-b px-3 py-2">
+                <Icon
+                  variant={
+                    selectedOption
+                      ? entryIcons[selectedOption.type]
+                      : 'PlusCircleIcon'
+                  }
+                  size={14}
+                />
+                <Text variant="subtext" weight="strong">
+                  Operation {position} ·{' '}
+                  {selectedOption ? selectedOption.type : 'Choose operation'}
+                </Text>
+                {selectedOption && (
+                  <Button
+                    className="ml-auto"
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => onSelectOption('')}
+                  >
+                    Change operation
+                  </Button>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-4 p-3">
+                {selectedOption ? (
+                  <>
+                    <div className="flex items-start gap-3">
+                      <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-cool-grey-100 dark:bg-dark-grey-700">
+                        <Icon
+                          variant={entryIcons[selectedOption.type]}
+                          size={18}
+                          theme="neutral"
+                        />
+                      </div>
+                      <div className="flex min-w-0 flex-col gap-1">
+                        <Text weight="strong">{selectedOption.name}</Text>
+                        <Text variant="subtext" theme="neutral">
+                          {selectedOption.detail}
+                        </Text>
+                        <Text flex variant="subtext" theme="neutral">
+                          <Icon variant="ArrowsInLineVerticalIcon" size={13} />
+                          Runs after {predecessor?.name ?? 'the queue starts'}
+                        </Text>
+                      </div>
+                    </div>
+
+                    <Divider />
+
+                    <div className="flex flex-col gap-2">
+                      <Text variant="subtext" weight="strong">
+                        Execution requirement
+                      </Text>
+                      <div className="grid gap-2 sm:grid-cols-2">
+                        <Button
+                          variant="secondary"
+                          aria-pressed={!required}
+                          className={cn(
+                            '!h-auto w-full !items-start !justify-start !whitespace-normal !p-3 text-left',
+                            !required && 'bg-blue-500/5 ring-1 ring-blue-500/20'
+                          )}
+                          onClick={() => onRequiredChange(false)}
+                        >
+                          <Icon variant="ArrowsInLineVerticalIcon" size={17} />
+                          <span className="flex flex-col gap-0.5">
+                            <Text weight="strong">Standard</Text>
+                            <Text variant="subtext" theme="neutral">
+                              Can be removed before it starts.
+                            </Text>
+                          </span>
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          aria-pressed={required}
+                          className={cn(
+                            '!h-auto w-full !items-start !justify-start !whitespace-normal !p-3 text-left',
+                            required && 'bg-blue-500/5 ring-1 ring-blue-500/20'
+                          )}
+                          onClick={() => onRequiredChange(true)}
+                        >
+                          <Icon variant="LockIcon" size={17} />
+                          <span className="flex flex-col gap-0.5">
+                            <Text weight="strong">Required</Text>
+                            <Text variant="subtext" theme="neutral">
+                              Must complete and cannot be discarded.
+                            </Text>
+                          </span>
+                        </Button>
+                      </div>
+                    </div>
+                  </>
+                ) : (
+                  <div className="flex flex-col gap-3">
+                    <div className="flex flex-col gap-1">
+                      <Text weight="strong">Choose an operation</Text>
+                      <Text variant="subtext" theme="neutral">
+                        Add a runbook or another install operation to this
+                        queue.
+                      </Text>
+                    </div>
+                    <div className="grid gap-2">
+                      {options.map((option) => (
+                        <Button
+                          key={option.id}
+                          variant="secondary"
+                          className="!h-auto w-full !justify-start !whitespace-normal !p-3 text-left"
+                          onClick={() => onSelectOption(option.id)}
+                        >
+                          <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-cool-grey-100 dark:bg-dark-grey-700">
+                            <Icon
+                              variant={entryIcons[option.type]}
+                              size={18}
+                              theme="neutral"
+                            />
+                          </div>
+                          <span className="flex min-w-0 flex-col gap-0.5">
+                            <Text weight="strong">{option.name}</Text>
+                            <Text variant="subtext" theme="neutral">
+                              {option.detail}
+                            </Text>
+                          </span>
+                          <Badge
+                            className="ml-auto"
+                            size="xs"
+                            variant="code"
+                            theme="default"
+                          >
+                            {option.type}
+                          </Badge>
+                        </Button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </Card>
+
+        <div className="flex flex-col gap-6 lg:sticky lg:top-4">
+          <Card className="!gap-4 !p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <Icon variant="EyeIcon" size={17} />
+                <Text variant="base" weight="strong">
+                  Queue preview
+                </Text>
+              </div>
+              <Badge size="sm" theme="neutral">
+                One at a time
+              </Badge>
+            </div>
+            <Divider />
+            <div className="flex flex-col gap-3">
+              {entries.map((entry, index) => (
+                <div key={entry.id} className="flex items-center gap-3">
+                  <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-cool-grey-100 text-xs font-semibold dark:bg-dark-grey-700">
+                    {index + 1}
+                  </span>
+                  <Text className="min-w-0 flex-1 truncate">{entry.name}</Text>
+                  {entry.required && <Icon variant="LockIcon" size={13} />}
+                </div>
+              ))}
+              <div
+                className={cn(
+                  'flex items-center gap-3 rounded-lg border border-dashed p-3',
+                  selectedOption && 'bg-blue-500/5 ring-1 ring-blue-500/20'
+                )}
+              >
+                <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-blue-500/10 text-xs font-semibold text-blue-700 dark:text-blue-400">
+                  {position}
+                </span>
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <Text weight="strong" className="truncate">
+                    {selectedOption?.name ?? 'Choose an operation'}
+                  </Text>
+                  <Text variant="subtext" theme="neutral">
+                    {selectedOption
+                      ? 'Waiting to be added'
+                      : 'New queue position'}
+                  </Text>
+                </div>
+                {required && selectedOption && (
+                  <Badge size="xs" theme="brand">
+                    <Icon variant="LockIcon" size={11} />
+                    Required
+                  </Badge>
+                )}
+              </div>
+            </div>
+          </Card>
+
+          <Card className="!gap-4 !p-4">
+            <div className="flex items-center gap-2">
+              <Icon variant="ShieldCheckIcon" theme="brand" size={18} />
+              <Text weight="strong">Admission behavior</Text>
+            </div>
+            <Text variant="subtext" theme="neutral">
+              Once added, direct attempts to run this operation are routed
+              through the queue. It starts only when earlier operations have
+              completed.
+            </Text>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const InstallOperationsQueue = ({
+  installName,
+  queueName,
+  status,
+  entries,
+  rules,
+  onAddOperation,
+  onConfigureRules,
+  onFinishOutsideOperation,
+  onRunOutsideQueue,
+  onStart,
+}: IInstallOperationsQueue) => {
+  const completeCount = entries.filter(
+    (entry) => entry.status === 'success'
+  ).length
+  const activeEntry = entries.find((entry) => entry.status === 'in-progress')
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-6">
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+        <div className="flex flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-3">
+            <Text as="h1" variant="h2" weight="stronger">
+              Operations queue
+            </Text>
+            <Badge size="md" theme={statusTheme[status]}>
+              {queueStatusLabels[status]}
+            </Badge>
+          </div>
+          <Text theme="neutral">
+            {queueName} for {installName}
+          </Text>
+        </div>
+        <QueueActions
+          status={status}
+          onAddOperation={onAddOperation}
+          onFinishOutsideOperation={onFinishOutsideOperation}
+          onRunOutsideQueue={onRunOutsideQueue}
+          onStart={onStart}
+        />
+      </div>
+
+      {status === 'out-of-band' && (
+        <Banner theme="warn">
+          <div className="flex flex-col gap-1">
+            <Text weight="strong">Operation running outside queue</Text>
+            <Text variant="subtext">
+              Normal queue dispatch is held automatically while this audited
+              operation bypasses ordering rules. Dispatch resumes when it ends.
+            </Text>
+          </div>
+        </Banner>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(18rem,1fr)]">
+        <Card className="!gap-4 !p-4">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex flex-col gap-1">
+              <Text variant="base" weight="strong">
+                Queue operations
+              </Text>
+              <Text variant="subtext" theme="neutral">
+                {completeCount} of {entries.length} complete
+                {activeEntry ? ` · Running ${activeEntry.name}` : ''}
+              </Text>
+            </div>
+            <Badge size="sm" theme="neutral">
+              <Icon variant="ArrowsInLineVerticalIcon" size={13} />
+              One at a time
+            </Badge>
+          </div>
+          <Divider />
+          <div className="divide-y">
+            {entries.map((entry, index) => (
+              <OperationRow key={entry.id} entry={entry} position={index + 1} />
+            ))}
+          </div>
+        </Card>
+
+        <div className="flex flex-col gap-6">
+          <Card className="!gap-4 !p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <Icon variant="ShieldCheckIcon" theme="brand" size={20} />
+                <Text variant="base" weight="strong">
+                  Queue rules
+                </Text>
+              </div>
+              {onConfigureRules && (
+                <Button variant="ghost" size="xs" onClick={onConfigureRules}>
+                  Configure rules
+                </Button>
+              )}
+            </div>
+            <Divider />
+            <div className="flex flex-col gap-4">
+              {rules.map((rule) => (
+                <div key={rule.id} className="flex items-start gap-3">
+                  <Icon
+                    className="mt-0.5 shrink-0"
+                    variant="CheckCircleIcon"
+                    theme="success"
+                    size={17}
+                  />
+                  <div className="flex min-w-0 flex-col gap-0.5">
+                    <Text weight="strong">{rule.name}</Text>
+                    <Text variant="subtext" theme="neutral">
+                      {rule.description}
+                    </Text>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Card>
+
+          <Card className="!gap-4 !p-4">
+            <div className="flex items-center gap-2">
+              <Icon variant="ShieldIcon" theme="warn" size={20} />
+              <Text variant="base" weight="strong">
+                Run outside queue
+              </Text>
+            </div>
+            <Text variant="subtext" theme="neutral">
+              Run one urgent operation outside ordering rules. Normal dispatch
+              is held automatically, and the operation and reason are recorded.
+            </Text>
+            <Text flex variant="subtext" theme="neutral">
+              <Icon variant="LockIcon" size={13} />
+              Permission and reason required
+            </Text>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/services/dashboard-ui/client/components/operation-queues/InstallOperationsQueue/index.ts
+++ b/services/dashboard-ui/client/components/operation-queues/InstallOperationsQueue/index.ts
@@ -1,0 +1,19 @@
+export {
+  AddQueueOperationStudio,
+  InstallOperationsQueue,
+  QueueAdmissionRulesStudio,
+} from './InstallOperationsQueue'
+export type {
+  IAddQueueOperationStudio,
+  IInstallOperationsQueue,
+  IOperationQueueEntry,
+  IOperationQueueRule,
+  IQueueAdmissionExemptionOption,
+  IQueueAdmissionRulesStudio,
+  IQueueOperationOption,
+  TQueueAdmissionPolicy,
+  TQueueExemptionOperationType,
+  TScheduledOperationsPolicy,
+  TOperationQueueEntryStatus,
+  TOperationQueueStatus,
+} from './InstallOperationsQueue'

--- a/services/dashboard-ui/client/components/operation-queues/InstallOperationsQueue/schema.ts
+++ b/services/dashboard-ui/client/components/operation-queues/InstallOperationsQueue/schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+export const admissionRulesSchema = z.object({
+  admissionPolicy: z.enum(['enqueue', 'strict']),
+  scheduledOperationsPolicy: z.enum(['direct', 'enqueue']),
+})
+
+export type AdmissionRulesValues = z.infer<typeof admissionRulesSchema>
+
+export const installQueueReorderSchema = z.object({
+  queuePosition: z.number().int().min(1),
+})
+
+export type InstallQueueReorderValues = z.infer<
+  typeof installQueueReorderSchema
+>

--- a/services/dashboard-ui/client/components/runbooks/InstallRunbooksTable/InstallRunbooksTable.tsx
+++ b/services/dashboard-ui/client/components/runbooks/InstallRunbooksTable/InstallRunbooksTable.tsx
@@ -24,6 +24,7 @@ export type TInstallRunbookRow = {
   href: string
   latestRunHref: string | null
   installRunbook: TInstallRunbook
+  runAction?: ReactNode
   removed?: boolean
 }
 
@@ -177,6 +178,8 @@ const columns: ColumnDef<TInstallRunbookRow>[] = [
               Run runbook
               <Icon variant="PlayIcon" />
             </Button>
+          ) : info.row.original.runAction ? (
+            info.row.original.runAction
           ) : (
             <RunRunbookButton
               installRunbook={info.row.original.installRunbook}

--- a/services/dashboard-ui/e2e/specs-ladle/install-operation-rules.spec.ts
+++ b/services/dashboard-ui/e2e/specs-ladle/install-operation-rules.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "@playwright/test";
+
+const ALL_DISABLED_STORY =
+  "/?story=operation-queues--install-operation-rules--all-disabled&mode=preview";
+const ALL_ENABLED_STORY =
+  "/?story=operation-queues--install-operation-rules--all-enabled&mode=preview";
+
+test.describe("InstallOperationRules enable all", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ALL_DISABLED_STORY, { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByRole("heading", { name: "Install operation rules" }),
+    ).toBeVisible();
+  });
+
+  test("enable all turns every rule on and back off", async ({ page }) => {
+    const enableAll = page.getByRole("switch", { name: "Enable all" });
+
+    await expect(page.getByText("0 of 5 operation types")).toBeVisible();
+
+    await enableAll.click();
+    await expect(page.getByText("5 of 5 operation types")).toBeVisible();
+    await expect(page.getByText("Rule enabled")).toHaveCount(5);
+
+    await enableAll.click();
+    await expect(page.getByText("0 of 5 operation types")).toBeVisible();
+    await expect(page.getByText("Rule enabled")).toHaveCount(0);
+  });
+});
+
+test.describe("InstallOperationRules window behavior", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(ALL_DISABLED_STORY, { waitUntil: "domcontentloaded" });
+    await page.getByRole("switch", { name: "Actions rule" }).click();
+  });
+
+  test("an anytime window has nothing to fall outside of", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: "Weekly" }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByText("When triggered outside of this window"),
+    ).toBeHidden();
+  });
+
+  test("save stays disabled until a weekly window picks a day", async ({
+    page,
+  }) => {
+    const save = page.getByRole("button", { name: "Save rules" });
+
+    await page.getByRole("button", { name: "Weekly" }).first().click();
+    await expect(page.getByText("Pick at least one day.")).toBeVisible();
+    await expect(save).toBeDisabled();
+
+    await page.getByRole("button", { name: "Wed" }).click();
+    await expect(page.getByText("Pick at least one day.")).toBeHidden();
+    await expect(save).toBeEnabled();
+  });
+
+  test("the outside-window checkbox gates the policy options", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Weekly" }).first().click();
+    await page.getByRole("button", { name: "Wed" }).click();
+
+    const askForPermission = page.getByRole("radio", {
+      name: /Ask for permission/,
+    });
+    await expect(askForPermission).toBeVisible();
+
+    await page.getByRole("checkbox").first().click();
+    await expect(askForPermission).toBeHidden();
+    await expect(
+      page.getByText("Operations triggered outside the window run normally."),
+    ).toBeVisible();
+  });
+
+  test("switching to monthly swaps the day picker", async ({ page }) => {
+    await page.getByRole("button", { name: "Weekly" }).first().click();
+    await expect(page.getByRole("button", { name: "Wed" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Monthly" }).first().click();
+    await expect(page.getByRole("button", { name: "Wed" })).toBeHidden();
+  });
+});
+
+test.describe("InstallOperationRules impact", () => {
+  test("summarizes the enforced windows and policies", async ({ page }) => {
+    await page.goto(ALL_ENABLED_STORY, { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText(/Outside their window, /)).toBeVisible();
+    await expect(page.getByText("Break glass: anytime.")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an interactive Ladle prototype for governing install operations through ordered queues. This is a UX proposal only; it does not add APIs, persistence, or production routing.

## What you can do after this PR

**Model ordered install operations.** Queue runbooks, deploys, actions, and sandbox operations while marking prerequisites as required and non-removable.

**Control admission.** Configure scheduled operations and label exemptions, or block all workflows unless they are already queued. Authorized outside-queue runs remain audited exceptions.

**Operate across install groups.** Preview group membership, deduplicate existing entries, reorder the required runbook per install, and track the resulting group operation.

**See enforcement from the runbooks page.** Attempting an invalid direct run shows the queue policy blocking it.

## What stays the same

No production workflow behavior changes. Existing runbook table behavior remains unchanged unless a story supplies its optional simulated run action.
