### PR TITLE
fix(stacks): make the published tf modules work on byoc control planes

### DIFF
--- a/docs/guides/provision-stacks-with-terraform-module.mdx
+++ b/docs/guides/provision-stacks-with-terraform-module.mdx
@@ -198,7 +198,7 @@ The rest of the process is completed by your customer, using the information you
     </CodeGroup>
 
     On GCP, the module reads the install's project and region from the control plane, so they appear only in the `google` provider block.
-    Before the install's first apply the control plane has nothing recorded, and the plan will fail asking for them — pass `project_id` and `region` to the module for that first apply, then drop them.
+    Before the install's first apply the control plane has nothing recorded, so the snippet also passes `project_id` and `region` to the module. Your customer can drop them once the install is provisioned.
 
     On Azure, the module reads the install's location from the control plane and takes the subscription from the `azurerm` provider, warning at plan time if the two disagree. `purge_soft_delete_on_destroy` is required: the module leaves purge protection off so a destroyed install's Key Vault name can be reused immediately, and without it Azure holds that name for 90 days.
   </Step>

--- a/sdks/stack/models/app_installer_s_d_k_a_w_s_config.go
+++ b/sdks/stack/models/app_installer_s_d_k_a_w_s_config.go
@@ -64,6 +64,9 @@ type AppInstallerSDKAWSConfig struct {
 
 	// runner machine type
 	RunnerMachineType string `json:"runner_machine_type,omitempty"`
+
+	// Deployed instead of the module's own VPC, which lacks its extra resources.
+	VpcNestedTemplateURL string `json:"vpc_nested_template_url,omitempty"`
 }
 
 // Validate validates this app installer s d k a w s config

--- a/sdks/stack/models/app_installer_s_d_k_config.go
+++ b/sdks/stack/models/app_installer_s_d_k_config.go
@@ -74,6 +74,9 @@ type AppInstallerSDKConfig struct {
 	// map[string]string with no room for per-key metadata, so this rides alongside
 	// like RequiredInputs.
 	SensitiveInputs []string `json:"sensitive_inputs"`
+
+	// Carried into the module's phone home so a new version produces a diff.
+	StackVersionID string `json:"stack_version_id,omitempty"`
 }
 
 // Validate validates this app installer s d k config

--- a/services/ctl-api/internal/app/install_stack_version.go
+++ b/services/ctl-api/internal/app/install_stack_version.go
@@ -112,6 +112,15 @@ var PhoneHomeTokenEligibleStatuses = []Status{
 	InstallStackVersionStatusActive,
 }
 
+// Statuses whose templates were uploaded. Earlier ones carry URLs written at
+// creation, pointing at objects that never landed.
+var InstallStackVersionTemplateReadyStatuses = []Status{
+	InstallStackVersionStatusPendingUser,
+	InstallStackVersionStatusProvisioning,
+	InstallStackVersionStatusActive,
+	InstallStackVersionStatusOutdated,
+}
+
 // PhoneHomeTokenEligible reports whether this version should hold a live phone-home
 // token. A tombstoned token is never reissued: that is what distinguishes a
 // deliberate revocation from a version that has simply never been minted for.

--- a/services/ctl-api/internal/app/installer_sdk_config.go
+++ b/services/ctl-api/internal/app/installer_sdk_config.go
@@ -32,6 +32,9 @@ type InstallerSDKConfig struct {
 
 	CustomStacks            []InstallerSDKCustomStack `json:"custom_stacks,omitempty"`
 	CustomStacksTemplateURL string                    `json:"custom_stacks_template_url,omitempty"`
+
+	// Carried into the module's phone home so a new version produces a diff.
+	StackVersionID string `json:"stack_version_id,omitempty"`
 }
 
 // InstallerSDKCustomStack is a custom nested stack.
@@ -49,6 +52,9 @@ type InstallerSDKAWSConfig struct {
 	Region            string `json:"region,omitempty"`
 	ClusterName       string `json:"cluster_name,omitempty"`
 	RunnerMachineType string `json:"runner_machine_type,omitempty"`
+
+	// Deployed instead of the module's own VPC, which lacks its extra resources.
+	VPCNestedTemplateURL string `json:"vpc_nested_template_url,omitempty"`
 
 	NuonSupportIAMRoleARNs []string `json:"nuon_support_iam_role_arns,omitempty"`
 

--- a/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config.go
+++ b/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config.go
@@ -165,31 +165,34 @@ func (h *Helpers) BuildInstallerSDKConfig(ctx context.Context, installID string)
 		CustomStacks:        customStacks,
 	}
 
