### PR TITLE
feat(ctl-api): serve the app's vpc template url to azure stack modules

### DIFF
--- a/sdks/stack/models/app_installer_s_d_k_azure_config.go
+++ b/sdks/stack/models/app_installer_s_d_k_azure_config.go
@@ -61,6 +61,9 @@ type AppInstallerSDKAzureConfig struct {
 
 	// subscription tenant id
 	SubscriptionTenantID string `json:"subscription_tenant_id,omitempty"`
+
+	// Deployed instead of the module's own network, which lacks its extra resources.
+	VpcNestedTemplateURL string `json:"vpc_nested_template_url,omitempty"`
 }
 
 // Validate validates this app installer s d k azure config

--- a/sdks/stack/models/app_installer_s_d_k_azure_config.go
+++ b/sdks/stack/models/app_installer_s_d_k_azure_config.go
@@ -53,6 +53,9 @@ type AppInstallerSDKAzureConfig struct {
 	// provision built in roles
 	ProvisionBuiltInRoles []string `json:"provision_built_in_roles"`
 
+	// runner nested template url
+	RunnerNestedTemplateURL string `json:"runner_nested_template_url,omitempty"`
+
 	// runner vm size
 	RunnerVMSize string `json:"runner_vm_size,omitempty"`
 

--- a/services/ctl-api/internal/app/installer_sdk_config.go
+++ b/services/ctl-api/internal/app/installer_sdk_config.go
@@ -127,7 +127,8 @@ type InstallerSDKAzureConfig struct {
 	ContainerImageTag string `json:"container_image_tag,omitempty"`
 
 	// Deployed instead of the module's own network, which lacks its extra resources.
-	VPCNestedTemplateURL string `json:"vpc_nested_template_url,omitempty"`
+	VPCNestedTemplateURL    string `json:"vpc_nested_template_url,omitempty"`
+	RunnerNestedTemplateURL string `json:"runner_nested_template_url,omitempty"`
 
 	ProvisionActions        []string `json:"provision_actions,omitempty"`
 	ProvisionBuiltInRoles   []string `json:"provision_built_in_roles,omitempty"`

--- a/services/ctl-api/internal/app/installer_sdk_config.go
+++ b/services/ctl-api/internal/app/installer_sdk_config.go
@@ -126,6 +126,9 @@ type InstallerSDKAzureConfig struct {
 	ContainerImageURL string `json:"container_image_url,omitempty"`
 	ContainerImageTag string `json:"container_image_tag,omitempty"`
 
+	// Deployed instead of the module's own network, which lacks its extra resources.
+	VPCNestedTemplateURL string `json:"vpc_nested_template_url,omitempty"`
+
 	ProvisionActions        []string `json:"provision_actions,omitempty"`
 	ProvisionBuiltInRoles   []string `json:"provision_built_in_roles,omitempty"`
 	MaintenanceActions      []string `json:"maintenance_actions,omitempty"`

--- a/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config.go
+++ b/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config.go
@@ -332,7 +332,8 @@ func (h *Helpers) BuildInstallerSDKConfig(ctx context.Context, installID string)
 			SubscriptionID:       install.AzureAccount.SubscriptionID,
 			SubscriptionTenantID: install.AzureAccount.SubscriptionTenantID,
 
-			VPCNestedTemplateURL: appCfg.StackConfig.VPCNestedTemplateURL,
+			VPCNestedTemplateURL:    appCfg.StackConfig.VPCNestedTemplateURL,
+			RunnerNestedTemplateURL: appCfg.StackConfig.RunnerNestedTemplateURL,
 
 			RunnerVMSize:      instanceType,
 			ContainerImageURL: install.RunnerGroup.Settings.ContainerImageURL,

--- a/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config.go
+++ b/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config.go
@@ -332,6 +332,8 @@ func (h *Helpers) BuildInstallerSDKConfig(ctx context.Context, installID string)
 			SubscriptionID:       install.AzureAccount.SubscriptionID,
 			SubscriptionTenantID: install.AzureAccount.SubscriptionTenantID,
 
+			VPCNestedTemplateURL: appCfg.StackConfig.VPCNestedTemplateURL,
+
 			RunnerVMSize:      instanceType,
 			ContainerImageURL: install.RunnerGroup.Settings.ContainerImageURL,
 			ContainerImageTag: install.RunnerGroup.Settings.ContainerImageTag,


### PR DESCRIPTION
Same gap we just closed on AWS: the Azure stack config never carried vpc_nested_template_url, so the published module always built its own network and a vendor who customised their ARM virtual network lost everything it adds beyond the reference topology. Their lovable Azure template declares dedicated agw, apiserver, postgres, private-endpoint, nodepool and publishing subnets plus the NSGs, none of which the module creates.

Serves the field on the azure block of stack_config so the module can deploy that template instead. Module half follows once the provider exposes it.