### PR TITLE
feat: (cloudformation-stack) Expose private runner telemetry endpoint

### DIFF
--- a/services/ctl-api/internal/app/installs/helpers/to_install_stack_state_test.go
+++ b/services/ctl-api/internal/app/installs/helpers/to_install_stack_state_test.go
@@ -1,0 +1,33 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/nuonco/nuon/pkg/render"
+	"github.com/nuonco/nuon/pkg/types/state"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToInstallStackStateTelemetryEndpoint(t *testing.T) {
+	for _, endpoint := range []string{"http://internal-acme-telemetry.elb.us-east-1.amazonaws.com:4318", ""} {
+		t.Run(endpoint, func(t *testing.T) {
+			outputs := app.InstallStackOutputs{
+				Data: pgtype.Hstore{"telemetry_endpoint": &endpoint},
+			}
+			require.NoError(t, outputs.AfterQuery(nil))
+			stack := &app.InstallStack{
+				InstallStackVersions: []app.InstallStackVersion{{}},
+				InstallStackOutputs:  outputs,
+			}
+			installState := state.State{InstallStack: ToInstallStackState(stack)}
+			data, err := installState.AsMap()
+			require.NoError(t, err)
+			got, err := render.RenderTextV2("{{ .nuon.install_stack.outputs.telemetry_endpoint }}", data)
+			require.NoError(t, err)
+			assert.Equal(t, endpoint, got)
+		})
+	}
+}

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
@@ -26,7 +26,7 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 	}
 
 	// build nested resources
-	stack, vpcParams, err := t.getVPCNestedStack(inp, tb)
+	stack, vpcParams, vpcOutputs, err := t.getVPCNestedStack(inp, tb)
 	if err != nil {
 		return nil, err
 	}
@@ -49,13 +49,31 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 	// resources to save ~5-6 minutes during stack creation.
 	// PhoneHome resources are always created as the provision workflow depends on
 	// the phone home callback to proceed.
+	telemetryEndpoint := ""
 	if !t.cfg.UseLocalRunners {
 		// NOTE(fd): this uses the configurable nested runner asg cf stack
-		runnerASG, err := t.getRunnerASGNestedStack(inp, tb)
+		runnerASG, supportsTelemetryIngress, err := t.getRunnerASGNestedStack(inp, tb)
 		if err != nil {
 			return nil, err
 		}
 		tmpl.Resources["RunnerAutoScalingGroup"] = runnerASG
+
+		if _, hasPrefixList := vpcOutputs["VpcIpv4PrefixListId"]; hasPrefixList && supportsTelemetryIngress {
+			parameter := cloudformation.Parameter{
+				Type:          "String",
+				Description:   ptr("Provision an internal OTLP HTTP endpoint for this install (additional AWS charges apply)"),
+				Default:       "false",
+				AllowedValues: []any{"true", "false"},
+			}
+			runnerParams["EnableTelemetryIngress"] = parameter
+			tmpl.Parameters["EnableTelemetryIngress"] = parameter
+			tmpl.Conditions["TelemetryIngressEnabled"] = cloudformation.Equals(cloudformation.Ref("EnableTelemetryIngress"), "true")
+			runnerASG.Parameters["EnableTelemetryIngress"] = cloudformation.Ref("EnableTelemetryIngress")
+			runnerASG.Parameters["VpcId"] = cloudformation.GetAtt("VPC", "Outputs.VPC")
+			runnerASG.Parameters["TelemetrySourcePrefixListId"] = cloudformation.GetAtt("VPC", "Outputs.VpcIpv4PrefixListId")
+			telemetryEndpoint = cloudformation.If("TelemetryIngressEnabled",
+				cloudformation.GetAtt("RunnerAutoScalingGroup", "Outputs.TelemetryEndpoint"), "")
+		}
 
 		// CloudWatch: logs
 		tmpl.Resources["RunnerCloudWatchLogGroup"] = t.getRunnerCloudWatchLogGroup(inp, tb)
@@ -92,7 +110,13 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 	if err := validatePhoneHomeScript(inp.PhonehomeScript); err != nil {
 		return nil, err
 	}
-	tmpl.Resources["PhoneHomeProps"] = t.getRunnerPhoneHomeProps(inp, customResult)
+	phoneHomeProps := t.getRunnerPhoneHomeProps(inp, customResult)
+	phoneHomeProps.Properties["telemetry_endpoint"] = telemetryEndpoint
+	tmpl.Resources["PhoneHomeProps"] = phoneHomeProps
+	tmpl.Outputs["TelemetryEndpoint"] = cloudformation.Output{
+		Description: ptr("Private OTLP HTTP endpoint, empty when not provisioned"),
+		Value:       telemetryEndpoint,
+	}
 	tmpl.Resources["RunnerPhoneHome"] = t.getRunnerPhoneHomeLambda(inp, tb)
 	tmpl.Resources["RunnerPhoneHomeRole"] = t.getRunnerPhoneHomeLambdaRole(inp, tb)
 

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template_test.go
@@ -1,8 +1,10 @@
 package cloudformation
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/awslabs/goformation/v7/cloudformation/ec2"
@@ -71,4 +73,108 @@ func TestGetAWSTemplate_RunnerResources(t *testing.T) {
 		assert.Contains(t, tmpl.Resources, "RunnerCloudWatchLogStream")
 		assert.Contains(t, tmpl.Resources, "RunnerCloudWatchLogPolicy")
 	})
