### PR TITLE
docs: changelog entries 041-043

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -319,6 +319,9 @@
         "icon": "clock-rotate-left",
         "pages": [
           "updates/updates",
+          "updates/043-container-actions-and-azure",
+          "updates/042-triggers-and-component-health",
+          "updates/041-terraform-stack-module",
           "updates/040-app-branches",
           "updates/039-oidc-federation",
           "updates/038-spacelift-and-cli-automation",

--- a/docs/updates/041-terraform-stack-module.mdx
+++ b/docs/updates/041-terraform-stack-module.mdx
@@ -1,0 +1,52 @@
+---
+title: 041 - Terraform stack modules
+description: Hand your customers a versioned Terraform module and an install ID instead of a tfvars file.
+boost: 0.3
+---
+
+_August 24, 2026_
+
+## Terraform stack modules
+
+<Note>This feature is behind a feature flag. Reach out to our team if you would like it enabled for your organization.</Note>
+
+Install stacks can be provisioned from a versioned Terraform module on the public registry, using an install ID and
+an API token instead of a generated `tfvars` file. The module reads the stack config from the control plane, and
+each stack gets its own service account, so the phone home ID no longer has to be rotated on every reprovision.
+
+```hcl
+provider "stack" {}
+
+module "aws_stack" {
+  source  = "nuonco/stack/aws"
+  version = "~> 1.0"
+
+  install_id = "<install-id>"
+
+  inputs = {
+    instance_type = "t3a.medium"
+  }
+
+  secrets = {
+    license_key = { value = var.license_key }
+  }
+}
+```
+
+When a new app version requires an input they have not set, the plan fails.
+
+```sh
+╷
+│ Error: Resource precondition failed
+│
+│   on .terraform/modules/aws_stack/phone_home.tf line 100, in resource "stack_phone_home" "this":
+│  100:       condition     = length(local.missing_required_inputs) == 0
+│     ├────────────────
+│     │ local.missing_required_inputs is tuple with 1 element
+│
+│ the app requires a value for these inputs: a_new_input.
+╵
+```
+
+The modules are published to the Terraform registry. See the
+[Provision Stack with a Terraform Module](/guides/provision-stacks-with-terraform-module) guide.

--- a/docs/updates/041-terraform-stack-module.mdx
+++ b/docs/updates/041-terraform-stack-module.mdx
@@ -8,11 +8,15 @@ _August 24, 2026_
 
 ## Terraform stack modules
 
-<Note>This feature is behind a feature flag. Reach out to our team if you would like it enabled for your organization.</Note>
+<Note>The TF Module tab is behind the `stack-tf-provider` org feature. Reach out to our team if you would like it
+enabled for your organization.</Note>
 
 Install stacks can be provisioned from a versioned Terraform module on the public registry, using an install ID and
 an API token instead of a generated `tfvars` file. The module reads the stack config from the control plane, and
 each stack gets its own service account, so the phone home ID no longer has to be rotated on every reprovision.
+
+Creating an install now offers a **TF Module** tab with the code for that install's cloud. There are published
+modules for AWS, Azure, and GCP.
 
 ```hcl
 provider "stack" {}

--- a/docs/updates/042-triggers-and-component-health.mdx
+++ b/docs/updates/042-triggers-and-component-health.mdx
@@ -1,0 +1,65 @@
+---
+title: 042 - Triggers and component health
+description: Start Nuon work from external events, and track whether every component on every install is running right now.
+boost: 0.3
+---
+
+_August 26, 2026_
+
+## Triggers
+
+<Note>Not to be confused with [action triggers](/updates/009-action-triggers-secrets-configs), which fire at points
+in a Nuon workflow. These are inbound webhooks from systems outside Nuon.</Note>
+
+A trigger is an inbound webhook endpoint with its own ingress URL. Nuon authenticates and deduplicates each event,
+then routes it through rules you author in your app config. A matching rule starts an install runbook or an app
+branch run, mapping values out of the event payload.
+
+```sh
+nuon triggers create my-trigger --preset github
+```
+
+```toml triggers.toml
+[[rules]]
+name       = "runbook-on-main-push"
+trigger    = "my-trigger"
+event_types = ["push"]
+
+[[rules.filters]]
+from  = "payload"
+op    = "eq"
+path  = "$.ref"
+value = "refs/heads/main"
+
+[rules.target]
+type    = "runbook"
+runbook = "redeploy"
+install = "acme-prod"
+```
+
+Presets cover GitHub, Slack, Datadog, EventBridge, SNS, Pub/Sub, and Event Grid, including the transport envelopes
+those providers wrap payloads in. Without a preset you choose the authentication scheme yourself.
+
+Every event is stored with its headers, body, and routing outcome.
+
+See [Triggers](/concepts/triggers) and [Configure triggers](/guides/triggers).
+
+## Component health
+
+<Note>Component health is behind the `component-health` org feature. Reach out to our team if you would like it
+enabled for your organization.</Note>
+
+Component health tracks whether each component on each install is running right now, continuously and separately
+from deploy status. Nuon never overwrites one with the other.
+
+The two answers differ more often than they should. `helm upgrade` exits 0 while the release sits in
+`pending-install`; Terraform and Helm skip when state already matches, so a component reports Active while its pods
+crash-loop. Nothing runs in your customers' clusters, since health reads them with the access your deploys already
+use.
+
+- Every resource a component manages, with live status per install.
+- Debounced alerts to Slack and webhooks naming the failing resource.
+- Deploy gates that hold until a component stays healthy through a bake period.
+- 90 days of timeline and uptime per component and install.
+
+See the [Component health](/guides/component-health) guide.

--- a/docs/updates/042-triggers-and-component-health.mdx
+++ b/docs/updates/042-triggers-and-component-health.mdx
@@ -8,8 +8,9 @@ _August 26, 2026_
 
 ## Triggers
 
-<Note>Not to be confused with [action triggers](/updates/009-action-triggers-secrets-configs), which fire at points
-in a Nuon workflow. These are inbound webhooks from systems outside Nuon.</Note>
+<Note>Triggers are behind the `triggers` org feature. Reach out to our team if you would like it enabled for your
+organization. Not to be confused with [action triggers](/updates/009-action-triggers-secrets-configs), which fire
+at points in a Nuon workflow. These are inbound webhooks from systems outside Nuon.</Note>
 
 A trigger is an inbound webhook endpoint with its own ingress URL. Nuon authenticates and deduplicates each event,
 then routes it through rules you author in your app config. A matching rule starts an install runbook or an app

--- a/docs/updates/043-container-actions-and-azure.mdx
+++ b/docs/updates/043-container-actions-and-azure.mdx
@@ -1,6 +1,6 @@
 ---
-title: 043 - Container actions and Azure install parity
-description: Ship a tooling image with an action, and give Azure customers the same one-click install AWS customers already get.
+title: 043 - Container actions, signed images, and Azure install parity
+description: Ship a tooling image with an action, require signed container images, and give Azure customers the same one-click install AWS customers already get.
 boost: 0.3
 ---
 
@@ -40,6 +40,44 @@ image = "{{.nuon.components.runbook_tools.outputs.image.ref}}"
 
 Images are pinned by digest, not tag. Every step in a container action must use `inline_contents`. See the
 [Container actions](/guides/container-actions) guide.
+
+## Container images
+
+Two additions to `container_image` components.
+
+**Signature verification.** A component can require a valid signature before Nuon copies the image into its
+registry. Verification runs at build time, after the tag resolves to an immutable digest and before the copy, so
+an unsigned or wrongly-signed image fails the build rather than reaching a customer.
+
+```toml components/api.toml
+[verification]
+require_signature = true
+
+[[verification.authorities]]
+type    = "keyless"
+issuer  = "https://token.actions.githubusercontent.com"
+subject = "https://github.com/acme/api/.github/workflows/release.yaml@refs/heads/main"
+```
+
+Sigstore keyless identities take `subject` or `subject_regexp`. Cosign key pairs use `type = "public_key"` with the
+public key committed alongside the app config; the private key is never provided to Nuon. See
+[Verify container image signatures](/guides/image-signature-verification).
+
+**Private Azure Container Registry.** An `azure_acr` block pulls from a private ACR through a service principal in
+your own tenant, authenticated with a client secret or certificate stored as an app secret and referenced by name.
+
+```toml components/acr_image.toml
+[azure_acr]
+image_url    = "vendoracr.azurecr.io/private-app"
+tag          = "latest"
+registry_url = "vendoracr.azurecr.io"
+tenant_id    = "00000000-0000-0000-0000-000000000000"
+client_id    = "11111111-1111-1111-1111-111111111111"
+
+client_secret_name = "acr_pull_secret"
+```
+
+See [Container image components](/guides/container-image-components).
 
 ## Azure installs
 

--- a/docs/updates/043-container-actions-and-azure.mdx
+++ b/docs/updates/043-container-actions-and-azure.mdx
@@ -1,0 +1,83 @@
+---
+title: 043 - Container actions and Azure install parity
+description: Ship a tooling image with an action, and give Azure customers the same one-click install AWS customers already get.
+boost: 0.3
+---
+
+_August 26, 2026_
+
+## Container actions
+
+<Note>Container actions are behind the `image-backed-actions` org feature flag, off by default, and require an AWS
+install runner. Reach out to our team if you would like it enabled for your organization.</Note>
+
+An action can declare a container image its steps run inside, so the tools a step needs ship with the action
+instead of being installed on the runner at the top of every run, inside your customer's network.
+
+```toml actions/db_migrate.toml
+# action
+name    = "db_migrate"
+timeout = "10m"
+image   = "ghcr.io/acme/migrate-tools:v1.4.0"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name            = "migrate"
+inline_contents = """
+#!/usr/bin/env sh
+migrate -database "$DATABASE_URL" -path /migrations up
+"""
+```
+
+For a private image, point `image` at a [container image component](/guides/container-image-components) and Nuon
+mirrors it into the install registry:
+
+```toml
+image = "{{.nuon.components.runbook_tools.outputs.image.ref}}"
+```
+
+Images are pinned by digest, not tag. Every step in a container action must use `inline_contents`. See the
+[Container actions](/guides/container-actions) guide.
+
+## Azure installs
+
+Azure has lagged AWS on the install itself. This release closes most of that gap.
+
+- **Deploy to Azure links collect your inputs.** Customer-facing app inputs render as ARM template parameters, and
+  default to the install's current value so a reprovision does not revert something set in the dashboard. This is
+  the Azure equivalent of the CloudFormation quick link.
+- **Stacks can deploy at subscription scope.** Set `deployment_scope = "subscription"` on the stack. Azure stacks
+  were previously resource-group scoped, so network, application, and security resources could not be split across
+  groups.
+- **The phone home authenticates with a managed identity token** rather than a shared value.
+- **`runner.instance_type` is honored.** The ARM stack hardcoded the VMSS SKU, so the field was silently ignored on
+  Azure while AWS and GCP applied it. The platform default moves to `Standard_D2s_v5`.
+- **AKS clusters using Azure RBAC can grant the runner access.** The runner's identity principal ID is now a stack
+  output. Previously, with local accounts disabled, secret sync failed with `namespaces is forbidden`.
+
+<Warning>
+  Existing Azure installs with no `instance_type` set move from Dsv3 to Dsv5 on their next reprovision. Azure vCPU
+  quota is per-family, so a subscription with headroom in Dsv3 but none in Dsv5 needs a quota increase or
+  `instance_type` pinned in `runner.toml`.
+</Warning>
+
+## Access and identity
+
+Follow-ons to [OIDC federation](/updates/039-oidc-federation):
+
+- A GitHub Actions preset on the trust policy modal lists every repo across your VCS connections and fills in the
+  issuer, audience, and `sub` claim.
+- An org can run more than one identity provider of the same type, each labeled on the sign-in page.
+- API tokens can be tied to your own account and carry your roles, alongside the existing service-account tokens.
+
+## Also improved
+
+- `nuon actions adhoc` runs a one-time action against an install.
+- Error reporting covers the whole run chain, not just component deploys: runner jobs, action preparation, runbook
+  steps, and sandbox builds surface a specific reason, including failures outside a job's own execution such as an
+  offline runner.
+- Helm releases stuck mid-operation are recovered automatically.
+- Install labels can be generated from Nuon templates.
+- Plans wrap long lines, and installs can be filtered by branch.

--- a/docs/updates/updates.mdx
+++ b/docs/updates/updates.mdx
@@ -7,6 +7,15 @@ boost: 0.4
 <Note>Nuon issues new Releases frequently, so we recommend you visit the Changelog regularly.</Note>
 
 <CardGroup cols={2}>
+  <Card title="043 - Container actions and Azure install parity" icon="cube" href="/updates/043-container-actions-and-azure">
+    Ship a tooling image with an action, and give Azure customers the same one-click install AWS customers already get. Plus OIDC follow-ons and error reporting across the whole run chain.
+  </Card>
+  <Card title="042 - Triggers and component health" icon="bolt" href="/updates/042-triggers-and-component-health">
+    Start Nuon work from external events with inbound webhook triggers, and track whether every component on every install is running right now.
+  </Card>
+  <Card title="041 - Terraform stack modules" icon="cloud" href="/updates/041-terraform-stack-module">
+    Hand your customers a versioned Terraform module and an install ID instead of a tfvars file.
+  </Card>
   <Card title="040 - App Branches" icon="code-branch" href="/updates/040-app-branches">
     Connect a git branch to your app and roll changes out across your customer fleet through ordered deployment groups, with a plan and an approval at every step. Plus a read-only role and a cleaner installs CLI.
   </Card>

--- a/docs/updates/updates.mdx
+++ b/docs/updates/updates.mdx
@@ -7,8 +7,8 @@ boost: 0.4
 <Note>Nuon issues new Releases frequently, so we recommend you visit the Changelog regularly.</Note>
 
 <CardGroup cols={2}>
-  <Card title="043 - Container actions and Azure install parity" icon="cube" href="/updates/043-container-actions-and-azure">
-    Ship a tooling image with an action, and give Azure customers the same one-click install AWS customers already get. Plus OIDC follow-ons and error reporting across the whole run chain.
+  <Card title="043 - Container actions, signed images, and Azure install parity" icon="cube" href="/updates/043-container-actions-and-azure">
+    Ship a tooling image with an action, require signed container images, and give Azure customers the same one-click install AWS customers already get. Plus OIDC follow-ons and error reporting across the whole run chain.
   </Card>
   <Card title="042 - Triggers and component health" icon="bolt" href="/updates/042-triggers-and-component-health">
     Start Nuon work from external events with inbound webhook triggers, and track whether every component on every install is running right now.


### PR DESCRIPTION
Restores 041 (terraform stack modules), removed from main by the #2299 revert, and adds two new entries:

- 042 triggers and component health. Both features shipped before 040's boundary and were never announced.
- 043 container actions, Azure install parity, OIDC follow-ons.

041 is not ready to publish: #2299's code revert still stands in main and #2293/#2312 are open, so the TF Module option the guide references does not exist yet. Included here for review only.