### PR TITLE
feat: update mcp setup

### DIFF
--- a/bins/cli/cmd/agents.go
+++ b/bins/cli/cmd/agents.go
@@ -19,15 +19,17 @@ Start here:
   nuon agents context   Print markdown orientation (auth, selection, how to use MCP)
   nuon agents mcp       Run a local stdio MCP proxy that injects your API token and org ID
 
-Register with Claude Code:
+Register with an MCP client:
 
-  claude mcp add nuon -- nuon agents mcp
-  # writes:
-  claude mcp add nuon -- nuon agents mcp --allow-writes
+  claude mcp add --transport stdio nuon -- nuon agents mcp
+  amp mcp add nuon -- nuon agents mcp
 
-Or add to .mcp.json / Cursor:
+Cursor / Cursor Agent: write ~/.cursor/mcp.json then agent mcp enable nuon.
+Stage: nuon -C /path/to/stage-config agents mcp
+Local: nuon agents mcp --url http://localhost:8088/mcp
 
-  {"mcpServers": {"nuon": {"command": "nuon", "args": ["agents", "mcp"]}}}
+  claude mcp add --transport stdio nuon -- nuon agents mcp --allow-writes
+  amp mcp add nuon -- nuon agents mcp --allow-writes
 
 Direct HTTP: point an MCP client at the URL from "nuon agents context"
 with Bearer token and X-Nuon-Org-ID headers.`,
@@ -63,6 +65,8 @@ Intended for LLM agents: run this first when asked to work with Nuon.`,
 
 func (c *cli) agentsMCPCmd() *cobra.Command {
 	var allowWrites bool
+	var mcpURL string
+	var serverName string
 
 	cmd := &cobra.Command{
 		Use:   "mcp",
@@ -75,11 +79,16 @@ Injects Authorization (Bearer) and X-Nuon-Org-ID from ~/.nuon on every
 upstream request. Read-only by default; pass --allow-writes to also
 expose mutating tools (descriptions prefixed with "WRITE OPERATION:").
 
-Example — register with Claude Code:
+Example — register:
 
-  claude mcp add nuon -- nuon agents mcp
+  claude mcp add --transport stdio nuon -- nuon agents mcp
+  amp mcp add nuon -- nuon agents mcp
+  # Cursor: write ~/.cursor/mcp.json, then agent mcp enable nuon
+  claude mcp add --transport stdio nuon-stage -- nuon -C /path/to/stage-config agents mcp
+  claude mcp add --transport stdio nuon-local -- nuon agents mcp --url http://localhost:8088/mcp
   # writes:
-  claude mcp add nuon -- nuon agents mcp --allow-writes
+  claude mcp add --transport stdio nuon -- nuon agents mcp --allow-writes
+  amp mcp add nuon -- nuon agents mcp --allow-writes
 
 Or add to .mcp.json:
 
@@ -90,10 +99,20 @@ Or add to .mcp.json:
 			if ReadOnly || readOnlyFromEnv() {
 				allowWrites = false
 			}
-			return mcpserver.New(c.cfg, allowWrites).Run(cmd.Context())
+			opts := make([]mcpserver.Option, 0, 2)
+			if mcpURL != "" {
+				opts = append(opts, mcpserver.WithEndpoint(mcpURL))
+			}
+			if serverName != "" {
+				opts = append(opts, mcpserver.WithName(serverName))
+			}
+			return mcpserver.New(c.cfg, allowWrites, opts...).Run(cmd.Context())
 		}),
 	}
 	cmd.Flags().BoolVar(&allowWrites, "allow-writes", false, "expose mutating tools whose descriptions start with WRITE OPERATION:")
+	cmd.Flags().StringVar(&mcpURL, "url", "", "MCP server URL (defaults based on the configured API URL)")
+	cmd.Flags().StringVar(&serverName, "name", "", "MCP server name exposed to the client (defaults based on the configured API URL)")
+	cmd.AddCommand(c.mcpSetupCmd())
 
 	return cmd
 }
