### PR TITLE
feat(telemetry-relay): make insecure JWKS access explicit

### DIFF
--- a/bins/telemetry-relay/Dockerfile
+++ b/bins/telemetry-relay/Dockerfile
@@ -2,7 +2,9 @@ FROM 821160992543.dkr.ecr.us-west-2.amazonaws.com/docker.io/library/golang:1.25-
 
 WORKDIR /src/bins/telemetry-relay
 
-COPY bins/telemetry-relay ./
+COPY build-config.yaml ./
+COPY extension ./extension/
+COPY processor ./processor/
 
 RUN --mount=type=cache,target=/go/pkg/mod,id=gomod-telemetry-relay \
     --mount=type=cache,target=/root/.cache/go-build,id=gobuild-telemetry-relay \
@@ -18,7 +20,7 @@ RUN apk add --no-cache ca-certificates && \
     adduser -S -D -H -u 10001 -G relay relay
 
 COPY --from=build /bin/nuon-telemetry-relay /bin/nuon-telemetry-relay
-COPY bins/telemetry-relay/config.yaml /etc/nuon-telemetry-relay/config.yaml
+COPY config.yaml /etc/nuon-telemetry-relay/config.yaml
 
 USER relay
 EXPOSE 4318 13133

--- a/bins/telemetry-relay/README.md
+++ b/bins/telemetry-relay/README.md
@@ -1,68 +1,25 @@
 # Nuon BYOC Telemetry Relay
 
-This OpenTelemetry Collector distribution accepts OTLP/HTTP from install runners, verifies the runner-scoped telemetry
-JWT issued by ctl-api, replaces all caller-supplied `nuon.*` attributes with authoritative resource identity, and
-forwards telemetry to one vendor OTLP/HTTP backend.
+An OpenTelemetry Collector distribution that forwards logs, metrics, and traces from Nuon install runners to an
+OTLP/HTTP backend. It verifies runner JWTs and replaces caller-supplied `nuon.*` attributes with verified identity.
 
-The relay intentionally has no sending queue or retry loop. A leaf Collector keeps each request in its dedicated
-persistent queue until the vendor backend accepts it through the relay.
-
-A downstream partial rejection permanently fails the whole upstream request. The vendor receives its accepted subset
-once; the leaf drops the rejected subset and records a permanent export failure rather than retrying the accepted data
-or treating the partial rejection as full success.
+The relay requires a Nuon control plane or a compatible token issuer; arbitrary JWTs are not supported.
+It has no persistent queue or retry loop. Senders provide buffering, and delivery is not lossless.
 
 ## Configuration
 
-| Environment variable | Purpose |
+The supplied [Collector configuration](config.yaml) uses these environment variables:
+
+| Variable | Purpose |
 |---|---|
-| `NUON_TELEMETRY_ISSUER` | Exact ctl-api JWT issuer |
-| `NUON_TELEMETRY_JWKS_URL` | Pinned ctl-api JWKS URL |
-| `VENDOR_OTLP_ENDPOINT` | Vendor OTLP/HTTP base endpoint |
-| `VENDOR_OTLP_AUTHORIZATION` | Complete vendor `Authorization` header value |
+| `NUON_TELEMETRY_ISSUER` | Expected JWT issuer |
+| `NUON_TELEMETRY_JWKS_URL` | Issuer's public signing-key URL |
+| `NUON_TELEMETRY_JWKS_ALLOW_INSECURE` | Permit HTTP issuer and JWKS URLs; defaults to `false` |
+| `VENDOR_OTLP_ENDPOINT` | Backend OTLP/HTTP base URL |
+| `VENDOR_OTLP_AUTHORIZATION` | Backend `Authorization` header value |
 
-Production issuer, JWKS, and vendor endpoints must use HTTPS. Loopback HTTP is supported for local validation of the
-issuer and JWKS endpoint.
+Issuer and JWKS URLs require HTTPS by default. Enable HTTP only over a trusted network; exact JWT issuer matching
+and HTTPS certificate verification remain enforced. Keep private signing keys on the issuer.
 