-	if (appCfg.RunnerConfig.Type == app.AppRunnerTypeAWS || appCfg.RunnerConfig.Type == app.AppRunnerTypeAzure) && len(customStacks) > 0 {
-		var latestVersion app.InstallStackVersion
-		// No "latest version" FK exists — InstallStackVersion.InstallStackID
-		// only points the other way — so created_at ordering resolves "latest".
-		res := h.db.WithContext(ctx).
-			Where(app.InstallStackVersion{InstallID: install.ID}).
-			Order("created_at DESC").
-			Limit(1).
-			First(&latestVersion)
-		switch {
-		case res.Error == nil:
-			cfg.CustomStacksTemplateURL = latestVersion.CustomStacksTemplateURL
-			// Never re-derive this: it runs on every terraform plan and must not
-			// fetch or parse templates.
-			for i := range cfg.CustomStacks {
-				cfg.CustomStacks[i].Outputs = latestVersion.CustomStacksOutputMap[cfg.CustomStacks[i].Name]
-				cfg.CustomStacks[i].InputParameters = customerInputParameters(
-					latestVersion.CustomStacksInputParametersMap[cfg.CustomStacks[i].Name],
-					customerInputNames,
-				)
-			}
-		case errors.Is(res.Error, gorm.ErrRecordNotFound):
-			// no stack version yet — leave empty
-		default:
-			return nil, fmt.Errorf("load latest install stack version: %w", res.Error)
+	var latestVersion app.InstallStackVersion
+	// No "latest version" FK exists — InstallStackVersion.InstallStackID
+	// only points the other way — so created_at ordering resolves "latest".
+	res := h.db.WithContext(ctx).
+		Where(app.InstallStackVersion{InstallID: install.ID}).
+		Where("composite_status->>'status' IN ?", app.InstallStackVersionTemplateReadyStatuses).
+		Order("created_at DESC").
+		Limit(1).
+		First(&latestVersion)
+	switch {
+	case res.Error == nil:
+		cfg.StackVersionID = latestVersion.ID
+	case errors.Is(res.Error, gorm.ErrRecordNotFound):
+		// no stack version yet — leave empty
+	default:
+		return nil, fmt.Errorf("load latest install stack version: %w", res.Error)
+	}
+
+	if (appCfg.RunnerConfig.Type == app.AppRunnerTypeAWS || appCfg.RunnerConfig.Type == app.AppRunnerTypeAzure) && len(customStacks) > 0 && latestVersion.ID != "" {
+		cfg.CustomStacksTemplateURL = latestVersion.CustomStacksTemplateURL
+		// Never re-derive this: it runs on every terraform plan and must not
+		// fetch or parse templates.
+		for i := range cfg.CustomStacks {
+			cfg.CustomStacks[i].Outputs = latestVersion.CustomStacksOutputMap[cfg.CustomStacks[i].Name]
+			cfg.CustomStacks[i].InputParameters = customerInputParameters(
+				latestVersion.CustomStacksInputParametersMap[cfg.CustomStacks[i].Name],
+				customerInputNames,
+			)
 		}
 	}
 
@@ -244,6 +247,8 @@ func (h *Helpers) BuildInstallerSDKConfig(ctx context.Context, installID string)
 			Region:            install.AWSAccount.Region,
 			ClusterName:       clusterName,
 			RunnerMachineType: instanceType,
+
+			VPCNestedTemplateURL: appCfg.StackConfig.VPCNestedTemplateURL,
 
 			NuonSupportIAMRoleARNs: supportARNs,
 

--- a/services/ctl-api/internal/app/installs/worker/activities/set_install_stack_version_composite_error.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/set_install_stack_version_composite_error.go
@@ -22,8 +22,8 @@ type SetInstallStackVersionCompositeErrorRequest struct {
 }
 
 // SetInstallStackVersionCompositeError freezes a StackTemplateRenderError onto
-// the given stack version row. Passing an empty Detail clears the field (nil),
-// which is used at the start of a retry to remove a stale error.
+// the given stack version row and marks it errored. Passing an empty Detail
+// clears the field (nil) and leaves status alone, used at the start of a retry.
 //
 // @temporal-gen-v2 activity
 // @max-retries 3
@@ -45,10 +45,19 @@ func (a *Activities) SetInstallStackVersionCompositeError(ctx context.Context, r
 		}
 	}
 
+	update := app.InstallStackVersion{CompositeError: data}
+	columns := []string{"composite_error"}
+	// A row left "generating" still wins "latest version" lookups.
+	if req.Detail != "" {
+		update.Status = app.NewCompositeStatus(ctx, app.StatusError)
+		update.Status.StatusHumanDescription = req.Detail
+		columns = append(columns, "composite_status")
+	}
+
 	res := a.db.WithContext(ctx).
 		Model(&app.InstallStackVersion{ID: req.StackVersionID}).
-		Select("composite_error").
-		Updates(app.InstallStackVersion{CompositeError: data})
+		Select(columns).
+		Updates(update)
 	if res.Error != nil {
 		return fmt.Errorf("unable to set install stack version composite error: %w", res.Error)
 	}

--- a/services/ctl-api/internal/app/runner_group_settings.go
+++ b/services/ctl-api/internal/app/runner_group_settings.go
@@ -160,6 +160,10 @@ func (i *RunnerGroupSettings) Views(db *gorm.DB) []migrations.View {
 func (r *RunnerGroupSettings) BeforeCreate(tx *gorm.DB) error {
 	if r.ID == "" {
 		r.ID = domains.NewRunnerGroupSettingsID()
+		// Assigning into a nil map panics, and a settings row built literally has one.
+		if r.Metadata == nil {
+			r.Metadata = map[string]*string{}
+		}
 		r.Metadata["runner_group.id"] = generics.ToPtr(r.ID)
 	}
 	if r.CreatedByID == "" {

--- a/services/ctl-api/internal/app/stacks/service/get_stack_service_account.go
+++ b/services/ctl-api/internal/app/stacks/service/get_stack_service_account.go
@@ -30,11 +30,14 @@ type StackServiceAccountResponse struct {
 	// ExpiresAt is the expiry of the longest-lived usable token; zero when
 	// HasLiveToken is false.
 	ExpiresAt time.Time `json:"expires_at,omitzero"`
+
+	// Without it a dashboard points the module's provider at production.
+	RunnerAPIURL string `json:"runner_api_url,omitzero"`
 }
 
 // @ID						GetStackServiceAccount
 // @Summary				get an install stack's service account
-// @Description			Return the service account an install stack's Terraform module authenticates as, and whether it holds a usable API token. Never returns a token value: create one with POST /v1/service-accounts/{account_id}/tokens, which returns it once.
+// @Description			Return the service account an install stack's Terraform module authenticates as, whether it holds a usable API token, and the runner API URL its provider authenticates against. Never returns a token value: create one with POST /v1/service-accounts/{account_id}/tokens, which returns it once.
 // @Param					install_id	path	string	true	"install ID"
 // @Tags					stacks
 // @Accept					json
@@ -90,11 +93,18 @@ func (s *service) GetStackServiceAccount(ctx *gin.Context) {
 		return
 	}
 
+	runnerAPIURL, err := s.stackRunnerAPIURL(ctx, installID, orgID)
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
 	ctx.JSON(http.StatusOK, StackServiceAccountResponse{
 		AccountID:    acct.ID,
 		Email:        acct.Email,
 		HasLiveToken: !expiresAt.IsZero(),
 		ExpiresAt:    expiresAt,
+		RunnerAPIURL: runnerAPIURL,
 	})
 }
 
@@ -116,4 +126,24 @@ func liveStackTokenExpiry(ctx context.Context, db *gorm.DB, accountID string) (t
 	}
 
 	return time.Time{}, fmt.Errorf("load stack token: %w", res.Error)
+}
+
+// Same precedence as BuildInstallerSDKConfig: the per-runner-group setting wins,
+// global config is the safety net for installs that pre-date it.
+func (s *service) stackRunnerAPIURL(ctx context.Context, installID, orgID string) (string, error) {
+	var install app.Install
+	if res := s.db.WithContext(ctx).
+		Preload("RunnerGroup.Settings").
+		Where(app.Install{ID: installID, OrgID: orgID}).
+		First(&install); res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return s.cfg.RunnerAPIURL, nil
+		}
+		return "", fmt.Errorf("load install: %w", res.Error)
+	}
+
+	if url := install.RunnerGroup.Settings.RunnerAPIURL; url != "" {
+		return url, nil
+	}
+	return s.cfg.RunnerAPIURL, nil
 }

