### PR TITLE
chore: (CI) Enable telemetry relay builds and promotions

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -109,6 +109,7 @@ jobs:
       matrix:
         service:
           - ctl-api
+          - telemetry-relay
           - dashboard-ui
           - runner
           - cli

--- a/.github/workflows/promote_from_branch.yml
+++ b/.github/workflows/promote_from_branch.yml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: ['ctl-api', 'dashboard-ui', 'runner', 'cli', 'wiki']
+        service: ['ctl-api', 'telemetry-relay', 'dashboard-ui', 'runner', 'cli', 'wiki']
     uses: ./.github/workflows/service.yml
     with:
       service: ${{matrix.service}}

--- a/.github/workflows/promote_single_service.yml
+++ b/.github/workflows/promote_single_service.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - ctl-api
+          - telemetry-relay
           - dashboard-ui
           - runner
           - cli

--- a/ci-triggers.yml
+++ b/ci-triggers.yml
@@ -12,6 +12,9 @@ services: |
     - go.sum
     - pkg/**
 
+  telemetry-relay:
+    - bins/telemetry-relay/**
+
   runner:
     - go.mod
     - go.sum


### PR DESCRIPTION
Adds telemetry-relay to the service CI path filters, full and branch promotion matrices, and single-service promotion picker.