### PR TITLE
fix: classify tail query deadlines as transient

### DIFF
--- a/services/ctl-api/internal/app/runners/service/get_runner_jobs_tail.go
+++ b/services/ctl-api/internal/app/runners/service/get_runner_jobs_tail.go
@@ -224,7 +224,7 @@ func (s *service) tailJobProbe(parent context.Context, runnerID string, grp app.
 		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		return nil, errors.Wrap(res.Error, "unable to query runner job tail")
+		return nil, errors.Wrap(tailProbeQueryError(ctx, res.Error), "unable to query runner job tail")
 	}
 	return &job, nil
 }

--- a/services/ctl-api/internal/app/runners/service/log_stream_tail_logs.go
+++ b/services/ctl-api/internal/app/runners/service/log_stream_tail_logs.go
@@ -378,7 +378,7 @@ func (s *service) tailProbe(parent context.Context, orgID, logStreamID string, c
 		Limit(tailPageSize + 1).
 		Find(&rows)
 	if res.Error != nil {
-		return nil, "", false, errors.Wrap(res.Error, "unable to query log tail")
+		return nil, "", false, errors.Wrap(tailProbeQueryError(ctx, res.Error), "unable to query log tail")
 	}
 
 	hasMore := len(rows) > tailPageSize

--- a/services/ctl-api/internal/app/runners/service/tail_errors.go
+++ b/services/ctl-api/internal/app/runners/service/tail_errors.go
@@ -23,6 +23,13 @@ func writeTailUnavailable(ctx *gin.Context) {
 	})
 }
 
+func tailProbeQueryError(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return errors.Join(err, ctxErr)
+	}
+	return err
+}
+
 func isTransientTailProbeError(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) ||
 		errors.Is(err, driver.ErrBadConn) ||

--- a/services/ctl-api/internal/app/runners/service/tail_errors_test.go
+++ b/services/ctl-api/internal/app/runners/service/tail_errors_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
@@ -37,4 +38,23 @@ func TestIsTransientTailProbeError(t *testing.T) {
 			assert.Equal(t, tt.transient, isTransientTailProbeError(tt.err))
 		})
 	}
+}
+
+func TestTailProbeQueryError(t *testing.T) {
+	queryErr := errors.New("driver timeout")
+
+	t.Run("expired query", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+
+		err := tailProbeQueryError(ctx, queryErr)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.ErrorIs(t, err, queryErr)
+		assert.True(t, isTransientTailProbeError(err))
+	})
+
+	t.Run("active query", func(t *testing.T) {
+		err := tailProbeQueryError(context.Background(), queryErr)
+		assert.Same(t, queryErr, err)
+	})
 }


### PR DESCRIPTION
## Why

Tail endpoints bound each database probe with a two-second context. Some drivers can return an opaque error when that context expires, causing the transient-error classifier to treat a deadline as permanent. Runner job tails then return 500 instead of retrying and ultimately returning 503 with `Retry-After`.

## What changed

- Preserve the driver error while joining the authoritative query-context error after a failed probe.
- Apply the normalization to both Postgres runner-job tails and ClickHouse log tails.
- Keep genuine query errors unchanged and classified as permanent.
- Add coverage for expired and active query contexts.


