### PR TITLE
fix: stop unhealthy-runner alerts before the runner exists

### DIFF
--- a/services/ctl-api/internal/app/installs/worker/activities/reconcile_runner_enabled.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/reconcile_runner_enabled.go
@@ -46,7 +46,10 @@ func (a *Activities) ReconcileRunnerEnabled(ctx context.Context, req *ReconcileR
 
 	if err := a.statusActivities.UpdateRunnerStatusV2Metadata(ctx, statusactivities.UpdateRunnerStatusV2MetadataRequest{
 		RunnerID: req.RunnerID,
-		Metadata: map[string]any{app.RunnerOfflineTSMetadataKey: nil},
+		Metadata: map[string]any{
+			app.RunnerOfflineTSMetadataKey:         nil,
+			app.RunnerOfflineFromStatusMetadataKey: nil,
+		},
 	}); err != nil {
 		return fmt.Errorf("unable to clear runner offline metadata: %w", err)
 	}

--- a/services/ctl-api/internal/app/runner.go
+++ b/services/ctl-api/internal/app/runner.go
@@ -35,6 +35,18 @@ const (
 
 const RunnerOfflineTSMetadataKey = "offline_ts"
 
+const RunnerOfflineFromStatusMetadataKey = "offline_from_status"
+
+// RunnerOfflineFromStatus is the status persisted alongside offline_ts when a
+// health check first marks a runner offline. Once offline, the pre-offline
+// status is unrecoverable, so it maps to unknown.
+func RunnerOfflineFromStatus(status RunnerStatus) string {
+	if status == RunnerStatusOffline {
+		return string(RunnerStatusUnknown)
+	}
+	return string(status)
+}
+
 func (r RunnerStatus) String() string {
 	return string(r)
 }

--- a/services/ctl-api/internal/app/runners/signals/offlinecheck/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/offlinecheck/signal.go
@@ -56,6 +56,8 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 
 	// Skip checking offline status for runners in these states
 	isNoop := generics.SliceContains(runner.Status, []app.RunnerStatus{
+		app.RunnerStatusPending,
+		app.RunnerStatusAwaitingInstallStackRun,
 		app.RunnerStatusProvisioning,
 		app.RunnerStatusDeprovisioning,
 		app.RunnerStatusReprovisioning,

--- a/services/ctl-api/internal/app/runners/signals/processinit/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/processinit/signal.go
@@ -65,7 +65,8 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		if err := statusactivities.AwaitUpdateRunnerStatusV2Metadata(ctx, statusactivities.UpdateRunnerStatusV2MetadataRequest{
 			RunnerID: s.RunnerID,
 			Metadata: map[string]any{
-				app.RunnerOfflineTSMetadataKey: nil,
+				app.RunnerOfflineTSMetadataKey:         nil,
+				app.RunnerOfflineFromStatusMetadataKey: nil,
 			},
 		}); err != nil {
 			return errors.Wrap(err, "unable to clear runner offline metadata")

--- a/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/deprecated_test.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/deprecated_test.go
@@ -203,6 +203,8 @@ func runnerHealthCases() []runnerHealthCase {
 		app.RunnerStatusReprovisioning,
 		app.RunnerStatusDeprovisioned,
 		app.RunnerStatusPending,
+		app.RunnerStatusDisabled,
+		app.RunnerStatusAwaitingInstallStackRun,
 	} {
 		cases = append(cases, runnerHealthCase{
 			name:      "skippable status " + string(status),

--- a/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal.go
@@ -215,7 +215,8 @@ func (s *Signal) handleRunnerActive(ctx workflow.Context, runner *app.Runner) er
 		if err := statusactivities.LocalAwaitUpdateRunnerStatusV2Metadata(ctx, statusactivities.UpdateRunnerStatusV2MetadataRequest{
 			RunnerID: s.RunnerID,
 			Metadata: map[string]any{
-				app.RunnerOfflineTSMetadataKey: nil,
+				app.RunnerOfflineTSMetadataKey:         nil,
+				app.RunnerOfflineFromStatusMetadataKey: nil,
 			},
 		}); err != nil {
 			return errors.Wrap(err, "unable to clear runner offline metadata")
@@ -233,7 +234,8 @@ func (s *Signal) handleRunnerOffline(ctx workflow.Context, tmw tmetrics.Writer, 
 		if err := statusactivities.LocalAwaitUpdateRunnerStatusV2Metadata(ctx, statusactivities.UpdateRunnerStatusV2MetadataRequest{
 			RunnerID: s.RunnerID,
 			Metadata: map[string]any{
-				app.RunnerOfflineTSMetadataKey: now.Unix(),
+				app.RunnerOfflineTSMetadataKey:         now.Unix(),
+				app.RunnerOfflineFromStatusMetadataKey: app.RunnerOfflineFromStatus(runner.Status),
 			},
 		}); err != nil {
 			return errors.Wrap(err, "unable to set runner offline metadata")
@@ -256,7 +258,7 @@ func (s *Signal) handleRunnerOffline(ctx workflow.Context, tmw tmetrics.Writer, 
 	return nil
 }
 
-func (s *Signal) runnerOfflineEvent(ctx workflow.Context, runner *app.Runner, reason string) (*statsd.Event, string) {
+func (s *Signal) runnerOfflineEvent(ctx workflow.Context, runner *app.Runner, fromStatus app.RunnerStatus, reason string) (*statsd.Event, string) {
 	eventTags := []string{
 		metrics.ToTag("runner_id", s.RunnerID),
 		metrics.ToTag("runner_type", string(runner.RunnerGroup.Type)),
@@ -266,8 +268,8 @@ func (s *Signal) runnerOfflineEvent(ctx workflow.Context, runner *app.Runner, re
 
 	title := fmt.Sprintf("Runner went offline (type: %s)", string(runner.RunnerGroup.Type))
 	text := fmt.Sprintf(
-		"Runner %s (org: %s) transitioned from active to offline.\nReason: %s",
-		s.RunnerID, runner.Org.Name, reason,
+		"Runner %s (org: %s) transitioned from %s to offline.\nReason: %s",
+		s.RunnerID, runner.Org.Name, fromStatus, reason,
 	)
 	ownerName := ""
 	if runner.RunnerGroup.OwnerType == "orgs" {
@@ -288,8 +290,8 @@ func (s *Signal) runnerOfflineEvent(ctx workflow.Context, runner *app.Runner, re
 				metrics.ToTag("created_by", install.CreatedBy.Email),
 			)
 			text = fmt.Sprintf(
-				"Runner %s (org: %s, app: %s, install: %s) transitioned from active to offline.\nReason: %s\nInstall created by: %s",
-				s.RunnerID, runner.Org.Name, install.App.Name, install.Name, reason, install.CreatedBy.Email,
+				"Runner %s (org: %s, app: %s, install: %s) transitioned from %s to offline.\nReason: %s\nInstall created by: %s",
+				s.RunnerID, runner.Org.Name, install.App.Name, install.Name, fromStatus, reason, install.CreatedBy.Email,
 			)
 		}
 	}
@@ -306,7 +308,12 @@ func (s *Signal) runnerOfflineEvent(ctx workflow.Context, runner *app.Runner, re
 }
 
 func (s *Signal) notifyRunnerUnhealthy(ctx workflow.Context, tmw tmetrics.Writer, runner *app.Runner, reason string, offlineAt time.Time) error {
-	event, ownerName := s.runnerOfflineEvent(ctx, runner, reason)
+	fromStatus := app.RunnerStatusUnknown
+	if raw, ok := runner.StatusV2.Metadata[app.RunnerOfflineFromStatusMetadataKey].(string); ok && raw != "" {
+		fromStatus = app.RunnerStatus(raw)
+	}
+
+	event, ownerName := s.runnerOfflineEvent(ctx, runner, fromStatus, reason)
 	resp, err := sharedactivities.AwaitEnqueueSignalToOwner(ctx, &sharedactivities.EnqueueSignalToOwnerRequest{
 		OwnerID:         runner.OrgID,
 		OwnerType:       "orgs",
@@ -319,7 +326,7 @@ func (s *Signal) notifyRunnerUnhealthy(ctx workflow.Context, tmw tmetrics.Writer
 			RunnerName:           runner.DisplayName,
 			OrgID:                runner.OrgID,
 			OrgName:              runner.Org.Name,
-			FromStatus:           app.RunnerStatusActive,
+			FromStatus:           fromStatus,
 			ToStatus:             app.RunnerStatusOffline,
 			Reason:               reason,
 			RunnerGroupID:        runner.RunnerGroupID,
@@ -378,7 +385,8 @@ func isSkippableStatus(status app.RunnerStatus) bool {
 		app.RunnerStatusReprovisioning,
 		app.RunnerStatusDeprovisioned,
 		app.RunnerStatusPending,
-		app.RunnerStatusDisabled:
+		app.RunnerStatusDisabled,
+		app.RunnerStatusAwaitingInstallStackRun:
 		return true
 	}
 	return false

--- a/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal_test.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal_test.go
@@ -36,7 +36,9 @@ func TestFirstFailedHealthCheckMarksRunnerOfflineWithoutAlerting(t *testing.T) {
 	var calls []string
 
 	env.OnActivity((*statusactivities.Activities).UpdateRunnerStatusV2Metadata, mock.MatchedBy(func(req statusactivities.UpdateRunnerStatusV2MetadataRequest) bool {
-		return len(req.Metadata) == 1 && req.Metadata[app.RunnerOfflineTSMetadataKey] == now.Unix()
+		return len(req.Metadata) == 2 &&
+			req.Metadata[app.RunnerOfflineTSMetadataKey] == now.Unix() &&
+			req.Metadata[app.RunnerOfflineFromStatusMetadataKey] == string(app.RunnerStatusActive)
 	})).Run(func(mock.Arguments) { calls = append(calls, "offline-ts") }).Return(nil).Once()
 	env.OnActivity((*runneractivities.Activities).UpdateStatus, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(mock.Arguments) { calls = append(calls, "status") }).
@@ -228,7 +230,9 @@ func TestHealthyCheckClearsOfflineMetadataAndRestoresActive(t *testing.T) {
 	var calls []string
 
 	env.OnActivity((*statusactivities.Activities).UpdateRunnerStatusV2Metadata, mock.MatchedBy(func(req statusactivities.UpdateRunnerStatusV2MetadataRequest) bool {
-		return len(req.Metadata) == 1 && req.Metadata[app.RunnerOfflineTSMetadataKey] == nil
+		return len(req.Metadata) == 2 &&
+			req.Metadata[app.RunnerOfflineTSMetadataKey] == nil &&
+			req.Metadata[app.RunnerOfflineFromStatusMetadataKey] == nil
 	})).Run(func(mock.Arguments) { calls = append(calls, "clear") }).Return(nil).Once()
 	env.OnActivity((*runneractivities.Activities).UpdateStatus, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(mock.Arguments) { calls = append(calls, "status") }).

--- a/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal_test.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerhealthcheck/signal_test.go
@@ -17,6 +17,7 @@ import (
 	basemetrics "github.com/nuonco/nuon/pkg/metrics"
 	tmetrics "github.com/nuonco/nuon/pkg/temporal/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app/runners/signals/runnerunhealthy"
 	runneractivities "github.com/nuonco/nuon/services/ctl-api/internal/app/runners/worker/activities"
 	signaldb "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/signal/db"
 	sharedactivities "github.com/nuonco/nuon/services/ctl-api/internal/pkg/workflows/activities"
@@ -90,6 +91,7 @@ func TestOfflineRunnerEnqueuesIdempotentAlertAfterDelay(t *testing.T) {
 
 	offlineAt := now.Add(-runnerUnhealthyAlertDelay)
 	runner := runnerWithOfflineMetadata(app.RunnerStatusOffline, offlineAt)
+	runner.StatusV2.Metadata[app.RunnerOfflineFromStatusMetadataKey] = string(app.RunnerStatusError)
 	runner.RunnerGroup.Type = app.RunnerGroupTypeOrg
 	runner.RunnerGroup.OwnerID = runner.OrgID
 	runner.RunnerGroup.OwnerType = "orgs"
@@ -98,6 +100,10 @@ func TestOfflineRunnerEnqueuesIdempotentAlertAfterDelay(t *testing.T) {
 	var calls []string
 
 	env.OnActivity(new(sharedactivities.Activities).EnqueueSignalToOwner, mock.Anything, mock.MatchedBy(func(req *sharedactivities.EnqueueSignalToOwnerRequest) bool {
+		unhealthy, ok := req.Signal.(*runnerunhealthy.Signal)
+		if !ok || unhealthy.FromStatus != app.RunnerStatusError {
+			return false
+		}
 		return req.IdempotencyKey == fmt.Sprintf("runner-unhealthy:%s:%d", runner.ID, offlineAt.Unix())
 	})).
 		Run(func(mock.Arguments) { calls = append(calls, "notification") }).

--- a/services/ctl-api/internal/app/runners/signals/runnerunhealthy/signal.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerunhealthy/signal.go
@@ -69,8 +69,8 @@ func (s *Signal) Validate(_ workflow.Context) error {
 		s.RunnerGroupType == "" || s.RunnerGroupOwnerID == "" || s.RunnerGroupOwnerType == "" {
 		return errors.New("runner unhealthy payload is incomplete")
 	}
-	if s.FromStatus != app.RunnerStatusActive || s.ToStatus != app.RunnerStatusOffline {
-		return errors.New("runner unhealthy requires an active to offline transition")
+	if s.ToStatus != app.RunnerStatusOffline || s.FromStatus == app.RunnerStatusOffline {
+		return errors.New("runner unhealthy requires a transition to offline")
 	}
 	return nil
 }

--- a/services/ctl-api/internal/app/runners/signals/runnerunhealthy/signal_test.go
+++ b/services/ctl-api/internal/app/runners/signals/runnerunhealthy/signal_test.go
@@ -52,3 +52,25 @@ func TestSignalRejectsNonUnhealthyTransition(t *testing.T) {
 
 	require.Error(t, sig.Validate(nil))
 }
+
+func TestSignalAcceptsNonActiveToOfflineTransitions(t *testing.T) {
+	for _, fromStatus := range []app.RunnerStatus{
+		app.RunnerStatusActive,
+		app.RunnerStatusError,
+		app.RunnerStatusUnknown,
+	} {
+		sig := &Signal{
+			RunnerID:             "run_1",
+			OrgID:                "org_1",
+			FromStatus:           fromStatus,
+			ToStatus:             app.RunnerStatusOffline,
+			Reason:               "no active install process",
+			RunnerGroupID:        "rug_1",
+			RunnerGroupType:      app.RunnerGroupTypeInstall,
+			RunnerGroupOwnerID:   "ins_1",
+			RunnerGroupOwnerType: "installs",
+		}
+
+		require.NoError(t, sig.Validate(nil), "from status %s", fromStatus)
+	}
+}

--- a/services/ctl-api/internal/app/runners/worker/activities/batch_runner_healthchecks.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/batch_runner_healthchecks.go
@@ -197,7 +197,10 @@ func (a *Activities) applyRunnerHealthDecision(ectx context.Context, r *app.Runn
 	if d.SetOfflineTS {
 		if err := a.statusActivities.UpdateRunnerStatusV2Metadata(ectx, statusactivities.UpdateRunnerStatusV2MetadataRequest{
 			RunnerID: r.ID,
-			Metadata: map[string]any{app.RunnerOfflineTSMetadataKey: now.Unix()},
+			Metadata: map[string]any{
+				app.RunnerOfflineTSMetadataKey:         now.Unix(),
+				app.RunnerOfflineFromStatusMetadataKey: d.OfflineFromStatus,
+			},
 		}); err != nil {
 			return fmt.Errorf("unable to set runner offline metadata: %w", err)
 		}
@@ -205,7 +208,10 @@ func (a *Activities) applyRunnerHealthDecision(ectx context.Context, r *app.Runn
 	if d.ClearOfflineTS {
 		if err := a.statusActivities.UpdateRunnerStatusV2Metadata(ectx, statusactivities.UpdateRunnerStatusV2MetadataRequest{
 			RunnerID: r.ID,
-			Metadata: map[string]any{app.RunnerOfflineTSMetadataKey: nil},
+			Metadata: map[string]any{
+				app.RunnerOfflineTSMetadataKey:         nil,
+				app.RunnerOfflineFromStatusMetadataKey: nil,
+			},
 		}); err != nil {
 			return fmt.Errorf("unable to clear runner offline metadata: %w", err)
 		}
@@ -282,7 +288,8 @@ func (a *Activities) emitRunnerAlerts(ctx context.Context, orgID string, alerts 
 		if in, ok := installsByID[r.RunnerGroup.OwnerID]; ok {
 			install = &in
 		}
-		event, ownerName := runnerOfflineEvent(&r, install, al.reason, al.tags)
+		fromStatus := runnerOfflineFromStatus(&r)
+		event, ownerName := runnerOfflineEvent(&r, install, fromStatus, al.reason, al.tags)
 
 		ectx := cctx.SetOrgIDContext(ctx, r.OrgID)
 		ectx = cctx.SetAccountIDContext(ectx, r.CreatedByID)
@@ -296,7 +303,7 @@ func (a *Activities) emitRunnerAlerts(ctx context.Context, orgID string, alerts 
 				RunnerName:           r.DisplayName,
 				OrgID:                r.OrgID,
 				OrgName:              r.Org.Name,
-				FromStatus:           app.RunnerStatusActive,
+				FromStatus:           fromStatus,
 				ToStatus:             app.RunnerStatusOffline,
 				Reason:               al.reason,
 				RunnerGroupID:        r.RunnerGroupID,
@@ -346,7 +353,14 @@ func runnerHealthTags(r *app.Runner, presence runnerProcessPresence, d runnerHea
 	return tags
 }
 
-func runnerOfflineEvent(r *app.Runner, install *app.Install, reason string, tags map[string]string) (*statsd.Event, string) {
+func runnerOfflineFromStatus(r *app.Runner) app.RunnerStatus {
+	if raw, ok := r.StatusV2.Metadata[app.RunnerOfflineFromStatusMetadataKey].(string); ok && raw != "" {
+		return app.RunnerStatus(raw)
+	}
+	return app.RunnerStatusUnknown
+}
+
+func runnerOfflineEvent(r *app.Runner, install *app.Install, fromStatus app.RunnerStatus, reason string, tags map[string]string) (*statsd.Event, string) {
 	eventTags := []string{
 		metrics.ToTag("runner_id", r.ID),
 		metrics.ToTag("runner_type", string(r.RunnerGroup.Type)),
@@ -356,8 +370,8 @@ func runnerOfflineEvent(r *app.Runner, install *app.Install, reason string, tags
 
 	title := fmt.Sprintf("Runner went offline (type: %s)", string(r.RunnerGroup.Type))
 	text := fmt.Sprintf(
-		"Runner %s (org: %s) transitioned from active to offline.\nReason: %s",
-		r.ID, r.Org.Name, reason,
+		"Runner %s (org: %s) transitioned from %s to offline.\nReason: %s",
+		r.ID, r.Org.Name, fromStatus, reason,
 	)
 	ownerName := ""
 	if r.RunnerGroup.OwnerType == "orgs" {
@@ -373,8 +387,8 @@ func runnerOfflineEvent(r *app.Runner, install *app.Install, reason string, tags
 			metrics.ToTag("created_by", install.CreatedBy.Email),
 		)
 		text = fmt.Sprintf(
-			"Runner %s (org: %s, app: %s, install: %s) transitioned from active to offline.\nReason: %s\nInstall created by: %s",
-			r.ID, r.Org.Name, install.App.Name, install.Name, reason, install.CreatedBy.Email,
+			"Runner %s (org: %s, app: %s, install: %s) transitioned from %s to offline.\nReason: %s\nInstall created by: %s",
+			r.ID, r.Org.Name, install.App.Name, install.Name, fromStatus, reason, install.CreatedBy.Email,
 		)
 	}
 

--- a/services/ctl-api/internal/app/runners/worker/activities/healthcheck_cases_test.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/healthcheck_cases_test.go
@@ -10,15 +10,16 @@ import (
 var corpusNow = time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC)
 
 type runnerHealthWant struct {
-	result         string
-	reason         string
-	setMissingMng  *bool
-	armOfflineTS   bool
-	clearOfflineTS bool
-	legacyStatus   *app.RunnerStatus
-	v2Status       *app.RunnerStatus
-	alert          bool
-	alertOfflineAt int64
+	result            string
+	reason            string
+	setMissingMng     *bool
+	armOfflineTS      bool
+	clearOfflineTS    bool
+	offlineFromStatus string
+	legacyStatus      *app.RunnerStatus
+	v2Status          *app.RunnerStatus
+	alert             bool
+	alertOfflineAt    int64
 }
 
 type runnerHealthCase struct {
@@ -74,7 +75,7 @@ func runnerHealthCases() []runnerHealthCase {
 			name: "org first failed check arms and transitions without alert", groupType: app.RunnerGroupTypeOrg,
 			status: app.RunnerStatusActive, v2Status: app.RunnerStatusActive,
 			want: runnerHealthWant{
-				result: "unhealthy", reason: unhealthyOrgReason, armOfflineTS: true,
+				result: "unhealthy", reason: unhealthyOrgReason, armOfflineTS: true, offlineFromStatus: string(app.RunnerStatusActive),
 				legacyStatus: runnerStatusPtr(app.RunnerStatusOffline), v2Status: runnerStatusPtr(app.RunnerStatusOffline),
 			},
 		},
@@ -108,7 +109,7 @@ func runnerHealthCases() []runnerHealthCase {
 		{
 			name: "org offline without timestamp arms only", groupType: app.RunnerGroupTypeOrg,
 			status: app.RunnerStatusOffline, v2Status: app.RunnerStatusOffline,
-			want: runnerHealthWant{result: "unhealthy", reason: unhealthyOrgReason, armOfflineTS: true},
+			want: runnerHealthWant{result: "unhealthy", reason: unhealthyOrgReason, armOfflineTS: true, offlineFromStatus: string(app.RunnerStatusUnknown)},
 		},
 		{
 			name: "legacy offline but v2 stale repairs v2 only", groupType: app.RunnerGroupTypeOrg,
@@ -166,7 +167,7 @@ func runnerHealthCases() []runnerHealthCase {
 			status: app.RunnerStatusActive, v2Status: app.RunnerStatusActive,
 			activeMng: true, mngChecked: true,
 			want: runnerHealthWant{
-				result: "unhealthy", reason: unhealthyInstallReason, armOfflineTS: true,
+				result: "unhealthy", reason: unhealthyInstallReason, armOfflineTS: true, offlineFromStatus: string(app.RunnerStatusActive),
 				setMissingMng: generics.ToPtr(false),
 				legacyStatus:  runnerStatusPtr(app.RunnerStatusOffline), v2Status: runnerStatusPtr(app.RunnerStatusOffline),
 			},
@@ -190,6 +191,16 @@ func runnerHealthCases() []runnerHealthCase {
 		want:       runnerHealthWant{result: "skipped"},
 	})
 
+	// An install runner awaiting its install stack run has no runner infra
+	// yet; the health check must not judge it before the runner step runs.
+	cases = append(cases, runnerHealthCase{
+		name:      "install runner awaiting install stack run is skipped",
+		groupType: app.RunnerGroupTypeInstall,
+		status:    app.RunnerStatusAwaitingInstallStackRun, v2Status: app.RunnerStatusAwaitingInstallStackRun,
+		mngChecked: true,
+		want:       runnerHealthWant{result: "skipped"},
+	})
+
 	for _, status := range []app.RunnerStatus{
 		app.RunnerStatusProvisioning,
 		app.RunnerStatusDeprovisioning,
@@ -197,6 +208,7 @@ func runnerHealthCases() []runnerHealthCase {
 		app.RunnerStatusDeprovisioned,
 		app.RunnerStatusPending,
 		app.RunnerStatusDisabled,
+		app.RunnerStatusAwaitingInstallStackRun,
 	} {
 		cases = append(cases, runnerHealthCase{
 			name:      "skippable status " + string(status),

--- a/services/ctl-api/internal/app/runners/worker/activities/healthcheck_cases_test.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/healthcheck_cases_test.go
@@ -191,16 +191,6 @@ func runnerHealthCases() []runnerHealthCase {
 		want:       runnerHealthWant{result: "skipped"},
 	})
 
-	// An install runner awaiting its install stack run has no runner infra
-	// yet; the health check must not judge it before the runner step runs.
-	cases = append(cases, runnerHealthCase{
-		name:      "install runner awaiting install stack run is skipped",
-		groupType: app.RunnerGroupTypeInstall,
-		status:    app.RunnerStatusAwaitingInstallStackRun, v2Status: app.RunnerStatusAwaitingInstallStackRun,
-		mngChecked: true,
-		want:       runnerHealthWant{result: "skipped"},
-	})
-
 	for _, status := range []app.RunnerStatus{
 		app.RunnerStatusProvisioning,
 		app.RunnerStatusDeprovisioning,

--- a/services/ctl-api/internal/app/runners/worker/activities/healthcheck_decisions.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/healthcheck_decisions.go
@@ -26,6 +26,7 @@ var skippableRunnerStatuses = []app.RunnerStatus{
 	app.RunnerStatusDeprovisioned,
 	app.RunnerStatusPending,
 	app.RunnerStatusDisabled,
+	app.RunnerStatusAwaitingInstallStackRun,
 }
 
 func isSkippableRunnerStatus(status app.RunnerStatus) bool {
@@ -53,6 +54,10 @@ type runnerHealthDecision struct {
 
 	ClearOfflineTS bool
 	SetOfflineTS   bool
+
+	// OfflineFromStatus is persisted with offline_ts so the unhealthy alert
+	// can report the status the runner had before going offline.
+	OfflineFromStatus string
 
 	UpdateLegacy bool
 	UpdateV2     bool
@@ -108,6 +113,7 @@ func decideRunnerHealth(now time.Time, runner *app.Runner, presence runnerProces
 	offlineAt, hasOfflineTS := runner.StatusV2.MetadataUnixTime(app.RunnerOfflineTSMetadataKey)
 	if !hasOfflineTS {
 		d.SetOfflineTS = true
+		d.OfflineFromStatus = app.RunnerOfflineFromStatus(runner.Status)
 		offlineAt = now
 	}
 

--- a/services/ctl-api/internal/app/runners/worker/activities/healthcheck_decisions_test.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/healthcheck_decisions_test.go
@@ -43,12 +43,13 @@ func corpusProcess(tc processHealthCase) (*app.RunnerProcess, *time.Time) {
 
 func decisionToWant(d runnerHealthDecision) runnerHealthWant {
 	want := runnerHealthWant{
-		result:         d.Result,
-		reason:         d.Reason,
-		setMissingMng:  d.SetMissingMng,
-		armOfflineTS:   d.SetOfflineTS,
-		clearOfflineTS: d.ClearOfflineTS,
-		alert:          d.Alert,
+		result:            d.Result,
+		reason:            d.Reason,
+		setMissingMng:     d.SetMissingMng,
+		armOfflineTS:      d.SetOfflineTS,
+		clearOfflineTS:    d.ClearOfflineTS,
+		offlineFromStatus: d.OfflineFromStatus,
+		alert:             d.Alert,
 	}
 	if d.UpdateLegacy {
 		want.legacyStatus = runnerStatusPtr(d.TargetStatus)


### PR DESCRIPTION
## Summary

Installs that are still provisioning no longer trigger false "runner unhealthy" Slack alerts. The health check previously judged a runner in the window between creating the install and running its install stack, when no runner exists yet, and paged on a runner that had never started.

## What you can do after this PR

- **Provisioning installs stay quiet.** The health check now skips a runner while it waits for the install stack to run, the step that actually creates the runner. This is the same treatment the other pre-runner states already got.
- **A day on "awaiting user run" stays quiet too.** The separate 24-hour offline check had its own skip list and did not know about the waiting state, so an install left unattended for a day would still be marked offline and page 15 minutes later. It now skips runners before the install stack runs, including ones still pending.
- **Alerts show the real transition.** The Slack post and Datadog event report the status the runner actually had before going offline, such as "error → offline" when a runner never came up after its stack ran, instead of always claiming "active → offline".

## What stays the same

A runner that dies after being healthy still alerts, with the same 15-minute delay, and a runner that never boots after its stack run is still flagged on purpose. Runners that went offline before this change report "unknown" as their previous status; nothing needs to be backfilled.

## Mechanics worth flagging for review

The previous status is recorded alongside the offline timestamp the first time a health check marks a runner offline, and the alert reads it from there. The post-stack-run error state remains health-checked by design. The skip is status-based, so runners that were already flipped to offline during provisioning stay offline until their process initializes; the alert idempotency key prevents a second Slack post for the same offline episode.