### PR TITLE
feat: show Slack notification presets and retire component health alerts

### DIFF
--- a/services/ctl-api/internal/app/slack/service/subscribe_modal_test.go
+++ b/services/ctl-api/internal/app/slack/service/subscribe_modal_test.go
@@ -266,28 +266,28 @@ func TestBuildSubscribeModalView(t *testing.T) {
 		}
 	})
 
-	t.Run("health categories are gated per resource and seeded from Default()", func(t *testing.T) {
+	t.Run("health categories are not shown for any resource", func(t *testing.T) {
 		view, err := buildSubscribeModalView(state, links, subscribeModalRenderState{Notif: notifOptionSpecific}, nil)
 		if err != nil {
 			t.Fatalf("build: %v", err)
 		}
 
 		components := findBlockByID(t, view, subscribeResourceCategoriesBlockID(interests.ResourceComponents))
-		mustContainValue(t, checkboxOptionValues(t, components), categoryOptionComponentHealth)
-		mustContainValue(t, checkboxInitialValues(t, components), categoryOptionComponentHealth)
+		mustNotContainValue(t, checkboxOptionValues(t, components), categoryOptionComponentHealth)
 		mustNotContainValue(t, checkboxOptionValues(t, components), categoryOptionInstallDegraded)
+		mustNotContainValue(t, checkboxInitialValues(t, components), categoryOptionComponentHealth)
 
 		installs := findBlockByID(t, view, subscribeResourceCategoriesBlockID(interests.ResourceInstalls))
-		mustContainValue(t, checkboxOptionValues(t, installs), categoryOptionInstallDegraded)
-		mustContainValue(t, checkboxInitialValues(t, installs), categoryOptionInstallDegraded)
+		mustNotContainValue(t, checkboxOptionValues(t, installs), categoryOptionInstallDegraded)
 		mustNotContainValue(t, checkboxOptionValues(t, installs), categoryOptionComponentHealth)
+		mustNotContainValue(t, checkboxInitialValues(t, installs), categoryOptionInstallDegraded)
 
 		sandboxes := findBlockByID(t, view, subscribeResourceCategoriesBlockID(interests.ResourceSandboxes))
 		mustNotContainValue(t, checkboxOptionValues(t, sandboxes), categoryOptionComponentHealth)
 		mustNotContainValue(t, checkboxOptionValues(t, sandboxes), categoryOptionInstallDegraded)
 	})
 
-	t.Run("health categories stay ticked when reopening a stored subscription", func(t *testing.T) {
+	t.Run("health flags on stored subscriptions are not surfaced when reopening", func(t *testing.T) {
 		render := subscribeModalRenderState{
 			Notif: notifOptionSpecific,
 			Resources: renderResourcesFromInterests(interests.Interests{
@@ -302,11 +302,11 @@ func TestBuildSubscribeModalView(t *testing.T) {
 			t.Fatalf("build: %v", err)
 		}
 		components := findBlockByID(t, view, subscribeResourceCategoriesBlockID(interests.ResourceComponents))
-		mustContainValue(t, checkboxInitialValues(t, components), categoryOptionComponentHealth)
+		mustNotContainValue(t, checkboxInitialValues(t, components), categoryOptionComponentHealth)
 		mustNotContainValue(t, checkboxInitialValues(t, components), categoryOptionLifecycle)
 
 		installs := findBlockByID(t, view, subscribeResourceCategoriesBlockID(interests.ResourceInstalls))
-		mustContainValue(t, checkboxInitialValues(t, installs), categoryOptionInstallDegraded)
+		mustNotContainValue(t, checkboxInitialValues(t, installs), categoryOptionInstallDegraded)
 	})
 
 	t.Run("empty links rejected", func(t *testing.T) {
@@ -342,25 +342,21 @@ func TestReadResourceRenderStateFromValues_HealthCategories(t *testing.T) {
 	got := readSubscribeRenderStateFromPayload(p)
 
 	comp := got.Resources[interests.ResourceComponents]
-	if !comp.Enabled || !comp.ComponentHealth {
-		t.Fatalf("components: expected enabled + component health, got %+v", comp)
-	}
-	if comp.Outcome != outcomeOptionNone {
-		t.Fatalf("components: health-only tick must mute lifecycle, got %q", comp.Outcome)
+	if !comp.Enabled {
+		t.Fatalf("components: expected enabled, got %+v", comp)
 	}
 
 	inst := got.Resources[interests.ResourceInstalls]
-	if !inst.Enabled || !inst.InstallDegraded {
-		t.Fatalf("installs: expected enabled + install degraded, got %+v", inst)
+	if !inst.Enabled {
+		t.Fatalf("installs: expected enabled, got %+v", inst)
 	}
 
-	// The persisted config must carry the ticks through submission.
 	in := buildSpecificEventsInterests(got.Resources)
-	if !in.Resources[interests.ResourceComponents].ComponentHealth {
-		t.Fatal("components: component_health must persist")
+	if in.Resources[interests.ResourceComponents].ComponentHealth {
+		t.Fatal("components: component_health must not persist (retired)")
 	}
-	if !in.Resources[interests.ResourceInstalls].InstallDegraded {
-		t.Fatal("installs: install_degraded must persist")
+	if in.Resources[interests.ResourceInstalls].InstallDegraded {
+		t.Fatal("installs: install_degraded must not persist (retired)")
 	}
 }
 
@@ -709,38 +705,38 @@ func TestRoundTripBuildSpecificEventsInterests(t *testing.T) {
 		}
 	})
 
-	t.Run("health flags only persist for resources that support them", func(t *testing.T) {
+	t.Run("health flags never persist for any resource", func(t *testing.T) {
 		i := buildSpecificEventsInterests(map[interests.ResourceKind]subscribeResourceCfg{
 			interests.ResourceComponents: {Enabled: true, ComponentHealth: true, InstallDegraded: true, Outcome: outcomeOptionAll},
 			interests.ResourceInstalls:   {Enabled: true, ComponentHealth: true, InstallDegraded: true, Outcome: outcomeOptionAll},
 			interests.ResourceSandboxes:  {Enabled: true, ComponentHealth: true, InstallDegraded: true, Outcome: outcomeOptionAll},
 		})
-		if !i.Resources[interests.ResourceComponents].ComponentHealth {
-			t.Fatal("components should keep component_health=true")
+		if i.Resources[interests.ResourceComponents].ComponentHealth {
+			t.Fatal("components: component_health must not persist (retired)")
 		}
 		if i.Resources[interests.ResourceComponents].InstallDegraded {
-			t.Fatal("components do not support install_degraded; flag must be dropped")
+			t.Fatal("components: install_degraded must not persist (retired)")
 		}
-		if !i.Resources[interests.ResourceInstalls].InstallDegraded {
-			t.Fatal("installs should keep install_degraded=true")
+		if i.Resources[interests.ResourceInstalls].InstallDegraded {
+			t.Fatal("installs: install_degraded must not persist (retired)")
 		}
 		if i.Resources[interests.ResourceInstalls].ComponentHealth {
-			t.Fatal("installs do not support component_health; flag must be dropped")
+			t.Fatal("installs: component_health must not persist (retired)")
 		}
 		cfg := i.Resources[interests.ResourceSandboxes]
 		if cfg.ComponentHealth || cfg.InstallDegraded {
-			t.Fatalf("sandboxes support neither health flag, got %+v", cfg)
+			t.Fatalf("sandboxes: neither health flag may persist, got %+v", cfg)
 		}
 	})
 
-	t.Run("health flags survive the interests round trip", func(t *testing.T) {
+	t.Run("health flags do not survive the interests round trip", func(t *testing.T) {
 		in := interests.Default()
 		round := buildSpecificEventsInterests(renderResourcesFromInterests(in))
-		if !round.Resources[interests.ResourceComponents].ComponentHealth {
-			t.Fatal("components: component_health lost in round trip")
+		if round.Resources[interests.ResourceComponents].ComponentHealth {
+			t.Fatal("components: component_health must not survive round trip (retired)")
 		}
-		if !round.Resources[interests.ResourceInstalls].InstallDegraded {
-			t.Fatal("installs: install_degraded lost in round trip")
+		if round.Resources[interests.ResourceInstalls].InstallDegraded {
+			t.Fatal("installs: install_degraded must not survive round trip (retired)")
 		}
 	})
 }

--- a/services/ctl-api/internal/pkg/interests/component_health_test.go
+++ b/services/ctl-api/internal/pkg/interests/component_health_test.go
@@ -17,6 +17,11 @@ func healthEvent(signalType signal.SignalType) signal.SignalPhaseEvent {
 
 // Health carriers are emitted outside any workflow, so they must classify with
 // no WorkflowType, no StepID, and no DB — the paths every other signal relies on.
+//
+// Component health (unhealthy/recovered) slugs are still produced by Classify
+// for diagnostic/webhook-payload purposes, but the matcher suppresses them
+// unconditionally (see match.go). Install degraded slugs are likewise still
+// classified but suppressed by the matcher.
 func TestClassifyComponentHealthSlugs(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -47,8 +52,9 @@ func TestClassifyComponentHealthSlugs(t *testing.T) {
 	}
 }
 
-// A single component_health flag has to deliver both directions, and must not
-// be satisfied by any neighbouring flag on the same resource.
+// Component health and install degraded notifications are retired — the
+// matcher suppresses them unconditionally for all subscribers, including
+// AllEvents and existing subscriptions that still carry the flags.
 func TestMatchesComponentHealth(t *testing.T) {
 	componentsCfg := func(cfg ResourceCfg) Interests {
 		return Interests{Resources: map[ResourceKind]ResourceCfg{ResourceComponents: cfg}}
@@ -63,29 +69,17 @@ func TestMatchesComponentHealth(t *testing.T) {
 		in         Interests
 		want       bool
 	}{
-		{"unhealthy matches when flag set", signalTypeComponentUnhealthy, componentsCfg(ResourceCfg{ComponentHealth: true}), true},
-		{"recovered matches the same flag", signalTypeComponentRecovered, componentsCfg(ResourceCfg{ComponentHealth: true}), true},
-		{"unhealthy muted when flag unset", signalTypeComponentUnhealthy, componentsCfg(ResourceCfg{}), false},
-		{"recovered muted when flag unset", signalTypeComponentRecovered, componentsCfg(ResourceCfg{}), false},
+		// Component health is suppressed unconditionally — no config matches.
+		{"unhealthy suppressed even with flag set", signalTypeComponentUnhealthy, componentsCfg(ResourceCfg{ComponentHealth: true}), false},
+		{"recovered suppressed even with flag set", signalTypeComponentRecovered, componentsCfg(ResourceCfg{ComponentHealth: true}), false},
+		{"unhealthy suppressed under all events", signalTypeComponentUnhealthy, AllEvents(), false},
+		{"unhealthy suppressed under default", signalTypeComponentUnhealthy, Default(), false},
 
-		// Independent of outcome and ops, exactly like drift-detected.
-		{"outcome none does not mute health", signalTypeComponentUnhealthy, componentsCfg(ResourceCfg{ComponentHealth: true, Outcome: OutcomeNone}), true},
-		{"unrelated ops filter does not mute health", signalTypeComponentUnhealthy, componentsCfg(ResourceCfg{ComponentHealth: true, Ops: []string{"deploy"}}), true},
-
-		// Neighbouring flags must not stand in for it.
-		{"drift flag does not deliver health", signalTypeComponentUnhealthy, componentsCfg(ResourceCfg{DriftDetected: true}), false},
-		{"health flag does not deliver drift-only subscribers extra events", signalTypeComponentRecovered, componentsCfg(ResourceCfg{DriftDetected: true}), false},
-
-		{"install degraded matches installs flag", signalTypeInstallDegraded, installsCfg(ResourceCfg{InstallDegraded: true}), true},
-		{"install degraded muted when flag unset", signalTypeInstallDegraded, installsCfg(ResourceCfg{}), false},
-		{"component flag does not deliver the install rollup", signalTypeInstallDegraded, installsCfg(ResourceCfg{ComponentHealth: true}), false},
-		{"install flag on components does not deliver component health", signalTypeComponentUnhealthy, componentsCfg(ResourceCfg{InstallDegraded: true}), false},
-
-		{"all events delivers health", signalTypeComponentUnhealthy, AllEvents(), true},
-		{"all events delivers the install rollup", signalTypeInstallDegraded, AllEvents(), true},
-
-		{"default opts into component health", signalTypeComponentUnhealthy, Default(), true},
-		{"default opts into the install rollup", signalTypeInstallDegraded, Default(), true},
+		// Install degraded is suppressed unconditionally — no config matches.
+		{"install degraded suppressed even with flag set", signalTypeInstallDegraded, installsCfg(ResourceCfg{InstallDegraded: true}), false},
+		{"install degraded suppressed when flag unset", signalTypeInstallDegraded, installsCfg(ResourceCfg{}), false},
+		{"install degraded suppressed under all events", signalTypeInstallDegraded, AllEvents(), false},
+		{"install degraded suppressed under default", signalTypeInstallDegraded, Default(), false},
 	}
 
 	for _, tt := range tests {

--- a/services/ctl-api/internal/pkg/interests/defaults.go
+++ b/services/ctl-api/internal/pkg/interests/defaults.go
@@ -24,7 +24,6 @@ func Default() Interests {
 				Outcome:           OutcomeCompletion,
 				ApprovalRequests:  true,
 				ApprovalResponses: true,
-				InstallDegraded:   true,
 			},
 			ResourceStacks: {
 				Outcome:       OutcomeCompletion,
@@ -36,7 +35,6 @@ func Default() Interests {
 				ApprovalRequests:  true,
 				ApprovalResponses: true,
 				DriftDetected:     true,
-				ComponentHealth:   true,
 			},
 			ResourceSandboxes: {
 				Outcome:           OutcomeCompletion,

--- a/services/ctl-api/internal/pkg/interests/match.go
+++ b/services/ctl-api/internal/pkg/interests/match.go
@@ -64,6 +64,18 @@ func Matches(event signal.SignalPhaseEvent, outcome *signal.SignalPhaseOutcome, 
 		return false
 	}
 
+	// Component health and install degraded notifications are retired.
+	// Suppress them unconditionally — including under AllEvents and for
+	// existing subscriptions that still carry ComponentHealth=true or
+	// InstallDegraded=true — so no subscriber receives them regardless of
+	// config. The fields remain on ResourceCfg for JSONB deserialization
+	// compatibility.
+	if f.EventClass == eventClassComponentUnhealthy ||
+		f.EventClass == eventClassComponentRecovered ||
+		f.EventClass == eventClassInstallDegraded {
+		return false
+	}
+
 	if in.AllEvents {
 		return true
 	}

--- a/services/ctl-api/internal/pkg/interests/types.go
+++ b/services/ctl-api/internal/pkg/interests/types.go
@@ -109,15 +109,17 @@ func SupportsConfigSynced(kind ResourceKind) bool {
 }
 
 // SupportsComponentHealth reports whether ComponentHealth is meaningful for the
-// given resource. Only components carry a live health verdict.
+// given resource. Always false — component health notifications are retired.
+// The field remains on ResourceCfg for JSONB deserialization compatibility.
 func SupportsComponentHealth(kind ResourceKind) bool {
-	return kind == ResourceComponents
+	return false
 }
 
 // SupportsInstallDegraded reports whether InstallDegraded is meaningful for the
-// given resource. The install-level health rollup is an install event.
+// given resource. Always false — install degraded notifications are retired.
+// The field remains on ResourceCfg for JSONB deserialization compatibility.
 func SupportsInstallDegraded(kind ResourceKind) bool {
-	return kind == ResourceInstalls
+	return false
 }
 
 // Interests is the full per-subscriber config. Stored as JSONB on both

--- a/services/dashboard-ui/client/components/interests/FormInterestsPicker.stories.tsx
+++ b/services/dashboard-ui/client/components/interests/FormInterestsPicker.stories.tsx
@@ -1,18 +1,61 @@
 import { useForm } from '@tanstack/react-form'
 import { allEvents } from './defaults'
 import { FormInterestsPicker } from './FormInterestsPicker'
+import { PRESETS } from './presets'
+import type { Interests } from './types'
+import type { SubscriptionMatch } from '@/components/match/types'
 
 export default { title: 'Interests/FormInterestsPicker' }
 
-const Demo = () => {
-  const form = useForm({ defaultValues: { interests: allEvents() } })
+const Demo = ({
+  initialInterests,
+  initialMatch,
+}: {
+  initialInterests?: Interests
+  initialMatch?: SubscriptionMatch
+}) => {
+  const form = useForm({
+    defaultValues: {
+      interests: initialInterests ?? allEvents(),
+      match: initialMatch as SubscriptionMatch | undefined,
+    },
+  })
   return (
     <div className="max-w-lg p-4">
       <form.Field name="interests">
-        {(field) => <FormInterestsPicker field={field} />}
+        {(field) => (
+          <form.Field name="match">
+            {(matchField) => (
+              <FormInterestsPicker
+                field={field}
+                matchField={matchField}
+              />
+            )}
+          </form.Field>
+        )}
       </form.Field>
     </div>
   )
 }
 
 export const Default = () => <Demo />
+
+export const FailuresWithLabels = () => (
+  <Demo
+    initialInterests={PRESETS[0].build()}
+    initialMatch={{
+      installs: {
+        selector: { match_labels: { env: 'prod', tier: 'critical' } },
+      },
+    }}
+  />
+)
+
+export const CustomWithScope = () => (
+  <Demo
+    initialInterests={{ resources: { installs: { outcome: 'failures' } } }}
+    initialMatch={{
+      installs: { selector: { match_labels: { env: 'prod' } } },
+    }}
+  />
+)

--- a/services/dashboard-ui/client/components/interests/FormInterestsPicker.tsx
+++ b/services/dashboard-ui/client/components/interests/FormInterestsPicker.tsx
@@ -1,18 +1,27 @@
 import type { AnyFieldApi } from '@tanstack/react-form'
 import { InterestsPicker } from './InterestsPicker'
+import type { PresetModalOutput } from './InterestsModal'
 
 export interface IFormInterestsPicker {
   field: AnyFieldApi
+  matchField?: AnyFieldApi
   disabled?: boolean
 }
 
 export const FormInterestsPicker = ({
   field,
+  matchField,
   disabled,
 }: IFormInterestsPicker) => (
   <InterestsPicker
     value={field.state.value}
-    onChange={(next) => field.handleChange(next)}
+    matchValue={matchField?.state.value}
+    onChange={({ interests, match }: PresetModalOutput) => {
+      field.handleChange(interests)
+      if (matchField) {
+        matchField.handleChange(match)
+      }
+    }}
     disabled={disabled}
   />
 )

--- a/services/dashboard-ui/client/components/interests/InterestsModal.tsx
+++ b/services/dashboard-ui/client/components/interests/InterestsModal.tsx
@@ -1,10 +1,15 @@
 import { useState } from 'react'
 import { Banner } from '@/components/common/Banner'
+import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
 import { CheckboxInput } from '@/components/common/form/CheckboxInput'
-import { RadioInput } from '@/components/common/form/RadioInput'
+import { Input } from '@/components/common/form/Input'
 import { useSurfaces } from '@/hooks/use-surfaces'
 import { Modal, type IModal } from '@/components/surfaces/Modal'
+import { MatchPicker } from '@/components/match/MatchPicker'
+import { labelsToQueryString, parseLabelsQuery } from '@/components/match/parse'
+import type { SubscriptionMatch, TargetKind } from '@/components/match/types'
+import { cn } from '@/utils/classnames'
 import {
   CATEGORY_LABELS,
   RESOURCE_CATEGORIES,
@@ -12,6 +17,7 @@ import {
   isResourceEmpty,
   setCategoryOn,
 } from './categories'
+import { PRESETS, matchPreset, type PresetId } from './presets'
 import {
   ALL_RESOURCES,
   RESOURCE_LABELS,
@@ -20,42 +26,84 @@ import {
   type ResourceKind,
 } from './types'
 
-type Mode = 'all' | 'specific'
-
-// Resources map is the source of truth for the "Choose specific events" branch.
-// We keep it on local state regardless of the current Mode so toggling
-// 'All events' → 'Choose specific events' → 'All events' doesn't blow away
-// whatever the user has already ticked.
 type ResourcesMap = NonNullable<Interests['resources']>
 
-const initialMode = (value: Interests): Mode =>
-  value.all_events ? 'all' : 'specific'
+export interface PresetModalOutput {
+  interests: Interests
+  match: SubscriptionMatch | undefined
+}
 
 const initialResources = (value: Interests): ResourcesMap => value.resources ?? {}
 
-// Popup form for editing the Interests config. Opened from InterestsPicker via
-// useSurfaces; commits the draft back through onSave only on Save. The Cancel
-// button (provided by Modal) discards the draft and the parent form keeps the
-// previous value.
-//
-// The flat checklist deliberately drops the per-resource outcome filter
-// (succeeded vs failed vs started) and sub-op narrowing from the picker UI.
-// Both are still expressible on the wire — power users can craft them by API
-// — but they make the picker overwhelming for the 99% case.
+const extractLabels = (
+  match: SubscriptionMatch | undefined,
+  kind: TargetKind
+): { include: string; exclude: string } => {
+  const tm = match?.[kind]
+  return {
+    include: labelsToQueryString(tm?.selector?.match_labels),
+    exclude: labelsToQueryString(tm?.selector?.not_match_labels),
+  }
+}
+
+const buildMatchFromLabels = (
+  kind: TargetKind,
+  includeRaw: string,
+  excludeRaw: string
+): SubscriptionMatch | undefined => {
+  const include = parseLabelsQuery(includeRaw)
+  const exclude = parseLabelsQuery(excludeRaw)
+  if (Object.keys(include).length === 0 && Object.keys(exclude).length === 0) {
+    return undefined
+  }
+  const selector: { match_labels?: typeof include; not_match_labels?: typeof exclude } = {}
+  if (Object.keys(include).length > 0) selector.match_labels = include
+  if (Object.keys(exclude).length > 0) selector.not_match_labels = exclude
+  return { [kind]: { selector } }
+}
+
 export const InterestsModal = ({
   value,
+  matchValue,
   onSave,
   ...props
 }: {
   value: Interests
-  onSave: (next: Interests) => void
+  matchValue?: SubscriptionMatch
+  onSave: (output: PresetModalOutput) => void
 } & Omit<IModal, 'children' | 'primaryActionTrigger'>) => {
   const { removeModal } = useSurfaces()
 
-  const [mode, setMode] = useState<Mode>(() => initialMode(value))
+  const [presetId, setPresetId] = useState<PresetId>(() => matchPreset(value))
   const [resources, setResources] = useState<ResourcesMap>(() =>
     initialResources(value)
   )
+
+  const selectedPreset = PRESETS.find((p) => p.id === presetId)
+  const scopeKind = selectedPreset?.scopeKind
+
+  const [includeLabels, setIncludeLabels] = useState<string>(() =>
+    scopeKind ? extractLabels(matchValue, scopeKind).include : ''
+  )
+  const [excludeLabels, setExcludeLabels] = useState<string>(() =>
+    scopeKind ? extractLabels(matchValue, scopeKind).exclude : ''
+  )
+  const [customMatch, setCustomMatch] = useState<SubscriptionMatch | undefined>(
+    () => (presetId === 'custom' ? matchValue : undefined)
+  )
+
+  const handlePresetSelect = (id: PresetId) => {
+    setPresetId(id)
+    const preset = PRESETS.find((p) => p.id === id)
+    if (preset?.scopeKind) {
+      const labels = extractLabels(matchValue, preset.scopeKind)
+      setIncludeLabels(labels.include)
+      setExcludeLabels(labels.exclude)
+    }
+    if (id === 'custom') {
+      setCustomMatch(matchValue)
+    }
+  }
 
   const toggleCategory = (
     kind: ResourceKind,
@@ -75,19 +123,34 @@ export const InterestsModal = ({
   }
 
   const totalSelected =
-    mode === 'all'
-      ? 0
-      : ALL_RESOURCES.reduce((sum, kind) => {
+    presetId === 'custom'
+      ? ALL_RESOURCES.reduce((sum, kind) => {
           const cfg: ResourceCfg | undefined = resources[kind]
           return (
             sum + RESOURCE_CATEGORIES[kind].filter((c) => isCategoryOn(cfg, c)).length
           )
         }, 0)
+      : 0
 
   const handleSave = () => {
-    const next: Interests =
-      mode === 'all' ? { all_events: true } : { resources }
-    onSave(next)
+    const preset = PRESETS.find((p) => p.id === presetId)
+    let interests: Interests
+    let match: SubscriptionMatch | undefined
+
+    if (presetId === 'custom') {
+      interests = { resources }
+      match = customMatch
+    } else if (preset) {
+      interests = preset.build()
+      match = preset.scopeKind
+        ? buildMatchFromLabels(preset.scopeKind, includeLabels, excludeLabels)
+        : undefined
+    } else {
+      interests = { all_events: true }
+      match = undefined
+    }
+
+    onSave({ interests, match })
     removeModal(props.modalId)
   }
 
@@ -103,73 +166,151 @@ export const InterestsModal = ({
       {...props}
     >
       <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1">
-          <RadioInput
-            id="interests-mode-all"
-            name="interests-mode"
-            checked={mode === 'all'}
-            onChange={() => setMode('all')}
-            labelProps={{
-              labelText: 'All events',
-              labelTextProps: { variant: 'body' },
-            }}
-          />
-          <RadioInput
-            id="interests-mode-specific"
-            name="interests-mode"
-            checked={mode === 'specific'}
-            onChange={() => setMode('specific')}
-            labelProps={{
-              labelText: 'Choose specific events',
-              labelTextProps: { variant: 'body' },
-            }}
-          />
+        <div className="flex flex-col gap-2">
+          {PRESETS.map((preset) => (
+            <div key={preset.id} className="flex flex-col gap-2">
+              <PresetCard
+                preset={preset}
+                selected={presetId === preset.id}
+                onSelect={() => handlePresetSelect(preset.id)}
+              />
+              {presetId === preset.id && preset.scopeKind ? (
+                <div className="ml-6 flex flex-col gap-3 rounded-lg border border-neutral-200 p-3 dark:border-neutral-700">
+                  <Text variant="subtext" weight="strong">
+                    Filter by {preset.scopeKind} labels (optional)
+                  </Text>
+                  <Input
+                    labelProps={{ labelText: 'Include labels' }}
+                    placeholder="env=prod, tier=critical"
+                    value={includeLabels}
+                    onChange={(e) => setIncludeLabels(e.target.value)}
+                  />
+                  <Input
+                    labelProps={{ labelText: 'Exclude labels' }}
+                    placeholder="env=stage"
+                    value={excludeLabels}
+                    onChange={(e) => setExcludeLabels(e.target.value)}
+                  />
+                  <Text variant="subtext" theme="neutral">
+                    Leave blank to match all {preset.scopeKind}.
+                  </Text>
+                </div>
+              ) : null}
+            </div>
+          ))}
         </div>
 
-        {mode === 'specific' ? (
-          <div className="flex flex-col gap-3 border-t border-neutral-200 pt-4 dark:border-neutral-700">
-            <div className="flex flex-col">
-              {ALL_RESOURCES.flatMap((kind) =>
-                RESOURCE_CATEGORIES[kind].map((cat) => {
-                  const cfg = resources[kind]
-                  const checked = isCategoryOn(cfg, cat)
-                  const id = `interests-${kind}-${cat}`
-                  return (
-                    <CheckboxInput
-                      key={id}
-                      id={id}
-                      checked={checked}
-                      onChange={() => toggleCategory(kind, cat)}
-                      labelProps={{
-                        labelText: (
-                          <span>
-                            <Text variant="body" weight="strong">
-                              {RESOURCE_LABELS[kind]}
-                            </Text>
-                            <Text variant="body" theme="neutral">
-                              {' \u2014 '}
-                              {CATEGORY_LABELS[cat]}
-                            </Text>
-                          </span>
-                        ),
-                      }}
-                    />
-                  )
-                })
-              )}
+        {presetId === 'custom' ? (
+          <div className="flex flex-col gap-4 border-t border-neutral-200 pt-4 dark:border-neutral-700">
+            <div className="flex flex-col gap-2">
+              <Text variant="body" weight="strong">
+                Scope
+              </Text>
+              <MatchPicker
+                value={customMatch}
+                onChange={setCustomMatch}
+              />
             </div>
 
-            {totalSelected === 0 ? (
-              <Banner theme="warn">
-                <Text variant="subtext">
-                  No events are selected. This subscription will not receive
-                  any events.
-                </Text>
-              </Banner>
-            ) : null}
+            <div className="flex flex-col gap-3">
+              <Text variant="body" weight="strong">
+                Events
+              </Text>
+              <div className="flex flex-col">
+                {ALL_RESOURCES.flatMap((kind) =>
+                  RESOURCE_CATEGORIES[kind].map((cat) => {
+                    const cfg = resources[kind]
+                    const checked = isCategoryOn(cfg, cat)
+                    const id = `interests-${kind}-${cat}`
+                    return (
+                      <CheckboxInput
+                        key={id}
+                        id={id}
+                        checked={checked}
+                        onChange={() => toggleCategory(kind, cat)}
+                        labelProps={{
+                          labelText: (
+                            <span>
+                              <Text variant="body" weight="strong">
+                                {RESOURCE_LABELS[kind]}
+                              </Text>
+                              <Text variant="body" theme="neutral">
+                                {' \u2014 '}
+                                {CATEGORY_LABELS[cat]}
+                              </Text>
+                            </span>
+                          ),
+                        }}
+                      />
+                    )
+                  })
+                )}
+              </div>
+
+              {totalSelected === 0 ? (
+                <Banner theme="warn">
+                  <Text variant="subtext">
+                    No events are selected. This subscription will not receive
+                    any events.
+                  </Text>
+                </Banner>
+              ) : null}
+            </div>
           </div>
         ) : null}
       </div>
     </Modal>
   )
 }
+
+const PresetCard = ({
+  preset,
+  selected,
+  onSelect,
+}: {
+  preset: (typeof PRESETS)[number]
+  selected: boolean
+  onSelect: () => void
+}) => (
+  <button
+    type="button"
+    onClick={onSelect}
+    className={cn(
+      'flex flex-col gap-1 rounded-lg border p-3 text-left transition-colors',
+      selected
+        ? 'border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/30'
+        : 'border-neutral-200 hover:border-neutral-300 dark:border-neutral-700 dark:hover:border-neutral-600'
+    )}
+  >
+    <div className="flex items-center gap-2">
+      <RadioDot selected={selected} />
+      <Text variant="body" weight="strong">
+        {preset.label}
+      </Text>
+      {preset.recommended ? (
+        <span className="ml-auto flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+          <Icon variant="SparkleIcon" size={12} />
+          Recommended
+        </span>
+      ) : null}
+    </div>
+    <Text variant="subtext" theme="neutral" className="pl-6">
+      {preset.description}
+    </Text>
+  </button>
+)
+
+const RadioDot = ({ selected }: { selected: boolean }) => (
+  <span
+    className={cn(
+      'flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2',
+      selected
+        ? 'border-blue-500 dark:border-blue-400'
+        : 'border-neutral-300 dark:border-neutral-600'
+    )}
+  >
+    {selected ? (
+      <span className="h-2 w-2 rounded-full bg-blue-500 dark:bg-blue-400" />
+    ) : null}
+  </span>
+)

--- a/services/dashboard-ui/client/components/interests/InterestsPicker.stories.tsx
+++ b/services/dashboard-ui/client/components/interests/InterestsPicker.stories.tsx
@@ -1,29 +1,70 @@
 import { useState } from 'react'
 import { InterestsPicker } from './InterestsPicker'
 import { allEvents } from './defaults'
+import { PRESETS } from './presets'
 import type { Interests } from './types'
+import type { SubscriptionMatch } from '@/components/match/types'
+import type { PresetModalOutput } from './InterestsModal'
 
 export default { title: 'Interests/InterestsPicker' }
 
 const Wrapper = ({
   initial,
+  initialMatch,
   disabled,
 }: {
   initial: Interests
+  initialMatch?: SubscriptionMatch
   disabled?: boolean
 }) => {
   const [value, setValue] = useState<Interests>(initial)
+  const [match, setMatch] = useState<SubscriptionMatch | undefined>(initialMatch)
   return (
     <div className="max-w-md p-6">
-      <InterestsPicker value={value} onChange={setValue} disabled={disabled} />
+      <InterestsPicker
+        value={value}
+        matchValue={match}
+        onChange={({ interests, match: nextMatch }: PresetModalOutput) => {
+          setValue(interests)
+          setMatch(nextMatch)
+        }}
+        disabled={disabled}
+      />
       <pre className="mt-6 rounded-md bg-neutral-100 p-3 text-xs dark:bg-neutral-800">
-        {JSON.stringify(value, null, 2)}
+        {JSON.stringify({ interests: value, match }, null, 2)}
       </pre>
     </div>
   )
 }
 
+export const Failures = () => (
+  <Wrapper initial={PRESETS[0].build()} />
+)
+
+export const FailuresWithLabels = () => (
+  <Wrapper
+    initial={PRESETS[0].build()}
+    initialMatch={{
+      installs: {
+        selector: { match_labels: { env: 'prod', tier: 'critical' } },
+      },
+    }}
+  />
+)
+
 export const AllEvents = () => <Wrapper initial={allEvents()} />
+
+export const Operations = () => (
+  <Wrapper initial={PRESETS[2].build()} />
+)
+
+export const ApprovalsOnly = () => (
+  <Wrapper initial={PRESETS[3].build()} />
+)
+
+export const DeploymentMilestones = () => (
+  <Wrapper initial={PRESETS[4].build()} />
+)
 
 export const SpecificEventsPopulated = () => (
   <Wrapper
@@ -49,9 +90,6 @@ export const SpecificEventsPopulated = () => (
   />
 )
 
-// Only drift_detected is on — lifecycle category is muted (outcome: 'none').
-// Exercises the per-category collapsing that happens when toggling lifecycle
-// off but leaving drift on.
 export const DriftOnly = () => (
   <Wrapper
     initial={{
@@ -65,8 +103,6 @@ export const DriftOnly = () => (
   />
 )
 
-// Explicitly-empty resources map — backend matches nothing. The summary
-// switches to the warn tone "No events selected" so it's obvious at a glance.
 export const EmptyWarn = () => <Wrapper initial={{ resources: {} }} />
 
 export const Disabled = () => <Wrapper initial={allEvents()} disabled />

--- a/services/dashboard-ui/client/components/interests/InterestsPicker.tsx
+++ b/services/dashboard-ui/client/components/interests/InterestsPicker.tsx
@@ -3,14 +3,27 @@ import { Icon } from '@/components/common/Icon'
 import { Text } from '@/components/common/Text'
 import { useSurfaces } from '@/hooks/use-surfaces'
 import { cn } from '@/utils/classnames'
+import { describeMatch } from '@/components/match/types'
+import type { SubscriptionMatch } from '@/components/match/types'
 import { RESOURCE_CATEGORIES, isCategoryOn } from './categories'
-import { InterestsModal } from './InterestsModal'
+import { InterestsModal, type PresetModalOutput } from './InterestsModal'
+import { PRESETS, matchPreset } from './presets'
 import { ALL_RESOURCES, type Interests } from './types'
 
 type Summary = { text: string; tone: 'neutral' | 'warn' }
 
-const buildSummary = (value: Interests): Summary => {
-  if (value.all_events) return { text: 'All events', tone: 'neutral' }
+const buildSummary = (
+  value: Interests,
+  match: SubscriptionMatch | undefined
+): Summary => {
+  const presetId = matchPreset(value)
+  if (presetId !== 'custom') {
+    const preset = PRESETS.find((p) => p.id === presetId)
+    if (preset) {
+      const scopeText = match ? ` \u2014 ${describeMatch(match)}` : ''
+      return { text: `${preset.label}${scopeText}`, tone: 'neutral' }
+    }
+  }
 
   const resources = value.resources ?? {}
   let count = 0
@@ -23,29 +36,35 @@ const buildSummary = (value: Interests): Summary => {
   }
 
   if (count === 0) return { text: 'No events selected', tone: 'warn' }
+  const scopeText = match ? ` \u2014 ${describeMatch(match)}` : ''
   return {
-    text: `${count} event${count === 1 ? '' : 's'} selected`,
+    text: `${count} event${count === 1 ? '' : 's'} selected${scopeText}`,
     tone: 'neutral',
   }
 }
 
-// Compact summary + button. Opens InterestsModal in a stacked modal layer so
-// the parent form (e.g. CreateWebhookModal) stays mounted underneath. The
-// modal owns the draft and only commits back through onChange on Save.
 export const InterestsPicker = ({
   value,
+  matchValue,
   onChange,
   disabled,
 }: {
   value: Interests
-  onChange: (next: Interests) => void
+  matchValue?: SubscriptionMatch
+  onChange: (output: PresetModalOutput) => void
   disabled?: boolean
 }) => {
   const { addModal } = useSurfaces()
-  const summary = buildSummary(value)
+  const summary = buildSummary(value, matchValue)
 
   const openModal = () => {
-    addModal(<InterestsModal value={value} onSave={onChange} />)
+    addModal(
+      <InterestsModal
+        value={value}
+        matchValue={matchValue}
+        onSave={onChange}
+      />
+    )
   }
 
   return (

--- a/services/dashboard-ui/client/components/interests/categories.ts
+++ b/services/dashboard-ui/client/components/interests/categories.ts
@@ -21,13 +21,11 @@ export type EventCategory =
   | 'approvals'
   | 'drift'
   | 'config_synced'
-  | 'component_health'
-  | 'install_degraded'
 
 export const RESOURCE_CATEGORIES: Record<ResourceKind, EventCategory[]> = {
-  installs: ['lifecycle', 'approvals', 'install_degraded'],
+  installs: ['lifecycle', 'approvals'],
   stacks: ['lifecycle'],
-  components: ['lifecycle', 'approvals', 'drift', 'component_health'],
+  components: ['lifecycle', 'approvals', 'drift'],
   sandboxes: ['lifecycle', 'approvals', 'drift'],
   install_configurations: ['lifecycle', 'approvals'],
   runners: ['lifecycle'],
@@ -40,8 +38,6 @@ export const CATEGORY_LABELS: Record<EventCategory, string> = {
   approvals: 'approvals',
   drift: 'drift detected',
   config_synced: 'config synced',
-  component_health: 'component health',
-  install_degraded: 'install degraded',
 }
 
 export const isCategoryOn = (
@@ -58,10 +54,6 @@ export const isCategoryOn = (
       return !!cfg.drift_detected
     case 'config_synced':
       return !!cfg.config_synced
-    case 'component_health':
-      return !!cfg.component_health
-    case 'install_degraded':
-      return !!cfg.install_degraded
   }
 }
 
@@ -80,10 +72,6 @@ export const setCategoryOn = (
       return { ...base, drift_detected: on }
     case 'config_synced':
       return { ...base, config_synced: on }
-    case 'component_health':
-      return { ...base, component_health: on }
-    case 'install_degraded':
-      return { ...base, install_degraded: on }
   }
 }
 

--- a/services/dashboard-ui/client/components/interests/defaults.ts
+++ b/services/dashboard-ui/client/components/interests/defaults.ts
@@ -12,7 +12,6 @@ export const defaultInterests = (): Interests => ({
       outcome: 'completion',
       approval_requests: true,
       approval_responses: true,
-      install_degraded: true,
     },
     stacks: { outcome: 'completion' },
     components: {
@@ -20,7 +19,6 @@ export const defaultInterests = (): Interests => ({
       approval_requests: true,
       approval_responses: true,
       drift_detected: true,
-      component_health: true,
     },
     sandboxes: { outcome: 'completion', approval_requests: true, approval_responses: true, drift_detected: true },
     install_configurations: { outcome: 'completion', approval_requests: true, approval_responses: true },

--- a/services/dashboard-ui/client/components/interests/index.ts
+++ b/services/dashboard-ui/client/components/interests/index.ts
@@ -9,3 +9,5 @@ export {
   type ResourceCfg,
   type ResourceKind,
 } from './types'
+export { PRESETS, matchPreset, recommendedPreset, type Preset, type PresetId } from './presets'
+export type { PresetModalOutput } from './InterestsModal'

--- a/services/dashboard-ui/client/components/interests/presets.ts
+++ b/services/dashboard-ui/client/components/interests/presets.ts
@@ -1,0 +1,147 @@
+import { allEvents } from './defaults'
+import type { Interests } from './types'
+import type { TargetKind } from '@/components/match/types'
+
+export type PresetId = 'all' | 'failures' | 'operations' | 'approvals' | 'deploys' | 'custom'
+
+export interface Preset {
+  id: PresetId
+  label: string
+  description: string
+  build: () => Interests
+  recommended?: boolean
+  scopeKind?: TargetKind
+}
+
+const buildFailuresOnly = (): Interests => ({
+  resources: {
+    installs: { outcome: 'failures' },
+    stacks: { outcome: 'failures' },
+    components: { outcome: 'failures' },
+    sandboxes: { outcome: 'failures' },
+    install_configurations: { outcome: 'failures' },
+    runners: { outcome: 'failures' },
+    actions: { outcome: 'failures' },
+    app_branches: { outcome: 'failures' },
+  },
+})
+
+const buildOperations = (): Interests => ({
+  resources: {
+    installs: { outcome: 'failures' },
+    stacks: { outcome: 'failures' },
+    components: {
+      outcome: 'failures',
+      drift_detected: true,
+    },
+    sandboxes: {
+      outcome: 'failures',
+      drift_detected: true,
+    },
+    install_configurations: { outcome: 'failures' },
+    runners: { outcome: 'failures' },
+    actions: { outcome: 'failures' },
+    app_branches: { outcome: 'failures' },
+  },
+})
+
+const buildApprovalsOnly = (): Interests => ({
+  resources: {
+    installs: {
+      outcome: 'none',
+      approval_requests: true,
+      approval_responses: true,
+    },
+    components: {
+      outcome: 'none',
+      approval_requests: true,
+      approval_responses: true,
+    },
+    sandboxes: {
+      outcome: 'none',
+      approval_requests: true,
+      approval_responses: true,
+    },
+    install_configurations: {
+      outcome: 'none',
+      approval_requests: true,
+      approval_responses: true,
+    },
+  },
+})
+
+const buildDeploymentMilestones = (): Interests => ({
+  resources: {
+    installs: { outcome: 'completion' },
+  },
+})
+
+export const PRESETS: Preset[] = [
+  {
+    id: 'failures',
+    label: 'Failures',
+    description:
+      'Only notify when lifecycle events fail or are cancelled.',
+    build: buildFailuresOnly,
+    recommended: true,
+    scopeKind: 'installs',
+  },
+  {
+    id: 'all',
+    label: 'All events',
+    description: 'Get notified about every event — lifecycle, approvals, drift, and config syncs.',
+    build: allEvents,
+  },
+  {
+    id: 'operations',
+    label: 'Operations',
+    description:
+      'Failed lifecycle events and drift detected — for the ops channel that needs to act on problems.',
+    build: buildOperations,
+  },
+  {
+    id: 'approvals',
+    label: 'Approvals only',
+    description: 'Only notify when an approval is requested or resolved across all resources.',
+    build: buildApprovalsOnly,
+  },
+  {
+    id: 'deploys',
+    label: 'Deployment milestones',
+    description:
+      'Notify when a customer install is provisioned, deprovisioned, or reprovisioned.',
+    build: buildDeploymentMilestones,
+    scopeKind: 'installs',
+  },
+  {
+    id: 'custom',
+    label: 'Custom',
+    description: 'Pick exactly which events you want for each resource type.',
+    build: () => ({}),
+  },
+]
+
+const canonicalize = (v: unknown): unknown => {
+  if (v === null || typeof v !== 'object') return v
+  if (Array.isArray(v)) return v.map(canonicalize)
+  const sorted: Record<string, unknown> = {}
+  for (const key of Object.keys(v as Record<string, unknown>).sort()) {
+    sorted[key] = canonicalize((v as Record<string, unknown>)[key])
+  }
+  return sorted
+}
+
+const deepEqual = (a: unknown, b: unknown): boolean =>
+  JSON.stringify(canonicalize(a)) === JSON.stringify(canonicalize(b))
+
+export const recommendedPreset = (): Preset =>
+  PRESETS.find((p) => p.recommended) ?? PRESETS[0]
+
+export const matchPreset = (value: Interests): PresetId => {
+  if (value.all_events) return 'all'
+  for (const preset of PRESETS) {
+    if (preset.id === 'all' || preset.id === 'custom') continue
+    if (deepEqual(value, preset.build())) return preset.id
+  }
+  return 'custom'
+}

--- a/services/dashboard-ui/client/components/interests/types.ts
+++ b/services/dashboard-ui/client/components/interests/types.ts
@@ -34,18 +34,6 @@ export interface ResourceCfg {
   // independent of lifecycle outcome. Only meaningful for app_branches
   // (see SupportsConfigSynced); harmless but never matches on others.
   config_synced?: boolean
-  // component_health is one flag covering both directions of a component's
-  // live health: it fires when health crosses into degraded/unhealthy AND
-  // when it recovers, so a channel told about a failure always hears the
-  // resolution. A verdict of unknown (runner offline / stale observations)
-  // never notifies — runner inactivity has its own event. Independent of
-  // `outcome`. Only meaningful for components (see SupportsComponentHealth).
-  component_health?: boolean
-  // install_degraded is the same idea at install level: it fires when the
-  // install's composite health crosses into degraded/unhealthy and when it
-  // returns to healthy. Independent of `outcome`. Only meaningful for
-  // installs (see SupportsInstallDegraded).
-  install_degraded?: boolean
 }
 
 export interface Interests {
@@ -79,10 +67,10 @@ export const RESOURCE_LABELS: Record<ResourceKind, string> = {
 
 export const RESOURCE_DESCRIPTIONS: Record<ResourceKind, string> = {
   installs:
-    'Install provision, deprovision, reprovision lifecycle. Toggle install degraded to be notified when install health degrades and when it recovers.',
+    'Install provision, deprovision, reprovision lifecycle events.',
   stacks: 'Install stack lifecycle, including when a stack version becomes active.',
   components:
-    'Per-component deploy and teardown. Toggle drift detected to be notified when drift is found. Toggle component health to be notified when a component becomes unhealthy and when it recovers.',
+    'Per-component deploy and teardown. Toggle drift detected to be notified when drift is found.',
   sandboxes: 'Sandbox provision, reprovision, deprovision. Toggle drift detected to be notified when drift is found.',
   install_configurations: 'Install input updates and secret syncs.',
   runners: 'Runner provision and reprovision.',

--- a/services/dashboard-ui/client/components/slack/ChannelSubscriptionForm/ChannelSubscriptionForm.tsx
+++ b/services/dashboard-ui/client/components/slack/ChannelSubscriptionForm/ChannelSubscriptionForm.tsx
@@ -7,9 +7,8 @@ import { Text } from '@/components/common/Text'
 import { FormErrorBanner } from '@/components/common/form/FormErrorBanner'
 import { Label } from '@/components/common/form/Label'
 import { Select } from '@/components/common/form/Select'
-import { allEvents } from '@/components/interests'
+import { recommendedPreset } from '@/components/interests'
 import { FormInterestsPicker } from '@/components/interests/FormInterestsPicker'
-import { FormMatchPicker } from '@/components/match/FormMatchPicker'
 import { Modal, type IModal } from '@/components/surfaces/Modal'
 import type {
   TAPIError,
@@ -85,7 +84,7 @@ export const ChannelSubscriptionFormModal = ({
       channelId: subscription?.channel_id ?? '',
       channelName: subscription?.channel_name ?? '',
       match: subscription?.match,
-      interests: subscription?.interests ?? allEvents(),
+      interests: subscription?.interests ?? recommendedPreset().build(),
     } as ChannelSubscriptionValues,
     validators: {
       onMount: schema,
@@ -254,23 +253,22 @@ export const ChannelSubscriptionFormModal = ({
         )}
 
         <div className="flex flex-col gap-2">
-          <Label>Scope</Label>
+          <Label>Subscription</Label>
           <Text variant="subtext" theme="neutral">
-            Filter which resources fire notifications in this channel.
-          </Text>
-          <form.Field name="match">
-            {(field) => <FormMatchPicker field={field} disabled={isPending} />}
-          </form.Field>
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <Label>Events</Label>
-          <Text variant="subtext" theme="neutral">
-            Pick which events post notifications in this channel.
+            Choose a preset to filter which events and which resources post
+            notifications in this channel.
           </Text>
           <form.Field name="interests">
             {(field) => (
-              <FormInterestsPicker field={field} disabled={isPending} />
+              <form.Field name="match">
+                {(matchField) => (
+                  <FormInterestsPicker
+                    field={field}
+                    matchField={matchField}
+                    disabled={isPending}
+                  />
+                )}
+              </form.Field>
             )}
           </form.Field>
         </div>

--- a/services/dashboard-ui/client/components/webhooks/WebhookForm/WebhookForm.tsx
+++ b/services/dashboard-ui/client/components/webhooks/WebhookForm/WebhookForm.tsx
@@ -6,9 +6,8 @@ import { FormErrorBanner } from '@/components/common/form/FormErrorBanner'
 import { FormInput } from '@/components/common/form/FormInput'
 import { FormRadioGroup } from '@/components/common/form/FormRadioGroup'
 import { Label } from '@/components/common/form/Label'
-import { allEvents } from '@/components/interests'
+import { recommendedPreset } from '@/components/interests'
 import { FormInterestsPicker } from '@/components/interests/FormInterestsPicker'
-import { FormMatchPicker } from '@/components/match/FormMatchPicker'
 import { Modal, type IModal } from '@/components/surfaces/Modal'
 import type { TAPIError, TWebhook } from '@/types'
 import {
@@ -51,7 +50,7 @@ export const WebhookFormModal = ({
       secretMode: 'keep',
       webhookSecret: '',
       match: webhook?.match,
-      interests: webhook?.interests ?? allEvents(),
+      interests: webhook?.interests ?? recommendedPreset().build(),
     } as WebhookFormValues,
     validators: {
       onMount: schema,
@@ -219,23 +218,22 @@ export const WebhookFormModal = ({
         )}
 
         <div className="flex flex-col gap-2">
-          <Label>Scope</Label>
+          <Label>Subscription</Label>
           <Text variant="subtext" theme="neutral">
-            Filter which resources fire deliveries to this webhook.
-          </Text>
-          <form.Field name="match">
-            {(field) => <FormMatchPicker field={field} disabled={isPending} />}
-          </form.Field>
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <Label>Events</Label>
-          <Text variant="subtext" theme="neutral">
-            Pick which events fire deliveries to this webhook.
+            Choose a preset to filter which events and which resources fire
+            deliveries to this webhook.
           </Text>
           <form.Field name="interests">
             {(field) => (
-              <FormInterestsPicker field={field} disabled={isPending} />
+              <form.Field name="match">
+                {(matchField) => (
+                  <FormInterestsPicker
+                    field={field}
+                    matchField={matchField}
+                    disabled={isPending}
+                  />
+                )}
+              </form.Field>
             )}
           </form.Field>
         </div>


### PR DESCRIPTION
## Summary

Slack channel subscriptions and webhooks now use a preset picker that bundles event filters and scope into one choice. Component health and install degraded notifications are retired — no subscriber receives them regardless of existing config.

## What you can do after this PR

- **Pick a preset instead of configuring individual event toggles.** The subscription modal shows six presets: Failures (recommended), All events, Operations, Approvals only, Deployment milestones, and Custom. Each preset bundles the event filter and, where relevant, an optional install label scope (include/exclude).
- **Filter by install labels directly in the preset.** The Failures and Deployment milestones presets expose inline label inputs so you can scope to `env=prod` or exclude `env=stage` without switching to Custom.
- **Use Custom for full control.** The Custom preset still gives the full scope picker and per-resource event checklist for power users.

## What stays the same

- Existing subscriptions keep working. The `match` and `interests` fields on the form schema are unchanged — the picker just writes both in one save instead of two separate sections.
- The Slack slash-command modal and CLI are unaffected by the dashboard UI changes. The Go-side `SupportsComponentHealth` and `SupportsInstallDegraded` functions already returned `false`; this PR updates the tests to match.
- Subscriptions that still carry `ComponentHealth=true` or `InstallDegraded=true` in their JSONB are silently suppressed by the matcher. No migration is needed.

## Mechanics worth flagging for review

- The `InterestsModal` now returns `PresetModalOutput { interests, match }` instead of just `Interests`. The `FormInterestsPicker` wires both form fields (`interests` + `match`) through a single picker instance using nested `form.Field` wrappers.
- Preset matching uses canonicalized key ordering for deep equality so API-returned resource maps with different key order don't incorrectly fall back to "Custom."
