### PR TITLE
chore(ctl-api): add vpc outputs to the install stack phone home

### DIFF
--- a/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
@@ -26,7 +26,7 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 	}
 
 	// build nested resources
-	stack, vpcParams, err := t.getVPCNestedStack(inp, tb)
+	stack, vpcParams, vpcOutputs, err := t.getVPCNestedStack(inp, tb)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 	if err := validatePhoneHomeScript(inp.PhonehomeScript); err != nil {
 		return nil, err
 	}
-	tmpl.Resources["PhoneHomeProps"] = t.getRunnerPhoneHomeProps(inp, customResult)
+	tmpl.Resources["PhoneHomeProps"] = t.getRunnerPhoneHomeProps(inp, customResult, vpcOutputs)
 	tmpl.Resources["RunnerPhoneHome"] = t.getRunnerPhoneHomeLambda(inp, tb)
 	tmpl.Resources["RunnerPhoneHomeRole"] = t.getRunnerPhoneHomeLambdaRole(inp, tb)
 

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_custom_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_custom_test.go
@@ -1197,7 +1197,7 @@ func TestGetRunnerPhoneHomeProps_DependsOnCustomStacks(t *testing.T) {
 			},
 		}
 
-		resource := tpl.getRunnerPhoneHomeProps(inp, customResult)
+		resource := tpl.getRunnerPhoneHomeProps(inp, customResult, nil)
 
 		// DependsOn should reference the last custom stack
 		assert.Equal(t, []string{"EksAccess"}, resource.AWSCloudFormationDependsOn)
@@ -1224,7 +1224,7 @@ func TestGetRunnerPhoneHomeProps_DependsOnCustomStacks(t *testing.T) {
 			stackOutputs: map[string]customNestedStackOutput{},
 		}
 
-		resource := tpl.getRunnerPhoneHomeProps(inp, customResult)
+		resource := tpl.getRunnerPhoneHomeProps(inp, customResult, nil)
 
 		// No DependsOn when no custom stacks
 		assert.Empty(t, resource.AWSCloudFormationDependsOn)
