### PR TITLE
fix: deprecate -y flag, split -y operation into --confirm and --auto-approve

### DIFF
--- a/bins/cli/cmd/installs.go
+++ b/bins/cli/cmd/installs.go
@@ -40,6 +40,8 @@ func (c *cli) installsCmd() *cobra.Command {
 		planOnly            bool
 		fileOrDir           string
 		confirm             bool
+		autoApprove         bool
+		deprecatedYes       bool
 		wait                bool
 		enable              bool
 		disable             bool
@@ -203,12 +205,19 @@ sandbox and components unprovisioned:
 		Long:  "Sync install(s) with the help of config files",
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
 			svc := c.installs
-			return svc.Sync(cmd.Context(), fileOrDir, appID, confirm, wait, dryRun, PrintJSON)
+			if deprecatedYes {
+				confirm = true
+				autoApprove = true
+			}
+			return svc.Sync(cmd.Context(), fileOrDir, appID, confirm, autoApprove, wait, dryRun, PrintJSON)
 		}),
 	}
 	syncCmd.Flags().StringVarP(&fileOrDir, "file", "d", "", "Path to an install config file or a directory with install config files to sync")
 	syncCmd.Flags().StringVarP(&appID, "app-id", "a", "", "The ID or name of the app the install belongs to")
-	syncCmd.Flags().BoolVarP(&confirm, "yes", "y", false, "Set to automatically approve diffs and workflows for synced installs")
+	syncCmd.Flags().BoolVar(&confirm, "confirm", false, "Set to skip the diff confirmation prompt for synced installs")
+	syncCmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Set to auto-approve workflows triggered by the sync, overriding each install's configured approval_option")
+	syncCmd.Flags().BoolVarP(&deprecatedYes, "yes", "y", false, "Set to automatically approve diffs and workflows for synced installs")
+	syncCmd.Flags().MarkDeprecated("yes", "use --confirm to skip the diff prompt and --auto-approve to auto-approve workflows")
 	syncCmd.Flags().BoolVarP(&wait, "wait", "w", false, "Set to wait for workflows to complete after syncing installs")
 	syncCmd.Flags().BoolVar(&dryRun, "dry-run", false, "If set the changes will not be applied, only the diffs will be shown")
 	syncCmd.MarkFlagRequired("file")

--- a/bins/cli/cmd/installs.go
+++ b/bins/cli/cmd/installs.go
@@ -40,7 +40,7 @@ func (c *cli) installsCmd() *cobra.Command {
 		planOnly            bool
 		fileOrDir           string
 		confirm             bool
-		autoApprove         bool
+		syncApproveAll      bool
 		deprecatedYes       bool
 		wait                bool
 		enable              bool
@@ -207,17 +207,17 @@ sandbox and components unprovisioned:
 			svc := c.installs
 			if deprecatedYes {
 				confirm = true
-				autoApprove = true
+				syncApproveAll = true
 			}
-			return svc.Sync(cmd.Context(), fileOrDir, appID, confirm, autoApprove, wait, dryRun, PrintJSON)
+			return svc.Sync(cmd.Context(), fileOrDir, appID, confirm, syncApproveAll, wait, dryRun, PrintJSON)
 		}),
 	}
 	syncCmd.Flags().StringVarP(&fileOrDir, "file", "d", "", "Path to an install config file or a directory with install config files to sync")
 	syncCmd.Flags().StringVarP(&appID, "app-id", "a", "", "The ID or name of the app the install belongs to")
 	syncCmd.Flags().BoolVar(&confirm, "confirm", false, "Set to skip the diff confirmation prompt for synced installs")
-	syncCmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Set to auto-approve workflows triggered by the sync, overriding each install's configured approval_option")
+	syncCmd.Flags().BoolVar(&syncApproveAll, "approve-all", false, "Set to approve all steps in the workflows triggered by the sync, overriding each install's configured approval_option")
 	syncCmd.Flags().BoolVarP(&deprecatedYes, "yes", "y", false, "Set to automatically approve diffs and workflows for synced installs")
-	syncCmd.Flags().MarkDeprecated("yes", "use --confirm to skip the diff prompt and --auto-approve to auto-approve workflows")
+	syncCmd.Flags().MarkDeprecated("yes", "use --confirm to skip the diff prompt and --approve-all to approve triggered workflows")
 	syncCmd.Flags().BoolVarP(&wait, "wait", "w", false, "Set to wait for workflows to complete after syncing installs")
 	syncCmd.Flags().BoolVar(&dryRun, "dry-run", false, "If set the changes will not be applied, only the diffs will be shown")
 	syncCmd.MarkFlagRequired("file")

