### PR TITLE
feat: simplify image verification authority types

### DIFF
--- a/docs/config-ref/container-image.mdx
+++ b/docs/config-ref/container-image.mdx
@@ -24,6 +24,7 @@ title: 'Container Image'
 | **`gcp_gar`**<br/>[GCPGARConfig](#gcp_gar) | GCP Artifact Registry image configuration Configuration for pulling images from Google Artifact Registry. Use when deploying images from private GAR repositories | **Optional** | - |
 | **`azure_acr`**<br/>[AzureACRConfig](#azure_acr) | Azure Container Registry image configuration Configuration for pulling images from Azure Container Registry. Use when deploying images from private ACR repositories | **Optional** | - |
 | **`public`**<br/>[PublicImageConfig](#public) | public registry image configuration Configuration for pulling images from public container registries (Docker Hub, Quay.io, GCR, etc) | **Optional** | - |
+| **`verification`**<br/>[Verification](#verification) | container image signature verification policy Require the resolved image digest to satisfy at least one configured Sigstore keyless identity or Cosign public key before Nuon copies it | **Optional** | - |
 | **`build_timeout`**<br/>string | build operation timeout Duration string for build operations (e.g., "30m", "1h"). Default: 15m. Max: 1h | **Optional**<br/>Default: `"15m"` | `"30m"`, `"1h"` |
 | **`deploy_timeout`**<br/>string | deploy operation timeout Duration string for deploy operations (e.g., "30m", "1h"). Default: 5m. Max: 1h | **Optional**<br/>Default: `"5m"` | `"30m"`, `"1h"` |
 
@@ -76,4 +77,11 @@ title: 'Container Image'
 | **`image_url`**<br/>string | container image URL Full URL to the container image from a public registry (Docker Hub, Quay.io, etc). Format: [registry/]\<repository\>/\<image-name\> | **✅ Required** | `"nginx:latest"`, `"docker.io/library/postgres"`, `"quay.io/myorg/myapp"`, `"gcr.io/myproject/myapp"` |
 | **`tag`**<br/>string | image tag Tag or version of the container image to deploy. Either tag or update_policy must be set. Supports templating (e.g., \{\{.nuon.install.id\}\}) | **Optional** | `"v1.0.0"`, `"latest"`, `"{{.nuon.install.id}}"` |
 | **`update_policy`**<br/>string | semver constraint for tag resolution Semver constraint for picking a tag at build time. When set, at each build the runner lists tags from the registry, filters to those that parse as semver and sa... | **Optional** | `"~1.25.0"`, `"^2.0.0"`, `"\u003e=1.0.0,\u003c2.0.0"`, `"1.x"`, `"^1.0 || ^2.0"` |
+
+### `verification`
+
+| Property | Description | Values | Example |
+|----------|----------|----------|----------|
+| **`require_signature`**<br/>boolean | - | **Optional** | - |
+| **`authorities`**<br/>array | - | **Optional** | - |
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -158,6 +158,7 @@
                 "group": "Components",
                 "pages": [
                   "guides/container-image-components",
+                  "guides/image-signature-verification",
                   "guides/image-update-policies",
                   "guides/helm-chart-components",
                   "guides/kubernetes-manifest-components",

--- a/docs/guides/container-image-components.mdx
+++ b/docs/guides/container-image-components.mdx
@@ -116,6 +116,12 @@ in a customer cloud account, and it is shared across all installs of the app
 rather than configured per install.
 </Note>
 
+## Verifying signed images
+
+Container image components can require the resolved image digest to be signed by a trusted Sigstore keyless identity or Cosign public key. Verification happens before Nuon copies the image, and a failed verification fails the component build.
+
+See [Verify Container Image Signatures](/guides/image-signature-verification) for keyless and key-based configuration, authority matching, and guidance on combining verification with OPA policies.
+
 ## Deployments
 
 Container image components _cannot_ be deployed directly in a customer install. When an image is released, it will be _synced_
@@ -166,7 +172,7 @@ tag       = "{{.nuon.components.app_image.image.tag}}"
 ## Image Syncing
 
 When a Container image component is released, Nuon will automatically sync the image into the end customer account. This
-image is stored in a local registry that is provisioned in the customer account.
+image is stored in a local registry that is provisioned in the customer account. OCI referrers and legacy Cosign digest tags are copied with the image so signatures, SBOMs, provenance, and other attestations remain available in the destination registry.
 
 Nuon image syncing allows you to sync images into accounts, without worrying about cross account permissions, registry
 authentication or publishing public images. Any `Dockerfile` in a repo can be built, and synced.

--- a/docs/guides/external-image-policies.mdx
+++ b/docs/guides/external-image-policies.mdx
@@ -9,6 +9,10 @@ External image policies allow you to enforce security requirements on container 
 
 Nuon automatically fetches rich metadata about container images including SBOMs, signatures, attestations, and in-toto statements, making this data available to your OPA policies.
 
+<Warning>
+OPA policies inspect the metadata Nuon discovers, but they do not cryptographically verify a signature. To prove that a trusted identity or key signed the resolved image digest, configure [native container image signature verification](/guides/image-signature-verification). Use OPA for additional requirements such as SBOM presence, provenance contents, registry allowlists, and tag rules.
+</Warning>
+
 ## Policy Input Structure
 
 When evaluating external image policies, Nuon provides the following input structure:
@@ -42,7 +46,7 @@ When evaluating external image policies, Nuon provides the following input struc
 | `input.image` | string | Image name (e.g., `nginx`, `gcr.io/project/app`) |
 | `input.tag` | string | Image tag (e.g., `latest`, `v1.2.3`) |
 | `input.digest` | string | Image digest (e.g., `sha256:abc...`) |
-| `input.metadata.signed` | bool | Whether the image has signatures |
+| `input.metadata.signed` | bool | Whether signature metadata was discovered; this does not indicate cryptographic verification |
 | `input.metadata.sbom.present` | bool | Whether an SBOM is present |
 | `input.metadata.sbom.format` | string | SBOM format: `spdx`, `cyclonedx`, or `unknown` |
 | `input.metadata.signatures` | array | List of signature details |
@@ -54,9 +58,9 @@ When evaluating external image policies, Nuon provides the following input struc
 
 ## Basic Image Requirements
 
-### Require Image Signing
+### Require Signature Metadata
 
-Ensure all images are cryptographically signed:
+Require Nuon to discover signature metadata for an image. This is useful as a metadata-presence rule, but it does not replace native cryptographic verification:
 
 ```rego
 package nuon
@@ -69,7 +73,7 @@ allow if {
 
 deny contains msg if {
     not input.metadata.signed
-    msg := sprintf("Image %s:%s must be signed", [input.image, input.tag])
+    msg := sprintf("Image %s:%s must include signature metadata", [input.image, input.tag])
 }
 ```
 
@@ -123,9 +127,9 @@ deny contains msg if {
 
 ## Signature Inspection
 
-### Check Signature Algorithm
+### Inspect Signature Algorithm
 
-Require a specific signing algorithm:
+Require discovered signature metadata to identify a specific signing format:
 
 ```rego
 package nuon
@@ -145,7 +149,7 @@ deny contains msg if {
 deny contains msg if {
     count(input.metadata.signatures) > 0
     not has_cosign_signature
-    msg := sprintf("Image %s:%s must be signed with cosign", [input.image, input.tag])
+    msg := sprintf("Image %s:%s must include Cosign signature metadata", [input.image, input.tag])
 }
 
 has_cosign_signature if {
@@ -154,9 +158,9 @@ has_cosign_signature if {
 }
 ```
 
-### Require Signature from Trusted Issuer
+### Inspect Signature Issuer
 
-Validate signature issuer for keyless signing (e.g., Sigstore):
+Check the issuer recorded in discovered keyless signature metadata. This does not validate the certificate chain or signature; use [native signature verification](/guides/image-signature-verification#verify-a-keyless-signature) to trust the issuer cryptographically.
 
 ```rego
 package nuon
@@ -175,7 +179,7 @@ allow if {
 
 deny contains msg if {
     not has_trusted_signature
-    msg := sprintf("Image %s:%s must be signed by a trusted issuer: %v", 
+    msg := sprintf("Image %s:%s must include signature metadata from an allowed issuer: %v", 
         [input.image, input.tag, trusted_issuers])
 }
 
@@ -262,7 +266,7 @@ deny contains msg if {
 
 When attestation layers are fetched with content decoding enabled, you can inspect the decoded in-toto statements.
 
-### Validate In-Toto Statement Type
+### Inspect In-Toto Statement Type
 
 ```rego
 package nuon
@@ -288,9 +292,9 @@ has_valid_intoto if {
 }
 ```
 
-### Verify Subject Digest Matches Image
+### Check the Declared Subject Digest
 
-Ensure attestation subjects match the image being validated:
+Check whether decoded attestation metadata declares the image digest as its subject. This is not proof that the attestation itself has a valid signature:
 
 ```rego
 package nuon
@@ -492,9 +496,9 @@ deny contains msg if {
 
 ## Combining Multiple Requirements
 
-### Production-Ready Image Policy
+### Image Metadata Policy
 
-A comprehensive policy combining multiple security requirements:
+A policy combining several image metadata requirements. Pair this with native signature verification when signer trust is required:
 
 ```rego
 package nuon
@@ -503,14 +507,14 @@ default allow := false
 
 # Image must meet ALL requirements
 allow if {
-    is_signed
+    has_signature_metadata
     has_sbom
     has_provenance
     not uses_blocked_tag
 }
 
-# Check if image is signed
-is_signed if {
+# Check whether signature metadata was discovered
+has_signature_metadata if {
     input.metadata.signed == true
 }
 
@@ -540,8 +544,8 @@ uses_blocked_tag if {
 
 # Generate specific denial messages
 deny contains msg if {
-    not is_signed
-    msg := sprintf("Image %s:%s must be signed", [input.image, input.tag])
+    not has_signature_metadata
+    msg := sprintf("Image %s:%s must include signature metadata", [input.image, input.tag])
 }
 
 deny contains msg if {
@@ -583,17 +587,21 @@ package nuon
 default allow := false
 
 allow if {
-    input.metadata.signed == true
+    has_signature_metadata
     input.metadata.sbom.present == true
 }
 
-deny contains msg if {
-    not input.metadata.signed
-    msg := sprintf("Image %s:%s must be signed", [input.image, input.tag])
+has_signature_metadata if {
+    input.metadata.signed == true
 }
 
 deny contains msg if {
-    not input.metadata.sbom.present  
+    not has_signature_metadata
+    msg := sprintf("Image %s:%s must include signature metadata", [input.image, input.tag])
+}
+
+deny contains msg if {
+    not input.metadata.sbom.present
     msg := sprintf("Image %s:%s must include an SBOM", [input.image, input.tag])
 }
 """
@@ -633,10 +641,10 @@ contents   = "file://policies/rego/container-image.rego"
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `key_id` | string | Key identifier (for keyed signing) |
-| `issuer` | string | OIDC issuer (for keyless signing) |
-| `subject` | string | OIDC subject identity |
-| `algorithm` | string | Signature algorithm/media type |
+| `key_id` | string | Discovered key identifier (for keyed signing) |
+| `issuer` | string | Discovered OIDC issuer (for keyless signing) |
+| `subject` | string | Discovered OIDC subject identity |
+| `algorithm` | string | Discovered signature algorithm/media type |
 
 ### `input.metadata.attestations`
 

--- a/docs/guides/image-signature-verification.mdx
+++ b/docs/guides/image-signature-verification.mdx
@@ -1,0 +1,101 @@
+---
+title: 'Verify Container Image Signatures'
+description: 'Require container images to be signed by trusted Sigstore identities or Cosign keys before Nuon copies them.'
+icon: "signature"
+keywords: ["container image", "signature verification", "sigstore", "cosign", "keyless", "public key", "software supply chain"]
+---
+
+Nuon can require a container image to have a valid signature before copying it into Nuon's registry. Verification runs when the container image component builds, after Nuon resolves the configured tag to an immutable digest and before it copies that digest.
+
+Add a `verification` block to any `container_image` component. If the image does not satisfy a configured authority, the component build fails and the image is not copied.
+
+## Verify a keyless signature
+
+Use `keyless` for images signed with a certificate issued through Sigstore. Pin both the OIDC issuer and the certificate subject so a valid signature from an unrelated identity is not accepted.
+
+```toml components/api.toml
+name = "api"
+type = "container_image"
+
+[public]
+image_url = "ghcr.io/acme/api"
+tag       = "v1.4.0"
+
+[verification]
+require_signature = true
+
+[[verification.authorities]]
+type    = "keyless"
+issuer  = "https://token.actions.githubusercontent.com"
+subject = "https://github.com/acme/api/.github/workflows/release.yaml@refs/heads/main"
+```
+
+For identities that intentionally vary, use `subject_regexp` instead of `subject`. Exactly one of the two fields is required.
+
+```toml
+[[verification.authorities]]
+type           = "keyless"
+issuer         = "https://token.actions.githubusercontent.com"
+subject_regexp = '^https://github\.com/acme/api/\.github/workflows/release\.yaml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+```
+
+Prefer an exact subject when one identity signs all releases. Keep regular expressions narrow enough that they cannot match pull request workflows, forks, or other repositories.
+
+## Verify with a Cosign public key
+
+Use `public_key` for images signed with a managed key pair. Commit the public key with the app configuration and reference it by relative path. Nuon reads the public key into the configuration during sync; the private key is never provided to Nuon.
+
+```toml components/api.toml
+name = "api"
+type = "container_image"
+
+[public]
+image_url = "ghcr.io/acme/api"
+tag       = "v1.4.0"
+
+[verification]
+require_signature = true
+
+[[verification.authorities]]
+type       = "public_key"
+public_key = "./cosign.pub"
+```
+
+The path is relative to the app's `components` directory. You can also provide the PEM-encoded public key directly.
+
+## Trust more than one authority
+
+Multiple authorities use **OR** semantics. A build succeeds when any one authority verifies the resolved image digest. This supports key rotation or a transition between key-based and keyless signing without an unsigned window.
+
+```toml
+[verification]
+require_signature = true
+
+[[verification.authorities]]
+type       = "public_key"
+public_key = "./current-cosign.pub"
+
+[[verification.authorities]]
+type       = "public_key"
+public_key = "./next-cosign.pub"
+```
+
+Remove the old authority after all published images are signed by the replacement authority.
+
+## What Nuon copies
+
+After verification succeeds, Nuon copies the resolved image and its attached OCI metadata. This includes recursively linked OCI referrers such as signatures, SBOMs, provenance, and other attestations. Nuon also copies legacy Cosign digest tags ending in `.sig`, `.att`, and `.sbom`.
+
+This preserves the metadata so the copied image can be inspected and verified in its destination registry. Registry credentials configured on the component are used for both image discovery and signature verification.
+
+## Signature verification and OPA policies
+
+Native signature verification and [external image policies](/guides/external-image-policies) solve different problems:
+
+| Requirement | Use |
+|---|---|
+| Prove that a trusted identity or key signed the exact image digest | Native `verification` block |
+| Require an SBOM, provenance predicate, approved registry, or allowed tag | OPA external image policy |
+| Inspect fields inside an attestation | OPA external image policy |
+
+OPA policies evaluate image metadata. They do not perform Cosign's certificate-chain, transparency-log, payload, or cryptographic signature checks. Use the native `verification` block whenever trust in the signer is required, then add OPA only for metadata or attestation rules that provide additional value.

--- a/pkg/config/external_image_component_test.go
+++ b/pkg/config/external_image_component_test.go
@@ -20,12 +20,12 @@ tag = "latest"
 require_signature = true
 
 [[verification.authorities]]
-type = "sigstore_keyless"
+type = "keyless"
 issuer = "https://issuer.example.com"
 subject_regexp = "^https://example.com/.+$"
 
 [[verification.authorities]]
-type = "cosign_key"
+type = "public_key"
 public_key = "./cosign.pub"
 `), &cfg))
 
@@ -33,12 +33,12 @@ public_key = "./cosign.pub"
 	require.True(t, cfg.Verification.RequireSignature)
 	require.Equal(t, []signature.Authority{
 		{
-			Type:          signature.AuthorityTypeSigstoreKeyless,
+			Type:          signature.AuthorityTypeKeyless,
 			Issuer:        "https://issuer.example.com",
 			SubjectRegexp: "^https://example.com/.+$",
 		},
 		{
-			Type:      signature.AuthorityTypeCosignKey,
+			Type:      signature.AuthorityTypePublicKey,
 			PublicKey: "./cosign.pub",
 		},
 	}, cfg.Verification.Authorities)

--- a/pkg/oci/signature/config.go
+++ b/pkg/oci/signature/config.go
@@ -11,8 +11,8 @@ import (
 type AuthorityType string
 
 const (
-	AuthorityTypeSigstoreKeyless AuthorityType = "sigstore_keyless"
-	AuthorityTypeCosignKey       AuthorityType = "cosign_key"
+	AuthorityTypeKeyless   AuthorityType = "keyless"
+	AuthorityTypePublicKey AuthorityType = "public_key"
 )
 
 type Verification struct {
@@ -21,7 +21,7 @@ type Verification struct {
 }
 
 type Authority struct {
-	Type          AuthorityType `json:"type" mapstructure:"type" toml:"type" jsonschema:"required,enum=sigstore_keyless,enum=cosign_key"`
+	Type          AuthorityType `json:"type" mapstructure:"type" toml:"type" jsonschema:"required,enum=keyless,enum=public_key"`
 	Issuer        string        `json:"issuer,omitempty" mapstructure:"issuer,omitempty" toml:"issuer,omitempty"`
 	Subject       string        `json:"subject,omitempty" mapstructure:"subject,omitempty" toml:"subject,omitempty"`
 	SubjectRegexp string        `json:"subject_regexp,omitempty" mapstructure:"subject_regexp,omitempty" toml:"subject_regexp,omitempty"`
@@ -50,27 +50,27 @@ func (v *Verification) Validate() error {
 
 func (a Authority) validate() error {
 	switch a.Type {
-	case AuthorityTypeSigstoreKeyless:
+	case AuthorityTypeKeyless:
 		if a.Issuer == "" {
-			return errors.New("issuer is required for sigstore_keyless")
+			return errors.New("issuer is required for keyless")
 		}
 		if (a.Subject == "") == (a.SubjectRegexp == "") {
-			return errors.New("exactly one of subject or subject_regexp is required for sigstore_keyless")
+			return errors.New("exactly one of subject or subject_regexp is required for keyless")
 		}
 		if a.PublicKey != "" {
-			return errors.New("public_key is not valid for sigstore_keyless")
+			return errors.New("public_key is not valid for keyless")
 		}
 		if a.SubjectRegexp != "" {
 			if _, err := regexp.Compile(a.SubjectRegexp); err != nil {
 				return fmt.Errorf("invalid subject_regexp: %w", err)
 			}
 		}
-	case AuthorityTypeCosignKey:
+	case AuthorityTypePublicKey:
 		if a.PublicKey == "" {
-			return errors.New("public_key is required for cosign_key")
+			return errors.New("public_key is required for a public_key authority")
 		}
 		if a.Issuer != "" || a.Subject != "" || a.SubjectRegexp != "" {
-			return errors.New("issuer, subject, and subject_regexp are not valid for cosign_key")
+			return errors.New("issuer, subject, and subject_regexp are not valid for a public_key authority")
 		}
 	default:
 		return fmt.Errorf("unsupported type %q", a.Type)

--- a/pkg/oci/signature/config_test.go
+++ b/pkg/oci/signature/config_test.go
@@ -16,7 +16,7 @@ func TestVerificationValidate(t *testing.T) {
 		{
 			name: "keyless exact subject",
 			config: &Verification{RequireSignature: true, Authorities: []Authority{{
-				Type:    AuthorityTypeSigstoreKeyless,
+				Type:    AuthorityTypeKeyless,
 				Issuer:  "https://issuer.example.com",
 				Subject: "https://example.com/workflow",
 			}}},
@@ -24,7 +24,7 @@ func TestVerificationValidate(t *testing.T) {
 		{
 			name: "keyless subject regexp",
 			config: &Verification{RequireSignature: true, Authorities: []Authority{{
-				Type:          AuthorityTypeSigstoreKeyless,
+				Type:          AuthorityTypeKeyless,
 				Issuer:        "https://issuer.example.com",
 				SubjectRegexp: `^https://example\.com/.+$`,
 			}}},
@@ -32,7 +32,7 @@ func TestVerificationValidate(t *testing.T) {
 		{
 			name: "public key",
 			config: &Verification{RequireSignature: true, Authorities: []Authority{{
-				Type:      AuthorityTypeCosignKey,
+				Type:      AuthorityTypePublicKey,
 				PublicKey: "public key contents",
 			}}},
 		},
@@ -44,7 +44,7 @@ func TestVerificationValidate(t *testing.T) {
 		{
 			name: "keyless missing issuer",
 			config: &Verification{RequireSignature: true, Authorities: []Authority{{
-				Type:    AuthorityTypeSigstoreKeyless,
+				Type:    AuthorityTypeKeyless,
 				Subject: "subject",
 			}}},
 			wantErr: "issuer is required",
@@ -52,7 +52,7 @@ func TestVerificationValidate(t *testing.T) {
 		{
 			name: "keyless ambiguous subject",
 			config: &Verification{RequireSignature: true, Authorities: []Authority{{
-				Type:          AuthorityTypeSigstoreKeyless,
+				Type:          AuthorityTypeKeyless,
 				Issuer:        "issuer",
 				Subject:       "subject",
 				SubjectRegexp: ".*",
@@ -62,7 +62,7 @@ func TestVerificationValidate(t *testing.T) {
 		{
 			name: "invalid regexp",
 			config: &Verification{RequireSignature: true, Authorities: []Authority{{
-				Type:          AuthorityTypeSigstoreKeyless,
+				Type:          AuthorityTypeKeyless,
 				Issuer:        "issuer",
 				SubjectRegexp: "[",
 			}}},
@@ -71,7 +71,7 @@ func TestVerificationValidate(t *testing.T) {
 		{
 			name: "key missing public key",
 			config: &Verification{RequireSignature: true, Authorities: []Authority{{
-				Type: AuthorityTypeCosignKey,
+				Type: AuthorityTypePublicKey,
 			}}},
 			wantErr: "public_key is required",
 		},

--- a/pkg/runner/oci/signature/verify.go
+++ b/pkg/runner/oci/signature/verify.go
@@ -52,7 +52,7 @@ func Verify(ctx context.Context, cfg *configs.OCIRegistryRepository, digest stri
 
 	var trustedRoot root.TrustedMaterial
 	for _, authority := range verification.Authorities {
-		if authority.Type == signaturecfg.AuthorityTypeSigstoreKeyless {
+		if authority.Type == signaturecfg.AuthorityTypeKeyless {
 			trustedRoot, err = cosign.TrustedRoot()
 			if err != nil {
 				return fmt.Errorf("load Sigstore trusted root: %w", err)
@@ -82,13 +82,13 @@ func verifyAuthority(ctx context.Context, ref name.Reference, nameOpts []name.Op
 	}
 
 	switch authority.Type {
-	case signaturecfg.AuthorityTypeSigstoreKeyless:
+	case signaturecfg.AuthorityTypeKeyless:
 		checkOpts.Identities = []cosign.Identity{{
 			Issuer:        authority.Issuer,
 			Subject:       authority.Subject,
 			SubjectRegExp: authority.SubjectRegexp,
 		}}
-	case signaturecfg.AuthorityTypeCosignKey:
+	case signaturecfg.AuthorityTypePublicKey:
 		verifier, err := cosignsignature.LoadPublicKeyRaw([]byte(authority.PublicKey), crypto.SHA256)
 		if err != nil {
 			return fmt.Errorf("load public key: %w", err)

--- a/pkg/runner/oci/signature/verify_integration_test.go
+++ b/pkg/runner/oci/signature/verify_integration_test.go
@@ -22,7 +22,7 @@ func TestVerifyPublicKeylessImage(t *testing.T) {
 	verification := &signaturecfg.Verification{
 		RequireSignature: true,
 		Authorities: []signaturecfg.Authority{{
-			Type:    signaturecfg.AuthorityTypeSigstoreKeyless,
+			Type:    signaturecfg.AuthorityTypeKeyless,
 			Issuer:  "https://token.actions.githubusercontent.com",
 			Subject: "https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main",
 		}},

--- a/sdks/nuon-go/models/signature_authority_type.go
+++ b/sdks/nuon-go/models/signature_authority_type.go
@@ -30,11 +30,11 @@ func (m SignatureAuthorityType) Pointer() *SignatureAuthorityType {
 
 const (
 
-	// SignatureAuthorityTypeSigstoreKeyless captures enum value "sigstore_keyless"
-	SignatureAuthorityTypeSigstoreKeyless SignatureAuthorityType = "sigstore_keyless"
+	// SignatureAuthorityTypeKeyless captures enum value "keyless"
+	SignatureAuthorityTypeKeyless SignatureAuthorityType = "keyless"
 
-	// SignatureAuthorityTypeCosignKey captures enum value "cosign_key"
-	SignatureAuthorityTypeCosignKey SignatureAuthorityType = "cosign_key"
+	// SignatureAuthorityTypePublicKey captures enum value "public_key"
+	SignatureAuthorityTypePublicKey SignatureAuthorityType = "public_key"
 )
 
 // for schema
@@ -42,7 +42,7 @@ var signatureAuthorityTypeEnum []any
 
 func init() {
 	var res []SignatureAuthorityType
-	if err := json.Unmarshal([]byte(`["sigstore_keyless","cosign_key"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["keyless","public_key"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/sdks/nuon-runner-go/models/signature_authority_type.go
+++ b/sdks/nuon-runner-go/models/signature_authority_type.go
@@ -30,11 +30,11 @@ func (m SignatureAuthorityType) Pointer() *SignatureAuthorityType {
 
 const (
 
-	// SignatureAuthorityTypeSigstoreKeyless captures enum value "sigstore_keyless"
-	SignatureAuthorityTypeSigstoreKeyless SignatureAuthorityType = "sigstore_keyless"
+	// SignatureAuthorityTypeKeyless captures enum value "keyless"
+	SignatureAuthorityTypeKeyless SignatureAuthorityType = "keyless"
 
-	// SignatureAuthorityTypeCosignKey captures enum value "cosign_key"
-	SignatureAuthorityTypeCosignKey SignatureAuthorityType = "cosign_key"
+	// SignatureAuthorityTypePublicKey captures enum value "public_key"
+	SignatureAuthorityTypePublicKey SignatureAuthorityType = "public_key"
 )
 
 // for schema
@@ -42,7 +42,7 @@ var signatureAuthorityTypeEnum []any
 
 func init() {
 	var res []SignatureAuthorityType
-	if err := json.Unmarshal([]byte(`["sigstore_keyless","cosign_key"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["keyless","public_key"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/services/ctl-api/internal/pkg/config/build/build_test.go
+++ b/services/ctl-api/internal/pkg/config/build/build_test.go
@@ -428,7 +428,7 @@ func TestExternalImageKeepsSignatureVerification(t *testing.T) {
 	verification := &signature.Verification{
 		RequireSignature: true,
 		Authorities: []signature.Authority{{
-			Type:    signature.AuthorityTypeSigstoreKeyless,
+			Type:    signature.AuthorityTypeKeyless,
 			Issuer:  "https://issuer.example.com",
 			Subject: "https://example.com/workflow",
 		}},


### PR DESCRIPTION
## Summary
- rename image signature authorities to the symmetric `keyless` and `public_key` values
- document native keyless and public-key image verification, including subject regex guidance
- clarify that OPA inspects image metadata rather than cryptographically verifying signatures
- document preservation of OCI referrers and legacy Cosign digest tags

