### PR TITLE
fix(ctl-api): drop authservice from api-mcp service graph

### DIFF
--- a/services/ctl-api/cmd/api_mcp.go
+++ b/services/ctl-api/cmd/api_mcp.go
@@ -28,7 +28,7 @@ func (c *cli) runMCPAPI(cmd *cobra.Command, _ []string) {
 
 	providers = append(providers,
 		fxmodules.MiddlewaresModule,
-		fxmodules.AllServicesModule,
+		fxmodules.MCPServicesModule,
 		fx.Provide(api.NewEndpointAudit),
 		fxmodules.MCPAPIModule,
 	)

--- a/services/ctl-api/internal/fxmodules/services.go
+++ b/services/ctl-api/internal/fxmodules/services.go
@@ -98,6 +98,12 @@ var AdminDashboardServicesModule = fx.Module("admin-dashboard-services",
 // SlackServicesModule provides services for the dedicated Slack API.
 var SlackServicesModule = fx.Module("slack-services", sharedServices)
 
+// MCPServicesModule provides services for the MCP server (excludes authservice).
+// The MCP server validates bearer tokens itself and no service registers MCP
+// tools through authservice, so pulling it in would only impose authservice's
+// config requirements (NUON_AUTH_CLIENT_SECRET et al) on the mcp deployment.
+var MCPServicesModule = fx.Module("mcp-services", sharedServices)
+
 // AllServicesModule provides all services including authservice (for dev mode).
 var AllServicesModule = fx.Module("all-services",
 	sharedServices,


### PR DESCRIPTION
## Summary

`api-mcp` was wired to `AllServicesModule`, copied from `api.go`. That module is `sharedServices` **plus `authservice`** — the one service the code comments explicitly call out as having "strict config requirements."

In BYOC, `NUON_AUTH_CLIENT_SECRET` is deliberately scoped under `auth.envSecrets` and mounted only on the auth deployment, so the mcp pod crash-looped on:

```
failed to load default identity provider: invalid google provider config: client_secret is required
```

Stage never hit this because mono's chart declares that secret in the top-level `envSecrets` list, which every deployment ranges over.

MCP gains nothing from `authservice`:
- it validates bearer tokens itself in `internal/app/mcp/server/auth.go`
- it derives the OAuth authorization server URL from `cfg.RootDomain`, not from `authservice`
- `authservice` implements no `RegisterMCPTools`, so it contributes zero MCP tools

So this adds an `MCPServicesModule` over `sharedServices` and points `api-mcp` at it, matching what `slack`, `public`, `runner`, and `internal` already do. The all-in-one `api` command keeps `AllServicesModule` for local dev.

## Test plan

- [x] `go build ./services/ctl-api/...` passes
- [ ] Once merged and tagged, bump the ctl-api image in byoc (currently pinned to `0.19.1160`) and confirm `ctl-api-mcp` reaches Ready in the test install
- [ ] Confirm an MCP tool call still authenticates end to end against `mcp.<public_domain>`