### PR TITLE
feat: (runner) persist customer audit delivery

### DIFF
--- a/bins/runner/build-config.yaml
+++ b/bins/runner/build-config.yaml
@@ -11,8 +11,6 @@ receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.150.0
 
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.150.0
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.150.0
   - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.150.0
 
 exporters:
@@ -20,3 +18,4 @@ exporters:
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.150.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.150.0

--- a/bins/runner/internal/pkg/audit/audit.go
+++ b/bins/runner/internal/pkg/audit/audit.go
@@ -37,8 +37,8 @@ const (
 )
 
 const (
-	AsyncRouteAddress = "127.0.0.1:4318"
-	SyncRouteAddress  = "127.0.0.1:4319"
+	AsyncRouteAddress = "127.0.0.1:14318"
+	SyncRouteAddress  = "127.0.0.1:14319"
 )
 
 var ErrUnavailable = errors.New("customer audit export is unavailable")

--- a/bins/runner/internal/pkg/audit/audit.go
+++ b/bins/runner/internal/pkg/audit/audit.go
@@ -11,8 +11,10 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	otellog "go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 	"go.uber.org/fx"
 
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/otelresource"
 	"github.com/nuonco/nuon/bins/runner/internal/pkg/process"
 	"github.com/nuonco/nuon/pkg/metrics"
 	"github.com/nuonco/nuon/pkg/runner/jobs"
@@ -137,15 +139,21 @@ func New(params Params) (*Writer, error) {
 		shutdownExporter(asyncExporter)
 		return nil, fmt.Errorf("create synchronous customer audit exporter: %w", err)
 	}
-	w := newWriter(processIdentity(params.Registrar.ProcessID(), params.Registrar.ProcessType(), params.Settings), params.Metrics, asyncExporter, syncExporter)
+	w := newWriter(processIdentity(params.Registrar.ProcessID(), params.Registrar.ProcessType(), params.Settings), params.Metrics, asyncExporter, syncExporter, otelresource.New(params.Settings, ""))
 	params.Lifecycle.Append(fx.Hook{
 		OnStop: w.stop,
 	})
 	return w, nil
 }
 
