### PR TITLE
fix(ui): log stream sort & add unit test

### DIFF
--- a/services/dashboard-ui/client/providers/log-stream-provider.test.tsx
+++ b/services/dashboard-ui/client/providers/log-stream-provider.test.tsx
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { useContext } from 'react'
+import { MemoryRouter, useSearchParams } from 'react-router'
+
+const getLogStreamLogs = mock(async (_args: unknown): Promise<unknown[]> => [])
+
+mock.module('@/lib/ctl-api/log-streams/get-log-stream-logs', () => ({
+  getLogStreamLogs,
+}))
+mock.module('@/components/log-stream/SSELogs', () => ({
+  LogsPageSkeleton: () => null,
+}))
+mock.module('@/hooks/use-org', () => ({
+  useOrg: () => ({ org: { id: 'org1' } }),
+}))
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = []
+
+  listeners: Record<string, ((event: unknown) => void)[]> = {}
+  onmessage: ((event: unknown) => void) | null = null
+  onerror: (() => void) | null = null
+  onopen: (() => void) | null = null
+
+  constructor(public url: string) {
+    FakeEventSource.instances.push(this)
+  }
+
+  addEventListener(type: string, cb: (event: unknown) => void) {
+    this.listeners[type] = [...(this.listeners[type] ?? []), cb]
+  }
+
+  close() {}
+
+  emitStatus(...data: string[]) {
+    act(() => {
+      for (const d of data) {
+        for (const cb of this.listeners.status ?? []) cb({ data: d })
+      }
+    })
+  }
+
+  emitLogs(logs: unknown[]) {
+    act(() => {
+      this.onmessage?.({ data: JSON.stringify(logs) })
+    })
+  }
+}
+
+// @ts-expect-error - minimal stand-in for the browser EventSource
+globalThis.EventSource = FakeEventSource
+
+const { LogStreamProvider, LogStreamContext } = await import(
+  './log-stream-provider'
+)
+
+const log = (id: string, runnerJobId?: string) => ({
+  id,
+  timestamp: `2026-01-01T00:00:0${id}.000Z`,
+  body: `line ${id}`,
+  runner_job_id: runnerJobId,
+})
+
+const Probe = () => {
+  const ctx = useContext(LogStreamContext)
+  const [, setSearchParams] = useSearchParams()
+  return (
+    <>
+      <div data-testid="ids">
+        {(ctx?.logs ?? []).map((l) => l.id).join(',')}
+      </div>
+      <button
+        data-testid="to-newest-first"
+        onClick={() => setSearchParams({ sort: 'desc' })}
+      />
+    </>
+  )
+}
+
+const renderProvider = ({
+  search = '',
+  runnerJobId,
+}: { search?: string; runnerJobId?: string } = {}) => {
+  const { getByTestId } = render(
+    <MemoryRouter initialEntries={[`/logs${search}`]}>
+      <LogStreamProvider logStreamId="ls1" runnerJobId={runnerJobId}>
+        <Probe />
+      </LogStreamProvider>
+    </MemoryRouter>
+  )
+  const stream = FakeEventSource.instances.at(-1)
+  if (!stream) throw new Error('expected the provider to open a stream')
+  return {
+    stream,
+    ids: () => getByTestId('ids').textContent,
+    switchToNewestFirst: () =>
+      fireEvent.click(getByTestId('to-newest-first')),
+  }
+}
+
+beforeEach(() => {
+  FakeEventSource.instances = []
+  getLogStreamLogs.mockClear()
+  getLogStreamLogs.mockImplementation(async () => [])
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+test('seeds the newest page from the desc read when a newest-first stream is catching up', async () => {
+  getLogStreamLogs.mockImplementation(async () => [log('9'), log('8')])
+
+  const { stream, ids } = renderProvider()
+  stream.emitLogs([log('1')])
+  stream.emitStatus('catching-up')
+
+  await waitFor(() => expect(getLogStreamLogs).toHaveBeenCalledTimes(1))
+  expect(getLogStreamLogs.mock.calls[0]?.[0]).toMatchObject({
+    logStreamId: 'ls1',
+    orgId: 'org1',
+    order: 'desc',
+  })
+  await waitFor(() => expect(ids()).toBe('1,9,8'))
+})
+
+test('does not re-add logs the stream already delivered', async () => {
+  getLogStreamLogs.mockImplementation(async () => [log('9'), log('1')])
+
+  const { stream, ids } = renderProvider()
+  stream.emitLogs([log('1')])
+  stream.emitStatus('catching-up')
+
+  await waitFor(() => expect(ids()).toBe('1,9'))
+})
+
+test('still seeds when catch-up ends in the same batch it started', async () => {
+  getLogStreamLogs.mockImplementation(async () => [log('9')])
+
+  const { stream, ids } = renderProvider()
+  stream.emitStatus('catching-up', 'live')
+
+  await waitFor(() => expect(getLogStreamLogs).toHaveBeenCalledTimes(1))
+  await waitFor(() => expect(ids()).toBe('9'))
+})
+
+test('seeds when the user switches to newest-first mid catch-up', async () => {
+  getLogStreamLogs.mockImplementation(async () => [log('9')])
+
+  const { stream, ids, switchToNewestFirst } = renderProvider({
+    search: '?sort=asc',
+  })
+  stream.emitStatus('catching-up')
+  expect(getLogStreamLogs).not.toHaveBeenCalled()
+
+  switchToNewestFirst()
+
+  await waitFor(() => expect(getLogStreamLogs).toHaveBeenCalledTimes(1))
+  await waitFor(() => expect(ids()).toBe('9'))
+})
+
+test('does not seed when the user is sorting oldest-first', async () => {
+  const { stream, ids } = renderProvider({ search: '?sort=asc' })
+  stream.emitStatus('catching-up')
+
+  await waitFor(() => expect(ids()).toBe(''))
+  expect(getLogStreamLogs).not.toHaveBeenCalled()
+})
+
+test('does not seed a stream that is already live', async () => {
+  const { stream, ids } = renderProvider()
+  stream.emitStatus('live')
+  stream.emitLogs([log('1')])
+
+  await waitFor(() => expect(ids()).toBe('1'))
+  expect(getLogStreamLogs).not.toHaveBeenCalled()
+})
+
+test('seeds at most once per stream', async () => {
+  const { stream } = renderProvider()
+  stream.emitStatus('catching-up')
+  await waitFor(() => expect(getLogStreamLogs).toHaveBeenCalledTimes(1))
+
+  stream.emitStatus('live')
+  stream.emitStatus('catching-up')
+
+  await waitFor(() => expect(getLogStreamLogs).toHaveBeenCalledTimes(1))
+})
+
+test('drops seeded logs that belong to another runner job', async () => {
+  getLogStreamLogs.mockImplementation(async () => [
+    log('9', 'job1'),
+    log('8', 'job2'),
+  ])
+
+  const { stream, ids } = renderProvider({ runnerJobId: 'job1' })
+  stream.emitStatus('catching-up')
+
+  await waitFor(() => expect(ids()).toBe('9'))
+})

--- a/services/dashboard-ui/client/providers/log-stream-provider.tsx
+++ b/services/dashboard-ui/client/providers/log-stream-provider.tsx
@@ -1,12 +1,15 @@
 import {
   createContext,
+  useCallback,
   useEffect,
   useState,
   useRef,
   type ReactNode,
 } from 'react'
+import { useSearchParams } from 'react-router'
 import { useOrg } from '@/hooks/use-org'
 import { LogsPageSkeleton } from '@/components/log-stream/SSELogs'
+import { getLogStreamLogs } from '@/lib'
 import type { TOTELLog, TAPIError } from '@/types'
 
 type ConnectionState =
@@ -41,6 +44,8 @@ export function LogStreamProvider({
   renderWhilePending?: boolean
 }) {
   const { org } = useOrg()
+  const [searchParams] = useSearchParams()
+  const isNewestFirst = searchParams.get('sort') !== 'asc'
 
   const [logs, setLogs] = useState<TOTELLog[]>([])
   const [connectionState, setConnectionState] =
@@ -54,6 +59,48 @@ export function LogStreamProvider({
   const isCompleteRef = useRef(false)
   const reconnectAttemptRef = useRef(0)
   const connStateRef = useRef<ConnectionState>('disconnected')
+  const seedRequestedRef = useRef(false)
+  const isNewestFirstRef = useRef(isNewestFirst)
+  const logStreamIdRef = useRef(logStreamId)
+
+  useEffect(() => {
+    isNewestFirstRef.current = isNewestFirst
+  }, [isNewestFirst])
+
+  const appendLogs = useCallback((incoming: TOTELLog[]) => {
+    const unique = incoming.filter((log) => {
+      if (seenIdsRef.current.has(log.id)) return false
+      seenIdsRef.current.add(log.id)
+      return true
+    })
+    if (unique.length > 0) {
+      setLogs((prev) => [...prev, ...unique])
+    }
+  }, [])
+
+  // The stream itself must stay ASC: the tail cursor only moves forward, so an
+  // `order=desc` stream would page backwards into history and never surface new
+  // lines on a running job. Instead fetch the newest page once, so newest-first
+  // has a correct top immediately and the ASC stream backfills below it.
+  const seedNewestPage = useCallback(
+    (streamId: string, orgId: string, jobId?: string) => {
+      if (seedRequestedRef.current || !isNewestFirstRef.current) return
+      seedRequestedRef.current = true
+
+      getLogStreamLogs({ logStreamId: streamId, orgId, order: 'desc' })
+        .then((newest) => {
+          if (streamId !== logStreamIdRef.current) return
+          if (!Array.isArray(newest)) return
+          appendLogs(
+            jobId
+              ? newest.filter((log) => log?.runner_job_id === jobId)
+              : newest
+          )
+        })
+        .catch(() => {})
+    },
+    [appendLogs]
+  )
 
   const setConnState = (state: ConnectionState) => {
     if (connStateRef.current === state) return
@@ -78,6 +125,8 @@ export function LogStreamProvider({
 
     isCompleteRef.current = false
     reconnectAttemptRef.current = 0
+    seedRequestedRef.current = false
+    logStreamIdRef.current = logStreamId
     seenIdsRef.current = new Set()
     setLogs([])
     setError(null)
@@ -99,14 +148,7 @@ export function LogStreamProvider({
       eventSource.onmessage = (event) => {
         try {
           const newLogs: TOTELLog[] = JSON.parse(event.data)
-          const unique = newLogs.filter((log) => {
-            if (seenIdsRef.current.has(log.id)) return false
-            seenIdsRef.current.add(log.id)
-            return true
-          })
-          if (unique.length > 0) {
-            setLogs((prev) => [...prev, ...unique])
-          }
+          appendLogs(newLogs)
           setConnState('connected')
           reconnectAttemptRef.current = 0
         } catch {
@@ -122,6 +164,7 @@ export function LogStreamProvider({
       eventSource.addEventListener('status', (event: MessageEvent) => {
         if (event.data === 'catching-up') {
           setIsCatchingUp(true)
+          seedNewestPage(logStreamId, org.id, runnerJobId)
         } else if (event.data === 'live') {
           setIsCatchingUp(false)
         } else if (event.data === 'complete') {
@@ -184,6 +227,20 @@ export function LogStreamProvider({
       disconnect()
     }
   }, [logStreamId, org?.id, runnerJobId])
+
+  // Switching to newest-first while a long catch-up is still draining needs the
+  // same seed; the `catching-up` event has already come and gone by then.
+  useEffect(() => {
+    if (!logStreamId || !org?.id || !isNewestFirst || !isCatchingUp) return
+    seedNewestPage(logStreamId, org.id, runnerJobId)
+  }, [
+    logStreamId,
+    org?.id,
+    runnerJobId,
+    isNewestFirst,
+    isCatchingUp,
+    seedNewestPage,
+  ])
 
   if (!logStreamId) {
     if (!renderWhilePending) return <LogsPageSkeleton />


### PR DESCRIPTION
Newest-first now shows the latest lines at the top immediately instead of after the whole backlog drains. Adds unit test for the  log-stream-provider.