--- a/bins/cli/internal/services/installs/app_install_syncer.go
+++ b/bins/cli/internal/services/installs/app_install_syncer.go
@@ -31,20 +31,22 @@ type appInstallSyncer struct {
 	appID, orgID string
 	interactive  bool
 	asJSON       bool
+	autoApprove  bool
 }
 
-func newAppInstallSyncer(api nuon.Client, appID, orgID string, interactive, asJSON bool) *appInstallSyncer {
+func newAppInstallSyncer(api nuon.Client, appID, orgID string, interactive, asJSON, autoApprove bool) *appInstallSyncer {
 	return &appInstallSyncer{
 		api:         api,
 		appID:       appID,
 		orgID:       orgID,
 		interactive: interactive,
 		asJSON:      asJSON,
+		autoApprove: autoApprove,
 	}
 }
 
 func (s *appInstallSyncer) syncInstall(
-	ctx context.Context, installCfg *config.Install, installID string, autoApprove, wait, dryRun bool,
+	ctx context.Context, installCfg *config.Install, installID string, confirm, wait, dryRun bool,
 ) (*models.AppInstall, error) {
 	var err error
 	if !s.asJSON {
@@ -60,7 +62,7 @@ func (s *appInstallSyncer) syncInstall(
 	}
 
 	if installID == "" {
-		appInstall, err := s.syncNewInstall(ctx, installCfg, autoApprove, wait, dryRun)
+		appInstall, err := s.syncNewInstall(ctx, installCfg, confirm, wait, dryRun)
 		return appInstall, err
 	}
 
@@ -69,11 +71,11 @@ func (s *appInstallSyncer) syncInstall(
 		return nil, fmt.Errorf("error getting install %s: %w", installCfg.Name, err)
 	}
 
-	appInstall, err = s.syncExistingInstall(ctx, installCfg, appInstall, autoApprove, wait, dryRun)
+	appInstall, err = s.syncExistingInstall(ctx, installCfg, appInstall, confirm, wait, dryRun)
 	return appInstall, err
 }
 
-func (s *appInstallSyncer) syncNewInstall(ctx context.Context, installCfg *config.Install, autoApprove, wait, dryRun bool) (*models.AppInstall, error) {
+func (s *appInstallSyncer) syncNewInstall(ctx context.Context, installCfg *config.Install, confirm, wait, dryRun bool) (*models.AppInstall, error) {
 	appInputCfg, err := s.api.GetAppInputLatestConfig(ctx, s.appID)
 	if err != nil {
 		return nil, fmt.Errorf("error getting latest input config for app %s: %w", s.appID, err)
@@ -116,7 +118,7 @@ func (s *appInstallSyncer) syncNewInstall(ctx context.Context, installCfg *confi
 		return nil, nil
 	}
 
-	if !autoApprove {
+	if !confirm {
 		ok, err := bubbles.ShowConfirmDialogWithNote(
 			"Do you want to proceed with creating this install?",
 			fmt.Sprintf("Install %q does not exist and will be created.", installCfg.Name),
@@ -184,7 +186,7 @@ func (s *appInstallSyncer) syncNewInstall(ctx context.Context, installCfg *confi
 		return nil, fmt.Errorf("error creating install %s: %w", installCfg.Name, err)
 	}
 
-	err = s.handleWorkflow(ctx, appInstall.WorkflowID, appInstall.ID, autoApprove, wait)
+	err = s.handleWorkflow(ctx, appInstall.WorkflowID, appInstall.ID, wait)
 	if err != nil {
 		return nil, fmt.Errorf("error handling workflow for install %s: %w", installCfg.Name, err)
 	}
@@ -196,7 +198,7 @@ func (s *appInstallSyncer) syncNewInstall(ctx context.Context, installCfg *confi
 }
 
 func (s *appInstallSyncer) syncExistingInstall(
-	ctx context.Context, installCfg *config.Install, appInstall *models.AppInstall, autoApprove, wait, dryRun bool,
+	ctx context.Context, installCfg *config.Install, appInstall *models.AppInstall, confirm, wait, dryRun bool,
 ) (*models.AppInstall, error) {
 	var err error
 
@@ -256,7 +258,7 @@ func (s *appInstallSyncer) syncExistingInstall(
 		return nil, nil
 	}
 
-	if !autoApprove {
+	if !confirm {
 		ok, err := bubbles.ShowConfirmDialog("Do you want to proceed with updating this install?", s.interactive)
 		if err != nil {
 			ui.PrintSuccess(fmt.Sprintf("skipping install %s, sync aborted by user", installCfg.Name))
@@ -365,7 +367,7 @@ func (s *appInstallSyncer) syncExistingInstall(
 			return nil, fmt.Errorf("error updating inputs for install %s: %w", appInstall.Name, err)
 		}
 
-		err = s.handleWorkflow(ctx, installInputs.WorkflowID, appInstall.ID, autoApprove, wait)
+		err = s.handleWorkflow(ctx, installInputs.WorkflowID, appInstall.ID, wait)
 		if err != nil {
 			return nil, fmt.Errorf("error handling workflow for install %s: %w", appInstall.Name, err)
 		}
@@ -409,14 +411,14 @@ func (s *appInstallSyncer) syncLabels(ctx context.Context, installID string, des
 	return nil
 }
 
-func (s *appInstallSyncer) handleWorkflow(ctx context.Context, workflowID string, installID string, autoApprove, wait bool) error {
+func (s *appInstallSyncer) handleWorkflow(ctx context.Context, workflowID string, installID string, wait bool) error {
 	workflow, err := s.api.GetWorkflow(ctx, workflowID)
 	if err != nil {
 		return nil
 	}
 
 	if workflow.ApprovalOption == models.AppInstallApprovalOptionPrompt {
-		if autoApprove && workflow.Status.Status == models.AppStatusPending {
+		if s.autoApprove && workflow.Status.Status == models.AppStatusPending {
 			_, err := s.api.UpdateWorkflow(ctx, workflow.ID, &models.ServiceUpdateWorkflowRequest{
 				ApprovalOption: models.AppInstallApprovalOptionApproveDashAll.Pointer(),
 			})

--- a/bins/cli/internal/services/installs/app_install_syncer.go
+++ b/bins/cli/internal/services/installs/app_install_syncer.go
@@ -31,17 +31,17 @@ type appInstallSyncer struct {
 	appID, orgID string
 	interactive  bool
 	asJSON       bool
-	autoApprove  bool
+	approveAll   bool
 }
 
-func newAppInstallSyncer(api nuon.Client, appID, orgID string, interactive, asJSON, autoApprove bool) *appInstallSyncer {
+func newAppInstallSyncer(api nuon.Client, appID, orgID string, interactive, asJSON, approveAll bool) *appInstallSyncer {
 	return &appInstallSyncer{
 		api:         api,
 		appID:       appID,
 		orgID:       orgID,
 		interactive: interactive,
 		asJSON:      asJSON,
-		autoApprove: autoApprove,
+		approveAll:  approveAll,
 	}
 }
 
@@ -418,7 +418,7 @@ func (s *appInstallSyncer) handleWorkflow(ctx context.Context, workflowID string
 	}
 
 	if workflow.ApprovalOption == models.AppInstallApprovalOptionPrompt {
-		if s.autoApprove && workflow.Status.Status == models.AppStatusPending {
+		if s.approveAll && workflow.Status.Status == models.AppStatusPending {
 			_, err := s.api.UpdateWorkflow(ctx, workflow.ID, &models.ServiceUpdateWorkflowRequest{
 				ApprovalOption: models.AppInstallApprovalOptionApproveDashAll.Pointer(),
 			})

--- a/bins/cli/internal/services/installs/sync.go
+++ b/bins/cli/internal/services/installs/sync.go
@@ -18,7 +18,7 @@ import (
 	"github.com/nuonco/nuon/pkg/config"
 )
 
-func (s *Service) Sync(ctx context.Context, fileOrDir string, appID string, confirm, autoApprove, wait, dryRun, asJSON bool) error {
+func (s *Service) Sync(ctx context.Context, fileOrDir string, appID string, confirm, approveAll, wait, dryRun, asJSON bool) error {
 	if fileOrDir == "" {
 		return ui.PrintError(fmt.Errorf("file or directory path is required"))
 	}
@@ -38,7 +38,7 @@ func (s *Service) Sync(ctx context.Context, fileOrDir string, appID string, conf
 		return ui.PrintError(fmt.Errorf("error listing installs for app %s: %w", appID, err))
 	}
 
-	is := newAppInstallSyncer(s.api, appID, s.cfg.OrgID, s.cfg.Interactive, asJSON, autoApprove)
+	is := newAppInstallSyncer(s.api, appID, s.cfg.OrgID, s.cfg.Interactive, asJSON, approveAll)
 
 	results := make([]syncedInstall, 0, len(installCfgs))
 	for _, installCfg := range installCfgs {

--- a/bins/cli/internal/services/installs/sync.go
+++ b/bins/cli/internal/services/installs/sync.go
@@ -18,7 +18,7 @@ import (
 	"github.com/nuonco/nuon/pkg/config"
 )
 
-func (s *Service) Sync(ctx context.Context, fileOrDir string, appID string, autoApprove, wait, dryRun, asJSON bool) error {
+func (s *Service) Sync(ctx context.Context, fileOrDir string, appID string, confirm, autoApprove, wait, dryRun, asJSON bool) error {
 	if fileOrDir == "" {
 		return ui.PrintError(fmt.Errorf("file or directory path is required"))
 	}
@@ -38,7 +38,7 @@ func (s *Service) Sync(ctx context.Context, fileOrDir string, appID string, auto
 		return ui.PrintError(fmt.Errorf("error listing installs for app %s: %w", appID, err))
 	}
 
-	is := newAppInstallSyncer(s.api, appID, s.cfg.OrgID, s.cfg.Interactive, asJSON)
+	is := newAppInstallSyncer(s.api, appID, s.cfg.OrgID, s.cfg.Interactive, asJSON, autoApprove)
 
 	results := make([]syncedInstall, 0, len(installCfgs))
 	for _, installCfg := range installCfgs {
@@ -63,7 +63,7 @@ func (s *Service) Sync(ctx context.Context, fileOrDir string, appID string, auto
 			}
 		}
 
-		synced, err := is.syncInstall(ctx, installCfg, installID, autoApprove, wait, dryRun)
+		synced, err := is.syncInstall(ctx, installCfg, installID, confirm, wait, dryRun)
 		if err != nil {
 			return ui.PrintError(fmt.Errorf("error syncing install %s: %w", installCfg.Name, err))
 		}

--- a/docs/guides/component-overrides.mdx
+++ b/docs/guides/component-overrides.mdx
@@ -88,7 +88,7 @@ key they set. For Terraform, they're applied as the last `-var-file`, so they wi
 Overrides are applied by syncing the install config with the CLI:
 
 ```bash
-nuon installs sync --file install.toml --app-id <your-app-id> --yes
+nuon installs sync --file install.toml --app-id <your-app-id> --confirm
 ```
 
 The CLI validates override syntax locally before making any API calls: `helm_values` must be valid YAML and `tf_vars`

--- a/docs/guides/github-actions.mdx
+++ b/docs/guides/github-actions.mdx
@@ -111,7 +111,7 @@ command: "apps branches trigger --branch-id main --no-wait --force"
 The `command` input takes any CLI command, so the same action covers whatever else your pipeline needs — for example, syncing install config files from your repo:
 
 ```yaml
-command: "installs sync -a ${{ vars.nuon_app_id }} -d ./installs --confirm --auto-approve"
+command: "installs sync -a ${{ vars.nuon_app_id }} -d ./installs --confirm --approve-all"
 ```
 
 ### Action inputs

--- a/docs/guides/github-actions.mdx
+++ b/docs/guides/github-actions.mdx
@@ -111,7 +111,7 @@ command: "apps branches trigger --branch-id main --no-wait --force"
 The `command` input takes any CLI command, so the same action covers whatever else your pipeline needs — for example, syncing install config files from your repo:
 
 ```yaml
-command: "installs sync -a ${{ vars.nuon_app_id }} -d ./installs --yes"
+command: "installs sync -a ${{ vars.nuon_app_id }} -d ./installs --confirm --auto-approve"
 ```
 
 ### Action inputs

--- a/docs/guides/install-configs.mdx
+++ b/docs/guides/install-configs.mdx
@@ -17,7 +17,7 @@ Install configs are defined by a [JSON Schema](/config-ref/install) that lists e
 Apply a generated config with the Nuon CLI:
 
 ```bash
-nuon installs sync --file <your-install>.toml --app-id <your-app-id> --yes
+nuon installs sync --file <your-install>.toml --app-id <your-app-id> --confirm
 ```
 
 For the full property list, see the [Install configuration reference](/config-ref/install).


### PR DESCRIPTION
nuon installs sync -y did two unrelated things: skipped the diff confirmation prompt and approve-all the triggered workflows, overriding each install's configured approval_option. Callers who wanted a non-interactive sync had no way to keep their approval gates.

Split into two flags:

- --confirm - skip the diff confirmation prompt
- --approve-all - auto-approve workflows triggered by the sync

-y/--yes is marked deprecated (hidden from help, prints a migration warning) and still sets both, so existing CI keeps working unchanged.
