### PR TITLE
fix(vcs): stop retrying removed GitHub installations

### DIFF
--- a/services/ctl-api/internal/app/vcs/helpers/client.go
+++ b/services/ctl-api/internal/app/vcs/helpers/client.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"golang.org/x/oauth2"
 )
 
@@ -30,6 +32,13 @@ func (H *Helpers) GetVCSConnectionClient(ctx context.Context, vcsConn *app.VCSCo
 
 	resp, _, err := H.ghClient.Apps.CreateInstallationToken(ctx, installID, &github.InstallationTokenOptions{})
 	if err != nil {
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusNotFound {
+			return nil, stderr.ErrNotFound{
+				Err:         fmt.Errorf("github installation not found: %w", err),
+				Description: "This GitHub installation is no longer available. Reconnect GitHub to restore repository access.",
+			}
+		}
 		return nil, fmt.Errorf("unable to get installation token: %w", err)
 	}
 

--- a/services/ctl-api/internal/app/vcs/helpers/client_test.go
+++ b/services/ctl-api/internal/app/vcs/helpers/client_test.go
@@ -1,0 +1,39 @@
+package helpers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-github/v50/github"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
+)
+
+func TestGetVCSConnectionClientMissingInstallation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/app/installations/123/access_tokens", r.URL.Path)
+		http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	client := github.NewClient(server.Client())
+	baseURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+	client.BaseURL = baseURL
+
+	helpers := &Helpers{ghClient: client}
+	_, err = helpers.GetVCSConnectionClient(context.Background(), &app.VCSConnection{GithubInstallID: "123"})
+
+	var notFoundErr stderr.ErrNotFound
+	require.ErrorAs(t, err, &notFoundErr)
+	var githubErr *github.ErrorResponse
+	require.ErrorAs(t, err, &githubErr)
+	require.Equal(t, http.StatusNotFound, githubErr.Response.StatusCode)
+	require.Equal(t, "This GitHub installation is no longer available. Reconnect GitHub to restore repository access.", notFoundErr.Description)
+}

--- a/services/dashboard-ui/client/hooks/use-vcs-repo-browser.ts
+++ b/services/dashboard-ui/client/hooks/use-vcs-repo-browser.ts
@@ -1,7 +1,13 @@
 import { useState, useEffect } from 'react'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { getVCSConnectionRepos, getConnectionBranches } from '@/lib'
-import type { TVCSConnectionRepo, TVCSBranch } from '@/types'
+import type { TAPIError, TVCSConnectionRepo } from '@/types'
+
+const retryVCSRequest = (failureCount: number, error: TAPIError) => {
+  const status = error?.status
+  if (status && status >= 400 && status < 500) return false
+  return failureCount < 2
+}
 
 export function useVcsRepoBrowser({
   orgId,
@@ -28,7 +34,7 @@ export function useVcsRepoBrowser({
     queryKey: ['vcs-repos', orgId, vcsConnectionId],
     queryFn: () => getVCSConnectionRepos({ orgId, connectionId: vcsConnectionId }),
     enabled: enabled && !!orgId && !!vcsConnectionId,
-    retry: 2,
+    retry: retryVCSRequest,
   })
 
   const repos = reposData?.repositories
@@ -70,7 +76,7 @@ export function useVcsRepoBrowser({
     queryKey: ['vcs-branches', orgId, vcsConnectionId, owner, repoName],
     queryFn: () => getConnectionBranches(orgId, vcsConnectionId, owner!, repoName!),
     enabled: enabled && !!orgId && !!vcsConnectionId && !!owner && !!repoName,
-    retry: 2,
+    retry: retryVCSRequest,
   })
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Removed GitHub App installations now return a client error instead of a server failure. This prevents permanent connection failures from inflating endpoint errors and triggering trace alerts.

## What you can do after this PR

**Avoid retries for permanent connection failures.** Repository and branch requests stop retrying 4xx responses while retaining bounded retries for transient server failures.

**Distinguish removed installations from control-plane failures.** GitHub installation-token 404 responses remain 404 responses through the API rather than being reported as 500 errors.

## What stays the same

Healthy GitHub connections continue loading repositories and branches normally. The dashboard keeps its existing error presentation and does not guess whether a missing resource needs reconnection.
