### PR TITLE
feat: support for gcp stack module

### DIFF
--- a/docs/guides/provision-stacks-with-terraform-module.mdx
+++ b/docs/guides/provision-stacks-with-terraform-module.mdx
@@ -6,8 +6,6 @@ boost: 10
 keywords: ['terraform', 'terraform module', 'terraform provider', 'provider', 'install-stacks', 'install stack', 'stack', 'terraform apply', 'nuonco/stack', 'stack provider', 'api token', 'backend', 'remote state', 'inputs', 'secrets']
 ---
 
-{/* TODO: confirm module version pin before release */}
-
 For customers that prefer to manage their stacks using Terraform, we publish [modules for each platform Nuon supports](https://registry.terraform.io/search/modules?namespace=nuonco&q=stack).
 
 <Note>
@@ -27,6 +25,7 @@ In order to use a Terraform module, your customer will need the following.
 - A Terraform project, with their own state backend configured.
 - A secret store.
 - Credentials for the cloud account they want to provision the stack in.
+- On GCP, the project and region to provision into, if the install has not been provisioned before. AWS records the region when the install is created; on GCP the target is recorded by the first apply, so the first one must pass `project_id` and `region` to the module.
 - Outbound network access to the Terraform Registry from their CI (to install the module and the `nuonco/stack` provider).
 - Outbound network access to the Nuon runner API from their CI (so the provider can fetch the stack configuration at plan time).
 
@@ -81,7 +80,8 @@ The rest of the process is completed by your customer, using the information you
   <Step title="Import the stack module">
     Your customer must import the module using the Terraform snippet you saved from the provision workflow.
 
-    ```hcl main.tf
+    <CodeGroup>
+    ```hcl AWS
     terraform {
       required_providers {
         aws   = { source = "hashicorp/aws" }
@@ -97,7 +97,7 @@ The rest of the process is completed by your customer, using the information you
 
     module "aws_stack" {
       source  = "nuonco/stack/aws"
-      version = "~> 0.2"
+      version = "~> 1.0"
 
       install_id = "<install-id>"
 
@@ -116,6 +116,47 @@ The rest of the process is completed by your customer, using the information you
       description = "License key that activates the product."
     }
     ```
+
+    ```hcl GCP
+    terraform {
+      required_providers {
+        google = { source = "hashicorp/google" }
+        stack  = { source = "nuonco/stack" }
+      }
+    }
+
+    provider "google" {
+      project = "my-project"
+      region  = "us-central1"
+    }
+
+    provider "stack" {}
+
+    module "gcp_stack" {
+      source  = "nuonco/stack/gcp"
+      version = "~> 0.1"
+
+      install_id = "<install-id>"
+
+      inputs = {
+        machine_type = "e2-standard-4"
+      }
+
+      secrets = {
+        license_key = { value = var.license_key }
+      }
+    }
+
+    variable "license_key" {
+      type        = string
+      sensitive   = true
+      description = "License key that activates the product."
+    }
+    ```
+    </CodeGroup>
+
+    On GCP, the module reads the install's project and region from the control plane, so they appear only in the `google` provider block.
+    Before the install's first apply the control plane has nothing recorded, and the plan will fail asking for them — pass `project_id` and `region` to the module for that first apply, then drop them.
   </Step>
   <Step title="Configure the secret values">
     Nuon credentials and app secret values are supplied using environment variables, so they are never written to Terraform files or committed to version control.
@@ -192,7 +233,7 @@ If you add a new secret, your customer should store the value in a secret store,
 ```hcl
 module "aws_stack" {
   source  = "nuonco/stack/aws"
-  version = "~> 0.2"
+  version = "~> 1.0"
 
   // other module config...
 
@@ -254,4 +295,4 @@ next plan will fail with an error message telling them to remove it.
 To upgrade the Terraform module itself, your customer will update the version pin, run `terraform init -upgrade`, then `terraform apply`.
 
 To avoid your customer having to upgrade too frequently, we recommend using a minor version constraint instead of pinning to a specific version.
-For example, with `version = "~> 0.2"`, running `terraform init -upgrade` will automatically pick up new patch versions.
+For example, with `version = "~> 1.0"`, running `terraform init -upgrade` will automatically pick up new minor and patch releases within the 1.x series.

--- a/services/ctl-api/internal/app/installer_sdk_config.go
+++ b/services/ctl-api/internal/app/installer_sdk_config.go
@@ -56,11 +56,17 @@ type InstallerSDKAWSConfig struct {
 }
 
 // InstallerSDKGCPConfig mirrors sdks/stack core.GCPConfig. ctl-api populates
-// the Nuon-generated fields; the customer-supplied project/region/machine-type/
-// GKE inputs are filled by the SDK from CLI options, so they are left empty here.
+// the Nuon-generated fields; the customer-supplied machine-type and GKE inputs
+// are filled by the SDK from CLI options, so they are left empty here.
 type InstallerSDKGCPConfig struct {
-	// NOTE: project + region are NOT set here — the customer supplies them at
-	// provision time via the CLI. ctl-api only emits the Nuon-generated inputs.
+	// The install's GCP target, from Install.GCPAccount — the GCP counterpart of
+	// InstallerSDKAWSConfig.Region. Both may be empty: unlike AWS, a GCP install
+	// can be created without a project/region and have them recorded by the
+	// first provision's phone home (see the UpdateGCPAccountRegion activity), so
+	// callers must tolerate empty values rather than treat them as an error.
+	ProjectID string `json:"project_id,omitempty"`
+	Region    string `json:"region,omitempty"`
+
 	RunnerInitScriptURL string `json:"runner_init_script_url,omitempty"`
 	RunnerAPIToken      string `json:"runner_api_token,omitempty"`
 	RunnerMachineType   string `json:"runner_machine_type,omitempty"`

--- a/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config.go
+++ b/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config.go
@@ -26,6 +26,7 @@ func (h *Helpers) BuildInstallerSDKConfig(ctx context.Context, installID string)
 	var install app.Install
 	if res := h.db.WithContext(ctx).
 		Preload("AWSAccount").
+		Preload("GCPAccount").
 		// Newest row only: AfterQuery promotes it to CurrentInstallInputs, which the
 		// customer-input values and the cluster_name resolution below both read.
 		Preload("InstallInputs", func(db *gorm.DB) *gorm.DB {
@@ -223,9 +224,16 @@ func (h *Helpers) BuildInstallerSDKConfig(ctx context.Context, installID string)
 		}
 
 	case app.AppRunnerTypeGCP:
-		// NOTE: project + region are NOT known server-side — the customer
-		// supplies them at provision time via the CLI. ctl-api only provides the
-		// Nuon-generated inputs.
+		// The GCP target, from the install's GCPAccount. Not required, unlike the
+		// AWS region above: a GCP install can be created without one, and the
+		// first provision records it via the UpdateGCPAccountRegion activity. So
+		// this serves what is known and leaves the rest empty for the module to
+		// take from its own project_id/region variables.
+		var gcpProjectID, gcpRegion string
+		if install.GCPAccount != nil {
+			gcpProjectID = install.GCPAccount.ProjectID
+			gcpRegion = install.GCPAccount.Region
+		}
 
 		// GCP provisions via the Terraform module, which authenticates the
 		// runner with a real API token (no IID-based auth like AWS).
@@ -244,6 +252,9 @@ func (h *Helpers) BuildInstallerSDKConfig(ctx context.Context, installID string)
 
 		cfg.Cloud = "gcp"
 		cfg.GCP = &app.InstallerSDKGCPConfig{
+			ProjectID: gcpProjectID,
+			Region:    gcpRegion,
+
 			RunnerInitScriptURL: initScriptURL,
 			RunnerAPIToken:      token.Token,
 			RunnerMachineType:   instanceType,

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAWSDetails/AwaitAWSDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitAWSDetails/AwaitAWSDetails.tsx
@@ -1,5 +1,4 @@
-import { useMemo, useState } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useMemo } from 'react'
 import { Button } from '@/components/common/Button'
 import { Card } from '@/components/common/Card'
 import { ClickToCopyButton } from '@/components/common/ClickToCopy'
@@ -9,15 +8,9 @@ import { Expand } from '@/components/common/Expand'
 import { Link } from '@/components/common/Link'
 import { Tabs } from '@/components/common/Tabs'
 import { Text } from '@/components/common/Text'
-import { ToggleButton } from '@/components/common/ToggleButton'
-import { CreateOIDCTrustPolicyButton } from '@/components/oidc-trust-policies'
-import { CreateServiceAccountTokenModalContainer } from '@/components/service-accounts/ServiceAccountToken'
-import { useConfig } from '@/hooks/use-config'
-import { useInstallAppConfig } from '@/hooks/use-install-app-config'
-import { useOIDCTrustPolicies } from '@/hooks/use-oidc-trust-policies'
-import { useStackServiceAccount } from '@/hooks/use-stack-service-account'
-import { useSurfaces } from '@/hooks/use-surfaces'
 import { createFileDownload } from '@/utils/file-download'
+import { TFModuleTab } from '../tf-module'
+import type { IMainTfParts } from '../tf-module'
 import type { IStackDetails } from '../types'
 
 interface IAwaitAWSDetails extends IStackDetails {
@@ -163,7 +156,7 @@ export const AwaitAWSDetails = ({
             ...(tfProvider
               ? {
                   tfmodule: (
-                    <TFModuleTab
+                    <AWSTFModuleTab
                       orgId={orgId}
                       installId={installId}
                       installAwsRegion={installAwsRegion}
@@ -559,181 +552,27 @@ const AWSTelemetryExportInstructions = ({
   )
 }
 
-interface ITFModuleTab {
+interface IAWSTFModuleTab {
   orgId: string
   installId?: string
   installAwsRegion?: string
 }
 
-const padTo = (name: string, width: number) => name.padEnd(width, ' ')
-
-// `inputs = { ... }`, indented for the module block. The module's `inputs` and
-// `secrets` maps only accept keys the app declares, so the snippet lists exactly the
-// customer-facing ones. Empty when the app declares no customer inputs — the module
-// treats an omitted map as "use control-plane values".
-const buildInputsBlock = (
-  inputs: Array<{ name?: string; default?: string }>
-): string => {
-  if (inputs.length === 0) return ''
-
-  const nameWidth = Math.max(
-    ...inputs.map((input) => (input.name ?? '').length)
-  )
-  const lines = inputs.map(
-    (input) =>
-      `    ${padTo(input.name ?? '', nameWidth)} = "${input.default ?? ''}"`
-  )
-
-  return `\n\n  inputs = {\n${lines.join('\n')}\n  }`
-}
-
-// `secrets = { ... }`. Auto-generated secrets are minted by the stack itself, so only
-// the customer-supplied ones belong in the snippet. Values come from the root-level
-// `variable` blocks, which Terraform populates from `TF_VAR_*`.
-const buildSecretsBlock = (secrets: Array<{ name?: string }>): string => {
-  if (secrets.length === 0) return ''
-
-  const width = Math.max(...secrets.map((secret) => (secret.name ?? '').length))
-  const lines = secrets.map(
-    (secret) =>
-      `    ${padTo(secret.name ?? '', width)} = { value = var.${secret.name ?? ''} }`
-  )
-
-  return `\n\n  secrets = {\n${lines.join('\n')}\n  }`
-}
-
-// Root-level `variable` blocks for each customer secret. Terraform fills them from
-// `TF_VAR_<name>`, so no real value is ever written to main.tf.
-const buildSecretVariablesBlock = (
-  secrets: Array<{ name?: string; description?: string }>
-): string => {
-  if (secrets.length === 0) return ''
-
-  const blocks = secrets.map((secret) => {
-    const description = secret.description?.trim()
-    // Widths match what `terraform fmt` would produce for the attributes present.
-    const width = description ? 'description'.length : 'sensitive'.length
-    const attrs = [
-      `  ${padTo('type', width)} = string`,
-      `  ${padTo('sensitive', width)} = true`,
-      ...(description
-        ? [`  ${padTo('description', width)} = "${description}"`]
-        : []),
-    ]
-    return `variable "${secret.name ?? ''}" {\n${attrs.join('\n')}\n}`
-  })
-
-  return `\n\n${blocks.join('\n\n')}`
-}
-
-// `export TF_VAR_<name>='<placeholder>'` lines, shown alongside both auth methods
-// since secrets are needed regardless of how the module authenticates.
-const buildSecretExports = (secrets: Array<{ name?: string }>): string =>
-  secrets
-    .map(
-      (secret) =>
-        `export TF_VAR_${secret.name ?? ''}='<${(secret.name ?? '').replace(/_/g, '-')}-value>'`
-    )
-    .join('\n')
-
-// OIDC auth is hidden until the experience is polished and fully tested; flip
-// this to restore the Static token / OIDC toggle.
-const OIDC_AUTH_ENABLED = false
-
-// Directions for the published nuonco/stack/aws module, which reads its whole config
-// from the API. Distinct from TerraformTab, which clones install-stacks and is driven
-// by generated tfvars.
-const TFModuleTab = ({ orgId, installId, installAwsRegion }: ITFModuleTab) => {
-  const queryClient = useQueryClient()
-  const { addModal } = useSurfaces()
-  const [authMethod, setAuthMethod] = useState<'token' | 'oidc'>('token')
-  // Only fetched once the OIDC pane is opened; most customers never need this list.
-  const { data: trustPolicies } = useOIDCTrustPolicies({
-    enabled: OIDC_AUTH_ENABLED && authMethod === 'oidc',
-  })
-  const {
-    data: serviceAccount,
-    isLoading,
-    isError,
-  } = useStackServiceAccount({
-    installId,
-    orgId,
-    enabled: true,
-  })
-
-  // Defaults to a day rather than the modal's usual year: this credential is pasted
-  // in by hand, so it is more exposed than one held by a service. Every other
-  // duration is still selectable.
-  const openCreateToken = () =>
-    addModal(
-      <CreateServiceAccountTokenModalContainer
-        accountId={serviceAccount?.account_id ?? ''}
-        identity={serviceAccount?.email ?? 'this install stack'}
-        defaultDuration="24h"
-        tokenName={`stack-${installId}`}
-        onCreated={() =>
-          queryClient.invalidateQueries({
-            queryKey: ['stack-service-account', installId],
-          })
-        }
-      />
-    )
-
-  // Derived from the timestamp rather than has_live_token, so the label stays honest
-  // if only one of the two arrives.
-  const liveUntil =
-    serviceAccount?.has_live_token && serviceAccount.expires_at
-      ? new Date(serviceAccount.expires_at).toLocaleString()
-      : null
-
+// The AWS half of the TF Module tab: which providers to require, and the module
+// source. Everything else — auth, inputs, secrets, the step layout — is shared.
+const AWSTFModuleTab = ({
+  orgId,
+  installId,
+  installAwsRegion,
+}: IAWSTFModuleTab) => {
   const region = installAwsRegion ?? '<your-install-region>'
 
-  // While the app config is still resolving, the snippet renders without the inputs
-  // and secrets blocks rather than blocking the rest of the directions.
-  const { appConfig } = useInstallAppConfig()
-
-  const customerInputs = useMemo(() => {
-    const declared = appConfig?.input?.inputs ?? []
-    const grouped = (appConfig?.input?.input_groups ?? []).flatMap(
-      (group) => group.app_inputs ?? []
-    )
-    const seen = new Set<string>()
-    return [...declared, ...grouped].filter((input) => {
-      if (!input.name || input.source !== 'customer') return false
-      if (seen.has(input.name)) return false
-      seen.add(input.name)
-      return true
-    })
-  }, [appConfig?.input?.inputs, appConfig?.input?.input_groups])
-
-  // Secrets carry no vendor/customer flag: everything not auto-generated is the
-  // customer's to provide.
-  const customerSecrets = useMemo(
-    () =>
-      (appConfig?.secrets?.secrets ?? []).filter(
-        (secret) => !!secret.name && !secret.auto_generate
-      ),
-    [appConfig?.secrets?.secrets]
-  )
-
-  const inputsBlock = useMemo(
-    () => buildInputsBlock(customerInputs),
-    [customerInputs]
-  )
-  const secretsBlock = useMemo(
-    () => buildSecretsBlock(customerSecrets),
-    [customerSecrets]
-  )
-  const secretVariablesBlock = useMemo(
-    () => buildSecretVariablesBlock(customerSecrets),
-    [customerSecrets]
-  )
-  const secretExports = useMemo(
-    () => buildSecretExports(customerSecrets),
-    [customerSecrets]
-  )
-
-  const mainTf = `terraform {
+  const buildMainTf = ({
+    installId: id,
+    inputsBlock,
+    secretsBlock,
+    secretVariablesBlock,
+  }: IMainTfParts) => `terraform {
   required_providers {
     aws   = { source = "hashicorp/aws" }
     stack = { source = "nuonco/stack" }
@@ -750,227 +589,14 @@ module "aws_stack" {
   source  = "nuonco/stack/aws"
   version = "~> 0.2"
 
-  install_id = "${installId ?? '<install-id>'}"${inputsBlock}${secretsBlock}
+  install_id = "${id}"${inputsBlock}${secretsBlock}
 }${secretVariablesBlock}`
 
-  // Always a placeholder: the token value is shown once, in the create modal.
-  const authCmd = `export NUON_API_TOKEN='<api-token>'`
-  const applyCmd = `terraform init && terraform apply`
-
   return (
-    <div className="flex flex-col gap-4 pt-4">
-      <div className="flex flex-col gap-4">
-        <Text variant="base" weight="strong">
-          1. Create your Terraform configuration
-        </Text>
-        <Card>
-          <span className="flex justify-between items-center">
-            <Text>
-              Save this as <code>main.tf</code>
-            </Text>
-            <ClickToCopyButton textToCopy={mainTf} />
-          </span>
-          <Code variant="preformated">{mainTf}</Code>
-        </Card>
-        {secretExports ? (
-          <Card>
-            <span className="flex justify-between items-center">
-              <Text>Export the app&apos;s secret values.</Text>
-              <ClickToCopyButton textToCopy={secretExports} />
-            </span>
-            <Code variant="preformated">{secretExports}</Code>
-          </Card>
-        ) : null}
-      </div>
-
-      <Divider />
-
-      <div className="flex flex-col gap-4">
-        <span className="flex justify-between items-center gap-4">
-          <Text variant="base" weight="strong">
-            2. Authenticate
-          </Text>
-          {OIDC_AUTH_ENABLED ? (
-            <ToggleButton<'token' | 'oidc'>
-              value={authMethod}
-              onChange={setAuthMethod}
-              options={[
-                { value: 'token', label: 'Static token' },
-                { value: 'oidc', label: 'OIDC' },
-              ]}
-            />
-          ) : null}
-        </span>
-        {OIDC_AUTH_ENABLED && authMethod === 'oidc' ? (
-          <OIDCAuthPane
-            installId={installId}
-            policyNames={(trustPolicies ?? [])
-              .map((policy) => policy.name ?? '')
-              .filter(Boolean)}
-          />
-        ) : (
-          <StaticTokenAuthPane
-            authCmd={authCmd}
-            isLoading={isLoading}
-            isError={isError}
-            liveUntil={liveUntil}
-            canCreate={!!serviceAccount?.account_id}
-            onCreateToken={openCreateToken}
-          />
-        )}
-      </div>
-
-      <Divider />
-
-      <div className="flex flex-col gap-4">
-        <Text variant="base" weight="strong">
-          3. Apply
-        </Text>
-        <Card>
-          <span className="flex justify-between items-center">
-            <Text>Initialize the module and create the stack</Text>
-            <ClickToCopyButton textToCopy={applyCmd} />
-          </span>
-          <Code variant="preformated">{applyCmd}</Code>
-        </Card>
-      </div>
-    </div>
-  )
-}
-
-const StaticTokenAuthPane = ({
-  authCmd,
-  isLoading,
-  isError,
-  liveUntil,
-  canCreate,
-  onCreateToken,
-}: {
-  authCmd: string
-  isLoading: boolean
-  isError: boolean
-  liveUntil: string | null
-  canCreate: boolean
-  onCreateToken: () => void
-}) => {
-  return (
-    <>
-      {isError ? (
-        <Text variant="subtext" theme="neutral">
-          This install stack has no service account yet. Reprovision the install
-          to create one, then reload this page.
-        </Text>
-      ) : null}
-      <Card>
-        <span className="flex justify-between items-center">
-          <Text>
-            This token authorizes the module to read its configuration. Treat it
-            as a secret.
-          </Text>
-          <ClickToCopyButton textToCopy={authCmd} />
-        </span>
-        <Code variant="preformated">{authCmd}</Code>
-        {/* Nothing to offer until the service account resolves; the guidance above
-              already explains why it might not. */}
-        {isLoading || isError || !canCreate ? null : (
-          <span className="flex justify-between items-center gap-4">
-            <Text variant="subtext" theme="neutral">
-              {liveUntil
-                ? `A token is active until ${liveUntil}. Creating another does not revoke it unless you ask it to.`
-                : 'No token yet. Create one to get its value — it is shown only once.'}
-            </Text>
-            <Button size="sm" variant="secondary" onClick={onCreateToken}>
-              Create token
-            </Button>
-          </span>
-        )}
-      </Card>
-    </>
-  )
-}
-
-// The alternative to handing a customer a token at all: Actions mints an ID token per
-// run and the control plane trades it for a short-lived Nuon token.
-const OIDCAuthPane = ({
-  installId,
-  policyNames,
-}: {
-  installId?: string
-  policyNames: string[]
-}) => {
-  const config = useConfig()
-  const policyName = `stack-${installId ?? 'install'}`
-  const existing = policyNames.includes(policyName)
-
-  // The runner API, not the public one the OIDC settings page prefills: the SDK
-  // requests its ID token with the URL it talks to and the control plane compares the
-  // audience literally, so prefilling this means the two agree with no extra config.
-  const audience = config.runnerApiUrl ?? ''
-
-  const workflowSnippet = `permissions:
-  id-token: write
-  contents: read
-
-env:
-  NUON_ORG_ID: \${{ vars.NUON_ORG_ID }}`
-
-  return (
-    <>
-      <Card>
-        <span className="flex justify-between items-center gap-4">
-          <Text>
-            A trust policy tells Nuon which repository and branch may exchange
-            an OIDC token for access to this org.
-          </Text>
-          {/* Without an audience the policy would be created with a blank one and
-              reject every token, so this offers nothing rather than something
-              broken. */}
-          {audience ? (
-            <CreateOIDCTrustPolicyButton
-              variant="secondary"
-              size="sm"
-              lockPreset
-              repoSource="manual"
-              githubAudience={audience}
-              defaultRole="org_admin"
-              defaultName={policyName}
-              reservedNames={policyNames}
-            >
-              {existing ? 'Create another' : 'Create trust policy'}
-            </CreateOIDCTrustPolicyButton>
-          ) : null}
-        </span>
-        {audience ? null : (
-          <Text variant="subtext" theme="neutral">
-            This control plane has not published its runner API URL, which the
-            policy needs as its audience. Set <code>NUON_RUNNER_API_URL</code>{' '}
-            on the dashboard and reload.
-          </Text>
-        )}
-        {existing ? (
-          <Text variant="subtext" theme="neutral">
-            A policy named <code>{policyName}</code> already exists. Check it
-            covers the repository and branch running this Terraform before
-            creating another.
-          </Text>
-        ) : null}
-      </Card>
-
-      <Card>
-        <span className="flex justify-between items-center">
-          <Text>
-            Add this to the workflow that applies the Terraform. No{' '}
-            <code>NUON_API_TOKEN</code>.
-          </Text>
-          <ClickToCopyButton textToCopy={workflowSnippet} />
-        </span>
-        <Code variant="preformated">{workflowSnippet}</Code>
-      </Card>
-
-      <Text variant="subtext" theme="neutral">
-        Without <code>id-token: write</code> the workflow cannot mint an ID
-        token and the provider falls back to looking for a static token.
-      </Text>
-    </>
+    <TFModuleTab
+      orgId={orgId}
+      installId={installId}
+      buildMainTf={buildMainTf}
+    />
   )
 }

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.stories.tsx
@@ -139,6 +139,7 @@ export const Default = () => (
     <AwaitGCPDetails
       stack={mockStack}
       step={mockStep}
+      orgId="org-1"
       installId="install-1"
       gcpProjectId="my-gcp-project"
       spaceliftEnabled
@@ -148,7 +149,12 @@ export const Default = () => (
 
 export const SpaceliftDisabled = () => (
   <div className="max-w-2xl p-4">
-    <AwaitGCPDetails stack={mockStack} step={mockStep} installId="install-1" />
+    <AwaitGCPDetails
+      stack={mockStack}
+      step={mockStep}
+      orgId="org-1"
+      installId="install-1"
+    />
   </div>
 )
 
@@ -157,6 +163,7 @@ export const LegacyContents = () => (
     <AwaitGCPDetails
       stack={mockLegacyStack}
       step={mockStep}
+      orgId="org-1"
       installId="install-1"
     />
   </div>
@@ -167,8 +174,23 @@ export const Loading = () => (
     <AwaitGCPDetails
       stack={mockStack}
       step={mockStep}
+      orgId="org-1"
       installId="install-1"
       loading
+    />
+  </div>
+)
+
+export const TerraformProvider = () => (
+  <div className="max-w-2xl p-4">
+    <AwaitGCPDetails
+      stack={mockStack}
+      step={mockStep}
+      orgId="org-1"
+      installId="install-1"
+      gcpProjectId="my-gcp-project"
+      gcpRegion="us-central1"
+      tfProvider
     />
   </div>
 )

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
@@ -10,6 +10,8 @@ import { Link } from '@/components/common/Link'
 import { Tabs } from '@/components/common/Tabs'
 import { Text } from '@/components/common/Text'
 import { createFileDownload } from '@/utils/file-download'
+import { TFModuleTab } from '../tf-module'
+import type { IMainTfParts } from '../tf-module'
 import type { IStackDetails } from '../types'
 
 interface StackEnvelope {
@@ -73,9 +75,12 @@ function withSpaceliftGCPPlaceholders(tfvars: string): string {
 }
 
 interface IAwaitGCPDetails extends IStackDetails {
+  orgId: string
   installId?: string
   gcpProjectId?: string
+  gcpRegion?: string
   spaceliftEnabled?: boolean
+  tfProvider?: boolean
 }
 
 const telemetryExportConfigFilename = 'telemetry-export-config.yaml'
@@ -94,9 +99,12 @@ exporters:
 
 export const AwaitGCPDetails = ({
   stack,
+  orgId,
   installId,
   gcpProjectId,
+  gcpRegion,
   spaceliftEnabled,
+  tfProvider = false,
   loading,
 }: IAwaitGCPDetails) => {
   const version = stack?.versions?.at(0)
@@ -165,10 +173,27 @@ export const AwaitGCPDetails = ({
         Setup your install stack
       </Text>
 
-      {hasSpacelift ? (
+      {hasSpacelift || tfProvider ? (
         <Tabs
-          initActiveTab="terraform"
+          // The published module is the recommended path, so it opens first
+          // wherever it is available.
+          initActiveTab={tfProvider ? 'tfmodule' : 'terraform'}
+          tabLabels={{ tfmodule: 'TF Module' }}
           tabs={{
+            // Gated on the org feature until the module release it depends on
+            // is published.
+            ...(tfProvider
+              ? {
+                  tfmodule: (
+                    <GCPTFModuleTab
+                      orgId={orgId}
+                      installId={installId}
+                      gcpProjectId={gcpProjectId}
+                      gcpRegion={gcpRegion}
+                    />
+                  ),
+                }
+              : {}),
             terraform: (
               <TerraformTab
                 inputsTfvars={envelope.inputs}
@@ -176,15 +201,19 @@ export const AwaitGCPDetails = ({
                 installId={installId}
               />
             ),
-            spacelift: (
-              <SpaceliftTab
-                adminTf={envelope.spaceliftAdminTf}
-                blueprintYaml={envelope.spaceliftBlueprintYaml}
-                inputsTfvars={envelope.inputs}
-                secretsTfvars={envelope.secrets}
-                installId={installId}
-              />
-            ),
+            ...(hasSpacelift
+              ? {
+                  spacelift: (
+                    <SpaceliftTab
+                      adminTf={envelope.spaceliftAdminTf}
+                      blueprintYaml={envelope.spaceliftBlueprintYaml}
+                      inputsTfvars={envelope.inputs}
+                      secretsTfvars={envelope.secrets}
+                      installId={installId}
+                    />
+                  ),
+                }
+              : {}),
           }}
         />
       ) : (
@@ -720,5 +749,65 @@ const BlueprintSubTab = ({ blueprintYaml }: IBlueprintSubTab) => {
         </Text>
       </div>
     </div>
+  )
+}
+
+interface IGCPTFModuleTab {
+  orgId: string
+  installId?: string
+  gcpProjectId?: string
+  gcpRegion?: string
+}
+
+// The GCP half of the TF Module tab: which providers to require, and the module
+// source. Everything else — auth, inputs, secrets, the step layout — is shared.
+//
+// project and region are interpolated into the google provider block only. The
+// module reads the install's target from the control plane, so repeating them as
+// module arguments would be a second copy of the same value to drift. They fall
+// back to placeholders before the first provision has recorded them, which is
+// also the case where the customer must pass project_id/region to the module —
+// see the module's README.
+const GCPTFModuleTab = ({
+  orgId,
+  installId,
+  gcpProjectId,
+  gcpRegion,
+}: IGCPTFModuleTab) => {
+  const project = gcpProjectId || '<gcp-project-id>'
+  const region = gcpRegion || '<gcp-region>'
+
+  const buildMainTf = ({
+    installId: id,
+    inputsBlock,
+    secretsBlock,
+    secretVariablesBlock,
+  }: IMainTfParts) => `terraform {
+  required_providers {
+    google = { source = "hashicorp/google" }
+    stack  = { source = "nuonco/stack" }
+  }
+}
+
+provider "google" {
+  project = "${project}"
+  region  = "${region}"
+}
+
+provider "stack" {}
+
+module "gcp_stack" {
+  source  = "nuonco/stack/gcp"
+  version = "~> 0.1"
+
+  install_id = "${id}"${inputsBlock}${secretsBlock}
+}${secretVariablesBlock}`
+
+  return (
+    <TFModuleTab
+      orgId={orgId}
+      installId={installId}
+      buildMainTf={buildMainTf}
+    />
   )
 }

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetailsContainer.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetailsContainer.tsx
@@ -1,4 +1,5 @@
 import { useInstall } from '@/hooks/use-install'
+import { useOrg } from '@/hooks/use-org'
 import { AwaitGCPDetails } from './AwaitGCPDetails'
 import type { IStackDetails } from '../types'
 
@@ -12,15 +13,19 @@ export const AwaitGCPDetailsContainer = ({
   spaceliftEnabled,
   loading,
 }: IAwaitGCPDetailsContainer) => {
+  const { org } = useOrg()
   const { install } = useInstall()
   return (
     <AwaitGCPDetails
       stack={stack}
       step={step}
       loading={loading}
+      orgId={org.id}
       installId={install?.id}
       gcpProjectId={install?.gcp_account?.project_id}
+      gcpRegion={install?.gcp_account?.region}
       spaceliftEnabled={spaceliftEnabled}
+      tfProvider={!!org?.features?.['stack-tf-provider']}
     />
   )
 }

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/tf-module/AuthPanes.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/tf-module/AuthPanes.tsx
@@ -1,0 +1,151 @@
+// How a published stack module authenticates its config read. Cloud-agnostic:
+// the credential authorizes the Nuon API call, not the cloud provider, so both
+// panes are identical for every target cloud.
+import { Button } from '@/components/common/Button'
+import { Card } from '@/components/common/Card'
+import { ClickToCopyButton } from '@/components/common/ClickToCopy'
+import { Code } from '@/components/common/Code'
+import { Text } from '@/components/common/Text'
+import { CreateOIDCTrustPolicyButton } from '@/components/oidc-trust-policies'
+import { useConfig } from '@/hooks/use-config'
+
+// OIDC auth is hidden until the experience is polished and fully tested; flip
+// this to restore the Static token / OIDC toggle.
+export const OIDC_AUTH_ENABLED = false
+
+export const StaticTokenAuthPane = ({
+  authCmd,
+  isLoading,
+  isError,
+  liveUntil,
+  canCreate,
+  onCreateToken,
+}: {
+  authCmd: string
+  isLoading: boolean
+  isError: boolean
+  liveUntil: string | null
+  canCreate: boolean
+  onCreateToken: () => void
+}) => {
+  return (
+    <>
+      {isError ? (
+        <Text variant="subtext" theme="neutral">
+          This install stack has no service account yet. Reprovision the install
+          to create one, then reload this page.
+        </Text>
+      ) : null}
+      <Card>
+        <span className="flex justify-between items-center">
+          <Text>
+            This token authorizes the module to read its configuration. Treat it
+            as a secret.
+          </Text>
+          <ClickToCopyButton textToCopy={authCmd} />
+        </span>
+        <Code variant="preformated">{authCmd}</Code>
+        {/* Nothing to offer until the service account resolves; the guidance above
+              already explains why it might not. */}
+        {isLoading || isError || !canCreate ? null : (
+          <span className="flex justify-between items-center gap-4">
+            <Text variant="subtext" theme="neutral">
+              {liveUntil
+                ? `A token is active until ${liveUntil}. Creating another does not revoke it unless you ask it to.`
+                : 'No token yet. Create one to get its value — it is shown only once.'}
+            </Text>
+            <Button size="sm" variant="secondary" onClick={onCreateToken}>
+              Create token
+            </Button>
+          </span>
+        )}
+      </Card>
+    </>
+  )
+}
+
+// The alternative to handing a customer a token at all: Actions mints an ID token per
+// run and the control plane trades it for a short-lived Nuon token.
+export const OIDCAuthPane = ({
+  installId,
+  policyNames,
+}: {
+  installId?: string
+  policyNames: string[]
+}) => {
+  const config = useConfig()
+  const policyName = `stack-${installId ?? 'install'}`
+  const existing = policyNames.includes(policyName)
+
+  // The runner API, not the public one the OIDC settings page prefills: the SDK
+  // requests its ID token with the URL it talks to and the control plane compares the
+  // audience literally, so prefilling this means the two agree with no extra config.
+  const audience = config.runnerApiUrl ?? ''
+
+  const workflowSnippet = `permissions:
+  id-token: write
+  contents: read
+
+env:
+  NUON_ORG_ID: \${{ vars.NUON_ORG_ID }}`
+
+  return (
+    <>
+      <Card>
+        <span className="flex justify-between items-center gap-4">
+          <Text>
+            A trust policy tells Nuon which repository and branch may exchange
+            an OIDC token for access to this org.
+          </Text>
+          {/* Without an audience the policy would be created with a blank one and
+              reject every token, so this offers nothing rather than something
+              broken. */}
+          {audience ? (
+            <CreateOIDCTrustPolicyButton
+              variant="secondary"
+              size="sm"
+              lockPreset
+              repoSource="manual"
+              githubAudience={audience}
+              defaultRole="org_admin"
+              defaultName={policyName}
+              reservedNames={policyNames}
+            >
+              {existing ? 'Create another' : 'Create trust policy'}
+            </CreateOIDCTrustPolicyButton>
+          ) : null}
+        </span>
+        {audience ? null : (
+          <Text variant="subtext" theme="neutral">
+            This control plane has not published its runner API URL, which the
+            policy needs as its audience. Set <code>NUON_RUNNER_API_URL</code>{' '}
+            on the dashboard and reload.
+          </Text>
+        )}
+        {existing ? (
+          <Text variant="subtext" theme="neutral">
+            A policy named <code>{policyName}</code> already exists. Check it
+            covers the repository and branch running this Terraform before
+            creating another.
+          </Text>
+        ) : null}
+      </Card>
+
+      <Card>
+        <span className="flex justify-between items-center">
+          <Text>
+            Add this to the workflow that applies the Terraform. No{' '}
+            <code>NUON_API_TOKEN</code>.
+          </Text>
+          <ClickToCopyButton textToCopy={workflowSnippet} />
+        </span>
+        <Code variant="preformated">{workflowSnippet}</Code>
+      </Card>
+
+      <Text variant="subtext" theme="neutral">
+        Without <code>id-token: write</code> the workflow cannot mint an ID
+        token and the provider falls back to looking for a static token.
+      </Text>
+    </>
+  )
+}

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/tf-module/TFModuleTab.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/tf-module/TFModuleTab.tsx
@@ -1,0 +1,232 @@
+// Directions for a published nuonco/stack/<cloud> module, which reads its whole
+// config from the API. Distinct from each cloud's TerraformTab, which clones
+// install-stacks and is driven by generated tfvars.
+//
+// Everything here is cloud-agnostic: the token authorizes the Nuon config read,
+// and the module's inputs/secrets maps have the same shape whatever the target.
+// The one difference is the main.tf itself — which providers to require and which
+// module to source — so callers pass that in as buildMainTf.
+import { useMemo, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { Card } from '@/components/common/Card'
+import { ClickToCopyButton } from '@/components/common/ClickToCopy'
+import { Code } from '@/components/common/Code'
+import { Divider } from '@/components/common/Divider'
+import { Text } from '@/components/common/Text'
+import { ToggleButton } from '@/components/common/ToggleButton'
+import { CreateServiceAccountTokenModalContainer } from '@/components/service-accounts/ServiceAccountToken'
+import { useInstallAppConfig } from '@/hooks/use-install-app-config'
+import { useOIDCTrustPolicies } from '@/hooks/use-oidc-trust-policies'
+import { useStackServiceAccount } from '@/hooks/use-stack-service-account'
+import { useSurfaces } from '@/hooks/use-surfaces'
+import {
+  OIDC_AUTH_ENABLED,
+  OIDCAuthPane,
+  StaticTokenAuthPane,
+} from './AuthPanes'
+import {
+  buildInputsBlock,
+  buildSecretExports,
+  buildSecretsBlock,
+  buildSecretVariablesBlock,
+} from './snippet'
+
+// The pieces buildMainTf interpolates. Each block is either empty or already
+// carries its own leading newlines, so they concatenate directly into the
+// template with no separator logic at the call site.
+export interface IMainTfParts {
+  installId: string
+  inputsBlock: string
+  secretsBlock: string
+  secretVariablesBlock: string
+}
+
+export interface ITFModuleTab {
+  orgId: string
+  installId?: string
+  buildMainTf: (parts: IMainTfParts) => string
+}
+
+export const TFModuleTab = ({
+  orgId,
+  installId,
+  buildMainTf,
+}: ITFModuleTab) => {
+  const queryClient = useQueryClient()
+  const { addModal } = useSurfaces()
+  const [authMethod, setAuthMethod] = useState<'token' | 'oidc'>('token')
+  // Only fetched once the OIDC pane is opened; most customers never need this list.
+  const { data: trustPolicies } = useOIDCTrustPolicies({
+    enabled: OIDC_AUTH_ENABLED && authMethod === 'oidc',
+  })
+  const {
+    data: serviceAccount,
+    isLoading,
+    isError,
+  } = useStackServiceAccount({
+    installId,
+    orgId,
+    enabled: true,
+  })
+
+  // Defaults to a day rather than the modal's usual year: this credential is pasted
+  // in by hand, so it is more exposed than one held by a service. Every other
+  // duration is still selectable.
+  const openCreateToken = () =>
+    addModal(
+      <CreateServiceAccountTokenModalContainer
+        accountId={serviceAccount?.account_id ?? ''}
+        identity={serviceAccount?.email ?? 'this install stack'}
+        defaultDuration="24h"
+        tokenName={`stack-${installId}`}
+        onCreated={() =>
+          queryClient.invalidateQueries({
+            queryKey: ['stack-service-account', installId],
+          })
+        }
+      />
+    )
+
+  // Derived from the timestamp rather than has_live_token, so the label stays honest
+  // if only one of the two arrives.
+  const liveUntil =
+    serviceAccount?.has_live_token && serviceAccount.expires_at
+      ? new Date(serviceAccount.expires_at).toLocaleString()
+      : null
+
+  // While the app config is still resolving, the snippet renders without the inputs
+  // and secrets blocks rather than blocking the rest of the directions.
+  const { appConfig } = useInstallAppConfig()
+
+  const customerInputs = useMemo(() => {
+    const declared = appConfig?.input?.inputs ?? []
+    const grouped = (appConfig?.input?.input_groups ?? []).flatMap(
+      (group) => group.app_inputs ?? []
+    )
+    const seen = new Set<string>()
+    return [...declared, ...grouped].filter((input) => {
+      if (!input.name || input.source !== 'customer') return false
+      if (seen.has(input.name)) return false
+      seen.add(input.name)
+      return true
+    })
+  }, [appConfig?.input?.inputs, appConfig?.input?.input_groups])
+
+  // Secrets carry no vendor/customer flag: everything not auto-generated is the
+  // customer's to provide.
+  const customerSecrets = useMemo(
+    () =>
+      (appConfig?.secrets?.secrets ?? []).filter(
+        (secret) => !!secret.name && !secret.auto_generate
+      ),
+    [appConfig?.secrets?.secrets]
+  )
+
+  const inputsBlock = useMemo(
+    () => buildInputsBlock(customerInputs),
+    [customerInputs]
+  )
+  const secretsBlock = useMemo(
+    () => buildSecretsBlock(customerSecrets),
+    [customerSecrets]
+  )
+  const secretVariablesBlock = useMemo(
+    () => buildSecretVariablesBlock(customerSecrets),
+    [customerSecrets]
+  )
+  const secretExports = useMemo(
+    () => buildSecretExports(customerSecrets),
+    [customerSecrets]
+  )
+
+  const mainTf = buildMainTf({
+    installId: installId ?? '<install-id>',
+    inputsBlock,
+    secretsBlock,
+    secretVariablesBlock,
+  })
+
+  // Always a placeholder: the token value is shown once, in the create modal.
+  const authCmd = `export NUON_API_TOKEN='<api-token>'`
+  const applyCmd = `terraform init && terraform apply`
+
+  return (
+    <div className="flex flex-col gap-4 pt-4">
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          1. Create your Terraform configuration
+        </Text>
+        <Card>
+          <span className="flex justify-between items-center">
+            <Text>
+              Save this as <code>main.tf</code>
+            </Text>
+            <ClickToCopyButton textToCopy={mainTf} />
+          </span>
+          <Code variant="preformated">{mainTf}</Code>
+        </Card>
+        {secretExports ? (
+          <Card>
+            <span className="flex justify-between items-center">
+              <Text>Export the app&apos;s secret values.</Text>
+              <ClickToCopyButton textToCopy={secretExports} />
+            </span>
+            <Code variant="preformated">{secretExports}</Code>
+          </Card>
+        ) : null}
+      </div>
+
+      <Divider />
+
+      <div className="flex flex-col gap-4">
+        <span className="flex justify-between items-center gap-4">
+          <Text variant="base" weight="strong">
+            2. Authenticate
+          </Text>
+          {OIDC_AUTH_ENABLED ? (
+            <ToggleButton<'token' | 'oidc'>
+              value={authMethod}
+              onChange={setAuthMethod}
+              options={[
+                { value: 'token', label: 'Static token' },
+                { value: 'oidc', label: 'OIDC' },
+              ]}
+            />
+          ) : null}
+        </span>
+        {OIDC_AUTH_ENABLED && authMethod === 'oidc' ? (
+          <OIDCAuthPane
+            installId={installId}
+            policyNames={(trustPolicies ?? [])
+              .map((policy) => policy.name ?? '')
+              .filter(Boolean)}
+          />
+        ) : (
+          <StaticTokenAuthPane
+            authCmd={authCmd}
+            isLoading={isLoading}
+            isError={isError}
+            liveUntil={liveUntil}
+            canCreate={!!serviceAccount?.account_id}
+            onCreateToken={openCreateToken}
+          />
+        )}
+      </div>
+
+      <Divider />
+
+      <div className="flex flex-col gap-4">
+        <Text variant="base" weight="strong">
+          3. Apply
+        </Text>
+        <Card>
+          <span className="flex justify-between items-center">
+            <Text>Initialize the module and create the stack</Text>
+            <ClickToCopyButton textToCopy={applyCmd} />
+          </span>
+          <Code variant="preformated">{applyCmd}</Code>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/tf-module/index.ts
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/tf-module/index.ts
@@ -1,0 +1,2 @@
+export { TFModuleTab } from './TFModuleTab'
+export type { IMainTfParts, ITFModuleTab } from './TFModuleTab'

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/tf-module/snippet.ts
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/tf-module/snippet.ts
@@ -1,0 +1,77 @@
+// Terraform snippet fragments shared by every published stack module's "TF
+// Module" tab. Nothing here is cloud-specific: the module's `inputs`, `secrets`,
+// and the root-level `variable` blocks have the same shape whatever the target,
+// so only the surrounding provider/module block differs per cloud.
+
+const padTo = (name: string, width: number) => name.padEnd(width, ' ')
+
+// `inputs = { ... }`, indented for the module block. The module's `inputs` and
+// `secrets` maps only accept keys the app declares, so the snippet lists exactly the
+// customer-facing ones. Empty when the app declares no customer inputs — the module
+// treats an omitted map as "use control-plane values".
+export const buildInputsBlock = (
+  inputs: Array<{ name?: string; default?: string }>
+): string => {
+  if (inputs.length === 0) return ''
+
+  const nameWidth = Math.max(
+    ...inputs.map((input) => (input.name ?? '').length)
+  )
+  const lines = inputs.map(
+    (input) =>
+      `    ${padTo(input.name ?? '', nameWidth)} = "${input.default ?? ''}"`
+  )
+
+  return `\n\n  inputs = {\n${lines.join('\n')}\n  }`
+}
+
+// `secrets = { ... }`. Auto-generated secrets are minted by the stack itself, so only
+// the customer-supplied ones belong in the snippet. Values come from the root-level
+// `variable` blocks, which Terraform populates from `TF_VAR_*`.
+export const buildSecretsBlock = (
+  secrets: Array<{ name?: string }>
+): string => {
+  if (secrets.length === 0) return ''
+
+  const width = Math.max(...secrets.map((secret) => (secret.name ?? '').length))
+  const lines = secrets.map(
+    (secret) =>
+      `    ${padTo(secret.name ?? '', width)} = { value = var.${secret.name ?? ''} }`
+  )
+
+  return `\n\n  secrets = {\n${lines.join('\n')}\n  }`
+}
+
+// Root-level `variable` blocks for each customer secret. Terraform fills them from
+// `TF_VAR_<name>`, so no real value is ever written to main.tf.
+export const buildSecretVariablesBlock = (
+  secrets: Array<{ name?: string; description?: string }>
+): string => {
+  if (secrets.length === 0) return ''
+
+  const blocks = secrets.map((secret) => {
+    const description = secret.description?.trim()
+    // Widths match what `terraform fmt` would produce for the attributes present.
+    const width = description ? 'description'.length : 'sensitive'.length
+    const attrs = [
+      `  ${padTo('type', width)} = string`,
+      `  ${padTo('sensitive', width)} = true`,
+      ...(description
+        ? [`  ${padTo('description', width)} = "${description}"`]
+        : []),
+    ]
+    return `variable "${secret.name ?? ''}" {\n${attrs.join('\n')}\n}`
+  })
+
+  return `\n\n${blocks.join('\n\n')}`
+}
+
+// `export TF_VAR_<name>='<placeholder>'` lines, shown alongside both auth methods
+// since secrets are needed regardless of how the module authenticates.
+export const buildSecretExports = (secrets: Array<{ name?: string }>): string =>
+  secrets
+    .map(
+      (secret) =>
+        `export TF_VAR_${secret.name ?? ''}='<${(secret.name ?? '').replace(/_/g, '-')}-value>'`
+    )
+    .join('\n')


### PR DESCRIPTION
## Summary

UI and doc updates for adding the GCP stack module alongside the AWS module. The Dashboard will display the same "TF Modue" tab in the "Await install stack" step for GCP, that it currently displays for AWS installs.