--- a/services/ctl-api/internal/app/stacks/service/get_stack_service_account_test.go
+++ b/services/ctl-api/internal/app/stacks/service/get_stack_service_account_test.go
@@ -13,6 +13,8 @@ import (
 	"go.uber.org/fx/fxtest"
 	"gorm.io/gorm"
 
+	"github.com/nuonco/nuon/pkg/shortid/domains"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/tests"
 	"github.com/nuonco/nuon/services/ctl-api/tests/testseed"
@@ -134,5 +136,95 @@ func (s *StackTokenExpiryTestSuite) TestLiveStackTokenExpiry() {
 		expiry, err := liveStackTokenExpiry(ctx, s.deps.DB, acct.ID)
 		require.NoError(t, err)
 		assert.True(t, expiry.IsZero())
+	})
+}
+
+type stackRunnerAPIURLDeps struct {
+	fx.In
+
+	DB     *gorm.DB `name:"psql"`
+	Cfg    *internal.Config
+	Seeder *testseed.Seeder
+}
+
+type StackRunnerAPIURLTestSuite struct {
+	tests.BaseDBTestSuite
+
+	fxApp *fxtest.App
+	deps  stackRunnerAPIURLDeps
+}
+
+func TestStackRunnerAPIURLSuite(t *testing.T) {
+	tests.SkipIfNotIntegration(t)
+	suite.Run(t, new(StackRunnerAPIURLTestSuite))
+}
+
+func (s *StackRunnerAPIURLTestSuite) SetupSuite() {
+	s.BaseDBTestSuite.SetupSuite()
+
+	options := append(
+		tests.CtlApiFXOptions(s.T()),
+		fx.Populate(&s.deps),
+	)
+	s.fxApp = fxtest.New(s.T(), options...)
+	s.fxApp.RequireStart()
+	s.SetDB(s.deps.DB)
+}
+
+func (s *StackRunnerAPIURLTestSuite) TearDownSuite() {
+	s.fxApp.RequireStop()
+}
+
+func (s *StackRunnerAPIURLTestSuite) seedInstall(ctx context.Context) (context.Context, *app.Install) {
+	t := s.T()
+	ctx, _ = s.deps.Seeder.EnsureAccount(ctx, t)
+	ctx, _ = s.deps.Seeder.EnsureOrg(ctx, t)
+	a := s.deps.Seeder.CreateApp(ctx, t)
+	s.deps.Seeder.CreateAppConfig(ctx, t, a.ID)
+
+	return ctx, s.deps.Seeder.CreateInstall(ctx, t, a)
+}
+
+// A wrong answer points the customer's Terraform at the wrong control plane.
+func (s *StackRunnerAPIURLTestSuite) TestStackRunnerAPIURL() {
+	t := s.T()
+	const globalURL = "https://runner.example.com"
+
+	svc := &service{db: s.deps.DB, cfg: &internal.Config{RunnerAPIURL: globalURL}}
+
+	s.Run("falls back to the global config when the group has no setting", func() {
+		ctx, install := s.seedInstall(context.Background())
+
+		url, err := svc.stackRunnerAPIURL(ctx, install.ID, install.OrgID)
+		require.NoError(t, err)
+		assert.Equal(t, globalURL, url)
+	})
+
+	s.Run("the runner group setting wins", func() {
+		ctx, install := s.seedInstall(context.Background())
+		const groupURL = "https://runner.byoc.example.net"
+
+		group := &app.RunnerGroup{
+			ID:        domains.NewRunnerGroupID(),
+			OrgID:     install.OrgID,
+			OwnerID:   install.ID,
+			OwnerType: "installs",
+			Type:      app.RunnerGroupTypeInstall,
+			Settings:  app.RunnerGroupSettings{RunnerAPIURL: groupURL},
+		}
+		require.NoError(t, s.deps.DB.WithContext(ctx).Create(group).Error)
+
+		url, err := svc.stackRunnerAPIURL(ctx, install.ID, install.OrgID)
+		require.NoError(t, err)
+		assert.Equal(t, groupURL, url)
+	})
+
+	// The endpoint answers not-found for it, so this lookup must not error first.
+	s.Run("an unknown install still reports the global config", func() {
+		ctx, install := s.seedInstall(context.Background())
+
+		url, err := svc.stackRunnerAPIURL(ctx, "inl00000000000000000000000", install.OrgID)
+		require.NoError(t, err)
+		assert.Equal(t, globalURL, url)
 	})
 }