-## Runner integration (pilot)
-
-Configure `TELEMETRY_RELAY_ENDPOINT` in ctl-api with the relay's HTTPS OTLP base URL and configure its telemetry signing
-key. Eligible install runners receive the endpoint through their authenticated settings. Existing runners need a build
-that includes vendor telemetry support. No per-install secret is needed; the existing
-`nuon/<install-id>/telemetry-export-config` secret controls only audit export.
-
-Telemetry defaults to disabled for existing installs when the setting is first introduced and for new installs.
-Configuring the relay endpoint alone does not activate collection. Enable each pilot install with an authenticated
-`PATCH /v1/installs/{install_id}/telemetry` request containing `{"enabled": true}`. Use `{"enabled": false}` to disable
-it, and `GET` on the same endpoint to read its setting.
-
-Changing the schema default does not reset stored flags in an environment that already ran the default-enabled pilot.
-Disable those installs explicitly before configuring the relay endpoint there.
-
-The runner polls settings every 15 seconds and starts, stops, or replaces its separate vendor Collector without
-restarting the runner or audit Collector. It obtains and renews short-lived relay JWTs independently, stores them in a
-protected file, and removes credentials on disable/shutdown. Existing tokens can remain valid at the relay until expiry.
-The vendor Collector accepts OTLP/gRPC on port 4317 and OTLP/HTTP on port 4318. These listeners require deliberately
-scoped cloud firewall/network access; they do not authenticate local senders.
-
-Logs, metrics, and traces each have a persistent byte-sized queue (1 GiB logical capacity per signal) under
-`/var/lib/nuon/telemetry-export/vendor`. Disabling stops collection/export but preserves queued data for re-enablement.
-The queue directories are separate from audit, not separate physical disks or quotas.
-
-This remains a pilot: expired or temporarily unverifiable tokens can cause permanent export failures and data loss.
-Production rollout requires the token-expiry/JWKS failure matrix, physical storage and process resource limits, and KMS
-key management. `nuonctl`/Grafana local-development integration is a separate Mono change.
-
-## Build and validate
-
-```bash
-go run go.opentelemetry.io/collector/cmd/builder@v0.150.0 \
-  --config build-config.yaml \
-  --skip-compilation
-go build -C otelcol-build -o nuon-telemetry-relay
-
-NUON_TELEMETRY_ISSUER=https://ctl-api.example.com \
-NUON_TELEMETRY_JWKS_URL=https://ctl-api.example.com/.well-known/jwks.json \
-VENDOR_OTLP_ENDPOINT=https://otlp.example.com \
-VENDOR_OTLP_AUTHORIZATION='Bearer example' \
-./otelcol-build/nuon-telemetry-relay validate --config config.yaml
-```
+The default configuration accepts authenticated OTLP/HTTP on port 4318 and serves health checks on port 13133.
+Terminate TLS in front of the relay and keep health checks private.

--- a/bins/telemetry-relay/config.yaml
+++ b/bins/telemetry-relay/config.yaml
@@ -6,6 +6,7 @@ extensions:
     issuer: ${env:NUON_TELEMETRY_ISSUER}
     audience: urn:nuon:telemetry
     jwks_url: ${env:NUON_TELEMETRY_JWKS_URL}
+    jwks_allow_insecure: ${env:NUON_TELEMETRY_JWKS_ALLOW_INSECURE:-false}
   nuonpartialsuccess:
 
 receivers:

