### PR TITLE
fix(runner): pack large source trees into one tarball layer

### DIFF
--- a/pkg/runner/oci/archive/pack.go
+++ b/pkg/runner/oci/archive/pack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.uber.org/zap"
@@ -16,6 +17,9 @@ import (
 const (
 	defaultArtifactType string = "artifact/nuon"
 	defaultLocalTag     string = "latest"
+
+	// ECR caps an image at 500 layers, and we push one layer per source file.
+	maxPerFileLayers int = 256
 )
 
 type FileRef struct {
@@ -32,26 +36,9 @@ func (r *archive) Pack(ctx context.Context, log *zap.Logger, filePaths []FileRef
 		log = l
 	}
 
-	fileDescriptors := make([]v1.Descriptor, 0, len(filePaths))
-
-	for _, f := range filePaths {
-		stat, err := os.Stat(f.AbsPath)
-		if err != nil {
-			return fmt.Errorf("unable to stat file: %w", err)
-		}
-
-		if stat.Size() < 1 {
-			log.Info("skipping empty file", zap.String("path", f.RelPath))
-			continue
-		}
-
-		fileDescriptor, err := r.store.Add(ctx, f.RelPath, f.FileType, f.AbsPath)
-		if err != nil {
-			return fmt.Errorf("unable to pack %s: %w", f.AbsPath, err)
-		}
-
-		fileDescriptors = append(fileDescriptors, fileDescriptor)
-		log.Debug("packed file", zap.String("path", f.RelPath), zap.String("abspath", f.AbsPath))
+	fileDescriptors, err := r.addLayers(ctx, log, filePaths)
+	if err != nil {
+		return err
 	}
 
 	descriptor, err := oras.Pack(ctx, r.store, defaultArtifactType, fileDescriptors, oras.PackOptions{
@@ -72,4 +59,48 @@ func (r *archive) Pack(ctx context.Context, log *zap.Logger, filePaths []FileRef
 	log.Info("found tag", zap.String("tag", defaultLocalTag))
 
 	return nil
+}
+
+func (r *archive) addLayers(ctx context.Context, log *zap.Logger, filePaths []FileRef) ([]v1.Descriptor, error) {
+	if len(filePaths) > maxPerFileLayers {
+		log.Info("packing source tree into a single tarball layer",
+			zap.Int("file_count", len(filePaths)),
+			zap.Int("max_per_file_layers", maxPerFileLayers),
+		)
+
+		tarballPath := filepath.Join(r.tmpDir, tarballName)
+		if err := writeTarGz(tarballPath, filePaths); err != nil {
+			return nil, fmt.Errorf("unable to write tarball: %w", err)
+		}
+
+		desc, err := r.store.Add(ctx, tarballName, tarballMediaType, tarballPath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to pack tarball: %w", err)
+		}
+		return []v1.Descriptor{desc}, nil
+	}
+
+	fileDescriptors := make([]v1.Descriptor, 0, len(filePaths))
+
+	for _, f := range filePaths {
+		stat, err := os.Stat(f.AbsPath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to stat file: %w", err)
+		}
+
+		if stat.Size() < 1 {
+			log.Info("skipping empty file", zap.String("path", f.RelPath))
+			continue
+		}
+
+		fileDescriptor, err := r.store.Add(ctx, f.RelPath, f.FileType, f.AbsPath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to pack %s: %w", f.AbsPath, err)
+		}
+
+		fileDescriptors = append(fileDescriptors, fileDescriptor)
+		log.Debug("packed file", zap.String("path", f.RelPath), zap.String("abspath", f.AbsPath))
+	}
+
+	return fileDescriptors, nil
 }

--- a/pkg/runner/oci/archive/pack_test.go
+++ b/pkg/runner/oci/archive/pack_test.go
@@ -1,0 +1,57 @@
+package ociarchive
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"oras.land/oras-go/v2/content"
+)
+
+func packFixture(t *testing.T, count int) ocispec.Manifest {
+	t.Helper()
+
+	src := t.TempDir()
+	files := make([]FileRef, 0, count)
+	for i := range count {
+		files = append(files, writeFile(t, src, fmt.Sprintf("f%d.tf", i), fmt.Sprintf("# %d\n", i), 0o644))
+	}
+
+	ctx := context.Background()
+	a := New()
+	require.NoError(t, a.Initialize(ctx))
+	t.Cleanup(func() { _ = a.Cleanup(ctx) })
+
+	require.NoError(t, a.Pack(ctx, zap.NewNop(), files))
+
+	desc, err := a.store.Resolve(ctx, defaultLocalTag)
+	require.NoError(t, err)
+
+	byts, err := content.FetchAll(ctx, a.store, desc)
+	require.NoError(t, err)
+
+	var m ocispec.Manifest
+	require.NoError(t, json.Unmarshal(byts, &m))
+	return m
+}
+
+func TestPackKeepsPerFileLayersBelowThreshold(t *testing.T) {
+	m := packFixture(t, 10)
+
+	require.Len(t, m.Layers, 10)
+	for _, layer := range m.Layers {
+		require.NotEqual(t, tarballMediaType, layer.MediaType)
+	}
+}
+
+func TestPackCollapsesLargeTreeIntoOneLayer(t *testing.T) {
+	m := packFixture(t, maxPerFileLayers+1)
+
+	require.Len(t, m.Layers, 1)
+	require.Equal(t, tarballMediaType, m.Layers[0].MediaType)
+	require.Equal(t, tarballName, m.Layers[0].Annotations[ocispec.AnnotationTitle])
+}

--- a/pkg/runner/oci/archive/tar.go
+++ b/pkg/runner/oci/archive/tar.go
@@ -1,0 +1,156 @@
+package ociarchive
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// Unpack keys off this to tell tarball artifacts from pre-tarball ones.
+	tarballMediaType string = "application/vnd.nuon.archive.tar+gzip"
+
+	tarballName string = "nuon-archive.tar.gz"
+)
+
+func writeTarGz(dst string, files []FileRef) (retErr error) {
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("unable to create tarball: %w", err)
+	}
+	defer func() {
+		if cerr := out.Close(); cerr != nil && retErr == nil {
+			retErr = cerr
+		}
+	}()
+
+	gz := gzip.NewWriter(out)
+	tw := tar.NewWriter(gz)
+
+	for _, f := range files {
+		if err := appendTarFile(tw, f); err != nil {
+			return err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("unable to close tar writer: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("unable to close gzip writer: %w", err)
+	}
+	return nil
+}
+
+func appendTarFile(tw *tar.Writer, f FileRef) error {
+	// Stat, not Lstat: the per-file packer dereferenced symlinks, so we do too.
+	stat, err := os.Stat(f.AbsPath)
+	if err != nil {
+		return fmt.Errorf("unable to stat %s: %w", f.AbsPath, err)
+	}
+	if stat.IsDir() {
+		return nil
+	}
+
+	hdr, err := tar.FileInfoHeader(stat, "")
+	if err != nil {
+		return fmt.Errorf("unable to build tar header for %s: %w", f.AbsPath, err)
+	}
+	hdr.Name = filepath.ToSlash(f.RelPath)
+
+	// Normalized so an unchanged tree hashes to the same layer and the
+	// registry skips re-uploading it.
+	hdr.ModTime = time.Time{}
+	hdr.AccessTime = time.Time{}
+	hdr.ChangeTime = time.Time{}
+	hdr.Uid, hdr.Gid = 0, 0
+	hdr.Uname, hdr.Gname = "", ""
+
+	if err := tw.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("unable to write tar header for %s: %w", f.RelPath, err)
+	}
+
+	in, err := os.Open(f.AbsPath)
+	if err != nil {
+		return fmt.Errorf("unable to open %s: %w", f.AbsPath, err)
+	}
+	defer in.Close()
+
+	if _, err := io.Copy(tw, in); err != nil {
+		return fmt.Errorf("unable to write %s into tarball: %w", f.RelPath, err)
+	}
+	return nil
+}
+
+func extractTarGz(src, dstDir string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("unable to open tarball: %w", err)
+	}
+	defer in.Close()
+
+	gz, err := gzip.NewReader(in)
+	if err != nil {
+		return fmt.Errorf("unable to read tarball: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("unable to read tar entry: %w", err)
+		}
+
+		dst, err := safeJoin(dstDir, hdr.Name)
+		if err != nil {
+			return err
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(dst, 0o755); err != nil {
+				return fmt.Errorf("unable to create %s: %w", hdr.Name, err)
+			}
+		case tar.TypeReg:
+			if err := writeTarEntry(tr, dst, hdr.FileInfo().Mode()); err != nil {
+				return err
+			}
+		default:
+			continue
+		}
+	}
+}
+
+func writeTarEntry(tr *tar.Reader, dst string, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("unable to create dir for %s: %w", dst, err)
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode.Perm())
+	if err != nil {
+		return fmt.Errorf("unable to create %s: %w", dst, err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, tr); err != nil {
+		return fmt.Errorf("unable to write %s: %w", dst, err)
+	}
+	return nil
+}
+
+func safeJoin(dir, name string) (string, error) {
+	dst := filepath.Join(dir, filepath.FromSlash(name))
+	if dst != dir && !strings.HasPrefix(dst, dir+string(os.PathSeparator)) {
+		return "", fmt.Errorf("tar entry %q escapes the archive root", name)
+	}
+	return dst, nil
+}

--- a/pkg/runner/oci/archive/tar_test.go
+++ b/pkg/runner/oci/archive/tar_test.go
@@ -1,0 +1,59 @@
+package ociarchive
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeFile(t *testing.T, dir, rel string, contents string, mode os.FileMode) FileRef {
+	t.Helper()
+
+	abs := filepath.Join(dir, rel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+	require.NoError(t, os.WriteFile(abs, []byte(contents), mode))
+	require.NoError(t, os.Chmod(abs, mode))
+
+	return FileRef{AbsPath: abs, RelPath: rel, FileType: "file/terraform"}
+}
+
+func TestTarGzRoundTrip(t *testing.T) {
+	src := t.TempDir()
+	files := []FileRef{
+		writeFile(t, src, "main.tf", "resource \"null_resource\" \"a\" {}\n", 0o644),
+		writeFile(t, src, ".terraform/modules/eks/main.tf", "module\n", 0o644),
+		writeFile(t, src, ".nuon-bin/linux_amd64/terraform", "#!/bin/sh\n", 0o755),
+		writeFile(t, src, "empty.tf", "", 0o644),
+	}
+
+	tarball := filepath.Join(t.TempDir(), tarballName)
+	require.NoError(t, writeTarGz(tarball, files))
+
+	dst := t.TempDir()
+	require.NoError(t, extractTarGz(tarball, dst))
+
+	for _, f := range files {
+		want, err := os.ReadFile(f.AbsPath)
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(filepath.Join(dst, f.RelPath))
+		require.NoError(t, err, "%s missing from extracted tarball", f.RelPath)
+		require.Equal(t, want, got, f.RelPath)
+	}
+
+	stat, err := os.Stat(filepath.Join(dst, ".nuon-bin/linux_amd64/terraform"))
+	require.NoError(t, err)
+	require.NotZero(t, stat.Mode()&0o111, "executable bit not preserved")
+}
+
+func TestSafeJoinRejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := safeJoin(dir, "../escaped")
+	require.Error(t, err)
+
+	_, err = safeJoin(dir, "nested/../ok.tf")
+	require.NoError(t, err)
+}

--- a/pkg/runner/oci/archive/unpack.go
+++ b/pkg/runner/oci/archive/unpack.go
@@ -2,7 +2,9 @@ package ociarchive
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -120,6 +122,44 @@ func (a *archive) Unpack(ctx context.Context, srcCfg *configs.OCIRegistryReposit
 		return fmt.Errorf("unable to fetch contents: %w", err)
 	}
 	l.Info("finished fetching artifact contents", zap.String("duration", time.Since(fetchStart).String()))
+
+	return a.expandTarball(ctx, l, manifest)
+}
+
+func (a *archive) expandTarball(ctx context.Context, l *zap.Logger, manifest ocispec.Descriptor) error {
+	byts, err := content.FetchAll(ctx, a.store, manifest)
+	if err != nil {
+		return fmt.Errorf("unable to read manifest: %w", err)
+	}
+
+	var m ocispec.Manifest
+	if err := json.Unmarshal(byts, &m); err != nil {
+		return fmt.Errorf("unable to parse manifest: %w", err)
+	}
+
+	for _, layer := range m.Layers {
+		if layer.MediaType != tarballMediaType {
+			continue
+		}
+
+		name := layer.Annotations[ocispec.AnnotationTitle]
+		if name == "" {
+			name = tarballName
+		}
+		path, err := safeJoin(a.basePath, name)
+		if err != nil {
+			return err
+		}
+
+		l.Info("expanding tarball layer", zap.String("path", path))
+		if err := extractTarGz(path, a.basePath); err != nil {
+			return fmt.Errorf("unable to expand tarball layer: %w", err)
+		}
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("unable to remove tarball layer: %w", err)
+		}
+		return nil
+	}
 
 	return nil
 }


### PR DESCRIPTION
Sandbox builds fail to push with `Limit on number of layers per image exceeded` because we push one OCI layer per source file, and ECR caps an image at 500 layers (measured, it's undocumented). With `terraform-provider-mirror` on, `terraform get` vendors the module tree into the source dir, so a typical EKS sandbox goes from ~40 files to ~1400.

Above 256 files the packer now writes a single gzipped tarball layer instead, with normalized mtime/uid so an unchanged tree hashes to the same layer and the registry skips re-uploading it. Unpack detects the tarball by media type and expands it, so artifacts built before this keep unpacking the old way. The threshold sits above anything we produce today (largest observed is 177 layers), so nothing that currently pushes changes format.

Verified end to end against a real ECR repo with the exact 1391-file tree that was failing: packs to one 256MB layer, pushes, and unpacks back to the same 1391 files.