### PR TITLE
fix: missing app branch working directory

### DIFF
--- a/bins/cli/internal/ui/print.go
+++ b/bins/cli/internal/ui/print.go
@@ -76,6 +76,12 @@ func printHumanError(err error) error {
 		return err
 	}
 
+	var parseErr parse.ParseErr
+	if errors.As(err, &parseErr) {
+		fmt.Println(bubbles.ErrorStyle.Render(parseErr.Error()))
+		return parseErr
+	}
+
 	var cfgErr config.ErrConfig
 	if errors.As(err, &cfgErr) {
 		if cfgErr.Warning {
@@ -103,16 +109,6 @@ func printHumanError(err error) error {
 	if errors.As(err, &syncAPIErr) {
 		fmt.Println(bubbles.ErrorStyle.Render(syncAPIErr.Error()))
 		return syncAPIErr
-	}
-
-	var parseErr parse.ParseErr
-	if errors.As(err, &parseErr) {
-		fmt.Println(bubbles.ErrorStyle.Render(parseErr.Error()))
-		if parseErr.Err != nil {
-			fmt.Println(bubbles.ErrorStyle.Render(parseErr.Err.Error()))
-		}
-
-		return parseErr
 	}
 
 	// Filter out ugly technical error messages that shouldn't be shown to users

--- a/pkg/config/app_input.go
+++ b/pkg/config/app_input.go
@@ -108,7 +108,7 @@ func (a AppInputConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Long("Array of paths to external files containing additional input definitions. Each file is loaded and merged into the inputs configuration. Supports YAML, JSON, and TOML formats")
 }
 
-func (a *AppInputConfig) parse() error {
+func (a *AppInputConfig) parse(rootDir string) error {
 	sources := make([]string, 0)
 	if a.Source != "" {
 		sources = append(sources, a.Source)
@@ -116,7 +116,7 @@ func (a *AppInputConfig) parse() error {
 	sources = append(sources, a.Sources...)
 
 	for _, src := range sources {
-		obj, err := source.LoadSource(src)
+		obj, err := source.LoadSourceFrom(src, rootDir)
 		if err != nil {
 			return ErrConfig{
 				Description: fmt.Sprintf("unable to load source %s", src),

--- a/pkg/config/app_runner.go
+++ b/pkg/config/app_runner.go
@@ -72,7 +72,7 @@ func (a AppRunnerConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Long("Deprecated: Array of name/value pairs for environment variables. Use the env_vars map instead")
 }
 
-func (a *AppRunnerConfig) parse() error {
+func (a *AppRunnerConfig) parse(rootDir string) error {
 	if a == nil {
 		return ErrConfig{
 			Description: "an app runner config is required",
@@ -89,7 +89,7 @@ func (a *AppRunnerConfig) parse() error {
 		return nil
 	}
 
-	obj, err := source.LoadSource(a.Source)
+	obj, err := source.LoadSourceFrom(a.Source, rootDir)
 	if err != nil {
 		return ErrConfig{
 			Description: fmt.Sprintf("unable to load source %s", a.Source),

--- a/pkg/config/app_sandbox.go
+++ b/pkg/config/app_sandbox.go
@@ -94,7 +94,7 @@ func (a AppSandboxConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 		Example("true")
 }
 
-func (a *AppSandboxConfig) parse() error {
+func (a *AppSandboxConfig) parse(rootDir string) error {
 	if a == nil {
 		return ErrConfig{
 			Description: "an app sandbox config is required",
@@ -111,7 +111,7 @@ func (a *AppSandboxConfig) parse() error {
 		return nil
 	}
 
-	obj, err := source.LoadSource(a.Source)
+	obj, err := source.LoadSourceFrom(a.Source, rootDir)
 	if err != nil {
 		return ErrConfig{
 			Description: fmt.Sprintf("unable to load source %s", a.Source),

--- a/pkg/config/component.go
+++ b/pkg/config/component.go
@@ -90,13 +90,13 @@ type Component struct {
 	Checksum   string     `mapstructure:"-" jsonschema:"-" toml:"checksum" nuonhash:"-"`
 }
 
-func (c *Component) parse() error {
+func (c *Component) parse(rootDir string) error {
 	if c == nil {
 		return nil
 	}
 
 	if c.HelmChart != nil {
-		if err := c.HelmChart.Parse(); err != nil {
+		if err := c.HelmChart.parse(rootDir); err != nil {
 			return err
 		}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -139,15 +139,16 @@ type parseFn struct {
 	fn   func() error
 }
 
-func (a *AppConfig) Parse() error {
+func (a *AppConfig) Parse(opts ...ParseOption) error {
+	cfg := parseOptions(opts...)
 	parseFns := []parseFn{
 		{
 			"sandbox",
-			a.Sandbox.parse,
+			func() error { return a.Sandbox.parse(cfg.RootDir) },
 		},
 		{
 			"runner",
-			a.Runner.parse,
+			func() error { return a.Runner.parse(cfg.RootDir) },
 		},
 	}
 
@@ -160,7 +161,7 @@ func (a *AppConfig) Parse() error {
 	if a.Inputs != nil {
 		parseFns = append(parseFns, parseFn{
 			"inputs",
-			a.Inputs.parse,
+			func() error { return a.Inputs.parse(cfg.RootDir) },
 		})
 	}
 	if a.Permissions != nil {
@@ -204,7 +205,7 @@ func (a *AppConfig) Parse() error {
 	for idx, comp := range a.Components {
 		parseFns = append(parseFns, parseFn{
 			fmt.Sprintf("components.%d", idx),
-			comp.parse,
+			func() error { return comp.parse(cfg.RootDir) },
 		})
 	}
 

--- a/pkg/config/decode_component.go
+++ b/pkg/config/decode_component.go
@@ -28,7 +28,13 @@ import (
 //return obj, nil
 //}
 
-func DecodeComponent(fromType reflect.Type, toType reflect.Type, from interface{}) (interface{}, error) {
+func DecodeComponent(rootDir string) mapstructure.DecodeHookFunc {
+	return func(fromType reflect.Type, toType reflect.Type, from interface{}) (interface{}, error) {
+		return decodeComponent(fromType, toType, from, rootDir)
+	}
+}
+
+func decodeComponent(fromType reflect.Type, toType reflect.Type, from interface{}, rootDir string) (interface{}, error) {
 	if fromType != reflect.TypeOf(map[string]interface{}{}) {
 		return from, nil
 	}
@@ -39,7 +45,7 @@ func DecodeComponent(fromType reflect.Type, toType reflect.Type, from interface{
 	obj := from.(map[string]interface{})
 	src, ok := obj["source"]
 	if ok {
-		srcObj, err := source.LoadSource(src.(string))
+		srcObj, err := source.LoadSourceFrom(src.(string), rootDir)
 		if err != nil {
 			return from, ErrConfig{
 				Description: "unable to load source",

--- a/pkg/config/decoder.go
+++ b/pkg/config/decoder.go
@@ -4,8 +4,9 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-func DecoderConfig() *mapstructure.DecoderConfig {
+func DecoderConfig(opts ...ParseOption) *mapstructure.DecoderConfig {
+	cfg := parseOptions(opts...)
 	return &mapstructure.DecoderConfig{
-		DecodeHook: mapstructure.ComposeDecodeHookFunc(DecodeSource, DecodeComponent, DecodeInstallInputs),
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(DecodeSource, DecodeComponent(cfg.RootDir), DecodeInstallInputs),
 	}
 }

--- a/pkg/config/helm_chart_component.go
+++ b/pkg/config/helm_chart_component.go
@@ -18,9 +18,9 @@ func (h HelmValue) JSONSchemaExtend(schema *jsonschema.Schema) {
 }
 
 type HelmValuesFile struct {
-	Source   string `toml:"source" mapstructure:"source,omitempty" features:"get,template"`
+	Source   string `toml:"source" mapstructure:"source,omitempty" features:"template"`
 	Contents string `toml:"contents" mapstructure:"contents,omitempty" features:"get,template"`
-	Path     string `toml:"path" mapstructure:"path,omitempty" features:"get"`
+	Path     string `toml:"path" mapstructure:"path,omitempty"`
 }
 
 func (h HelmValuesFile) JSONSchemaExtend(schema *jsonschema.Schema) {
@@ -141,6 +141,10 @@ func (h HelmRepoConfig) JSONSchemaExtend(schema *jsonschema.Schema) {
 }
 
 func (h *HelmChartComponentConfig) Parse() error {
+	return h.parse("")
+}
+
+func (h *HelmChartComponentConfig) parse(rootDir string) error {
 	if len(h.Values) > 0 {
 		return ErrConfig{
 			Description: "the value array is deprecated, please use values instead.",
@@ -158,7 +162,7 @@ func (h *HelmChartComponentConfig) Parse() error {
 			continue
 		}
 
-		byts, err := source.ReadSource(sourceToUse)
+		byts, err := source.ReadSourceFrom(sourceToUse, rootDir)
 		if err != nil {
 			return ErrConfig{
 				Description: "error loading values file " + sourceToUse,

--- a/pkg/config/parse/err.go
+++ b/pkg/config/parse/err.go
@@ -1,5 +1,7 @@
 package parse
 
+import "fmt"
+
 type ParseErr struct {
 	Filename    string
 	Description string
@@ -7,8 +9,16 @@ type ParseErr struct {
 }
 
 func (p ParseErr) Error() string {
-	if p.Filename != "" {
-		return p.Filename + ": " + p.Description
+	description := p.Description
+	if p.Err != nil {
+		description = fmt.Sprintf("%s: %v", description, p.Err)
 	}
-	return p.Description
+	if p.Filename != "" {
+		return p.Filename + ": " + description
+	}
+	return description
+}
+
+func (p ParseErr) Unwrap() error {
+	return p.Err
 }

--- a/pkg/config/parse/err_test.go
+++ b/pkg/config/parse/err_test.go
@@ -1,0 +1,20 @@
+package parse
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseErrIncludesAndUnwrapsCause(t *testing.T) {
+	cause := errors.New("source values/chart.yaml does not exist")
+	err := ParseErr{
+		Filename:    "components/chart.toml",
+		Description: "error parsing config",
+		Err:         cause,
+	}
+
+	require.EqualError(t, err, "components/chart.toml: error parsing config: source values/chart.yaml does not exist")
+	require.ErrorIs(t, err, cause)
+}

--- a/pkg/config/parse/parse.go
+++ b/pkg/config/parse/parse.go
@@ -2,6 +2,7 @@ package parse
 
 import (
 	"bytes"
+	"path/filepath"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/mitchellh/mapstructure"
@@ -63,7 +64,11 @@ func Parse(parseCfg ParseConfig) (*config.AppConfig, error) {
 
 	// go from map[string]interface{} => config.AppConfig
 	var cfg config.AppConfig
-	mapDecCfg := config.DecoderConfig()
+	rootDir := ""
+	if parseCfg.Filename != "" {
+		rootDir = filepath.Dir(parseCfg.Filename)
+	}
+	mapDecCfg := config.DecoderConfig(config.WithRootDir(rootDir))
 	mapDecCfg.Result = &cfg
 	mapDec, err := mapstructure.NewDecoder(mapDecCfg)
 	if err != nil {
@@ -79,7 +84,7 @@ func Parse(parseCfg ParseConfig) (*config.AppConfig, error) {
 		}
 	}
 
-	err = cfg.Parse()
+	err = cfg.Parse(config.WithRootDir(rootDir))
 	if err != nil {
 		return nil, ParseErr{
 			Filename:    parseCfg.Filename,

--- a/pkg/config/parse/parse_dir.go
+++ b/pkg/config/parse/parse_dir.go
@@ -55,9 +55,11 @@ func ParseDir(ctx context.Context, parseCfg ParseConfig) (*config.AppConfig, err
 	// parse the directory
 	var obj ConfigDir
 	if err := dir.Parse(ctx, cfgFS, &obj, &dir.ParseOptions{
-		Root:     fp,
-		Ext:      ".toml",
-		ParserFn: func(rc io.ReadCloser, s string, a any) error { return parseTomlFile(rc, s, a, parseCfg.FileProcessor) },
+		Root: fp,
+		Ext:  ".toml",
+		ParserFn: func(rc io.ReadCloser, s string, a any) error {
+			return parseTomlFile(rc, s, a, parseCfg.FileProcessor, fp)
+		},
 	}); err != nil {
 		return nil, errors.Wrap(err, "unable to parse directory")
 	}
@@ -110,7 +112,7 @@ func ParseDir(ctx context.Context, parseCfg ParseConfig) (*config.AppConfig, err
 		}
 	}
 
-	err = appCfg.Parse()
+	err = appCfg.Parse(config.WithRootDir(fp))
 	if err != nil {
 		return nil, ParseErr{
 			Description: "error parsing config",

--- a/pkg/config/parse/parse_dir_test.go
+++ b/pkg/config/parse/parse_dir_test.go
@@ -107,3 +107,95 @@ app_branch = "main"
 	require.Equal(t, "$.tag", cfg.Triggers.Rules[0].Filters[0].Path)
 	require.Equal(t, "main", cfg.Triggers.Rules[0].Target.AppBranch)
 }
+
+func TestParseDirResolvesHelmValuesFromConfigRoot(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "components"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "values"), 0755))
+
+	files := map[string]string{
+		"metadata.toml": `version = "v2"`,
+		"sandbox.toml": `
+terraform_version = "1.11.3"
+[public_repo]
+repo = "nuonco/aws-eks-sandbox"
+directory = "."
+branch = "main"
+`,
+		"runner.toml": `
+runner_type = "aws"
+helm_driver = "configmap"
+init_script_url = "https://example.com/init.sh"
+`,
+		"components/chart.toml": `
+name = "chart"
+type = "helm_chart"
+chart_name = "chart"
+[helm_repo]
+repo_url = "https://example.com"
+chart = "chart"
+version = "1.0.0"
+[[values_file]]
+source = "values/chart.yaml"
+[[values_file]]
+path = "./values/path.yaml"
+`,
+		"values/chart.yaml": "replicaCount: 2\n",
+		"values/path.yaml":  "replicaCount: 4\n",
+	}
+	for name, contents := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(contents), 0644))
+	}
+
+	t.Chdir(t.TempDir())
+	cfg, err := ParseDir(context.Background(), ParseConfig{
+		Dirname:       dir,
+		FileProcessor: func(_ string, obj map[string]any) map[string]any { return obj },
+	})
+	require.NoError(t, err)
+	require.Equal(t, "replicaCount: 2\n", cfg.Components[0].HelmChart.ValuesFiles[0].Contents)
+	require.Equal(t, "replicaCount: 4\n", cfg.Components[0].HelmChart.ValuesFiles[1].Contents)
+}
+
+func TestParseDirGetsHelmValuesContentsFromComponentDir(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "components", "values"), 0755))
+
+	files := map[string]string{
+		"metadata.toml": `version = "v2"`,
+		"sandbox.toml": `
+terraform_version = "1.11.3"
+[public_repo]
+repo = "nuonco/aws-eks-sandbox"
+directory = "."
+branch = "main"
+`,
+		"runner.toml": `
+runner_type = "aws"
+helm_driver = "configmap"
+init_script_url = "https://example.com/init.sh"
+`,
+		"components/chart.toml": `
+name = "chart"
+type = "helm_chart"
+chart_name = "chart"
+[helm_repo]
+repo_url = "https://example.com"
+chart = "chart"
+version = "1.0.0"
+[[values_file]]
+contents = "./values/chart.yaml"
+`,
+		"components/values/chart.yaml": "replicaCount: 3\n",
+	}
+	for name, contents := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(contents), 0644))
+	}
+
+	cfg, err := ParseDir(context.Background(), ParseConfig{
+		Dirname:       dir,
+		FileProcessor: func(_ string, obj map[string]any) map[string]any { return obj },
+	})
+	require.NoError(t, err)
+	require.Equal(t, "replicaCount: 3\n", cfg.Components[0].HelmChart.ValuesFiles[0].Contents)
+}

--- a/pkg/config/parse/toml.go
+++ b/pkg/config/parse/toml.go
@@ -12,7 +12,7 @@ import (
 // FileProcessor is a function to process config files before they're marshalled into a config struct and synced to the api.
 type FileProcessor func(string, map[string]any) map[string]any
 
-func parseTomlFile(rw io.ReadCloser, name string, out any, processor FileProcessor) error {
+func parseTomlFile(rw io.ReadCloser, name string, out any, processor FileProcessor, rootDir string) error {
 
 	tomlDec := toml.NewDecoder(rw)
 
@@ -33,7 +33,7 @@ func parseTomlFile(rw io.ReadCloser, name string, out any, processor FileProcess
 	obj = processor(name, obj)
 
 	// go from map[string]interface{} => config.AppConfig
-	mapDecCfg := config.DecoderConfig()
+	mapDecCfg := config.DecoderConfig(config.WithRootDir(rootDir))
 	mapDecCfg.Result = out
 	mapDec, err := mapstructure.NewDecoder(mapDecCfg)
 	if err != nil {

--- a/pkg/config/parse_opts.go
+++ b/pkg/config/parse_opts.go
@@ -1,0 +1,21 @@
+package config
+
+type ParseOptions struct {
+	RootDir string
+}
+
+type ParseOption func(*ParseOptions)
+
+func WithRootDir(rootDir string) ParseOption {
+	return func(opts *ParseOptions) {
+		opts.RootDir = rootDir
+	}
+}
+
+func parseOptions(opts ...ParseOption) ParseOptions {
+	var cfg ParseOptions
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/pkg/config/source/source.go
+++ b/pkg/config/source/source.go
@@ -11,7 +11,11 @@ import (
 
 // TODO(jm): this should be a global decoder hook
 func ReadSource(val string) ([]byte, error) {
-	path, err := expandSourcePath(val)
+	return ReadSourceFrom(val, "")
+}
+
+func ReadSourceFrom(val, baseDir string) ([]byte, error) {
+	path, err := expandSourcePath(val, baseDir)
 	if err != nil {
 		return nil, fmt.Errorf("unable to expand source path: %w", err)
 	}
@@ -25,7 +29,11 @@ func ReadSource(val string) ([]byte, error) {
 }
 
 func LoadSource(val string) (map[string]interface{}, error) {
-	byts, err := ReadSource(val)
+	return LoadSourceFrom(val, "")
+}
+
+func LoadSourceFrom(val, baseDir string) (map[string]interface{}, error) {
+	byts, err := ReadSourceFrom(val, baseDir)
 	if err != nil {
 		return nil, err
 	}
@@ -38,10 +46,13 @@ func LoadSource(val string) (map[string]interface{}, error) {
 	return obj, nil
 }
 
-func expandSourcePath(source string) (string, error) {
+func expandSourcePath(source, baseDir string) (string, error) {
 	path, err := homedir.Expand(source)
 	if err != nil {
 		return "", fmt.Errorf("unable to expand directory")
+	}
+	if baseDir != "" && !filepath.IsAbs(path) {
+		path = filepath.Join(baseDir, path)
 	}
 	path, err = filepath.Abs(path)
 	if err != nil {

--- a/pkg/config/source/source_test.go
+++ b/pkg/config/source/source_test.go
@@ -1,0 +1,32 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadSourceUsesBaseDir(t *testing.T) {
+	baseDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, "values.yaml"), []byte("base"), 0644))
+
+	otherDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(otherDir, "values.yaml"), []byte("cwd"), 0644))
+	t.Chdir(otherDir)
+
+	contents, err := ReadSourceFrom("values.yaml", baseDir)
+	require.NoError(t, err)
+	require.Equal(t, "base", string(contents))
+}
+
+func TestReadSourceFallsBackToWorkingDir(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("cwd"), 0644))
+	t.Chdir(dir)
+
+	contents, err := ReadSource("values.yaml")
+	require.NoError(t, err)
+	require.Equal(t, "cwd", string(contents))
+}

--- a/pkg/gen/temporal-gen-v2/internal/generator/activity_generator.go
+++ b/pkg/gen/temporal-gen-v2/internal/generator/activity_generator.go
@@ -159,6 +159,9 @@ func GenerateLocalActivity(data ActivityData) ([]byte, error) {
 	}
 
 	tmpl, err := template.New("activity_local").Funcs(template.FuncMap{
+		"durationToNs": func(d time.Duration) int64 {
+			return d.Nanoseconds()
+		},
 		"ToPascal": func(s string) string {
 			if s == "" {
 				return ""

--- a/pkg/gen/temporal-gen-v2/internal/generator/activity_generator_test.go
+++ b/pkg/gen/temporal-gen-v2/internal/generator/activity_generator_test.go
@@ -61,6 +61,53 @@ func TestGenerateLocalActivity(t *testing.T) {
 	assert.NotContains(t, code, "workflow.ExecuteActivity(")
 }
 
+func TestGenerateLocalActivityHonorsAnnotatedTimeouts(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        *parser.ActivityOptions
+		contains    string
+		notContains string
+	}{
+		{
+			name: "start-to-close applies when schedule-to-close is unset",
+			opts: &parser.ActivityOptions{
+				IsLocal:             true,
+				StartToCloseTimeout: 5 * time.Minute,
+			},
+			contains:    "ScheduleToCloseTimeout: time.Duration(300000000000)",
+			notContains: "10 * time.Second",
+		},
+		{
+			name: "schedule-to-close wins over start-to-close",
+			opts: &parser.ActivityOptions{
+				IsLocal:                true,
+				ScheduleToCloseTimeout: time.Hour,
+				StartToCloseTimeout:    5 * time.Minute,
+			},
+			contains:    "ScheduleToCloseTimeout: time.Duration(3600000000000)",
+			notContains: "time.Duration(300000000000)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := GenerateLocalActivity(ActivityData{
+				Name:         "CloneRepo",
+				OriginalName: "CloneRepo",
+				InputType:    "CloneRepoRequest",
+				OutputType:   "*CloneRepoResult",
+				Receiver:     "*Activities",
+				Options:      tt.opts,
+			})
+			require.NoError(t, err)
+
+			code := string(output)
+			assert.Contains(t, code, tt.contains)
+			assert.NotContains(t, code, tt.notContains)
+		})
+	}
+}
+
 func TestGenerateLocalActivityWithByField(t *testing.T) {
 	data := ActivityData{
 		Name:         "GetRunner",

--- a/pkg/gen/temporal-gen-v2/internal/generator/templates/activity_local.tmpl
+++ b/pkg/gen/temporal-gen-v2/internal/generator/templates/activity_local.tmpl
@@ -9,7 +9,13 @@
 func LocalAwait{{.Name | ToPascal}}(ctx workflow.Context, input {{if .Options.ByFieldOnly}}{{.ByFieldType}}{{else}}{{$reqType}}{{end}}) ({{if .OutputType}}{{.OutputType}}, {{end}}error) {
 	{{if .OutputType}}var result {{.OutputType}}{{end}}
 	localCtx := workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{
+		{{- if .Options.ScheduleToCloseTimeout}}
+		ScheduleToCloseTimeout: time.Duration({{.Options.ScheduleToCloseTimeout | durationToNs}}),
+		{{- else if .Options.StartToCloseTimeout}}
+		ScheduleToCloseTimeout: time.Duration({{.Options.StartToCloseTimeout | durationToNs}}),
+		{{- else}}
 		ScheduleToCloseTimeout: 10 * time.Second,
+		{{- end}}
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 1,
 		},


### PR DESCRIPTION
## Summary

Fixes for 3 bugs found while testing App Branches.

1. The working directory was not being set, when an app branch run was triggered by VCS or the Dashboard. This caused references to values files from helm components to fail to resolve.
2. The error message from that failed resolve was not being unwrapped, so the UI did not display it. It simply said there was a generic parse error.
3. When running locally, the git clone for the app config was failing. Turns out that local activities were not respecting the configured start to close timeout, and falling back to 10 seconds. For larger app configs, especially over a slower connection, this is too restrictive.