@@ -144,9 +163,22 @@ func (c *cli) agentsContextMarkdown() string {
 	b.WriteString("### Preferred: local stdio proxy\n\n")
 	b.WriteString("Runs on the user's machine, injects token + org ID, forwards tools to the control plane:\n\n")
 	b.WriteString("```bash\nnuon agents mcp\n# writes:\nnuon agents mcp --allow-writes\n```\n\n")
-	b.WriteString("Register with Claude Code:\n\n")
-	b.WriteString("```bash\nclaude mcp add nuon -- nuon agents mcp\n# writes:\nclaude mcp add nuon -- nuon agents mcp --allow-writes\n```\n\n")
-	b.WriteString("Or MCP client config (.mcp.json):\n\n")
+	b.WriteString("Register with an MCP client:\n\n")
+	b.WriteString("```bash\n")
+	b.WriteString("claude mcp add --transport stdio nuon -- nuon agents mcp\n")
+	b.WriteString("amp mcp add nuon -- nuon agents mcp\n")
+	b.WriteString("# Cursor: write ~/.cursor/mcp.json, then:\n")
+	b.WriteString("agent mcp enable nuon\n")
+	b.WriteString("# stage / local:\n")
+	b.WriteString("claude mcp add --transport stdio nuon-stage -- nuon -C /path/to/stage-config agents mcp\n")
+	b.WriteString("claude mcp add --transport stdio nuon-local -- nuon agents mcp --url http://localhost:8088/mcp\n")
+	b.WriteString("amp mcp add nuon-stage -- nuon -C /path/to/stage-config agents mcp\n")
+	b.WriteString("amp mcp add nuon-local -- nuon agents mcp --url http://localhost:8088/mcp\n")
+	b.WriteString("# writes:\n")
+	b.WriteString("claude mcp add --transport stdio nuon -- nuon agents mcp --allow-writes\n")
+	b.WriteString("amp mcp add nuon -- nuon agents mcp --allow-writes\n")
+	b.WriteString("```\n\n")
+	b.WriteString("Cursor JSON (`~/.cursor/mcp.json` or `.cursor/mcp.json`):\n\n")
 	b.WriteString("```json\n{\"mcpServers\": {\"nuon\": {\"command\": \"nuon\", \"args\": [\"agents\", \"mcp\"]}}}\n```\n\n")
 	b.WriteString("The proxy sets `X-Nuon-Org-ID`. Do not call `select_org` unless the header is missing (`select_org` is a write tool).\n\n")
 	b.WriteString("### Direct: control-plane HTTP MCP\n\n")

--- a/bins/cli/cmd/mcp_setup.go
+++ b/bins/cli/cmd/mcp_setup.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 
 	"github.com/nuonco/nuon/bins/cli/internal/services/mcpserver"
@@ -20,43 +21,36 @@ func (c *cli) mcpSetupCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "setup",
-		Short: "Write MCP client config for Claude Code, Cursor, or Amp",
-		Long: `Write MCP client configuration so an AI agent can reach the Nuon
-control-plane HTTP MCP server.
+		Short: "Write stdio MCP client config for Claude Code, Cursor, or Amp",
+		Long: `Write MCP client configuration that runs "nuon agents mcp" over stdio.
 
-Reads the API token and org ID from the current CLI config (~/.nuon or -C).
-Run "nuon auth login" and "nuon orgs select" first.
+Auth stays in the CLI config (~/.nuon or -C). The client never stores the API token.
 
 Writes in the current directory:
   claude-code, claude    .mcp.json
   cursor                 .cursor/mcp.json
   amp                    .amp/settings.json
 
---url overrides the MCP HTTP URL (defaults from the configured API URL).
---name overrides the client list name (nuon, nuon-stage, or nuon-local).`,
+List name defaults from api_url (nuon, nuon-stage, nuon-local).
+--url and --name are passed through to "nuon agents mcp" when set.`,
 		PersistentPreRunE: c.persistentPreRunE,
 		Annotations:       outputsAnnotation(OutputTable),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
-			if c.cfg.APIToken == "" {
-				return fmt.Errorf("no API token found — run \"nuon auth login\" first")
-			}
-			if c.cfg.OrgID == "" {
-				return fmt.Errorf("no org selected — run \"nuon orgs select\" first")
-			}
-
-			if mcpURL == "" {
-				mcpURL = mcpserver.EndpointFromAPIURL(c.cfg.APIURL)
-			}
 			if name == "" {
 				name = mcpserver.NameFromAPIURL(c.cfg.APIURL)
 			}
 
-			return setupProjectMCP(mcpURL, c.cfg.APIToken, c.cfg.OrgID, platform, name)
+			args, err := stdioMCPArgs(cmd.Flags().Changed("url"), mcpURL, cmd.Flags().Changed("name"), name)
+			if err != nil {
+				return err
+			}
+
+			return setupProjectMCP(mcpSetupCommand(), args, platform, name)
 		}),
 	}
 
 	cmd.Flags().StringVar(&platform, "platform", "", "MCP client platform (claude-code, cursor, amp)")
-	cmd.Flags().StringVar(&mcpURL, "url", "", "MCP server URL (defaults based on the configured API URL)")
+	cmd.Flags().StringVar(&mcpURL, "url", "", "MCP server URL passed through to nuon agents mcp")
 	cmd.Flags().StringVar(&name, "name", "", "name in the client's MCP list (defaults based on the configured API URL)")
 	_ = cmd.MarkFlagRequired("platform")
 
@@ -64,18 +58,86 @@ Writes in the current directory:
 }
 
 type mcpServerEntry struct {
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
 	URL     string            `json:"url,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
 }
 
-func nuonMCPEntry(mcpURL, apiToken, orgID string) mcpServerEntry {
-	return mcpServerEntry{
-		URL: mcpURL,
-		Headers: map[string]string{
-			"Authorization": "Bearer " + apiToken,
-			"X-Nuon-Org-ID": orgID,
-		},
+func stdioMCPEntry(command string, args []string) mcpServerEntry {
+	return mcpServerEntry{Command: command, Args: args}
+}
+
+func mcpSetupCommand() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return "nuon"
 	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return exe
+}
+
+func stdioMCPArgs(urlSet bool, url string, nameSet bool, name string) ([]string, error) {
+	var args []string
+
+	configArgs, err := mcpSetupConfigFlagArgs()
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, configArgs...)
+	args = append(args, "agents", "mcp")
+	if urlSet {
+		args = append(args, "--url", url)
+	}
+	if nameSet {
+		args = append(args, "--name", name)
+	}
+	return args, nil
+}
+
+func mcpSetupConfigFlagArgs() ([]string, error) {
+	path := ConfigFile
+	if env := os.Getenv("NUON_CONFIG_FILE"); env != "" {
+		path = env
+	}
+	if isDefaultNuonConfig(path) {
+		return nil, nil
+	}
+
+	expanded, err := homedir.Expand(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to expand config path: %w", err)
+	}
+	abs, err := filepath.Abs(expanded)
+	if err != nil {
+		return nil, fmt.Errorf("unable to resolve config path: %w", err)
+	}
+	return []string{"-C", abs}, nil
+}
+
+func isDefaultNuonConfig(path string) bool {
+	if path == "" || path == DefaultConfigFilePath {
+		return true
+	}
+	left, err := homedir.Expand(path)
+	if err != nil {
+		return false
+	}
+	right, err := homedir.Expand(DefaultConfigFilePath)
+	if err != nil {
+		return false
+	}
+	left, err = filepath.Abs(left)
+	if err != nil {
+		return false
+	}
+	right, err = filepath.Abs(right)
+	if err != nil {
+		return false
+	}
+	return left == right
 }
 
 func normalizeMCPPlatform(platform string) (string, error) {
@@ -91,13 +153,13 @@ func normalizeMCPPlatform(platform string) (string, error) {
 	}
 }
 
-func setupProjectMCP(mcpURL, apiToken, orgID, platform, name string) error {
+func setupProjectMCP(command string, args []string, platform, name string) error {
 	platform, err := normalizeMCPPlatform(platform)
 	if err != nil {
 		return err
 	}
 
-	entry := nuonMCPEntry(mcpURL, apiToken, orgID)
+	entry := stdioMCPEntry(command, args)
 	var configPath string
 	switch platform {
 	case "claude-code":
@@ -125,8 +187,7 @@ func setupProjectMCP(mcpURL, apiToken, orgID, platform, name string) error {
 
 	fmt.Printf("Configured %s MCP at %s\n", platform, configPath)
 	fmt.Printf("  Name: %s\n", name)
-	fmt.Printf("  URL: %s\n", mcpURL)
-	fmt.Printf("  Org: %s\n", orgID)
+	fmt.Printf("  Command: %s %v\n", command, args)
 	return nil
 }
 
@@ -161,7 +222,7 @@ func writeMCPServersFile(configPath, serversKey, name string, entry mcpServerEnt
 	}
 	data = append(data, '\n')
 
-	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+	if err := os.WriteFile(configPath, data, 0o644); err != nil {
 		return fmt.Errorf("unable to write %s: %w", configPath, err)
 	}
 	return nil

--- a/bins/cli/cmd/mcp_setup.go
+++ b/bins/cli/cmd/mcp_setup.go
@@ -15,20 +15,25 @@ func (c *cli) mcpSetupCmd() *cobra.Command {
 	var (
 		platform string
 		mcpURL   string
+		name     string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "setup",
-		Short: "Configure an MCP client to connect to the Nuon control plane",
+		Short: "Write MCP client config for Claude Code, Cursor, or Amp",
 		Long: `Write MCP client configuration so an AI agent can reach the Nuon
 control-plane HTTP MCP server.
 
-Reads the API token and org ID from ~/.nuon. Run "nuon auth login" and
-"nuon orgs select" first.
+Reads the API token and org ID from the current CLI config (~/.nuon or -C).
+Run "nuon auth login" and "nuon orgs select" first.
 
 Writes in the current directory:
-  claude-code    .mcp.json
-  cursor         .cursor/mcp.json`,
+  claude-code, claude    .mcp.json
+  cursor                 .cursor/mcp.json
+  amp                    .amp/settings.json
+
+--url overrides the MCP HTTP URL (defaults from the configured API URL).
+--name overrides the client list name (nuon, nuon-stage, or nuon-local).`,
 		PersistentPreRunE: c.persistentPreRunE,
 		Annotations:       outputsAnnotation(OutputTable),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
@@ -40,36 +45,27 @@ Writes in the current directory:
 			}
 
 			if mcpURL == "" {
-				mcpURL = defaultMCPURL(c.cfg.APIURL)
+				mcpURL = mcpserver.EndpointFromAPIURL(c.cfg.APIURL)
+			}
+			if name == "" {
+				name = mcpserver.NameFromAPIURL(c.cfg.APIURL)
 			}
 
