### PR TITLE
fix: preserve ambient auth for legacy Azure stacks

### DIFF
--- a/services/ctl-api/internal/pkg/operation-roles/selector.go
+++ b/services/ctl-api/internal/pkg/operation-roles/selector.go
@@ -444,6 +444,7 @@ func getRoleMap(appCfg *app.AppConfig, stackOutputs app.StackOutput, installStat
 		{appCfg.PermissionsConfig.DeprovisionRole.Name, stackOutputs.DeprovisionRoleID},
 		{appCfg.PermissionsConfig.MaintenanceRole.Name, stackOutputs.MaintenanceRoleID},
 	}
+	allowEmptyStandardRoleIDs := isLegacyAzureStack(stackOutputs)
 
 	for _, r := range standardRoles {
 		rendered, err := render.RenderV2(r.name, stateMap)
@@ -454,15 +455,27 @@ func getRoleMap(appCfg *app.AppConfig, stackOutputs app.StackOutput, installStat
 		if err != nil {
 			return nil, fmt.Errorf("unable to fetch role ID for %q: %w", r.name, err)
 		}
-		// An empty ID means the stack did not create the role — disabled in the
-		// customer's module, or granted no policies. Leaving it out lets
-		// resolveRoleARN return its "please enable it in install stack" error
-		// instead of handing an empty ARN to cloud auth.
-		if roleID == "" {
+		// Modern stacks use an empty ID when the role is disabled or grants no
+		// policies. Legacy Azure stacks predate per-operation identities and use
+		// an empty standard-role ID to select the runner's ambient identity.
+		if roleID == "" && !allowEmptyStandardRoleIDs {
 			continue
 		}
 		availableRoles[rendered] = roleID
 	}
 
 	return availableRoles, nil
+}
+
+func isLegacyAzureStack(stackOutputs app.StackOutput) bool {
+	azureOutputs, ok := stackOutputs.(*app.AzureStackOutputs)
+	if !ok {
+		return false
+	}
+
+	return azureOutputs.ProvisionIdentityClientID == "" &&
+		azureOutputs.MaintenanceIdentityClientID == "" &&
+		azureOutputs.DeprovisionIdentityClientID == "" &&
+		len(azureOutputs.CustomIdentityClientIDs) == 0 &&
+		len(azureOutputs.BreakGlassIdentityClientIDs) == 0
 }

--- a/services/ctl-api/internal/pkg/operation-roles/selector_test.go
+++ b/services/ctl-api/internal/pkg/operation-roles/selector_test.go
@@ -110,6 +110,43 @@ func TestResolveRoleARN(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			name:     "legacy Azure stack uses ambient identity",
+			roleName: "maintenance",
+			appCfg: &app.AppConfig{
+				PermissionsConfig: app.AppPermissionsConfig{
+					ProvisionRole:   app.AppAWSIAMRoleConfig{Name: "provision"},
+					MaintenanceRole: app.AppAWSIAMRoleConfig{Name: "maintenance"},
+					DeprovisionRole: app.AppAWSIAMRoleConfig{Name: "deprovision"},
+				},
+			},
+			stackOutputs: &app.InstallStackOutputs{
+				AzureStackOutputs: &app.AzureStackOutputs{},
+			},
+			installState: installState,
+			expectedARN:  "",
+			expectError:  false,
+		},
+		{
+			name:     "modern Azure stack rejects missing maintenance identity",
+			roleName: "maintenance",
+			appCfg: &app.AppConfig{
+				PermissionsConfig: app.AppPermissionsConfig{
+					ProvisionRole:   app.AppAWSIAMRoleConfig{Name: "provision"},
+					MaintenanceRole: app.AppAWSIAMRoleConfig{Name: "maintenance"},
+					DeprovisionRole: app.AppAWSIAMRoleConfig{Name: "deprovision"},
+				},
+			},
+			stackOutputs: &app.InstallStackOutputs{
+				AzureStackOutputs: &app.AzureStackOutputs{
+					ProvisionIdentityClientID: "provision-client-id",
+				},
+			},
+			installState:  installState,
+			expectedARN:   "",
+			expectError:   true,
+			errorContains: "role maintenance not found in install stack outputs",
+		},
+		{
 			name:     "role found in deprovision role",
 			roleName: "deprovision",
 			appCfg: &app.AppConfig{


### PR DESCRIPTION
## Summary

- restore the existing ambient managed-identity fallback for Azure stacks that predate per-operation identities
- keep empty role identifiers unavailable for AWS, GCP, and modern Azure stacks
- cover both the legacy fallback and the modern fail-closed behavior with regression tests

## Regression

PR #2272 began omitting standard roles with empty identifiers from the available-role map. Legacy Azure stacks intentionally have no per-operation identity client IDs, so role selection previously returned an empty identifier and cloud auth selected the runner ambient identity. Omitting the role makes selection fail before that documented fallback can run.

The legacy check is limited to Azure outputs where every standard, custom, and break-glass identity output is absent. If any per-operation identity output exists, a missing selected role continues to return the enable-it-in-the-install-stack error.

## Test plan

- go test ./services/ctl-api/internal/pkg/operation-roles