### PR TITLE
fix: allow-writes flag for platform selection

### DIFF
--- a/bins/cli/cmd/agents.go
+++ b/bins/cli/cmd/agents.go
@@ -179,7 +179,7 @@ func (c *cli) agentsContextMarkdown() string {
 	b.WriteString("```json\n{\"mcpServers\": {\"nuon\": {\"command\": \"nuon\", \"args\": [\"agents\", \"mcp\"]}}}\n```\n\n")
 	b.WriteString(fmt.Sprintf("The upstream URL above (`%s`) comes from `api_url` in the CLI config. Override it with `--url`, and the name in the client's MCP list with `--name`:\n\n", mcpURL))
 	b.WriteString("```bash\nnuon agents mcp --url https://mcp.example.com/mcp --name nuon-example\n```\n\n")
-	b.WriteString("Both flags pass through `nuon agents mcp setup`, which also copies a non-default `-C` config path into the command it writes.\n\n")
+	b.WriteString("`--url`, `--name`, and `--allow-writes` pass through `nuon agents mcp setup`, which also copies a non-default `-C` config path into the command it writes.\n\n")
 	b.WriteString("The proxy sets `X-Nuon-Org-ID`. Do not call `select_org` unless the header is missing.\n\n")
 	b.WriteString("### Direct: control-plane HTTP MCP\n\n")
 	b.WriteString(fmt.Sprintf("Point an MCP HTTP client at `%s` with:\n\n", mcpURL))

--- a/bins/cli/cmd/mcp_setup.go
+++ b/bins/cli/cmd/mcp_setup.go
@@ -14,9 +14,10 @@ import (
 
 func (c *cli) mcpSetupCmd() *cobra.Command {
 	var (
-		platform string
-		mcpURL   string
-		name     string
+		platform    string
+		mcpURL      string
+		name        string
+		allowWrites bool
 	)
 
 	cmd := &cobra.Command{
@@ -33,9 +34,11 @@ Writes in the current directory:
 
 The server is registered as "nuon" and connects to https://mcp.nuon.co/mcp.
 Override either with --url and --name; both are written into the generated
-command. A non-default -C config path is copied in as well.
+command. Pass --allow-writes to include it on the generated command so the
+client exposes mutating tools. A non-default -C config path is copied in as well.
 
-  nuon agents mcp setup --platform cursor --url https://mcp.example.com/mcp --name nuon-example`,
+  nuon agents mcp setup --platform cursor --url https://mcp.example.com/mcp --name nuon-example
+  nuon agents mcp setup --platform cursor --allow-writes`,
 		PersistentPreRunE: c.persistentPreRunE,
 		Annotations:       outputsAnnotation(OutputTable),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
@@ -43,7 +46,7 @@ command. A non-default -C config path is copied in as well.
 				name = mcpserver.NameFromAPIURL(c.cfg.APIURL)
 			}
 
-			args, err := stdioMCPArgs(cmd.Flags().Changed("url"), mcpURL, cmd.Flags().Changed("name"), name)
+			args, err := stdioMCPArgs(cmd.Flags().Changed("url"), mcpURL, cmd.Flags().Changed("name"), name, allowWrites)
 			if err != nil {
 				return err
 			}
@@ -55,6 +58,7 @@ command. A non-default -C config path is copied in as well.
 	cmd.Flags().StringVar(&platform, "platform", "", "MCP client platform (claude-code, cursor, amp)")
 	cmd.Flags().StringVar(&mcpURL, "url", "", "upstream MCP server URL passed through to nuon agents mcp (default https://mcp.nuon.co/mcp)")
 	cmd.Flags().StringVar(&name, "name", "", "name in the client's MCP list (default nuon, derived from the configured API URL)")
+	cmd.Flags().BoolVar(&allowWrites, "allow-writes", false, "pass --allow-writes through to nuon agents mcp")
 	_ = cmd.MarkFlagRequired("platform")
 
 	return cmd
@@ -82,7 +86,7 @@ func mcpSetupCommand() string {
 	return exe
 }
 
-func stdioMCPArgs(urlSet bool, url string, nameSet bool, name string) ([]string, error) {
+func stdioMCPArgs(urlSet bool, url string, nameSet bool, name string, allowWrites bool) ([]string, error) {
 	var args []string
 
 	configArgs, err := mcpSetupConfigFlagArgs()
@@ -96,6 +100,9 @@ func stdioMCPArgs(urlSet bool, url string, nameSet bool, name string) ([]string,
 	}
 	if nameSet {
 		args = append(args, "--name", name)
+	}
+	if allowWrites {
+		args = append(args, "--allow-writes")
 	}
 	return args, nil
 }

--- a/bins/cli/cmd/mcp_setup_test.go
+++ b/bins/cli/cmd/mcp_setup_test.go
@@ -38,9 +38,20 @@ func TestStdioMCPArgsIncludesOverrides(t *testing.T) {
 	ConfigFile = DefaultConfigFilePath
 	t.Cleanup(func() { ConfigFile = prev })
 
-	args, err := stdioMCPArgs(true, "http://localhost:8088/mcp", true, "nuon-local")
+	args, err := stdioMCPArgs(true, "http://localhost:8088/mcp", true, "nuon-local", false)
 	require.NoError(t, err)
 	require.Equal(t, []string{"agents", "mcp", "--url", "http://localhost:8088/mcp", "--name", "nuon-local"}, args)
+}
+
+func TestStdioMCPArgsIncludesAllowWrites(t *testing.T) {
+	t.Setenv("NUON_CONFIG_FILE", "")
+	prev := ConfigFile
+	ConfigFile = DefaultConfigFilePath
+	t.Cleanup(func() { ConfigFile = prev })
+
+	args, err := stdioMCPArgs(true, "https://mcp.nuon.co/mcp", true, "nuon-byoc", true)
+	require.NoError(t, err)
+	require.Equal(t, []string{"agents", "mcp", "--url", "https://mcp.nuon.co/mcp", "--name", "nuon-byoc", "--allow-writes"}, args)
 }
 
 func TestStdioMCPArgsIncludesConfigFile(t *testing.T) {
@@ -53,7 +64,7 @@ func TestStdioMCPArgsIncludesConfigFile(t *testing.T) {
 	ConfigFile = cfgPath
 	t.Cleanup(func() { ConfigFile = prev })
 
-	args, err := stdioMCPArgs(false, "", false, "")
+	args, err := stdioMCPArgs(false, "", false, "", false)
 	require.NoError(t, err)
 	require.Equal(t, []string{"-C", cfgPath, "agents", "mcp"}, args)
 }

--- a/docs/cli-commands.mdx
+++ b/docs/cli-commands.mdx
@@ -90,7 +90,7 @@ Operate Nuon from an LLM client. See [Agents](/guides/agents/overview).
 |---------|--------------|
 | `nuon agents context` | Print auth, selected org/app/install, and the MCP HTTP URL. |
 | `nuon agents mcp` | Stdio MCP proxy to `https://mcp.nuon.co/mcp` (read-only). Add `--allow-writes` to expose mutating tools. `--url` / `--name` override the upstream server and the name in the client's MCP list. |
-| `nuon agents mcp setup --platform <platform>` | Write stdio MCP client config (`claude-code`, `cursor`, or `amp`). `--url` / `--name` are passed through to `nuon agents mcp`. |
+| `nuon agents mcp setup --platform <platform>` | Write stdio MCP client config (`claude-code`, `cursor`, or `amp`). `--url` / `--name` / `--allow-writes` are passed through to `nuon agents mcp`. |
 
 ## Help
 

--- a/docs/guides/agents/mcp-walkthrough.mdx
+++ b/docs/guides/agents/mcp-walkthrough.mdx
@@ -61,9 +61,10 @@ You do not need `select_org` when using the stdio proxy (org is already in `X-Nu
 
 <Step title="Writes (optional)">
 
-Restart the proxy with `--allow-writes` only when you need to mutate (approve steps, run actions, preview branches, and so on):
+Pass `--allow-writes` only when you need to mutate (approve steps, run actions, preview branches, and so on). Re-run setup so the client config includes it, or start the proxy directly:
 
 ```bash
+nuon agents mcp setup --platform cursor --allow-writes
 nuon agents mcp --allow-writes
 ```
 

--- a/docs/guides/agents/overview.mdx
+++ b/docs/guides/agents/overview.mdx
@@ -54,10 +54,11 @@ The proxy derives its upstream URL from `api_url` in your CLI config, which reso
 nuon agents mcp --url https://mcp.example.com/mcp --name nuon-example
 ```
 
-Both flags pass through `setup`, so the generated client config keeps them:
+`--url`, `--name`, and `--allow-writes` pass through `setup`, so the generated client config keeps them:
 
 ```bash
 nuon agents mcp setup --platform cursor --url https://mcp.example.com/mcp --name nuon-example
+nuon agents mcp setup --platform cursor --allow-writes
 ```
 
 A non-default CLI config (`-C /path/to/config`) carries its own token, org, and `api_url`. `setup` copies the `-C` into the command it writes, so the client keeps using that config.


### PR DESCRIPTION
allow-writes flag when using --platform for nuon mcp setup