### PR TITLE
ci: run flow lane on every PR and main pushes

### DIFF
--- a/.github/workflows/ctl-api-integration.yml
+++ b/.github/workflows/ctl-api-integration.yml
@@ -1,5 +1,5 @@
 ---
-name: ctl-api integration (manual)
+name: ctl-api integration
 "on":
   workflow_dispatch:
     inputs:
@@ -7,6 +7,14 @@ name: ctl-api integration (manual)
         description: "Build nuonctl from this branch instead of pulling :latest"
         type: boolean
         default: false
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ctl-api-dispatch-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
 
 defaults:
   run:
@@ -22,8 +30,8 @@ jobs:
         run: |
           gh workflow run ctl-api-integration.yml \
             --repo nuonco/mono \
-            --field nuon_ref=${{ github.sha }} \
-            --field nuon_branch=${{ github.ref_name }} \
+            --field nuon_ref=${{ github.event.pull_request.head.sha || github.sha }} \
+            --field nuon_branch=${{ github.head_ref || github.ref_name }} \
             --field source_run_id=${{ github.run_id }} \
             --field source_actor=${{ github.actor }} \
-            --field local_nctl=${{ inputs.local_nctl }}
+            --field local_nctl=${{ inputs.local_nctl || false }}


### PR DESCRIPTION
## Summary

The flow-lane integration suite now runs on every pull request and on every commit merged to main, instead of only when someone triggers it by hand.

## What you can do after this PR

- **Open a PR and get the integration suite as a check.** The check fans out to the dedicated runner lane and reports back on the PR, testing the branch tip rather than a merge commit.
- **See regressions on main immediately.** Pushes to main run the same suite without any manual trigger.
- **Stop waiting on stale runs.** A new push to a PR cancels the previous run for that PR, and the same applies on main.

## What stays the same

- Manual triggers keep working with the same inputs, so anything that calls the workflow by hand is unaffected.
- The check is informational during an initial soak period; it does not block merges yet.