### PR TITLE
feat: add azure gcp custom stacks

### DIFF
--- a/bins/cli/cmd/installs.go
+++ b/bins/cli/cmd/installs.go
@@ -127,8 +127,7 @@ provided labels must match (AND semantics):
 		Short: "Create an install",
 		Long: `Create a new install of your app.
 
---region is required for AWS apps. For GCP and Azure apps the region is
-determined automatically from the stack output after provisioning.
+--region is required for every cloud. It is the AWS or GCP region, or the Azure location.
 
 Use --label (repeatable, format key=value) to attach labels at creation time:
 
@@ -157,7 +156,7 @@ sandbox and components unprovisioned:
 	if !c.cfg.Preview {
 		createCmd.MarkFlagRequired("name")
 	}
-	createCmd.Flags().StringVarP(&region, "region", "r", "", "The region to provision this install in (required for AWS installs)")
+	createCmd.Flags().StringVarP(&region, "region", "r", "", "The AWS or GCP region, or Azure location (required)")
 	createCmd.Flags().StringVar(&awsAccountID, "aws-account-id", "", "The AWS account ID this install targets (required when phone home authentication is enabled for your org; immutable after creation)")
 	createCmd.Flags().StringVar(&azureSubscriptionID, "azure-subscription-id", "", "The Azure subscription ID this install targets (required when phone home authentication is enabled for your org; immutable after creation)")
 	createCmd.Flags().StringVar(&gcpProjectID, "gcp-project-id", "", "The GCP project ID this install targets (required when phone home authentication is enabled for your org; immutable after creation)")

--- a/bins/cli/internal/services/installs/create.go
+++ b/bins/cli/internal/services/installs/create.go
@@ -81,10 +81,9 @@ func (s *Service) Create(ctx context.Context, appID, name, region string, target
 	}
 
 	// we collect these and pass them down so we can pre-fill specific fields
-	inputsMap := make(map[string]string)
-	for _, kv := range inputs {
-		kvT := strings.Split(kv, "=")
-		inputsMap[kvT[0]] = kvT[1]
+	inputsMap, err := parseInstallInputs(inputs)
+	if err != nil {
+		return ui.PrintError(err)
 	}
 
 	req, err := s.buildCreateInstallRequest(ctx, appID, name, region, target, inputsMap, labelsMap)
@@ -135,23 +134,48 @@ func (s *Service) buildCreateInstallRequest(ctx context.Context, appID, name, re
 
 	switch runnerCfg.CloudPlatform {
 	case models.AppCloudPlatformGcp:
+		if err := requireInstallRegion(region, "GCP"); err != nil {
+			return nil, err
+		}
 		req.GcpAccount = &models.HelpersCreateInstallGCPAccountParams{
 			ProjectID: target.GCPProjectID,
 			Region:    region,
 		}
 	case models.AppCloudPlatformAzure:
+		if err := requireInstallRegion(region, "Azure"); err != nil {
+			return nil, err
+		}
 		req.AzureAccount = &models.HelpersCreateInstallAzureAccountParams{
 			SubscriptionID: target.AzureSubscriptionID,
 			Location:       region,
 		}
 	default:
-		if region == "" {
-			return nil, fmt.Errorf("--region is required for AWS installs")
+		if err := requireInstallRegion(region, "AWS"); err != nil {
+			return nil, err
 		}
 		req.AwsAccount = &models.HelpersCreateInstallAWSAccountParams{Region: region, AccountID: target.AWSAccountID}
 	}
 
 	return req, nil
+}
+
+func requireInstallRegion(region, cloud string) error {
+	if region == "" {
+		return fmt.Errorf("--region is required for %s installs", cloud)
+	}
+	return nil
+}
+
+func parseInstallInputs(inputs []string) (map[string]string, error) {
+	inputsMap := make(map[string]string, len(inputs))
+	for _, input := range inputs {
+		name, value, ok := strings.Cut(input, "=")
+		if !ok || name == "" {
+			return nil, fmt.Errorf("invalid input %q: expected name=value", input)
+		}
+		inputsMap[name] = value
+	}
+	return inputsMap, nil
 }
 
 // inputsWithDefaults merges app input defaults with any explicitly provided values.

--- a/bins/cli/internal/services/installs/create_test.go
+++ b/bins/cli/internal/services/installs/create_test.go
@@ -1,0 +1,30 @@
+package installs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireInstallRegion(t *testing.T) {
+	for _, cloud := range []string{"AWS", "Azure", "GCP"} {
+		t.Run(cloud, func(t *testing.T) {
+			require.EqualError(t, requireInstallRegion("", cloud), "--region is required for "+cloud+" installs")
+			require.NoError(t, requireInstallRegion("us-west-2", cloud))
+		})
+	}
+}
+
+func TestParseInstallInputs(t *testing.T) {
+	inputs, err := parseInstallInputs([]string{"token=part=two", "empty="})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"token": "part=two", "empty": ""}, inputs)
+
+	for _, input := range []string{"missing-separator", "=missing-name"} {
+		t.Run(input, func(t *testing.T) {
+			_, err := parseInstallInputs([]string{input})
+			require.EqualError(t, err, `invalid input "`+input+`": expected name=value`)
+		})
+	}
+}

--- a/docs/config-ref/install.mdx
+++ b/docs/config-ref/install.mdx
@@ -49,5 +49,5 @@ title: 'Install'
 |----------|----------|----------|----------|
 | **`vpc_nested_template_url`**<br/>string | VPC nested template URL override Per-install override for the VPC nested CloudFormation template URL. Overrides the app-level default from stack.toml. | **Optional** | `"https://nuon-artifacts.s3.us-west-2.amazonaws.com/templates/custom-vpc.yaml"` |
 | **`runner_nested_template_url`**<br/>string | Runner nested template URL override Per-install override for the runner nested CloudFormation template URL. Overrides the app-level default from stack.toml. | **Optional** | `"https://nuon-artifacts.s3.us-west-2.amazonaws.com/templates/custom-runner.yaml"` |
-| **`custom_nested_stacks`**<br/>object | Custom nested stack overrides Per-install overrides for custom nested CloudFormation stacks. Entries with the same name as app-level stacks replace them; new names are appended. | **Optional** | - |
+| **`custom_nested_stacks`**<br/>object | Custom nested stack overrides Per-install overrides for custom install stacks. Entries with the same name as app-level stacks replace them; new names are appended. Supports AWS CloudFormation, Azur... | **Optional** | - |
 

--- a/docs/config-ref/stack.mdx
+++ b/docs/config-ref/stack.mdx
@@ -11,11 +11,11 @@ title: 'Stack'
 
 | Property | Description | Values | Example |
 |----------|----------|----------|----------|
-| **`name`**<br/>string | stack name Name of the CloudFormation stack when deployed in the customer account. Supports Go templating | **✅ Required** | `"myapp-{{.nuon.install.id}}"`, `"production-stack"` |
-| **`description`**<br/>string | stack description Description of the stack, displayed in the CloudFormation console. Supports templating | **✅ Required** | `"Infrastructure stack for MyApp application"` |
-| **`vpc_nested_template_url`**<br/>string | VPC nested template URL URL to the CloudFormation nested template for VPC resources | **✅ Required** | `"https://s3.amazonaws.com/bucket/vpc-template.yaml"` |
-| **`runner_nested_template_url`**<br/>string | runner nested template URL URL to the CloudFormation nested template for the Nuon runner infrastructure | **✅ Required** | `"https://s3.amazonaws.com/bucket/runner-template.yaml"` |
+| **`name`**<br/>string | stack name Name of the install stack when deployed in the customer account or project. Supports Go templating | **✅ Required** | `"myapp-{{.nuon.install.id}}"`, `"production-stack"` |
+| **`description`**<br/>string | stack description Description of the install stack. Supports Go templating | **✅ Required** | `"Infrastructure stack for MyApp application"` |
 | **`type`**<br/>string | stack type Type of infrastructure stack. Supported values: 'aws-cloudformation', 'azure-bicep' (Azure), 'gcp-terraform' (Google Cloud). | **Optional** | `"aws-cloudformation"`, `"azure-bicep"`, `"gcp-terraform"` |
+| **`vpc_nested_template_url`**<br/>string | VPC nested template URL URL to the CloudFormation nested template for VPC resources | **Optional** | `"https://s3.amazonaws.com/bucket/vpc-template.yaml"` |
+| **`runner_nested_template_url`**<br/>string | runner nested template URL URL to the CloudFormation nested template for the Nuon runner infrastructure | **Optional** | `"https://s3.amazonaws.com/bucket/runner-template.yaml"` |
 | **`deployment_scope`**<br/>string | deployment scope Scope the generated install stack root template deploys at. Only supported for 'azure-bicep'. Supported values: 'resource_group' (the default) confines every resource to the instal... | **Optional** | `"subscription"` |
-| **`custom_nested_stacks`**<br/>object | custom nested stacks Custom CloudFormation nested stack templates to include. Each entry has a name, template_url, index, and optional parameters. The index field determines execution order (ascend... | **Optional** | - |
+| **`custom_nested_stacks`**<br/>object | custom nested stacks Custom install-stack resources to include. Each entry has a name, template_url, index, and optional parameters. AWS uses CloudFormation templates, Azure uses compiled ARM JSON,... | **Optional** | - |
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -221,6 +221,7 @@
               "guides/using-readmes",
               "guides/programmable-readmes",
               "guides/custom-nested-stacks",
+              "guides/nuon-stack-terraform-provider",
               "guides/customizing-terraform-stack-templates",
               "guides/cli-extensions",
               "guides/external-image-policies",

--- a/docs/guides/custom-nested-stacks.mdx
+++ b/docs/guides/custom-nested-stacks.mdx
@@ -1,113 +1,220 @@
 ---
-title: 'Custom Nested CloudFormation Stacks'
-description: 'Extend the install stack with custom CloudFormation nested templates.'
+title: 'Custom Install Stacks'
+description: 'Provision additional AWS, Azure, or GCP resources with the install stack.'
 icon: "layer-group"
-keywords: ["installs", "runners", "nested stack", "CloudFormation template", "extend install stack", "custom stack", "stack.toml"]
+keywords: ["installs", "runners", "nested stack", "CloudFormation", "ARM template", "GCP module", "custom stack", "stack.toml"]
 ---
 
-The install stack supports custom nested CloudFormation templates beyond the built-in VPC and runner stacks. This
-enables vendors to provision custom AWS or Kubernetes resources as part of the install stack itself — before the sandbox
-or any components run. This feature is useful for setting up resources that must exist before the sandbox provisions but
-that require permissions the vendor does not need to retain throughout the remainder of an app's lifetime.
+Custom install stacks provision additional infrastructure with the customer's install stack, before the sandbox or any
+components run. The same `[[custom_nested_stacks]]` configuration works across AWS, Azure, and GCP:
 
-<Warning>
-Custom nested stacks are supported on **CloudFormation** and **`azure-bicep`** install stacks. The Terraform Stack
-templates do not include them or reference them. If you rely on this feature and your customers want to deploy via
-Terraform, see [Customizing Terraform Stack Templates](/guides/customizing-terraform-stack-templates), to learn how make
-equivalent changes to the Terraform templates.
-</Warning>
+- AWS deploys CloudFormation nested stacks.
+- Azure deploys linked ARM templates through an Azure Deployment Stack.
+- GCP instantiates reviewed Terraform modules from the install-stack repository.
 
 <Note>
-On `azure-bicep`, templates must be compiled ARM JSON — a `.bicep` source file will not parse. Parameter resolution,
-output wiring, and hoisting behave identically to CloudFormation, with the Azure-specific reserved parameters and
-first-class outputs listed below.
+GCP deliberately does not execute an arbitrary Terraform module named by app configuration. It only allows modules
+implemented and reviewed in the selected install-stack repository's `gcp/modules` collection.
 </Note>
+
+## Backward compatibility
+
+Existing valid AWS `stack.toml` files require no changes. The `name`, `template_url`, `index`, and `parameters` fields
+retain their original behavior. Azure and GCP support is additive, and apps without `custom_nested_stacks` continue to
+produce the same install stack. Configurations with duplicate names or indices now fail during sync instead of
+producing ambiguous resources.
+
+Per-install overrides also keep the existing merge behavior: an override with the same `name` replaces the app-level
+entry, while a new name is appended.
+
+### Capabilities
+
+| Capability | AWS | Azure | GCP |
+| ---------- | --- | ----- | --- |
+| App-level and per-install configuration | Yes | Yes | Yes |
+| Install-input parameters | Yes | Yes | Yes |
+| Outputs available to app templates | Yes | Yes | Yes |
+| Relative source uploaded during sync | Yes | Yes | Not applicable |
+| Sequential stacks and output wiring | Yes | Yes | Unique `index` only; modules do not chain |
+| User-supplied implementation | CloudFormation | Compiled ARM JSON | Reviewed module only |
+| Managed deletion with the install stack | Yes | Yes | Yes, except retained KMS keys |
+
+The GCP differences are intentional safety boundaries, not configuration differences. Add a reviewed module to the
+install-stack repository when you need a new GCP resource type.
 
 ## Use Cases
 
-For BYO-EKS
-
-- Create Kubernetes namespaces in an existing EKS cluster.
-- Create EKS access entries for the runner IAM roles.
-- Grant the Runner Subnet Security Group access to an existing EKS Cluster.
-
-More generally, these custom nested stacks can be used to create core resources that do not change and need not be
-re-deployed via a Nuon component. This is particularly useful for networking components.
-
-- Create a dedicated RDS Subnet in the freshly created VPC.
-- Configure an AWS Transit VPC in addition to a dedicated VPC for a BYOC app.
+- Create Kubernetes namespaces or access entries for an existing cluster.
+- Add network, database, DNS, storage, or identity resources that must exist before the sandbox.
+- Pass those resources' outputs to the sandbox or application components.
+- Provision stable infrastructure that should share the install stack's lifecycle rather than redeploy with a component.
 
 ## Configuration
 
-Custom nested stacks are configured in `[[custom_nested_stacks]]` blocks in `stack.toml`:
+Custom stacks are configured in `[[custom_nested_stacks]]` blocks in `stack.toml`. The block shape is the same for
+every cloud; only `template_url` identifies a cloud-specific implementation.
+
+### AWS
 
 ```toml
