### PR TITLE
fix: keep OCI archives below ECR layer limits

### DIFF
--- a/pkg/runner/jobs/build/pulumi/exec.go
+++ b/pkg/runner/jobs/build/pulumi/exec.go
@@ -71,6 +71,9 @@ func (h *handler) getSourceFiles(ctx context.Context, root string) ([]ociarchive
 			return err
 		}
 
+		if info.IsDir() && info.Name() == ".git" {
+			return filepath.SkipDir
+		}
 		if info.IsDir() {
 			return nil
 		}

--- a/pkg/runner/jobs/build/sandbox/files.go
+++ b/pkg/runner/jobs/build/sandbox/files.go
@@ -21,6 +21,9 @@ func (h *handler) getSourceFiles(ctx context.Context, root string) ([]ociarchive
 			return err
 		}
 
+		if info.IsDir() && info.Name() == ".git" {
+			return filepath.SkipDir
+		}
 		if info.IsDir() {
 			return nil
 		}

--- a/pkg/runner/jobs/build/terraform/files.go
+++ b/pkg/runner/jobs/build/terraform/files.go
@@ -24,6 +24,9 @@ func (h *handler) getSourceFiles(ctx context.Context, root string) ([]ociarchive
 			return err
 		}
 
+		if info.IsDir() && info.Name() == ".git" {
+			return filepath.SkipDir
+		}
 		if info.IsDir() {
 			return nil
 		}