-			switch platform {
-			case "claude-code", "cursor":
-				return setupProjectMCP(mcpURL, c.cfg.APIToken, c.cfg.OrgID, platform)
-			default:
-				return fmt.Errorf("unsupported platform %q — supported: claude-code, cursor", platform)
-			}
+			return setupProjectMCP(mcpURL, c.cfg.APIToken, c.cfg.OrgID, platform, name)
 		}),
 	}
 
-	cmd.Flags().StringVar(&platform, "platform", "", "MCP client platform (claude-code, cursor)")
-	cmd.Flags().StringVar(&mcpURL, "url", "", "MCP server URL (defaults based on environment)")
+	cmd.Flags().StringVar(&platform, "platform", "", "MCP client platform (claude-code, cursor, amp)")
+	cmd.Flags().StringVar(&mcpURL, "url", "", "MCP server URL (defaults based on the configured API URL)")
+	cmd.Flags().StringVar(&name, "name", "", "name in the client's MCP list (defaults based on the configured API URL)")
 	_ = cmd.MarkFlagRequired("platform")
 
 	return cmd
 }
 
-func defaultMCPURL(apiURL string) string {
-	return mcpserver.EndpointFromAPIURL(apiURL)
-}
-
-type mcpClientConfig struct {
-	MCPServers map[string]mcpServerEntry `json:"mcpServers"`
-}
-
 type mcpServerEntry struct {
-	URL     string            `json:"url"`
-	Headers map[string]string `json:"headers"`
+	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
 }
 
 func nuonMCPEntry(mcpURL, apiToken, orgID string) mcpServerEntry {
@@ -82,40 +78,91 @@ func nuonMCPEntry(mcpURL, apiToken, orgID string) mcpServerEntry {
 	}
 }
 
