### PR TITLE
feat: support customer inputs on azure click-to-deploy

### DIFF
--- a/docs/platform-support/azure.mdx
+++ b/docs/platform-support/azure.mdx
@@ -87,6 +87,29 @@ Once the resource group has been created, they can provision the stack.
 az stack group create --name {{install_id}}-stack --resource-group {{install_id}}-rg --template-uri https://nuon-install-templates-stage.s3.us-east-1.amazonaws.com/templates/inlgofml5mnk1e69dw9w1w0xzt/ist5hnwpr1q36mpegdj6o1terw.json --deny-settings-mode "denyDelete" --aou deleteAll
 ```
 
+### Customer Inputs
+
+Every app input declared with `source = "customer"` is a parameter on the install stack template, named
+`input<CamelCaseName>` — `db_name` becomes `inputDbName`. The Deploy to Azure quick link renders one form field per
+input, and on the CLI they are `--parameters` arguments:
+
+```sh
+az stack group create ... --parameters inputDbName="orders" inputApiKey="<value>"
+```
+
+The values the stack deploys with are reported back and become the install's inputs, so they show up on the install's
+Inputs page and are available to components as `{{ .nuon.inputs.inputs.<name> }}`.
+
+Each parameter defaults to the value the install already has, falling back to the input's declared default. An input
+that has neither and is marked required has no default at all, so Azure refuses the deploy until a value is supplied
+rather than writing a blank one. Omitting a parameter keeps the install's current value.
+
+<Note>
+  Customer inputs are ordinary template parameters, so their values are visible in the deployment history of the
+  customer's own subscription. Anything that needs to stay secret belongs in the app's `secrets` config, which is
+  written to Key Vault instead.
+</Note>
+
 ## Updating
 
 If you make changes to the install stack template, and need to update an install, your customer must re-provision the

--- a/services/ctl-api/internal/pkg/stacks/arm/app_inputs.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/app_inputs.go
@@ -1,0 +1,197 @@
+package arm
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
+)
+
+// installInputsEnvName carries the whole install_inputs object into the phone-home
+// script as a single JSON blob rather than one env var per input — see
+// installInputsObjectExpr for why that distinction is load-bearing.
+const installInputsEnvName = "INSTALL_INPUTS_JSON"
+
+// camelParamName builds an ARM parameter name from a config-supplied name. The portal
+// derives its form label from the parameter name, so this camelCases rather than
+// carrying the config's underscores through: db_password reads as "Db Password".
+func camelParamName(prefix, name string) string {
+	out := prefix
+	for _, part := range strings.FieldsFunc(name, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		r := []rune(part)
+		out += strings.ToUpper(string(r[0])) + string(r[1:])
+	}
+	return out
+}
+
+// azureInputParamName turns a customer-source app input name into an ARM parameter
+// name.
+//
+// The prefix is not cosmetic: an input name is vendor-chosen, so without it an input
+// called `location` would collide with a Nuon-managed parameter and an unlucky one
+// could shadow a parameter hoisted off a custom VNet template.
+func azureInputParamName(name string) string {
+	return camelParamName("input", name)
+}
+
+type azureInput struct {
+	name        string
+	paramName   string
+	label       string
+	description string
+
+	// value is what the portal pre-fills and the CLI defaults to.
+	//
+	// Seeded from the install's current inputs rather than the app's declared
+	// default because the phone-home reports every parameter back as the install's
+	// inputs: defaulting to the vendor's default would revert a value the customer
+	// set through the dashboard on the next reprovision.
+	value string
+
+	required bool
+}
+
+// azureCustomerInputs are the app inputs the customer supplies at deploy time.
+// Sorted so the render is deterministic.
+//
+// Reads InputConfig.AppInputs alone, which carries every declared input, grouped ones
+// included — AppInputGroups.AppInputs is not loaded on the config the renderer
+// receives, and the CloudFormation renderer partitions the same flat list by group.
+func azureCustomerInputs(inp *stacks.TemplateInput) []azureInput {
+	if inp == nil || inp.AppCfg == nil {
+		return nil
+	}
+
+	current := map[string]*string{}
+	if inp.Install != nil && inp.Install.CurrentInstallInputs != nil {
+		current = inp.Install.CurrentInstallInputs.Values
+	}
+
+	var out []azureInput
+	for _, in := range inp.AppCfg.InputConfig.AppInputs {
+		if in.Source != app.AppInputSourceCustomer {
+			continue
+		}
+
+		// Blank counts as unset, matching how the install's input state resolves a
+		// materialized-but-empty value back to the declared default.
+		value := in.Default
+		if v := generics.FromPtrStr(current[in.Name]); v != "" {
+			value = v
+		}
+
+		label := in.DisplayName
+		if label == "" {
+			label = humanizeParamName(camelParamName("", in.Name))
+		}
+
+		out = append(out, azureInput{
+			name:        in.Name,
+			paramName:   azureInputParamName(in.Name),
+			label:       label,
+			description: in.Description,
+			value:       value,
+			required:    in.Required,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].name < out[j].name })
+
+	return out
+}
+
+// azureInputParameter surfaces one customer input as a root parameter, which the
+// portal renders as a field on the deployment form and `az stack ... --parameters`
+// sets from the command line.
+//
+// Always a plain string, whatever the input's declared type. Install inputs are
+// stored and validated as strings by the control plane, and ARM's own scalar types
+// would both rewrite and reject legitimate values on the way through: string(true)
+// is "True", not "true", and an int parameter refuses the fractional value an app
+// input of type number is allowed to hold.
+//
+// Sensitive inputs are not securestring. A securestring's value still has to reach
+// the phone-home script's environment to be reported back, where it is readable by
+// anyone with read access on the resource group — a masked field over a value that
+// is not actually protected is worse than an honest one. Secrets belong in the app's
+// secrets config, which renders as securestring into Key Vault.
+func azureInputParameter(in azureInput) ARMParameter {
+	p := ARMParameter{Type: "string"}
+
+	// A required input with nothing to prefill gets no default at all: that is what
+	// makes ARM refuse the deploy rather than write a blank value.
+	if !in.required || in.value != "" {
+		p.DefaultValue = in.value
+	}
+	if in.description != "" {
+		p.Metadata = &ARMParameterMetadata{Description: in.description}
+	}
+
+	return p
+}
+
+// addCustomerInputParameters declares the customer inputs on the root template.
+//
+// Called after every other parameter source has written, so a name that collides
+// with one of theirs is an error rather than a silent overwrite — the overwrite would
+// render a template that deploys and then reports the wrong value home.
+func addCustomerInputParameters(tmpl *ARMTemplate, inp *stacks.TemplateInput) error {
+	claimed := map[string]string{}
+	for _, in := range azureCustomerInputs(inp) {
+		if other, dup := claimed[in.paramName]; dup {
+			return fmt.Errorf("customer inputs %q and %q both map to ARM parameter %q", other, in.name, in.paramName)
+		}
+		if _, taken := tmpl.Parameters[in.paramName]; taken {
+			return fmt.Errorf("customer input %q maps to ARM parameter %q, which is already declared", in.name, in.paramName)
+		}
+		if slices.Contains(ReservedParamNames, in.paramName) {
+			return fmt.Errorf("customer input %q maps to reserved ARM parameter %q", in.name, in.paramName)
+		}
+
+		claimed[in.paramName] = in.name
+		tmpl.Parameters[in.paramName] = azureInputParameter(in)
+	}
+
+	return nil
+}
+
+// azureInputLabels is the portal field label for each customer-input parameter, keyed
+// by parameter name, so the customer reads the vendor's display name rather than the
+// name the renderer derived from the input.
+func azureInputLabels(inp *stacks.TemplateInput) map[string]string {
+	labels := map[string]string{}
+	for _, in := range azureCustomerInputs(inp) {
+		labels[in.paramName] = in.label
+	}
+	return labels
+}
+
+// installInputsObjectExpr is the install_inputs object as an ARM expression that
+// evaluates to its JSON text.
+//
+// The escaping is the point. Every other field in the phone-home payload is
+// interpolated into the heredoc as `"key": "$VAR"`, which holds only because those
+// values are Azure resource IDs. An input value is whatever the customer typed, so a
+// quote, backslash or newline in one would produce a malformed body and fail the
+// deploy on a valid input. ARM's string() escapes the values for us, and the result
+// is spliced into the payload unquoted because it is already a JSON object.
+func installInputsObjectExpr(inputs []azureInput) string {
+	args := make([]string, 0, len(inputs)*2)
+	for _, in := range inputs {
+		args = append(args, armStringLiteral(in.name), fmt.Sprintf("parameters('%s')", in.paramName))
+	}
+	return fmt.Sprintf("[string(createObject(%s))]", strings.Join(args, ", "))
+}
+
+// armStringLiteral quotes a value as an ARM string literal, where a single quote is
+// escaped by doubling it. Needed here and not elsewhere in the package because these
+// keys are vendor-chosen input names rather than renderer-owned identifiers.
+func armStringLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}

--- a/services/ctl-api/internal/pkg/stacks/arm/app_inputs_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/app_inputs_test.go
@@ -1,0 +1,353 @@
+package arm
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/nuonco/nuon/pkg/generics"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
+)
+
+func customerInputsTemplateInput(inputs ...app.AppInput) *stacks.TemplateInput {
+	inp := minimalTemplateInput()
+	inp.AppCfg.InputConfig.AppInputs = inputs
+	return inp
+}
+
+func customerInput(name string) app.AppInput {
+	return app.AppInput{Name: name, Source: app.AppInputSourceCustomer}
+}
+
+func TestCustomerInputs_RootParameters(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+
+	dbName := customerInput("db_name")
+	dbName.Default = "postgres"
+	dbName.Description = "The database to connect to."
+
+	replicas := customerInput("replica-count")
+	replicas.Type = app.AppInputTypeNumber
+	replicas.Default = "3"
+
+	apiKey := customerInput("api_key")
+	apiKey.Required = true
+
+	optional := customerInput("log_level")
+
+	vendorOwned := app.AppInput{Name: "internal_thing", Source: app.AppInputSourceVendor, Default: "x"}
+
+	armTmpl, err := tmpl.getAzureTemplate(customerInputsTemplateInput(
+		dbName, replicas, apiKey, optional, vendorOwned,
+	))
+	if err != nil {
+		t.Fatalf("getAzureTemplate returned error: %v", err)
+	}
+
+	if _, present := armTmpl.Parameters["inputInternalThing"]; present {
+		t.Error("vendor-source input must not be exposed as a template parameter")
+	}
+
+	for _, tc := range []struct {
+		param    string
+		wantType string
+		// wantDefault nil asserts the parameter carries no defaultValue at all,
+		// which is what makes ARM refuse the deploy without a value.
+		wantDefault any
+		wantDesc    string
+	}{
+		{param: "inputDbName", wantType: "string", wantDefault: "postgres", wantDesc: "The database to connect to."},
+		// A number input is still a string parameter: ARM's int would reject the
+		// fractional values an app input of type number may hold.
+		{param: "inputReplicaCount", wantType: "string", wantDefault: "3"},
+		{param: "inputApiKey", wantType: "string", wantDefault: nil},
+		// Optional with no declared default: an empty default keeps the deploy
+		// possible without a value.
+		{param: "inputLogLevel", wantType: "string", wantDefault: ""},
+	} {
+		p, present := armTmpl.Parameters[tc.param]
+		if !present {
+			t.Errorf("template missing parameter %s", tc.param)
+			continue
+		}
+		if p.Type != tc.wantType {
+			t.Errorf("%s type = %q, want %q", tc.param, p.Type, tc.wantType)
+		}
+		if p.DefaultValue != tc.wantDefault {
+			t.Errorf("%s defaultValue = %#v, want %#v", tc.param, p.DefaultValue, tc.wantDefault)
+		}
+		desc := ""
+		if p.Metadata != nil {
+			desc = p.Metadata.Description
+		}
+		if desc != tc.wantDesc {
+			t.Errorf("%s description = %q, want %q", tc.param, desc, tc.wantDesc)
+		}
+	}
+
+	tmplBytes, err := json.MarshalIndent(armTmpl, "", "  ")
+	if err != nil {
+		t.Fatalf("unable to marshal ARM template: %v", err)
+	}
+	assertNoNestedBrackets(t, tmplBytes)
+
+	// omitempty on an interface field only drops a nil, so an empty default has to
+	// survive the marshal — dropping it would make an optional input mandatory.
+	if !strings.Contains(string(tmplBytes), `"inputLogLevel": {`) ||
+		!strings.Contains(string(tmplBytes), `"defaultValue": ""`) {
+		t.Errorf("optional input lost its empty defaultValue:\n%s", tmplBytes)
+	}
+}
+
+// The phone home reports every parameter back as the install's inputs, so a
+// parameter defaulting to the vendor's default would revert a value the customer
+// set through the dashboard on the next reprovision.
+func TestCustomerInputs_CurrentInstallValueWins(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+
+	declared := customerInput("db_name")
+	declared.Default = "postgres"
+	blanked := customerInput("log_level")
+	blanked.Default = "info"
+
+	inp := customerInputsTemplateInput(declared, blanked)
+	inp.Install.CurrentInstallInputs = &app.InstallInputs{
+		Values: pgtype.Hstore{
+			"db_name": generics.ToPtr("orders"),
+			// Materialized but blank counts as unset, matching how the install's
+			// input state resolves one back to the declared default.
+			"log_level": generics.ToPtr(""),
+		},
+	}
+
+	armTmpl, err := tmpl.getAzureTemplate(inp)
+	if err != nil {
+		t.Fatalf("getAzureTemplate returned error: %v", err)
+	}
+
+	if got := armTmpl.Parameters["inputDbName"].DefaultValue; got != "orders" {
+		t.Errorf("inputDbName defaultValue = %#v, want %q", got, "orders")
+	}
+	if got := armTmpl.Parameters["inputLogLevel"].DefaultValue; got != "info" {
+		t.Errorf("inputLogLevel defaultValue = %#v, want %q", got, "info")
+	}
+}
+
+func TestCustomerInputs_PhoneHomePayload(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+
+	res := phoneHomeScript(t, tmpl, customerInputsTemplateInput(
+		customerInput("db_name"), customerInput("api_key"),
+	), nil)
+
+	props := res["properties"].(map[string]any)
+	script := props["scriptContent"].(string)
+	// Unquoted: the env var already holds a JSON object, so quoting it would send a
+	// string where the endpoint decodes a map.
+	if !strings.Contains(script, `"install_inputs": $INSTALL_INPUTS_JSON`) {
+		t.Errorf("payload missing install_inputs:\n%s", script)
+	}
+
+	var got string
+	for _, env := range props["environmentVariables"].([]map[string]any) {
+		if env["name"] == installInputsEnvName {
+			got = env["value"].(string)
+		}
+	}
+	// Sorted by input name, so the render is stable across reprovisions.
+	want := "[string(createObject('api_key', parameters('inputApiKey'), 'db_name', parameters('inputDbName')))]"
+	if got != want {
+		t.Errorf("install_inputs env value = %q, want %q", got, want)
+	}
+
+	resBytes, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	assertNoNestedBrackets(t, resBytes)
+}
+
+// An app that declares no customer inputs must not gain the field: the goldens
+// assert the rest of the payload, and an empty env var would splice invalid JSON.
+func TestCustomerInputs_PhoneHomePayloadOmittedWhenNone(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+	res := phoneHomeScript(t, tmpl, minimalTemplateInput(), nil)
+
+	script := res["properties"].(map[string]any)["scriptContent"].(string)
+	if strings.Contains(script, "install_inputs") {
+		t.Errorf("payload should not mention install_inputs:\n%s", script)
+	}
+}
+
+// ARM escapes a single quote by doubling it. Unescaped, an input name carrying one
+// would truncate the createObject argument list into a template that fails preflight.
+func TestCustomerInputs_PhoneHomeQuotesInputNames(t *testing.T) {
+	got := installInputsObjectExpr([]azureInput{{name: "it's_fine", paramName: "inputItSFine"}})
+	want := "[string(createObject('it''s_fine', parameters('inputItSFine')))]"
+	if got != want {
+		t.Errorf("expression = %q, want %q", got, want)
+	}
+}
+
+func TestCustomerInputs_ParameterCollisions(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+
+	t.Run("two inputs mapping to one parameter", func(t *testing.T) {
+		_, err := tmpl.getAzureTemplate(customerInputsTemplateInput(
+			customerInput("db_name"), customerInput("db-name"),
+		))
+		if err == nil {
+			t.Fatal("expected an error for inputs colliding on one ARM parameter")
+		}
+		if !strings.Contains(err.Error(), "inputDbName") {
+			t.Errorf("error does not name the parameter: %v", err)
+		}
+	})
+
+	// The realistic shadowing case is a parameter hoisted off a custom VNet or nested
+	// stack template that happens to be named like a derived input one. A silent
+	// overwrite there would deploy and then report the wrong value home, so the
+	// adder is exercised against an already-populated parameter map directly.
+	t.Run("input shadowing a parameter another source owns", func(t *testing.T) {
+		existing := &ARMTemplate{
+			Parameters: map[string]ARMParameter{
+				"inputDbName": {Type: "string", DefaultValue: "hoisted"},
+			},
+		}
+
+		err := addCustomerInputParameters(existing, customerInputsTemplateInput(customerInput("db_name")))
+		if err == nil {
+			t.Fatal("expected an error for an input colliding with an existing parameter")
+		}
+		if got := existing.Parameters["inputDbName"].DefaultValue; got != "hoisted" {
+			t.Errorf("existing parameter was overwritten: %#v", got)
+		}
+	})
+}
+
+// The prefix is what keeps a vendor-chosen input name off the Nuon-managed
+// parameters, so it has to hold for the names most likely to collide.
+func TestCustomerInputs_ReservedNamesAreUnreachable(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+
+	var inputs []app.AppInput
+	for _, name := range ReservedParamNames {
+		inputs = append(inputs, customerInput(name))
+	}
+
+	armTmpl, err := tmpl.getAzureTemplate(customerInputsTemplateInput(inputs...))
+	if err != nil {
+		t.Fatalf("getAzureTemplate returned error: %v", err)
+	}
+
+	if got := armTmpl.Parameters["location"].DefaultValue; got != "eastus" {
+		t.Errorf("location parameter was clobbered: %#v", got)
+	}
+	if _, present := armTmpl.Parameters["inputLocation"]; !present {
+		t.Error("an input named location should render as inputLocation")
+	}
+}
+
+func TestCustomerInputs_QuickLinkBasics(t *testing.T) {
+	labelled := customerInput("db_name")
+	labelled.DisplayName = "Database"
+	labelled.Default = "postgres"
+	labelled.Description = "The database to connect to."
+
+	unlabelled := customerInput("replica_count")
+	unlabelled.Default = "3"
+
+	required := customerInput("api_key")
+	required.Required = true
+
+	optional := customerInput("log_level")
+
+	inp := customerInputsTemplateInput(labelled, unlabelled, required, optional)
+	inp.DeploymentScope = app.StackDeploymentScopeSubscription
+
+	_, params := renderUIDef(t, inp)
+
+	byName := map[string]map[string]any{}
+	for _, element := range params["basics"].([]any) {
+		el := element.(map[string]any)
+		byName[el["name"].(string)] = el
+	}
+
+	for _, tc := range []struct {
+		param        string
+		wantLabel    string
+		wantRequired bool
+		wantDefault  any
+		wantToolTip  string
+	}{
+		// The vendor's display name, so the portal reads the same as the dashboard.
+		{param: "inputDbName", wantLabel: "Database", wantRequired: true, wantDefault: "postgres", wantToolTip: "The database to connect to."},
+		{param: "inputReplicaCount", wantLabel: "Replica Count", wantRequired: true, wantDefault: "3"},
+		{param: "inputApiKey", wantLabel: "Api Key", wantRequired: true, wantDefault: nil},
+		// Blank is a legitimate answer here, so requiring it would leave the form
+		// unsubmittable.
+		{param: "inputLogLevel", wantLabel: "Log Level", wantRequired: false, wantDefault: ""},
+	} {
+		el, present := byName[tc.param]
+		if !present {
+			t.Errorf("basics step missing %s", tc.param)
+			continue
+		}
+		if el["label"] != tc.wantLabel {
+			t.Errorf("%s label = %v, want %q", tc.param, el["label"], tc.wantLabel)
+		}
+		if el["defaultValue"] != tc.wantDefault {
+			t.Errorf("%s defaultValue = %#v, want %#v", tc.param, el["defaultValue"], tc.wantDefault)
+		}
+		if el["toolTip"] != tc.wantToolTip {
+			t.Errorf("%s toolTip = %v, want %q", tc.param, el["toolTip"], tc.wantToolTip)
+		}
+		required, _ := el["constraints"].(map[string]any)["required"].(bool)
+		if required != tc.wantRequired {
+			t.Errorf("%s required = %v, want %v", tc.param, required, tc.wantRequired)
+		}
+
+		outputs := params["outputs"].(map[string]any)
+		if got := outputs[tc.param]; got != "[basics('"+tc.param+"')]" {
+			t.Errorf("%s output = %v", tc.param, got)
+		}
+	}
+}
+
+// The portal builds its form from the wrapper, so a parameter the wrapper does not
+// re-declare and pass through is a field the customer fills in and the stack never
+// sees.
+func TestCustomerInputs_QuickLinkWrapperPassthrough(t *testing.T) {
+	tmpl := &Templates{cfg: &internal.Config{}}
+
+	inp := customerInputsTemplateInput(customerInput("db_name"))
+	inp.DeploymentScope = app.StackDeploymentScopeSubscription
+
+	byts, _, err := tmpl.QuickLinkWrapper(inp, "https://example.com/template.json")
+	if err != nil {
+		t.Fatalf("QuickLinkWrapper returned error: %v", err)
+	}
+
+	var wrapper struct {
+		Parameters map[string]ARMParameter `json:"parameters"`
+		Resources  []struct {
+			Properties struct {
+				Parameters map[string]map[string]any `json:"parameters"`
+			} `json:"properties"`
+		} `json:"resources"`
+	}
+	if err := json.Unmarshal(byts, &wrapper); err != nil {
+		t.Fatalf("unmarshal wrapper: %v", err)
+	}
+
+	if _, present := wrapper.Parameters["inputDbName"]; !present {
+		t.Error("wrapper does not re-declare inputDbName")
+	}
+	if got := wrapper.Resources[0].Properties.Parameters["inputDbName"]["value"]; got != "[parameters('inputDbName')]" {
+		t.Errorf("wrapper does not pass inputDbName through: %v", got)
+	}
+}

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_key_vault.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_key_vault.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"unicode"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
@@ -24,19 +23,10 @@ func azureKeyVaultSecretName(name string) string {
 	return strings.ReplaceAll(name, "_", "-")
 }
 
-// azureSecretParamName turns an app-config secret name into an ARM parameter name.
-// The portal derives its form label from the parameter name, so this is camelCased
-// rather than carrying the config's underscores through: db_password reads as
-// "Secret Db Password".
+// azureSecretParamName turns an app-config secret name into an ARM parameter name:
+// db_password reads as "Secret Db Password" on the portal's deployment form.
 func azureSecretParamName(name string) string {
-	out := "secret"
-	for _, part := range strings.FieldsFunc(name, func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
-	}) {
-		r := []rune(part)
-		out += strings.ToUpper(string(r[0])) + string(r[1:])
-	}
-	return out
+	return camelParamName("secret", name)
 }
 
 type azureSecret struct {

--- a/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/resource_phone_home.go
@@ -90,6 +90,12 @@ func (t *Templates) getPhoneHomeResources(inp *stacks.TemplateInput, customOutpu
 	}
 	payloadFields = append(payloadFields, secretPayloadFields...)
 
+	customerInputs := azureCustomerInputs(inp)
+	if len(customerInputs) > 0 {
+		// Unquoted, unlike every other field: the env var already holds a JSON object.
+		payloadFields = append(payloadFields, fmt.Sprintf(`  "install_inputs": $%s`, installInputsEnvName))
+	}
+
 	// Outputs a custom VNet template declares beyond the fixed contract. Namespaced
 	// under vnet_ because the raw names collide: a VNet stack that makes its own
 	// resource group emits resourceGroupName, which is already Nuon's install group.
@@ -206,6 +212,12 @@ fi
 		})
 	}
 	envVars = append(envVars, secretEnvVars...)
+	if len(customerInputs) > 0 {
+		envVars = append(envVars, map[string]any{
+			"name":  installInputsEnvName,
+			"value": installInputsObjectExpr(customerInputs),
+		})
+	}
 	envVars = append(envVars, vnetExtraEnvVars...)
 	envVars = append(envVars, customEnvVars...)
 	envVars = append(envVars, identityEnvVars...)

--- a/services/ctl-api/internal/pkg/stacks/arm/template.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/template.go
@@ -164,6 +164,13 @@ func (t *Templates) getAzureTemplate(inp *stacks.TemplateInput) (*ARMTemplate, e
 		}
 	}
 
+	// Customer-supplied app inputs. Declared after every other parameter source has
+	// written so a name that collides with one of theirs is an error rather than a
+	// silent overwrite.
+	if err := addCustomerInputParameters(tmpl, inp); err != nil {
+		return nil, err
+	}
+
 	// Phone home deployment script, and the identity it authenticates as
 	tmpl.Resources = append(tmpl.Resources, t.getPhoneHomeResources(inp, customOutputs, vnetExtraOutputs, scope)...)
 

--- a/services/ctl-api/internal/pkg/stacks/arm/uidefinition.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/uidefinition.go
@@ -108,12 +108,13 @@ func (t *Templates) QuickLinkUIDefinition(inp *stacks.TemplateInput) ([]byte, st
 		outputs["location"] = "[location()]"
 	}
 
+	inputLabels := azureInputLabels(inp)
 	for _, name := range sortedParamNames(wrapperParams) {
 		if name == "location" || name == "deployTimestamp" {
 			continue
 		}
 
-		element, output, ok := basicsElement(name, wrapperParams[name])
+		element, output, ok := basicsElement(name, wrapperParams[name], inputLabels[name])
 		if !ok {
 			continue
 		}
@@ -173,17 +174,26 @@ func sortedParamNames(params map[string]ARMParameter) []string {
 // VNet address space or subnet CIDR, and left apps whose parameters all had
 // defaults with a Basics step showing nothing but subscription and region.
 //
-// Defaulted fields are still marked required, so a customer who clears one cannot
-// submit an empty string in place of the default.
+// A field carrying a non-empty default is still marked required, so a customer who
+// clears one cannot submit an empty string in place of the default. A default that
+// is itself empty is the one case where blank is a legitimate answer — an optional
+// app input the vendor declared no default for — so requiring it there would leave
+// the form unsubmittable.
+//
+// label overrides the name-derived one, for parameters whose config carries a
+// display name of its own. Empty falls back to the derived label.
 //
 // Object and array parameters have no sensible Basics element and are skipped, so
 // the wrapper's own default applies. Nothing currently reaches the root with those
 // types: a nested template's non-scalar default is either Nuon-managed or left
 // unhoisted.
-func basicsElement(name string, p ARMParameter) (map[string]any, string, bool) {
+func basicsElement(name string, p ARMParameter, label string) (map[string]any, string, bool) {
+	if label == "" {
+		label = humanizeParamName(name)
+	}
 	element := map[string]any{
 		"name":    name,
-		"label":   humanizeParamName(name),
+		"label":   label,
 		"toolTip": "",
 	}
 	if p.Metadata != nil && p.Metadata.Description != "" {
@@ -215,8 +225,9 @@ func basicsElement(name string, p ARMParameter) (map[string]any, string, bool) {
 		return element, fmt.Sprintf("[int(basics('%s'))]", name), true
 	case "string":
 		element["type"] = "Microsoft.Common.TextBox"
-		element["constraints"] = map[string]any{"required": true}
-		if def, ok := p.DefaultValue.(string); ok {
+		def, hasDefault := p.DefaultValue.(string)
+		element["constraints"] = map[string]any{"required": !hasDefault || def != ""}
+		if hasDefault {
 			element["defaultValue"] = def
 		}
 	default:

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.stories.tsx
@@ -3,7 +3,7 @@ export default {
 }
 
 import { AwaitAzureDetails } from './AwaitAzureDetails'
-import type { TAppSecretConfig } from '@/types'
+import type { TAppInput, TAppSecretConfig } from '@/types'
 
 const mockStack = {
   versions: [
@@ -37,6 +37,26 @@ const mockSecrets = [
     auto_generate: false,
   },
 ] satisfies TAppSecretConfig[]
+
+const mockInputs = [
+  {
+    name: 'api_key',
+    display_name: 'API key',
+    description: 'Issued from your vendor account.',
+    source: 'customer',
+    required: true,
+  },
+  {
+    name: 'log_level',
+    description: 'Verbosity of the application logs.',
+    source: 'customer',
+    default: 'info',
+  },
+  {
+    name: 'internal_toggle',
+    source: 'vendor',
+  },
+] satisfies TAppInput[]
 
 export const Default = () => (
   <div className="max-w-2xl p-4">
@@ -81,6 +101,33 @@ export const WithApplicationSecrets = () => (
       installId="install-1"
       azureLocation="eastus"
       secrets={mockSecrets}
+    />
+  </div>
+)
+
+export const WithCustomerInputs = () => (
+  <div className="max-w-2xl p-4">
+    <AwaitAzureDetails
+      stack={mockStack}
+      step={mockStep}
+      installId="install-1"
+      azureLocation="eastus"
+      inputs={mockInputs}
+    />
+  </div>
+)
+
+// api_key already has a value, so the deploy command must not offer to replace it
+// with a placeholder.
+export const WithCustomerInputsAlreadySet = () => (
+  <div className="max-w-2xl p-4">
+    <AwaitAzureDetails
+      stack={mockStack}
+      step={mockStep}
+      installId="install-1"
+      azureLocation="eastus"
+      inputs={mockInputs}
+      setInputNames={new Set(['api_key'])}
     />
   </div>
 )

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetails.tsx
@@ -6,7 +6,11 @@ import { Divider } from '@/components/common/Divider'
 import { Expand } from '@/components/common/Expand'
 import { Link } from '@/components/common/Link'
 import { Text } from '@/components/common/Text'
-import type { TAppSecretConfig, TStackDeploymentScope } from '@/types'
+import type {
+  TAppInput,
+  TAppSecretConfig,
+  TStackDeploymentScope,
+} from '@/types'
 import { createFileDownload } from '@/utils/file-download'
 import type { IStackDetails } from '../types'
 import { DeployToAzureBadge } from './DeployToAzureBadge'
@@ -15,8 +19,21 @@ interface IAwaitAzureDetails extends IStackDetails {
   installId: string
   azureLocation?: string
   secrets?: TAppSecretConfig[]
+  inputs?: TAppInput[]
+  // Presence only, never the value: sensitive inputs come back redacted, and the
+  // value is not needed to know the template already carries a default for one.
+  setInputNames?: Set<string>
   deploymentScope?: TStackDeploymentScope
 }
+
+// Mirrors azureInputParamName in ctl-api's ARM renderer, which owns the mapping. The
+// template declares only the names it derives, so one built any other way is rejected
+// at deploy time as an undeclared parameter.
+const azureInputParamName = (name: string) =>
+  'input' +
+  (name.match(/[A-Za-z0-9]+/g) ?? [])
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join('')
 
 const telemetryExportConfigFilename = 'telemetry-export-config.yaml'
 const telemetryExportConfig = `version: v1
@@ -37,6 +54,8 @@ export const AwaitAzureDetails = ({
   installId,
   azureLocation,
   secrets,
+  inputs,
+  setInputNames,
   deploymentScope,
   loading,
 }: IAwaitAzureDetails) => {
@@ -83,6 +102,45 @@ export const AwaitAzureDetails = ({
     deploymentScope === 'subscription'
       ? stack?.versions?.at(0)?.quick_link_url
       : undefined
+
+  const customerInputs = (inputs ?? []).filter(
+    (input) => !!input.name && input.source === 'customer'
+  )
+  // An input the template already carries a default for needs no --parameters entry,
+  // and passing one would replace the install's current value with a placeholder.
+  const unsetInputs = customerInputs.filter(
+    (input) => !input.default && !setInputNames?.has(input.name!)
+  )
+  const requiredInputs = unsetInputs.filter((input) => input.required)
+  const overridableInputs = customerInputs.filter(
+    (input) => !requiredInputs.includes(input)
+  )
+  const inputParamFlag = (input: TAppInput) =>
+    `${azureInputParamName(input.name!)}="<value>"`
+  const requiredParamsFlag = requiredInputs.length
+    ? ` --parameters ${requiredInputs.map(inputParamFlag).join(' ')}`
+    : ''
+
+  const renderInputCard = (input: TAppInput) => {
+    const flag = `--parameters ${inputParamFlag(input)}`
+    return (
+      <Card key={input.name}>
+        <span className="flex justify-between items-center">
+          <Text>
+            {input.display_name || input.name}
+            {requiredInputs.includes(input) && (
+              <span className="text-red-500 ml-1">*</span>
+            )}
+          </Text>
+          <ClickToCopyButton className="w-fit self-end" textToCopy={flag} />
+        </span>
+        {input.description && (
+          <Text variant="subtext">{input.description}</Text>
+        )}
+        <Code>{flag}</Code>
+      </Card>
+    )
+  }
 
   const vaultName = installId.slice(0, 24)
   const customerSecrets = secrets?.filter((s) => !s.auto_generate)
@@ -235,6 +293,40 @@ export const AwaitAzureDetails = ({
         </div>
       )}
 
+      {customerInputs.length > 0 && (
+        <div className="flex flex-col gap-4">
+          <Text variant="base" weight="strong">
+            Set the app&apos;s inputs
+          </Text>
+          <Text variant="subtext">
+            These reach the stack as template parameters, and the values you
+            deploy with become the install&apos;s inputs. The portal asks for
+            them on its deployment form; on the CLI they are{' '}
+            <code>--parameters</code> arguments on the deploy command below.
+          </Text>
+
+          {requiredInputs.map(renderInputCard)}
+          {overridableInputs.length > 0 && (
+            <Expand
+              id="overridable-inputs"
+              heading={
+                <Text variant="subtext">
+                  Optional overrides ({overridableInputs.length})
+                </Text>
+              }
+            >
+              <div className="flex flex-col gap-4 p-2">
+                <Text variant="subtext">
+                  These already have a value. Pass one only to change it —
+                  omitting it keeps what the install has.
+                </Text>
+                {overridableInputs.map(renderInputCard)}
+              </div>
+            </Expand>
+          )}
+        </div>
+      )}
+
       <div className="flex flex-col gap-4">
         <Text variant="base" weight="strong">
           Deploy the install stack using the Azure CLI
@@ -245,11 +337,11 @@ export const AwaitAzureDetails = ({
             <Text>Preview changes (dry-run)</Text>
             <ClickToCopyButton
               className="w-fit self-end"
-              textToCopy={`az deployment group what-if --resource-group ${installId}-rg --template-uri ${stack?.versions?.at(0)?.template_url}`}
+              textToCopy={`az deployment group what-if --resource-group ${installId}-rg --template-uri ${stack?.versions?.at(0)?.template_url}${requiredParamsFlag}`}
             />
           </span>
           <Code>{`
-            az deployment group what-if --resource-group ${installId}-rg --template-uri ${stack?.versions?.at(0)?.template_url}
+            az deployment group what-if --resource-group ${installId}-rg --template-uri ${stack?.versions?.at(0)?.template_url}${requiredParamsFlag}
           `}</Code>
         </Card>
 
@@ -258,11 +350,11 @@ export const AwaitAzureDetails = ({
             <Text>Deploy the stack to the resource group</Text>
             <ClickToCopyButton
               className="w-fit self-end"
-              textToCopy={`az stack group create --name ${installId}-stack --resource-group ${installId}-rg --template-uri ${stack?.versions?.at(0)?.template_url} --deny-settings-mode "denyDelete" --aou deleteAll`}
+              textToCopy={`az stack group create --name ${installId}-stack --resource-group ${installId}-rg --template-uri ${stack?.versions?.at(0)?.template_url} --deny-settings-mode "denyDelete" --aou deleteAll${requiredParamsFlag}`}
             />
           </span>
           <Code>{`
-            az stack group create --name ${installId}-stack --resource-group ${installId}-rg --template-uri ${stack?.versions?.at(0)?.template_url} --deny-settings-mode "denyDelete" --aou deleteAll
+            az stack group create --name ${installId}-stack --resource-group ${installId}-rg --template-uri ${stack?.versions?.at(0)?.template_url} --deny-settings-mode "denyDelete" --aou deleteAll${requiredParamsFlag}
           `}</Code>
         </Card>
       </div>

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetailsContainer.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAzureDetails/AwaitAzureDetailsContainer.tsx
@@ -1,8 +1,9 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
 import { useInstall } from '@/hooks/use-install'
 import { useInstallAppConfig } from '@/hooks/use-install-app-config'
 import { useOrg } from '@/hooks/use-org'
-import { getAppSecretsConfig } from '@/lib'
+import { getAppSecretsConfig, getInstallCurrentInputs } from '@/lib'
 import { AwaitAzureDetails } from './AwaitAzureDetails'
 import type { IStackDetails } from '../types'
 
@@ -26,6 +27,26 @@ export const AwaitAzureDetailsContainer = ({
     enabled: !!org?.id && !!install?.app_id,
   })
 
+  const { data: currentInputs } = useQuery({
+    placeholderData: keepPreviousData,
+    queryKey: ['install-current-inputs', org?.id, install?.id],
+    queryFn: () =>
+      getInstallCurrentInputs({ orgId: org.id, installId: install.id }),
+    enabled: !!org?.id && !!install?.id,
+  })
+
+  // Names only. Sensitive inputs come back redacted, and knowing which inputs are
+  // already set is enough to tell which the deploy command has to supply.
+  const setInputNames = useMemo(
+    () =>
+      new Set(
+        Object.entries(currentInputs?.values ?? {})
+          .filter(([, value]) => !!value)
+          .map(([name]) => name)
+      ),
+    [currentInputs?.values]
+  )
+
   // The install's current app config is only the scope of this stack version if
   // the version was rendered from it. A step viewed after the install repinned
   // to a newer config would otherwise be judged against a scope its template
@@ -41,6 +62,8 @@ export const AwaitAzureDetailsContainer = ({
       installId={install?.id ?? ''}
       azureLocation={install?.azure_account?.location}
       secrets={secretsConfig?.secrets}
+      inputs={appConfig?.input?.inputs}
+      setInputNames={setInputNames}
       deploymentScope={
         renderedFromCurrentConfig
           ? appConfig?.stack?.deployment_scope


### PR DESCRIPTION
Customer-source app inputs now render as ARM template parameters, so the Azure portal quick link collects them and the phone home reports the values back as the install's inputs. Parameters default to the install's current value so a reprovision doesn't revert a value set in the dashboard.