### PR TITLE
refactor(ui): follow styleguide for rendering text

### DIFF
--- a/.claude/commands/dashboard-ui/component.md
+++ b/.claude/commands/dashboard-ui/component.md
@@ -88,6 +88,16 @@ For visual decisions (tokens, spacing, borders, dark mode), follow `services/das
 
 For `Tabs`: keys are rendered via `toSentenceCase(camelToWords(key))` which lowercases everything after the first character — always write keys all-lowercase (`'create your own app'`, not `'Create Your Own App'`).
 
+## Rendered strings (casing, font, chip)
+
+Every string you render is exactly one of three classes; the class fixes its casing, font, and (as a chip) its component. Classify with these tests, then apply the treatment. Full record: `DESIGN.md` §1 / UXDR 019.
+
+1. **Identifier** — *Could a user copy this exact string into a terminal, config, or search?* (names, IDs, k8s kinds, terraform/cloud resource types, image tags, paths, versions, label keys/values) → **verbatim, never re-cased, mono** (`ID`, `Code`, `Badge variant="code"`, `LabelBadge`, `Text family="mono"`).
+2. **API vocabulary** — *Is the full value set enumerable from our Go code?* (statuses, trigger/workflow/plan/step types, ops) → **`humanize()` from `@/utils/string-utils` (sentence case, acronyms preserved), sans**. `Status` humanizes for you; never re-case vocabulary by hand at a call site.
+3. **UI copy** — neither of the above → `COPY_STYLE.md`.
+
+**Chip pick:** value changes on its own while you watch (lifecycle) → `Status`; static classification (type/kind/count/version) → `Badge` (`variant="code"` iff identifier content, default sans variant iff vocabulary); user key:value label → `LabelBadge`. **mono ⇔ identifier.** Never `humanize()` a string that contains a user identifier (mixed strings, e.g. a step name) or a free-text API sentence (`status_human_description`) — render those verbatim.
+
 ## Icons
 
 Use the `Icon` component from `@/components/common/Icon` for ALL icons. Always use the `Icon` suffix for variant names (e.g., `HouseIcon` not `House`).
@@ -134,3 +144,5 @@ The `Button` owns its tooltip via `tooltipProps` (`Omit<ITooltip, 'children'>`).
 - **Do not** use `StoryObj` or `render:` in stories — Ladle v5 requires plain function exports
 - **Do not** import icons directly from `@phosphor-icons/react` — always use the `Icon` component
 - **Do not** hand-build a `*Skeleton` component — use the primitive `loading` prop, `<Table isLoading>`, or a spinner for unknown shape
+- **Do not** render a raw API enum (`{role.type}`, `{step.type}`) or re-case vocabulary at a call site (`toSentenceCase`/`toTitleCase`/hand-rolled) — route vocabulary through `humanize()`, render identifiers verbatim + mono (see "Rendered strings")
+- **Do not** add a `Record<string, string>` display map whose entries just equal `humanize(key)`, put a lifecycle status in a `Badge` (use `Status`), or make a chip mono for vocabulary / sans for an identifier

--- a/services/dashboard-ui/COPY_STYLE.md
+++ b/services/dashboard-ui/COPY_STYLE.md
@@ -40,6 +40,12 @@ Rules that apply to all UI copy, regardless of surface.
 
 **Exceptions:** Proper nouns (AWS, Nuon, Terraform, GitHub, Slack) and acronyms (API, CLI, VCS, URL).
 
+**Scope:** this guide owns UI copy we write (class 3). Strings that come from the API — enum
+vocabulary (statuses, types, ops) and identifiers (names, IDs, k8s kinds) — are governed by the
+rendered-string taxonomy in [DESIGN.md §1](./DESIGN.md), not here. Vocabulary is cased by
+`humanize()` (sentence case, acronyms preserved); identifiers render verbatim and mono. Never
+re-case an API string by hand at a call site.
+
 ## Pronouns & possessives
 
 **Use "your" sparingly — only for account-level possessions.** "Your org", "your team", "your account" are fine. For resources (installs, components, webhooks, runners), use the entity name or "this [thing]".

--- a/services/dashboard-ui/DESIGN.md
+++ b/services/dashboard-ui/DESIGN.md
@@ -56,13 +56,37 @@ Rules:
 - Prefer these over native elements. Native `<button>`, ad-hoc `<input>`, or a bespoke table is a
   smell unless the design system genuinely lacks the primitive.
 - Use semantic helpers for data: `Time` for timestamps (never manual date formatting), `Duration`,
-  `ID`/`Hash`/`ClickToCopy` for identifiers, `Status`/`Badge` for state, `Code`/`JSONViewer` for
-  payloads, `LabeledValue`/`PropertyGrid`/`KeyValueList` for key→value display.
+  `ID`/`Hash`/`ClickToCopy` for identifiers, `Status`/`Badge` for state, `LabelBadge` for resource
+  labels (never a raw `Badge` over a `labels` map), `Code`/`JSONViewer` for payloads,
+  `LabeledValue`/`PropertyGrid`/`KeyValueList` for key→value display.
 - Anything using `Modal`/`Panel`/`Toast` (or `useSurfaces`) must be mounted under `SurfacesProvider`
   — including Ladle stories, or it throws. In stories, use the `ModalStory`/`PanelStory` helpers
   from `components/__stories__/helpers.tsx`.
 - Code conventions for these components (container/component split, stories format, icon imports,
   date handling) live in [AGENTS.md](./AGENTS.md) — follow it rather than restating rules here.
+
+### Rendered-string taxonomy (casing, font, chip)
+
+Every string rendered in the UI is exactly one of three classes; the class fixes its casing, font,
+and (when it's a chip) its component. Classify with the tests, then apply the treatment. Full
+decision record: [UXDR 019](./.planning/ux/019-uxdr-rendered-string-taxonomy.md).
+
+| Class | Test | Casing & font | Component |
+|-------|------|---------------|-----------|
+| **Identifier** — user-typed or external-system-defined (names, IDs, k8s kinds, terraform/cloud resource types, image tags, paths, versions, label keys/values) | Could a user need to copy this exact string into a terminal, config, or search? | Verbatim, never re-cased, **mono** | `ID`, `Code`, `Badge variant="code"`, `LabelBadge`, `Text family="mono"` |
+| **API vocabulary** — enums our platform defines (statuses, trigger/workflow/plan/step types, ops) | Is the full value set enumerable from our Go code? | `humanize()` (snake/kebab → words → sentence case, acronyms preserved), **sans** | `Status` (lifecycle) or `Badge` default variant (static classification) |
+| **UI copy** — written by us | Neither of the above | [COPY_STYLE.md](./COPY_STYLE.md) | any |
+
+- **`humanize()` (`utils/string-utils.ts`) is the only place vocabulary gets cased** — never
+  `toSentenceCase`/`toTitleCase`/hand-rolled re-casing at a call site. `Status` humanizes for you.
+- **Chip pick:** value changes on its own while you watch (lifecycle) → `Status`; static
+  classification (type/kind/count/version) → `Badge` (`variant="code"` iff the content is an
+  identifier, default sans variant iff vocabulary); user-defined key:value label → `LabelBadge`.
+- **mono ⇔ identifier.** Nothing else is mono; no identifier is sans.
+- **Never re-case a string that contains a user identifier** (e.g. a step name like `Sync and plan
+  some-name`) — render it verbatim. **Free-text API sentences** (`status_human_description` and
+  friends) are server-authored copy → render verbatim; quality issues are fixed at the Go source,
+  never client-side.
 
 ---
 
@@ -151,6 +175,12 @@ These are the specific inconsistencies that make the UI look "off". Treat each a
    Every other action, including the CTA in an empty state, is `secondary`/`ghost`. This holds even
    when the page's primary button is disabled — a disabled primary still counts, so don't add a
    second primary elsewhere to compensate. If two actions feel equally important, one of them isn't.
+9. **No ad-hoc string casing.** Rendering a raw API enum (`{role.type}`, `{step.type}`) or
+   re-casing vocabulary at a call site (`toSentenceCase`/`toTitleCase`/hand-rolled) is a slop —
+   route vocabulary through `humanize()`, and see §1's rendered-string taxonomy. A new
+   `Record<string, string>` display map whose entries just equal `humanize(key)` is dead weight.
+   A `Badge` rendering a lifecycle status (use `Status`), a mono/`variant="code"` chip over
+   vocabulary, or a sans chip over an identifier are all mis-classifications.
 
 ---
 

--- a/services/dashboard-ui/client/components/actions/InstallActionRunHeader/InstallActionRunHeader.tsx
+++ b/services/dashboard-ui/client/components/actions/InstallActionRunHeader/InstallActionRunHeader.tsx
@@ -13,7 +13,6 @@ import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
 import type { TActionConfigTriggerType, TInstallActionRun, TWorkflow, TWorkflowStep } from '@/types'
 import { cn } from '@/utils/classnames'
-import { toSentenceCase } from '@/utils/string-utils'
 
 interface IInstallActionRunHeader {
   actionId: string
@@ -103,9 +102,7 @@ export const InstallActionRunHeader = ({
               status: installActionRun?.status_v2?.status,
             }}
             tooltipProps={{
-              tipContent: toSentenceCase(
-                installActionRun?.status_v2?.status_human_description
-              ),
+              tipContent: installActionRun?.status_v2?.status_human_description,
             }}
           />
 

--- a/services/dashboard-ui/client/components/actions/InstallActionsTable/InstallActionsTable.tsx
+++ b/services/dashboard-ui/client/components/actions/InstallActionsTable/InstallActionsTable.tsx
@@ -11,7 +11,6 @@ import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
 import { RemovedFromAppConfigBadge } from '@/components/installs/RemovedFromAppConfig'
 import type { TActionConfigTriggerType, TInstallAction } from '@/types'
-import { toSentenceCase } from '@/utils/string-utils'
 import { ActionTriggerType } from '../ActionTriggerType'
 
 export type InstallActionRow = {
@@ -65,9 +64,7 @@ export function parseInstallActionsLatestRunsToTableData(
           statusProps={{ status: recentRun?.status_v2?.status }}
           tooltipProps={{
             position: 'top',
-            tipContent: toSentenceCase(
-              recentRun?.status_v2?.status_human_description
-            ),
+            tipContent: recentRun?.status_v2?.status_human_description,
           }}
         />
       ) : (

--- a/services/dashboard-ui/client/components/approvals/ApprovalBanner.tsx
+++ b/services/dashboard-ui/client/components/approvals/ApprovalBanner.tsx
@@ -10,7 +10,7 @@ import {
   getApprovalType,
   getApprovalResponseType,
 } from '@/utils/approval-utils'
-import { toSentenceCase } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 import { ApprovePlanButton } from './ApprovePlan'
 import { DenyPlanButton } from './DenyPlan'
 import { RetryPlanButton } from './RetryPlan'
@@ -140,15 +140,15 @@ const ApprovedPlanBanner = ({ step }: IApprovalBanner) => {
               ? `Plan was ${responseType}`
               : optimistic
                 ? 'Response submitted'
-                : toSentenceCase(step?.status?.status)}
+                : humanize(step?.status?.status)}
           </Text>
           <Text variant="subtext" theme="neutral">
             {responseType
               ? `This ${getApprovalType(step?.approval?.type)} plan was ${responseType}.`
               : optimistic
                 ? 'Waiting for the workflow to process your response.'
-                : toSentenceCase(step?.status?.status_human_description) ||
-                  toSentenceCase(step?.status?.metadata?.reason as string)}
+                : step?.status?.status_human_description ||
+                  (step?.status?.metadata?.reason as string)}
           </Text>
         </div>
       </div>

--- a/services/dashboard-ui/client/components/approvals/ApproveAll/ApproveAll.tsx
+++ b/services/dashboard-ui/client/components/approvals/ApproveAll/ApproveAll.tsx
@@ -4,7 +4,7 @@ import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
 import { Modal, type IModal } from '@/components/surfaces/Modal'
 import type { TAPIError } from '@/types'
-import { toSentenceCase } from '@/utils/string-utils'
+import { getWorkflowStepTitle } from '@/utils/workflow-utils'
 
 interface IApproveAllModal extends Omit<IModal, 'onSubmit'> {
   pendingSteps: { id: string; name: string }[]
@@ -57,8 +57,8 @@ export const ApproveAllModal = ({
         </Text>
         <div className="flex flex-wrap gap-2">
           {pendingSteps.map((s) => (
-            <Badge variant="code" key={s.id} size="sm">
-              {toSentenceCase(s.name)}
+            <Badge key={s.id} size="sm">
+              {getWorkflowStepTitle(s)}
             </Badge>
           ))}
         </div>

--- a/services/dashboard-ui/client/components/approvals/plan-diffs/app-config/AppConfigDiff.tsx
+++ b/services/dashboard-ui/client/components/approvals/plan-diffs/app-config/AppConfigDiff.tsx
@@ -13,6 +13,7 @@ import { diffLines } from '@/utils/code-utils'
 import { cn } from '@/utils/classnames'
 import { scrollElementIntoView } from '@/utils/scroll'
 import type { TConfigDiffFocus } from '../config-diff-focus'
+import { humanize } from '@/utils/string-utils'
 
 const SECTION_CONFIG: Record<string, { displayName: string; icon: TIconVariant; grouped: boolean }> = {
   components: { displayName: 'Components', icon: 'CubeIcon', grouped: true },
@@ -387,7 +388,7 @@ const FileDiffRow = ({
           </Text>
           <div className="flex items-center pr-4 self-center">
             <Badge theme={OP_BADGE_THEME[file.op] || 'neutral'} size="sm">
-              {file.op}
+              {humanize(file.op)}
             </Badge>
           </div>
         </div>
@@ -460,7 +461,7 @@ const EntityRow = ({
         </div>
         <div className="flex items-center pr-4 self-center">
           <Badge theme={OP_BADGE_THEME[entity.op] || 'neutral'} size="sm">
-            {entity.op}
+            {humanize(entity.op)}
           </Badge>
         </div>
       </div>
@@ -503,7 +504,7 @@ const FieldRow = ({ field, sectionKey, idx }: { field: DiffFieldEntry; sectionKe
         <Text variant="subtext" theme="neutral" family="mono">{field.diff}</Text>
       </div>
       <Badge theme={OP_BADGE_THEME[field.op as AppConfigOp] || 'neutral'} size="sm">
-        {field.op}
+        {humanize(field.op)}
       </Badge>
     </div>
   )

--- a/services/dashboard-ui/client/components/approvals/plan-diffs/helm/HelmDiff.tsx
+++ b/services/dashboard-ui/client/components/approvals/plan-diffs/helm/HelmDiff.tsx
@@ -14,6 +14,7 @@ import {
   getHelmActionBorderColor,
 } from '../diff-style-utils'
 import { HelmDiffSummary } from './HelmDiffSummary'
+import { humanize } from '@/utils/string-utils'
 import { DiffFilter } from '../DiffFilter'
 
 export const HelmDiff = ({ plan }: { plan: THelmPlan }) => {
@@ -38,7 +39,7 @@ export const HelmDiff = ({ plan }: { plan: THelmPlan }) => {
           Helm changes
         </Text>
         <Text variant="subtext" theme="neutral">
-          Operation: {plan.op}
+          Operation: {humanize(plan.op)}
         </Text>
       </div>
 

--- a/services/dashboard-ui/client/components/apps/CreateInstall/CreateInstallContainer.tsx
+++ b/services/dashboard-ui/client/components/apps/CreateInstall/CreateInstallContainer.tsx
@@ -26,7 +26,6 @@ import {
   createAppInstall,
   getAWSAccountConnections,
 } from '@/lib'
-import { toSentenceCase } from '@/utils/string-utils'
 import { CreateInstallButton as CreateInstallButtonComponent } from './CreateInstall'
 
 const noop = () => {}
@@ -183,11 +182,10 @@ const CreateInstallModalContainer = ({ ...props }: IModal) => {
           submitError={
             submitError
               ? ({
-                  error: toSentenceCase(
+                  error:
                     (submitError as any).error ||
-                      (submitError as any).description ||
-                      'Unable to create install.'
-                  ),
+                    (submitError as any).description ||
+                    'Unable to create install.',
                 } as any)
               : null
           }

--- a/services/dashboard-ui/client/components/branches/WorkflowStepsPipeline/WorkflowStepsPipeline.tsx
+++ b/services/dashboard-ui/client/components/branches/WorkflowStepsPipeline/WorkflowStepsPipeline.tsx
@@ -5,7 +5,7 @@ import { Loading } from '@/components/common/Loading'
 import { Text } from '@/components/common/Text'
 import { cn } from '@/utils/classnames'
 import type { TInstallWorkflowStep } from '@/types'
-import { toSentenceCase } from '@/utils/string-utils'
+import { getWorkflowStepTitle } from '@/utils/workflow-utils'
 import { stepStatusCategory, type TStepStatusCategory } from '../shared/step-status'
 
 interface IWorkflowStepsPipeline {
@@ -213,7 +213,7 @@ export const WorkflowStepsPipeline = ({
                     weight="strong"
                     className="text-center leading-tight max-w-[160px] text-cool-grey-900 dark:text-cool-grey-100"
                   >
-                    {toSentenceCase(step.name || 'Unknown')}
+                    {getWorkflowStepTitle(step) || 'Unknown'}
                   </Text>
 
                   {step.execution_time ? (

--- a/services/dashboard-ui/client/components/builds/BuildHeader/BuildHeader.tsx
+++ b/services/dashboard-ui/client/components/builds/BuildHeader/BuildHeader.tsx
@@ -25,7 +25,6 @@ import { useToast } from '@/hooks/use-toast'
 import { cancelComponentBuild } from '@/lib'
 import type { TApp, TAPIError, TBuild, TComponent } from '@/types'
 import { isImageBuild } from '@/utils/image-ref'
-import { toSentenceCase } from '@/utils/string-utils'
 
 interface IBuildHeader {
   component: TComponent
@@ -88,7 +87,7 @@ export const BuildHeader = ({ component, build, app }: IBuildHeader) => {
               tipContentClassName: 'w-fit',
               tipContent: (
                 <Text nowrap variant="subtext">
-                  {toSentenceCase(build?.status_v2?.status_human_description)}
+                  {build?.status_v2?.status_human_description}
                 </Text>
               ),
               position: 'bottom',

--- a/services/dashboard-ui/client/components/common/Status.tsx
+++ b/services/dashboard-ui/client/components/common/Status.tsx
@@ -2,7 +2,7 @@ import type { HTMLAttributes } from 'react'
 import { Icon } from '@/components/common/Icon'
 import type { TTheme } from '@/types'
 import { cn } from '@/utils/classnames'
-import { kebabToWords, toSentenceCase } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 import { getStatusTheme, getStatusIconVariant } from '@/utils/status-utils'
 import { SKELETON_CLASSES } from './Skeleton'
 import { Text } from './Text'
@@ -151,8 +151,8 @@ export const Status = ({
       {isWithoutText ? null : (
         <span className={statusTextClass}>
           {typeof children === 'string'
-            ? toSentenceCase(kebabToWords(children))
-            : children || toSentenceCase(kebabToWords(status || 'unknown'))}
+            ? humanize(children)
+            : children || humanize(status || 'unknown')}
         </span>
       )}
     </span>

--- a/services/dashboard-ui/client/components/common/TimelineEvent.tsx
+++ b/services/dashboard-ui/client/components/common/TimelineEvent.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { cn } from '@/utils/classnames'
-import { toSentenceCase } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 import { Badge, type IBadge } from './Badge'
 import { Status, type TStatusType } from './Status'
 import { Text } from './Text'
@@ -49,7 +49,7 @@ export const TimelineEvent = ({
         tipContentClassName="flex"
         tipContent={
           <Text variant="subtext" family="mono">
-            {toSentenceCase(status)}
+            {humanize(status)}
           </Text>
         }
         position="right"

--- a/services/dashboard-ui/client/components/components/ComponentType.tsx
+++ b/services/dashboard-ui/client/components/components/ComponentType.tsx
@@ -76,6 +76,9 @@ const COMPONENT_TYPE_CONFIG: Record<
   },
 } as const
 
+export const componentTypeName = (type: TComponentType): string =>
+  (COMPONENT_TYPE_CONFIG[type] || COMPONENT_TYPE_CONFIG.unknown).name
+
 export const ComponentType = ({
   colorVariant = 'mono',
   type: configType,

--- a/services/dashboard-ui/client/components/components/ComponentsTooltip.tsx
+++ b/services/dashboard-ui/client/components/components/ComponentsTooltip.tsx
@@ -4,7 +4,7 @@ import {
 } from '@/components/common/ContextTooltip'
 import { Status } from '@/components/common/Status'
 import type { TComponent, TInstallComponent } from '@/types'
-import { toSentenceCase } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 
 export function getContextTooltipItemsFromComponents(
   components: TComponent[],
@@ -22,7 +22,7 @@ export function getContextTooltipItemsFromComponents(
       />
     ),
     title: comp?.name,
-    subtitle: toSentenceCase(comp?.status),
+    subtitle: humanize(comp?.status),
   }))
 }
 
@@ -47,14 +47,14 @@ function getComponentSubtitle(
   status: string | undefined,
   lifecycleStatus?: string
 ): string {
-  if (!status) return toSentenceCase(status)
+  if (!status) return humanize(status)
   if (lifecycleStatus === 'deprovisioned') {
-    return DEPROVISIONED_COMPONENT_SUBTITLES[status] ?? toSentenceCase(status)
+    return DEPROVISIONED_COMPONENT_SUBTITLES[status] ?? humanize(status)
   }
   if (lifecycleStatus === 'deprovisioning') {
-    return DEPROVISIONING_COMPONENT_SUBTITLES[status] ?? toSentenceCase(status)
+    return DEPROVISIONING_COMPONENT_SUBTITLES[status] ?? humanize(status)
   }
-  return toSentenceCase(status)
+  return humanize(status)
 }
 
 export function getContextTooltipItemsFromInstallComponents(

--- a/services/dashboard-ui/client/components/deploys/DeployHeader/DeployHeader.tsx
+++ b/services/dashboard-ui/client/components/deploys/DeployHeader/DeployHeader.tsx
@@ -13,7 +13,6 @@ import { Time } from '@/components/common/Time'
 import { ComponentType } from '@/components/components/ComponentType'
 import { ComponentConfigContextTooltip } from '@/components/components/ComponentConfigContextTooltip'
 import type { TComponent, TDeploy, TInstall, TWorkflow } from '@/types'
-import { toSentenceCase } from '@/utils/string-utils'
 import { DeploySwitcher } from '@/components/deploys/DeploySwitcher'
 import { OCIArtifactCard } from '@/components/deploys/OCIArtifactCard'
 import { ManagementDropdown } from '@/components/deploys/management/ManagementDropdown'
@@ -99,7 +98,7 @@ export const DeployHeader = ({
               tipContentClassName: 'w-fit',
               tipContent: (
                 <Text nowrap variant="subtext">
-                  {toSentenceCase(deploy?.status_v2?.status_human_description)}
+                  {deploy?.status_v2?.status_human_description}
                 </Text>
               ),
               position: 'bottom',

--- a/services/dashboard-ui/client/components/install-health/HealthTimeline/HealthTimeline.tsx
+++ b/services/dashboard-ui/client/components/install-health/HealthTimeline/HealthTimeline.tsx
@@ -22,7 +22,7 @@ import {
   bearsHealthVerdict,
   compareHealthSeverityDesc,
 } from '@/utils/health-utils'
-import { kebabToWords, toSentenceCase } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 import { formatToRelativeDay } from '@/utils/timeline-utils'
 
 const BAR_NEUTRAL_CLASS = 'bg-cool-grey-200 dark:bg-dark-grey-700'
@@ -54,7 +54,7 @@ function dayDowntimePercent(day: THealthTimelineDay): number {
 }
 
 function formatHealth(health?: string): string {
-  return toSentenceCase(kebabToWords(health || 'unknown'))
+  return humanize(health || 'unknown')
 }
 
 // A component nobody observed has 0% uptime arithmetically, which reads as

--- a/services/dashboard-ui/client/components/install-resources/InstallResourcesTable/InstallResourcesTable.tsx
+++ b/services/dashboard-ui/client/components/install-resources/InstallResourcesTable/InstallResourcesTable.tsx
@@ -31,7 +31,7 @@ import {
   isFailingHealth,
   worstHealth,
 } from '@/utils/health-utils'
-import { kebabToWords, toSentenceCase } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 import { isStaleObservation, latestTimestamp } from '@/utils/time-utils'
 
 // Synthetic filter value covering everything that carries no verdict, so the
@@ -67,7 +67,7 @@ const MIN_FOLDED_ROWS = 3
 
 function healthFilterLabel(value: string): string {
   if (value === NO_SIGNAL_FILTER) return 'No signal'
-  return toSentenceCase(kebabToWords(value))
+  return humanize(value)
 }
 
 // Cloud identity rows (aws/gcp/azure) never bear a verdict — mirrors the

--- a/services/dashboard-ui/client/components/installs/ArchitectureDiagram/diagram-nodes.tsx
+++ b/services/dashboard-ui/client/components/installs/ArchitectureDiagram/diagram-nodes.tsx
@@ -6,11 +6,11 @@ import { ContextTooltip } from '@/components/common/ContextTooltip'
 import { Status } from '@/components/common/Status'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
-import { ComponentType } from '@/components/components/ComponentType'
+import { ComponentType, componentTypeName } from '@/components/components/ComponentType'
 import type { TIconVariant } from '@/components/common/Icon'
 import type { TComponentType } from '@/types'
 import { cn } from '@/utils/classnames'
-import { toSentenceCase } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 import type { TRoleInfo } from './diagram-layout'
 
 const CONTAINER_STYLES: Record<number, string> = {
@@ -84,16 +84,6 @@ export const SectionLabelNode = memo(({ data }: NodeProps) => (
 
 SectionLabelNode.displayName = 'SectionLabelNode'
 
-const COMPONENT_TYPE_LABELS: Record<string, string> = {
-  helm_chart: 'Helm chart',
-  terraform_module: 'Terraform module',
-  kubernetes_manifest: 'Kubernetes manifest',
-  docker_build: 'Docker build',
-  external_image: 'External image',
-  job: 'Job',
-  pulumi: 'Pulumi',
-}
-
 export const ComponentCardNode = memo(({ data }: NodeProps) => {
   const status = data.status as string
   const isDrifted = data.isDrifted as boolean
@@ -115,7 +105,7 @@ export const ComponentCardNode = memo(({ data }: NodeProps) => {
           id: 'status',
           title: 'Status',
           subtitle:
-            (data.statusDescription as string) || toSentenceCase(status),
+            (data.statusDescription as string) || humanize(status),
           leftContent: (
             <Status
               status={status}
@@ -133,7 +123,7 @@ export const ComponentCardNode = memo(({ data }: NodeProps) => {
                 subtitle: (
                   <span className="flex items-center gap-1">
                     <Text variant="label" theme="neutral">
-                      {toSentenceCase(data.latestDeployStatus as string)}
+                      {humanize(data.latestDeployStatus as string)}
                     </Text>
                     {latestDeployAt && (
                       <>
@@ -174,7 +164,7 @@ export const ComponentCardNode = memo(({ data }: NodeProps) => {
         {
           id: 'view',
           title: 'View details',
-          subtitle: COMPONENT_TYPE_LABELS[componentType] || 'Component',
+          subtitle: componentTypeName(componentType),
           href,
           leftContent: (
             <ComponentType
@@ -202,7 +192,7 @@ export const ComponentCardNode = memo(({ data }: NodeProps) => {
       ]}
     >
       <div
-        aria-label={`${name} — ${COMPONENT_TYPE_LABELS[componentType] || 'Component'}`}
+        aria-label={`${name} — ${componentTypeName(componentType)}`}
         className={cn(
           'rounded-lg border bg-white dark:bg-dark-grey-900 px-3 py-2 flex items-center gap-2 transition-shadow hover:shadow-sm overflow-hidden',
           isDrifted && '!border-orange-400 dark:!border-orange-500/40'
@@ -224,7 +214,7 @@ export const ComponentCardNode = memo(({ data }: NodeProps) => {
             {name}
           </span>
           <span className="text-[11px] leading-[16px] text-cool-grey-600 dark:text-white/70 overflow-hidden text-ellipsis whitespace-nowrap block">
-            {COMPONENT_TYPE_LABELS[componentType] || 'Component'}
+            {componentTypeName(componentType)}
           </span>
         </div>
         <div className="flex items-center gap-1.5 shrink-0">

--- a/services/dashboard-ui/client/components/installs/CreateInstall/CreateInstallFromAppContainer.tsx
+++ b/services/dashboard-ui/client/components/installs/CreateInstall/CreateInstallFromAppContainer.tsx
@@ -23,7 +23,6 @@ import {
   getAWSAccountConnections,
 } from '@/lib'
 import type { TApp } from '@/types'
-import { toSentenceCase } from '@/utils/string-utils'
 import { BranchConnectionStep } from './BranchConnectionStep'
 import {
   CreateInstallFormFields,
@@ -267,11 +266,10 @@ export const CreateInstallFromAppContainer = ({
           submitError={
             submitError
               ? ({
-                  error: toSentenceCase(
+                  error:
                     (submitError as any).error ||
-                      (submitError as any).description ||
-                      'Unable to create install.'
-                  ),
+                    (submitError as any).description ||
+                    'Unable to create install.',
                 } as any)
               : null
           }

--- a/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.tsx
+++ b/services/dashboard-ui/client/components/installs/InstallStatuses/InstallStatuses.tsx
@@ -20,7 +20,7 @@ import { cn } from '@/utils/classnames'
 import { Time } from '@/components/common/Time'
 import { getInstallStatusTitle } from '@/utils/install-utils'
 import { getStatusTheme, getWorstStatusTheme } from '@/utils/status-utils'
-import { toSentenceCase } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 
 export interface IInstallStatuses
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
@@ -257,7 +257,7 @@ export const InstallStatuses = ({
         {
           href: `/${install.org_id}/installs/${install.id}/runner`,
           id: install?.runner_id,
-          title: `${install.runner_type === 'aws' ? 'AWS' : toSentenceCase(install?.runner_type)} runner`,
+          title: `${humanize(install?.runner_type)} runner`,
           subtitle: getInstallStatusTitle(
             'runner_status',
             install?.runner_status,
@@ -298,7 +298,7 @@ export const InstallStatuses = ({
         {
           href: sandboxHref,
           id: install?.install_sandbox_runs?.at(0)?.id,
-          title: toSentenceCase(install?.install_sandbox_runs?.at(0)?.run_type),
+          title: humanize(install?.install_sandbox_runs?.at(0)?.run_type),
           subtitle: sandboxSubtitle,
           leftContent: (
             <Status
@@ -371,7 +371,7 @@ export const InstallStatuses = ({
           title: 'Component health',
           subtitle:
             install?.composite_health_status_description ??
-            toSentenceCase(healthStatus),
+            humanize(healthStatus),
           href: `/${install.org_id}/installs/${install.id}/resources?health=${healthStatus}`,
           leftContent: (
             <Status
@@ -404,7 +404,7 @@ export const InstallStatuses = ({
         {
           href: `/${install.org_id}/installs/${install.id}/stacks`,
           id: latestStackVersion?.id ?? 'stack',
-          title: toSentenceCase(stackStatus),
+          title: humanize(stackStatus),
           subtitle: latestStackVersion?.created_at ? (
             <Time
               time={latestStackVersion.created_at}
@@ -462,7 +462,7 @@ export const InstallStatuses = ({
           {
             id: 'stack',
             title: 'Stack',
-            subtitle: toSentenceCase(stackStatus),
+            subtitle: humanize(stackStatus),
             href: `/${install.org_id}/installs/${install.id}/stacks`,
             leftContent: (
               <Status
@@ -528,7 +528,7 @@ export const InstallStatuses = ({
             title: 'Component health',
             subtitle:
               install?.composite_health_status_description ??
-              toSentenceCase(healthStatus),
+              humanize(healthStatus),
             href: `/${install.org_id}/installs/${install.id}/resources?health=${healthStatus}`,
             leftContent: (
               <Status

--- a/services/dashboard-ui/client/components/interests/subops.ts
+++ b/services/dashboard-ui/client/components/interests/subops.ts
@@ -9,6 +9,7 @@
 // Drift surfaces only through the dedicated drift_detected event class, gated
 // by the per-resource drift_detected toggle (see RESOURCES_WITH_DRIFT_DETECTED).
 
+import { humanize } from '@/utils/string-utils'
 import type { ResourceKind } from './types'
 
 export const SUB_OPS: Record<ResourceKind, string[]> = {
@@ -29,19 +30,9 @@ export const RESOURCES_WITH_DRIFT_DETECTED: ReadonlySet<ResourceKind> =
   new Set<ResourceKind>(['components', 'sandboxes'])
 
 const SUB_OP_LABELS: Record<string, string> = {
-  provision: 'Provision',
-  deprovision: 'Deprovision',
-  reprovision: 'Reprovision',
-  deploy: 'Deploy',
-  teardown: 'Teardown',
   inputs: 'Input updates',
   secrets: 'Secret syncs',
-  inactive: 'Inactive',
-  unhealthy: 'Unhealthy',
-  run: 'Run',
-  version_active: 'Version active',
 }
 
 export const labelForSubOp = (op: string): string =>
-  SUB_OP_LABELS[op] ??
-  op.replace(/_/g, ' ').replace(/^./, (c) => c.toUpperCase())
+  SUB_OP_LABELS[op] ?? humanize(op)

--- a/services/dashboard-ui/client/components/onboarding/steps/v2/ProvisioningStep/ProvisioningStepContainer.tsx
+++ b/services/dashboard-ui/client/components/onboarding/steps/v2/ProvisioningStep/ProvisioningStepContainer.tsx
@@ -10,7 +10,6 @@ import { completeDeployStep, getApp, getCurrentOnboarding, getInstall, getInstal
 import { isRecentTimestamp } from '@/utils/time-utils'
 import { getStatusTheme } from '@/utils/status-utils'
 import { cn } from '@/utils/classnames'
-import { toSentenceCase } from '@/utils/string-utils'
 import type { TOnboarding, TWorkflow, TWorkflowStep } from '@/types'
 import type { IWizardStepComponentProps } from '@/providers/onboarding-wizard-provider'
 
@@ -197,7 +196,7 @@ function useProvisioningRows(steps: TWorkflowStep[]): IRow[] {
       const errorInfo = status === 'error' ? getErrorInfo(compSteps) : {}
       rows.push({
         id: `component-${compName}`,
-        label: toTitleCase(compName),
+        label: compName,
         description: apiDesc || fallback[status],
         errorDescription: errorInfo.description,
         errorStepId: errorInfo.stepId,
@@ -209,12 +208,6 @@ function useProvisioningRows(steps: TWorkflowStep[]): IRow[] {
 
     return rows
   }, [steps])
-}
-
-function toTitleCase(str: string): string {
-  return str
-    .replace(/[-_]/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
 const AVG_SECONDS_PER_STEP = 90
@@ -568,7 +561,7 @@ export const ProvisioningStepContainer = ({
   return (
     <div className="flex flex-col gap-8">
       {isError && workflow?.status?.status_human_description && (
-        <Banner theme="error">{toSentenceCase(workflow.status.status_human_description)}</Banner>
+        <Banner theme="error">{workflow.status.status_human_description}</Banner>
       )}
 
       <Card className="!gap-0 !p-4">

--- a/services/dashboard-ui/client/components/orgs/OrgStatusBar/OrgStatusBar.tsx
+++ b/services/dashboard-ui/client/components/orgs/OrgStatusBar/OrgStatusBar.tsx
@@ -9,7 +9,7 @@ import { Tooltip } from '@/components/common/Tooltip'
 import { Time } from '@/components/common/Time'
 import { InstallStatuses } from '@/components/installs/InstallStatuses'
 import { VCSConnectionsStatusIndicator } from '@/components/vcs-connections/VCSConnectionsStatusIndicator'
-import { toSentenceCase } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 import { getStatusTheme } from '@/utils/status-utils'
 import type { TApp, TAppBranch, TAppConfig, TInstall, TInstallStack, TOrg, TWorkflow, TWorkflowStepApproval } from '@/types'
 
@@ -127,7 +127,7 @@ export const OrgStatusBar = ({
               items={[
                 {
                   id: latestConfig.id ?? 'config',
-                  title: toSentenceCase(latestConfig.status ?? ''),
+                  title: humanize(latestConfig.status ?? ''),
                   subtitle: latestConfig.created_at ? (
                     <Time
                       time={latestConfig.created_at}

--- a/services/dashboard-ui/client/components/orgs/OrgStatusBar/OrgStatusBarContainer.tsx
+++ b/services/dashboard-ui/client/components/orgs/OrgStatusBar/OrgStatusBarContainer.tsx
@@ -13,7 +13,8 @@ import {
   getInstall,
   getInstallStack,
 } from '@/lib'
-import { toSentenceCase, snakeToWords } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
+import { getWorkflowStepTitle } from '@/utils/workflow-utils'
 import { OrgStatusBar } from './OrgStatusBar'
 
 export const OrgStatusBarContainer = () => {
@@ -63,7 +64,7 @@ export const OrgStatusBarContainer = () => {
 
   const workflowItems: TContextTooltipItem[] = activeWorkflows.map((workflow) => ({
     id: workflow.id ?? '',
-    title: workflow.name || toSentenceCase(snakeToWords(workflow.type)),
+    title: workflow.name || humanize(workflow.type),
     subtitle: workflow.metadata?.owner_name || workflow.status?.status || undefined,
     href: workflow.owner_id
       ? `/${org.id}/installs/${workflow.owner_id}/workflows/${workflow.id}`
@@ -93,7 +94,7 @@ export const OrgStatusBarContainer = () => {
     const installName = step?.owner_id ? ownerNames.get(step.owner_id) : undefined
     return {
       id: approval.id ?? '',
-      title: step?.name ? toSentenceCase(step.name) : 'Approval required',
+      title: step?.name ? getWorkflowStepTitle(step) : 'Approval required',
       subtitle: installName || approval.type || undefined,
       href,
     }

--- a/services/dashboard-ui/client/components/orgs/PendingApprovals/PendingApprovals.tsx
+++ b/services/dashboard-ui/client/components/orgs/PendingApprovals/PendingApprovals.tsx
@@ -5,8 +5,7 @@ import { Status } from '@/components/common/Status'
 import { Text } from '@/components/common/Text'
 import { getRunTitle } from '@/components/branches/shared/run-title'
 import { getApprovalType } from '@/utils/approval-utils'
-import { toSentenceCase } from '@/utils/string-utils'
-import { getWorkflowHref } from '@/utils/workflow-utils'
+import { getWorkflowHref, getWorkflowStepTitle } from '@/utils/workflow-utils'
 import type { TWorkflowStepApproval, TWorkflow } from '@/types'
 
 interface IPendingApprovals {
@@ -47,7 +46,7 @@ export const PendingApprovals = ({ orgId, approvals, activeWorkflows }: IPending
           const name = isBranchRun
             ? getRunTitle(workflow)
             : step?.name
-              ? toSentenceCase(step.name)
+              ? getWorkflowStepTitle(step)
               : 'Approval required'
           const installName = workflow?.metadata?.owner_name
 

--- a/services/dashboard-ui/client/components/roles/AppRoleDetail.tsx
+++ b/services/dashboard-ui/client/components/roles/AppRoleDetail.tsx
@@ -4,6 +4,7 @@ import { LabeledValue } from '@/components/common/LabeledValue'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
 import { IAMRolePoliciesCard, IAMRoleBoundaryExpand } from './IAMRoles'
+import { humanize } from '@/utils/string-utils'
 
 type TAppRole = {
   id?: string
@@ -40,8 +41,8 @@ export const AppRoleDetail = ({ role }: { role: TAppRole }) => {
           </LabeledValue>
           <LabeledValue label="Name">{role?.name}</LabeledValue>
           <LabeledValue label="Type">
-            <Badge variant="code" size="sm">
-              {role?.type}
+            <Badge size="sm">
+              {humanize(role?.type)}
             </Badge>
           </LabeledValue>
         </div>

--- a/services/dashboard-ui/client/components/roles/IAMRoles.tsx
+++ b/services/dashboard-ui/client/components/roles/IAMRoles.tsx
@@ -20,6 +20,7 @@ import type {
 } from '@/lib/ctl-api/installs/get-install-app-permissions-config'
 import type { TInstallRole } from '@/lib/ctl-api/installs/get-latest-install-roles'
 import { decodeAsString } from '@/utils/data-utils'
+import { humanize } from '@/utils/string-utils'
 
 export const IAMRoleBoundaryExpand = ({
   permissionsBoundary,
@@ -311,8 +312,8 @@ export const IAMRoles = ({ appConfig }: { appConfig: TAppConfig }) => {
               </LabeledValue>
               <LabeledValue label="Name">{role?.name}</LabeledValue>
               <LabeledValue label="Type">
-                <Badge variant="code" size="sm">
-                  {role?.type}
+                <Badge size="sm">
+                  {humanize(role?.type)}
                 </Badge>
               </LabeledValue>
             </div>
@@ -356,8 +357,8 @@ export const InstallIAMRoles = ({
                 </LabeledValue>
                 <LabeledValue label="Name">{role.name}</LabeledValue>
                 <LabeledValue label="Type">
-                  <Badge variant="code" size="sm">
-                    {role.type}
+                  <Badge size="sm">
+                    {humanize(role.type)}
                   </Badge>
                 </LabeledValue>
                 <LabeledValue label="Status">

--- a/services/dashboard-ui/client/components/roles/InstallRoleDetail.tsx
+++ b/services/dashboard-ui/client/components/roles/InstallRoleDetail.tsx
@@ -18,6 +18,7 @@ import { useSurfaces } from '@/hooks/use-surfaces'
 import { getInstallRoleUsages } from '@/lib'
 import type { TInstallRoleUsage } from '@/types'
 import { IAMRolePoliciesCard, IAMRoleBoundaryExpand } from './IAMRoles'
+import { humanize } from '@/utils/string-utils'
 import type { TInstallRole } from '@/lib/ctl-api/installs/get-latest-install-roles'
 
 const USAGE_LIMIT = 10
@@ -173,8 +174,8 @@ export const InstallRoleDetail = ({
           </LabeledValue>
           <LabeledValue label="Name">{role.name}</LabeledValue>
           <LabeledValue label="Type">
-            <Badge variant="code" size="sm">
-              {role.type}
+            <Badge size="sm">
+              {humanize(role.type)}
             </Badge>
           </LabeledValue>
           <LabeledValue label="Status">

--- a/services/dashboard-ui/client/components/roles/InstallRolesTable/InstallRolesTable.tsx
+++ b/services/dashboard-ui/client/components/roles/InstallRolesTable/InstallRolesTable.tsx
@@ -11,6 +11,7 @@ import { Time } from '@/components/common/Time'
 import { Panel } from '@/components/surfaces/Panel'
 import { InstallRoleDetail } from '../InstallRoleDetail'
 import type { TInstallRole } from '@/lib/ctl-api/installs/get-latest-install-roles'
+import { humanize } from '@/utils/string-utils'
 
 const panelLinkClass =
   '!p-0 !h-auto !border-none !rounded-none !bg-transparent hover:!bg-transparent active:!bg-transparent focus:!shadow-none text-primary-600 dark:text-primary-500 hover:text-primary-800 hover:dark:text-primary-400 active:text-primary-900 active:dark:text-primary-600'
@@ -66,8 +67,8 @@ export const InstallRolesTable = ({
         accessorKey: 'app_role_config.type',
         header: 'Type',
         cell: ({ row }) => (
-          <Badge variant="code" theme="neutral">
-            {row.original.app_role_config?.type}
+          <Badge theme="neutral">
+            {humanize(row.original.app_role_config?.type)}
           </Badge>
         ),
       },

--- a/services/dashboard-ui/client/components/runbooks/RunbookStep.tsx
+++ b/services/dashboard-ui/client/components/runbooks/RunbookStep.tsx
@@ -9,6 +9,7 @@ import { Link } from '@/components/common/Link'
 import { Text } from '@/components/common/Text'
 import type { TRunbookStep } from '@/lib/ctl-api/apps/runbooks/get-runbooks'
 import { objectToKeyValueArray } from '@/utils/data-utils'
+import { humanize } from '@/utils/string-utils'
 
 export interface IRunbookStep {
   index: number
@@ -38,8 +39,8 @@ export const RunbookStep = ({ index, step, actionBasePath }: IRunbookStep) => {
           <Text weight="strong">
             {index + 1}. {step.name}
           </Text>
-          <Badge variant="code" size="sm" theme="neutral">
-            {step.type}
+          <Badge size="sm" theme="neutral">
+            {humanize(step.type)}
           </Badge>
         </span>
       }

--- a/services/dashboard-ui/client/components/runbooks/RunbookStepCard/RunbookStepCard.tsx
+++ b/services/dashboard-ui/client/components/runbooks/RunbookStepCard/RunbookStepCard.tsx
@@ -14,7 +14,6 @@ import { Status } from '@/components/common/Status'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
 import type { TCompositeError, TInstallActionRun, TWorkflowStep } from '@/types'
-import { toSentenceCase } from '@/utils/string-utils'
 
 type TStatusHistoryEntry = NonNullable<
   NonNullable<TWorkflowStep['status']>['history']
@@ -111,7 +110,7 @@ export const RunbookStepCard = ({
         <div className="flex items-center gap-3">
           <Text variant="body" className="!inline-flex gap-2">
             {stepStatus ? <Status status={stepStatus} isWithoutText /> : null}
-            {toSentenceCase(step.name)}
+            {step.name}
           </Text>
         </div>
         <Link href={`${workflowUrl}?panel=${step.id}`}>

--- a/services/dashboard-ui/client/components/runners/ProcessCard/ProcessCard.tsx
+++ b/services/dashboard-ui/client/components/runners/ProcessCard/ProcessCard.tsx
@@ -14,7 +14,7 @@ import type {
   TRunnerHealthCheck,
   TRunnerSettings,
 } from '@/types'
-import { toSentenceCase } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 
 function healthCheckColorClass(hc: TRunnerHealthCheck): string {
   if (hc?.status_code === 0) return 'bg-green-500'
@@ -120,7 +120,7 @@ export const ProcessCard = ({
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-3">
             <Text variant="base" weight="strong">
-              {toSentenceCase(process.type || 'unknown')} process
+              {humanize(process.type || 'unknown')} process
             </Text>
             <Status status={process.composite_status?.status} variant="badge" />
             {process.labels?.map((label) => (

--- a/services/dashboard-ui/client/components/sandbox/SandboxRunsTimeline/SandboxRunsTimeline.tsx
+++ b/services/dashboard-ui/client/components/sandbox/SandboxRunsTimeline/SandboxRunsTimeline.tsx
@@ -4,7 +4,7 @@ import { Link } from '@/components/common/Link'
 import { Timeline } from '@/components/common/Timeline'
 import { TimelineEvent } from '@/components/common/TimelineEvent'
 import type { TSandboxRun } from '@/types'
-import { toSentenceCase, snakeToWords } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 
 interface ISandboxRunsTimeline {
   runs: TSandboxRun[]
@@ -35,7 +35,7 @@ export const SandboxRunsTimeline = ({
                 <Link
                   href={`/${orgId}/installs/${installId}/sandbox/runs/${run?.id}`}
                 >
-                  {toSentenceCase(snakeToWords(run?.run_type))}
+                  {humanize(run?.run_type)}
                 </Link>
                 {run?.status_v2?.status === 'drifted' ? (
                   <Badge variant="code" size="sm">

--- a/services/dashboard-ui/client/components/workflows/ActiveWorkflowCard.tsx
+++ b/services/dashboard-ui/client/components/workflows/ActiveWorkflowCard.tsx
@@ -10,7 +10,7 @@ import { useOrg } from '@/hooks/use-org'
 import { useWorkflowApprovals } from '@/hooks/use-workflow-approvals'
 import type { TInstall, TWorkflow } from '@/types'
 import { cn } from '@/utils/classnames'
-import { toSentenceCase, snakeToWords } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 import {
   getWorkflowHref,
   getWorkflowPendingApprovals,
@@ -166,7 +166,7 @@ export const ActiveWorkflowCard = ({
             </LabeledValue>
             <LabeledValue label="Type" className="flex-1">
               <Text variant="subtext" className="truncate">
-                {toSentenceCase(snakeToWords(workflow.type))}
+                {humanize(workflow.type)}
               </Text>
             </LabeledValue>
             <CancelWorkflowButton workflow={workflow} size="sm">

--- a/services/dashboard-ui/client/components/workflows/step-details/RetryStep/RetryStepContainer.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/RetryStep/RetryStepContainer.tsx
@@ -9,7 +9,7 @@ import { useSurfaces } from '@/hooks/use-surfaces'
 import { useToast } from '@/hooks/use-toast'
 import { retryWorkflowStep } from '@/lib'
 import type { TAPIError, TWorkflowStep } from '@/types'
-import { toSentenceCase } from '@/utils/string-utils'
+import { getWorkflowStepTitle } from '@/utils/workflow-utils'
 import { RetryStepModal } from './RetryStep'
 
 interface IRetryStep {
@@ -40,7 +40,7 @@ export const RetryStepModalContainer = ({
     onSuccess: () => {
       addToast(
         <Toast heading="Step retry initiated" theme="success">
-          <Text>{toSentenceCase(step.name)} is being retried.</Text>
+          <Text>{getWorkflowStepTitle(step)} is being retried.</Text>
         </Toast>
       )
       queryClient.invalidateQueries({ queryKey: ['workflow-approvals'] })

--- a/services/dashboard-ui/client/components/workflows/step-details/SkipStep/SkipStepContainer.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/SkipStep/SkipStepContainer.tsx
@@ -9,7 +9,7 @@ import { useSurfaces } from '@/hooks/use-surfaces'
 import { useToast } from '@/hooks/use-toast'
 import { skipWorkflowStep } from '@/lib'
 import type { TAPIError, TWorkflowStep } from '@/types'
-import { toSentenceCase } from '@/utils/string-utils'
+import { getWorkflowStepTitle } from '@/utils/workflow-utils'
 import { SkipStepModal } from './SkipStep'
 
 interface ISkipStep {
@@ -40,7 +40,7 @@ export const SkipStepModalContainer = ({
       addToast(
         <Toast heading="Step skipped" theme="success">
           <Text>
-            {toSentenceCase(step.name)} was skipped. The workflow will continue
+            {getWorkflowStepTitle(step)} was skipped. The workflow will continue
             with the remaining steps.
           </Text>
         </Toast>

--- a/services/dashboard-ui/client/components/workflows/step-details/action-run-details/AdhocActionDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/action-run-details/AdhocActionDetails.tsx
@@ -7,7 +7,7 @@ import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
 import { InstallActionRunOutputs } from '@/components/actions/InstallActionRunOutputs'
 import { InstallActionRunProvider } from '@/providers/install-action-run-provider'
-import { toSentenceCase } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 import type { IAdhocActionDetails } from './types'
 
 export const AdhocActionDetails = ({ actionRun }: IAdhocActionDetails) => {
@@ -30,7 +30,7 @@ export const AdhocActionDetails = ({ actionRun }: IAdhocActionDetails) => {
               variant="subtext"
               theme="neutral"
             >
-              {toSentenceCase(firstStep?.status)}{' '}
+              {humanize(firstStep?.status)}{' '}
               {(firstStep?.execution_duration ?? 0) > 1000000 ? (
                 <>
                   in{' '}

--- a/services/dashboard-ui/client/components/workflows/step-details/action-run-details/StandardActionSteps.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/action-run-details/StandardActionSteps.tsx
@@ -4,7 +4,7 @@ import { Duration } from '@/components/common/Duration'
 import { Status } from '@/components/common/Status'
 import { Text } from '@/components/common/Text'
 import { hydrateActionRunSteps, sortByIdx } from '@/utils/action-utils'
-import { toSentenceCase } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 import type { IStandardActionSteps } from './types'
 
 export const StandardActionSteps = ({
@@ -50,7 +50,7 @@ export const StandardActionSteps = ({
         >
           <span className="flex items-center gap-2">
             <Status status={actionStep.status} isWithoutText />
-            <Text>{toSentenceCase(actionStep?.name)}</Text>
+            <Text>{actionStep?.name}</Text>
           </span>
 
           <Text
@@ -58,7 +58,7 @@ export const StandardActionSteps = ({
             variant="subtext"
             theme="neutral"
           >
-            {toSentenceCase(actionStep.status)}{' '}
+            {humanize(actionStep.status)}{' '}
             {actionStep?.execution_duration > 1000000 ? (
               <>
                 in{' '}

--- a/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowDetailsSection/WorkflowDetailsSection.tsx
+++ b/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowDetailsSection/WorkflowDetailsSection.tsx
@@ -9,7 +9,7 @@ import { PropertyGrid } from '@/components/common/PropertyGrid'
 import { Text } from '@/components/common/Text'
 import { Time } from '@/components/common/Time'
 import { Modal } from '@/components/surfaces/Modal'
-import { toSentenceCase, snakeToWords } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 import { getInputDisplayName } from '@/utils/install-utils'
 import type { TWorkflow, TInstall } from '@/types'
 import { WorkflowMetadata } from '../WorkflowMetadata'
@@ -108,7 +108,7 @@ export const WorkflowDetailsSection = ({
             )}
 
             <LabeledValue label="Trigger">
-              {toSentenceCase(snakeToWords(workflow.type))}
+              {humanize(workflow.type)}
             </LabeledValue>
 
             <div className="ml-auto">

--- a/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowHeader/WorkflowHeader.tsx
+++ b/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowHeader/WorkflowHeader.tsx
@@ -4,7 +4,7 @@ import { Badge } from '@/components/common/Badge'
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
-import { toSentenceCase, snakeToWords } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 import { WorkflowActionButtons } from '../WorkflowActionButtons'
 import type { TWorkflow, TInstall } from '@/types'
 
@@ -35,7 +35,7 @@ export const WorkflowHeader = ({ workflow, install }: IWorkflowHeader) => {
             {workflow?.type === 'action_workflow_run' &&
             workflow?.metadata?.adhoc_action
               ? `Adhoc action run (${workflow?.metadata?.install_action_workflow_name})`
-              : workflow.name || toSentenceCase(snakeToWords(workflow.type))}
+              : workflow.name || humanize(workflow.type)}
 
             {hasDrift ? (
               <Badge variant="code" theme="warn" size="sm">

--- a/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowStatusSection/WorkflowStatusSection.tsx
+++ b/services/dashboard-ui/client/components/workflows/workflow-details/WorkflowStatusSection/WorkflowStatusSection.tsx
@@ -9,7 +9,7 @@ import type {
   TWorkflowQueuePosition,
 } from '@/lib/ctl-api/workflows/get-workflow-queue-position'
 import { getStatusTheme } from '@/utils/status-utils'
-import { toSentenceCase, snakeToWords } from '@/utils/string-utils'
+import { snakeToWords, humanize } from '@/utils/string-utils'
 import type { TWorkflow } from '@/types'
 import { Link } from '@/components/common/Link'
 
@@ -38,15 +38,15 @@ export const WorkflowStatusSection = ({
           weight="stronger"
           className="inline-flex gap-2 max-w-[600px]"
           theme={getStatusTheme(workflow.status.status) as any}
-          title={toSentenceCase(
-            workflow.status.status_human_description || workflow.status.status
-          )}
+          title={
+            workflow.status.status_human_description ||
+            humanize(workflow.status.status)
+          }
         >
           <Status status={workflow.status.status} variant="timeline" />
           <span className="truncate">
-            {toSentenceCase(
-              workflow.status.status_human_description || workflow.status.status
-            )}
+            {workflow.status.status_human_description ||
+              humanize(workflow.status.status)}
           </span>
         </Text>
 

--- a/services/dashboard-ui/client/providers/workflow-approvals-provider.tsx
+++ b/services/dashboard-ui/client/providers/workflow-approvals-provider.tsx
@@ -12,8 +12,7 @@ import { Link } from '@/components/common/Link'
 import { Text } from '@/components/common/Text'
 import { Toast } from '@/components/surfaces/Toast'
 import { getRunTitle } from '@/components/branches/shared/run-title'
-import { toSentenceCase } from '@/utils/string-utils'
-import { getWorkflowHref } from '@/utils/workflow-utils'
+import { getWorkflowHref, getWorkflowStepTitle } from '@/utils/workflow-utils'
 import type { TWorkflowStepApproval } from '@/types'
 
 type WorkflowApprovalsContextValue = {
@@ -75,7 +74,7 @@ export function WorkflowApprovalsProvider({
         const heading = isBranchRun
           ? getRunTitle(workflow)
           : stepName
-            ? toSentenceCase(stepName)
+            ? getWorkflowStepTitle(step)
             : 'Approval required'
         const workflowUrl = workflow
           ? getWorkflowHref(org.id, workflow)

--- a/services/dashboard-ui/client/utils/status-utils.ts
+++ b/services/dashboard-ui/client/utils/status-utils.ts
@@ -22,13 +22,11 @@ const STATUS_THEME_MAP: Record<string, TStatusTheme> = {
   error: 'error',
   bad: 'error',
   'access-error': 'error',
-  access_error: 'error',
   'timed-out': 'error',
   unhealthy: 'error',
-  'not connected': 'error',
   'not-connected': 'error',
   suspended: 'error',
-  policy_failed: 'error',
+  'policy-failed': 'error',
   'failed-pending-retry': 'error',
 
   'approval-denied': 'warn',
@@ -70,8 +68,8 @@ const STATUS_THEME_MAP: Record<string, TStatusTheme> = {
   inactive: 'neutral',
   disabled: 'neutral',
   pending: 'neutral',
-  'Not deployed': 'neutral',
-  'No build': 'neutral',
+  'not-deployed': 'neutral',
+  'no-build': 'neutral',
   'not-attempted': 'neutral',
   deprovisioned: 'warn',
   skeleton: 'neutral',
@@ -94,13 +92,11 @@ const STATUS_ICON_MAP: Record<string, TIconVariant> = {
   error: 'XCircleIcon',
   bad: 'XCircleIcon',
   'access-error': 'XCircleIcon',
-  access_error: 'XCircleIcon',
   'timed-out': 'XCircleIcon',
   unknown: 'XCircleIcon',
   unhealthy: 'XCircleIcon',
-  'not connected': 'XCircleIcon',
   'not-connected': 'XCircleIcon',
-  policy_failed: 'XCircleIcon',
+  'policy-failed': 'XCircleIcon',
   'failed-pending-retry': 'XCircleIcon',
 
   'approval-denied': 'WarningIcon',
@@ -133,8 +129,8 @@ const STATUS_ICON_MAP: Record<string, TIconVariant> = {
   disabled: 'ProhibitIcon',
   pending: 'ClockCountdownIcon',
   offline: 'ClockCountdownIcon',
-  'Not deployed': 'ClockCountdownIcon',
-  'No build': 'ClockCountdownIcon',
+  'not-deployed': 'ClockCountdownIcon',
+  'no-build': 'ClockCountdownIcon',
   deprovisioned: 'WarningIcon',
 
   'not-applicable': 'MinusCircleIcon',
@@ -150,12 +146,15 @@ const STATUS_ICON_MAP: Record<string, TIconVariant> = {
   skeleton: 'none' as TIconVariant,
 }
 
+const normalizeStatusKey = (status: string): string =>
+  status.toLowerCase().replace(/[\s_]+/g, '-')
+
 export function getStatusTheme(status: string): TStatusTheme {
-  return STATUS_THEME_MAP[status] ?? 'neutral'
+  return STATUS_THEME_MAP[normalizeStatusKey(status)] ?? 'neutral'
 }
 
 export function getStatusIconVariant(status: string): TIconVariant {
-  return STATUS_ICON_MAP[status] ?? 'ClockCountdownIcon'
+  return STATUS_ICON_MAP[normalizeStatusKey(status)] ?? 'ClockCountdownIcon'
 }
 
 const THEME_PRIORITY: TStatusTheme[] = [

--- a/services/dashboard-ui/client/utils/string-utils.test.ts
+++ b/services/dashboard-ui/client/utils/string-utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   toSentenceCase,
-  toTitleCase,
+  humanize,
   getInitials,
   kebabToWords,
   snakeToWords,
@@ -14,6 +14,43 @@ import {
 } from './string-utils'
 
 describe('string-utils', () => {
+  describe('humanize', () => {
+    test('sentence-cases snake_case vocabulary', () => {
+      expect(humanize('access_error')).toBe('Access error')
+    })
+
+    test('sentence-cases kebab-case vocabulary', () => {
+      expect(humanize('not-connected')).toBe('Not connected')
+      expect(humanize('in-progress')).toBe('In progress')
+    })
+
+    test('preserves acronyms anywhere in the string', () => {
+      expect(humanize('aws')).toBe('AWS')
+      expect(humanize('oidc_config')).toBe('OIDC config')
+      expect(humanize('aws_permission_error')).toBe('AWS permission error')
+      expect(humanize('install_id')).toBe('Install ID')
+      expect(humanize('aws-eks')).toBe('AWS EKS')
+    })
+
+    test('normalizes acronym casing to canonical form', () => {
+      expect(humanize('K8S')).toBe('K8s')
+      expect(humanize('k8s')).toBe('K8s')
+    })
+
+    test('lowercases non-acronym words after the first', () => {
+      expect(humanize('Access_Error')).toBe('Access error')
+    })
+
+    test('trims and collapses whitespace', () => {
+      expect(humanize('  access   error  ')).toBe('Access error')
+    })
+
+    test('handles empty string', () => {
+      expect(humanize('')).toBe('')
+      expect(humanize()).toBe('')
+    })
+  })
+
   describe('toSentenceCase', () => {
     test('should capitalize first letter', () => {
       expect(toSentenceCase('hello world')).toBe('Hello world')
@@ -26,20 +63,6 @@ describe('string-utils', () => {
 
     test('should lowercase remaining letters', () => {
       expect(toSentenceCase('HELLO WORLD')).toBe('Hello world')
-    })
-  })
-
-  describe('toTitleCase', () => {
-    test('should convert to title case', () => {
-      expect(toTitleCase('hello world')).toBe('Hello World')
-    })
-
-    test('should handle dashes and underscores', () => {
-      expect(toTitleCase('hello-world_foo')).toBe('Hello World Foo')
-    })
-
-    test('should handle empty string', () => {
-      expect(toTitleCase('')).toBe('')
     })
   })
 

--- a/services/dashboard-ui/client/utils/string-utils.ts
+++ b/services/dashboard-ui/client/utils/string-utils.ts
@@ -1,13 +1,44 @@
 export const toSentenceCase = (str: string = ''): string =>
   str.length ? str.charAt(0).toUpperCase() + str.slice(1).toLowerCase() : ''
 
-export const toTitleCase = (str: string = ''): string =>
-  str
-    .replace(/[-_]/g, ' ')
-    .toLowerCase()
-    .replace(/\b(\w)/g, (char) => char.toUpperCase())
-    .replace(/\s+/g, ' ')
+const ACRONYMS: Record<string, string> = {
+  aws: 'AWS',
+  gcp: 'GCP',
+  gke: 'GKE',
+  vcs: 'VCS',
+  oidc: 'OIDC',
+  api: 'API',
+  id: 'ID',
+  iam: 'IAM',
+  k8s: 'K8s',
+  oci: 'OCI',
+  ecr: 'ECR',
+  eks: 'EKS',
+  ecs: 'ECS',
+  acr: 'ACR',
+  aks: 'AKS',
+  tls: 'TLS',
+  dns: 'DNS',
+  url: 'URL',
+}
+
+export const humanize = (str: string = ''): string => {
+  const words = str
     .trim()
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+
+  return words
+    .map((word, i) => {
+      const acronym = ACRONYMS[word.toLowerCase()]
+      if (acronym) return acronym
+      const lower = word.toLowerCase()
+      return i === 0 ? lower.charAt(0).toUpperCase() + lower.slice(1) : lower
+    })
+    .join(' ')
+}
 
 export const getInitials = (str: string = ''): string => {
   if (!str) return ''

--- a/services/dashboard-ui/client/utils/workflow-utils.ts
+++ b/services/dashboard-ui/client/utils/workflow-utils.ts
@@ -8,7 +8,9 @@ export type TBadgeCfg = {
   theme?: TBadgeTheme
 }
 
-export function getWorkflowStepTitle(step?: TWorkflowStep): string {
+export function getWorkflowStepTitle(
+  step?: { name?: string; links?: { event_wait?: unknown } | null } | null
+): string {
   if (step?.links?.event_wait) {
     const normalizedName = step?.name?.replace(/[-_]+/g, ' ').trim() ?? ''
     const waitForPrefix = /^wait\s+for(?:\s+|$)/i

--- a/services/dashboard-ui/client/views/app/ActionDetail.tsx
+++ b/services/dashboard-ui/client/views/app/ActionDetail.tsx
@@ -6,6 +6,7 @@ import { Code } from '@/components/common/Code'
 import { Duration } from '@/components/common/Duration'
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { ID } from '@/components/common/ID'
+import { LabelBadge } from '@/components/common/LabelBadge'
 import { LabeledValue } from '@/components/common/LabeledValue'
 import { Text } from '@/components/common/Text'
 import { ActionStep } from '@/components/actions/ActionStep'
@@ -22,7 +23,7 @@ import { sortByIdx } from '@/utils/action-utils'
 export const ActionDetail = () => {
   const { actionId, branchId } = useParams()
   const { org } = useOrg()
-  const { app } = useApp()
+  const { app, labelColors } = useApp()
   const appBase = branchId
     ? `/${org?.id}/apps/${app?.id}/branches/${branchId}`
     : `/${org?.id}/apps/${app?.id}`
@@ -66,9 +67,7 @@ export const ActionDetail = () => {
               {Object.keys(action.labels)
                 .sort()
                 .map((k) => (
-                  <Badge key={k} variant="code" size="sm" theme="neutral">
-                    {k}: {action.labels[k]}
-                  </Badge>
+                  <LabelBadge key={k} labelKey={k} labelValue={action.labels[k]} size="sm" customColor={labelColors?.[k]} />
                 ))}
             </span>
           ) : null}

--- a/services/dashboard-ui/client/views/app/ComponentDetail.tsx
+++ b/services/dashboard-ui/client/views/app/ComponentDetail.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { Badge } from '@/components/common/Badge'
+import { LabelBadge } from '@/components/common/LabelBadge'
 import { BackLink } from '@/components/common/BackLink'
 import { Button } from '@/components/common/Button'
 import { EmptyState } from '@/components/common/EmptyState/EmptyState'
@@ -32,7 +33,7 @@ import {
 export const ComponentDetail = () => {
   const { componentId, branchId } = useParams()
   const { org } = useOrg()
-  const { app } = useApp()
+  const { app, labelColors } = useApp()
   const { addPanel } = useSurfaces()
 
   const { data: component, isLoading: isLoadingComponent } = useQuery({
@@ -175,9 +176,7 @@ export const ComponentDetail = () => {
                 {Object.keys(component.labels)
                   .sort()
                   .map((k) => (
-                    <Badge key={k} variant="code" size="sm" theme="neutral">
-                      {k}: {component.labels[k]}
-                    </Badge>
+                    <LabelBadge key={k} labelKey={k} labelValue={component.labels[k]} size="sm" customColor={labelColors?.[k]} />
                   ))}
               </span>
             ) : null}

--- a/services/dashboard-ui/client/views/app/RunbookDetailLayout.tsx
+++ b/services/dashboard-ui/client/views/app/RunbookDetailLayout.tsx
@@ -2,6 +2,7 @@ import { Outlet, useParams } from 'react-router'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { BackLink } from '@/components/common/BackLink'
 import { Badge } from '@/components/common/Badge'
+import { LabelBadge } from '@/components/common/LabelBadge'
 import { HeadingGroup } from '@/components/common/HeadingGroup'
 import { ID } from '@/components/common/ID'
 import { Text } from '@/components/common/Text'
@@ -16,7 +17,7 @@ import { getRunbook } from '@/lib'
 export const RunbookDetailLayout = () => {
   const { runbookId, branchId } = useParams()
   const { org } = useOrg()
-  const { app } = useApp()
+  const { app, labelColors } = useApp()
 
   const { data: runbook, isLoading } = useQuery({
     placeholderData: keepPreviousData,
@@ -75,9 +76,7 @@ export const RunbookDetailLayout = () => {
                     {Object.keys(runbook.labels)
                       .sort()
                       .map((k) => (
-                        <Badge key={k} variant="code" size="sm" theme="neutral">
-                          {k}: {runbook.labels[k]}
-                        </Badge>
+                        <LabelBadge key={k} labelKey={k} labelValue={runbook.labels[k]} size="sm" customColor={labelColors?.[k]} />
                       ))}
                   </span>
                 ) : null}

--- a/services/dashboard-ui/client/views/install/WorkflowDetail.tsx
+++ b/services/dashboard-ui/client/views/install/WorkflowDetail.tsx
@@ -9,7 +9,7 @@ import { WorkflowProvider } from '@/providers/workflow-provider'
 import { useWorkflow } from '@/hooks/use-workflow'
 import { useInstall } from '@/hooks/use-install'
 import { useOrg } from '@/hooks/use-org'
-import { snakeToWords, toSentenceCase } from '@/utils/string-utils'
+import { humanize } from '@/utils/string-utils'
 
 export const WorkflowDetail = () => {
   const { workflowId } = useParams()
@@ -28,7 +28,7 @@ const WorkflowDetailContent = () => {
   const { workflow } = useWorkflow()
 
   const workflowName =
-    workflow?.name || toSentenceCase(snakeToWords(workflow?.type)) || 'Workflow'
+    workflow?.name || humanize(workflow?.type) || 'Workflow'
 
   return (
     <PageSection className="!gap-2">


### PR DESCRIPTION
This PR updates the copy styleguide, all the sub agents and skills to follow the rules around rendering text in the dashboard. Audit & update all the places that didn't follow the styleguide