### PR TITLE
fix(cli): reject invalid action roles

### DIFF
--- a/bins/cli/internal/services/actions/adhoc.go
+++ b/bins/cli/internal/services/actions/adhoc.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -39,6 +40,15 @@ func (s *Service) CreateAdHocRun(ctx context.Context, params AdHocParams, asJSON
 	installID, err := lookup.InstallID(ctx, s.api, params.InstallID)
 	if err != nil {
 		return view.Error(err)
+	}
+	if params.Role != "" {
+		roles, err := s.api.GetAvailableRoles(ctx, installID)
+		if err != nil {
+			return view.Error(fmt.Errorf("get available roles: %w", err))
+		}
+		if err := validateRole(params.Role, roles); err != nil {
+			return view.Error(err)
+		}
 	}
 
 	inlineContents, err := readAdHocInput(params.Command, params.ScriptPath)
@@ -111,6 +121,24 @@ func (s *Service) CreateAdHocRun(ctx context.Context, params AdHocParams, asJSON
 	})
 
 	return nil
+}
+
+func validateRole(requested string, roles []*models.ServiceAvailableRole) error {
+	available := make([]string, 0, len(roles))
+	for _, role := range roles {
+		if role.Name == requested {
+			return nil
+		}
+		if role.Name != "" {
+			available = append(available, role.Name)
+		}
+	}
+
+	sort.Strings(available)
+	if len(available) == 0 {
+		return fmt.Errorf("role %q is not available; this install has no available roles", requested)
+	}
+	return fmt.Errorf("role %q is not available; available roles: %s", requested, strings.Join(available, ", "))
 }
 
 func (s *Service) waitForAdHocRun(ctx context.Context, installID, runID string, writer io.Writer) (*models.AppInstallActionWorkflowRun, error) {

--- a/bins/cli/internal/services/actions/adhoc_test.go
+++ b/bins/cli/internal/services/actions/adhoc_test.go
@@ -21,6 +21,7 @@ type adHocAPI struct {
 	nuon.Client
 	installID     string
 	request       *models.ServiceCreateAdHocActionRequest
+	roles         []*models.ServiceAvailableRole
 	runs          []*models.AppInstallActionWorkflowRun
 	runIndex      int
 	logPages      []adHocLogPage
@@ -38,6 +39,10 @@ type adHocLogPage struct {
 func (a *adHocAPI) GetInstall(_ context.Context, installID string) (*models.AppInstall, error) {
 	a.installID = installID
 	return &models.AppInstall{ID: "inst_resolved"}, nil
+}
+
+func (a *adHocAPI) GetAvailableRoles(_ context.Context, _ string) ([]*models.ServiceAvailableRole, error) {
+	return a.roles, nil
 }
 
 func (a *adHocAPI) CreateAdHocAction(_ context.Context, installID string, req *models.ServiceCreateAdHocActionRequest) (*models.ServiceCreateAdHocActionResponse, error) {
@@ -83,7 +88,7 @@ func TestCreateAdHocRunUsesSelectedInstallAndBuildsRequest(t *testing.T) {
 	v := viper.New()
 	v.Set("install_id", "selected-install")
 	cfg := &config.Config{Viper: v}
-	api := &adHocAPI{}
+	api := &adHocAPI{roles: []*models.ServiceAvailableRole{{Name: "maintenance"}}}
 	service := New(validator.New(), api, cfg)
 
 	err := service.CreateAdHocRun(context.Background(), AdHocParams{
@@ -104,6 +109,24 @@ func TestCreateAdHocRunUsesSelectedInstallAndBuildsRequest(t *testing.T) {
 	require.Equal(t, "maintenance", api.request.Role)
 	require.NotNil(t, api.request.EnableKubeConfig)
 	require.False(t, *api.request.EnableKubeConfig)
+}
+
+func TestCreateAdHocRunRejectsUnknownRole(t *testing.T) {
+	api := &adHocAPI{roles: []*models.ServiceAvailableRole{
+		{Name: "install-provision"},
+		{Name: "install-maintenance"},
+	}}
+	service := New(validator.New(), api, &config.Config{Viper: viper.New()})
+
+	err := service.CreateAdHocRun(context.Background(), AdHocParams{
+		InstallID: "inst_123",
+		Command:   "echo hello",
+		Timeout:   time.Minute,
+		Role:      "provision",
+	}, false)
+
+	require.EqualError(t, err, `role "provision" is not available; available roles: install-maintenance, install-provision`)
+	require.Nil(t, api.request)
 }
 
 func TestParseAdHocEnvMergesFileAndFlags(t *testing.T) {

--- a/bins/cli/internal/services/actions/create_run.go
+++ b/bins/cli/internal/services/actions/create_run.go
@@ -9,6 +9,19 @@ import (
 )
 
 func (s *Service) CreateRun(ctx context.Context, installID, actionWorkflowID string, roleName string, asJSON bool) error {
+	if roleName != "" {
+		roles, err := s.api.GetAvailableRoles(ctx, installID)
+		if err != nil {
+			err = fmt.Errorf("get available roles: %w", err)
+			ui.PrintError(err)
+			return err
+		}
+		if err := validateRole(roleName, roles); err != nil {
+			ui.PrintError(err)
+			return err
+		}
+	}
+
 	awc, err := s.api.GetActionWorkflowLatestConfig(ctx, actionWorkflowID)
 	if err != nil {
 		ui.PrintError(fmt.Errorf("error getting action workflow config: %w", err))

--- a/bins/cli/internal/services/actions/create_run_test.go
+++ b/bins/cli/internal/services/actions/create_run_test.go
@@ -1,0 +1,46 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/bins/cli/internal/config"
+	"github.com/nuonco/nuon/sdks/nuon-go"
+	"github.com/nuonco/nuon/sdks/nuon-go/models"
+)
+
+type createRunAPI struct {
+	nuon.Client
+	roles   []*models.ServiceAvailableRole
+	request *models.ServiceCreateInstallActionWorkflowRunRequest
+}
+
+func (a *createRunAPI) GetAvailableRoles(_ context.Context, _ string) ([]*models.ServiceAvailableRole, error) {
+	return a.roles, nil
+}
+
+func (a *createRunAPI) GetActionWorkflowLatestConfig(_ context.Context, _ string) (*models.AppActionWorkflowConfig, error) {
+	return &models.AppActionWorkflowConfig{ID: "awc_123"}, nil
+}
+
+func (a *createRunAPI) CreateInstallActionWorkflowRun(_ context.Context, _ string, req *models.ServiceCreateInstallActionWorkflowRunRequest) error {
+	a.request = req
+	return nil
+}
+
+func TestCreateRunRejectsUnknownRole(t *testing.T) {
+	api := &createRunAPI{roles: []*models.ServiceAvailableRole{
+		{Name: "install-provision"},
+		{Name: "install-maintenance"},
+	}}
+	service := New(validator.New(), api, &config.Config{Viper: viper.New()})
+
+	err := service.CreateRun(context.Background(), "inst_123", "action_123", "provision", false)
+
+	require.EqualError(t, err, `role "provision" is not available; available roles: install-maintenance, install-provision`)
+	require.Nil(t, api.request)
+}

--- a/sdks/nuon-go/client.go
+++ b/sdks/nuon-go/client.go
@@ -197,6 +197,7 @@ type Client interface {
 	GetAllInstalls(ctx context.Context, query *models.GetPaginatedQuery) ([]*models.AppInstall, bool, error)
 
 	GetInstall(ctx context.Context, installID string) (*models.AppInstall, error)
+	GetAvailableRoles(ctx context.Context, installID string) ([]*models.ServiceAvailableRole, error)
 	UpdateInstall(ctx context.Context, installID string, req *models.ServiceUpdateInstallRequest) (*models.AppInstall, error)
 	DeleteInstall(ctx context.Context, installID string) (*models.AppWorkflowResponse, error)
 	ForgetInstall(ctx context.Context, installID string) (bool, error)

--- a/sdks/nuon-go/installs.go
+++ b/sdks/nuon-go/installs.go
@@ -68,6 +68,18 @@ func (c *client) GetInstall(ctx context.Context, installID string) (*models.AppI
 	return resp.Payload, nil
 }
 
+func (c *client) GetAvailableRoles(ctx context.Context, installID string) ([]*models.ServiceAvailableRole, error) {
+	resp, err := c.genClient.Operations.GetAvailableRoles(&operations.GetAvailableRolesParams{
+		InstallID: installID,
+		Context:   ctx,
+	}, c.getOrgIDAuthInfo())
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Payload.Roles, nil
+}
+
 func (c *client) UpdateInstall(ctx context.Context, installID string, req *models.ServiceUpdateInstallRequest) (*models.AppInstall, error) {
 	resp, err := c.genClient.Operations.UpdateInstall(&operations.UpdateInstallParams{
 		Req:       req,

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run_test.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_action_workflow_run_test.go
@@ -27,6 +27,7 @@ func TestGetRoleForAction(t *testing.T) {
 		expectedOperation  app.OperationType
 		expectedRoleSource operationroles.RoleSelectionSource
 		expectedRoleName   string
+		expectedError      string
 		description        string
 	}{
 		// No operation rules
@@ -310,17 +311,15 @@ func TestGetRoleForAction(t *testing.T) {
 			description:        "Should fallback to default when matrix role is missing from stack outputs",
 		},
 		{
-			name:               "runtime_role_missing_fallback_to_default",
-			actionName:         "deploy-action",
-			actionConfigRole:   "",
-			breakGlassRoleARN:  "",
-			runtimeRole:        "MissingRuntimeRole", // Not in stack outputs
-			matrixRules:        nil,
-			useAzure:           false,
-			expectedOperation:  app.OperationTrigger,
-			expectedRoleSource: operationroles.RoleSelectionSourceDefault,
-			expectedRoleName:   "MaintenanceRole",
-			description:        "Should fallback to default when runtime role is missing from stack outputs",
+			name:              "runtime_role_missing_returns_error",
+			actionName:        "deploy-action",
+			actionConfigRole:  "",
+			breakGlassRoleARN: "",
+			runtimeRole:       "MissingRuntimeRole", // Not in stack outputs
+			matrixRules:       nil,
+			useAzure:          false,
+			expectedError:     `unable to use requested role "MissingRuntimeRole"`,
+			description:       "Should reject a runtime role missing from stack outputs",
 		},
 		{
 			name:               "break_glass_role_missing_fallback_to_default",
@@ -451,6 +450,12 @@ func TestGetRoleForAction(t *testing.T) {
 				nil,
 			)
 
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+				require.Nil(t, roleSelection)
+				require.Empty(t, operation)
+				return
+			}
 			require.NoError(t, err, "getRoleForAction should not return error for test: %s", tt.description)
 			assert.Equal(t, tt.expectedOperation, operation, "Operation type mismatch: %s", tt.description)
 			assert.Equal(t, tt.expectedRoleSource, roleSelection.Source, "Role source mismatch: %s", tt.description)

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan_test.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan_test.go
@@ -22,6 +22,7 @@ func TestGetRoleForDeploy(t *testing.T) {
 		expectedOperation  app.OperationType
 		expectedRoleSource operationroles.RoleSelectionSource
 		expectedRoleName   string
+		expectedError      string
 		description        string
 	}{
 		// No operation rules anywhere, runs as always, no change in operation
@@ -312,15 +313,13 @@ func TestGetRoleForDeploy(t *testing.T) {
 			description:        "Should fallback to default when matrix role is missing from stack outputs",
 		},
 		{
-			name:               "runtime_role_missing_fallback_to_default",
-			installDeployType:  app.InstallDeployTypeApply,
-			installDeployRole:  "MissingRuntimeRole", // This role won't be in stack outputs
-			componentRoles:     map[app.OperationType]string{},
-			matrixRules:        nil,
-			expectedOperation:  app.OperationDeploy,
-			expectedRoleSource: operationroles.RoleSelectionSourceDefault,
-			expectedRoleName:   "MaintenanceRole",
-			description:        "Should fallback to default when runtime role is missing from stack outputs",
+			name:              "runtime_role_missing_returns_error",
+			installDeployType: app.InstallDeployTypeApply,
+			installDeployRole: "MissingRuntimeRole", // This role won't be in stack outputs
+			componentRoles:    map[app.OperationType]string{},
+			matrixRules:       nil,
+			expectedError:     `unable to use requested role "MissingRuntimeRole"`,
+			description:       "Should reject a runtime role missing from stack outputs",
 		},
 		{
 			name:              "matrix_role_missing_teardown_fallback",
@@ -434,6 +433,12 @@ func TestGetRoleForDeploy(t *testing.T) {
 				nil,
 			)
 
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+				require.Nil(t, roleSelection)
+				require.Empty(t, operation)
+				return
+			}
 			require.NoError(t, err, "getRoleForDeploy should not return error for test: %s", tt.description)
 			assert.Equal(t, tt.expectedOperation, operation, "Operation type mismatch: %s", tt.description)
 			assert.Equal(t, tt.expectedRoleSource, roleSelection.Source, "Role source mismatch: %s", tt.description)

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_sandbox_run_test.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_sandbox_run_test.go
@@ -86,6 +86,7 @@ func TestGetRoleForSandbox(t *testing.T) {
 		expectedOperation  app.OperationType
 		expectedRoleSource operationroles.RoleSelectionSource
 		expectedRoleName   string
+		expectedError      string
 		description        string
 	}{
 		{
@@ -479,26 +480,22 @@ func TestGetRoleForSandbox(t *testing.T) {
 			description:        "Should fallback to default when matrix role is missing from stack outputs",
 		},
 		{
-			name:               "runtime_role_missing_fallback_provision",
+			name:               "runtime_role_missing_provision_returns_error",
 			sandboxRunType:     app.SandboxRunTypeProvision,
 			sandboxRuntimeRole: "MissingRuntimeRole", // Not in stack outputs
 			sandboxEntityRoles: pgtype.Hstore{},
 			matrixRules:        nil,
-			expectedOperation:  app.OperationProvision,
-			expectedRoleSource: operationroles.RoleSelectionSourceDefault,
-			expectedRoleName:   "ProvisionRole",
-			description:        "Should fallback to default when runtime role is missing from stack outputs",
+			expectedError:      `unable to use requested role "MissingRuntimeRole"`,
+			description:        "Should reject a runtime role missing from stack outputs",
 		},
 		{
-			name:               "runtime_role_missing_fallback_deprovision",
+			name:               "runtime_role_missing_deprovision_returns_error",
 			sandboxRunType:     app.SandboxRunTypeDeprovision,
 			sandboxRuntimeRole: "MissingRuntimeRole", // Not in stack outputs
 			sandboxEntityRoles: pgtype.Hstore{},
 			matrixRules:        nil,
-			expectedOperation:  app.OperationDeprovision,
-			expectedRoleSource: operationroles.RoleSelectionSourceDefault,
-			expectedRoleName:   "DeprovisionRole",
-			description:        "Should fallback to default deprovision when runtime role is missing",
+			expectedError:      `unable to use requested role "MissingRuntimeRole"`,
+			description:        "Should reject a runtime role missing from stack outputs",
 		},
 	}
 
@@ -583,6 +580,12 @@ func TestGetRoleForSandbox(t *testing.T) {
 				installState,
 			)
 
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+				require.Nil(t, roleSelection)
+				require.Empty(t, operation)
+				return
+			}
 			require.NoError(t, err, "getRoleForSandbox should not return error for test: %s", tt.description)
 			assert.Equal(t, tt.expectedOperation, operation, "Operation type mismatch: %s", tt.description)
 			assert.Equal(t, tt.expectedRoleSource, roleSelection.Source, "Role source mismatch: %s", tt.description)

--- a/services/ctl-api/internal/pkg/operation-roles/builders.go
+++ b/services/ctl-api/internal/pkg/operation-roles/builders.go
@@ -44,6 +44,10 @@ func GetRoleForDeploy(
 
 	roleSelection, err := SelectRole(selectionCtx, l)
 	if err != nil {
+		if selectionCtx.RuntimeRole != "" {
+			return nil, "", fmt.Errorf("unable to use requested role %q: %w", selectionCtx.RuntimeRole, err)
+		}
+
 		var selErr *SelectionError
 		var failedTrace []app.InstallRoleSelectionRecord
 		if errors.As(err, &selErr) {
@@ -112,6 +116,10 @@ func GetRoleForSandbox(
 
 	roleSelection, err := SelectRole(selectionCtx, l)
 	if err != nil {
+		if selectionCtx.RuntimeRole != "" {
+			return nil, "", fmt.Errorf("unable to use requested role %q: %w", selectionCtx.RuntimeRole, err)
+		}
+
 		var selErr *SelectionError
 		var failedTrace []app.InstallRoleSelectionRecord
 		if errors.As(err, &selErr) {
@@ -179,6 +187,10 @@ func GetRoleForAction(
 
 	roleSelection, err := SelectRole(selectionCtx, l)
 	if err != nil {
+		if selectionCtx.RuntimeRole != "" {
+			return nil, "", fmt.Errorf("unable to use requested role %q: %w", selectionCtx.RuntimeRole, err)
+		}
+
 		var selErr *SelectionError
 		var failedTrace []app.InstallRoleSelectionRecord
 		if errors.As(err, &selErr) {

--- a/services/ctl-api/internal/pkg/operation-roles/builders_test.go
+++ b/services/ctl-api/internal/pkg/operation-roles/builders_test.go
@@ -1,0 +1,45 @@
+package operationroles
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/nuonco/nuon/pkg/types/state"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+func TestGetRoleForActionRejectsUnknownRuntimeRole(t *testing.T) {
+	appCfg := &app.AppConfig{
+		PermissionsConfig: app.AppPermissionsConfig{
+			MaintenanceRole: app.AppAWSIAMRoleConfig{Name: "install-maintenance"},
+		},
+	}
+	run := &app.InstallActionWorkflowRun{
+		Role: "provision",
+		ActionWorkflowConfig: app.ActionWorkflowConfig{
+			ActionWorkflow: app.ActionWorkflow{Name: "diagnostics"},
+		},
+	}
+	stack := &app.InstallStack{
+		InstallStackOutputs: app.InstallStackOutputs{
+			AWSStackOutputs: &app.AWSStackOutputs{
+				MaintenanceIAMRoleARN: "arn:aws:iam::123456789012:role/install-maintenance",
+			},
+		},
+	}
+
+	selection, operation, err := GetRoleForAction(
+		zap.NewNop(),
+		appCfg,
+		run,
+		stack,
+		&state.State{ID: "inst_123", Name: "example"},
+		nil,
+	)
+
+	require.ErrorContains(t, err, `unable to use requested role "provision"`)
+	require.Nil(t, selection)
+	require.Empty(t, operation)
+}


### PR DESCRIPTION
## Summary

Action runs now validate selected IAM roles before queueing. Invalid explicit roles fail instead of silently using the default maintenance role.

## What you can do after this PR

**Catch incorrect role names immediately.** Regular and ad-hoc action commands reject unavailable roles and show valid alternatives.

**Rely on explicit role selection.** Actions, deploys, and sandboxes stop when an explicitly requested role cannot be used.

## What stays the same

Runs without an explicit role continue using the existing role-selection hierarchy and defaults.