--- a/bins/telemetry-relay/extension/nuonjwtauthextension/config.go
+++ b/bins/telemetry-relay/extension/nuonjwtauthextension/config.go
@@ -2,49 +2,38 @@ package nuonjwtauthextension
 
 import (
 	"fmt"
-	"net"
 	"net/url"
 )
 
 const defaultAudience = "urn:nuon:telemetry"
 
 type Config struct {
-	Issuer   string `mapstructure:"issuer"`
-	Audience string `mapstructure:"audience"`
-	JWKSURL  string `mapstructure:"jwks_url"`
+	Issuer            string `mapstructure:"issuer"`
+	Audience          string `mapstructure:"audience"`
+	JWKSURL           string `mapstructure:"jwks_url"`
+	JWKSAllowInsecure bool   `mapstructure:"jwks_allow_insecure"`
 }
 
 func (c *Config) Validate() error {
-	if err := validateHTTPSOrLoopbackURL("issuer", c.Issuer); err != nil {
+	if err := validateEndpointURL("issuer", c.Issuer, c.JWKSAllowInsecure); err != nil {
 		return err
 	}
 	if c.Audience == "" {
 		return fmt.Errorf("audience is required")
 	}
-	if err := validateHTTPSOrLoopbackURL("JWKS URL", c.JWKSURL); err != nil {
+	if err := validateEndpointURL("JWKS URL", c.JWKSURL, c.JWKSAllowInsecure); err != nil {
 		return err
 	}
 	return nil
 }
 
-func validateHTTPSOrLoopbackURL(name, value string) error {
+func validateEndpointURL(name, value string, allowInsecure bool) error {
 	parsed, err := url.Parse(value)
 	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
 		return fmt.Errorf("%s must be an absolute URL without userinfo, query, or fragment", name)
 	}
-	if parsed.Scheme == "https" {
+	if parsed.Scheme == "https" || (parsed.Scheme == "http" && allowInsecure) {
 		return nil
 	}
-	if parsed.Scheme != "http" {
-		return fmt.Errorf("%s must use HTTPS", name)
-	}
-
-	host := parsed.Hostname()
-	if host == "localhost" {
-		return nil
-	}
-	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
-		return nil
-	}
-	return fmt.Errorf("%s may use HTTP only on loopback", name)
+	return fmt.Errorf("%s must use HTTPS, or HTTP with jwks_allow_insecure enabled", name)
 }

--- a/bins/telemetry-relay/extension/nuonjwtauthextension/extension_test.go
+++ b/bins/telemetry-relay/extension/nuonjwtauthextension/extension_test.go
@@ -107,10 +107,12 @@ func newTestExtension(t *testing.T, contents *atomic.Value) (*telemetryJWTAuthEx
 		_, _ = response.Write(value.([]byte))
 	}))
 	extension := newExtension(Config{
-		Issuer:   "https://ctl.example.com",
-		Audience: defaultAudience,
-		JWKSURL:  server.URL,
+		Issuer:            "https://ctl.example.com",
+		Audience:          defaultAudience,
+		JWKSURL:           server.URL,
+		JWKSAllowInsecure: true,
 	}, zap.NewNop())