-func setupProjectMCP(mcpURL, apiToken, orgID, platform string) error {
+func normalizeMCPPlatform(platform string) (string, error) {
+	switch platform {
+	case "claude-code", "claude":
+		return "claude-code", nil
+	case "cursor":
+		return "cursor", nil
+	case "amp":
+		return "amp", nil
+	default:
+		return "", fmt.Errorf("unsupported platform %q — supported: claude-code, cursor, amp", platform)
+	}
+}
+
+func setupProjectMCP(mcpURL, apiToken, orgID, platform, name string) error {
+	platform, err := normalizeMCPPlatform(platform)
+	if err != nil {
+		return err
+	}
+
+	entry := nuonMCPEntry(mcpURL, apiToken, orgID)
 	var configPath string
 	switch platform {
 	case "claude-code":
 		configPath = ".mcp.json"
+		if err := writeMCPServersFile(configPath, "mcpServers", name, entry); err != nil {
+			return err
+		}
 	case "cursor":
 		configPath = filepath.Join(".cursor", "mcp.json")
-		if err := os.MkdirAll(".cursor", 0755); err != nil {
+		if err := os.MkdirAll(".cursor", 0o755); err != nil {
 			return fmt.Errorf("unable to create .cursor directory: %w", err)
+		}
+		if err := writeMCPServersFile(configPath, "mcpServers", name, entry); err != nil {
+			return err
+		}
+	case "amp":
+		configPath = filepath.Join(".amp", "settings.json")
+		if err := os.MkdirAll(".amp", 0o755); err != nil {
+			return fmt.Errorf("unable to create .amp directory: %w", err)
+		}
+		if err := writeMCPServersFile(configPath, "amp.mcpServers", name, entry); err != nil {
+			return err
 		}
 	}
 
-	cfg := mcpClientConfig{MCPServers: map[string]mcpServerEntry{}}
+	fmt.Printf("Configured %s MCP at %s\n", platform, configPath)
+	fmt.Printf("  Name: %s\n", name)
+	fmt.Printf("  URL: %s\n", mcpURL)
+	fmt.Printf("  Org: %s\n", orgID)
+	return nil
+}
 
-	if data, err := os.ReadFile(configPath); err == nil {
-		_ = json.Unmarshal(data, &cfg)
+func writeMCPServersFile(configPath, serversKey, name string, entry mcpServerEntry) error {
+	root := map[string]json.RawMessage{}
+	if data, err := os.ReadFile(configPath); err == nil && len(data) > 0 {
+		if err := json.Unmarshal(data, &root); err != nil {
+			return fmt.Errorf("unable to parse %s: %w", configPath, err)
+		}
 	}
-	if cfg.MCPServers == nil {
-		cfg.MCPServers = map[string]mcpServerEntry{}
+
+	servers := map[string]mcpServerEntry{}
+	if raw, ok := root[serversKey]; ok {
+		if err := json.Unmarshal(raw, &servers); err != nil {
+			return fmt.Errorf("unable to parse %s %s: %w", configPath, serversKey, err)
+		}
 	}
+	if servers == nil {
+		servers = map[string]mcpServerEntry{}
+	}
+	servers[name] = entry
 
-	cfg.MCPServers["nuon-api"] = nuonMCPEntry(mcpURL, apiToken, orgID)
+	encoded, err := json.Marshal(servers)
+	if err != nil {
+		return fmt.Errorf("unable to marshal MCP servers: %w", err)
+	}
+	root[serversKey] = encoded
 
-	data, err := json.MarshalIndent(cfg, "", "  ")
+	data, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
 		return fmt.Errorf("unable to marshal config: %w", err)
 	}
+	data = append(data, '\n')
 
-	if err := os.WriteFile(configPath, data, 0644); err != nil {
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
 		return fmt.Errorf("unable to write %s: %w", configPath, err)
 	}
-
-	fmt.Printf("Configured %s MCP at %s\n", platform, configPath)
-	fmt.Printf("  URL: %s\n", mcpURL)
-	fmt.Printf("  Org: %s\n", orgID)
 	return nil
 }

--- a/bins/cli/cmd/mcp_setup_test.go
+++ b/bins/cli/cmd/mcp_setup_test.go
@@ -18,17 +18,44 @@ func TestNormalizeMCPPlatform(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestSetupProjectMCPWritesPlatformsAndOverrides(t *testing.T) {
+func TestSetupProjectMCPWritesStdioConfig(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	require.NoError(t, setupProjectMCP("http://localhost:8088/mcp", "tok_test", "org_test", "cursor", "nuon-local"))
-	require.NoError(t, setupProjectMCP("https://mcp.stage.nuon.co/mcp", "tok_test", "org_test", "claude", "nuon-stage"))
-	require.NoError(t, setupProjectMCP("https://mcp.nuon.co/mcp", "tok_test", "org_test", "amp", "nuon"))
+	args := []string{"-C", "/tmp/stage.yml", "agents", "mcp"}
+	require.NoError(t, setupProjectMCP("nuon", args, "cursor", "nuon-local"))
+	require.NoError(t, setupProjectMCP("nuon", args, "claude", "nuon-stage"))
+	require.NoError(t, setupProjectMCP("nuon", args, "amp", "nuon"))
 
-	assertHTTPServer(t, filepath.Join(dir, ".cursor", "mcp.json"), "mcpServers", "nuon-local", "http://localhost:8088/mcp")
-	assertHTTPServer(t, filepath.Join(dir, ".mcp.json"), "mcpServers", "nuon-stage", "https://mcp.stage.nuon.co/mcp")
-	assertHTTPServer(t, filepath.Join(dir, ".amp", "settings.json"), "amp.mcpServers", "nuon", "https://mcp.nuon.co/mcp")
+	assertStdioServer(t, filepath.Join(dir, ".cursor", "mcp.json"), "mcpServers", "nuon-local", args)
+	assertStdioServer(t, filepath.Join(dir, ".mcp.json"), "mcpServers", "nuon-stage", args)
+	assertStdioServer(t, filepath.Join(dir, ".amp", "settings.json"), "amp.mcpServers", "nuon", args)
+}
+
+func TestStdioMCPArgsIncludesOverrides(t *testing.T) {
+	t.Setenv("NUON_CONFIG_FILE", "")
+	prev := ConfigFile
+	ConfigFile = DefaultConfigFilePath
+	t.Cleanup(func() { ConfigFile = prev })
+
+	args, err := stdioMCPArgs(true, "http://localhost:8088/mcp", true, "nuon-local")
+	require.NoError(t, err)
+	require.Equal(t, []string{"agents", "mcp", "--url", "http://localhost:8088/mcp", "--name", "nuon-local"}, args)
+}
+
+func TestStdioMCPArgsIncludesConfigFile(t *testing.T) {
+	t.Setenv("NUON_CONFIG_FILE", "")
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "stage.yml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("api_url: https://api.stage.nuon.co\n"), 0o600))
+
+	prev := ConfigFile
+	ConfigFile = cfgPath
+	t.Cleanup(func() { ConfigFile = prev })
+
+	args, err := stdioMCPArgs(false, "", false, "")
+	require.NoError(t, err)
+	require.Equal(t, []string{"-C", cfgPath, "agents", "mcp"}, args)
 }
 
 func TestWriteMCPServersFilePreservesExistingServers(t *testing.T) {
@@ -36,7 +63,7 @@ func TestWriteMCPServersFilePreservesExistingServers(t *testing.T) {
 	path := filepath.Join(dir, "settings.json")
 	require.NoError(t, os.WriteFile(path, []byte(`{"other":true,"amp.mcpServers":{"datadog":{"url":"https://example"}}}`), 0o600))
 
-	require.NoError(t, writeMCPServersFile(path, "amp.mcpServers", "nuon-stage", nuonMCPEntry("https://mcp.stage.nuon.co/mcp", "tok", "org")))
+	require.NoError(t, writeMCPServersFile(path, "amp.mcpServers", "nuon-stage", stdioMCPEntry("nuon", []string{"agents", "mcp"})))
 
 	raw, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -48,11 +75,11 @@ func TestWriteMCPServersFilePreservesExistingServers(t *testing.T) {
 	servers := map[string]mcpServerEntry{}
 	require.NoError(t, json.Unmarshal(root["amp.mcpServers"], &servers))
 	require.Equal(t, "https://example", servers["datadog"].URL)
-	require.Equal(t, "https://mcp.stage.nuon.co/mcp", servers["nuon-stage"].URL)
-	require.Equal(t, "Bearer tok", servers["nuon-stage"].Headers["Authorization"])
+	require.Equal(t, "nuon", servers["nuon-stage"].Command)
+	require.Equal(t, []string{"agents", "mcp"}, servers["nuon-stage"].Args)
 }
 
-func assertHTTPServer(t *testing.T, path, key, name, url string) {
+func assertStdioServer(t *testing.T, path, key, name string, args []string) {
 	t.Helper()
 
 	raw, err := os.ReadFile(path)
@@ -63,6 +90,8 @@ func assertHTTPServer(t *testing.T, path, key, name, url string) {
 
 	servers := map[string]mcpServerEntry{}
 	require.NoError(t, json.Unmarshal(root[key], &servers))
-	require.Equal(t, url, servers[name].URL)
-	require.Equal(t, "org_test", servers[name].Headers["X-Nuon-Org-ID"])
+	require.Equal(t, "nuon", servers[name].Command)
+	require.Equal(t, args, servers[name].Args)
+	require.Empty(t, servers[name].URL)
+	require.Empty(t, servers[name].Headers)
 }

--- a/bins/cli/cmd/mcp_setup_test.go
+++ b/bins/cli/cmd/mcp_setup_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeMCPPlatform(t *testing.T) {
+	got, err := normalizeMCPPlatform("claude")
+	require.NoError(t, err)
+	require.Equal(t, "claude-code", got)
+
+	_, err = normalizeMCPPlatform("windsurf")
+	require.Error(t, err)
+}
+
+func TestSetupProjectMCPWritesPlatformsAndOverrides(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	require.NoError(t, setupProjectMCP("http://localhost:8088/mcp", "tok_test", "org_test", "cursor", "nuon-local"))
+	require.NoError(t, setupProjectMCP("https://mcp.stage.nuon.co/mcp", "tok_test", "org_test", "claude", "nuon-stage"))
+	require.NoError(t, setupProjectMCP("https://mcp.nuon.co/mcp", "tok_test", "org_test", "amp", "nuon"))
+
+	assertHTTPServer(t, filepath.Join(dir, ".cursor", "mcp.json"), "mcpServers", "nuon-local", "http://localhost:8088/mcp")
+	assertHTTPServer(t, filepath.Join(dir, ".mcp.json"), "mcpServers", "nuon-stage", "https://mcp.stage.nuon.co/mcp")
+	assertHTTPServer(t, filepath.Join(dir, ".amp", "settings.json"), "amp.mcpServers", "nuon", "https://mcp.nuon.co/mcp")
+}
+
+func TestWriteMCPServersFilePreservesExistingServers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"other":true,"amp.mcpServers":{"datadog":{"url":"https://example"}}}`), 0o600))
+
+	require.NoError(t, writeMCPServersFile(path, "amp.mcpServers", "nuon-stage", nuonMCPEntry("https://mcp.stage.nuon.co/mcp", "tok", "org")))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var root map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &root))
+	require.JSONEq(t, `true`, string(root["other"]))
+
+	servers := map[string]mcpServerEntry{}
+	require.NoError(t, json.Unmarshal(root["amp.mcpServers"], &servers))
+	require.Equal(t, "https://example", servers["datadog"].URL)
+	require.Equal(t, "https://mcp.stage.nuon.co/mcp", servers["nuon-stage"].URL)
+	require.Equal(t, "Bearer tok", servers["nuon-stage"].Headers["Authorization"])
+}
+
+func assertHTTPServer(t *testing.T, path, key, name, url string) {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var root map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &root))
+
+	servers := map[string]mcpServerEntry{}
+	require.NoError(t, json.Unmarshal(root[key], &servers))
+	require.Equal(t, url, servers[name].URL)
+	require.Equal(t, "org_test", servers[name].Headers["X-Nuon-Org-ID"])
+}

--- a/bins/cli/internal/services/mcpserver/service.go
+++ b/bins/cli/internal/services/mcpserver/service.go
@@ -15,10 +15,30 @@ import (
 type Service struct {
 	cfg         *config.Config
 	allowWrites bool
+	endpoint    string
+	name        string
 }
 
-func New(cfg *config.Config, allowWrites bool) *Service {
-	return &Service{cfg: cfg, allowWrites: allowWrites}
+type Option func(*Service)
+
+func WithEndpoint(endpoint string) Option {
+	return func(s *Service) {
+		s.endpoint = endpoint
+	}
+}
+
+func WithName(name string) Option {
+	return func(s *Service) {
+		s.name = name
+	}
+}
+
+func New(cfg *config.Config, allowWrites bool, opts ...Option) *Service {
+	svc := &Service{cfg: cfg, allowWrites: allowWrites}
+	for _, opt := range opts {
+		opt(svc)
+	}
+	return svc
 }
 
 func (s *Service) Run(ctx context.Context) error {
@@ -37,17 +57,40 @@ func (s *Service) Run(ctx context.Context) error {
 }
 
 func (s *Service) mcpEndpoint() string {
+	if s.endpoint != "" {
+		return s.endpoint
+	}
 	return EndpointFromAPIURL(s.cfg.APIURL)
 }
 
 // EndpointFromAPIURL returns the control-plane MCP HTTP URL for a given API URL.
 func EndpointFromAPIURL(apiURL string) string {
-	switch apiURL {
+	switch strings.TrimRight(apiURL, "/") {
 	case "https://api.nuon.co":
-		return "https://ctl.nuon.co/mcp"
+		return "https://mcp.nuon.co/mcp"
+	case "https://api.stage.nuon.co":
+		return "https://mcp.stage.nuon.co/mcp"
 	default:
 		return "http://localhost:8088/mcp"
 	}
+}
+
+func NameFromAPIURL(apiURL string) string {
+	switch strings.TrimRight(apiURL, "/") {
+	case "https://api.nuon.co":
+		return "nuon"
+	case "https://api.stage.nuon.co":
+		return "nuon-stage"
+	default:
+		return "nuon-local"
+	}
+}
+
+func (s *Service) serverName() string {
+	if s.name != "" {
+		return s.name
+	}
+	return NameFromAPIURL(s.cfg.APIURL)
 }
 
 func (s *Service) connectUpstream(ctx context.Context) (*mcp.ClientSession, error) {
@@ -82,7 +125,7 @@ func (s *Service) buildProxyServer(ctx context.Context, upstream *mcp.ClientSess
 	}
 
 	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "nuon",
+		Name:    s.serverName(),
 		Version: version.Version,
 	}, nil)
 

--- a/bins/cli/internal/services/mcpserver/service_test.go
+++ b/bins/cli/internal/services/mcpserver/service_test.go
@@ -54,13 +54,10 @@ func fakeUpstream(t *testing.T) (*mcp.Server, *mcp.ClientSession) {
 	return server, session
 }
 
-func connectProxy(t *testing.T, upstream *mcp.ClientSession, allowWrites bool) *mcp.ClientSession {
+func connectProxy(t *testing.T, upstream *mcp.ClientSession, allowWrites bool, opts ...Option) *mcp.ClientSession {
 	t.Helper()
 
-	svc := &Service{
-		cfg:         &config.Config{},
-		allowWrites: allowWrites,
-	}
+	svc := New(&config.Config{}, allowWrites, opts...)
 
 	server, err := svc.buildProxyServer(context.Background(), upstream)
 	require.NoError(t, err)
@@ -126,4 +123,52 @@ func TestProxyListApps(t *testing.T) {
 
 	text := res.Content[0].(*mcp.TextContent).Text
 	require.Contains(t, text, "my-app")
+}
+
+func TestEndpointAndNameFromAPIURL(t *testing.T) {
+	tests := []struct {
+		apiURL   string
+		endpoint string
+		name     string
+	}{
+		{
+			apiURL:   "https://api.nuon.co",
+			endpoint: "https://mcp.nuon.co/mcp",
+			name:     "nuon",
+		},
+		{
+			apiURL:   "https://api.stage.nuon.co/",
+			endpoint: "https://mcp.stage.nuon.co/mcp",
+			name:     "nuon-stage",
+		},
+		{
+			apiURL:   "http://localhost:8081",
+			endpoint: "http://localhost:8088/mcp",
+			name:     "nuon-local",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.endpoint, EndpointFromAPIURL(test.apiURL))
+			require.Equal(t, test.name, NameFromAPIURL(test.apiURL))
+		})
+	}
+}
+
+func TestProxyServerNameOverride(t *testing.T) {
+	_, upstream := fakeUpstream(t)
+
+	session := connectProxy(t, upstream, false, WithName("custom-server"))
+	require.Equal(t, "custom-server", session.InitializeResult().ServerInfo.Name)
+}
+
+func TestEndpointOverride(t *testing.T) {
+	svc := New(
+		&config.Config{APIURL: "https://api.stage.nuon.co"},
+		false,
+		WithEndpoint("https://example.com/mcp"),
+	)
+
+	require.Equal(t, "https://example.com/mcp", svc.mcpEndpoint())
 }

--- a/docs/cli-commands.mdx
+++ b/docs/cli-commands.mdx
@@ -90,7 +90,7 @@ Operate Nuon from an LLM client. See [Agents](/guides/agents/overview).
 |---------|--------------|
 | `nuon agents context` | Print auth, selected org/app/install, and the MCP HTTP URL. |
 | `nuon agents mcp` | Stdio MCP proxy (read-only). Add `--allow-writes` to expose mutating tools. `--url` / `--name` override the upstream URL and handshake name. |
-| `nuon agents mcp setup --platform <platform>` | Write HTTP MCP client config (`claude-code`, `cursor`, or `amp`). Defaults follow `api_url` in `~/.nuon` or `-C`. `--url` / `--name` override. |
+| `nuon agents mcp setup --platform <platform>` | Write stdio MCP client config (`claude-code`, `cursor`, or `amp`). List name follows `api_url` in `~/.nuon` or `-C`. `--url` / `--name` are passed through to `nuon agents mcp`. |
 
 ## Help
 

--- a/docs/cli-commands.mdx
+++ b/docs/cli-commands.mdx
@@ -89,7 +89,8 @@ Operate Nuon from an LLM client. See [Agents](/guides/agents/overview).
 | Command | What it does |
 |---------|--------------|
 | `nuon agents context` | Print auth, selected org/app/install, and the MCP HTTP URL. |
-| `nuon agents mcp` | Stdio MCP proxy (read-only). Add `--allow-writes` to expose mutating tools. |
+| `nuon agents mcp` | Stdio MCP proxy (read-only). Add `--allow-writes` to expose mutating tools. `--url` / `--name` override the upstream URL and handshake name. |
+| `nuon agents mcp setup --platform <platform>` | Write HTTP MCP client config (`claude-code`, `cursor`, or `amp`). Defaults follow `api_url` in `~/.nuon` or `-C`. `--url` / `--name` override. |
 
 ## Help
 

--- a/docs/guides/agents/mcp-walkthrough.mdx
+++ b/docs/guides/agents/mcp-walkthrough.mdx
@@ -14,9 +14,15 @@ icon: "route"
 <Steps>
 <Step title="Register the MCP server">
 
-Add the MCP server. Stdio keeps the token in `~/.nuon` (or `-C`). HTTP setup copies token + org into the client file.
+Add the stdio proxy. Token and org stay in `~/.nuon` (or `-C`).
 
-Stdio:
+```bash
+nuon agents mcp setup --platform claude-code
+nuon agents mcp setup --platform cursor
+nuon agents mcp setup --platform amp
+```
+
+Or register with the client CLI:
 
 <CodeGroup>
 ```bash Claude Code
@@ -28,15 +34,7 @@ amp mcp add nuon -- nuon agents mcp
 ```
 </CodeGroup>
 
-Or HTTP (Claude Code, Cursor, Amp):
-
-```bash
-nuon agents mcp setup --platform claude-code
-nuon agents mcp setup --platform cursor
-nuon agents mcp setup --platform amp
-```
-
-Stage: pass `-C /path/to/stage-config` so URL and list name follow that file's `api_url`. Overrides: `--url` and `--name`. Cursor Agent: `agent mcp enable <name>` after setup. Full examples: [Connect](/guides/agents/overview#connect).
+Stage: `nuon -C /path/to/stage-config agents mcp setup --platform cursor`. Overrides: `--url` and `--name`. Cursor Agent: `agent mcp enable <name>` after setup. Full examples: [Connect](/guides/agents/overview#connect).
 
 </Step>
 

--- a/docs/guides/agents/mcp-walkthrough.mdx
+++ b/docs/guides/agents/mcp-walkthrough.mdx
@@ -14,19 +14,29 @@ icon: "route"
 <Steps>
 <Step title="Register the MCP server">
 
-Add the stdio proxy to your MCP client. It injects your token and org from `~/.nuon`:
+Add the MCP server. Stdio keeps the token in `~/.nuon` (or `-C`). HTTP setup copies token + org into the client file.
 
-```json
-{"mcpServers": {"nuon": {"command": "nuon", "args": ["agents", "mcp"]}}}
+Stdio:
+
+<CodeGroup>
+```bash Claude Code
+claude mcp add --transport stdio nuon -- nuon agents mcp
 ```
 
-Claude Code:
+```bash Amp
+amp mcp add nuon -- nuon agents mcp
+```
+</CodeGroup>
+
+Or HTTP (Claude Code, Cursor, Amp):
 
 ```bash
-claude mcp add nuon -- nuon agents mcp
+nuon agents mcp setup --platform claude-code
+nuon agents mcp setup --platform cursor
+nuon agents mcp setup --platform amp
 ```
 
-For a direct HTTP connection instead, see [Connect](/guides/agents/overview#connect).
+Stage: pass `-C /path/to/stage-config` so URL and list name follow that file's `api_url`. Overrides: `--url` and `--name`. Cursor Agent: `agent mcp enable <name>` after setup. Full examples: [Connect](/guides/agents/overview#connect).
 
 </Step>
 

--- a/docs/guides/agents/overview.mdx
+++ b/docs/guides/agents/overview.mdx
@@ -2,7 +2,7 @@
 title: "Agents"
 description: "Operate Nuon from LLM clients via MCP."
 icon: "robot"
-keywords: ["MCP", "agents", "Claude Code", "Cursor", "nuon agents mcp"]
+keywords: ["MCP", "agents", "Claude Code", "Cursor", "Amp", "nuon agents mcp"]
 ---
 
 <Note>
@@ -24,35 +24,97 @@ nuon orgs select
 
 ## Connect
 
-**Recommended:** the CLI stdio proxy forwards to the control-plane MCP server and injects your token and org ID from `~/.nuon`. Read-only by default.
+Two ways to register MCP:
 
-```json
-{"mcpServers": {"nuon": {"command": "nuon", "args": ["agents", "mcp"]}}}
-```
+1. **Stdio proxy (recommended)** — the client runs `nuon agents mcp`. Token and org stay in `~/.nuon` (or `-C`).
+2. **`nuon agents mcp setup`** — writes an HTTP client config for Claude Code, Cursor, or Amp. Token and org are copied into that file.
+
+Defaults for MCP URL and list name come from `api_url` in the current CLI config. Use `-C` for a non-default file (stage). `--url` and `--name` override those defaults.
+
+| `api_url` | MCP URL | List name |
+| --- | --- | --- |
+| `https://api.nuon.co` | `https://mcp.nuon.co/mcp` | `nuon` |
+| `https://api.stage.nuon.co` | `https://mcp.stage.nuon.co/mcp` | `nuon-stage` |
+| anything else | `http://localhost:8088/mcp` | `nuon-local` |
+
+### HTTP setup
+
+Writes a Streamable HTTP entry (POST-only, no durable session) with `Authorization` and `X-Nuon-Org-ID` from the CLI config.
 
 ```bash
-claude mcp add nuon -- nuon agents mcp
+nuon agents mcp setup --platform claude-code
+nuon agents mcp setup --platform cursor
+nuon agents mcp setup --platform amp
+
+# stage (URL + name from that file's api_url)
+nuon -C /path/to/stage-config agents mcp setup --platform amp
+
+# overrides
+nuon agents mcp setup --platform cursor --url http://localhost:8088/mcp --name nuon-local
 ```
 
-Pass `--allow-writes` on that command (or in `args`) to expose tools whose descriptions start with `WRITE OPERATION:`. Those tools also need a token with create permission.
+`--platform claude` is an alias for `claude-code`. `nuon mcp setup` is the same command.
 
-**Direct HTTP:** point an MCP HTTP client at the URL from `nuon agents context`. The server is stateless Streamable HTTP (POST-only, no durable session), so auth and org go on every request as headers:
+| Platform | File |
+| --- | --- |
+| `claude-code` | `.mcp.json` |
+| `cursor` | `.cursor/mcp.json` |
+| `amp` | `.amp/settings.json` (`amp.mcpServers`) |
 
-```json
+Existing servers in the file are kept. Prefer stdio (below) if you do not want the API token written into the client config.
+
+### Stdio proxy
+
+Read-only by default. The name you pass to the client (`nuon`, `nuon-stage`, `nuon-local`) is what appears in its MCP list.
+
+<CodeGroup>
+```bash Claude Code
+claude mcp add --transport stdio nuon -- nuon agents mcp
+claude mcp add --transport stdio nuon-stage -- nuon -C /path/to/stage-config agents mcp
+claude mcp add --transport stdio nuon-local -- nuon agents mcp --url http://localhost:8088/mcp
+
+# writes
+claude mcp add --transport stdio nuon -- nuon agents mcp --allow-writes
+```
+
+```bash Amp
+amp mcp add nuon -- nuon agents mcp
+amp mcp add nuon-stage -- nuon -C /path/to/stage-config agents mcp
+amp mcp add nuon-local -- nuon agents mcp --url http://localhost:8088/mcp
+
+# writes
+amp mcp add nuon -- nuon agents mcp --allow-writes
+
+# this workspace only
+amp mcp add nuon --workspace -- nuon agents mcp
+```
+```json Cursor
 {
   "mcpServers": {
     "nuon": {
-      "url": "https://api.nuon.co/mcp",
-      "headers": {
-        "Authorization": "Bearer <api_token>",
-        "X-Nuon-Org-ID": "<org_id>"
-      }
+      "command": "nuon",
+      "args": ["agents", "mcp"]
+    },
+    "nuon-stage": {
+      "command": "nuon",
+      "args": ["-C", "/path/to/stage-config", "agents", "mcp"]
+    },
+    "nuon-local": {
+      "command": "nuon",
+      "args": ["agents", "mcp", "--url", "http://localhost:8088/mcp"]
     }
   }
 }
 ```
+</CodeGroup>
 
-Create the token with `nuon orgs api-tokens create --name <name>`. Because both paths set the org, you do not need `select_org` — only call it on HTTP without the header, and note it is a write tool.
+Cursor / Cursor Agent has no `mcp add`. Save the JSON above as `~/.cursor/mcp.json` or project `.cursor/mcp.json`, then `agent mcp enable <name>` — or run `nuon agents mcp setup --platform cursor` and enable the name it printed.
+
+Use an absolute path for `-C` in Cursor JSON; it does not expand `~`. Pass `--allow-writes` in stdio `args` when you need writes. Your token must have create permission.
+
+On the proxy itself, `--url` and `--name` override the upstream URL and handshake identity. That does not change the name in the client's list.
+
+Create a token with `nuon orgs api-tokens create --name <name>` if you are not using CLI login. You do not need `select_org` when the org is already set (stdio header or setup file). `select_org` is a write tool.
 
 ## Tools
 

--- a/docs/guides/agents/overview.mdx
+++ b/docs/guides/agents/overview.mdx
@@ -24,33 +24,28 @@ nuon orgs select
 
 ## Connect
 
-Two ways to register MCP:
+**Recommended:** register the stdio proxy so the client runs `nuon agents mcp`. Token and org stay in `~/.nuon` (or `-C`).
 
-1. **Stdio proxy (recommended)** — the client runs `nuon agents mcp`. Token and org stay in `~/.nuon` (or `-C`).
-2. **`nuon agents mcp setup`** — writes an HTTP client config for Claude Code, Cursor, or Amp. Token and org are copied into that file.
+`nuon agents mcp setup` writes that stdio config for Claude Code, Cursor, or Amp. List name defaults from `api_url`. Use `-C` for a non-default CLI config (stage). `--url` and `--name` are passed through to `nuon agents mcp` when set.
 
-Defaults for MCP URL and list name come from `api_url` in the current CLI config. Use `-C` for a non-default file (stage). `--url` and `--name` override those defaults.
-
-| `api_url` | MCP URL | List name |
+| `api_url` | Upstream MCP URL (proxy default) | List name |
 | --- | --- | --- |
 | `https://api.nuon.co` | `https://mcp.nuon.co/mcp` | `nuon` |
 | `https://api.stage.nuon.co` | `https://mcp.stage.nuon.co/mcp` | `nuon-stage` |
 | anything else | `http://localhost:8088/mcp` | `nuon-local` |
 
-### HTTP setup
-
-Writes a Streamable HTTP entry (POST-only, no durable session) with `Authorization` and `X-Nuon-Org-ID` from the CLI config.
+### Setup (stdio)
 
 ```bash
 nuon agents mcp setup --platform claude-code
 nuon agents mcp setup --platform cursor
 nuon agents mcp setup --platform amp
 
-# stage (URL + name from that file's api_url)
-nuon -C /path/to/stage-config agents mcp setup --platform amp
+# stage (-C is copied into the generated command)
+nuon -C /path/to/stage-config agents mcp setup --platform cursor
 
-# overrides
-nuon agents mcp setup --platform cursor --url http://localhost:8088/mcp --name nuon-local
+# overrides passed through to nuon agents mcp
+nuon agents mcp setup --platform amp --url http://localhost:8088/mcp --name nuon-local
 ```
 
 `--platform claude` is an alias for `claude-code`. `nuon mcp setup` is the same command.
@@ -61,11 +56,11 @@ nuon agents mcp setup --platform cursor --url http://localhost:8088/mcp --name n
 | `cursor` | `.cursor/mcp.json` |
 | `amp` | `.amp/settings.json` (`amp.mcpServers`) |
 
-Existing servers in the file are kept. Prefer stdio (below) if you do not want the API token written into the client config.
+Existing servers in the file are kept. Cursor Agent: `agent mcp enable <name>` after setup.
 
-### Stdio proxy
+### Client CLIs
 
-Read-only by default. The name you pass to the client (`nuon`, `nuon-stage`, `nuon-local`) is what appears in its MCP list.
+You can also register stdio yourself. Read-only by default. The name you pass (`nuon`, `nuon-stage`, `nuon-local`) is what appears in the client's MCP list.
 
 <CodeGroup>
 ```bash Claude Code
@@ -108,13 +103,13 @@ amp mcp add nuon --workspace -- nuon agents mcp
 ```
 </CodeGroup>
 
-Cursor / Cursor Agent has no `mcp add`. Save the JSON above as `~/.cursor/mcp.json` or project `.cursor/mcp.json`, then `agent mcp enable <name>` — or run `nuon agents mcp setup --platform cursor` and enable the name it printed.
+Cursor / Cursor Agent has no `mcp add`. Save the JSON above as `~/.cursor/mcp.json` or project `.cursor/mcp.json`, then `agent mcp enable <name>` — or run `nuon agents mcp setup --platform cursor`.
 
 Use an absolute path for `-C` in Cursor JSON; it does not expand `~`. Pass `--allow-writes` in stdio `args` when you need writes. Your token must have create permission.
 
 On the proxy itself, `--url` and `--name` override the upstream URL and handshake identity. That does not change the name in the client's list.
 
-Create a token with `nuon orgs api-tokens create --name <name>` if you are not using CLI login. You do not need `select_org` when the org is already set (stdio header or setup file). `select_org` is a write tool.
+You do not need `select_org` when the org is already in the CLI config (the stdio proxy sends `X-Nuon-Org-ID`). `select_org` is a write tool.
 
 ## Tools
 

--- a/sdks/nuon-go/client/nuon_client.go
+++ b/sdks/nuon-go/client/nuon_client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+
 	"github.com/nuonco/nuon/sdks/nuon-go/client/operations"
 )
 

--- a/sdks/nuon-runner-go/client/nuon_runner_api_client.go
+++ b/sdks/nuon-runner-go/client/nuon_runner_api_client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+
 	"github.com/nuonco/nuon/sdks/nuon-runner-go/client/operations"
 )
 


### PR DESCRIPTION
 ## Summary
  - Point the CLI MCP proxy at `mcp.nuon.co` / `mcp.stage.nuon.co` (or localhost) from `api_url`, with `--url` / `--name` overrides.
  - Expand `nuon agents mcp setup` to Claude Code, Cursor, and Amp