### PR TITLE
fix(docs): changed mention of BYOC Nuon to Nuon BYOC, our correct product name

### DIFF
--- a/docs/architecture/platform.mdx
+++ b/docs/architecture/platform.mdx
@@ -28,7 +28,7 @@ The Control Plane orchestrates and monitors jobs across all Install Runners and 
 
 The central interface for managing apps, installs, and jobs. The [Dashboard](/dashboard) and [CLI](/cli) are built on top of it, and you can integrate with it directly to build custom interfaces.
 
-<Note>[Nuon Cloud](https://app.nuon.co) is multi-tenant with logical isolation per org. Nuon can also be deployed as a BYOC app into a customer's own cloud account. See the [BYOC Nuon repo](https://github.com/nuonco/byoc) for details.</Note>
+<Note>[Nuon Cloud](https://app.nuon.co) is multi-tenant with logical isolation per org. Nuon can also be deployed as a BYOC app into a customer's own cloud account. See the [Nuon BYOC repo](https://github.com/nuonco/byoc) for details.</Note>
 
 ### Runner API
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -116,7 +116,7 @@ nuon auth login #or other nuon CLI commands.
 
 By default, the CLI will use api.nuon.co as the API URL.
 
-`nuon auth login` also prompts the user to either use Nuon Cloud (api.nuon.co) or BYOC Nuon where the user can enter
+`nuon auth login` also prompts the user to either use Nuon Cloud (api.nuon.co) or Nuon BYOC where the user can enter
 their Nuon control place URL
 
 ![Nuon auth login](./images/resources/cli/cli-auth-login.png)

--- a/docs/guides/byoc/aws.mdx
+++ b/docs/guides/byoc/aws.mdx
@@ -161,7 +161,7 @@ cloud-specific steps, and verification guidance.
 
 ## Configure DNS (Optional)
 
-To host your BYOC Nuon instance under a custom domain, configure DNS for your root domain to point to the Route53 Zone
+To host your Nuon BYOC instance under a custom domain, configure DNS for your root domain to point to the Route53 Zone
 created in the sandbox.
 
 After the sandbox provisions, you'll receive:

--- a/docs/guides/byoc/gcp.mdx
+++ b/docs/guides/byoc/gcp.mdx
@@ -78,7 +78,7 @@ You'll need a GCP project with a few APIs enabled. The install stack provisions 
 make sure your account has IAM permissions to create those resources and the project has not hit quota limits for VPCs,
 Cloud SQL instances, or GKE clusters.
 
-The following APIs are required by the `install-stack` and BYOC Nuon. These will be enabled by the `install-stack`
+The following APIs are required by the `install-stack` and Nuon BYOC. These will be enabled by the `install-stack`
 terraform module.
 
 - Secret Manager API
@@ -100,12 +100,12 @@ bring your own at any time.
 
 ## Provision the Install Stack
 
-BYOC Nuon on GCP is provisioned with terraform using the the
+Nuon BYOC on GCP is provisioned with terraform using the the
 [`nuonco/install-stacks`](https://github.com/nuonco/install-stacks) module. Nuon will share `inputs.auto.tfvars` and
 `secrets.auto.tfvars` files with the values specific to your install which you will augment with configuration and input
 values you control. Once the vars files are populated and the module is in your CI pipeline, you will apply the
-[`nuonco/install-stacks`](https://github.com/nuonco/install-stacks) module to provision the following resources for BYOC
-Nuon:
+[`nuonco/install-stacks`](https://github.com/nuonco/install-stacks) module to provision the following resources for Nuon
+BYOC:
 
 - VPC
 - GKE cluster
@@ -150,7 +150,7 @@ The values fall into two categories.
 | ------------------------ | ------------------------------------------------------------- |
 | `nuon_install_id`        | Your Nuon install ID.                                         |
 | `nuon_org_id`            | Your Nuon org ID.                                             |
-| `nuon_app_id`            | The Nuon app ID for the BYOC Nuon control plane.              |
+| `nuon_app_id`            | The Nuon app ID for the Nuon BYOC control plane.              |
 | `runner_api_url`         | The Nuon Runner API URL (typically `https://runner.nuon.co`). |
 | `runner_api_token`       | The auth token your Nuon Runner uses to poll Nuon Cloud.      |
 | `runner_id`              | The Nuon Runner ID assigned to this install.                  |

--- a/docs/guides/byoc/requirements.mdx
+++ b/docs/guides/byoc/requirements.mdx
@@ -98,7 +98,7 @@ To use Google as your IdP, set up an OAuth client in the Google Cloud Console.
 
 | Setting                       | Value                                    |
 | ----------------------------- | ---------------------------------------- |
-| Name                          | `BYOC Nuon` (or any name)                |
+| Name                          | `Nuon BYOC` (or any name)                |
 | Authorized JavaScript origins | `https://auth.<your-root-domain>`        |
 | Authorized redirect URIs      | `https://auth.<your-root-domain>/auth`   |
 
@@ -192,7 +192,7 @@ Create a Native Application for CLI authentication.
 | Setting | Value |
 |---------|-------|
 | Name | `Nuon CTL API - <your-install-name>` |
-| Description | `For BYOC Nuon Install <your-install-id>` |
+| Description | `For Nuon BYOC Install <your-install-id>` |
 | Allow Cross-Origin Authentication | `true` |
 | Device Code (Advanced > Grant Types) | Checked |
 

--- a/docs/guides/self-hosted/supported-platforms.mdx
+++ b/docs/guides/self-hosted/supported-platforms.mdx
@@ -35,12 +35,12 @@ backing Temporal's persistence layer.
 
 **AWS:**
 
-Our [BYOC Nuon terraform module](https://github.com/nuonco/byoc/tree/main/byoc-nuon/src/components/rds_cluster_nuon) is
+Our [Nuon BYOC terraform module](https://github.com/nuonco/byoc/tree/main/byoc-nuon/src/components/rds_cluster_nuon) is
 a useful reference.
 
 **GCP:**
 
-Our [BYOC Nuon GCP terraform module](https://github.com/nuonco/byoc/tree/main/byoc-nuon-gcp/src/components) provides
+Our [Nuon BYOC GCP terraform module](https://github.com/nuonco/byoc/tree/main/byoc-nuon-gcp/src/components) provides
 references for both `cloudsql_nuon` and `cloudsql_temporal`.
 
 ### Container Registry
@@ -63,7 +63,7 @@ Artifact Registry is used for container image storage.
 The `ctl-api` deployment relies on an IAM role (attached to the service account) with specific permissions which we
 enumerate here.
 
-The [BYOC Nuon terraform module](https://github.com/nuonco/byoc/tree/main/byoc-nuon/src/components/management) is a
+The [Nuon BYOC terraform module](https://github.com/nuonco/byoc/tree/main/byoc-nuon/src/components/management) is a
 useful reference.
 
 #### ECR
@@ -82,7 +82,7 @@ The blob storage requires the `ctl-api` to be able to read and write from an S3 
 **GCP:**
 
 The `ctl-api` and `dashboard-ui` deployments rely on GCP service accounts bound to Kubernetes service accounts via
-Workload Identity. The [BYOC Nuon GCP management
+Workload Identity. The [Nuon BYOC GCP management
 component](https://github.com/nuonco/byoc/tree/main/byoc-nuon-gcp/src/components/management) is a useful reference for
 the required service accounts and IAM bindings.
 

--- a/docs/updates/007-secret-formats.mdx
+++ b/docs/updates/007-secret-formats.mdx
@@ -18,7 +18,7 @@ The following secret will be expected as a base64 encoded secret when inserted i
 [[secret]]
 name         = "github_app_key"
 display_name = "GitHub App Key"
-description  = "Github App Key for BYOC Nuon Install {{.nuon.id}}"
+description  = "Github App Key for Nuon BYOC Install {{.nuon.id}}"
 required     = true
 
 kubernetes_sync             = true

--- a/docs/updates/029-auth-inputs-better-nested-templates.mdx
+++ b/docs/updates/029-auth-inputs-better-nested-templates.mdx
@@ -26,7 +26,7 @@ CloudFormation but addresses an issue with earlier versions that affected strict
 ![Nuon Auth](assets/029/auth-service.png)
 
 BYOC installs now have the option of using the new Nuon Auth service which adds support for `google` and generic `oidc`
-providers. Users can bring their own IdP and BYOC Nuon no longer has a dependency on Auth0.
+providers. Users can bring their own IdP and Nuon BYOC no longer has a dependency on Auth0.
 
 Key features:
 


### PR DESCRIPTION
When Nuon deploys its control plane into a software vendor's cloud, that product name is called "Nuon BYOC" - in contract to our SaaS product called "Nuon Cloud".

There are inconsistencies in the Nuon docs still use the old name, "BYOC Nuon" so this PR fixes the following:

Here's the full list of all 15 corrected instances ("BYOC Nuon" → "Nuon BYOC"), with sentence context, across 8 files:

1. cli.mdx:119
nuon auth login also prompts the user to either use Nuon Cloud (api.nuon.co) or Nuon BYOC where the user can enter
2. updates/029-auth-inputs-better-nested-templates.mdx:29
providers. Users can bring their own IdP and Nuon BYOC no longer has a dependency on Auth0.
3. updates/007-secret-formats.mdx:21 (code string)
description  = "Github App Key for **Nuon BYOC** Install {{.nuon.id}}"
4. guides/byoc/requirements.mdx:101 (table cell)
| Name | \Nuon BYOC` (or any name) |`
5. guides/byoc/requirements.mdx:195 (table cell)
| Description | \For Nuon BYOC Install <your-install-id>` |`
6. guides/self-hosted/supported-platforms.mdx:38 (link text)
Our [Nuon BYOC](https://github.com/nuonco/nuon/compare/mm/.../byoc-nuon/src/components/rds_cluster_nuon)[ terraform module ](https://github.com/nuonco/nuon/compare/mm/.../byoc-nuon/src/components/rds_cluster_nuon)is a useful reference.
7. guides/self-hosted/supported-platforms.mdx:43 (link text)
Our [Nuon BYOC](https://github.com/nuonco/nuon/compare/mm/.../byoc-nuon-gcp/src/components)[ GCP terraform module](https://github.com/nuonco/nuon/compare/mm/.../byoc-nuon-gcp/src/components) provides references for both cloudsql_nuon and cloudsql_temporal.
8. guides/self-hosted/supported-platforms.mdx:66 (link text)
The [Nuon BYOC](https://github.com/nuonco/nuon/compare/mm/.../byoc-nuon/src/components/management)[ terraform module](https://github.com/nuonco/nuon/compare/mm/.../byoc-nuon/src/components/management) is a useful reference.
9. guides/self-hosted/supported-platforms.mdx:85 (link text, wraps)
Workload Identity. The [Nuon BYOC](https://github.com/nuonco/nuon/compare/mm/.../byoc-nuon-gcp/src/components/management)[ GCP management component](https://github.com/nuonco/nuon/compare/mm/.../byoc-nuon-gcp/src/components/management) is a useful reference for...
10. guides/byoc/aws.mdx:164
To host your Nuon BYOC instance under a custom domain, configure DNS for your root domain to point to the Route53 Zone
11. guides/byoc/gcp.mdx:81
The following APIs are required by the install-stack and Nuon BYOC. These will be enabled by the install-stack terraform module.
12. guides/byoc/gcp.mdx:103
Nuon BYOC on GCP is provisioned with terraform using the...
13. guides/byoc/gcp.mdx:107-108 (was split across a line wrap)
...you will apply the [nuonco/install-stacks ](https://github.com/nuonco/nuon/compare/mm/...)module to provision the following resources for Nuon BYOC:
14. guides/byoc/gcp.mdx:153 (table cell)
| \nuon_app_id` | The Nuon app ID for the **Nuon BYOC** control plane. |`
15. architecture/platform.mdx:31 (link text; URL unchanged)
Nuon can also be deployed as a BYOC app into a customer's own cloud account. See the [Nuon BYOC](https://github.com/nuonco/byoc)[ repo](https://github.com/nuonco/byoc) for details.