-# stack
 type        = "aws-cloudformation"
-name        = "byo-eks-{{.nuon.install.id}}"
-description = "Application deplyed into an existing AWS EKS k8s Cluster."
+name        = "payments-{{.nuon.install.id}}"
+description = "Application install stack."
 
 vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/.../byo-vpc.yaml"
 runner_nested_template_url = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/.../runner-asg.yaml"
 
 [[custom_nested_stacks]]
-name         = "k8s_namespaces"
-template_url = "https://vender.s3.amazonaws.com/templates/k8s-namespaces.yaml"
+name         = "storage"
+template_url = "./cloudformation/storage.yaml"
 index        = 0
 
 [custom_nested_stacks.parameters]
-Namespaces = "{{.nuon.install.inputs.namespaces}}"
-
-[[custom_nested_stacks]]
-name         = "eks_access_entries"
-template_url = "https://my-bucket.s3.amazonaws.com/templates/eks-access-entries.yaml"
-index        = 1
-
-[custom_nested_stacks.parameters]
-Namespaces = "{{.nuon.install.inputs.namespaces}}"
-
-[[custom_nested_stacks]]
-name         = "runner_sg_eks_access"
-template_url = "https://inlzqy4v3qyo0wagcmilgnxpry-byoc-nuon-install-templates.s3.eu-west-1.amazonaws.com/templates/runner-sg-eks-access.yaml"
-index        = 2
-
-[custom_nested_stacks.parameters]
-ClusterName = "{{.nuon.install.inputs.cluster_name}}"
+BucketName = "{{.nuon.install.id}}-storage"
 ```
+
+Relative templates are uploaded by Nuon during app sync. Existing public S3 URLs continue to work.
+
+### Azure
+
+```toml
+type        = "azure-bicep"
+name        = "payments-{{.nuon.install.id}}"
+description = "Application install stack."
+
+vpc_nested_template_url    = "https://raw.githubusercontent.com/nuonco/install-stacks/main/azure/vnet.json"
+runner_nested_template_url = "https://raw.githubusercontent.com/nuonco/install-stacks/main/azure/runner.json"
+
+[[custom_nested_stacks]]
+name         = "storage"
+template_url = "./arm/storage.json"
+index        = 0
+
+[custom_nested_stacks.parameters]
+accountName = "{{.nuon.install.id | substr 0 18}}store"
+```
+
+Azure templates must be compiled ARM JSON. A `.bicep` `template_url` or a non-JSON body fails at sync with the compile
+command to run:
+
+```bash
+az bicep build --file arm/storage.bicep --outfile arm/storage.json
+nuon apps sync
+```
+
+Relative ARM templates are uploaded during sync. A public HTTPS URL also works.
+
+### GCP
+
+```toml
+type        = "gcp-terraform"
+name        = "payments-{{.nuon.install.id}}"
+description = "Application install stack."
+
+[[custom_nested_stacks]]
+name         = "storage"
+template_url = "github.com/nuonco/install-stacks//gcp/modules/bucket"
+index        = 0
+
+[custom_nested_stacks.parameters]
+location   = "US"
+versioning = "{{.nuon.install.inputs.bucket_versioning}}"
+```
+
+For a fork, replace the repository prefix but preserve `//gcp/modules/<name>`. The module must exist in that fork's GCP
+install stack. The built-in collection supports `bucket`, `kms`, `service_account`, and `dns`.
 
 ### Properties
 
-| Property       | Type                | Required | Description                                                                                                                                   |
-| -------------- | ------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`         | `string`            | Yes      | Name of the nested stack. Used as the CloudFormation logical ID (converted to CamelCase) and parameter group label.                           |
-| `template_url` | `string`            | Yes      | S3 URL to the CloudFormation template YAML. Must be publicly accessible or accessible via the stack's execution role. Supports Go templating. |
-| `index`        | `int`               | Yes      | Execution order (ascending). Must be unique across all custom nested stacks.                                                                  |
-| `parameters`   | `map[string]string` | No       | Explicit parameter values. Supports Go templating. See [Parameter Mapping](#parameter-mapping).                                               |
+| Property       | Type                | Required | Description |
+| -------------- | ------------------- | -------- | ----------- |
+| `name`         | `string`            | Yes      | Stable, unique key used for deployment naming and output lookup. |
+| `template_url` | `string`            | Yes      | AWS template URL/path, Azure ARM JSON URL/path, or GCP curated module path. |
+| `index`        | `int`               | Yes      | Unique ordering key. AWS and Azure execute stacks in ascending order. |
+| `parameters`   | `map[string]string` | No       | Explicit parameter values. Supports Go templating. See [Parameter Mapping](#parameter-mapping). |
 
 {/* prettier-ignore-start */}
-<Tip>
-The `template_url` field supports Go templating, so you can dynamically construct URLs if needed.
-</Tip>
+<Tip>Use a relative AWS or Azure template path when the template lives beside the app config. Nuon uploads it during sync.</Tip>
 {/* prettier-ignore-end */}
+
+## Apply the Install Stack
+
+After syncing the app and creating an install:
+
+- AWS customers open the install's CloudFormation quick link and create or update the stack as usual.
+- Azure and GCP customers apply the corresponding `nuonco/stack` Terraform module. Custom stacks are read from the
+  authenticated `stack_config` data source; no custom-stack variables are required.
+
+```hcl
+provider "stack" {}
+
+module "install_stack" {
+  source  = "nuonco/stack/azure" # use nuonco/stack/gcp for GCP
+  version = "~> 1.0"
+
+  install_id = var.install_id
+}
+```
+
+The Stack provider reads `NUON_API_TOKEN` and `NUON_API_URL` from the environment. See
+[The Nuon Stack Terraform Provider](/guides/nuon-stack-terraform-provider) for authentication and complete examples.
+
+## Use Custom Stack Outputs
+
+All clouds report outputs under the same path:
+
+```text
+.nuon.install_stack.outputs.custom_nested_stacks.<stack-name>.outputs.<output-name>
+```
+
+For example, a sandbox or component can consume the `name` output from the `storage` stack:
+
+```toml
+[vars]
+bucket_name = "{{.nuon.install_stack.outputs.custom_nested_stacks.storage.outputs.name}}"
+```
+
+Output names retain the template or curated module's spelling. Azure matching is case-insensitive internally, so ARM's
+output-name normalization does not drop values.
+
+### GCP Curated Modules
+
+| Module | Parameters | Outputs |
+| ------ | ---------- | ------- |
+| `bucket` | `location`, `versioning`, `force_destroy` | `name`, `url`, `self_link` |
+| `kms` | `location`, `rotation_period` | `id`, `key_ring`, `name` |
+| `service_account` | `display_name`, `description` | `email`, `unique_id`, `name` |
+| `dns` | `dns_name`, `visibility`, `description`, `force_destroy` | `name`, `name_servers`, `managed_zone_id` |
+
+Booleans are the strings `"true"` or `"false"`. Destructive options default to `"false"`. Each module names resources from
+the install ID and stack `name`.
+
+<Warning>
+GCP does not support deleting Cloud KMS key rings or keys. Destroy removes the `kms` module from Terraform state, but
+the key material remains in the project. A later apply creates a new suffixed key instead of adopting or replacing the
+retained key.
+</Warning>
 
 ## Execution Order
 
-Custom nested stacks execute **after** the VPC and runner nested stacks. The `index` field determines the order among
-custom stacks:
+AWS and Azure custom stacks execute **after** the built-in network and runner stacks. The `index` field determines the
+order among custom stacks:
 
-1. VPC nested stack
-2. Runner ASG nested stack
+1. Built-in VPC or VNet stack
+2. Built-in runner stack
 3. Custom nested stacks ordered by `index`, ascending.
 
-The first custom nested stack (lowest index) depends on the `VPC` and `RunnerAutoScalingGroup` resources. Each
-subsequent stack depends on the previous one. This means stacks are provisioned sequentially, and a failure in one will
-prevent later stacks from executing.
+Each AWS or Azure stack depends on the previous one. A failure prevents later stacks from executing.
+
+GCP validates unique indices, but curated modules do not depend on each other. Terraform cannot order mixed module
+types from runtime `index` values without cycles or state-address changes. Set any value another stack needs in
+`parameters` or install inputs; do not rely on `index` for GCP data flow.
 
 ## Reserved Parameters
 
-Nuon automatically injects the following reserved parameters into your nested template if they are defined in the
-template's `Parameters` section. These are always set by Nuon and are never hoisted to the parent stack or exposed to
-the customer.
+For AWS and Azure, Nuon injects reserved parameters when the template declares them. They are never hoisted or exposed
+for manual input. GCP curated modules receive the install ID, project, region, and configured parameter map directly
+from the Terraform install-stack module.
 
 ### Nuon Identity Parameters
 
@@ -203,9 +310,8 @@ already account-scoped, so nothing needs hoisting to the parent.
 
 ## First-Class Output Wiring
 
-If a parameter in your custom template matches the name of an **output** from the VPC or runner nested stacks, Nuon
-automatically wires it using `!GetAtt`. This lets your template consume outputs from the built-in stacks without any
-explicit configuration.
+On AWS and Azure, if a custom template parameter matches an output from the built-in network or runner stack, Nuon
+wires it automatically. This lets the custom template consume built-in infrastructure without explicit configuration.
 
 For example, if the VPC template outputs `VPC` and `RunnerSubnet`, and your custom template declares parameters with
 those same names, they will be automatically populated:
@@ -228,17 +334,20 @@ wired to `[reference('vnetDeployment').outputs.<name>.value]`.
 
 ## Inter-Stack Output Wiring
 
-Outputs from earlier custom nested stacks are automatically wired to matching parameters in later custom stacks, using
-the same mechanism as first-class output wiring. If stack A (index 0) declares an output called `SharedSubnetID`, and
-stack B (index 1) declares a parameter called `SharedSubnetID`, Nuon will automatically set the parameter value using
-`!GetAtt StackA.Outputs.SharedSubnetID`.
+On AWS and Azure, outputs from earlier custom stacks are automatically wired to matching parameters in later custom
+stacks. If stack A (index 0) declares an output called `SharedSubnetID`, and stack B (index 1) declares a parameter
+called `SharedSubnetID`, Nuon supplies stack A's value.
 
 This works across any number of stacks in the chain — stack C can consume outputs from both stack A and stack B.
 
-Auto-wired parameters from inter-stack outputs are not hoisted to the parent stack.
+Auto-wired parameters are not hoisted to the parent stack.
 
 **Precedence:** First-class outputs (from the VPC and runner stacks) always take priority over custom stack outputs. If
-both the VPC stack and a custom stack produce an output with the same name, the VPC stack output is used.
+both the built-in network stack and a custom stack produce an output with the same name, the built-in output is used.
+
+<Note>
+GCP curated modules currently expose outputs to Nuon, but do not wire one custom module's output into another module.
+</Note>
 
 ```yaml
 # Stack A (index 0) - produces outputs
@@ -255,13 +364,13 @@ Parameters:
 
 ## Parameter Hoisting
 
-Any non-reserved parameters defined in your nested template that are not auto-wired from first-class outputs and not
-explicitly mapped via `parameters` are **hoisted** into the parent CloudFormation stack. This means:
+On AWS and Azure, non-reserved template parameters that are not auto-wired or explicitly mapped are **hoisted** into
+the generated parent template. This means:
 
-- Parameters appear in the CloudFormation console UI when the customer creates or updates the stack.
-- Parameters are grouped under a label matching the stack `name`.
+- AWS parameters appear in the CloudFormation console when the customer creates or updates the stack.
+- AWS parameters are grouped under a label matching the stack `name`.
 - Default values from your template are preserved.
-- Parameter types (e.g., `AWS::EC2::VPC::Id`, `String`, `Number`) are preserved.
+- Parameter types are preserved.
 
 **Important:** *Hoisted* parameter names must be unique across all nested stacks (including the VPC and runner stacks).
 If two stacks hoist a parameter with the same name, install stack generation fails with a conflict error. Names that are
@@ -315,11 +424,11 @@ they only exist after the stack has been applied. Reference those from component
 </Warning>
 {/* prettier-ignore-end */}
 
-## Authoring Templates
+## Authoring AWS and Azure Templates
 
 ### Template Structure
 
-Templates must be valid CloudFormation YAML. At minimum:
+AWS templates must be valid CloudFormation YAML or JSON. At minimum:
 
 ```yaml
 AWSTemplateFormatVersion: '2010-09-09'
@@ -336,6 +445,12 @@ Resources:
 Outputs:
   # Optional outputs
 ```
+
+Azure templates must be valid compiled ARM JSON with a resource-group or subscription deployment schema. Nuon reads
+their `parameters`, `resources`, and `outputs`; it does not compile Bicep source.
+
+GCP custom stacks are Terraform child modules maintained under `gcp/modules` in the install-stack repository. Each
+curated module defines its own accepted parameters and returns a single `outputs` object.
 
 ### Naming Conventions
 