-func newWriter(identity map[string]string, metrics metricsWriter, asyncExporter, syncExporter exporter) *Writer {
-	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(syncProcessor{}))
+func newWriter(identity map[string]string, metrics metricsWriter, asyncExporter, syncExporter exporter, rsrc *sdkresource.Resource) *Writer {
+	if rsrc == nil {
+		rsrc = sdkresource.Empty()
+	}
+	provider := sdklog.NewLoggerProvider(
+		sdklog.WithResource(rsrc),
+		sdklog.WithProcessor(syncProcessor{}),
+	)
 	return &Writer{
 		otel:          provider.Logger("github.com/nuonco/nuon/bins/runner/audit"),
 		identity:      identity,
@@ -361,6 +369,9 @@ func JobEvent(job *models.AppRunnerJob, message, outcome string, attributes map[
 	}
 	for key, value := range attributes {
 		attrs[key] = value
+	}
+	if job.LogStreamID != "" {
+		attrs["log_stream.id"] = job.LogStreamID
 	}
 	return Event{Name: jobEventTypes[job.Group], Message: message, Outcome: outcome, Attributes: attrs}, true
 }

--- a/bins/runner/internal/pkg/audit/audit_test.go
+++ b/bins/runner/internal/pkg/audit/audit_test.go
@@ -11,9 +11,12 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	otellog "go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/otelresource"
 	"github.com/nuonco/nuon/pkg/runner/settings"
 	"github.com/nuonco/nuon/pkg/runner/version"
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/models"
@@ -111,7 +114,7 @@ func TestProcessIdentityUsesRegisteredProcessAndConfiguredImage(t *testing.T) {
 
 func TestWriteSyncWaitsForAcknowledgementAndReturnsErrors(t *testing.T) {
 	syncExporter := new(testExporter)
-	w := newWriter(map[string]string{"runner_process.id": "proc-123"}, nil, new(testExporter), syncExporter)
+	w := newWriter(map[string]string{"runner_process.id": "proc-123"}, nil, new(testExporter), syncExporter, nil)
 	w.enabled = true
 
 	event := Event{Name: "test", Message: "test event", Outcome: OutcomeSucceeded}
@@ -138,7 +141,7 @@ func TestWriteSyncWaitsForAcknowledgementAndReturnsErrors(t *testing.T) {
 
 func TestWriteSyncEnforcesConfiguredTimeout(t *testing.T) {
 	syncExporter := &testExporter{wait: true}
-	w := newWriter(nil, nil, new(testExporter), syncExporter)
+	w := newWriter(nil, nil, new(testExporter), syncExporter, nil)
 	w.enabled = true
 	w.syncTimeout = 10 * time.Millisecond
 
@@ -150,7 +153,7 @@ func TestWriteSyncEnforcesConfiguredTimeout(t *testing.T) {
 
 func TestWriteSyncPropagatesCallerCancellation(t *testing.T) {
 	syncExporter := &testExporter{wait: true}
-	w := newWriter(nil, nil, new(testExporter), syncExporter)
+	w := newWriter(nil, nil, new(testExporter), syncExporter, nil)
 	w.enabled = true
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -164,7 +167,8 @@ func TestWriteSyncPropagatesCallerCancellation(t *testing.T) {
 func TestWriteAsyncSendsToCollector(t *testing.T) {
 	asyncExporter := new(testExporter)
 	syncExporter := new(testExporter)
-	w := newWriter(nil, nil, asyncExporter, syncExporter)
+	rsrc := otelresource.New(&settings.Settings{Metadata: map[string]string{"runner.id": "run-123"}}, "")
+	w := newWriter(nil, nil, asyncExporter, syncExporter, rsrc)
 	w.enabled = true
 	before := time.Now()
 	if err := w.WriteAsync(Event{Name: "test", Message: "queued", Outcome: OutcomeStarted}); err != nil {
@@ -178,6 +182,17 @@ func TestWriteAsyncSendsToCollector(t *testing.T) {
 	}
 	if timestamp := asyncExporter.records[0].Timestamp(); timestamp.Before(before) || timestamp.After(time.Now()) {
 		t.Fatalf("collector record timestamp = %s, want write time", timestamp)
+	}
+	wantResource := map[attribute.Key]string{
+		semconv.ServiceNamespaceKey:  "nuon",
+		semconv.ServiceNameKey:       "runner",
+		semconv.ServiceInstanceIDKey: "run-123",
+	}
+	for key, want := range wantResource {
+		got, ok := asyncExporter.records[0].Resource().Set().Value(key)
+		if !ok || got.AsString() != want {
+			t.Errorf("collector record %s = %q, want %q", key, got.AsString(), want)
+		}
 	}
 }
 
@@ -200,7 +215,7 @@ func TestOTLPWriteSyncWaitsForCollectorResponse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newOTLPExporter() error = %v", err)
 	}
-	w := newWriter(nil, nil, new(testExporter), exp)
+	w := newWriter(nil, nil, new(testExporter), exp, nil)
 	w.enabled = true
 
 	started := time.Now()
@@ -219,7 +234,7 @@ func TestOTLPWriteSyncWaitsForCollectorResponse(t *testing.T) {
 
 func TestEnableEmitsStartupOnce(t *testing.T) {
 	syncExporter := new(testExporter)
-	w := newWriter(map[string]string{"runner_process.id": "proc-123"}, nil, new(testExporter), syncExporter)
+	w := newWriter(map[string]string{"runner_process.id": "proc-123"}, nil, new(testExporter), syncExporter, nil)
 
 	w.Enable()
 	w.Disable()
@@ -231,7 +246,7 @@ func TestEnableEmitsStartupOnce(t *testing.T) {
 
 func TestEnableRetriesStartupAfterFailedExport(t *testing.T) {
 	syncExporter := &testExporter{err: errors.New("collector unavailable")}
-	w := newWriter(map[string]string{"runner_process.id": "proc-123"}, nil, new(testExporter), syncExporter)
+	w := newWriter(map[string]string{"runner_process.id": "proc-123"}, nil, new(testExporter), syncExporter, nil)
 
 	if err := w.Enable(); err == nil {
 		t.Fatal("Enable() returned nil for failed startup export")
@@ -253,7 +268,7 @@ func TestEnableRetriesStartupAfterFailedExport(t *testing.T) {
 func TestLifecycleEnvelopeAndStoppingAreSynchronousAndDeduplicated(t *testing.T) {
 	asyncExporter := new(testExporter)
 	syncExporter := new(testExporter)
-	w := newWriter(map[string]string{"runner_process.id": "proc-123"}, nil, asyncExporter, syncExporter)
+	w := newWriter(map[string]string{"runner_process.id": "proc-123"}, nil, asyncExporter, syncExporter, nil)
 	w.Enable()
 	if err := w.ProcessStopping(context.Background(), "host_shutdown", "systemd_logind"); err != nil {
 		t.Fatalf("ProcessStopping() error = %v", err)
@@ -276,7 +291,7 @@ func TestLifecycleEnvelopeAndStoppingAreSynchronousAndDeduplicated(t *testing.T)
 
 func TestProcessStoppingRetriesAfterFailedExport(t *testing.T) {
 	syncExporter := &testExporter{err: errors.New("collector rejected record")}
-	w := newWriter(nil, nil, new(testExporter), syncExporter)
+	w := newWriter(nil, nil, new(testExporter), syncExporter, nil)
 	w.enabled = true
 
 	if err := w.ProcessStopping(context.Background(), "host_shutdown", "systemd_logind"); err == nil {
@@ -298,7 +313,7 @@ func TestProcessStoppingRetriesAfterFailedExport(t *testing.T) {
 
 func TestProcessStoppingSerializesConcurrentCalls(t *testing.T) {
 	syncExporter := new(testExporter)
-	w := newWriter(nil, nil, new(testExporter), syncExporter)
+	w := newWriter(nil, nil, new(testExporter), syncExporter, nil)
 	w.enabled = true
 
 	const callers = 16
@@ -330,7 +345,7 @@ func TestWritesRecordDeliveryMetrics(t *testing.T) {
 	metrics := new(testMetrics)
 	asyncExporter := new(testExporter)
 	syncExporter := new(testExporter)
-	w := newWriter(nil, metrics, asyncExporter, syncExporter)
+	w := newWriter(nil, metrics, asyncExporter, syncExporter, nil)
 	w.enabled = true
 
 	event := Event{Name: "test", Message: "test event", Outcome: OutcomeSucceeded}
@@ -387,12 +402,13 @@ func TestJobEventPreservesExistingEnvelope(t *testing.T) {
 		CreatedByID:     "acct-123",
 		OrgID:           "org-123",
 		RunnerProcessID: "proc-123",
+		LogStreamID:     "log-123",
 		Metadata:        map[string]string{"install_id": "inst-123"},
 	}, "job execution started", OutcomeStarted, nil)
 	if !ok {
 		t.Fatal("deploy job was not auditable")
 	}
-	if event.Name != "install_deploy" || event.Attributes["user.id"] != "acct-123" || event.Attributes["install.id"] != "inst-123" || event.Attributes["runner_process.id"] != "proc-123" {
+	if event.Name != "install_deploy" || event.Attributes["user.id"] != "acct-123" || event.Attributes["install.id"] != "inst-123" || event.Attributes["runner_process.id"] != "proc-123" || event.Attributes["log_stream.id"] != "log-123" {
 		t.Fatalf("unexpected job audit event: %#v", event)
 	}
 	if _, ok := JobEvent(&models.AppRunnerJob{Group: models.AppRunnerJobGroupBuild}, "ignored", OutcomeStarted, nil); ok {

--- a/bins/runner/internal/pkg/audit/client.go
+++ b/bins/runner/internal/pkg/audit/client.go
@@ -112,6 +112,7 @@ func (c *Client) run(ctx context.Context) {
 			retryAt = time.Time{}
 		case !enabled && (retryAt.IsZero() || !time.Now().Before(retryAt)):
 			if err := c.writer.Enable(); err != nil {
+				// TODO: Support fail-closed job admission and durable async fallback as explicit startup failure modes.
 				c.writer.Disable()
 				retryAt = time.Now().Add(c.retryInterval)
 				c.logger.Warn("customer audit startup event was not acknowledged by the synchronous route",

--- a/bins/runner/internal/pkg/audit/client_test.go
+++ b/bins/runner/internal/pkg/audit/client_test.go
@@ -156,7 +156,7 @@ func TestClientStopsBeforeOwnedRouteLifecycle(t *testing.T) {
 	var order []string
 	var mu sync.Mutex
 	exporter := &orderedExporter{mu: &mu, order: &order}
-	w := newWriter(nil, nil, new(testExporter), exporter)
+	w := newWriter(nil, nil, new(testExporter), exporter, nil)
 	w.enabled = true
 
 	app := fx.New(

--- a/bins/runner/internal/pkg/jobloop/worker.go
+++ b/bins/runner/internal/pkg/jobloop/worker.go
@@ -3,7 +3,6 @@ package jobloop
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	smithytime "github.com/aws/smithy-go/time"
@@ -44,10 +43,12 @@ func (j *jobLoop) runWorker() {
 		l.Info("worker exited cleanly due to drain")
 		return
 	}
+	if j.pollCtx.Err() != nil {
+		return
+	}
 
 	l.Warn("shutting down runner due to closing job loop")
-	os.Exit(155)
-	if err := j.shutdowner.Shutdown(fx.ExitCode(1)); err != nil {
+	if err := j.shutdowner.Shutdown(fx.ExitCode(155)); err != nil {
 		l.Warn("unable to shut down", zap.Error(err))
 	}
 }

--- a/bins/runner/internal/pkg/monitor/check_runner_service.go
+++ b/bins/runner/internal/pkg/monitor/check_runner_service.go
@@ -18,8 +18,10 @@ import (
 
 // NOTE: the process will require ownership of /opt/nuon/runner and its children
 const (
-	ConfigDirectory     = "/opt/nuon/runner"
-	ImageConfigFilename = "/opt/nuon/runner/image"
+	ConfigDirectory                 = "/opt/nuon/runner"
+	ImageConfigFilename             = "/opt/nuon/runner/image"
+	TelemetryExportStorageDirectory = "/opt/nuon/runner/telemetry-export"
+	telemetryExportStorageMount     = TelemetryExportStorageDirectory + ":/var/lib/nuon/telemetry-export"
 )
 
 //go:embed templates/image.env

--- a/bins/runner/internal/pkg/monitor/check_runner_service_test.go
+++ b/bins/runner/internal/pkg/monitor/check_runner_service_test.go
@@ -1,0 +1,26 @@
+package monitor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunnerServiceTemplatesPersistTelemetryExportStorage(t *testing.T) {
+	for platform, service := range map[string]string{
+		"aws":   runnerServiceAWS,
+		"azure": runnerServiceAzure,
+		"gcp":   runnerServiceGCP,
+	} {
+		t.Run(platform, func(t *testing.T) {
+			if !strings.Contains(service, telemetryExportStorageMount) {
+				t.Fatalf("runner service does not mount persistent telemetry storage: %s", service)
+			}
+			if !strings.Contains(service, "install -d -m 0700 "+TelemetryExportStorageDirectory) {
+				t.Fatalf("runner service does not create protected telemetry storage: %s", service)
+			}
+			if strings.Contains(service, "find "+TelemetryExportStorageDirectory) {
+				t.Fatalf("runner service cleanup removes telemetry storage: %s", service)
+			}
+		})
+	}
+}

--- a/bins/runner/internal/pkg/monitor/templates/runner-service.aws.service
+++ b/bins/runner/internal/pkg/monitor/templates/runner-service.aws.service
@@ -10,8 +10,9 @@ ExecStartPre=-/bin/sh -c "/usr/bin/docker stop $(/usr/bin/docker ps -a -q --filt
 ExecStartPre=-/bin/sh -c "/usr/bin/docker rm   $(/usr/bin/docker ps -a -q --filter=\"name=%n\")"
 EnvironmentFile=/opt/nuon/runner/image
 EnvironmentFile=/opt/nuon/runner/env
+ExecStartPre=+/usr/bin/install -d -m 0700 /opt/nuon/runner/telemetry-export
 ExecStartPre=/usr/bin/docker pull ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG}
-ExecStart=/usr/bin/docker run --network host --volume /tmp/nuon-runner:/tmp --rm --name %n --memory "3750g" --cpus="1.75" --env-file /opt/nuon/runner/env --log-driver=awslogs --log-opt awslogs-region=${AWS_REGION} --log-opt awslogs-group=runner-${RUNNER_ID} ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG} install
+ExecStart=/usr/bin/docker run --network host --volume /tmp/nuon-runner:/tmp --volume /opt/nuon/runner/telemetry-export:/var/lib/nuon/telemetry-export --rm --name %n --memory "3750g" --cpus="1.75" --env-file /opt/nuon/runner/env --log-driver=awslogs --log-opt awslogs-region=${AWS_REGION} --log-opt awslogs-group=runner-${RUNNER_ID} ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG} install
 ExecStopPost=-+/usr/bin/find /tmp/nuon-runner -mindepth 1 -delete
 ExecStopPost=-/bin/sh -c "/usr/bin/docker rmi $(/usr/bin/docker images -a -q)"
 ExecStopPost=-/bin/sh -c "yes | /usr/bin/docker system prune -a"

--- a/bins/runner/internal/pkg/monitor/templates/runner-service.azure.service
+++ b/bins/runner/internal/pkg/monitor/templates/runner-service.azure.service
@@ -10,8 +10,9 @@ ExecStartPre=-/bin/sh -c "/usr/bin/docker stop $(/usr/bin/docker ps -a -q --filt
 ExecStartPre=-/bin/sh -c "/usr/bin/docker rm   $(/usr/bin/docker ps -a -q --filter=\"name=%n\")"
 EnvironmentFile=/opt/nuon/runner/image
 EnvironmentFile=/opt/nuon/runner/env
+ExecStartPre=+/usr/bin/install -d -m 0700 /opt/nuon/runner/telemetry-export
 ExecStartPre=/usr/bin/docker pull ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG}
-ExecStart=/usr/bin/docker run --network host --volume /tmp/nuon-runner:/tmp --rm --name %n --memory "3750g" --cpus="1.75" --env-file /opt/nuon/runner/env ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG} install
+ExecStart=/usr/bin/docker run --network host --volume /tmp/nuon-runner:/tmp --volume /opt/nuon/runner/telemetry-export:/var/lib/nuon/telemetry-export --rm --name %n --memory "3750g" --cpus="1.75" --env-file /opt/nuon/runner/env ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG} install
 ExecStopPost=-+/usr/bin/find /tmp/nuon-runner -mindepth 1 -delete
 ExecStopPost=-/bin/sh -c "/usr/bin/docker rmi $(/usr/bin/docker images -a -q)"
 ExecStopPost=-/bin/sh -c "yes | /usr/bin/docker system prune -a"

--- a/bins/runner/internal/pkg/monitor/templates/runner-service.gcp.service
+++ b/bins/runner/internal/pkg/monitor/templates/runner-service.gcp.service
@@ -10,8 +10,9 @@ ExecStartPre=-/bin/sh -c "/usr/bin/docker stop $(/usr/bin/docker ps -a -q --filt
 ExecStartPre=-/bin/sh -c "/usr/bin/docker rm   $(/usr/bin/docker ps -a -q --filter=\"name=%n\")"
 EnvironmentFile=/opt/nuon/runner/image
 EnvironmentFile=/opt/nuon/runner/env
+ExecStartPre=+/usr/bin/install -d -m 0700 /opt/nuon/runner/telemetry-export
 ExecStartPre=/usr/bin/docker pull ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG}
-ExecStart=/usr/bin/docker run --network host --volume /tmp/nuon-runner:/tmp --rm --name %n --memory "3750m" --cpus="1.75" --env-file /opt/nuon/runner/env ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG} install
+ExecStart=/usr/bin/docker run --network host --volume /tmp/nuon-runner:/tmp --volume /opt/nuon/runner/telemetry-export:/var/lib/nuon/telemetry-export --rm --name %n --memory "3750m" --cpus="1.75" --env-file /opt/nuon/runner/env ${CONTAINER_IMAGE_URL}:${CONTAINER_IMAGE_TAG} install
 ExecStopPost=-+/usr/bin/find /tmp/nuon-runner -mindepth 1 -delete
 ExecStopPost=-/bin/sh -c "/usr/bin/docker rmi $(/usr/bin/docker images -a -q)"
 ExecStopPost=-/bin/sh -c "yes | /usr/bin/docker system prune -a"

--- a/bins/runner/internal/pkg/otelresource/resource.go
+++ b/bins/runner/internal/pkg/otelresource/resource.go
@@ -1,4 +1,4 @@
-package slog
+package otelresource
 
 import (
 	"github.com/nuonco/nuon/pkg/generics"
@@ -10,7 +10,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
-func getResource(set *settings.Settings, logStreamID string) *resource.Resource {
+func New(set *settings.Settings, logStreamID string) *resource.Resource {
 	attrs := []attribute.KeyValue{}
 	builtInAttrs := map[string]string{
 		string(semconv.ServiceNamespaceKey): "nuon",

--- a/bins/runner/internal/pkg/otelresource/resource_test.go
+++ b/bins/runner/internal/pkg/otelresource/resource_test.go
@@ -1,4 +1,4 @@
-package slog
+package otelresource
 
 import (
 	"testing"
@@ -16,7 +16,7 @@ func TestResourceIncludesNuonServiceIdentity(t *testing.T) {
 		"service.name":      "overridden",
 		"service.namespace": "overridden",
 	}}
-	rsrc := getResource(set, "log123")
+	rsrc := New(set, "log123")
 
 	want := map[attribute.Key]string{
 		semconv.ServiceNamespaceKey:    "nuon",
@@ -34,7 +34,7 @@ func TestResourceIncludesNuonServiceIdentity(t *testing.T) {
 }
 
 func TestResourceOmitsEmptyServiceInstanceID(t *testing.T) {
-	rsrc := getResource(&settings.Settings{Metadata: map[string]string{}}, "")
+	rsrc := New(&settings.Settings{Metadata: map[string]string{}}, "")
 	if _, ok := rsrc.Set().Value(semconv.ServiceInstanceIDKey); ok {
 		t.Fatal("empty service.instance.id was included")
 	}

--- a/bins/runner/internal/pkg/slog/otel.go
+++ b/bins/runner/internal/pkg/slog/otel.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/sdk/log"
 
+	"github.com/nuonco/nuon/bins/runner/internal/pkg/otelresource"
 	runnerconfig "github.com/nuonco/nuon/pkg/runner/config"
 	"github.com/nuonco/nuon/pkg/runner/settings"
 )
@@ -18,7 +19,7 @@ const (
 
 func NewOTELProvider(cfg *runnerconfig.Config, set *settings.Settings, logStreamID string) (*log.LoggerProvider, error) {
 	opts := []log.LoggerProviderOption{
-		log.WithResource(getResource(set, logStreamID)),
+		log.WithResource(otelresource.New(set, logStreamID)),
 	}
 
 	if set.EnableLogging {

--- a/bins/runner/internal/pkg/telemetryexport/config.go
+++ b/bins/runner/internal/pkg/telemetryexport/config.go
@@ -19,11 +19,15 @@ import (
 var headerNamePattern = regexp.MustCompile(`^[!#$%&'*+.^_` + "`" + `|~0-9A-Za-z-]+$`)
 
 const (
-	configVersionV1 = "v1"
-	maxSecretSize   = 64 * 1024
-	maxEndpointLen  = 4096
-	maxHeaders      = 32
-	maxHeaderLen    = 4096
+	configVersionV1        = "v1"
+	fileStorageExtensionID = "file_storage/audit"
+	collectorStorageDir    = "/var/lib/nuon/telemetry-export"
+	auditQueueSize         = 10_000
+	auditQueueConsumers    = 2
+	maxSecretSize          = 64 * 1024
+	maxEndpointLen         = 4096
+	maxHeaders             = 32
+	maxHeaderLen           = 4096
 )
 
 type configEnvelope struct {
@@ -140,13 +144,17 @@ func validateOTLPHTTPExporter(exporter otlpHTTPExporter) error {
 
 func collectorConfig(cfg config) ([]byte, []string, error) {
 	pipelines := make(map[string]any)
+	extensions := map[string]any{"health_check": map[string]any{"endpoint": "127.0.0.1:13133"}}
+	serviceExtensions := []string{"health_check"}
+	service := map[string]any{
+		"extensions": serviceExtensions,
+		"pipelines":  pipelines,
+		// TODO: Export Collector queue and delivery metrics through the operator telemetry pipeline for alerting.
+		"telemetry": map[string]any{"logs": map[string]any{"level": "warn"}},
+	}
 	document := map[string]any{
-		"extensions": map[string]any{"health_check": map[string]any{"endpoint": "127.0.0.1:13133"}},
-		"service": map[string]any{
-			"extensions": []string{"health_check"},
-			"pipelines":  pipelines,
-			"telemetry":  map[string]any{"logs": map[string]any{"level": "warn"}},
-		},
+		"extensions": extensions,
+		"service":    service,
 	}
 	if !cfg.AuditLogsEnabled {
 		contents, err := yaml.Marshal(document)
@@ -167,24 +175,30 @@ func collectorConfig(cfg config) ([]byte, []string, error) {
 		headers[name] = "${env:" + envName + "}"
 		environment = append(environment, envName+"="+value)
 	}
+	extensions[fileStorageExtensionID] = map[string]any{
+		"directory":             collectorStorageDir,
+		"create_directory":      true,
+		"directory_permissions": "0700",
+		"fsync":                 true,
+		"compaction": map[string]any{
+			"on_rebound":       true,
+			"directory":        collectorStorageDir,
+			"cleanup_on_start": true,
+		},
+	}
+	service["extensions"] = append(serviceExtensions, fileStorageExtensionID)
 	document["receivers"] = map[string]any{
 		"otlp/async": map[string]any{"protocols": map[string]any{"http": map[string]any{"endpoint": audit.AsyncRouteAddress}}},
 		"otlp/sync":  map[string]any{"protocols": map[string]any{"http": map[string]any{"endpoint": audit.SyncRouteAddress}}},
 	}
 	document["processors"] = map[string]any{
 		"memory_limiter": map[string]any{"check_interval": "1s", "limit_mib": 128, "spike_limit_mib": 32},
-		"filter/audit": map[string]any{
-			"error_mode": "ignore",
-			"logs": map[string]any{
-				"log_record": []string{`attributes["nuon.audit"] != "true"`},
-			},
-		},
 	}
 	document["exporters"] = map[string]any{
 		"otlp_http/async": map[string]any{
 			"endpoint": cfg.OTLPHTTP.Endpoint, "headers": headers, "compression": "gzip",
-			"sending_queue":    map[string]any{"enabled": true, "queue_size": 1000, "num_consumers": 2},
-			"retry_on_failure": map[string]any{"enabled": true, "initial_interval": "1s", "max_interval": "30s", "max_elapsed_time": "5m"},
+			"sending_queue":    map[string]any{"enabled": true, "queue_size": auditQueueSize, "num_consumers": auditQueueConsumers, "storage": fileStorageExtensionID, "block_on_overflow": false},
+			"retry_on_failure": map[string]any{"enabled": true, "initial_interval": "1s", "max_interval": "30s", "max_elapsed_time": "0s"},
 		},
 		"otlp_http/sync": map[string]any{
 			"endpoint": cfg.OTLPHTTP.Endpoint, "headers": headers, "compression": "gzip", "timeout": audit.SyncExportTimeout.String(),
@@ -192,8 +206,8 @@ func collectorConfig(cfg config) ([]byte, []string, error) {
 			"retry_on_failure": map[string]any{"enabled": false},
 		},
 	}
-	pipelines["logs/audit_async"] = map[string]any{"receivers": []string{"otlp/async"}, "processors": []string{"memory_limiter", "filter/audit"}, "exporters": []string{"otlp_http/async"}}
-	pipelines["logs/audit_sync"] = map[string]any{"receivers": []string{"otlp/sync"}, "processors": []string{"memory_limiter", "filter/audit"}, "exporters": []string{"otlp_http/sync"}}
+	pipelines["logs/audit_async"] = map[string]any{"receivers": []string{"otlp/async"}, "processors": []string{"memory_limiter"}, "exporters": []string{"otlp_http/async"}}
+	pipelines["logs/audit_sync"] = map[string]any{"receivers": []string{"otlp/sync"}, "processors": []string{"memory_limiter"}, "exporters": []string{"otlp_http/sync"}}
 
 	contents, err := yaml.Marshal(document)
 	return contents, environment, err

--- a/bins/runner/internal/pkg/telemetryexport/config_test.go
+++ b/bins/runner/internal/pkg/telemetryexport/config_test.go
@@ -3,6 +3,7 @@ package telemetryexport
 import (
 	"encoding/base64"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -119,22 +120,36 @@ func TestCollectorConfigKeepsHeaderValuesOutOfFile(t *testing.T) {
 	if len(environment) != 1 || !strings.HasSuffix(environment[0], "=super-secret-value") {
 		t.Fatalf("unexpected child environment: %q", environment)
 	}
-	for _, component := range []string{"127.0.0.1:4318", "127.0.0.1:4319", "logs/audit_async:", "logs/audit_sync:", "otlp_http/async:", "otlp_http/sync:"} {
+	for _, component := range []string{audit.AsyncRouteAddress, audit.SyncRouteAddress, "logs/audit_async:", "logs/audit_sync:", "otlp_http/async:", "otlp_http/sync:"} {
 		if !strings.Contains(string(contents), component) {
 			t.Fatalf("generated collector configuration lacks %q", component)
 		}
 	}
-	if !strings.Contains(string(contents), `attributes["nuon.audit"] != "true"`) {
-		t.Fatal("generated collector configuration does not filter non-audit logs")
-	}
-	if !strings.Contains(string(contents), "- filter/audit") {
-		t.Fatal("generated collector pipeline does not use the audit filter")
+	for _, standardOTLPEndpoint := range []string{"127.0.0.1:4317", "127.0.0.1:4318"} {
+		if strings.Contains(string(contents), standardOTLPEndpoint) {
+			t.Fatalf("generated audit collector configuration uses standard OTLP endpoint %q", standardOTLPEndpoint)
+		}
 	}
 	var generated struct {
+		Extensions map[string]struct {
+			Directory            string `yaml:"directory"`
+			CreateDirectory      bool   `yaml:"create_directory"`
+			DirectoryPermissions string `yaml:"directory_permissions"`
+			Fsync                bool   `yaml:"fsync"`
+			Compaction           struct {
+				OnRebound      bool   `yaml:"on_rebound"`
+				Directory      string `yaml:"directory"`
+				CleanupOnStart bool   `yaml:"cleanup_on_start"`
+			} `yaml:"compaction"`
+		} `yaml:"extensions"`
 		Exporters map[string]struct {
 			Timeout      string `yaml:"timeout"`
 			SendingQueue struct {
-				Enabled bool `yaml:"enabled"`
+				Enabled         bool   `yaml:"enabled"`
+				QueueSize       int    `yaml:"queue_size"`
+				NumConsumers    int    `yaml:"num_consumers"`
+				Storage         string `yaml:"storage"`
+				BlockOnOverflow bool   `yaml:"block_on_overflow"`
 			} `yaml:"sending_queue"`
 			Retry struct {
 				Enabled         bool   `yaml:"enabled"`
@@ -143,13 +158,23 @@ func TestCollectorConfigKeepsHeaderValuesOutOfFile(t *testing.T) {
 				MaxElapsedTime  string `yaml:"max_elapsed_time"`
 			} `yaml:"retry_on_failure"`
 		} `yaml:"exporters"`
+		Service struct {
+			Extensions []string `yaml:"extensions"`
+		} `yaml:"service"`
 	}
 	if err := yaml.Unmarshal(contents, &generated); err != nil {
 		t.Fatal(err)
 	}
 	async := generated.Exporters["otlp_http/async"]
-	if !async.SendingQueue.Enabled || !async.Retry.Enabled || async.Retry.InitialInterval != "1s" || async.Retry.MaxInterval != "30s" || async.Retry.MaxElapsedTime != "5m" {
+	if !async.SendingQueue.Enabled || async.SendingQueue.QueueSize != auditQueueSize || async.SendingQueue.NumConsumers != auditQueueConsumers || async.SendingQueue.Storage != fileStorageExtensionID || async.SendingQueue.BlockOnOverflow || !async.Retry.Enabled || async.Retry.InitialInterval != "1s" || async.Retry.MaxInterval != "30s" || async.Retry.MaxElapsedTime != "0s" {
 		t.Fatalf("asynchronous exporter does not queue and retry: %#v", async)
+	}
+	storage := generated.Extensions[fileStorageExtensionID]
+	if storage.Directory != collectorStorageDir || !storage.CreateDirectory || storage.DirectoryPermissions != "0700" || !storage.Fsync || !storage.Compaction.OnRebound || storage.Compaction.Directory != collectorStorageDir || !storage.Compaction.CleanupOnStart {
+		t.Fatalf("asynchronous exporter storage is not durable: %#v", storage)
+	}
+	if !slices.Contains(generated.Service.Extensions, fileStorageExtensionID) {
+		t.Fatalf("file storage extension is not enabled by the collector service: %q", generated.Service.Extensions)
 	}
 	sync := generated.Exporters["otlp_http/sync"]
 	if sync.SendingQueue.Enabled || sync.Retry.Enabled || sync.Timeout != audit.SyncExportTimeout.String() {
@@ -176,7 +201,7 @@ func TestCollectorConfigOmitsAuditPipelineWhenDisabled(t *testing.T) {
 	if !strings.Contains(config, "health_check:") || !strings.Contains(config, "pipelines: {}") {
 		t.Fatalf("generated collector configuration does not contain an empty service: %s", config)
 	}
-	for _, unexpected := range []string{"127.0.0.1:4318", "127.0.0.1:4319", "logs/audit_async:", "logs/audit_sync:", "filter/audit:", "otlp_http/async:", "otlp_http/sync:"} {
+	for _, unexpected := range []string{audit.AsyncRouteAddress, audit.SyncRouteAddress, "logs/audit_async:", "logs/audit_sync:", "otlp_http/async:", "otlp_http/sync:", fileStorageExtensionID, collectorStorageDir} {
 		if strings.Contains(config, unexpected) {
 			t.Fatalf("generated collector configuration contains disabled audit component %q", unexpected)
 		}

--- a/bins/runner/internal/pkg/telemetryexport/telemetryexport.go
+++ b/bins/runner/internal/pkg/telemetryexport/telemetryexport.go
@@ -49,6 +49,8 @@ type Supervisor struct {
 	mu               sync.Mutex
 	child            *childProcess
 	active           string
+	rejectedConfig   string
+	restartConfig    string
 	backoff          time.Duration
 	nextStart        time.Time
 	reported         bool
@@ -146,25 +148,41 @@ func (s *Supervisor) reconcile(update configUpdate) {
 	}
 	value := update.value
 	if value == s.active {
+		s.rejectedConfig = ""
+		return
+	}
+	if value == s.rejectedConfig {
+		return
+	}
+	if value == s.restartConfig {
 		return
 	}
 	cfg, err := parseSecret(value)
 	if err != nil {
+		s.rejectedConfig = value
 		s.logger.Warn("telemetry export configuration is invalid")
 		return
 	}
 	if err := s.replaceChildFn(cfg); err != nil {
 		s.logger.Warn("telemetry export collector failed to start")
 		if s.active != "" {
+			s.rejectedConfig = value
 			if previous, parseErr := parseSecret(s.active); parseErr == nil {
 				if rollbackErr := s.replaceChildFn(previous); rollbackErr != nil {
-					s.nextStart = time.Now().Add(s.backoff)
+					s.scheduleRestart(s.active)
+				} else {
+					s.restartConfig = ""
+					s.nextStart = time.Time{}
 				}
 			}
+		} else {
+			s.scheduleRestart(value)
 		}
 		return
 	}
 	s.active = value
+	s.rejectedConfig = ""
+	s.restartConfig = ""
 	s.backoff = time.Second
 	s.nextStart = time.Time{}
 	s.logEnabled(cfg)
@@ -173,6 +191,8 @@ func (s *Supervisor) reconcile(update configUpdate) {
 func (s *Supervisor) disable(reason string) {
 	s.stopChildFn()
 	s.active = ""
+	s.rejectedConfig = ""
+	s.restartConfig = ""
 	s.nextStart = time.Time{}
 	if !s.reported || s.collectorEnabled {
 		s.logger.Info("runner telemetry export collector disabled",
@@ -308,14 +328,14 @@ func (s *Supervisor) restartCrashed(_ context.Context) {
 			if time.Since(child.startedAt) >= 30*time.Second {
 				s.backoff = time.Second
 			}
-			s.nextStart = time.Now().Add(s.backoff)
+			s.scheduleRestart(s.active)
 		default:
 		}
 	}
-	if s.active == "" || s.nextStart.IsZero() || time.Now().Before(s.nextStart) {
+	if s.restartConfig == "" || s.nextStart.IsZero() || time.Now().Before(s.nextStart) {
 		return
 	}
-	cfg, err := parseSecret(s.active)
+	cfg, err := parseSecret(s.restartConfig)
 	if err != nil {
 		return
 	}
@@ -330,7 +350,15 @@ func (s *Supervisor) restartCrashed(_ context.Context) {
 		s.logger.Warn("telemetry export collector restart failed")
 		return
 	}
+	s.active = s.restartConfig
+	s.restartConfig = ""
 	s.nextStart = time.Time{}
+	s.logEnabled(cfg)
+}
+
+func (s *Supervisor) scheduleRestart(value string) {
+	s.restartConfig = value
+	s.nextStart = time.Now().Add(s.backoff)
 }
 
 func childEnvironment(secretHeaders []string) []string {

--- a/bins/runner/internal/pkg/telemetryexport/telemetryexport_test.go
+++ b/bins/runner/internal/pkg/telemetryexport/telemetryexport_test.go
@@ -67,8 +67,12 @@ func TestReconcilePreservesLastKnownGoodConfiguration(t *testing.T) {
 	}
 
 	s.reconcile(configUpdate{state: configAvailable, value: invalid})
-	if replacements != 0 || stops != 0 || s.active != valid {
+	if replacements != 0 || stops != 0 || s.active != valid || s.rejectedConfig != invalid {
 		t.Fatal("invalid update changed the active collector")
+	}
+	s.reconcile(configUpdate{state: configAvailable, value: invalid})
+	if replacements != 0 || stops != 0 {
+		t.Fatal("unchanged invalid update was retried")
 	}
 
 	s.reconcile(configUpdate{state: configLookupFailed, err: errors.New("temporary failure")})
@@ -97,7 +101,7 @@ func TestReconcileAppliesChangedValidConfigurationOnce(t *testing.T) {
 
 	s.reconcile(configUpdate{state: configAvailable, value: valid})
 	s.reconcile(configUpdate{state: configAvailable, value: valid})
-	if replacements != 1 || s.active != valid {
+	if replacements != 1 || s.active != valid || s.rejectedConfig != "" {
 		t.Fatal("valid configuration was not applied exactly once")
 	}
 }
@@ -117,8 +121,51 @@ func TestReconcileSchedulesRestartWhenUpdateAndRollbackFail(t *testing.T) {
 	}
 
 	s.reconcile(configUpdate{state: configAvailable, value: updated})
-	if s.nextStart.IsZero() || s.active != current {
+	if s.nextStart.IsZero() || s.active != current || s.rejectedConfig != updated || s.restartConfig != current {
 		t.Fatal("failed rollback did not schedule recovery of the last-known-good configuration")
+	}
+}
+
+func TestReconcileSchedulesRestartAfterInitialStartFailure(t *testing.T) {
+	value := auditEnabledConfig("https://otlp.example.com")
+	attempts := 0
+	s := &Supervisor{
+		installID: "inst-test",
+		logger:    zap.NewNop(),
+		backoff:   time.Second,
+		replaceChildFn: func(config) error {
+			attempts++
+			return errors.New("start failed")
+		},
+		stopChildFn: func() {},
+	}
+
+	s.reconcile(configUpdate{state: configAvailable, value: value})
+	s.reconcile(configUpdate{state: configAvailable, value: value})
+	if attempts != 1 || s.active != "" || s.restartConfig != value || s.nextStart.IsZero() {
+		t.Fatalf("initial failure did not schedule restart: active=%q restart=%q next=%s", s.active, s.restartConfig, s.nextStart)
+	}
+}
+
+func TestRestartActivatesPendingConfiguration(t *testing.T) {
+	value := auditEnabledConfig("https://otlp.example.com")
+	restarts := 0
+	s := &Supervisor{
+		installID:     "inst-test",
+		logger:        zap.NewNop(),
+		restartConfig: value,
+		nextStart:     time.Now().Add(-time.Second),
+		backoff:       time.Second,
+		replaceChildFn: func(config) error {
+			restarts++
+			return nil
+		},
+		stopChildFn: func() {},
+	}
+
+	s.restartCrashed(context.Background())
+	if restarts != 1 || s.active != value || s.restartConfig != "" || !s.nextStart.IsZero() || !s.collectorEnabled {
+		t.Fatalf("pending configuration was not activated: restarts=%d active=%q pending=%q next=%s enabled=%t", restarts, s.active, s.restartConfig, s.nextStart, s.collectorEnabled)
 	}
 }
 
@@ -142,8 +189,35 @@ func TestReconcileFailedUpdateRestoresLastKnownGoodCollector(t *testing.T) {
 	}
 
 	s.reconcile(configUpdate{state: configAvailable, value: updated})
-	if s.active != current || len(endpoints) != 2 || endpoints[0] != "https://updated.example.com" || endpoints[1] != "https://current.example.com" {
+	s.reconcile(configUpdate{state: configAvailable, value: updated})
+	if s.active != current || s.rejectedConfig != updated || len(endpoints) != 2 || endpoints[0] != "https://updated.example.com" || endpoints[1] != "https://current.example.com" {
 		t.Fatalf("failed update did not restore the active collector: active=%q endpoints=%q", s.active, endpoints)
+	}
+}
+
+func TestReconcileRetriesRejectedConfigurationAfterSecretChanges(t *testing.T) {
+	current := auditEnabledConfig("https://current.example.com")
+	rejected := auditEnabledConfig("https://rejected.example.com")
+	corrected := auditEnabledConfig("https://corrected.example.com")
+	var endpoints []string
+	s := &Supervisor{
+		installID: "inst-test",
+		logger:    zap.NewNop(),
+		active:    current,
+		replaceChildFn: func(cfg config) error {
+			endpoints = append(endpoints, cfg.OTLPHTTP.Endpoint)
+			if cfg.OTLPHTTP.Endpoint == "https://rejected.example.com" {
+				return errors.New("start failed")
+			}
+			return nil
+		},
+		stopChildFn: func() {},
+	}
+
+	s.reconcile(configUpdate{state: configAvailable, value: rejected})
+	s.reconcile(configUpdate{state: configAvailable, value: corrected})
+	if s.active != corrected || s.rejectedConfig != "" || len(endpoints) != 3 {
+		t.Fatalf("changed secret did not replace a rejected configuration: active=%q rejected=%q endpoints=%q", s.active, s.rejectedConfig, endpoints)
 	}
 }
 
@@ -154,13 +228,16 @@ func TestReconcileDisablesUnavailableSecret(t *testing.T) {
 		installID:        "inst-test",
 		logger:           zap.NewNop(),
 		active:           valid,
+		rejectedConfig:   "rejected",
+		restartConfig:    valid,
+		nextStart:        time.Now().Add(time.Minute),
 		collectorEnabled: true,
 		reported:         true,
 		stopChildFn:      func() { stops++ },
 	}
 
 	s.reconcile(configUpdate{state: configUnavailable})
-	if stops != 1 || s.active != "" || s.collectorEnabled {
+	if stops != 1 || s.active != "" || s.rejectedConfig != "" || s.restartConfig != "" || !s.nextStart.IsZero() || s.collectorEnabled {
 		t.Fatal("unavailable secret did not disable the collector")
 	}
 }
@@ -174,6 +251,7 @@ func TestReconcileKeepsCollectorWithoutAuditPipeline(t *testing.T) {
 		installID:        "inst-test",
 		logger:           zap.NewNop(),
 		active:           active,
+		restartConfig:    active,
 		nextStart:        time.Now().Add(time.Minute),
 		collectorEnabled: true,
 		reported:         true,
@@ -185,7 +263,7 @@ func TestReconcileKeepsCollectorWithoutAuditPipeline(t *testing.T) {
 	}
 
 	s.reconcile(configUpdate{state: configAvailable, value: disabledAudit})
-	if replacements != 1 || stops != 0 || s.active != disabledAudit || !s.nextStart.IsZero() || !s.collectorEnabled {
+	if replacements != 1 || stops != 0 || s.active != disabledAudit || s.restartConfig != "" || !s.nextStart.IsZero() || !s.collectorEnabled {
 		t.Fatal("disabled audit logs did not leave the collector running without the audit pipeline")
 	}
 }

--- a/bins/runner/internal/registry/lifecycle.go
+++ b/bins/runner/internal/registry/lifecycle.go
@@ -2,10 +2,12 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"log"
+	"net/http"
 
 	"go.uber.org/fx"
+	"go.uber.org/zap"
 )
 
 func (s *Registry) LifecycleHook() fx.Hook {
@@ -13,8 +15,11 @@ func (s *Registry) LifecycleHook() fx.Hook {
 		// start the background loop to update the settings
 		OnStart: func(ctx context.Context) error {
 			s.wg.Go(func() {
-				if err := s.ListenAndServe(); err != nil {
-					log.Fatal(err)
+				if err := s.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+					s.l.Error("embedded registry stopped unexpectedly", zap.Error(err))
+					if err := s.shutdown.Shutdown(fx.ExitCode(1)); err != nil {
+						s.l.Warn("unable to request runner shutdown", zap.Error(err))
+					}
 				}
 			})
 

--- a/bins/runner/internal/registry/registry.go
+++ b/bins/runner/internal/registry/registry.go
@@ -8,6 +8,7 @@ import (
 	ociregistry "github.com/distribution/distribution/v3/registry"
 	"github.com/sourcegraph/conc"
 	"go.uber.org/fx"
+	"go.uber.org/zap"
 
 	runnerconfig "github.com/nuonco/nuon/pkg/runner/config"
 )
@@ -15,16 +16,20 @@ import (
 type Params struct {
 	fx.In
 
-	LC  fx.Lifecycle
-	Cfg *runnerconfig.Config
+	LC         fx.Lifecycle
+	Shutdowner fx.Shutdowner
+	Cfg        *runnerconfig.Config
+	L          *zap.Logger `name:"system"`
 }
 
 type Registry struct {
 	cfg *runnerconfig.Config
+	l   *zap.Logger
 	*ociregistry.Registry
 
 	ctx      context.Context
 	cancelFn func()
+	shutdown fx.Shutdowner
 
 	wg *conc.WaitGroup
 }
@@ -36,8 +41,10 @@ func New(params Params) (*Registry, error) {
 	reg := &Registry{
 		wg:       conc.NewWaitGroup(),
 		cfg:      params.Cfg,
+		l:        params.L,
 		ctx:      ctx,
 		cancelFn: cancelFn,
+		shutdown: params.Shutdowner,
 	}
 
 	// distribution inits otel unconditionally inside NewRegistry with no config knob to disable it,

--- a/services/dashboard-ui/client/components/common/CompositeError/CompositeError.tsx
+++ b/services/dashboard-ui/client/components/common/CompositeError/CompositeError.tsx
@@ -30,7 +30,11 @@ const SectionBody = ({ section }: { section: TCompositeErrorSection }) => {
   switch (section?.kind) {
     case 'code':
       return (
-        <CodeBlock language="text" showCopy>
+        <CodeBlock
+          language="text"
+          showCopy
+          className="!whitespace-pre-wrap !break-all !pr-12 [&_code]:!whitespace-pre-wrap [&_code]:!break-all"
+        >
           {body}
         </CodeBlock>
       )


### PR DESCRIPTION
Back asynchronous audit delivery with an fsync-enabled persistent Collector queue, a 10,000-record capacity, and an indefinite retry window for retryable failures. Use dedicated audit receiver ports and mount Collector storage in newly provisioned AWS, Azure, and GCP VM runner services.

Restart failed Collectors with bounded backoff while preserving the last-known-good configuration. Handle embedded registry failures through Fx shutdown so graceful runner lifecycle audit events can complete instead of being bypassed by an immediate process exit.