+}
+
+func TestGetAWSTemplate_TelemetryIngress(t *testing.T) {
+	const telemetryRunner = `
+Parameters:
+  EnableTelemetryIngress: {Type: String, Default: "false"}
+  VpcId: {Type: String, Default: ""}
+  TelemetrySourcePrefixListId: {Type: String, Default: ""}
+Outputs:
+  TelemetryEndpoint: {Value: ""}
+`
+	const vpcOutputs = `
+Outputs:
+  VPC: {Value: vpc-example}
+  VpcIpv4PrefixListId: {Value: pl-example}
+`
+	for _, tc := range []struct {
+		name          string
+		runner        string
+		vpc           string
+		local         bool
+		wantSupported bool
+	}{
+		{"managed VPC", telemetryRunner, mockVPCTemplateYAML + vpcOutputs, false, true},
+		{"BYO VPC without CIDR parameter", telemetryRunner, mockBYOVPCTemplateYAML + vpcOutputs, false, true},
+		{"older runner template", mockRunnerASGTemplateYAML, mockVPCTemplateYAML + vpcOutputs, false, false},
+		{"missing nested output", strings.ReplaceAll(telemetryRunner, "TelemetryEndpoint", "OtherEndpoint"), mockVPCTemplateYAML + vpcOutputs, false, false},
+		{"missing network parameter", strings.ReplaceAll(telemetryRunner, "VpcId", "OtherVpcId"), mockVPCTemplateYAML + vpcOutputs, false, false},
+		{"older CIDR-based runner", strings.ReplaceAll(telemetryRunner, "TelemetrySourcePrefixListId", "VpcCIDR"), mockVPCTemplateYAML + vpcOutputs, false, false},
+		{"older managed VPC", telemetryRunner, mockVPCTemplateYAML, false, false},
+		{"older BYO VPC", telemetryRunner, mockBYOVPCTemplateYAML, false, false},
+		{"local runner", telemetryRunner, mockVPCTemplateYAML + vpcOutputs, true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/vpc.yaml" {
+					_, _ = w.Write([]byte(tc.vpc))
+					return
+				}
+				_, _ = w.Write([]byte(tc.runner))
+			}))
+			defer server.Close()
+
+			inp := &stacks.TemplateInput{
+				Install:                    &app.Install{ID: "inl123", AppID: "app123", OrgID: "org123"},
+				Runner:                     &app.Runner{ID: "run123"},
+				Settings:                   &app.RunnerGroupSettings{},
+				CloudFormationStackVersion: &app.InstallStackVersion{PhoneHomeURL: server.URL + "/phone-home"},
+				PhonehomeScript:            "print('phone home')",
+				AppCfg: &app.AppConfig{StackConfig: app.AppStackConfig{
+					VPCNestedTemplateURL:    server.URL + "/vpc.yaml",
+					RunnerNestedTemplateURL: server.URL + "/runner.yaml",
+				}},
+			}
+			tpl := &Templates{cfg: &internal.Config{UseLocalRunners: tc.local}}
+			tmpl, err := tpl.getAWSTemplate(inp)
+			require.NoError(t, err)
+			raw, err := tmpl.JSON()
+			require.NoError(t, err)
+			var rendered map[string]any
+			require.NoError(t, json.Unmarshal(raw, &rendered))
+			resources := rendered["Resources"].(map[string]any)
+			props := resources["PhoneHomeProps"].(map[string]any)["Properties"].(map[string]any)
+			output := rendered["Outputs"].(map[string]any)["TelemetryEndpoint"].(map[string]any)
+
+			if !tc.wantSupported {
+				assert.NotContains(t, tmpl.Parameters, "EnableTelemetryIngress")
+				assert.NotContains(t, tmpl.Conditions, "TelemetryIngressEnabled")
+				assert.Equal(t, "", props["telemetry_endpoint"])
+				assert.Equal(t, "", output["Value"])
+				assert.NotContains(t, string(raw), "Outputs.TelemetryEndpoint")
+				if !tc.local {
+					params := resources["RunnerAutoScalingGroup"].(map[string]any)["Properties"].(map[string]any)["Parameters"].(map[string]any)
+					assert.NotContains(t, params, "EnableTelemetryIngress")
+					assert.NotContains(t, params, "VpcId")
+					assert.NotContains(t, params, "VpcCIDR")
+					assert.NotContains(t, params, "TelemetrySourcePrefixListId")
+				}
+				return
+			}
+
+			assert.NotContains(t, tmpl.Parameters, "VpcId")
+			assert.NotContains(t, tmpl.Parameters, "TelemetrySourcePrefixListId")
+			parameter := tmpl.Parameters["EnableTelemetryIngress"]
+			assert.Equal(t, "false", parameter.Default)
+			assert.Equal(t, []any{"true", "false"}, parameter.AllowedValues)
+			condition := rendered["Conditions"].(map[string]any)["TelemetryIngressEnabled"]
+			assert.Equal(t, map[string]any{"Fn::Equals": []any{map[string]any{"Ref": "EnableTelemetryIngress"}, "true"}}, condition)
+			params := resources["RunnerAutoScalingGroup"].(map[string]any)["Properties"].(map[string]any)["Parameters"].(map[string]any)
+			assert.Equal(t, map[string]any{"Ref": "EnableTelemetryIngress"}, params["EnableTelemetryIngress"])
+			assert.Equal(t, map[string]any{"Fn::GetAtt": []any{"VPC", "Outputs.VpcIpv4PrefixListId"}}, params["TelemetrySourcePrefixListId"])
+			assert.NotContains(t, params, "VpcCIDR")
+			assert.Equal(t, map[string]any{"Fn::GetAtt": []any{"VPC", "Outputs.VPC"}}, params["VpcId"])
+			wantEndpoint := map[string]any{"Fn::If": []any{
+				"TelemetryIngressEnabled",
+				map[string]any{"Fn::GetAtt": []any{"RunnerAutoScalingGroup", "Outputs.TelemetryEndpoint"}},
+				"",
+			}}
+			assert.Equal(t, wantEndpoint, props["telemetry_endpoint"])
+			assert.Equal(t, wantEndpoint, output["Value"])
+			groups := tmpl.Metadata["AWS::CloudFormation::Interface"].(map[string]any)["ParameterGroups"].([]map[string]any)
+			assert.Contains(t, groups[0]["Parameters"], "EnableTelemetryIngress")
+		})
+	}
 }

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_runner_asg.go
@@ -18,11 +18,11 @@ import (
 // getRunnerASGNestedStack returns a nested stack template for runner ASG resources.
 // It fetches the runner template to discover its parameters, conditionally including
 // RunnerApiToken only if the template defines it.
-func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuilder) (*nestedcloudformation.Stack, error) {
+func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuilder) (*nestedcloudformation.Stack, bool, error) {
 	// fetch the runner template to inspect its declared parameters
 	tmpl, err := a.fetchTemplate(inp.AppCfg.StackConfig.RunnerNestedTemplateURL)
 	if err != nil {
-		return nil, fmt.Errorf("runner ASG nested stack: %w", err)
+		return nil, false, fmt.Errorf("runner ASG nested stack: %w", err)
 	}
 
 	stackTags := []tags.Tag{
@@ -69,13 +69,20 @@ func (a *Templates) getRunnerASGNestedStack(inp *stacks.TemplateInput, t tagBuil
 		params["RunnerEnvVars"] = inp.RunnerEnvVars
 	}
 
+	_, supportsTelemetryIngress := tmpl.Outputs["TelemetryEndpoint"]
+	for _, name := range []string{"EnableTelemetryIngress", "VpcId", "TelemetrySourcePrefixListId"} {
+		if _, ok := tmpl.Parameters[name]; !ok {
+			supportsTelemetryIngress = false
+		}
+	}
+
 	return &nestedcloudformation.Stack{
 		Parameters: params,
 		TemplateURL: cloudformation.Join("", []interface{}{
 			inp.AppCfg.StackConfig.RunnerNestedTemplateURL,
 		}),
 		Tags: t.apply(stackTags, "runner"),
-	}, nil
+	}, supportsTelemetryIngress, nil
 }
 
 func (a *Templates) runnerAPIURL(inp *stacks.TemplateInput) string {

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc.go
@@ -41,10 +41,10 @@ func (tpl *Templates) getClusterName(inp *stacks.TemplateInput) string {
 }
 
 // VPCNestedStack returns a nested stack template for VPC resources
-func (tpl *Templates) getVPCNestedStack(inp *stacks.TemplateInput, t tagBuilder) (*nestedcloudformation.Stack, map[string]cloudformation.Parameter, error) {
-	parameters, defaultParameters, reservedInTemplate, _, err := tpl.extractNestedStackParameters(inp.AppCfg.StackConfig.VPCNestedTemplateURL)
+func (tpl *Templates) getVPCNestedStack(inp *stacks.TemplateInput, t tagBuilder) (*nestedcloudformation.Stack, map[string]cloudformation.Parameter, map[string]struct{}, error) {
+	parameters, defaultParameters, reservedInTemplate, outputs, err := tpl.extractNestedStackParameters(inp.AppCfg.StackConfig.VPCNestedTemplateURL)
 	if err != nil {
-		return nil, nil, fmt.Errorf("VPC nested stack: %w", err)
+		return nil, nil, nil, fmt.Errorf("VPC nested stack: %w", err)
 	}
 
 	// these common params should always be set by nuon so they are explicitly
@@ -72,7 +72,7 @@ func (tpl *Templates) getVPCNestedStack(inp *stacks.TemplateInput, t tagBuilder)
 		Tags: t.apply(nil, "vpc"),
 	}
 
-	return stack, defaultParameters, nil
+	return stack, defaultParameters, outputs, nil
 }
 
 type cfnParameterShape struct {

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/nested_template_vpc_test.go
@@ -283,7 +283,7 @@ func TestGetRunnerASGNestedStack_WithoutRunnerApiToken(t *testing.T) {
 	}
 	tb := tagBuilder{installID: inp.Install.ID}
 
-	stack, err := tpl.getRunnerASGNestedStack(inp, tb)
+	stack, _, err := tpl.getRunnerASGNestedStack(inp, tb)
 	require.NoError(t, err)
 
 	assert.NotContains(t, stack.Parameters, "RunnerApiToken",
@@ -321,7 +321,7 @@ func TestGetRunnerASGNestedStack_WithRunnerApiToken(t *testing.T) {
 	}
 	tb := tagBuilder{installID: inp.Install.ID}
 
-	stack, err := tpl.getRunnerASGNestedStack(inp, tb)
+	stack, _, err := tpl.getRunnerASGNestedStack(inp, tb)
 	require.NoError(t, err)
 
 	assert.Contains(t, stack.Parameters, "RunnerApiToken",
@@ -457,7 +457,7 @@ func TestGetVPCNestedStack_OmitsClusterNameWhenNotInTemplate(t *testing.T) {
 	}
 	tb := tagBuilder{installID: inp.Install.ID}
 
-	stack, _, err := tpl.getVPCNestedStack(inp, tb)
+	stack, _, _, err := tpl.getVPCNestedStack(inp, tb)
 	require.NoError(t, err)
 
 	assert.NotContains(t, stack.Parameters, "ClusterName", "ClusterName should not be in stack parameters when template does not define it")
@@ -488,7 +488,7 @@ func TestGetVPCNestedStack_IncludesClusterNameWhenInTemplate(t *testing.T) {
 	}
 	tb := tagBuilder{installID: inp.Install.ID}
 
-	stack, _, err := tpl.getVPCNestedStack(inp, tb)
+	stack, _, _, err := tpl.getVPCNestedStack(inp, tb)
 	require.NoError(t, err)
 
 	assert.Contains(t, stack.Parameters, "ClusterName", "ClusterName should be in stack parameters when template defines it")


### PR DESCRIPTION
## Summary

Adds support for an optional private OTLP/HTTP endpoint for install runners, backed by an internal NLB in the companion CloudFormation templates.

- Exposes `EnableTelemetryIngress` when both nested templates support telemetry ingress.
- Passes the VPC ID and VPC-owned IPv4 prefix list to the runner stack automatically.
- Exposes `TelemetryEndpoint` in CloudFormation outputs and phone-home data, making it available to components as:
  `{{ .nuon.install_stack.outputs.telemetry_endpoint }}`
- Preserves compatibility with older templates and local-runner mode. The endpoint is empty when disabled or unsupported.

The infrastructure toggle provisions the endpoint; runtime telemetry forwarding remains independently controlled.