@@ -354,11 +469,14 @@ The logical ID must not conflict with existing resources in the parent stack (e.
 The following conditions will cause a sync error:
 
 - Missing `name` or `template_url`
+- Duplicate `name` values
 - Duplicate `index` values across custom stacks
-- `name` that produces an empty or invalid CloudFormation logical ID
-- Logical ID that conflicts with an existing resource in the parent stack
-- Duplicate logical IDs across custom stacks
-- Parameter name conflicts across stacks
+- An invalid GCP curated module path
+- An `azure-bicep` template whose `template_url` ends in `.bicep`, or whose contents are not ARM JSON
+- A parameter template that references state unavailable before the install stack is applied
+
+AWS and Azure generation additionally rejects invalid template documents, deployment names, output collisions, and
+hoisted parameter conflicts before the customer applies the stack.
 
 ### Using Lambda Custom Resources
 
@@ -424,16 +542,19 @@ if event["RequestType"] == "Delete":
     return
 ```
 
-## Hosting Templates
+## Hosting AWS Templates
 
-Templates must be hosted on S3. CloudFormation requires that nested stack template URLs point to an S3 bucket — other
-URL types (e.g., GitHub raw URLs, arbitrary HTTPS endpoints) are not supported by CloudFormation.
+Public AWS nested template URLs must point to S3. Alternatively, use a relative path and Nuon will upload the template
+to its managed template bucket during app sync.
 
 Upload your templates to an S3 bucket and reference them using the full S3 URL:
 
 ```
 https://my-bucket.s3.amazonaws.com/templates/my-stack.yaml
 ```
+
+Azure accepts a public HTTPS URL or an uploaded relative ARM JSON path. GCP uses a curated module path rather than a
+hosted template.
 
 ## Example: Kubernetes Namespaces
 

--- a/docs/guides/customizing-terraform-stack-templates.mdx
+++ b/docs/guides/customizing-terraform-stack-templates.mdx
@@ -1,13 +1,18 @@
 ---
 title: 'Customizing Terraform Stack Templates'
-description: 'Fork the open-source install-stacks repo to customize the Terraform install stack for your customers.'
+description: 'Fork or wrap an open-source Terraform install-stack module.'
 icon: "code-fork"
 keywords: ["installs", "stacks", "terraform", "install-stacks", "customize", "fork"]
 ---
 
-The Terraform stack templates live in the open-source
-[`nuonco/install-stacks`](https://github.com/nuonco/install-stacks) repo. The defaults work out of the box in most cases,
-but if you need to meet specific networking, compliance, or naming requirements you can fork the repo, or create your own customer terraform module from scratch.
+The Terraform install-stack modules are open source:
+
+- [AWS](https://github.com/nuonco/terraform-aws-stack)
+- [Azure](https://github.com/nuonco/terraform-azure-stack)
+- [GCP](https://github.com/nuonco/terraform-gcp-stack)
+
+The defaults work out of the box in most cases. Fork or wrap a module when you need different networking, compliance,
+or naming behavior.
 
 The runner and control plane have some requirements that the Stack must fulfill. Each cloud has its own contract — the
 shape is similar but the resource types and payload keys differ. As long as your fork preserves the contract for the
@@ -20,7 +25,7 @@ provider](/guides/nuon-stack-terraform-provider), then layers the customer-provi
 
 ```hcl
 data "stack_config" "this" {
-  phone_home_id = var.phone_home_id
+  install_id = var.install_id
 }
 
 locals {
@@ -32,13 +37,14 @@ locals {
 }
 ```
 
-If you fork a module, keep this pattern: the customer supplies only `phone_home_id`, an optional `api_url`, the target
-cloud region, and any secret values — everything else comes from the data source. The attribute reference for every
-value the data source exposes is in [The Nuon Stack Terraform Provider](/guides/nuon-stack-terraform-provider).
+If you fork a module, keep this pattern: the customer supplies the `install_id`, cloud provider configuration, and any
+input or secret overrides. The Stack provider authenticates the read; the install ID is not a credential. The attribute
+reference for every value the data source exposes is in
+[The Nuon Stack Terraform Provider](/guides/nuon-stack-terraform-provider).
 
 ## AWS
 
-The AWS stack lives in [`install-stacks/aws/`](https://github.com/nuonco/install-stacks/tree/main/aws).
+The AWS stack lives in [`terraform-aws-stack`](https://github.com/nuonco/terraform-aws-stack).
 
 ### Runner instance
 
@@ -107,13 +113,13 @@ The required keys (matching the CloudFormation phone-home Lambda payload exactly
 
 ## GCP
 
-The GCP stack lives in [`install-stacks/gcp/`](https://github.com/nuonco/install-stacks/tree/main/gcp).
+The GCP stack lives in [`terraform-gcp-stack`](https://github.com/nuonco/terraform-gcp-stack).
 
 ### Runner instance
 
 - A `google_compute_instance` (or MIG) in a subnet with outbound HTTPS to the Nuon API and to GitHub raw.
-- The runner authenticates using the **runner service account's GCP-issued identity token** — no shared secrets in
-  metadata.
+- The runner authenticates with the token returned by `data.stack_config.this.gcp.runner_api_token`. Protect Terraform
+  state as sensitive because the token is stored in instance metadata.
 - The same `init-mng-v2.sh` flow applies: instance metadata must carry `nuon_runner_id`, `nuon_runner_api_url`, and
   `nuon_install_id` so the init script can read them.
 
@@ -132,8 +138,8 @@ Attached to the runner instance. The IAM policy must allow:
 - Each must grant the runner service account `roles/iam.serviceAccountTokenCreator` so the runner can impersonate it.
 - Permissions on each service account come from your `stack.toml` (inline + managed policies are translated into IAM
   bindings on the project).
-- **Service account names must match `each.key` from `stack.toml` verbatim.** ctl-api looks them up by exact short
-  name (the part before `@<project>.iam.gserviceaccount.com`).
+- Report each role under its exact configured role name. Resource names may use deterministic hashes to satisfy GCP's
+  30-character service-account ID limit.
 
 ### Phone-home payload
 
@@ -154,6 +160,26 @@ resource or a POST to the `phone_home_url` from the data source). Required keys:
 | `install_inputs` | Echo of the install inputs (`data.stack_config.this.install_inputs`). |
 | `<secret_name>` | One key per secret declared in `stack.toml`, flattened into the top-level payload (Secret Manager secret names, not ARNs). |
 
+## Azure
+
+The Azure stack lives in [`terraform-azure-stack`](https://github.com/nuonco/terraform-azure-stack).
+
+### Runner virtual machine
+
+- A Linux virtual machine in a subnet with outbound HTTPS to the Nuon API and artifact hosts.
+- Metadata passed to cloud-init must include the runner ID and runner API URL from `stack_config`.
+- The runner identity needs the role assignments required to assume configured operation, break-glass, and custom roles.
+
+### Phone-home payload
+
+Report the subscription, resource group, VNet, runner subnet, runner identity, configured role IDs, install inputs, and
+custom-stack outputs through `stack_phone_home`. Keep the payload keys emitted by the published module even if a fork
+changes the underlying Azure resources; ctl-api and app templates treat those keys as the stable contract.
+
+Azure custom stacks use an Azure Deployment Stack backed by the uploaded linked ARM template. Preserve its
+`actionOnUnmanage` and delete query parameters unless intentionally changing whether removed resources are deleted or
+detached. See [Custom Install Stacks](/guides/custom-nested-stacks) for the cross-cloud custom-stack contract.
+
 ## What you can customize freely
 
 - VPC / VNet / VPC layout, CIDRs, subnet count and sizes — as long as the runner subnet has working egress to the
@@ -162,24 +188,23 @@ resource or a POST to the `phone_home_url` from the data source). Required keys:
 - Instance type / machine type and image — anything that supports cloud-init and can run the `runner` binary works
   (AL2023, Ubuntu LTS, Amazon Linux 2, Debian, COS).
 - Tags / labels, KMS keys, access logging, flow logs, private service endpoints, peering, transit gateways, DNS zones.
-- Wrapping the published module from a parent Terraform configuration instead of forking — `install-stacks/aws` and
-  `install-stacks/gcp` are normal Terraform modules and can be consumed directly:
+- Wrapping the published registry module from a parent Terraform configuration instead of forking:
 
   ```hcl
-  module "nuon" {
-    source = "github.com/nuonco/install-stacks//aws"
+  provider "stack" {}
 
-    phone_home_id = var.phone_home_id
-    aws = {
-      region = "us-west-2"
-    }
+  module "nuon" {
+    source  = "nuonco/stack/azure"
+    version = "~> 1.0"
+
+    install_id = var.install_id
   }
   ```
 
   The module reads the rest of its configuration from the control plane via the `stack_config` data source, so you
-  only pass `phone_home_id`, the target region, and any secret overrides.
+  pass only the install ID and supported overrides. Use each module's README for its current source, version, required
+  cloud provider configuration, and supported overrides.
 
 ## Contributing
 
-We welcome contributions to [`nuonco/install-stacks`](https://github.com/nuonco/install-stacks). If you make any
-changes that you think others might find useful, please open a PR.
+Contributions to the AWS, Azure, and GCP repositories above are welcome.

--- a/docs/guides/nuon-stack-terraform-provider.mdx
+++ b/docs/guides/nuon-stack-terraform-provider.mdx
@@ -1,0 +1,97 @@
+---
+title: 'Nuon Stack Terraform Provider'
+description: 'Read install configuration and report Terraform install-stack results.'
+icon: "layer-group"
+keywords: ["terraform", "provider", "stack_config", "stack_phone_home", "install stack"]
+---
+
+The [`nuonco/stack`](https://registry.terraform.io/providers/nuonco/stack/latest) provider gives an install-stack module
+two authenticated operations:
+
+- `stack_config` reads the rendered configuration for an install.
+- `stack_phone_home` reports create, update, and delete results to Nuon.
+
+Published Nuon AWS, Azure, and GCP modules already include this wiring. Use the provider directly when wrapping or
+forking one of those modules.
+
+## Configure Authentication
+
+```hcl
+terraform {
+  required_providers {
+    stack = {
+      source  = "nuonco/stack"
+      version = ">= 0.7.0"
+    }
+  }
+}
+
+provider "stack" {}
+```
+
+Set credentials outside Terraform so they are not written into the plan:
+
+```bash
+export NUON_API_TOKEN="<token>"
+export NUON_API_URL="https://runner.nuon.co"
+```
+
+`NUON_API_URL` is optional for the hosted control plane. The provider also supports ambient OIDC with
+`NUON_ORG_ID` and either `NUON_OIDC_TOKEN`, `NUON_OIDC_TOKEN_FILE`, or a GitHub Actions ID token.
+
+<Warning>
+The install ID identifies the configuration to read; it does not authorize access. Never replace provider
+authentication with the install ID.
+</Warning>
+
+## Read Install Configuration
+
+```hcl
+variable "install_id" {
+  type = string
+}
+
+data "stack_config" "this" {
+  install_id = var.install_id
+}
+```
+
+The data source returns common values such as:
+
+- `runner_id`, `runner_api_url`, and `phone_home_url`
+- `install_inputs`, `required_input_names`, and `secrets`
+- `aws`, `azure`, or `gcp` cloud-specific runner and permission configuration
+- `custom_stacks` and `custom_stacks_template_url`
+
+Secrets and cloud runner tokens are sensitive. Use encrypted remote state with tightly scoped access.
+
+## Report Results
+
+`stack_phone_home` maps Terraform resource lifecycle events to Nuon's `Create`, `Update`, and `Delete` request types.
+
+```hcl
+resource "stack_phone_home" "this" {
+  install_id      = data.stack_config.this.install_id
+  phone_home_url  = data.stack_config.this.phone_home_url
+  phone_home_type = "azure"
+
+  payload = jsonencode({
+    resource_group       = azurerm_resource_group.this.name
+    custom_nested_stacks = local.custom_stack_outputs
+  })
+}
+```
+
+Use `aws`, `azure`, or `gcp` for `phone_home_type`. Keep cloud-specific payload keys compatible with the published
+module because Nuon exposes them to app templates as `.nuon.install_stack.outputs`.
+
+The `inputs` argument may update only customer-source app inputs. Vendor and computed inputs are rendered by Nuon and
+must remain in the payload rather than being submitted as customer overrides.
+
+## Custom Stack Fields
+
+Each `custom_stacks` entry includes its stable `name`, rendered `parameters`, customer `input_parameters`, and output
+mapping. AWS and Azure additionally use `custom_stacks_template_url` for the generated custom-only template. GCP uses
+the curated module name derived from its module path.
+
+See [Custom Install Stacks](/guides/custom-nested-stacks) for app configuration and output consumption.

--- a/pkg/config/app_stack.go
+++ b/pkg/config/app_stack.go
@@ -48,14 +48,16 @@ type CustomNestedStack struct {
 func (a CustomNestedStack) JSONSchemaExtend(schema *jsonschema.Schema) {
 	NewSchemaBuilder(schema).
 		Field("name").Short("nested stack name").Required().
-		Long("Unique name for this custom nested stack. Used as the CloudFormation logical ID and parameter group label.").
+		Long("Stable, unique name for the custom stack. Used for deployment naming and output lookup.").
 		Example("k8s_namespaces").
 		Example("eks_access_entries").
-		Field("template_url").Short("nested stack template URL").Required().
-		Long("URL to the CloudFormation nested template. Parameters are extracted and hoisted into the parent stack.").
+		Field("template_url").Short("custom stack template or module").Required().
+		Long("AWS CloudFormation template URL or relative path, Azure compiled ARM JSON URL or relative path, or GCP curated module path.").
 		Example("https://nuon-artifacts.s3.us-west-2.amazonaws.com/templates/k8s-namespaces.yaml").
+		Example("./arm/storage.json").
+		Example("github.com/nuonco/install-stacks//gcp/modules/bucket").
 		Field("index").Short("execution order index").Required().
-		Long("Determines the execution order of custom nested stacks (ascending). Each stack must have a unique index. Lower indices execute first.").
+		Long("Unique ordering key. AWS and Azure custom stacks execute in ascending order.").
 		Example("0").
 		Example("1").
 		Field("parameters").Short("parameter values").
@@ -88,6 +90,28 @@ func (c CustomNestedStack) GCPModuleName() string {
 	return name
 }
 
+// ValidateGCPCustomNestedStacks validates requirements that are known before
+// Terraform runs in the customer's project.
+func ValidateGCPCustomNestedStacks(stackType string, stacks []CustomNestedStack) error {
+	if stackType != "gcp-terraform" {
+		return nil
+	}
+
+	for i, stack := range stacks {
+		moduleName := stack.GCPModuleName()
+		if moduleName == "" {
+			msg := fmt.Sprintf("custom_nested_stacks[%d] (%s): gcp-terraform custom stacks must reference a gcp modules path (<repo>%s<name>), e.g. %s<name>", i, stack.Name, GCPCustomStackModuleMarker, GCPCustomStackModulePrefix)
+			return ErrConfig{Description: msg, Err: fmt.Errorf("%s", msg)}
+		}
+		if moduleName == "dns" && strings.TrimSpace(stack.Parameters["dns_name"]) == "" {
+			msg := fmt.Sprintf("custom_nested_stacks[%d] (%s): parameters.dns_name is required for the GCP dns module", i, stack.Name)
+			return ErrConfig{Description: msg, Err: fmt.Errorf("%s", msg)}
+		}
+	}
+
+	return nil
+}
+
 // Deployment scopes for the generated Azure install stack root template.
 //
 // The empty string is equivalent to StackDeploymentScopeResourceGroup and is
@@ -108,8 +132,8 @@ type StackConfig struct {
 	Name        string `mapstructure:"name" toml:"name" jsonschema:"required" features:"template"`
 	Description string `mapstructure:"description" toml:"description" jsonschema:"required" features:"template"`
 
-	VPCNestedTemplateURL    string `mapstructure:"vpc_nested_template_url" toml:"vpc_nested_template_url" jsonschema:"required" features features:"template"`
-	RunnerNestedTemplateURL string `mapstructure:"runner_nested_template_url" toml:"runner_nested_template_url" jsonschema:"required" features features:"template"`
+	VPCNestedTemplateURL    string `mapstructure:"vpc_nested_template_url" toml:"vpc_nested_template_url" features features:"template"`
+	RunnerNestedTemplateURL string `mapstructure:"runner_nested_template_url" toml:"runner_nested_template_url" features features:"template"`
 
 	DeploymentScope string `mapstructure:"deployment_scope" toml:"deployment_scope,omitempty"`
 
@@ -124,11 +148,11 @@ func (a StackConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Example("azure-bicep").
 		Example("gcp-terraform").
 		Field("name").Short("stack name").Required().
-		Long("Name of the CloudFormation stack when deployed in the customer account. Supports Go templating").
+		Long("Name of the install stack when deployed in the customer account or project. Supports Go templating").
 		Example("myapp-{{.nuon.install.id}}").
 		Example("production-stack").
 		Field("description").Short("stack description").Required().
-		Long("Description of the stack, displayed in the CloudFormation console. Supports templating").
+		Long("Description of the install stack. Supports Go templating").
 		Example("Infrastructure stack for MyApp application").
 		Field("vpc_nested_template_url").Short("VPC nested template URL").
 		Long("URL to the CloudFormation nested template for VPC resources").
@@ -140,7 +164,7 @@ func (a StackConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Long("Scope the generated install stack root template deploys at. Only supported for 'azure-bicep'. Supported values: 'resource_group' (the default) confines every resource to the install's own resource group; 'subscription' deploys at subscription scope, which lets nested stack templates create their own resource groups — needed when an app splits networking, application and security resources across several groups.").
 		Example("subscription").
 		Field("custom_nested_stacks").Short("custom nested stacks").
-		Long("Custom CloudFormation nested stack templates to include. Each entry has a name, template_url, index, and optional parameters. The index field determines execution order (ascending). The parameters field maps CloudFormation parameter names to Nuon install input references using {{.nuon.install.inputs.<name>}} syntax. Remaining parameters are hoisted into a top-level group named after the stack. Executed after first-class nested stacks.").
+		Long("Custom install-stack resources to include. Each entry has a name, template_url, index, and optional parameters. AWS uses CloudFormation templates, Azure uses compiled ARM JSON, and GCP uses curated install-stack modules.").
 		Nullable()
 }
 
@@ -335,19 +359,11 @@ func (a *StackConfig) parse() error {
 			}
 		}
 	}
-	// gcp-terraform custom stacks are curated: template_url must select a
-	// child module of the install-stacks gcp root.
-	if a.Type == "gcp-terraform" {
-		for i, stack := range a.CustomNestedStacks {
-			if stack.GCPModuleName() == "" {
-				return ErrConfig{
-					Description: fmt.Sprintf("custom_nested_stacks[%d] (%s): gcp-terraform custom stacks must reference a gcp modules path (<repo>%s<name>), e.g. %s<name>", i, stack.Name, GCPCustomStackModuleMarker, GCPCustomStackModulePrefix),
-					Err:         fmt.Errorf("custom_nested_stacks[%d] (%s): gcp-terraform custom stacks must reference a gcp modules path (<repo>%s<name>), e.g. %s<name>", i, stack.Name, GCPCustomStackModuleMarker, GCPCustomStackModulePrefix),
-				}
-			}
-		}
+	if err := ValidateGCPCustomNestedStacks(a.Type, a.CustomNestedStacks); err != nil {
+		return err
 	}
 	seenIndices := map[int]string{}
+	seenNames := map[string]int{}
 	for i, stack := range a.CustomNestedStacks {
 		if stack.Name == "" {
 			return ErrConfig{
@@ -355,6 +371,13 @@ func (a *StackConfig) parse() error {
 				Err:         fmt.Errorf("custom_nested_stacks[%d]: name is required", i),
 			}
 		}
+		if prev, exists := seenNames[stack.Name]; exists {
+			return ErrConfig{
+				Description: fmt.Sprintf("custom_nested_stacks[%d] (%s): name is already used by custom_nested_stacks[%d]; each stack must have a unique name", i, stack.Name, prev),
+				Err:         fmt.Errorf("custom_nested_stacks[%d] (%s): name is already used by custom_nested_stacks[%d]; each stack must have a unique name", i, stack.Name, prev),
+			}
+		}
+		seenNames[stack.Name] = i
 		if stack.TemplateURL == "" {
 			return ErrConfig{
 				Description: fmt.Sprintf("custom_nested_stacks[%d] (%s): template_url is required", i, stack.Name),

--- a/pkg/config/app_stack_test.go
+++ b/pkg/config/app_stack_test.go
@@ -395,3 +395,34 @@ func TestStackConfig_Parse_GCPCustomStacks(t *testing.T) {
 		require.Error(t, cfg.parse(), badURL)
 	}
 }
+
+func TestStackConfigParseRequiresGCPDNSName(t *testing.T) {
+	cfg := &StackConfig{
+		Type:        "gcp-terraform",
+		Name:        "my-stack",
+		Description: "test stack",
+		CustomNestedStacks: []CustomNestedStack{
+			{Name: "dns", TemplateURL: "github.com/nuonco/install-stacks//gcp/modules/dns", Index: 0},
+		},
+	}
+
+	require.EqualError(t, cfg.parse(), "custom_nested_stacks[0] (dns): parameters.dns_name is required for the GCP dns module")
+	cfg.CustomNestedStacks[0].Parameters = map[string]string{"dns_name": "app.example.com."}
+	require.NoError(t, cfg.parse())
+}
+
+func TestStackConfig_ParseRejectsDuplicateCustomStackNames(t *testing.T) {
+	cfg := &StackConfig{
+		Type:        "gcp-terraform",
+		Name:        "my-stack",
+		Description: "test stack",
+		CustomNestedStacks: []CustomNestedStack{
+			{Name: "bucket", TemplateURL: "github.com/nuonco/install-stacks//gcp/modules/bucket", Index: 0},
+			{Name: "bucket", TemplateURL: "github.com/nuonco/install-stacks//gcp/modules/bucket", Index: 1},
+		},
+	}
+
+	err := cfg.parse()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "each stack must have a unique name")
+}

--- a/pkg/config/azure_custom_stacks.go
+++ b/pkg/config/azure_custom_stacks.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+)
+
+const bicepFileExtension = ".bicep"
+
+// ValidateAzureCustomNestedStacks rejects azure-bicep custom nested stacks whose
+// template is Bicep source instead of the compiled ARM JSON that ARM's
+// templateLink can actually fetch. Called from the CLI validation path and from
+// the server-side config builder, so a config that bypasses the CLI — a direct
+// API sync or a VCS branch run — is rejected the same way.
+//
+// Contents is the template body resolved from template_url; it is empty on call
+// paths that have not fetched it yet, and the check is skipped there.
+func ValidateAzureCustomNestedStacks(stackType string, stacks []CustomNestedStack) error {
+	if stackType != "azure-bicep" {
+		return nil
+	}
+
+	for i, stack := range stacks {
+		if strings.HasSuffix(strings.ToLower(stack.TemplateURL), bicepFileExtension) {
+			return newAzureBicepSourceErr(i, stack, fmt.Sprintf(
+				"template_url %q is Bicep source",
+				stack.TemplateURL,
+			))
+		}
+
+		if strings.TrimSpace(stack.Contents) == "" {
+			continue
+		}
+
+		if !isARMJSON(stack.Contents) {
+			return newAzureBicepSourceErr(i, stack, fmt.Sprintf(
+				"the contents of template_url %q are not valid ARM JSON",
+				stack.TemplateURL,
+			))
+		}
+	}
+
+	return nil
+}
+
+func newAzureBicepSourceErr(index int, stack CustomNestedStack, problem string) error {
+	msg := fmt.Sprintf(
+		"custom_nested_stacks[%d] (%s): azure-bicep custom stacks must reference compiled ARM JSON, but %s. Compile it and point template_url at the output:\n\n    %s",
+		index, stack.Name, problem, bicepBuildCommand(stack.TemplateURL),
+	)
+
+	return ErrConfig{
+		Description: msg,
+		Err:         fmt.Errorf("%s", msg),
+	}
+}
+
+func isARMJSON(contents string) bool {
+	var tmpl struct {
+		Schema         string            `json:"$schema"`
+		ContentVersion string            `json:"contentVersion"`
+		Resources      []json.RawMessage `json:"resources"`
+	}
+	return json.Unmarshal([]byte(contents), &tmpl) == nil &&
+		tmpl.Schema != "" &&
+		tmpl.ContentVersion != "" &&
+		tmpl.Resources != nil
+}
+
+func bicepBuildCommand(templateURL string) string {
+	base := strings.TrimSuffix(templateURL, path.Ext(templateURL))
+	source := templateURL
+	outfile := base + ".json"
+	if !strings.EqualFold(path.Ext(templateURL), bicepFileExtension) {
+		source = base + bicepFileExtension
+		outfile = templateURL
+	}
+
+	return fmt.Sprintf("az bicep build --file %s --outfile %s", source, outfile)
+}

--- a/pkg/config/azure_custom_stacks_test.go
+++ b/pkg/config/azure_custom_stacks_test.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const armTemplateJSON = `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": []
+}`
+
+const bicepSource = `param location string = resourceGroup().location
+
+resource sa 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: 'acmestorage'
+  location: location
+}`
+
+func TestValidateAzureCustomNestedStacks_RejectsBicepTemplateURL(t *testing.T) {
+	err := ValidateAzureCustomNestedStacks("azure-bicep", []CustomNestedStack{
+		{Name: "networking", Index: 0, TemplateURL: "./arm/networking.json", Contents: armTemplateJSON},
+		{Name: "storage", Index: 1, TemplateURL: "./arm/storage.bicep", Contents: armTemplateJSON},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "custom_nested_stacks[1] (storage)")
+	assert.Contains(t, err.Error(), `template_url "./arm/storage.bicep" is Bicep source`)
+	assert.Contains(t, err.Error(), "az bicep build --file ./arm/storage.bicep --outfile ./arm/storage.json")
+}
+
+func TestValidateAzureCustomNestedStacks_RejectsBicepTemplateURLUppercase(t *testing.T) {
+	err := ValidateAzureCustomNestedStacks("azure-bicep", []CustomNestedStack{
+		{Name: "storage", Index: 0, TemplateURL: "./arm/Storage.BICEP"},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "az bicep build --file ./arm/Storage.BICEP --outfile ./arm/Storage.json")
+}
+
+func TestValidateAzureCustomNestedStacks_RejectsNonARMJSONContents(t *testing.T) {
+	err := ValidateAzureCustomNestedStacks("azure-bicep", []CustomNestedStack{
+		{Name: "storage", Index: 0, TemplateURL: "./arm/storage.json", Contents: bicepSource},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "custom_nested_stacks[0] (storage)")
+	assert.Contains(t, err.Error(), `contents of template_url "./arm/storage.json" are not valid ARM JSON`)
+	assert.Contains(t, err.Error(), "az bicep build --file ./arm/storage.bicep --outfile ./arm/storage.json")
+}
+
+func TestValidateAzureCustomNestedStacks_RejectsNonObjectContents(t *testing.T) {
+	err := ValidateAzureCustomNestedStacks("azure-bicep", []CustomNestedStack{
+		{Name: "storage", Index: 0, TemplateURL: "https://example.com/storage.json", Contents: `["not", "a", "template"]`},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "are not valid ARM JSON")
+}
+
+func TestValidateAzureCustomNestedStacks_RejectsJSONWithoutARMContract(t *testing.T) {
+	err := ValidateAzureCustomNestedStacks("azure-bicep", []CustomNestedStack{
+		{Name: "storage", Index: 0, TemplateURL: "./arm/storage.json", Contents: `{"resources":[]}`},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "are not valid ARM JSON")
+}
+
+func TestValidateAzureCustomNestedStacks_AllowsValidARMJSON(t *testing.T) {
+	require.NoError(t, ValidateAzureCustomNestedStacks("azure-bicep", []CustomNestedStack{
+		{Name: "networking", Index: 0, TemplateURL: "./arm/networking.json", Contents: armTemplateJSON},
+		{Name: "storage", Index: 1, TemplateURL: "https://example.com/storage.json", Contents: armTemplateJSON},
+	}))
+}
+
+func TestValidateAzureCustomNestedStacks_SkipsUnfetchedContents(t *testing.T) {
+	require.NoError(t, ValidateAzureCustomNestedStacks("azure-bicep", []CustomNestedStack{
+		{Name: "storage", Index: 0, TemplateURL: "https://example.com/storage.json"},
+	}))
+}
+
+func TestValidateAzureCustomNestedStacks_SkipsNonAzureStackTypes(t *testing.T) {
+	stacks := []CustomNestedStack{
+		{Name: "namespaces", Index: 0, TemplateURL: "./cfn/namespaces.yaml", Contents: "Resources: {}"},
+		{Name: "bicep_named", Index: 1, TemplateURL: "./cfn/thing.bicep", Contents: "Resources: {}"},
+	}
+
+	for _, stackType := range []string{"aws-cloudformation", "gcp-terraform", ""} {
+		require.NoError(t, ValidateAzureCustomNestedStacks(stackType, stacks), stackType)
+	}
+}
+
+func TestValidateAzureCustomNestedStacks_NoStacks(t *testing.T) {
+	require.NoError(t, ValidateAzureCustomNestedStacks("azure-bicep", nil))
+}

--- a/pkg/config/install.go
+++ b/pkg/config/install.go
@@ -149,7 +149,7 @@ func (a InstallStackOverrides) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Long("Per-install override for the runner nested CloudFormation template URL. Overrides the app-level default from stack.toml.").
 		Example("https://nuon-artifacts.s3.us-west-2.amazonaws.com/templates/custom-runner.yaml").
 		Field("custom_nested_stacks").Short("Custom nested stack overrides").
-		Long("Per-install overrides for custom nested CloudFormation stacks. Entries with the same name as app-level stacks replace them; new names are appended.").
+		Long("Per-install overrides for custom install stacks. Entries with the same name as app-level stacks replace them; new names are appended. Supports AWS CloudFormation, Azure ARM, and curated GCP modules.").
 		Nullable()
 }
 

--- a/pkg/config/validate/validate.go
+++ b/pkg/config/validate/validate.go
@@ -80,6 +80,9 @@ func Validate(ctx context.Context, v *validator.Validate, a *config.AppConfig) e
 		func() error {
 			return ValidateAzureRunnerIdentities(a)
 		},
+		func() error {
+			return validateAzureCustomNestedStacks(a)
+		},
 		//
 		func() error {
 			if err := a.OperationRoles.Validate(); err != nil {
@@ -102,5 +105,23 @@ func Validate(ctx context.Context, v *validator.Validate, a *config.AppConfig) e
 		}
 	}
 
+	return nil
+}
+
+func validateAzureCustomNestedStacks(a *config.AppConfig) error {
+	if a.Stack == nil {
+		return nil
+	}
+	if err := config.ValidateAzureCustomNestedStacks(a.Stack.Type, a.Stack.CustomNestedStacks); err != nil {
+		return err
+	}
+	for _, install := range a.Installs {
+		if install.StackOverrides == nil {
+			continue
+		}
+		if err := config.ValidateAzureCustomNestedStacks(a.Stack.Type, install.StackOverrides.CustomNestedStacks); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/config/validate/validate_custom_nested_stacks_test.go
+++ b/pkg/config/validate/validate_custom_nested_stacks_test.go
@@ -144,3 +144,21 @@ func TestValidateCustomNestedStackOutputs_UnfetchableTemplateSkipped(t *testing.
 	})
 	assert.NoError(t, err)
 }
+
+func TestValidateAzureCustomNestedStacksChecksInstallOverrides(t *testing.T) {
+	err := validateAzureCustomNestedStacks(&config.AppConfig{
+		Stack: &config.StackConfig{Type: "azure-bicep"},
+		Installs: []*config.Install{
+			{
+				Name: "example",
+				StackOverrides: &config.InstallStackOverrides{
+					CustomNestedStacks: []config.CustomNestedStack{
+						{Name: "storage", Index: 0, TemplateURL: "./arm/storage.bicep", Contents: "param location string"},
+					},
+				},
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "az bicep build --file ./arm/storage.bicep --outfile ./arm/storage.json")
+}

--- a/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config.go
+++ b/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config.go
@@ -90,10 +90,6 @@ func (h *Helpers) BuildInstallerSDKConfig(ctx context.Context, installID string)
 	}
 
 	app.ApplyInstallStackOverrides(&install, &appCfg.StackConfig)
-	customStacks, err := buildInstallerSDKCustomStacks(appCfg.StackConfig.CustomNestedStacks, stateData)
-	if err != nil {
-		return nil, fmt.Errorf("build custom nested stacks: %w", err)
-	}
 
 	// Real values, not names: the read is authenticated. Current value per
 	// customer-source input, falling back to the app input's default.
@@ -105,10 +101,12 @@ func (h *Helpers) BuildInstallerSDKConfig(ctx context.Context, installID string)
 	var installInputs map[string]string
 	var requiredInputs []string
 	var sensitiveInputs []string
+	customerInputNames := make(map[string]struct{})
 	for _, in := range appCfg.InputConfig.AppInputs {
 		if in.Source != app.AppInputSourceCustomer {
 			continue
 		}
+		customerInputNames[in.Name] = struct{}{}
 		if installInputs == nil {
 			installInputs = map[string]string{}
 		}
@@ -127,6 +125,11 @@ func (h *Helpers) BuildInstallerSDKConfig(ctx context.Context, installID string)
 		if in.Sensitive {
 			sensitiveInputs = append(sensitiveInputs, in.Name)
 		}
+	}
+
+	customStacks, err := buildInstallerSDKCustomStacks(appCfg.StackConfig.CustomNestedStacks, stateData, customerInputNames)
+	if err != nil {
+		return nil, fmt.Errorf("build custom nested stacks: %w", err)
 	}
 
 	// Auto-generated secrets are the stack's to mint, the rest the customer's to
@@ -162,7 +165,7 @@ func (h *Helpers) BuildInstallerSDKConfig(ctx context.Context, installID string)
 		CustomStacks:        customStacks,
 	}
 
-	if appCfg.RunnerConfig.Type == app.AppRunnerTypeAWS && len(customStacks) > 0 {
+	if (appCfg.RunnerConfig.Type == app.AppRunnerTypeAWS || appCfg.RunnerConfig.Type == app.AppRunnerTypeAzure) && len(customStacks) > 0 {
 		var latestVersion app.InstallStackVersion
 		// No "latest version" FK exists — InstallStackVersion.InstallStackID
 		// only points the other way — so created_at ordering resolves "latest".
@@ -178,7 +181,10 @@ func (h *Helpers) BuildInstallerSDKConfig(ctx context.Context, installID string)
 			// fetch or parse templates.
 			for i := range cfg.CustomStacks {
 				cfg.CustomStacks[i].Outputs = latestVersion.CustomStacksOutputMap[cfg.CustomStacks[i].Name]
-				cfg.CustomStacks[i].InputParameters = latestVersion.CustomStacksInputParametersMap[cfg.CustomStacks[i].Name]
+				cfg.CustomStacks[i].InputParameters = customerInputParameters(
+					latestVersion.CustomStacksInputParametersMap[cfg.CustomStacks[i].Name],
+					customerInputNames,
+				)
 			}
 		case errors.Is(res.Error, gorm.ErrRecordNotFound):
 			// no stack version yet — leave empty
@@ -359,9 +365,26 @@ func rolesToSDKConfigMap(rs []awsstacks.AWSRoleRaw, enabled bool) map[string]app
 
 // buildInstallerSDKCustomStacks renders custom nested stack parameter values
 // and sorts by Index.
-func buildInstallerSDKCustomStacks(stacks []config.CustomNestedStack, stateData map[string]any) ([]app.InstallerSDKCustomStack, error) {
+func buildInstallerSDKCustomStacks(stacks []config.CustomNestedStack, stateData map[string]any, customerInputNames map[string]struct{}) ([]app.InstallerSDKCustomStack, error) {
 	if len(stacks) == 0 {
 		return nil, nil
+	}
+
+	inputParameters := make(map[string]map[string]string, len(stacks))
+	for _, stack := range stacks {
+		for parameterName, value := range stack.Parameters {
+			inputName, err := config.ParseInstallInputReference(value)
+			if err != nil {
+				continue
+			}
+			if _, ok := customerInputNames[inputName]; !ok {
+				continue
+			}
+			if inputParameters[stack.Name] == nil {
+				inputParameters[stack.Name] = make(map[string]string)
+			}
+			inputParameters[stack.Name][parameterName] = inputName
+		}
 	}
 
 	if err := config.RenderCustomNestedStackParameters(stacks, stateData); err != nil {
@@ -377,13 +400,28 @@ func buildInstallerSDKCustomStacks(stacks []config.CustomNestedStack, stateData 
 	out := make([]app.InstallerSDKCustomStack, len(rendered))
 	for i, s := range rendered {
 		out[i] = app.InstallerSDKCustomStack{
-			Name:       s.Name,
-			Index:      s.Index,
-			Parameters: s.Parameters,
-			Module:     s.GCPModuleName(),
+			Name:            s.Name,
+			Index:           s.Index,
+			Parameters:      s.Parameters,
+			Module:          s.GCPModuleName(),
+			InputParameters: inputParameters[s.Name],
 		}
 	}
 	return out, nil
+}
+
+func customerInputParameters(inputParameters map[string]string, customerInputNames map[string]struct{}) map[string]string {
+	var out map[string]string
+	for parameterName, inputName := range inputParameters {
+		if _, ok := customerInputNames[inputName]; !ok {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]string)
+		}
+		out[parameterName] = inputName
+	}
+	return out
 }
 
 func gcpRolesToSDKMap(rs []gcpstacks.GCPRoleRaw, enabled bool) map[string]app.InstallerSDKGCPRole {

--- a/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config_test.go
+++ b/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config_test.go
@@ -246,6 +246,16 @@ func (s *InstallerSDKConfigTestSuite) TestCustomStacksInstallOverrideMerge() {
 
 func (s *InstallerSDKConfigTestSuite) TestCustomStacksInputParametersFromLatestStackVersion() {
 	t := s.T()
+	s.customerInput("namespaces", "", false)
+	require.NoError(t, s.deps.DB.WithContext(s.ctx).Create(&app.AppInput{
+		AppInputConfigID: s.inputCfg.ID,
+		AppInputGroupID:  s.group.ID,
+		Name:             "vendor_setting",
+		Description:      "vendor_setting",
+		Type:             app.AppInputTypeString,
+		Source:           app.AppInputSourceVendor,
+		Default:          "default",
+	}).Error)
 
 	require.NoError(t, s.deps.DB.WithContext(s.ctx).
 		Model(&app.AppStackConfig{}).
@@ -261,7 +271,10 @@ func (s *InstallerSDKConfigTestSuite) TestCustomStacksInputParametersFromLatestS
 		InstallID:      install.ID,
 		InstallStackID: installStack.ID,
 		CustomStacksInputParametersMap: map[string]map[string]string{
-			"k8s-namespaces": {"K8SNamespacesNamespaces": "namespaces"},
+			"k8s-namespaces": {
+				"K8SNamespacesNamespaces": "namespaces",
+				"VendorSetting":           "vendor_setting",
+			},
 		},
 	}).Error)
 
@@ -272,6 +285,16 @@ func (s *InstallerSDKConfigTestSuite) TestCustomStacksInputParametersFromLatestS
 
 func (s *InstallerSDKConfigTestSuite) TestCustomStacksGCPModuleName() {
 	t := s.T()
+	s.customerInput("bucket_location", "", false)
+	require.NoError(t, s.deps.DB.WithContext(s.ctx).Create(&app.AppInput{
+		AppInputConfigID: s.inputCfg.ID,
+		AppInputGroupID:  s.group.ID,
+		Name:             "bucket_versioning",
+		Description:      "bucket_versioning",
+		Type:             app.AppInputTypeBool,
+		Source:           app.AppInputSourceVendor,
+		Default:          "false",
+	}).Error)
 
 	require.NoError(t, s.deps.DB.WithContext(s.ctx).
 		Model(&app.AppStackConfig{}).
@@ -281,6 +304,10 @@ func (s *InstallerSDKConfigTestSuite) TestCustomStacksGCPModuleName() {
 				Name:        "bucket",
 				Index:       0,
 				TemplateURL: "github.com/nuonco/install-stacks//gcp/modules/bucket",
+				Parameters: map[string]string{
+					"location":   "{{.nuon.install.inputs.bucket_location}}",
+					"versioning": "{{.nuon.install.inputs.bucket_versioning}}",
+				},
 			},
 			{
 				Name:        "cf-nested",
@@ -290,9 +317,15 @@ func (s *InstallerSDKConfigTestSuite) TestCustomStacksGCPModuleName() {
 		}).Error)
 
 	install := s.seedInstallWithRunner()
+	s.deps.Seed.CreateInstallInputs(s.ctx, t, install.ID, s.inputCfg.ID, map[string]*string{
+		"bucket_location":   generics.ToPtr("US"),
+		"bucket_versioning": generics.ToPtr("true"),
+	})
 
 	cfg := s.build(install.ID)
 	require.Len(t, cfg.CustomStacks, 2)
 	assert.Equal(t, "bucket", cfg.CustomStacks[0].Module)
+	assert.Equal(t, map[string]string{"location": "US", "versioning": "true"}, cfg.CustomStacks[0].Parameters)
+	assert.Equal(t, map[string]string{"location": "bucket_location"}, cfg.CustomStacks[0].InputParameters)
 	assert.Equal(t, "", cfg.CustomStacks[1].Module)
 }

--- a/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/generateinstallstackversion/signal.go
@@ -364,9 +364,6 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 			}
 		}
 
-		if err := stackworkflow.RenderAndUploadCustomStacksTemplate(ctx, install.ID, stackVersion, *inp, s.cfg.AWSCloudFormationStackTemplateBucket); err != nil {
-			return err
-		}
 	case app.AppRunnerTypeAzure:
 		if cfg.RunnerConfig.InitScriptURL != "" {
 			inp.RunnerInitScriptURL = cfg.RunnerConfig.InitScriptURL
@@ -395,6 +392,10 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		checksum = armResult.Checksum
 		quickLinkWrapperByts = armResult.QuickLinkWrapperJSON
 		quickLinkUIDefByts = armResult.QuickLinkUIDefJSON
+	}
+
+	if err := stackworkflow.RenderAndUploadCustomStacksTemplate(ctx, install.ID, stackVersion, *inp, s.cfg.AWSCloudFormationStackTemplateBucket); err != nil {
+		return err
 	}
 
 	if s.cfg.AWSCloudFormationStackTemplateBucket == "" {

--- a/services/ctl-api/internal/app/installs/worker/activities/create_install_stack_version.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/create_install_stack_version.go
@@ -128,7 +128,7 @@ func (a *Activities) CreateInstallStackVersion(ctx context.Context, req *CreateI
 			obj.TemplateURL = loc.templateURL
 			obj.QuickLinkURL = loc.quickLinkURL
 
-			if req.Platform == "aws" && req.HasCustomNestedStacks {
+			if (req.Platform == "aws" || req.Platform == "azure") && req.HasCustomNestedStacks {
 				obj.CustomStacksAWSBucketKey = fmt.Sprintf("templates/%s/%s-custom.json", req.InstallID, id)
 				baseURL := strings.TrimSuffix(a.cfg.AWSCloudFormationStackTemplateBaseURL, "/")
 				obj.CustomStacksTemplateURL = fmt.Sprintf("%s/%s", baseURL, obj.CustomStacksAWSBucketKey)

--- a/services/ctl-api/internal/app/installs/worker/activities/render_arm_stack_template.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/render_arm_stack_template.go
@@ -14,8 +14,10 @@ type RenderARMStackTemplateRequest struct {
 }
 
 type RenderARMStackTemplateResponse struct {
-	RAWJson  []byte `temporaljson:"raw_json"`
-	Checksum string `temporaljson:"checksum"`
+	RAWJson                        []byte                       `temporaljson:"raw_json"`
+	Checksum                       string                       `temporaljson:"checksum"`
+	CustomStacksOutputMap          map[string]map[string]string `temporaljson:"custom_stacks_output_map"`
+	CustomStacksInputParametersMap map[string]map[string]string `temporaljson:"custom_stacks_input_parameters_map"`
 
 	// QuickLinkWrapperJSON is the template behind the Azure portal quick link, and
 	// is empty unless the stack version carries a QuickLinkBucketKey. It is a
@@ -38,6 +40,22 @@ func (a *Activities) RenderARMStackTemplate(ctx context.Context, req *RenderARMS
 	armTemplates := arm.NewTemplates(arm.Params{
 		Cfg: a.cfg,
 	})
+	if req.Input.CustomStacksOnly {
+		tmplByts, checksum, outputMap, inputParametersMap, err := armTemplates.CustomStacksTemplate(&req.Input)
+		if err != nil {
+			return res, temporal.NewNonRetryableApplicationError(
+				"unable to create custom stacks ARM template",
+				"arm_template_error",
+				err,
+			)
+		}
+		res.RAWJson = tmplByts
+		res.Checksum = checksum
+		res.CustomStacksOutputMap = outputMap
+		res.CustomStacksInputParametersMap = inputParametersMap
+		return res, nil
+	}
+
 	tmplByts, checksum, err := armTemplates.Template(&req.Input)
 	if err != nil {
 		return res, temporal.NewNonRetryableApplicationError(

--- a/services/ctl-api/internal/app/installs/worker/stack/custom_stacks.go
+++ b/services/ctl-api/internal/app/installs/worker/stack/custom_stacks.go
@@ -10,8 +10,6 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
 )
 
-// RenderAndUploadCustomStacksTemplate renders and uploads the custom-stacks-only
-// CloudFormation artifact for the Terraform install path.
 func RenderAndUploadCustomStacksTemplate(
 	ctx workflow.Context,
 	installID string,
@@ -25,19 +23,38 @@ func RenderAndUploadCustomStacksTemplate(
 
 	inp.CustomStacksOnly = true
 
-	customRendered, err := activities.AwaitRenderAWSStackTemplate(ctx, &activities.RenderAWSStackTemplateRequest{
-		Input: inp,
-	})
-	if err != nil {
-		return errors.Wrap(err, "unable to render custom stacks only template")
+	var template []byte
+	var outputMap map[string]map[string]string
+	var inputParametersMap map[string]map[string]string
+	switch inp.AppCfg.RunnerConfig.Type {
+	case app.AppRunnerTypeAWS:
+		customRendered, err := activities.AwaitRenderAWSStackTemplate(ctx, &activities.RenderAWSStackTemplateRequest{
+			Input: inp,
+		})
+		if err != nil {
+			return errors.Wrap(err, "unable to render custom stacks only template")
+		}
+		template = customRendered.RAWJson
+		outputMap = customRendered.CustomStacksOutputMap
+		inputParametersMap = customRendered.CustomStacksInputParametersMap
+	case app.AppRunnerTypeAzure:
+		customRendered, err := activities.AwaitRenderARMStackTemplate(ctx, &activities.RenderARMStackTemplateRequest{
+			Input: inp,
+		})
+		if err != nil {
+			return errors.Wrap(err, "unable to render custom stacks only template")
+		}
+		template = customRendered.RAWJson
+		outputMap = customRendered.CustomStacksOutputMap
+		inputParametersMap = customRendered.CustomStacksInputParametersMap
+	default:
+		return nil
 	}
 
-	// BuildInstallerSDKConfig reads it back off stackVersion instead of
-	// re-fetching/parsing templates on every terraform plan.
 	if err := activities.AwaitSaveInstallStackVersionCustomStacksOutputMap(ctx, &activities.SaveInstallStackVersionCustomStacksOutputMapRequest{
 		ID:                 stackVersion.ID,
-		OutputMap:          customRendered.CustomStacksOutputMap,
-		InputParametersMap: customRendered.CustomStacksInputParametersMap,
+		OutputMap:          outputMap,
+		InputParametersMap: inputParametersMap,
 	}); err != nil {
 		return errors.Wrap(err, "unable to save custom stacks output map")
 	}
@@ -49,7 +66,7 @@ func RenderAndUploadCustomStacksTemplate(
 
 	if err := activities.AwaitUploadAWSCloudFormationStackVersionTemplate(ctx, &activities.UploadAWSCloudFormationStackVersionTemplateRequest{
 		BucketKey: stackVersion.CustomStacksAWSBucketKey,
-		Template:  customRendered.RAWJson,
+		Template:  template,
 	}); err != nil {
 		return errors.Wrap(err, "unable to upload custom stacks only template")
 	}

--- a/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
+++ b/services/ctl-api/internal/app/installs/worker/stack/generate_install_stack_version.go
@@ -295,10 +295,6 @@ func (w *Workflows) GenerateInstallStackVersion(ctx workflow.Context, sreq Gener
 			}
 		}
 
-		if err := RenderAndUploadCustomStacksTemplate(ctx, install.ID, stackVersion, *inp, w.cfg.AWSCloudFormationStackTemplateBucket); err != nil {
-			return err
-		}
-
 	case app.AppRunnerTypeAzure:
 		if cfg.RunnerConfig.InitScriptURL != "" {
 			inp.RunnerInitScriptURL = cfg.RunnerConfig.InitScriptURL
@@ -318,6 +314,10 @@ func (w *Workflows) GenerateInstallStackVersion(ctx workflow.Context, sreq Gener
 		}
 		tmplByts = renderedTemplate.RAWJson
 		checksum = renderedTemplate.Checksum
+	}
+
+	if err := RenderAndUploadCustomStacksTemplate(ctx, install.ID, stackVersion, *inp, w.cfg.AWSCloudFormationStackTemplateBucket); err != nil {
+		return err
 	}
 
 	if w.cfg.AWSCloudFormationStackTemplateBucket == "" {

--- a/services/ctl-api/internal/app/stacks/service/post_stack_phone_home.go
+++ b/services/ctl-api/internal/app/stacks/service/post_stack_phone_home.go
@@ -116,7 +116,7 @@ func (s *service) PostStackPhoneHome(ctx *gin.Context) {
 	// Accepted and dropped, like the legacy route, so a deprovisioned stack stays
 	// deletable.
 	if requestType == installshelpers.PhoneHomeRequestTypeDelete {
-		ctx.JSON(http.StatusOK, app.EmptyResponse{})
+		ctx.JSON(http.StatusCreated, app.EmptyResponse{})
 		return
 	}
 

--- a/services/ctl-api/internal/app/stacks/service/post_stack_phone_home_test.go
+++ b/services/ctl-api/internal/app/stacks/service/post_stack_phone_home_test.go
@@ -217,7 +217,7 @@ func (s *StackPhoneHomeTestSuite) TestDeleteIsAcceptedWithoutRecording() {
 	rr := s.post(install.ID, map[string]any{
 		"request_type": installshelpers.PhoneHomeRequestTypeDelete,
 	})
-	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
 
 	var runs []app.InstallStackVersionRun
 	require.NoError(t, s.deps.DB.

--- a/services/ctl-api/internal/pkg/config/build/build_test.go
+++ b/services/ctl-api/internal/pkg/config/build/build_test.go
@@ -279,6 +279,111 @@ func TestStackConfigRejectsNestedStackWithoutContents(t *testing.T) {
 	assert.Contains(t, err.Error(), "contents is required")
 }
 
+func TestStackConfigRejectsInvalidCustomStackIdentity(t *testing.T) {
+	for name, stacks := range map[string][]config.CustomNestedStack{
+		"duplicate names": {
+			{Name: "shared", Index: 0, TemplateURL: "https://example.com/a.yaml", Contents: "{}"},
+			{Name: "shared", Index: 1, TemplateURL: "https://example.com/b.yaml", Contents: "{}"},
+		},
+		"duplicate indices": {
+			{Name: "first", Index: 0, TemplateURL: "https://example.com/a.yaml", Contents: "{}"},
+			{Name: "second", Index: 0, TemplateURL: "https://example.com/b.yaml", Contents: "{}"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := StackConfig(&config.StackConfig{
+				Type:               string(app.StackTypeAWS),
+				Name:               "stack",
+				Description:        "stack",
+				CustomNestedStacks: stacks,
+			}, "app1", "cfg1")
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestStackConfigRejectsAzureBicepCustomStackSource(t *testing.T) {
+	const armJSON = `{"$schema":"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[]}`
+
+	for name, tc := range map[string]struct {
+		stacks  []config.CustomNestedStack
+		wantErr string
+	}{
+		"bicep template_url": {
+			stacks:  []config.CustomNestedStack{{Name: "storage", Index: 0, TemplateURL: "./arm/storage.bicep", Contents: armJSON}},
+			wantErr: "az bicep build --file ./arm/storage.bicep --outfile ./arm/storage.json",
+		},
+		"bicep contents": {
+			stacks:  []config.CustomNestedStack{{Name: "storage", Index: 0, TemplateURL: "./arm/storage.json", Contents: "param location string = resourceGroup().location"}},
+			wantErr: "are not valid ARM JSON",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := StackConfig(&config.StackConfig{
+				Type:               string(app.StackTypeAzure),
+				Name:               "stack",
+				Description:        "stack",
+				CustomNestedStacks: tc.stacks,
+			}, "app1", "cfg1")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestStackConfigAllowsAzureARMJSONCustomStack(t *testing.T) {
+	obj, err := StackConfig(&config.StackConfig{
+		Type:        string(app.StackTypeAzure),
+		Name:        "stack",
+		Description: "stack",
+		CustomNestedStacks: []config.CustomNestedStack{
+			{Name: "storage", Index: 0, TemplateURL: "./arm/storage.json", Contents: `{"$schema":"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[]}`},
+		},
+	}, "app1", "cfg1")
+	require.NoError(t, err)
+	require.Len(t, obj.CustomNestedStacks, 1)
+	assert.Equal(t, config.CustomNestedStackStatusPending, obj.CustomNestedStacks[0].Status)
+}
+
+func TestStackConfigRejectsInvalidGCPCustomStackModule(t *testing.T) {
+	_, err := StackConfig(&config.StackConfig{
+		Type:        string(app.StackTypeGCP),
+		Name:        "stack",
+		Description: "stack",
+		CustomNestedStacks: []config.CustomNestedStack{
+			{Name: "bucket", Index: 0, TemplateURL: "https://example.com/template.tf", Contents: "{}"},
+		},
+	}, "app1", "cfg1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must reference a gcp modules path")
+}
+
+func TestStackConfigAllowsGCPModuleWithoutTemplateContents(t *testing.T) {
+	obj, err := StackConfig(&config.StackConfig{
+		Type:        string(app.StackTypeGCP),
+		Name:        "stack",
+		Description: "stack",
+		CustomNestedStacks: []config.CustomNestedStack{
+			{Name: "storage", Index: 0, TemplateURL: "github.com/nuonco/install-stacks//gcp/modules/bucket"},
+		},
+	}, "app1", "cfg1")
+	require.NoError(t, err)
+	require.Len(t, obj.CustomNestedStacks, 1)
+	assert.Equal(t, config.CustomNestedStackStatusReady, obj.CustomNestedStacks[0].Status)
+}
+
+func TestStackConfigRejectsGCPDNSWithoutName(t *testing.T) {
+	_, err := StackConfig(&config.StackConfig{
+		Type:        string(app.StackTypeGCP),
+		Name:        "stack",
+		Description: "stack",
+		CustomNestedStacks: []config.CustomNestedStack{
+			{Name: "dns", Index: 0, TemplateURL: "github.com/nuonco/install-stacks//gcp/modules/dns"},
+		},
+	}, "app1", "cfg1")
+	require.EqualError(t, err, "custom_nested_stacks[0] (dns): parameters.dns_name is required for the GCP dns module")
+}
+
 func TestPoliciesConfigKeepsName(t *testing.T) {
 	obj, err := PoliciesConfig(PolicyInputsFromConfig(&config.PoliciesConfig{
 		Policies: []config.AppPolicy{

--- a/services/ctl-api/internal/pkg/config/build/stack.go
+++ b/services/ctl-api/internal/pkg/config/build/stack.go
@@ -24,18 +24,34 @@ func StackConfig(stack *config.StackConfig, appID, appConfigID string) (*app.App
 	if err := config.ValidateDeploymentScope(stack.DeploymentScope, stack.Type); err != nil {
 		return nil, err
 	}
+	if err := config.ValidateAzureCustomNestedStacks(stack.Type, stack.CustomNestedStacks); err != nil {
+		return nil, err
+	}
+	if err := config.ValidateGCPCustomNestedStacks(stack.Type, stack.CustomNestedStacks); err != nil {
+		return nil, err
+	}
 
 	// Copy so marking the upload status pending does not mutate the caller's
 	// parsed config.
 	customNestedStacks := make([]config.CustomNestedStack, 0, len(stack.CustomNestedStacks))
+	seenNames := make(map[string]int, len(stack.CustomNestedStacks))
+	seenIndices := make(map[int]string, len(stack.CustomNestedStacks))
 	for i, nested := range stack.CustomNestedStacks {
 		if nested.Name == "" {
 			return nil, fmt.Errorf("custom_nested_stacks[%d]: name is required", i)
 		}
+		if prev, exists := seenNames[nested.Name]; exists {
+			return nil, fmt.Errorf("custom_nested_stacks[%d] (%s): name is already used by custom_nested_stacks[%d]; each stack must have a unique name", i, nested.Name, prev)
+		}
+		seenNames[nested.Name] = i
+		if prev, exists := seenIndices[nested.Index]; exists {
+			return nil, fmt.Errorf("custom_nested_stacks: index %d is used by both %q and %q; each stack must have a unique index", nested.Index, prev, nested.Name)
+		}
+		seenIndices[nested.Index] = nested.Name
 		if nested.TemplateURL == "" {
 			return nil, fmt.Errorf("custom_nested_stacks[%d] (%s): template_url is required", i, nested.Name)
 		}
-		if nested.Contents == "" {
+		if stackType != app.StackTypeGCP && nested.Contents == "" {
 			return nil, fmt.Errorf("custom_nested_stacks[%d] (%s): contents is required when template_url is set", i, nested.Name)
 		}
 		for paramName, paramValue := range nested.Parameters {
@@ -44,9 +60,11 @@ func StackConfig(stack *config.StackConfig, appID, appConfigID string) (*app.App
 			}
 		}
 
-		// Pending until the contents have been uploaded to S3; consumers gate
-		// on Status before generating a stack from these templates.
-		nested.Status = config.CustomNestedStackStatusPending
+		if stackType == app.StackTypeGCP {
+			nested.Status = config.CustomNestedStackStatusReady
+		} else {
+			nested.Status = config.CustomNestedStackStatusPending
+		}
 		customNestedStacks = append(customNestedStacks, nested)
 	}
 

--- a/services/ctl-api/internal/pkg/stacks/arm/arm.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/arm.go
@@ -41,6 +41,24 @@ func (t *Templates) Template(inp *stacks.TemplateInput) ([]byte, string, error) 
 		return nil, "", err
 	}
 
+	return marshalTemplate(tmpl)
+}
+
+func (t *Templates) CustomStacksTemplate(inp *stacks.TemplateInput) ([]byte, string, map[string]map[string]string, map[string]map[string]string, error) {
+	tmpl, outputMap, inputParametersMap, err := t.getAzureCustomStacksOnlyTemplate(inp)
+	if err != nil {
+		return nil, "", nil, nil, err
+	}
+
+	tmplBytes, checksum, err := marshalTemplate(tmpl)
+	if err != nil {
+		return nil, "", nil, nil, err
+	}
+
+	return tmplBytes, checksum, outputMap, inputParametersMap, nil
+}
+
+func marshalTemplate(tmpl *ARMTemplate) ([]byte, string, error) {
 	tmplBytes, err := json.MarshalIndent(tmpl, "", "  ")
 	if err != nil {
 		return nil, "", fmt.Errorf("unable to marshal ARM template: %w", err)

--- a/services/ctl-api/internal/pkg/stacks/arm/custom_stacks_only_template.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/custom_stacks_only_template.go
@@ -1,0 +1,159 @@
+package arm
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/nuonco/nuon/pkg/config"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks"
+)
+
+const customStacksResourceGroupParameter = "nuonResourceGroupName"
+
+func (t *Templates) getAzureCustomStacksOnlyTemplate(inp *stacks.TemplateInput) (*ARMTemplate, map[string]map[string]string, map[string]map[string]string, error) {
+	scope := armScope{subscription: true}
+	tmpl := &ARMTemplate{
+		Schema:         subscriptionTemplateSchema,
+		ContentVersion: "1.0.0.0",
+		Parameters:     make(map[string]ARMParameter),
+		Variables: map[string]any{
+			installRGVarName: "[parameters('" + customStacksResourceGroupParameter + "')]",
+			locationVarName:  "[parameters('location')]",
+		},
+		Resources: []any{},
+		Outputs:   make(map[string]ARMOutput),
+	}
+
+	contractParameters := append([]string{}, vnetContractOutputs...)
+	contractParameters = append(contractParameters, customStacksResourceGroupParameter, "location")
+	for _, name := range contractParameters {
+		tmpl.Parameters[name] = ARMParameter{Type: "string"}
+	}
+
+	resources, params, identities, outputs, err := t.getCustomLinkedDeployments(inp)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if len(resources) == 0 {
+		return nil, nil, nil, fmt.Errorf("custom stacks only template requested but app config has no custom_nested_stacks configured")
+	}
+
+	tmpl.Resources = append(tmpl.Resources, resources...)
+	rootParameterNames := make(map[string]string, len(tmpl.Parameters))
+	for name := range tmpl.Parameters {
+		rootParameterNames[strings.ToLower(name)] = name
+	}
+	for name, param := range params {
+		if existing, exists := rootParameterNames[strings.ToLower(name)]; exists {
+			return nil, nil, nil, fmt.Errorf("custom stacks only template: parameter %q conflicts with the Nuon module contract parameter %q", name, existing)
+		}
+		tmpl.Parameters[name] = param
+		rootParameterNames[strings.ToLower(name)] = name
+	}
+	inputParametersMap, err := liftCustomStackInstallInputs(tmpl, inp, resources, outputs)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	for _, identity := range identities {
+		tmpl.Resources = append(tmpl.Resources, t.getCustomDeploymentRoleAssignment(identity, inp.Install.ID, scope))
+	}
+
+	outputMap := make(map[string]map[string]string, len(outputs))
+	seen := make(map[string]string)
+	for _, stackOutput := range outputs {
+		stackMap := make(map[string]string, len(stackOutput.OutputKeys))
+		for _, outputKey := range stackOutput.OutputKeys {
+			flatName := sanitizeDeploymentName(stackOutput.StackName) + sanitizeDeploymentName(outputKey)
+			if flatName == "" {
+				return nil, nil, nil, fmt.Errorf("custom stacks only template: stack %q output %q produces an empty output name", stackOutput.StackName, outputKey)
+			}
+			canonicalName := strings.ToLower(flatName)
+			if owner, exists := seen[canonicalName]; exists {
+				return nil, nil, nil, fmt.Errorf("custom stacks only template: output name %q collides between %s and %s.%s", flatName, owner, stackOutput.StackName, outputKey)
+			}
+			seen[canonicalName] = stackOutput.StackName + "." + outputKey
+			stackMap[outputKey] = flatName
+			tmpl.Outputs[flatName] = ARMOutput{
+				Type:  "string",
+				Value: fmt.Sprintf("[string(reference('%s').outputs.%s.value)]", stackOutput.DeploymentName, outputKey),
+			}
+		}
+		outputMap[stackOutput.StackName] = stackMap
+	}
+
+	return tmpl, outputMap, inputParametersMap, nil
+}
+
+func liftCustomStackInstallInputs(
+	tmpl *ARMTemplate,
+	inp *stacks.TemplateInput,
+	resources []any,
+	outputs []customDeploymentOutputs,
+) (map[string]map[string]string, error) {
+	deploymentNames := make(map[string]string, len(outputs))
+	for _, output := range outputs {
+		deploymentNames[output.StackName] = output.DeploymentName
+	}
+	deployments := make(map[string]map[string]any, len(resources))
+	for _, resource := range resources {
+		deployment := resource.(map[string]any)
+		deployments[deployment["name"].(string)] = deployment
+	}
+
+	result := make(map[string]map[string]string)
+	owners := make(map[string]string)
+	rootParameterNames := make(map[string]struct{}, len(tmpl.Parameters))
+	for name := range tmpl.Parameters {
+		rootParameterNames[strings.ToLower(name)] = struct{}{}
+	}
+	customerInputNames := make(map[string]struct{})
+	for _, input := range inp.AppCfg.InputConfig.AppInputs {
+		if input.Source == app.AppInputSourceCustomer {
+			customerInputNames[input.Name] = struct{}{}
+		}
+	}
+	for _, stack := range inp.AppCfg.StackConfig.CustomNestedStacks {
+		deployment := deployments[deploymentNames[stack.Name]]
+		if deployment == nil {
+			continue
+		}
+		properties := deployment["properties"].(map[string]any)
+		parameters := properties["parameters"].(map[string]any)
+
+		for _, parameterName := range slices.Sorted(maps.Keys(inp.UnrenderedCustomStackParameters[stack.Name])) {
+			inputName, err := config.ParseInstallInputReference(inp.UnrenderedCustomStackParameters[stack.Name][parameterName])
+			if err != nil {
+				continue
+			}
+			if _, ok := customerInputNames[inputName]; !ok {
+				continue
+			}
+			if _, exists := parameters[parameterName]; !exists {
+				continue
+			}
+
+			topLevelName := sanitizeDeploymentName(stack.Name) + sanitizeDeploymentName(parameterName)
+			canonicalName := strings.ToLower(topLevelName)
+			if owner, exists := owners[canonicalName]; exists {
+				return nil, fmt.Errorf("custom stacks only template: input parameter name %q collides between %s and %s.%s", topLevelName, owner, stack.Name, parameterName)
+			}
+			if _, exists := rootParameterNames[canonicalName]; exists {
+				return nil, fmt.Errorf("custom stacks only template: input parameter %s.%s conflicts with root parameter %q", stack.Name, parameterName, topLevelName)
+			}
+
+			owners[canonicalName] = stack.Name + "." + parameterName
+			rootParameterNames[canonicalName] = struct{}{}
+			tmpl.Parameters[topLevelName] = ARMParameter{Type: "string"}
+			parameters[parameterName] = map[string]any{"value": "[parameters('" + topLevelName + "')]"}
+			if result[stack.Name] == nil {
+				result[stack.Name] = make(map[string]string)
+			}
+			result[stack.Name][topLevelName] = inputName
+		}
+	}
+
+	return result, nil
+}

--- a/services/ctl-api/internal/pkg/stacks/arm/custom_stacks_only_template_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/custom_stacks_only_template_test.go
@@ -1,0 +1,115 @@
+package arm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+)
+
+const customStacksOnlyTestTemplate = `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vnetId": { "type": "string" },
+    "setting": { "type": "string", "defaultValue": "default" }
+  },
+  "resources": [],
+  "outputs": {
+    "resourceName": { "type": "string", "value": "[parameters('setting')]" }
+  }
+}`
+
+func TestAzureCustomStacksOnlyTemplate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(customStacksOnlyTestTemplate))
+	}))
+	defer server.Close()
+
+	inp := armCustomStackInput(t, server.URL, map[string]string{"setting": "sensitive-value"})
+	inp.CustomStacksOnly = true
+	inp.UnrenderedCustomStackParameters = map[string]map[string]string{
+		"route53_zones": {"setting": "{{.nuon.install.inputs.setting}}"},
+	}
+	inp.AppCfg.InputConfig.AppInputs = []app.AppInput{
+		{Name: "setting", Source: app.AppInputSourceCustomer},
+	}
+
+	templates := &Templates{cfg: &internal.Config{}}
+	tmpl, outputMap, inputParametersMap, err := templates.getAzureCustomStacksOnlyTemplate(inp)
+	require.NoError(t, err)
+
+	assert.Equal(t, subscriptionTemplateSchema, tmpl.Schema)
+	assert.Contains(t, tmpl.Parameters, customStacksResourceGroupParameter)
+	assert.Contains(t, tmpl.Parameters, "location")
+	assert.Contains(t, tmpl.Parameters, "vnetId")
+	assert.NotContains(t, tmpl.Parameters, "setting")
+	assert.Contains(t, tmpl.Parameters, "Route53ZonesSetting")
+	assert.Equal(t, "[parameters('"+customStacksResourceGroupParameter+"')]", tmpl.Variables[installRGVarName])
+
+	require.Len(t, tmpl.Resources, 1)
+	deployment := tmpl.Resources[0].(map[string]any)
+	assert.Equal(t, "[variables('"+installRGVarName+"')]", deployment["resourceGroup"])
+	assert.Empty(t, deployment["dependsOn"])
+	assert.Equal(t, "[parameters('vnetId')]", armDeploymentParamValue(t, deployment, "vnetId"))
+	assert.Equal(t, "[parameters('Route53ZonesSetting')]", armDeploymentParamValue(t, deployment, "setting"))
+	assert.Equal(t, "setting", inputParametersMap["route53_zones"]["Route53ZonesSetting"])
+
+	flatName := outputMap["route53_zones"]["resourceName"]
+	require.NotEmpty(t, flatName)
+	assert.Equal(t, "[string(reference('"+deployment["name"].(string)+"').outputs.resourceName.value)]", tmpl.Outputs[flatName].Value)
+}
+
+func TestAzureCustomStacksOnlyTemplateBakesVendorInputs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(customStacksOnlyTestTemplate))
+	}))
+	defer server.Close()
+
+	inp := armCustomStackInput(t, server.URL, map[string]string{"setting": "vendor-value"})
+	inp.CustomStacksOnly = true
+	inp.UnrenderedCustomStackParameters = map[string]map[string]string{
+		"route53_zones": {"setting": "{{.nuon.install.inputs.setting}}"},
+	}
+	inp.AppCfg.InputConfig.AppInputs = []app.AppInput{
+		{Name: "setting", Source: app.AppInputSourceVendor},
+	}
+
+	templates := &Templates{cfg: &internal.Config{}}
+	tmpl, _, inputParametersMap, err := templates.getAzureCustomStacksOnlyTemplate(inp)
+	require.NoError(t, err)
+
+	assert.NotContains(t, tmpl.Parameters, "Route53ZonesSetting")
+	deployment := tmpl.Resources[0].(map[string]any)
+	assert.Equal(t, "vendor-value", armDeploymentParamValue(t, deployment, "setting"))
+	assert.Empty(t, inputParametersMap)
+}
+
+func TestAzureCustomStacksOnlyTemplateTargetsSubscriptionScopedChildren(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+		  "$schema": "` + subscriptionTemplateSchema + `",
+		  "contentVersion": "1.0.0.0",
+		  "resources": [],
+		  "outputs": {}
+		}`))
+	}))
+	defer server.Close()
+
+	inp := armCustomStackInput(t, server.URL, nil)
+	inp.CustomStacksOnly = true
+
+	templates := &Templates{cfg: &internal.Config{}}
+	tmpl, _, _, err := templates.getAzureCustomStacksOnlyTemplate(inp)
+	require.NoError(t, err)
+
+	require.Len(t, tmpl.Resources, 1)
+	deployment := tmpl.Resources[0].(map[string]any)
+	assert.NotContains(t, deployment, "resourceGroup")
+	assert.Equal(t, "[variables('location')]", deployment["location"])
+}

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom.go
@@ -92,12 +92,18 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 	prevDeploymentName := ""
 
 	scope := scopeFor(inp)
+	if inp.CustomStacksOnly {
+		scope = armScope{subscription: true}
+	}
 	vnetDeployment := scope.vnetDeploymentName(inp.Install.ID)
 
-	// param name -> producing deployment; seeded with vnet outputs so they win over custom ones
 	wiredOutputs := map[string]string{}
 	for _, name := range vnetContractOutputs {
-		wiredOutputs[name] = vnetDeployment
+		if inp.CustomStacksOnly {
+			wiredOutputs[name] = fmt.Sprintf("[parameters('%s')]", name)
+			continue
+		}
+		wiredOutputs[name] = fmt.Sprintf("[reference('%s').outputs.%s.value]", vnetDeployment, name)
 	}
 
 	for i, stack := range sorted {
@@ -124,7 +130,9 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 
 		// Resolve template URL (use uploaded S3 URL if contents were uploaded)
 		templateURL := stack.TemplateURL
-		if stack.ContentsHash != "" && t.cfg.AWSCloudFormationStackTemplateBaseURL != "" {
+		if stack.TemplateSourceURL != "" {
+			templateURL = stack.TemplateSourceURL
+		} else if stack.ContentsHash != "" && t.cfg.AWSCloudFormationStackTemplateBaseURL != "" {
 			templateURL = cloudformation.CustomNestedStackTemplateURL(
 				t.cfg.AWSCloudFormationStackTemplateBaseURL,
 				inp.Install.OrgID,
@@ -199,7 +207,7 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 			// Evaluated in the root, so it has to follow the root's declaration of the
 			// region — a parameter at resource-group scope, a variable at subscription
 			// scope where it is hidden from the portal's deployment form.
-			"location": scopeFor(inp).rootLocationRef(),
+			"location": scope.rootLocationRef(),
 		}
 		for paramName := range params {
 			if val, ok := nuonParams[paramName]; ok {
@@ -232,18 +240,23 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 			if _, alreadySet := deploymentParams[paramName]; alreadySet {
 				continue
 			}
-			sourceDeployment, ok := wiredOutputs[paramName]
+			sourceValue, ok := wiredOutputs[paramName]
 			if !ok {
 				continue
 			}
 
 			deploymentParams[paramName] = map[string]any{
-				"value": fmt.Sprintf("[reference('%s').outputs.%s.value]", sourceDeployment, paramName),
+				"value": sourceValue,
 			}
 			delete(defaultParams, paramName)
 		}
 
-		// Runs after pruning: only names that actually reach the parent can conflict
+		for paramName, param := range defaultParams {
+			if !hoistableDefault(param.DefaultValue) {
+				delete(defaultParams, paramName)
+			}
+		}
+
 		for paramName := range defaultParams {
 			if owner, exists := allParamNames[paramName]; exists {
 				return nil, nil, nil, nil, fmt.Errorf("custom_nested_stacks[%d] (%s): parameter %q conflicts with stack %q", i, stack.Name, paramName, owner)
@@ -267,7 +280,7 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 		var dependsOn []string
 		if prevDeploymentName != "" {
 			dependsOn = append(dependsOn, prevDeploymentName)
-		} else {
+		} else if !inp.CustomStacksOnly {
 			dependsOn = append(dependsOn, vnetDeployment)
 			if !t.cfg.UseLocalRunners {
 				dependsOn = append(dependsOn, "runnerDeployment")
@@ -288,6 +301,14 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 			},
 		}
 
+		if isSubscriptionScopedTemplate(armTmpl) {
+			scope.targetSubscription(deployment)
+		} else if inp.CustomStacksOnly {
+			deployment["resourceGroup"] = scope.rgNameExpr()
+		} else {
+			scope.targetInstallRG(deployment)
+		}
+
 		resources = append(resources, deployment)
 
 		// Registered after the deployment so a stack cannot wire to its own outputs
@@ -297,7 +318,7 @@ func (t *Templates) getCustomLinkedDeployments(inp *stacks.TemplateInput) ([]any
 				continue
 			}
 			if _, exists := wiredOutputs[key]; !exists {
-				wiredOutputs[key] = deploymentName
+				wiredOutputs[key] = fmt.Sprintf("[reference('%s').outputs.%s.value]", deploymentName, key)
 			}
 		}
 

--- a/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom_test.go
+++ b/services/ctl-api/internal/pkg/stacks/arm/linked_deployment_custom_test.go
@@ -107,6 +107,59 @@ func TestGetCustomLinkedDeployments_ExplicitParameters(t *testing.T) {
 	})
 }
 
+func TestGetCustomLinkedDeployments_UsesUploadedTemplateSourceURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/uploaded.json", r.URL.Path)
+		_, _ = w.Write([]byte(mockARMCustomTemplateJSON))
+	}))
+	defer server.Close()
+
+	inp := armCustomStackInput(t, "relative", map[string]string{"rootDomain": "example.com"})
+	inp.AppCfg.StackConfig.CustomNestedStacks[0].TemplateURL = "./stack.json"
+	inp.AppCfg.StackConfig.CustomNestedStacks[0].TemplateSourceURL = server.URL + "/uploaded.json"
+
+	templates := &Templates{cfg: &internal.Config{}}
+	resources, _, _, _, err := templates.getCustomLinkedDeployments(inp)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+
+	deployment := resources[0].(map[string]any)
+	properties := deployment["properties"].(map[string]any)
+	templateLink := properties["templateLink"].(map[string]any)
+	assert.Equal(t, server.URL+"/uploaded.json", templateLink["uri"])
+}
+
+func TestGetCustomLinkedDeployments_NonHoistableDefaultDoesNotConflict(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defaultValue := `"literal"`
+		if r.URL.Path == "/expression.json" {
+			defaultValue = `"[variables('computed')]"`
+		}
+		_, _ = w.Write([]byte(`{
+		  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+		  "contentVersion": "1.0.0.0",
+		  "parameters": {
+		    "setting": { "type": "string", "defaultValue": ` + defaultValue + ` }
+		  },
+		  "resources": [],
+		  "outputs": {}
+		}`))
+	}))
+	defer server.Close()
+
+	inp := minimalTemplateInput()
+	inp.AppCfg.StackConfig.CustomNestedStacks = []config.CustomNestedStack{
+		{Name: "literal", Index: 0, TemplateURL: server.URL + "/literal.json"},
+		{Name: "expression", Index: 1, TemplateURL: server.URL + "/expression.json"},
+	}
+
+	templates := &Templates{cfg: &internal.Config{}}
+	_, hoisted, _, _, err := templates.getCustomLinkedDeployments(inp)
+	require.NoError(t, err)
+	require.Contains(t, hoisted, "setting")
+	assert.Equal(t, "literal", hoisted["setting"].DefaultValue)
+}
+
 func armDeploymentParamValue(t *testing.T, resource any, name string) any {
 	t.Helper()
 

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/custom_stacks_only_template_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/custom_stacks_only_template_test.go
@@ -155,6 +155,12 @@ func newCustomStacksOnlyInput(customStacks []config.CustomNestedStack) *stacks.T
 			StackConfig: app.AppStackConfig{
 				CustomNestedStacks: customStacks,
 			},
+			InputConfig: app.AppInputConfig{
+				AppInputs: []app.AppInput{
+					{Name: "namespaces", Source: app.AppInputSourceCustomer},
+					{Name: "some_arn", Source: app.AppInputSourceCustomer},
+				},
+			},
 		},
 		Settings:         &app.RunnerGroupSettings{},
 		CustomStacksOnly: true,
@@ -475,6 +481,40 @@ func TestGetAWSCustomStacksOnlyTemplate_SimpleInstallInputParameterIsHoisted(t *
 	require.Contains(t, tmpl.Parameters, "K8SNamespacesNamespaces")
 	assert.Equal(t, "String", tmpl.Parameters["K8SNamespacesNamespaces"].Type)
 	assert.NotContains(t, tmpl.Parameters, "K8SNamespacesRootDomain")
+}
+
+func TestGetAWSCustomStacksOnlyTemplate_VendorInputParameterIsBaked(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(mockHoistableParamTemplateYAML))
+	}))
+	defer server.Close()
+
+	tpl := &Templates{cfg: &internal.Config{}}
+	inp := newCustomStacksOnlyInput([]config.CustomNestedStack{
+		{
+			Name:        "k8s-namespaces",
+			TemplateURL: server.URL + "/stack.yaml",
+			Index:       0,
+			Parameters: map[string]string{
+				"Namespaces": "vendor-namespace",
+				"RootDomain": "example.com",
+			},
+		},
+	})
+	inp.AppCfg.InputConfig.AppInputs = []app.AppInput{
+		{Name: "namespaces", Source: app.AppInputSourceVendor},
+	}
+	inp.UnrenderedCustomStackParameters = map[string]map[string]string{
+		"k8s-namespaces": {"Namespaces": "{{.nuon.install.inputs.namespaces}}"},
+	}
+
+	tmpl, err := tpl.getAWSTemplate(inp)
+	require.NoError(t, err)
+	assert.NotContains(t, tmpl.Parameters, "K8SNamespacesNamespaces")
+
+	stack := tmpl.Resources["K8SNamespaces"].(*nestedcloudformation.Stack)
+	assert.Equal(t, "vendor-namespace", stack.Parameters["Namespaces"])
+	require.Empty(t, ExtractAndStripCustomStacksInputParameters(tmpl))
 }
 
 func TestGetAWSCustomStacksOnlyTemplate_ComplexExpressionParameterIsBaked(t *testing.T) {

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_custom.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_custom.go
@@ -258,21 +258,29 @@ func (tpl *Templates) buildCustomNestedStack(inp *stacks.TemplateInput, stack co
 	hoistedParams := map[string]string{}
 	installInputParams := map[string]string{}
 	explicitlyConfigured := map[string]bool{}
+	customerInputNames := map[string]struct{}{}
+	for _, input := range inp.AppCfg.InputConfig.AppInputs {
+		if input.Source == app.AppInputSourceCustomer {
+			customerInputNames[input.Name] = struct{}{}
+		}
+	}
 
 	for cfnParamName, templateValue := range stack.Parameters {
 		explicitlyConfigured[cfnParamName] = true
 		if inp.CustomStacksOnly {
 			if unrendered, ok := inp.UnrenderedCustomStackParameters[stack.Name][cfnParamName]; ok {
 				if inputName, err := config.ParseInstallInputReference(unrendered); err == nil {
-					topLevelParamName := logicalID + cfnParamName
-					_, contractCollision := roleParams[topLevelParamName]
-					_, reservedCollision := reservedParamNames[topLevelParamName]
-					contractCollision = contractCollision || slices.Contains(AWSCustomStacksOnlyContractParams, topLevelParamName)
-					if !contractCollision && !reservedCollision {
-						hoistedParams[topLevelParamName] = inputName
-						parameters[cfnParamName] = cloudformation.Ref(topLevelParamName)
-						delete(defaultParameters, cfnParamName)
-						continue
+					if _, ok := customerInputNames[inputName]; ok {
+						topLevelParamName := logicalID + cfnParamName
+						_, contractCollision := roleParams[topLevelParamName]
+						_, reservedCollision := reservedParamNames[topLevelParamName]
+						contractCollision = contractCollision || slices.Contains(AWSCustomStacksOnlyContractParams, topLevelParamName)
+						if !contractCollision && !reservedCollision {
+							hoistedParams[topLevelParamName] = inputName
+							parameters[cfnParamName] = cloudformation.Ref(topLevelParamName)
+							delete(defaultParameters, cfnParamName)
+							continue
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Custom nested stacks now work on Azure and GCP the same way AWS already does. The control plane renders ARM templates, validates compiled ARM JSON, filters vendor-owned inputs out of customer-hoisted parameters, and rejects invalid GCP module paths and missing DNS names at sync time. Existing AWS configs are unchanged; installs without custom stacks stay a no-op. `--region` is required for every cloud on install create.