### PR TITLE
perf: use temporal signals for signal enqueueing instead of updates

### DIFF
--- a/services/ctl-api/internal/pkg/queue/enqueue.go
+++ b/services/ctl-api/internal/pkg/queue/enqueue.go
@@ -11,6 +11,8 @@ import (
 
 const EnqueueUpdateName string = "enqueue"
 
+const EnqueueSignalName string = "enqueue"
+
 const enqueuUpdateType = handlerTypeUpdate
 
 type EnqueueResponse struct {
@@ -30,30 +32,38 @@ type EnqueueHandlerInput struct {
 // @temporal-gen-v2 update
 // @id enqueue
 func (w *queue) enqueueHandler(ctx workflow.Context, input EnqueueHandlerInput) (*EnqueueResponse, error) {
+	if err := w.enqueue(ctx, input); err != nil {
+		return nil, err
+	}
+
+	return &EnqueueResponse{
+		ID:         input.QueueSignalID,
+		WorkflowID: input.WorkflowID,
+	}, nil
+}
+
+func (w *queue) enqueue(ctx workflow.Context, input EnqueueHandlerInput) error {
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := workflow.Await(ctx, func() bool {
 		return w.ready
 	}); err != nil {
-		return nil, errors.Wrap(err, "unable to await for ready")
+		return errors.Wrap(err, "unable to await for ready")
 	}
 
 	w.lastActivityTime = workflow.Now(ctx)
 
 	if len(w.state.QueueRefs) > w.maxDepth {
-		return nil, errors.Errorf("unable to queue item, depth of %d reached", w.maxDepth)
+		return errors.Errorf("unable to queue item, depth of %d reached", w.maxDepth)
 	}
 
 	if w.inFlightSignals[input.QueueSignalID] {
 		l.Info("signal already in-flight via requeueSignals, skipping re-dispatch",
 			zap.String("queue-signal-id", input.QueueSignalID))
-		return &EnqueueResponse{
-			ID:         input.QueueSignalID,
-			WorkflowID: input.WorkflowID,
-		}, nil
+		return nil
 	}
 
 	handlerworkflow.StartHandler(ctx, input.WorkflowID, handlerworkflow.HandlerRequest{
@@ -72,8 +82,41 @@ func (w *queue) enqueueHandler(ctx workflow.Context, input EnqueueHandlerInput) 
 			zap.String("signal-id", input.QueueSignalID))
 	}
 
-	return &EnqueueResponse{
-		ID:         input.QueueSignalID,
-		WorkflowID: input.WorkflowID,
-	}, nil
+	return nil
+}
+
+func (w *queue) startEnqueueSignalLoop(ctx workflow.Context) {
+	sigCh := workflow.GetSignalChannel(ctx, EnqueueSignalName)
+	workflow.Go(ctx, func(gCtx workflow.Context) {
+		l, err := log.WorkflowLogger(gCtx)
+		if err != nil {
+			return
+		}
+		for {
+			var input EnqueueHandlerInput
+			if !sigCh.Receive(gCtx, &input) {
+				return
+			}
+			if err := w.enqueue(gCtx, input); err != nil {
+				l.Warn("unable to enqueue signal from enqueue signal channel",
+					zap.String("queue-signal-id", input.QueueSignalID),
+					zap.Error(err))
+			}
+		}
+	})
+}
+
+// Drained signals are not dispatched — requeueSignals recovers them on the next run.
+func (w *queue) drainEnqueueSignalChannel(ctx workflow.Context, l *zap.Logger) int {
+	sigCh := workflow.GetSignalChannel(ctx, EnqueueSignalName)
+	drained := 0
+	for {
+		var input EnqueueHandlerInput
+		if !sigCh.ReceiveAsync(&input) {
+			return drained
+		}
+		drained++
+		l.Info("draining buffered enqueue signal before run end",
+			zap.String("queue-signal-id", input.QueueSignalID))
+	}
 }

--- a/services/ctl-api/internal/pkg/queue/enqueuer/process_one.go
+++ b/services/ctl-api/internal/pkg/queue/enqueuer/process_one.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	tclient "go.temporal.io/sdk/client"
 	"go.uber.org/zap"
 
 	"github.com/nuonco/nuon/pkg/metrics"
@@ -23,7 +22,7 @@ const (
 )
 
 // EnqueueInline synchronously enqueues a queue signal by performing the
-// UpdateWithStart call inline with the caller. It records enqueue timing
+// SignalWithStart call inline with the caller. It records enqueue timing
 // metadata (including the enqueue source) and marks the signal as enqueued
 // on success.
 func (e *Enqueuer) EnqueueInline(ctx context.Context, queueSignalID string, source string) error {
@@ -46,21 +45,18 @@ func (e *Enqueuer) EnqueueInline(ctx context.Context, queueSignalID string, sour
 	enqueueStart := time.Now().UTC()
 	enqueueStartedAt := enqueueStart.Format(time.RFC3339)
 
-	startOp := e.queueStartOperation(&q)
-	_, err := e.tClient.UpdateWithStartWorkflowInNamespace(ctx, q.Workflow.Namespace, tclient.UpdateWithStartWorkflowOptions{
-		UpdateOptions: tclient.UpdateWorkflowOptions{
-			WorkflowID:   q.Workflow.ID,
-			UpdateName:   queue.EnqueueUpdateName,
-			WaitForStage: tclient.WorkflowUpdateStageAccepted,
-			Args: []any{
-				queue.EnqueueHandlerInput{
-					QueueSignalID: qs.ID,
-					WorkflowID:    qs.Workflow.ID,
-				},
-			},
+	startOpts, wkflowReq := e.queueStartOptions(&q)
+	_, err := e.tClient.SignalWithStartWorkflowInNamespace(ctx, q.Workflow.Namespace,
+		q.Workflow.ID,
+		queue.EnqueueSignalName,
+		queue.EnqueueHandlerInput{
+			QueueSignalID: qs.ID,
+			WorkflowID:    qs.Workflow.ID,
 		},
-		StartWorkflowOperation: startOp,
-	})
+		startOpts,
+		"Queue",
+		wkflowReq,
+	)
 
 	enqueueFinishedAt := time.Now().UTC().Format(time.RFC3339)
 
@@ -96,7 +92,7 @@ func (e *Enqueuer) EnqueueInline(ctx context.Context, queueSignalID string, sour
 		})
 		e.mw.Incr("queue_signals.enqueue", failTags)
 		e.mw.Timing("queue_signals.enqueue.latency", time.Since(enqueueStart), failTags)
-		return errors.Wrap(err, "enqueue UpdateWithStart failed")
+		return errors.Wrap(err, "enqueue SignalWithStart failed")
 	}
 
 	enqueueTags := metrics.ToTags(map[string]string{
@@ -111,7 +107,7 @@ func (e *Enqueuer) EnqueueInline(ctx context.Context, queueSignalID string, sour
 }
 
 // processOne looks up the queue signal and its parent queue, performs the
-// UpdateWithStart call, and marks the signal as enqueued.
+// SignalWithStart call, and marks the signal as enqueued.
 func (e *Enqueuer) processOne(queueSignalID string) {
 	ctx, cancel := context.WithTimeout(e.ctx, processOneTimeout)
 	defer cancel()

--- a/services/ctl-api/internal/pkg/queue/enqueuer/start_operation.go
+++ b/services/ctl-api/internal/pkg/queue/enqueuer/start_operation.go
@@ -12,7 +12,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/taskqueue"
 )
 
-func (e *Enqueuer) queueStartOperation(q *app.Queue) tclient.WithStartWorkflowOperation {
+func (e *Enqueuer) queueStartOptions(q *app.Queue) (tclient.StartWorkflowOptions, queue.QueueWorkflowRequest) {
 	wkflowReq := queue.QueueWorkflowRequest{
 		QueueID: q.ID,
 		Version: e.cfg.Version,
@@ -31,5 +31,5 @@ func (e *Enqueuer) queueStartOperation(q *app.Queue) tclient.WithStartWorkflowOp
 			MaximumAttempts: 0,
 		},
 	}
-	return e.tClient.NewWithStartWorkflowOperation(startOpts, "Queue", wkflowReq)
+	return startOpts, wkflowReq
 }

--- a/services/ctl-api/internal/pkg/queue/run.go
+++ b/services/ctl-api/internal/pkg/queue/run.go
@@ -71,6 +71,9 @@ func (q *queue) run(ctx workflow.Context) (bool, error) {
 		return false, errors.Wrap(err, "unable to start dispatcher")
 	}
 
+	l.Info("starting enqueue signal loop")
+	q.startEnqueueSignalLoop(ctx)
+
 	l.Info("requeuing any remaining signals")
 	if err := q.requeueSignals(ctx); err != nil {
 		return false, errors.Wrap(err, "unable to requeue signals")
@@ -173,6 +176,8 @@ func (q *queue) run(ctx workflow.Context) (bool, error) {
 			zap.Int("active_workers", q.activeWorkers))
 	}
 
+	drained := q.drainEnqueueSignalChannel(ctx, l)
+
 	if q.restarted {
 		q.setStatus(ctx, l, QueueStatusRestarted)
 		return false, nil
@@ -189,7 +194,8 @@ func (q *queue) run(ctx workflow.Context) (bool, error) {
 	}
 
 	// handle idle functionality
-	if q.isIdle(ctx) && q.activeWorkers == 0 {
+	// drained > 0 forces continue-as-new so requeueSignals recovers those signals
+	if q.isIdle(ctx) && q.activeWorkers == 0 && drained == 0 {
 		l.Info("queue is idle, terminating workflow")
 		q.setStatus(ctx, l, QueueStatusIdle)
 		return true, nil


### PR DESCRIPTION
When enqueing large numbers of singnals back to back, when temporal is slow, update request might fail due to busy workflow errors
this creates a retry loop which is resource consuming and can be eleminated with signals / pull based approach where workflow pulls for enqueued
signals. 
Moreover we dont use the output of update handler anywhere so we're not loosing on much, if in future we decide we need outputs of update handler, we
can bring it back. 
