### PR TITLE
fix(ctl-api): own execute-workflow signals so approvals can find the handler

### DIFF
--- a/services/ctl-api/internal/app/installs/helpers/enqueue_install_signal.go
+++ b/services/ctl-api/internal/app/installs/helpers/enqueue_install_signal.go
@@ -5,12 +5,25 @@ import (
 	"fmt"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeflow"
 	queueclient "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/client"
 	queuesignal "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 )
 
 // EnqueueInstallSignal enqueues a v2 signal onto the named queue for an install.
 func (h *Helpers) EnqueueInstallSignal(ctx context.Context, installID, queueName string, sig queuesignal.Signal) error {
+	return h.enqueueInstallSignal(ctx, installID, queueName, sig, "", "")
+}
+
+// EnqueueInstallWorkflow starts an install workflow. The queue signal must be owned
+// by the workflow: approve/cancel/retry/pause look the handler up by owner_id.
+func (h *Helpers) EnqueueInstallWorkflow(ctx context.Context, installID, workflowID string) error {
+	return h.enqueueInstallSignal(ctx, installID, InstallWorkflowsQueueName,
+		&executeflow.Signal{WorkflowID: workflowID},
+		workflowID, (&app.Workflow{}).TableName())
+}
+
+func (h *Helpers) enqueueInstallSignal(ctx context.Context, installID, queueName string, sig queuesignal.Signal, ownerID, ownerType string) error {
 	var q app.Queue
 	if res := h.db.WithContext(ctx).
 		Where(app.Queue{OwnerID: installID, Name: queueName}).
@@ -19,8 +32,10 @@ func (h *Helpers) EnqueueInstallSignal(ctx context.Context, installID, queueName
 	}
 
 	_, err := h.queueClient.EnqueueSignal(ctx, &queueclient.EnqueueSignalRequest{
-		QueueID: q.ID,
-		Signal:  sig,
+		QueueID:   q.ID,
+		Signal:    sig,
+		OwnerID:   ownerID,
+		OwnerType: ownerType,
 	})
 	return err
 }

--- a/services/ctl-api/internal/app/installs/signals/driftcheck/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/driftcheck/signal.go
@@ -123,6 +123,8 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		Signal: &executeflow.Signal{
 			WorkflowID: wkflw.ID,
 		},
+		SignalOwnerID:   wkflw.ID,
+		SignalOwnerType: (&app.Workflow{}).TableName(),
 	})
 	if err != nil {
 		return fmt.Errorf("unable to enqueue flow execution signal: %w", err)

--- a/services/ctl-api/internal/app/installs/signals/driftchecksandbox/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/driftchecksandbox/signal.go
@@ -83,6 +83,8 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		Signal: &executeflow.Signal{
 			WorkflowID: wkflw.ID,
 		},
+		SignalOwnerID:   wkflw.ID,
+		SignalOwnerType: (&app.Workflow{}).TableName(),
 	}); err != nil {
 		return fmt.Errorf("unable to enqueue flow execution signal: %w", err)
 	}

--- a/services/ctl-api/internal/app/installs/signals/stackrun/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/stackrun/signal.go
@@ -443,6 +443,8 @@ func (s *Signal) processOutputs(ctx workflow.Context, install *app.Install, vers
 				Signal: &executeflow.Signal{
 					WorkflowID: inputResp.WorkflowID,
 				},
+				SignalOwnerID:   inputResp.WorkflowID,
+				SignalOwnerType: (&app.Workflow{}).TableName(),
 			}); err != nil {
 				l.Warn("unable to enqueue input update workflow signal", zap.Error(err))
 			}

--- a/services/ctl-api/internal/app/installs/worker/activities/approve_plan.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/approve_plan.go
@@ -2,9 +2,11 @@ package activities
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	tclient "go.temporal.io/sdk/client"
+	"gorm.io/gorm"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/handler"
@@ -51,6 +53,14 @@ func (a *Activities) ApprovePlan(ctx context.Context, req *ApprovePlanRequest) (
 		}).
 		Order("created_at DESC").
 		First(&qs)
+	if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+		// Older enqueue paths left owner_id empty; the payload still names the workflow.
+		res = a.db.WithContext(ctx).
+			Where(app.QueueSignal{Type: signal.SignalType("execute-workflow")}).
+			Where("signal->'data'->>'workflow_id' = ?", req.InstallWorkflowID).
+			Order("created_at DESC").
+			First(&qs)
+	}
 	if res.Error != nil {
 		return nil, fmt.Errorf("queue signal not found for install_workflow %s: %w", req.InstallWorkflowID, res.Error)
 	}

--- a/services/ctl-api/internal/app/stacks/service/post_stack_phone_home.go
+++ b/services/ctl-api/internal/app/stacks/service/post_stack_phone_home.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app/installs/signals/stackrun"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
-	executeflow "github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeflow"
 )
 
 // StackPhoneHomeRequest is the body of a stack phone home: the stack's outputs plus
@@ -172,10 +171,7 @@ func (s *service) PostStackPhoneHome(ctx *gin.Context) {
 
 	// The workflow was created above; this makes it run.
 	if inputWorkflow != nil {
-		if err := s.installsHelpers.EnqueueInstallSignal(reqCtx, install.ID,
-			installshelpers.InstallWorkflowsQueueName, &executeflow.Signal{
-				WorkflowID: inputWorkflow.ID,
-			}); err != nil {
+		if err := s.installsHelpers.EnqueueInstallWorkflow(reqCtx, install.ID, inputWorkflow.ID); err != nil {
 			ctx.Error(fmt.Errorf("enqueue input update workflow signal: %w", err))
 			return
 		}

--- a/services/ctl-api/internal/pkg/flow/client/client.go
+++ b/services/ctl-api/internal/pkg/flow/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.uber.org/fx"
@@ -10,6 +11,7 @@ import (
 
 	temporalclient "github.com/nuonco/nuon/pkg/temporal/client"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/flow/signals/executeflow"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal"
 )
 
@@ -51,6 +53,14 @@ func (c *Client) findQueueSignalByOwner(ctx context.Context, ownerID, ownerType 
 		}).
 		Order("created_at DESC").
 		First(&qs)
+	if errors.Is(res.Error, gorm.ErrRecordNotFound) && signalType == executeflow.SignalType {
+		// Older enqueue paths left owner_id empty; the payload still names the workflow.
+		res = c.db.WithContext(ctx).
+			Where(app.QueueSignal{Type: signalType}).
+			Where("signal->'data'->>'workflow_id' = ?", ownerID).
+			Order("created_at DESC").
+			First(&qs)
+	}
 	if res.Error != nil {
 		return nil, fmt.Errorf("queue signal not found for owner %s type %s: %w", ownerID, signalType, res.Error)
 	}


### PR DESCRIPTION
Stack phone-home, stackrun and drift enqueued execute-workflow signals without owner_id, so ApprovePlan (and cancel/retry/pause via flowclient) got record not found and approvals dead-ended. Sets the workflow as signal owner at those sites and falls back to the payload workflow_id for rows already written.