### PR TITLE
fix: decode BuildKit image attestations

### DIFF
--- a/pkg/oci/metadata/fetcher.go
+++ b/pkg/oci/metadata/fetcher.go
@@ -550,8 +550,7 @@ func fetchAttestationLayer(
 	bytesRead := int64(len(rawJSON))
 	layer.RawJSON = rawJSON
 
-	// Try to decode as DSSE envelope
-	decoded, err := decodeDSSEEnvelope(rawJSON)
+	decoded, err := decodeInTotoStatement(rawJSON)
 	if err == nil && decoded != nil {
 		layer.Decoded = decoded
 		if layer.PredicateType == "" && decoded.PredicateType != "" {
@@ -560,6 +559,15 @@ func fetchAttestationLayer(
 	}
 
 	return layer, bytesRead, nil
+}
+
+func decodeInTotoStatement(data []byte) (*InTotoStatement, error) {
+	var statement InTotoStatement
+	if err := json.Unmarshal(data, &statement); err == nil && statement.Type != "" && statement.PredicateType != "" {
+		return &statement, nil
+	}
+
+	return decodeDSSEEnvelope(data)
 }
 
 // decodeDSSEEnvelope decodes a DSSE envelope and extracts the in-toto statement.

--- a/pkg/oci/metadata/fetcher_test.go
+++ b/pkg/oci/metadata/fetcher_test.go
@@ -1,0 +1,42 @@
+package metadata
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+)
+
+func TestDecodeInTotoStatement(t *testing.T) {
+	statement := `{
+		"_type": "https://in-toto.io/Statement/v0.1",
+		"predicateType": "https://slsa.dev/provenance/v0.2",
+		"subject": [{"name": "example/image"}],
+		"predicate": {"materials": []}
+	}`
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{name: "direct", data: statement},
+		{
+			name: "DSSE envelope",
+			data: fmt.Sprintf(`{"payloadType":"application/vnd.in-toto+json","payload":%q}`, base64.StdEncoding.EncodeToString([]byte(statement))),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decoded, err := decodeInTotoStatement([]byte(tt.data))
+			if err != nil {
+				t.Fatalf("decodeInTotoStatement() error = %v", err)
+			}
+			if decoded.PredicateType != "https://slsa.dev/provenance/v0.2" {
+				t.Fatalf("PredicateType = %q", decoded.PredicateType)
+			}
+			if len(decoded.Subject) != 1 || decoded.Subject[0].Name != "example/image" {
+				t.Fatalf("Subject = %#v", decoded.Subject)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Container image policies can inspect provenance and SBOM statements emitted directly by BuildKit. These statements are now decoded alongside DSSE-wrapped attestations.

## What you can do after this PR

**Evaluate BuildKit provenance with OPA.** Policies can inspect the decoded predicate, including declared image materials such as pinned base-image digests.

## What stays the same

DSSE-wrapped in-toto attestations continue to decode as before. Unrecognized attestation payloads remain available as raw metadata.