--- a/pkg/runner/oci/archive/archive_test.go
+++ b/pkg/runner/oci/archive/archive_test.go
@@ -1,0 +1,292 @@
+package ociarchive
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"go.uber.org/zap"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/content/file"
+)
+
+func TestPackUnpackRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	sourceDir := t.TempDir()
+	files := []FileRef{
+		writeTestFile(t, sourceDir, "nested/main.tf", "terraform {}", 0644),
+		writeTestFile(t, sourceDir, "bin/terraform", "executable", 0755),
+		writeTestFile(t, sourceDir, "empty.txt", "", 0644),
+	}
+
+	packed := newTestArchive(t, ctx)
+	if err := packed.Pack(ctx, zap.NewNop(), files); err != nil {
+		t.Fatalf("Pack() error = %v", err)
+	}
+	manifest := resolveTestManifest(t, ctx, packed)
+	layers := manifestLayers(t, ctx, packed.store, manifest)
+	if len(layers) != 2 {
+		t.Fatalf("layer count = %d, want 2", len(layers))
+	}
+	for _, layer := range layers {
+		if layer.MediaType != tarLayerMediaType {
+			t.Fatalf("layer media type = %q, want %q", layer.MediaType, tarLayerMediaType)
+		}
+	}
+
+	unpacked := newTestArchive(t, ctx)
+	_, err := oras.Copy(ctx, packed.store, defaultLocalTag, unpacked.store, defaultLocalTag, oras.DefaultCopyOptions)
+	if err != nil {
+		t.Fatalf("oras.Copy() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(unpacked.BasePath(), "nested/main.tf")); err != nil {
+		t.Fatalf("legacy reader did not auto-unpack new tar layers: %v", err)
+	}
+	for _, file := range files[:2] {
+		got, err := os.ReadFile(filepath.Join(unpacked.BasePath(), filepath.FromSlash(file.RelPath)))
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", file.RelPath, err)
+		}
+		want, err := os.ReadFile(file.AbsPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != string(want) {
+			t.Errorf("content for %q = %q, want %q", file.RelPath, got, want)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(unpacked.BasePath(), "empty.txt")); !os.IsNotExist(err) {
+		t.Fatalf("empty file stat error = %v, want not found", err)
+	}
+	mode, err := os.Stat(filepath.Join(unpacked.BasePath(), "bin/terraform"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode.Mode().Perm() != 0755 {
+		t.Errorf("executable mode = %o, want 755", mode.Mode().Perm())
+	}
+}
+
+func TestPackDeterministic(t *testing.T) {
+	ctx := context.Background()
+	firstDir := t.TempDir()
+	secondDir := t.TempDir()
+	firstFiles := []FileRef{
+		writeTestFile(t, firstDir, "z.txt", "last", 0600),
+		writeTestFile(t, firstDir, "a.txt", "first", 0750),
+	}
+	secondFiles := []FileRef{
+		writeTestFile(t, secondDir, "a.txt", "first", 0700),
+		writeTestFile(t, secondDir, "z.txt", "last", 0644),
+	}
+	for _, file := range secondFiles {
+		if err := os.Chtimes(file.AbsPath, time.Now(), time.Now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	first := newTestArchive(t, ctx)
+	if err := first.Pack(ctx, zap.NewNop(), firstFiles); err != nil {
+		t.Fatal(err)
+	}
+	second := newTestArchive(t, ctx)
+	if err := second.Pack(ctx, zap.NewNop(), secondFiles); err != nil {
+		t.Fatal(err)
+	}
+
+	firstDigest := resolveTestManifest(t, ctx, first).Digest
+	secondDigest := resolveTestManifest(t, ctx, second).Digest
+	if firstDigest != secondDigest {
+		t.Fatalf("manifest digests differ: %s != %s", firstDigest, secondDigest)
+	}
+}
+
+func TestPackReusesUnchangedDirectoryLayer(t *testing.T) {
+	ctx := context.Background()
+	firstDir := t.TempDir()
+	secondDir := t.TempDir()
+	first := newTestArchive(t, ctx)
+	if err := first.Pack(ctx, zap.NewNop(), []FileRef{
+		writeTestFile(t, firstDir, "stable/main.tf", "unchanged", 0644),
+		writeTestFile(t, firstDir, "changed/main.tf", "before", 0644),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	second := newTestArchive(t, ctx)
+	if err := second.Pack(ctx, zap.NewNop(), []FileRef{
+		writeTestFile(t, secondDir, "stable/main.tf", "unchanged", 0644),
+		writeTestFile(t, secondDir, "changed/main.tf", "after", 0644),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	firstLayers := manifestLayersByTitle(t, ctx, first)
+	secondLayers := manifestLayersByTitle(t, ctx, second)
+	if firstLayers["stable"].Digest != secondLayers["stable"].Digest {
+		t.Fatal("unchanged directory layer digest changed")
+	}
+	if firstLayers["changed"].Digest == secondLayers["changed"].Digest {
+		t.Fatal("changed directory layer digest did not change")
+	}
+}
+
+func TestPackUnpackDirectorySymlink(t *testing.T) {
+	ctx := context.Background()
+	sourceDir := t.TempDir()
+	target := writeTestFile(t, sourceDir, "target/main.tf", "terraform {}", 0644)
+	linkPath := filepath.Join(sourceDir, "linked")
+	if err := os.Symlink("target", linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	packed := newTestArchive(t, ctx)
+	if err := packed.Pack(ctx, zap.NewNop(), []FileRef{
+		target,
+		{AbsPath: linkPath, RelPath: "linked", FileType: "application/octet-stream"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	unpacked := newTestArchive(t, ctx)
+	if _, err := oras.Copy(ctx, packed.store, defaultLocalTag, unpacked.store, defaultLocalTag, oras.DefaultCopyOptions); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Lstat(filepath.Join(unpacked.BasePath(), "linked"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("linked mode = %s, want symlink", info.Mode())
+	}
+	contents, err := os.ReadFile(filepath.Join(unpacked.BasePath(), "linked", "main.tf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "terraform {}" {
+		t.Fatalf("linked file content = %q", contents)
+	}
+}
+
+func TestGroupArchiveLayersFallsBackAboveLimit(t *testing.T) {
+	files := make([]FileRef, maxArchiveLayers+1)
+	for i := range files {
+		files[i].RelPath = filepath.ToSlash(filepath.Join("dir-"+strconv.Itoa(i), "file"))
+	}
+
+	atLimit := groupArchiveLayers(files[:maxArchiveLayers])
+	if len(atLimit) != maxArchiveLayers {
+		t.Fatalf("layer count at limit = %d, want %d", len(atLimit), maxArchiveLayers)
+	}
+
+	layers := groupArchiveLayers(files)
+	if len(layers) != 1 {
+		t.Fatalf("layer count = %d, want 1", len(layers))
+	}
+	if layers[0].title != tarLayerTitle {
+		t.Fatalf("layer title = %q, want %q", layers[0].title, tarLayerTitle)
+	}
+	if len(layers[0].files) != len(files) {
+		t.Fatalf("layer file count = %d, want %d", len(layers[0].files), len(files))
+	}
+}
+
+func TestUnpackLegacyPerFileLayers(t *testing.T) {
+	ctx := context.Background()
+	sourceDir := t.TempDir()
+	legacyStore, err := file.New(filepath.Join(t.TempDir(), "legacy-store"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = legacyStore.Close() })
+
+	legacyFile := writeTestFile(t, sourceDir, "modules/example/main.tf", "terraform {}", 0644)
+	layer, err := legacyStore.Add(ctx, legacyFile.RelPath, "application/octet-stream", legacyFile.AbsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := oras.Pack(ctx, legacyStore, defaultArtifactType, []v1.Descriptor{layer}, oras.PackOptions{
+		PackImageManifest: true,
+		ManifestAnnotations: map[string]string{
+			v1.AnnotationCreated: "1970-01-01T00:00:00Z",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := legacyStore.Tag(ctx, manifest, defaultLocalTag); err != nil {
+		t.Fatal(err)
+	}
+
+	unpacked := newTestArchive(t, ctx)
+	_, err = oras.Copy(ctx, legacyStore, defaultLocalTag, unpacked.store, defaultLocalTag, oras.DefaultCopyOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(unpacked.BasePath(), filepath.FromSlash(legacyFile.RelPath)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "terraform {}" {
+		t.Fatalf("legacy file content = %q", got)
+	}
+}
+
+func newTestArchive(t *testing.T, ctx context.Context) *archive {
+	t.Helper()
+	a := New()
+	if err := a.Initialize(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = a.Cleanup(ctx) })
+	return a
+}
+
+func writeTestFile(t *testing.T, root, relPath, contents string, mode os.FileMode) FileRef {
+	t.Helper()
+	absPath := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(absPath, []byte(contents), mode); err != nil {
+		t.Fatal(err)
+	}
+	return FileRef{AbsPath: absPath, RelPath: relPath, FileType: "application/octet-stream"}
+}
+
+func resolveTestManifest(t *testing.T, ctx context.Context, a *archive) v1.Descriptor {
+	t.Helper()
+	manifest, err := a.store.Resolve(ctx, defaultLocalTag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func manifestLayers(t *testing.T, ctx context.Context, store *file.Store, manifest v1.Descriptor) []v1.Descriptor {
+	t.Helper()
+	data, err := content.FetchAll(ctx, store, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed v1.Manifest
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	return parsed.Layers
+}
+
+func manifestLayersByTitle(t *testing.T, ctx context.Context, archive *archive) map[string]v1.Descriptor {
+	t.Helper()
+	layers := manifestLayers(t, ctx, archive.store, resolveTestManifest(t, ctx, archive))
+	byTitle := make(map[string]v1.Descriptor, len(layers))
+	for _, layer := range layers {
+		byTitle[layer.Annotations[v1.AnnotationTitle]] = layer
+	}
+	return byTitle
+}

--- a/pkg/runner/oci/archive/pack.go
+++ b/pkg/runner/oci/archive/pack.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.uber.org/zap"
 	"oras.land/oras-go/v2"
+	orasfile "oras.land/oras-go/v2/content/file"
 
 	pkgctx "github.com/nuonco/nuon/pkg/runner/ctx"
 	"github.com/nuonco/nuon/pkg/runner/op"
@@ -16,12 +20,20 @@ import (
 const (
 	defaultArtifactType string = "artifact/nuon"
 	defaultLocalTag     string = "latest"
+	tarLayerMediaType   string = "application/vnd.nuon.archive.layer.v1.tar+gzip"
+	tarLayerTitle       string = "."
+	maxArchiveLayers           = 400
 )
 
 type FileRef struct {
 	AbsPath  string `mapstructure:"abs_path,omitempty"`
 	RelPath  string `mapstructure:"rel_path,omitempty"`
 	FileType string `mapstructure:"file_type,omitempty"`
+}
+
+type archiveLayer struct {
+	title string
+	files []FileRef
 }
 
 func (r *archive) Pack(ctx context.Context, log *zap.Logger, filePaths []FileRef) (retErr error) {
@@ -32,33 +44,43 @@ func (r *archive) Pack(ctx context.Context, log *zap.Logger, filePaths []FileRef
 		log = l
 	}
 
-	fileDescriptors := make([]v1.Descriptor, 0, len(filePaths))
-
-	for _, f := range filePaths {
-		stat, err := os.Stat(f.AbsPath)
+	nonEmptyFiles := make([]FileRef, 0, len(filePaths))
+	for _, file := range filePaths {
+		stat, err := os.Stat(file.AbsPath)
 		if err != nil {
 			return fmt.Errorf("unable to stat file: %w", err)
 		}
-
 		if stat.Size() < 1 {
-			log.Info("skipping empty file", zap.String("path", f.RelPath))
+			log.Info("skipping empty file", zap.String("path", file.RelPath))
 			continue
 		}
-
-		fileDescriptor, err := r.store.Add(ctx, f.RelPath, f.FileType, f.AbsPath)
-		if err != nil {
-			return fmt.Errorf("unable to pack %s: %w", f.AbsPath, err)
-		}
-
-		fileDescriptors = append(fileDescriptors, fileDescriptor)
-		log.Debug("packed file", zap.String("path", f.RelPath), zap.String("abspath", f.AbsPath))
+		nonEmptyFiles = append(nonEmptyFiles, file)
 	}
 
-	descriptor, err := oras.Pack(ctx, r.store, defaultArtifactType, fileDescriptors, oras.PackOptions{
+	archiveLayers := groupArchiveLayers(nonEmptyFiles)
+	layers := make([]v1.Descriptor, 0, len(archiveLayers))
+	for i, archiveLayer := range archiveLayers {
+		tarPath := filepath.Join(r.tmpDir, fmt.Sprintf("archive-v1-%03d.tar.gz", i))
+		if err := writeTarLayer(tarPath, archiveLayer.files); err != nil {
+			return fmt.Errorf("unable to create tar layer %q: %w", archiveLayer.title, err)
+		}
+
+		layer, err := r.store.Add(ctx, archiveLayer.title, tarLayerMediaType, tarPath)
+		if err != nil {
+			return fmt.Errorf("unable to add tar layer %q: %w", archiveLayer.title, err)
+		}
+		layer.Annotations[orasfile.AnnotationUnpack] = "true"
+		layers = append(layers, layer)
+	}
+
+	descriptor, err := oras.Pack(ctx, r.store, defaultArtifactType, layers, oras.PackOptions{
 		PackImageManifest: true,
+		ManifestAnnotations: map[string]string{
+			v1.AnnotationCreated: "1970-01-01T00:00:00Z",
+		},
 	})
 	if err != nil {
-		return fmt.Errorf("unable to pack: %w", err)
+		return fmt.Errorf("unable to pack manifest: %w", err)
 	}
 
 	if err := r.store.Tag(ctx, descriptor, defaultLocalTag); err != nil {
@@ -72,4 +94,34 @@ func (r *archive) Pack(ctx context.Context, log *zap.Logger, filePaths []FileRef
 	log.Info("found tag", zap.String("tag", defaultLocalTag))
 
 	return nil
+}
+
+func groupArchiveLayers(files []FileRef) []archiveLayer {
+	if len(files) == 0 {
+		return nil
+	}
+
+	filesByTitle := make(map[string][]FileRef)
+	for _, file := range files {
+		title := tarLayerTitle
+		if topLevel, _, ok := strings.Cut(file.RelPath, "/"); ok {
+			title = topLevel
+		}
+		filesByTitle[title] = append(filesByTitle[title], file)
+	}
+	if len(filesByTitle) > maxArchiveLayers {
+		return []archiveLayer{{title: tarLayerTitle, files: files}}
+	}
+
+	titles := make([]string, 0, len(filesByTitle))
+	for title := range filesByTitle {
+		titles = append(titles, title)
+	}
+	sort.Strings(titles)
+
+	layers := make([]archiveLayer, 0, len(titles))
+	for _, title := range titles {
+		layers = append(layers, archiveLayer{title: title, files: filesByTitle[title]})
+	}
+	return layers
 }

--- a/pkg/runner/oci/archive/tar.go
+++ b/pkg/runner/oci/archive/tar.go
@@ -1,0 +1,145 @@
+package ociarchive
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sort"
+	"time"
+)
+
+func writeTarLayer(dst string, files []FileRef) (retErr error) {
+	sorted := append([]FileRef(nil), files...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].RelPath < sorted[j].RelPath
+	})
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := out.Close(); retErr == nil {
+			retErr = err
+		}
+	}()
+
+	gz := gzip.NewWriter(out)
+	gz.Header.ModTime = time.Unix(0, 0)
+	gz.Header.OS = 255
+	tw := tar.NewWriter(gz)
+	seen := make(map[string]struct{}, len(sorted))
+	directories := make(map[string]struct{})
+	for _, file := range sorted {
+		if err := validateTarPath(file.RelPath); err != nil {
+			return err
+		}
+		if _, ok := seen[file.RelPath]; ok {
+			return fmt.Errorf("duplicate archive path %q", file.RelPath)
+		}
+		seen[file.RelPath] = struct{}{}
+		for dir := path.Dir(file.RelPath); dir != "."; dir = path.Dir(dir) {
+			directories[dir] = struct{}{}
+		}
+	}
+	directoryNames := make([]string, 0, len(directories))
+	for dir := range directories {
+		directoryNames = append(directoryNames, dir)
+	}
+	sort.Strings(directoryNames)
+	for _, dir := range directoryNames {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     dir,
+			Mode:     0755,
+			ModTime:  time.Unix(0, 0),
+			Typeflag: tar.TypeDir,
+			Format:   tar.FormatPAX,
+		}); err != nil {
+			return fmt.Errorf("unable to write directory header for %s: %w", dir, err)
+		}
+	}
+
+	for _, file := range sorted {
+		info, err := os.Lstat(file.AbsPath)
+		if err != nil {
+			return fmt.Errorf("unable to stat %s: %w", file.AbsPath, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			stat, err := os.Stat(file.AbsPath)
+			if err != nil {
+				return fmt.Errorf("unable to stat symlink target for %s: %w", file.AbsPath, err)
+			}
+			if stat.IsDir() {
+				link, err := os.Readlink(file.AbsPath)
+				if err != nil {
+					return fmt.Errorf("unable to read symlink %s: %w", file.AbsPath, err)
+				}
+				header, err := tar.FileInfoHeader(info, link)
+				if err != nil {
+					return fmt.Errorf("unable to create symlink header for %s: %w", file.AbsPath, err)
+				}
+				header.Name = file.RelPath
+				header.ModTime = time.Unix(0, 0)
+				header.AccessTime = time.Time{}
+				header.ChangeTime = time.Time{}
+				header.Uid = 0
+				header.Gid = 0
+				header.Uname = ""
+				header.Gname = ""
+				header.Format = tar.FormatPAX
+				if err := tw.WriteHeader(header); err != nil {
+					return fmt.Errorf("unable to write symlink header for %s: %w", file.AbsPath, err)
+				}
+				continue
+			}
+			info = stat
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("archive path %q is not a regular file", file.RelPath)
+		}
+
+		mode := int64(0644)
+		if info.Mode().Perm()&0111 != 0 {
+			mode = 0755
+		}
+		header := &tar.Header{
+			Name:     file.RelPath,
+			Mode:     mode,
+			Size:     info.Size(),
+			ModTime:  time.Unix(0, 0),
+			Typeflag: tar.TypeReg,
+			Format:   tar.FormatPAX,
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return fmt.Errorf("unable to write header for %s: %w", file.RelPath, err)
+		}
+
+		in, err := os.Open(file.AbsPath)
+		if err != nil {
+			return fmt.Errorf("unable to open %s: %w", file.AbsPath, err)
+		}
+		_, copyErr := io.Copy(tw, in)
+		closeErr := in.Close()
+		if copyErr != nil {
+			return fmt.Errorf("unable to archive %s: %w", file.AbsPath, copyErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("unable to close %s: %w", file.AbsPath, closeErr)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return gz.Close()
+}
+
+func validateTarPath(name string) error {
+	if name == "" || path.IsAbs(name) || path.Clean(name) != name || name == ".." || len(name) >= 3 && name[:3] == "../" {
+		return fmt.Errorf("invalid relative archive path %q", name)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

OCI-backed builds now bundle archive contents into deterministic compressed layers by top-level directory, preventing ECR layer-limit failures while allowing unchanged directories to reuse cached layers.

## What you can do after this PR

**Reuse unchanged directory layers across builds.** Changes in one top-level directory do not invalidate layers for the others.

**Push large build archives without exceeding ECR layer limits.** Root files share one layer. If an archive has more than 400 top-level groups, all contents fall back to one deterministic layer, leaving headroom below ECR’s observed 500-layer limit.

**Avoid including VCS metadata.** Recursive archive collection skips `.git` directories for sandbox, Terraform, and Pulumi builds.

## What stays the same

Existing per-file-layer artifacts remain readable. Directory symlinks retain their prior behavior, zero-byte files remain excluded, and relative paths plus executable permissions are preserved.

## Mechanics worth flagging for review

Directory layers use a versioned tar-layer media type and ORAS unpack annotation. The 400-layer ceiling preserves compatibility with older readers; producing multiple overflow clusters would require a coordinated reader format change.