--- a/services/ctl-api/internal/pkg/stacks/aws/render.go
+++ b/services/ctl-api/internal/pkg/stacks/aws/render.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -308,8 +309,74 @@ func managedPolicyArnsForRole(role app.AppAWSIAMRoleConfig) []string {
 // Each policy.Contents is expected to be a full IAM policy JSON document of
 // the form `{"Version": "...", "Statement": [...]}`. Non-Contents policies
 // (i.e. ManagedPolicyName-only entries) are skipped.
+// Only this path merges a role's policy files into one document (CloudFormation
+// emits one AWS::IAM::Policy per file), so two files may share a Sid and IAM then
+// rejects the merged result.
+func dedupeStatementIDs(sources []string, statements []json.RawMessage) ([]json.RawMessage, error) {
+	seen := map[string]bool{}
+	out := make([]json.RawMessage, len(statements))
+
+	for i, raw := range statements {
+		out[i] = raw
+
+		var stmt map[string]any
+		if err := json.Unmarshal(raw, &stmt); err != nil {
+			return nil, fmt.Errorf("parse merged statement %d: %w", i, err)
+		}
+		sid, _ := stmt["Sid"].(string)
+		if sid == "" {
+			continue
+		}
+		if !seen[sid] {
+			seen[sid] = true
+			continue
+		}
+
+		source := ""
+		if i < len(sources) {
+			source = sources[i]
+		}
+		unique := sid + sidSuffix(source)
+		for n := 2; seen[unique]; n++ {
+			unique = fmt.Sprintf("%s%s%d", sid, sidSuffix(source), n)
+		}
+		seen[unique] = true
+
+		stmt["Sid"] = unique
+		rewritten, err := json.Marshal(stmt)
+		if err != nil {
+			return nil, fmt.Errorf("re-marshal statement %d after Sid rename: %w", i, err)
+		}
+		out[i] = rewritten
+	}
+
+	return out, nil
+}
+
+// IAM only allows alphanumerics in a Sid.
+func sidSuffix(policyName string) string {
+	var b strings.Builder
+	upperNext := true
+	for _, r := range policyName {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			if upperNext && r >= 'a' && r <= 'z' {
+				b.WriteRune(r - 32)
+			} else {
+				b.WriteRune(r)
+			}
+			upperNext = false
+		default:
+			upperNext = true
+		}
+	}
+
+	return b.String()
+}
+
 func mergedInlinePolicyDocument(role app.AppAWSIAMRoleConfig) (string, error) {
 	var statements []json.RawMessage
+	var sources []string
 	for _, policy := range role.Policies {
 		if len(policy.Contents) == 0 {
 			continue
@@ -325,9 +392,16 @@ func mergedInlinePolicyDocument(role app.AppAWSIAMRoleConfig) (string, error) {
 			return "", fmt.Errorf("policy %q: parse inline policy JSON: %w", policy.Name, err)
 		}
 		statements = append(statements, doc.Statement...)
+		for range doc.Statement {
+			sources = append(sources, policy.Name)
+		}
 	}
 	if len(statements) == 0 {
 		return "", nil
+	}
+	statements, err := dedupeStatementIDs(sources, statements)
+	if err != nil {
+		return "", fmt.Errorf("role %q: %w", role.Name, err)
 	}
 	merged := struct {
 		Version   string            `json:"Version"`

--- a/services/ctl-api/internal/pkg/stacks/aws/render_raw.go
+++ b/services/ctl-api/internal/pkg/stacks/aws/render_raw.go
@@ -100,6 +100,7 @@ func ExtractAWSRolesFromListRaw(roles []app.AppAWSIAMRoleConfig) ([]AWSRoleRaw, 
 // single IAM policy document, excluding managed-policy references.
 func mergedInlinePolicyDocumentRaw(role app.AppAWSIAMRoleConfig) (string, error) {
 	var statements []json.RawMessage
+	var sources []string
 	for _, policy := range role.Policies {
 		if len(policy.Contents) == 0 {
 			continue
@@ -114,9 +115,16 @@ func mergedInlinePolicyDocumentRaw(role app.AppAWSIAMRoleConfig) (string, error)
 			return "", fmt.Errorf("policy %q: parse inline policy JSON: %w", policy.Name, err)
 		}
 		statements = append(statements, doc.Statement...)
+		for range doc.Statement {
+			sources = append(sources, policy.Name)
+		}
 	}
 	if len(statements) == 0 {
 		return "", nil
+	}
+	statements, err := dedupeStatementIDs(sources, statements)
+	if err != nil {
+		return "", fmt.Errorf("role %q: %w", role.Name, err)
 	}
 	merged := struct {
 		Version   string            `json:"Version"`

--- a/services/ctl-api/internal/pkg/stacks/aws/render_test.go
+++ b/services/ctl-api/internal/pkg/stacks/aws/render_test.go
@@ -396,3 +396,74 @@ func TestRenderChecksumDiffersWithInlinePolicy(t *testing.T) {
 
 	assert.NotEqual(t, base, withInline, "inline policy should affect the checksum")
 }
+
+// Valid config on CloudFormation, where each file is its own AWS::IAM::Policy;
+// only the merged Terraform document has to disambiguate.
+func TestRenderInlinePolicyDedupesRepeatedSids(t *testing.T) {
+	inp := testInput()
+	inp.AppCfg.PermissionsConfig.Roles = []app.AppAWSIAMRoleConfig{
+		{
+			CloudPlatform: "aws",
+			Type:          app.AWSIAMRoleTypeRunnerProvision,
+			Name:          "provision",
+			Policies: []app.AppAWSIAMPolicyConfig{
+				{Name: "maintenance-base", Contents: []byte(`{"Statement":[{"Sid":"Reads","Effect":"Allow","Action":"ec2:Describe*","Resource":"*"}]}`)},
+				{Name: "rds-db-metrics", Contents: []byte(`{"Statement":[{"Sid":"Reads","Effect":"Allow","Action":"rds:DescribeDBClusters","Resource":"*"}]}`)},
+			},
+		},
+	}
+
+	out, _, err := Render(inp, "")
+	require.NoError(t, err)
+
+	doc := unquoteHCLJSONString(t, findVarValue(t, extractTfvars(t, out), "provision_inline_policy_document"))
+	var parsed struct {
+		Statement []map[string]any
+	}
+	require.NoError(t, json.Unmarshal([]byte(doc), &parsed))
+	require.Len(t, parsed.Statement, 2)
+
+	assert.Equal(t, "Reads", parsed.Statement[0]["Sid"], "first use of a Sid is left alone")
+	assert.Equal(t, "ReadsRdsDbMetrics", parsed.Statement[1]["Sid"], "the collision is suffixed with its source policy")
+	assert.Equal(t, "rds:DescribeDBClusters", parsed.Statement[1]["Action"], "renaming a Sid must not touch the permissions")
+
+	sids := map[string]bool{}
+	for _, stmt := range parsed.Statement {
+		sid, _ := stmt["Sid"].(string)
+		require.False(t, sids[sid], "merged document must not repeat Sid %q", sid)
+		sids[sid] = true
+	}
+}
+
+func TestRenderInlinePolicyDedupesThreeWayAndSkipsSidless(t *testing.T) {
+	inp := testInput()
+	inp.AppCfg.PermissionsConfig.Roles = []app.AppAWSIAMRoleConfig{
+		{
+			CloudPlatform: "aws",
+			Type:          app.AWSIAMRoleTypeRunnerProvision,
+			Name:          "provision",
+			Policies: []app.AppAWSIAMPolicyConfig{
+				{Name: "one", Contents: []byte(`{"Statement":[{"Sid":"Reads","Effect":"Allow","Action":"a:One","Resource":"*"}]}`)},
+				{Name: "two", Contents: []byte(`{"Statement":[{"Sid":"Reads","Effect":"Allow","Action":"a:Two","Resource":"*"}]}`)},
+				{Name: "two", Contents: []byte(`{"Statement":[{"Sid":"Reads","Effect":"Allow","Action":"a:Three","Resource":"*"},{"Effect":"Allow","Action":"a:Four","Resource":"*"}]}`)},
+			},
+		},
+	}
+
+	out, _, err := Render(inp, "")
+	require.NoError(t, err)
+
+	doc := unquoteHCLJSONString(t, findVarValue(t, extractTfvars(t, out), "provision_inline_policy_document"))
+	var parsed struct {
+		Statement []map[string]any
+	}
+	require.NoError(t, json.Unmarshal([]byte(doc), &parsed))
+	require.Len(t, parsed.Statement, 4)
+
+	assert.Equal(t, "Reads", parsed.Statement[0]["Sid"])
+	assert.Equal(t, "ReadsTwo", parsed.Statement[1]["Sid"])
+	assert.Equal(t, "ReadsTwo2", parsed.Statement[2]["Sid"], "same source policy name twice falls back to an ordinal")
+	_, hasSid := parsed.Statement[3]["Sid"]
+	assert.False(t, hasSid, "a statement without a Sid stays without one")
+	assert.Equal(t, "a:Four", parsed.Statement[3]["Action"])
+}

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.stories.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.stories.tsx
@@ -181,6 +181,19 @@ export const Loading = () => (
   </div>
 )
 
+// No project or region recorded yet, so the module block carries them.
+export const TFModuleFirstApply = () => (
+  <div className="max-w-2xl p-4">
+    <AwaitGCPDetails
+      orgId="org-1"
+      stack={mockStack}
+      step={mockStep}
+      installId="install-1"
+      tfProvider
+    />
+  </div>
+)
+
 export const TFModule = () => (
   <div className="max-w-2xl p-4">
     <AwaitGCPDetails

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/AwaitGCPDetails/AwaitGCPDetails.tsx
@@ -766,6 +766,8 @@ interface IGCPTFModuleTab {
 // install's target from the control plane, so repeating them as module arguments
 // would be a second copy of the same value to drift. They fall back to
 // placeholders before the first provision has recorded them.
+//
+// GCP records that target on the first apply, so pass them until it does.
 const GCPTFModuleTab = ({
   orgId,
   installId,
@@ -774,6 +776,10 @@ const GCPTFModuleTab = ({
 }: IGCPTFModuleTab) => {
   const project = gcpProjectId || '<gcp-project-id>'
   const region = gcpRegion || '<gcp-region>'
+  const targetBlock =
+    gcpProjectId && gcpRegion
+      ? ''
+      : `\n  project_id = "${project}"\n  region     = "${region}"`
 
   const buildMainTf = ({
     installId: id,
@@ -799,7 +805,7 @@ module "gcp_stack" {
   source  = "nuonco/stack/gcp"
   version = "~> 1.0"
 
-  install_id = "${id}"${inputsBlock}${secretsBlock}
+  install_id = "${id}"${targetBlock}${inputsBlock}${secretsBlock}
 }${secretVariablesBlock}`
 
   return (

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/tf-module/AuthPanes.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/tf-module/AuthPanes.tsx
@@ -6,7 +6,6 @@ import { ClickToCopyButton } from '@/components/common/ClickToCopy'
 import { Code } from '@/components/common/Code'
 import { Text } from '@/components/common/Text'
 import { CreateOIDCTrustPolicyButton } from '@/components/oidc-trust-policies'
-import { useConfig } from '@/hooks/use-config'
 
 // OIDC auth is hidden until the experience is polished and fully tested; flip
 // this to restore the Static token / OIDC toggle.
@@ -68,17 +67,16 @@ export const StaticTokenAuthPane = ({
 export const OIDCAuthPane = ({
   installId,
   policyNames,
+  // The runner API, not the public one: the SDK requests its ID token with the URL it
+  // talks to, and the audience is compared literally.
+  audience,
 }: {
   installId?: string
   policyNames: string[]
+  audience: string
 }) => {
-  const config = useConfig()
   const policyName = `stack-${installId ?? 'install'}`
   const existing = policyNames.includes(policyName)
-
-  // The runner API, not the public one: the SDK requests its ID token with the URL it
-  // talks to, and the audience is compared literally.
-  const audience = config.runnerApiUrl ?? ''
 
   const workflowSnippet = `permissions:
   id-token: write

--- a/services/dashboard-ui/client/components/workflows/step-details/stack-details/tf-module/TFModuleTab.tsx
+++ b/services/dashboard-ui/client/components/workflows/step-details/stack-details/tf-module/TFModuleTab.tsx
@@ -138,9 +138,11 @@ export const TFModuleTab = ({
 
   const config = useConfig()
   // The provider defaults to the production runner API, so a local, stage, or BYOC
-  // control plane has to name itself here.
-  const providerBlock = config.runnerApiUrl
-    ? `provider "stack" {\n  api_url = "${config.runnerApiUrl}"\n}`
+  // control plane has to name itself here, and the service account carries it.
+  const runnerApiUrl =
+    config.runnerApiUrl || serviceAccount?.runner_api_url || ''
+  const providerBlock = runnerApiUrl
+    ? `provider "stack" {\n  api_url = "${runnerApiUrl}"\n}`
     : 'provider "stack" {}'
 
   const mainTf = buildMainTf({
@@ -169,7 +171,7 @@ export const TFModuleTab = ({
             <ClickToCopyButton textToCopy={mainTf} />
           </span>
           <Code variant="preformated">{mainTf}</Code>
-          {config.runnerApiUrl ? null : (
+          {runnerApiUrl ? null : (
             <Text variant="subtext" theme="neutral">
               This control plane has not published its runner API URL, so the
               provider will default to production. Set{' '}
@@ -209,6 +211,7 @@ export const TFModuleTab = ({
         {OIDC_AUTH_ENABLED && authMethod === 'oidc' ? (
           <OIDCAuthPane
             installId={installId}
+            audience={runnerApiUrl}
             policyNames={(trustPolicies ?? [])
               .map((policy) => policy.name ?? '')
               .filter(Boolean)}

--- a/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
+++ b/services/dashboard-ui/client/types/nuon-oapi-v3.d.ts
@@ -5,6 +5,13 @@
 
 
 export interface paths {
+  "/.well-known/jwks.json": {
+    /**
+     * Get telemetry JWT public keys
+     * @description Returns the public RSA keys used to verify BYOC telemetry access tokens.
+     */
+    get: operations["GetTelemetryJWKS"];
+  };
   "/slack/commands/nuon": {
     /**
      * Slack /nuon slash command webhook
@@ -2116,7 +2123,7 @@ export interface paths {
   "/v1/installs/{install_id}/reprovision-stack": {
     /**
      * reprovision an install stack
-     * @description Reprovision an install stack, recreating the runner and its infrastructure. Set `skip_components` to avoid redeploying components on top of the new stack.
+     * @description Reprovision an install stack, recreating the runner and its infrastructure. Components are not redeployed.
      */
     post: operations["ReprovisionInstallStack"];
   };
@@ -2249,6 +2256,12 @@ export interface paths {
      * @description Execute the sync secrets workflow.
      */
     post: operations["SyncSecrets"];
+  };
+  "/v1/installs/{install_id}/telemetry": {
+    /** Get an install's telemetry settings */
+    get: operations["GetInstallTelemetrySettings"];
+    /** Update an install's telemetry settings */
+    patch: operations["UpdateInstallTelemetrySettings"];
   };
   "/v1/installs/{install_id}/workflows": {
     /**
@@ -2980,7 +2993,7 @@ export interface paths {
   "/v1/stacks/{install_id}/service-account": {
     /**
      * get an install stack's service account
-     * @description Return the service account an install stack's Terraform module authenticates as, and whether it holds a usable API token. Never returns a token value: create one with POST /v1/service-accounts/{account_id}/tokens, which returns it once.
+     * @description Return the service account an install stack's Terraform module authenticates as, whether it holds a usable API token, and the runner API URL its provider authenticates against. Never returns a token value: create one with POST /v1/service-accounts/{account_id}/tokens, which returns it once.
      */
     get: operations["GetStackServiceAccount"];
   };
@@ -3791,6 +3804,7 @@ export interface components {
       runner?: components["schemas"]["app.AppRunnerConfig"];
       sandbox?: components["schemas"]["app.AppSandboxConfig"];
       secrets?: components["schemas"]["app.AppSecretsConfig"];
+      source_config?: components["schemas"]["blobstore.Blob"];
       stack?: components["schemas"]["app.AppStackConfig"];
       state?: string;
       status?: components["schemas"]["app.AppConfigStatus"];
@@ -6135,7 +6149,9 @@ export interface components {
       runner_group_id?: string;
       /** @description configuration for managing the runner server side */
       sandbox_mode?: boolean;
+      telemetry_relay_endpoint?: string;
       updated_at?: string;
+      vendor_telemetry_enabled?: boolean;
       vm_max_uptime?: number;
     };
     /** @enum {string} */
@@ -8019,21 +8035,20 @@ export interface components {
        * it matches this RE2 pattern. Omit to carry the current setting forward; send
        * an empty string to clear it.
        */
-      ignore_changes_regex?: string;
+      ignore_changes_regex?: string | null;
       install_groups?: components["schemas"]["service.InstallGroupRequest"][];
       /**
        * @description PostDeployRunbookIDs run on each install, in order, after its deploy succeeds.
        * Omit to carry the current setting forward; send an empty array to clear it.
        */
       post_deploy_runbook_ids?: string[];
-      /** @description PreviewConfig sets branch-level preview defaults. Omit to carry forward. */
       preview_config?: components["schemas"]["app.AppBranchPreviewConfig"];
       public_git_vcs_config?: components["schemas"]["helpers.PublicGitVCSConfigRequest"];
       /**
        * @description SendStatusesOnIgnore posts a successful commit status for runs ignored by
        * IgnoreChangesRegex. Omit to carry the current setting forward.
        */
-      send_statuses_on_ignore?: boolean;
+      send_statuses_on_ignore?: boolean | null;
     };
     "service.CreateAppBranchRequest": {
       managed_by?: string;
@@ -8780,7 +8795,7 @@ export interface components {
        * @description AutoApproveOnPoliciesPassing approves this group's plan step without user
        * input when its policy checks pass. Omit to leave it unset (off).
        */
-      auto_approve_on_policies_passing?: boolean;
+      auto_approve_on_policies_passing?: boolean | null;
       install_ids?: string[];
       /**
        * @description LabelSelector dynamically resolves installs at deploy time.
@@ -8837,6 +8852,9 @@ export interface components {
     };
     "service.InstallPhoneHomeRequest": {
       [key: string]: unknown;
+    };
+    "service.InstallTelemetrySettings": {
+      enabled?: boolean;
     };
     "service.InstallsHealthResponse": {
       all_healthy?: boolean;
@@ -9027,7 +9045,6 @@ export interface components {
     "service.ReprovisionInstallStackRequest": {
       plan_only?: boolean;
       role?: string;
-      skip_components?: boolean;
     };
     "service.ResetInstallHealthBaselineResponse": {
       baseline_at?: string;
@@ -9094,6 +9111,8 @@ export interface components {
        * expired or been revoked; the caller fixes both the same way.
        */
       has_live_token?: boolean;
+      /** @description Without it a dashboard points the module's provider at production. */
+      runner_api_url?: string;
     };
     "service.SyncSecretsRequest": {
       plan_only?: boolean;
@@ -9105,6 +9124,17 @@ export interface components {
     "service.TeardownInstallComponentsRequest": {
       plan_only?: boolean;
       role?: string;
+    };
+    "service.TelemetryJSONWebKey": {
+      alg?: string;
+      e?: string;
+      kid?: string;
+      kty?: string;
+      n?: string;
+      use?: string;
+    };
+    "service.TelemetryJSONWebKeySet": {
+      keys?: components["schemas"]["service.TelemetryJSONWebKey"][];
     };
     "service.TimeseriesBucket": {
       denies?: number;
@@ -9145,9 +9175,9 @@ export interface components {
        * @description IgnoreChangesRegex marks a run not-attempted when every changed file path in
        * it matches this RE2 pattern. Send an empty string to clear it.
        */
-      ignore_changes_regex?: string;
+      ignore_changes_regex?: string | null;
       /** @description SendStatusesOnIgnore posts a successful commit status for ignored runs. */
-      send_statuses_on_ignore?: boolean;
+      send_statuses_on_ignore?: boolean | null;
     };
     "service.UpdateAppBranchRequest": {
       name: string;
@@ -9230,6 +9260,9 @@ export interface components {
       name?: string;
     };
     "service.UpdateInstallRoleRequest": {
+      enabled: boolean;
+    };
+    "service.UpdateInstallTelemetryRequest": {
       enabled: boolean;
     };
     "service.UpdateNotebookRequest": {
@@ -9544,6 +9577,26 @@ export type external = Record<string, never>;
 
 export interface operations {
 
+  /**
+   * Get telemetry JWT public keys
+   * @description Returns the public RSA keys used to verify BYOC telemetry access tokens.
+   */
+  GetTelemetryJWKS: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["service.TelemetryJSONWebKeySet"];
+        };
+      };
+      /** @description Service Unavailable */
+      503: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+    };
+  };
   /**
    * Slack /nuon slash command webhook
    * @description Slack invokes this endpoint when a user runs `/nuon <subcommand>` in any channel of an installed workspace. Authenticated via the Slack signing-secret middleware (X-Slack-Signature + X-Slack-Request-Timestamp); not via API key. Subcommands: subscribe, unsubscribe, status, help. Responses are ephemeral.
@@ -25143,7 +25196,7 @@ export interface operations {
   };
   /**
    * reprovision an install stack
-   * @description Reprovision an install stack, recreating the runner and its infrastructure. Set `skip_components` to avoid redeploying components on top of the new stack.
+   * @description Reprovision an install stack, recreating the runner and its infrastructure. Components are not redeployed.
    */
   ReprovisionInstallStack: {
     parameters: {
@@ -26314,6 +26367,100 @@ export interface operations {
       201: {
         content: {
           "application/json": components["schemas"]["app.WorkflowResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+    };
+  };
+  /** Get an install's telemetry settings */
+  GetInstallTelemetrySettings: {
+    parameters: {
+      path: {
+        /** @description Install ID */
+        install_id: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["service.InstallTelemetrySettings"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        content: {
+          "application/json": components["schemas"]["stderr.ErrResponse"];
+        };
+      };
+    };
+  };
+  /** Update an install's telemetry settings */
+  UpdateInstallTelemetrySettings: {
+    parameters: {
+      path: {
+        /** @description Install ID */
+        install_id: string;
+      };
+    };
+    /** @description Input */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["service.UpdateInstallTelemetryRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["service.InstallTelemetrySettings"];
         };
       };
       /** @description Bad Request */
@@ -31064,7 +31211,7 @@ export interface operations {
   };
   /**
    * get an install stack's service account
-   * @description Return the service account an install stack's Terraform module authenticates as, and whether it holds a usable API token. Never returns a token value: create one with POST /v1/service-accounts/{account_id}/tokens, which returns it once.
+   * @description Return the service account an install stack's Terraform module authenticates as, whether it holds a usable API token, and the runner API URL its provider authenticates against. Never returns a token value: create one with POST /v1/service-accounts/{account_id}/tokens, which returns it once.
    */
   GetStackServiceAccount: {
     parameters: {


### PR DESCRIPTION
Testing the published stack modules end to end on a BYOC control plane turned up a handful of control-plane bugs. The TF Module tab pointed the stack provider at the production runner API on any dashboard without NUON_RUNNER_API_URL, and the GCP snippet left out project_id/region so a copy-paste first apply failed. Stack config now also serves vpc_nested_template_url (so a module can deploy a vendor's customised VPC template instead of building its own) and stack_version_id (so a new version makes the module's phone home produce a diff, instead of the await step hanging on an already-applied stack).

Also: a render failure left the stack version stuck in generating forever, which then won latest-version lookups and served a template URL that 404s; the Terraform renderer merged a role's policy files into one document and IAM rejected it when two files shared a Sid, so the merge now disambiguates rather than making vendors rename statements; and RunnerGroupSettings.BeforeCreate panicked on a nil map.

Verified against a real BYOC install on all three clouds: GCP 112 resources, Azure 54, AWS 47, each phoning home and unblocking the await install stack step. Provider and module halves are nuonco/terraform-provider-stack#16, nuonco/terraform-aws-stack#7, nuonco/terraform-azure-stack#3 and nuonco/terraform-gcp-stack#5.