+	require.NoError(t, extension.config.Validate())
 	require.NoError(t, extension.Start(context.Background(), nil))
 	t.Cleanup(func() {
 		require.NoError(t, extension.Shutdown(context.Background()))
@@ -153,6 +155,9 @@ func TestAuthenticateRejectsInvalidTokens(t *testing.T) {
 	}{
 		"wrong audience": {
 			mutateClaims: func(claims *telemetryClaims) { claims.Audience = jwt.ClaimStrings{"other"} },
+		},
+		"wrong issuer": {
+			mutateClaims: func(claims *telemetryClaims) { claims.Issuer = "http://other.example.com" },
 		},
 		"extra audience": {
 			mutateClaims: func(claims *telemetryClaims) { claims.Audience = append(claims.Audience, "other") },
@@ -238,11 +243,13 @@ func TestStartRejectsJWKSRedirect(t *testing.T) {
 	t.Cleanup(redirect.Close)
 
 	extension := newExtension(Config{
-		Issuer:   "https://ctl.example.com",
-		Audience: defaultAudience,
-		JWKSURL:  redirect.URL,
+		Issuer:            "https://ctl.example.com",
+		Audience:          defaultAudience,
+		JWKSURL:           redirect.URL,
+		JWKSAllowInsecure: true,
 	}, zap.NewNop())
 
+	require.NoError(t, extension.config.Validate())
 	require.ErrorIs(t, extension.Start(context.Background(), nil), errJWKSUnavailable)
 }
 
@@ -281,24 +288,64 @@ func TestKeyCacheBoundsKnownKeyStaleness(t *testing.T) {
 	require.ErrorIs(t, err, errJWKSUnavailable)
 }
 
-func TestConfigRequiresHTTPSExceptForLoopback(t *testing.T) {
+func TestConfigHTTPRequiresExplicitOptIn(t *testing.T) {
 	for _, test := range []struct {
-		name    string
-		url     string
-		wantErr bool
+		name   string
+		url    string
+		secure bool
 	}{
-		{name: "HTTPS", url: "https://ctl.example.com"},
+		{name: "HTTPS", url: "https://ctl.example.com", secure: true},
 		{name: "localhost", url: "http://localhost:8081"},
 		{name: "loopback", url: "http://127.0.0.1:8081"},
-		{name: "remote HTTP", url: "http://ctl.example.com", wantErr: true},
+		{name: "IPv6 loopback", url: "http://[::1]:8081"},
+		{name: "nuon host", url: "http://host.nuon.dev:8081"},
+		{name: "docker host", url: "http://host.docker.internal:8081"},
+		{name: "remote HTTP", url: "http://ctl.example.com"},
+		{name: "private IP", url: "http://192.168.1.2"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			err := validateHTTPSOrLoopbackURL("issuer", test.url)
-			if test.wantErr {
-				require.Error(t, err)
-				return
+			for _, field := range []string{"issuer", "JWKS URL"} {
+				t.Run(field, func(t *testing.T) {
+					cfg := createDefaultConfig().(*Config)
+					cfg.Issuer = "https://issuer.example.com"
+					cfg.JWKSURL = "https://keys.example.com/jwks"
+					if field == "issuer" {
+						cfg.Issuer = test.url
+					} else {
+						cfg.JWKSURL = test.url + "/jwks"
+					}
+					if test.secure {
+						require.NoError(t, cfg.Validate())
+					} else {
+						require.ErrorContains(t, cfg.Validate(), field+" must use HTTPS")
+					}
+					cfg.JWKSAllowInsecure = true
+					require.NoError(t, cfg.Validate())
+				})
 			}
-			require.NoError(t, err)
+		})
+	}
+}
+
+func TestInsecureOptInStillValidatesURLs(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		url  string
+	}{
+		{name: "empty", url: ""},
+		{name: "relative", url: "/jwks"},
+		{name: "malformed", url: "http://[::1/jwks"},
+		{name: "userinfo", url: "http://user@keys.example.com/jwks"},
+		{name: "query", url: "http://keys.example.com/jwks?key=value"},
+		{name: "fragment", url: "http://keys.example.com/jwks#key"},
+		{name: "other scheme", url: "ftp://keys.example.com/jwks"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := Config{Issuer: "https://issuer.example.com", Audience: defaultAudience, JWKSURL: test.url, JWKSAllowInsecure: true}
+			require.Error(t, cfg.Validate())
+			cfg.Issuer = test.url
+			cfg.JWKSURL = "https://keys.example.com/jwks"
+			require.Error(t, cfg.Validate())
 		})
 	}
 }


### PR DESCRIPTION
Require HTTPS for issuer and JWKS URLs unless `NUON_TELEMETRY_JWKS_ALLOW_INSECURE` is enabled, without hostname-specific exceptions.

Preserve issuer matching and redirect rejection, cover the flag boundaries, and simplify the public README.