### PR TITLE
perf: speed up drifted objects view by removing redundant CTEs

### DIFF
--- a/services/ctl-api/internal/app/drifted_object.go
+++ b/services/ctl-api/internal/app/drifted_object.go
@@ -27,14 +27,14 @@ func (d *DriftedObject) UseView() bool {
 }
 
 func (d *DriftedObject) ViewVersion() string {
-	return "v3"
+	return "v4"
 }
 
 func (d *DriftedObject) Views(db *gorm.DB) []migrations.View {
 	return []migrations.View{
 		{
-			Name:          views.DefaultViewName(db, &DriftedObject{}, 3),
-			SQL:           viewsql.DriftsViewV3,
+			Name:          views.DefaultViewName(db, &DriftedObject{}, 4),
+			SQL:           viewsql.DriftsViewV4,
 			AlwaysReapply: true,
 		},
 	}

--- a/services/ctl-api/internal/app/install_deploy.go
+++ b/services/ctl-api/internal/app/install_deploy.go
@@ -149,6 +149,13 @@ func (c *InstallDeploy) Indexes(db *gorm.DB) []migrations.Index {
 			},
 			Option: "WHERE status = 'drifted'",
 		},
+		{
+			Name: indexes.Name(db, &InstallDeploy{}, "install_component_created_at"),
+			Columns: []string{
+				"install_component_id",
+				"created_at DESC",
+			},
+		},
 	}
 }
 

--- a/services/ctl-api/internal/app/install_sandbox_run.go
+++ b/services/ctl-api/internal/app/install_sandbox_run.go
@@ -120,6 +120,13 @@ func (i *InstallSandboxRun) Indexes(db *gorm.DB) []migrations.Index {
 			},
 			Option: "WHERE status = 'drifted'",
 		},
+		{
+			Name: indexes.Name(db, &InstallSandboxRun{}, "install_sandbox_created_at"),
+			Columns: []string{
+				"install_sandbox_id",
+				"created_at DESC",
+			},
+		},
 		// Without this the install_audit_logs_view arm seq scans the whole table.
 		{
 			Name: indexes.Name(db, &InstallSandboxRun{}, "install_created_at"),

--- a/services/ctl-api/internal/pkg/db/viewsql/drifts_view_v4.sql
+++ b/services/ctl-api/internal/pkg/db/viewsql/drifts_view_v4.sql
@@ -1,0 +1,74 @@
+-- Create view that shows unique drifted installs from both deploy and sandbox runs.
+-- v4: removes the latest_drifted_deploys / latest_drifted_sandbox_runs CTEs. The
+-- ROW_NUMBER() window functions in those CTEs were redundant with the NOT EXISTS
+-- anti-joins: if a row is drifted AND no newer row exists (any status), it is
+-- automatically the latest drifted row. The CTEs forced materialization before the
+-- caller's WHERE org_id/install_id filter could be pushed down, so the query scanned
+-- all drifted deploys/sandbox runs across every org on every call. Without the CTEs,
+-- PostgreSQL inlines the view and applies the caller's filter through the joins.
+--
+-- The NOT EXISTS tiebreaker (d2.created_at > id.created_at OR (d2.created_at = ... AND d2.id > ...))
+-- preserves the CTE's one-row-per-component deduplication when two drifted rows share
+-- the same created_at, without needing a window function.
+SELECT
+    'install_deploy' AS target_type,
+    id.id AS target_id,
+    id.install_workflow_id,
+    NULL AS app_sandbox_config_id,
+    id.component_build_id,
+    ic.install_id,
+    i.org_id,
+    id.install_component_id,
+    NULL AS install_sandbox_id,
+    c.name AS component_name
+FROM
+    install_deploys id
+JOIN
+    install_components ic ON id.install_component_id = ic.id
+JOIN
+    installs i ON ic.install_id = i.id
+JOIN
+    components c ON ic.component_id = c.id
+WHERE
+    id.status = 'drifted'
+    AND NOT EXISTS (
+        SELECT 1
+        FROM install_deploys d2
+        WHERE d2.install_component_id = id.install_component_id
+          AND (
+              d2.created_at > id.created_at
+              OR (d2.created_at = id.created_at AND d2.id > id.id)
+          )
+    )
+
+UNION ALL
+
+SELECT
+    'install_sandbox_run' AS target_type,
+    isr.id AS target_id,
+    isr.install_workflow_id,
+    isr.app_sandbox_config_id,
+    NULL AS component_build_id,
+    isr.install_id,
+    i.org_id,
+    NULL AS install_component_id,
+    isr.install_sandbox_id,
+    NULL AS component_name
+FROM
+    install_sandbox_runs isr
+JOIN
+    installs i ON isr.install_id = i.id
+WHERE
+    isr.status = 'drifted'
+    AND NOT EXISTS (
+        SELECT 1
+        FROM install_sandbox_runs sr2
+        WHERE sr2.install_sandbox_id = isr.install_sandbox_id
+          AND (
+              sr2.created_at > isr.created_at
+              OR (sr2.created_at = isr.created_at AND sr2.id > isr.id)
+          )
+    )
+
+ORDER BY
+    target_type, target_id;

--- a/services/ctl-api/internal/pkg/db/viewsql/viewsql.go
+++ b/services/ctl-api/internal/pkg/db/viewsql/viewsql.go
@@ -40,6 +40,9 @@ var DriftsViewV2 string
 //go:embed drifts_view_v3.sql
 var DriftsViewV3 string
 
+//go:embed drifts_view_v4.sql
+var DriftsViewV4 string
+
 //go:embed app_configs_view_v2.sql
 var AppConfigViewV2 string
 


### PR DESCRIPTION
## Summary

The drifted objects view was scanning all drifted deploys and sandbox runs across every org on every query. Removing the redundant window-function CTEs lets PostgreSQL push the caller's org/install filter through the joins instead of materializing first. Two new composite indexes serve the anti-join subqueries that were previously unindexed.

## What changes

**Drifted objects queries are faster.** The view behind `GET /v1/installs/:install_id/drifted-objects` and the drift lookups on install/component detail endpoints no longer force a full-table CTE materialization before applying the org or install filter. In production this caused a 6.60s spike; typical queries were 0.01-0.05s but the CTE scan dominated under load.

**New indexes on deploys and sandbox runs.** Both tables get a non-partial composite index on `(component_id, created_at DESC)` to serve the `NOT EXISTS` anti-join that checks whether a newer row exists. The existing partial indexes only covered `WHERE status = 'drifted'`, but the anti-join scans all statuses.

## What stays the same

The view returns the same rows as before. The CTE's `ROW_NUMBER() ... rn=1` deduplication (one row per component when two drifted rows share the same `created_at`) is preserved by an id-based tiebreaker in the `NOT EXISTS` condition. Verified against six edge cases including timestamp ties, interleaved statuses, and single-row scenarios.

The old `drifts_view_v3` SQL and its embed are kept in the codebase. The migration system drops and recreates the view on next startup via `AlwaysReapply: true`.

## Mechanics worth flagging for review

The `NOT EXISTS` tiebreaker uses `(d2.created_at > id.created_at OR (d2.created_at = id.created_at AND d2.id > id.id))` instead of just `d2.created_at > id.created_at`. This is necessary to preserve one-row-per-component deduplication when two drifted rows share the same timestamp. Without it, the view would return duplicate rows for tied entries, breaking the `First()` call in the single-component endpoint.
