### PR TITLE
fix(ctl-api): tag install-registry artifacts by build, not deploy

### DIFF
--- a/services/ctl-api/internal/app/installs/worker/plan/install_registry_tag.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/install_registry_tag.go
@@ -1,0 +1,10 @@
+package plan
+
+import (
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+// Keyed on the build, not the deploy: per-deploy tags grow unbounded on an unchanged manifest and eventually hit the registry's per-manifest tag cap.
+func installRegistryTag(deploy *app.InstallDeploy) string {
+	return deploy.ComponentBuildID
+}

--- a/services/ctl-api/internal/app/installs/worker/plan/install_registry_tag_test.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/install_registry_tag_test.go
@@ -1,0 +1,24 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+func TestInstallRegistryTagIsStableAcrossDeploysOfSameBuild(t *testing.T) {
+	first := &app.InstallDeploy{ID: "dpl1", ComponentBuildID: "bld1"}
+	second := &app.InstallDeploy{ID: "dpl2", ComponentBuildID: "bld1"}
+
+	assert.Equal(t, installRegistryTag(first), installRegistryTag(second))
+	assert.NotEqual(t, first.ID, installRegistryTag(first))
+}
+
+func TestInstallRegistryTagDistinguishesBuilds(t *testing.T) {
+	old := &app.InstallDeploy{ID: "dpl1", ComponentBuildID: "bld1"}
+	rebuilt := &app.InstallDeploy{ID: "dpl2", ComponentBuildID: "bld2"}
+
+	assert.NotEqual(t, installRegistryTag(old), installRegistryTag(rebuilt))
+}

--- a/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/plan_deploy_plan.go
@@ -82,9 +82,9 @@ func (p *Planner) createDeployPlan(ctx workflow.Context, req *CreateDeployPlanRe
 	// immutable identity of the artifact.
 	//
 	// For non-image builds and image builds without SourceDigest, the sync
-	// plan still tags the install-registry copy with the install-deploy ID,
-	// so we fall back to that here.
-	srcTag := deploy.ID
+	// plan tags the install-registry copy with installRegistryTag, so we read
+	// it back under the same tag.
+	srcTag := installRegistryTag(deploy)
 	srcDigest := ""
 	if build.SourceDigest != "" {
 		srcTag = build.SourceDigest

--- a/services/ctl-api/internal/app/installs/worker/plan/workflow_plan_sync_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/plan/workflow_plan_sync_plan.go
@@ -66,11 +66,10 @@ func (p *Planner) createSyncPlan(ctx workflow.Context, req *CreateSyncPlanReques
 
 	// For image-type builds with source-identity recorded, copy the
 	// artifact by digest and tag the install-registry copy with the
-	// resolved tag instead of an internal ID. Fall back to build/deploy ID
-	// tagging for non-image components and image builds without source
-	// identity.
+	// resolved tag instead of an internal ID. Fall back to installRegistryTag
+	// for non-image components and image builds without source identity.
 	srcTag := deploy.ComponentBuildID
-	dstTag := deploy.ID
+	dstTag := installRegistryTag(deploy)
 	if compBuild.SourceDigest != "" {
 		// oras.Copy resolves both tags and digest references, so passing
 		// the manifest digest as the source ref pulls the exact same


### PR DESCRIPTION
Drift scans reuse the deploy path, so every scan creates an install_deploy and tags the install-registry copy with the deploy ID. On an unchanged component that adds a new tag to the same manifest on every run, so a component on a 30 minute drift schedule exhausted the registry's per-manifest tag cap in about 16 days and then failed every scan after that (998 consecutive failures on one install before this was noticed). Tagging by component build instead means repeat deploys of one build reuse a single tag, which is what the image path already does with resolved tags. Verified against a local stack: eight deploys of one build all emitted the same tag, three plan-only runs produced drift verdicts, and a real terraform apply completed through the new tag.