### PR TITLE
fix: docs dev under bun

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,10 +5,11 @@ configuration live in `docs.json`.
 
 ### Development
 
-Preview the docs locally with nuonctl:
+Preview the docs locally with nuonctl. `--skip-all` keeps it from also starting
+every other service:
 
 ```
-nuonctl dev --dev=docs
+nuonctl dev --dev=docs --skip-all
 ```
 
 Or run the dev server directly from this directory:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,31 +1,37 @@
-# Mintlify Starter Kit
+# Nuon Docs
 
-Click on `Use this template` to copy the Mintlify starter kit. The starter kit contains examples including
-
-- Guide pages
-- Navigation
-- Customizations
-- API Reference pages
-- Use of popular components
+The public Nuon documentation, built with [Mintlify](https://mintlify.com). Navigation and
+configuration live in `docs.json`.
 
 ### Development
 
-Install the [Mintlify CLI](https://www.npmjs.com/package/mintlify) to preview the documentation changes locally. To install, use the following command
+Preview the docs locally with nuonctl:
 
 ```
-npm i -g mint
+nuonctl dev --dev=docs
 ```
 
-Run the following command at the root of your documentation (where mint.json is)
+Or run the dev server directly from this directory:
 
 ```
-mintlify dev
+./dev.sh
 ```
+
+Either way the preview is served at http://localhost:3333.
+
+`dev.sh` pins the mint version to match `Dockerfile` and picks a node that mint
+supports. mint refuses to run on node 25, which bun reports itself as, so
+running `mint` under bun or an active node 25 fails. Overrides: `MINT_NODE`,
+`MINT_VERSION`, `PORT`.
+
 ### Publishing Changes
 
 Install our Github App to autopropagate changes from youre repo to your deployment. Changes will be deployed to production automatically after pushing to the default branch. Find the link to install on your dashboard.
 
 #### Troubleshooting
 
-- Mintlify dev isn't running - Run `mintlify install` it'll re-install dependencies.
-- Page loads as a 404 - Make sure you are running in a folder with `mint.json`
+- `mintlify is not supported on node 25` - `dev.sh` should avoid this; if it
+  can't find a supported node, install one (`brew install node@24`) or point
+  `MINT_NODE` at one.
+- Page loads as a 404 - Make sure you are running in this directory, where
+  `docs.json` lives.

--- a/docs/dev.sh
+++ b/docs/dev.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Runs the mintlify dev server for local docs development.
+#
+# mint refuses to run on node 25, and bun reports itself as node 25+, so `npx`
+# backed by bun (or an active node 25) fails. This finds a supported node and
+# runs mint under it.
+set -euo pipefail
+
+MINT_VERSION="${MINT_VERSION:-4.2.314}"
+PORT="${PORT:-3333}"
+
+# node is supported if it is real node (not bun) and >= 20.17, != 25.x
+node_supported() {
+  local bin="$1"
+  [[ -x "$bin" ]] || return 1
+  "$bin" -e '
+    if (typeof Bun !== "undefined" || typeof Deno !== "undefined") process.exit(1);
+    const [maj, min] = process.versions.node.split(".").map(Number);
+    process.exit(maj === 25 || maj < 20 || (maj === 20 && min < 17) ? 1 : 0);
+  ' >/dev/null 2>&1
+}
+
+find_node() {
+  local candidates=()
+  [[ -n "${MINT_NODE:-}" ]] && candidates+=("$MINT_NODE")
+  candidates+=("$(command -v node || true)")
+  for v in 24 22 20; do
+    candidates+=("/opt/homebrew/opt/node@$v/bin/node" "/usr/local/opt/node@$v/bin/node")
+    while IFS= read -r n; do candidates+=("$n"); done < <(
+      ls -d "$HOME"/.nvm/versions/node/v$v.*/bin/node 2>/dev/null | sort -rV
+    )
+  done
+
+  for c in "${candidates[@]}"; do
+    if node_supported "$c"; then
+      echo "$c"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if ! NODE_BIN="$(find_node)"; then
+  echo "docs: no supported node found (need >= 20.17, not 25.x, not bun)." >&2
+  echo "      install one (e.g. 'brew install node@24') or set MINT_NODE=/path/to/node" >&2
+  exit 1
+fi
+
+NODE_DIR="$(dirname "$NODE_BIN")"
+echo "docs: using node $("$NODE_BIN" --version) from $NODE_DIR"
+
+# docs/.npmrc sets min-release-age, which makes npx refuse the pinned mint version
+export NPM_CONFIG_MIN_RELEASE_AGE=0
+export PATH="$NODE_DIR:$PATH"
+
+exec "$NODE_DIR/npx" --yes "mint@${MINT_VERSION}" dev --no-open --port "$PORT"

--- a/docs/service.yml
+++ b/docs/service.yml
@@ -8,7 +8,7 @@ env_secrets: {}
 disable_watch: true
 local_startup_cmds: []
 local_cmds:
-  - npx --yes mint dev --no-open --port 3333
+  - ./dev.sh
 disable_config_map: true
 docker_cmds:
   - cmd: mint


### PR DESCRIPTION
`nuonctl dev --dev=docs` ran `npx --yes mint dev`, so whichever runtime the developer had active got used. Under bun (or node 25) mint hard-exits with "mintlify is not supported on node 25" — bun reports itself as node 25+. `docs/.npmrc`'s `min-release-age` also fights npx version resolution.

- `docs/dev.sh`: picks a supported node (skips bun/Deno, node 25.x, <20.17), sets `NPM_CONFIG_MIN_RELEASE_AGE=0`, runs `mint@4.2.314` (matches `Dockerfile`) on port 3333. Overridable via `MINT_NODE`/`MINT_VERSION`/`PORT`.
- `service.yml` local_cmds -> `./dev.sh`
- refresh `docs/README.md`, which was still Mintlify starter-kit boilerplate

Verified with `~/.bun/bin` first on PATH: skipped bun, used node 24, health check endpoint returned 200.

Ref: https://nuonco.slack.com/archives/C093P00E77F/p1788302641443899