@@ -1236,7 +1236,7 @@ func TestGetRunnerPhoneHomeProps_DependsOnCustomStacks(t *testing.T) {
 	})
 
 	t.Run("nil custom stacks", func(t *testing.T) {
-		resource := tpl.getRunnerPhoneHomeProps(inp, nil)
+		resource := tpl.getRunnerPhoneHomeProps(inp, nil, nil)
 
 		assert.Empty(t, resource.AWSCloudFormationDependsOn)
 

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc.go
@@ -41,10 +41,10 @@ func (tpl *Templates) getClusterName(inp *stacks.TemplateInput) string {
 }
 
 // VPCNestedStack returns a nested stack template for VPC resources
-func (tpl *Templates) getVPCNestedStack(inp *stacks.TemplateInput, t tagBuilder) (*nestedcloudformation.Stack, map[string]cloudformation.Parameter, error) {
-	parameters, defaultParameters, reservedInTemplate, _, err := tpl.extractNestedStackParameters(inp.AppCfg.StackConfig.VPCNestedTemplateURL)
+func (tpl *Templates) getVPCNestedStack(inp *stacks.TemplateInput, t tagBuilder) (*nestedcloudformation.Stack, map[string]cloudformation.Parameter, map[string]struct{}, error) {
+	parameters, defaultParameters, reservedInTemplate, outputs, err := tpl.extractNestedStackParameters(inp.AppCfg.StackConfig.VPCNestedTemplateURL)
 	if err != nil {
-		return nil, nil, fmt.Errorf("VPC nested stack: %w", err)
+		return nil, nil, nil, fmt.Errorf("VPC nested stack: %w", err)
 	}
 
 	// these common params should always be set by nuon so they are explicitly
@@ -72,7 +72,7 @@ func (tpl *Templates) getVPCNestedStack(inp *stacks.TemplateInput, t tagBuilder)
 		Tags: t.apply(nil, "vpc"),
 	}
 
-	return stack, defaultParameters, nil
+	return stack, defaultParameters, outputs, nil
 }
 
 type cfnParameterShape struct {

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc_test.go
@@ -457,7 +457,7 @@ func TestGetVPCNestedStack_OmitsClusterNameWhenNotInTemplate(t *testing.T) {
 	}
 	tb := tagBuilder{installID: inp.Install.ID}
 
-	stack, _, err := tpl.getVPCNestedStack(inp, tb)
+	stack, _, _, err := tpl.getVPCNestedStack(inp, tb)
 	require.NoError(t, err)
 
 	assert.NotContains(t, stack.Parameters, "ClusterName", "ClusterName should not be in stack parameters when template does not define it")
@@ -469,7 +469,13 @@ func TestGetVPCNestedStack_OmitsClusterNameWhenNotInTemplate(t *testing.T) {
 func TestGetVPCNestedStack_IncludesClusterNameWhenInTemplate(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/yaml")
-		w.Write([]byte(mockVPCTemplateYAML))
+		w.Write([]byte(mockVPCTemplateYAML + `
+Outputs:
+  VPC:
+    Value: !Ref VPC
+  AdditionalResource:
+    Value: additional-resource
+`))
 	}))
 	defer server.Close()
 
@@ -488,12 +494,13 @@ func TestGetVPCNestedStack_IncludesClusterNameWhenInTemplate(t *testing.T) {
 	}
 	tb := tagBuilder{installID: inp.Install.ID}
 
-	stack, _, err := tpl.getVPCNestedStack(inp, tb)
+	stack, _, outputs, err := tpl.getVPCNestedStack(inp, tb)
 	require.NoError(t, err)
 
 	assert.Contains(t, stack.Parameters, "ClusterName", "ClusterName should be in stack parameters when template defines it")
 	assert.Equal(t, inp.Install.ID, stack.Parameters["ClusterName"])
 	assert.Equal(t, inp.Install.ID, stack.Parameters["NuonInstallID"])
+	assert.Equal(t, map[string]struct{}{"VPC": {}, "AdditionalResource": {}}, outputs)
 }
 
 func TestExtractNestedStackParameters_InvalidURL(t *testing.T) {

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/resource_runner_phone_home_lambda.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/resource_runner_phone_home_lambda.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
 )
 
-func (a *Templates) getRunnerPhoneHomeProps(inp *stacks.TemplateInput, customStacks *customNestedStackResult) *cloudformation.CustomResource {
+func (a *Templates) getRunnerPhoneHomeProps(inp *stacks.TemplateInput, customStacks *customNestedStackResult, vpcOutputKeys map[string]struct{}) *cloudformation.CustomResource {
 	breakGlassRoleArns := make(map[string]interface{})
 	customRoleArns := make(map[string]interface{})
 
@@ -83,6 +83,12 @@ func (a *Templates) getRunnerPhoneHomeProps(inp *stacks.TemplateInput, customSta
 	if !a.cfg.UseLocalRunners {
 		lambdaprops["runner_iam_role_arn"] = cloudformation.GetAttPtr("RunnerAutoScalingGroup", "Outputs.RunnerInstanceRole")
 	}
+
+	vpcOutputs := make(map[string]any, len(vpcOutputKeys))
+	for outputKey := range vpcOutputKeys {
+		vpcOutputs[outputKey] = cloudformation.GetAtt("VPC", "Outputs."+outputKey)
+	}
+	lambdaprops["vpc_outputs"] = vpcOutputs
 
 	for _, secret := range inp.AppCfg.SecretsConfig.Secrets {
 		if secret.AutoGenerate || secret.Required {

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/resource_runner_phone_home_lambda_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/resource_runner_phone_home_lambda_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/awslabs/goformation/v7/cloudformation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -34,6 +35,25 @@ func phoneHomeAuthTestInput(installID string) *stacks.TemplateInput {
 	inp.PhoneHomeSecretRegion = "us-west-2"
 
 	return inp
+}
+
+func TestGetRunnerPhoneHomeProps_IncludesAllVPCOutputs(t *testing.T) {
+	tpl := &Templates{cfg: &internal.Config{}}
+	inp := phoneHomeTestInput("instabcdefghijklmnopqrstuv")
+	vpcOutputKeys := map[string]struct{}{
+		"VPC":                {},
+		"PrivateSubnets":     {},
+		"AdditionalResource": {},
+	}
+
+	props := tpl.getRunnerPhoneHomeProps(inp, nil, vpcOutputKeys)
+
+	vpcOutputs, ok := props.Properties["vpc_outputs"].(map[string]any)
+	require.True(t, ok)
+	require.Len(t, vpcOutputs, len(vpcOutputKeys))
+	for outputKey := range vpcOutputKeys {
+		assert.Equal(t, cloudformation.GetAtt("VPC", "Outputs."+outputKey), vpcOutputs[outputKey])
+	}
 }
 
 // The Lambda fetches its token at invocation time, so the template only has to carry
@@ -120,7 +140,7 @@ func TestGetRunnerPhoneHomeProps_DoesNotEchoSecretARN(t *testing.T) {
 	tpl := &Templates{cfg: &internal.Config{AWSPhoneHomeCMKARN: testPhoneHomeCMKARN}}
 	inp := phoneHomeAuthTestInput("instabcdefghijklmnopqrstuv")
 
-	props := tpl.getRunnerPhoneHomeProps(inp, nil)
+	props := tpl.getRunnerPhoneHomeProps(inp, nil, nil)
 
 	require.NotNil(t, props)
 	for key, value := range props.Properties {
@@ -224,7 +244,7 @@ func TestGetRunnerPhoneHomeProps_DoesNotEchoRoleName(t *testing.T) {
 	tpl := &Templates{cfg: &internal.Config{}}
 	inp := phoneHomeTestInput("instabcdefghijklmnopqrstuv")
 
-	props := tpl.getRunnerPhoneHomeProps(inp, nil)
+	props := tpl.getRunnerPhoneHomeProps(inp, nil, nil)
 
 	require.NotNil(t, props)
 	for key, value := range props.Properties {

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/resource_telemetry_export_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/resource_telemetry_export_test.go
@@ -50,7 +50,7 @@ func TestTelemetryExportIsNotAddedToPhoneHome(t *testing.T) {
 		Settings:                   &app.RunnerGroupSettings{},
 	}
 
-	phoneHomeJSON, err := json.Marshal(tpl.getRunnerPhoneHomeProps(inp, nil))
+	phoneHomeJSON, err := json.Marshal(tpl.getRunnerPhoneHomeProps(inp, nil, nil))
 	require.NoError(t, err)
 	assert.NotContains(t, string(phoneHomeJSON), telemetryExportSecret)
 }


### PR DESCRIPTION
This way, custom stacks can emit additional resource arns for other components and actions to consume. 