### PR TITLE
fix(ctl-api): target custom nested deployments at their own scope

### DIFF
--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom.go
@@ -251,6 +251,15 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 			allParamNames[paramName] = stack.Name
 		}
 
+		// An expression default is computed in the template's own parameter scope;
+		// hoisting it re-binds it to the parent's. See hoistableDefault.
+		for paramName, param := range defaultParams {
+			if !hoistableDefault(param.DefaultValue) {
+				delete(defaultParams, paramName)
+				delete(allParamNames, paramName)
+			}
+		}
+
 		// Remaining params are hoisted into parent
 		for paramName := range defaultParams {
 			if _, alreadySet := deploymentParams[paramName]; !alreadySet {
@@ -286,6 +295,15 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 				},
 				"parameters": deploymentParams,
 			},
+		}
+
+		// Guessing a stack's scope wrong fails the whole deployment with
+		// InvalidScope, so take it from the template's own $schema, as
+		// getVNetLinkedDeployment does.
+		if isSubscriptionScopedTemplate(armTmpl) {
+			scope.targetSubscription(deployment)
+		} else {
+			scope.targetInstallRG(deployment)
 		}
 
 		resources = append(resources, deployment)

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom_scope_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom_scope_test.go
@@ -1,0 +1,74 @@
+package arm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nuonco/nuon/pkg/config"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+const rgScopedCustomStackFixture = `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "resources": [],
+  "outputs": {}
+}`
+
+const subscriptionScopedCustomStackFixture = `{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "resources": [],
+  "outputs": {}
+}`
+
+// At subscription scope ARM takes a nested deployment's target from its own
+// resourceGroup/location, not the root's. With neither set, an RG-scoped child
+// fails with InvalidScope and a subscription-scoped one has no location.
+func TestGetCustomLinkedDeployments_SubscriptionScopeTargeting(t *testing.T) {
+	rgServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(rgScopedCustomStackFixture))
+	}))
+	defer rgServer.Close()
+
+	subServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(subscriptionScopedCustomStackFixture))
+	}))
+	defer subServer.Close()
+
+	tmpl := &Templates{cfg: &internal.Config{}}
+	inp := minimalTemplateInput()
+	inp.DeploymentScope = app.StackDeploymentScopeSubscription
+	inp.AppCfg.StackConfig.CustomNestedStacks = []config.CustomNestedStack{
+		{Name: "rg_stack", TemplateURL: rgServer.URL + "/stack.json", Index: 0},
+		{Name: "sub_stack", TemplateURL: subServer.URL + "/stack.json", Index: 1},
+	}
+
+	resources, _, _, _, err := tmpl.getCustomLinkedDeployments(inp)
+	if err != nil {
+		t.Fatalf("getCustomLinkedDeployments: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(resources))
+	}
+
+	rgDep := resources[0].(map[string]any)
+	if got, present := rgDep["resourceGroup"]; !present || got != "[variables('installResourceGroupName')]" {
+		t.Errorf("rg-scoped custom stack deployment: resourceGroup = %v (present=%v), want install RG", got, present)
+	}
+	if got, present := rgDep["location"]; present {
+		t.Errorf("rg-scoped custom stack deployment must not set location, got %v", got)
+	}
+
+	subDep := resources[1].(map[string]any)
+	if got, present := subDep["resourceGroup"]; present {
+		t.Errorf("subscription-scoped custom stack deployment must not set resourceGroup, got %v", got)
+	}
+	if _, present := subDep["location"]; !present {
+		t.Error("subscription-scoped custom stack deployment requires an explicit location")
+	}
+}


### PR DESCRIPTION
## Summary

Custom nested stack deployments are emitted with no `resourceGroup` and no `location`, so at `deployment_scope = "subscription"` they inherit the root's subscription scope. A resource-group-scoped custom template then fails with `InvalidScope`. A subscription-scoped one is missing the `location` ARM requires for a subscription target.

Every deploy of a subscription-scope install that declares `custom_nested_stacks` fails. No test covered the combination.

The fix chooses the target per stack from its own template's `$schema`, matching `getVNetLinkedDeployment`.

Also applies `hoistableDefault` filtering to custom stack parameters. Without it, a default that is an unresolved ARM expression hoists verbatim into the parent, where at subscription scope the Nuon IDs it references are variables rather than parameters and ARM rejects the template.

Resource-group scope output is unchanged.