### PR TITLE
fix(ctl-api): recover panics from every middleware and serve the runner template url

### DIFF
--- a/sdks/stack/models/app_installer_s_d_k_a_w_s_config.go
+++ b/sdks/stack/models/app_installer_s_d_k_a_w_s_config.go
@@ -65,6 +65,9 @@ type AppInstallerSDKAWSConfig struct {
 	// runner machine type
 	RunnerMachineType string `json:"runner_machine_type,omitempty"`
 
+	// runner nested template url
+	RunnerNestedTemplateURL string `json:"runner_nested_template_url,omitempty"`
+
 	// Deployed instead of the module's own VPC, which lacks its extra resources.
 	VpcNestedTemplateURL string `json:"vpc_nested_template_url,omitempty"`
 }

--- a/services/ctl-api/internal/app/installer_sdk_config.go
+++ b/services/ctl-api/internal/app/installer_sdk_config.go
@@ -54,7 +54,8 @@ type InstallerSDKAWSConfig struct {
 	RunnerMachineType string `json:"runner_machine_type,omitempty"`
 
 	// Deployed instead of the module's own VPC, which lacks its extra resources.
-	VPCNestedTemplateURL string `json:"vpc_nested_template_url,omitempty"`
+	VPCNestedTemplateURL    string `json:"vpc_nested_template_url,omitempty"`
+	RunnerNestedTemplateURL string `json:"runner_nested_template_url,omitempty"`
 
 	NuonSupportIAMRoleARNs []string `json:"nuon_support_iam_role_arns,omitempty"`
 

--- a/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config.go
+++ b/services/ctl-api/internal/app/installs/helpers/build_installer_sdk_config.go
@@ -248,7 +248,8 @@ func (h *Helpers) BuildInstallerSDKConfig(ctx context.Context, installID string)
 			ClusterName:       clusterName,
 			RunnerMachineType: instanceType,
 
-			VPCNestedTemplateURL: appCfg.StackConfig.VPCNestedTemplateURL,
+			VPCNestedTemplateURL:    appCfg.StackConfig.VPCNestedTemplateURL,
+			RunnerNestedTemplateURL: appCfg.StackConfig.RunnerNestedTemplateURL,
 
 			NuonSupportIAMRoleARNs: supportARNs,
 

--- a/services/ctl-api/internal/middlewares/org/runner.go
+++ b/services/ctl-api/internal/middlewares/org/runner.go
@@ -59,6 +59,17 @@ func (m *runnerMiddleware) Handler() gin.HandlerFunc {
 			return
 		}
 
+		// Orgs is filled alongside OrgIDs, so a short one means the account was
+		// loaded without its roles' orgs; indexing it would panic.
+		if len(acct.Orgs) < 1 {
+			ctx.Error(stderr.ErrAuthorization{
+				Err:         fmt.Errorf("runner account has no org loaded"),
+				Description: "please retry request correct runner account",
+			})
+			ctx.Abort()
+			return
+		}
+
 		cctx.SetOrgIDGinContext(ctx, acct.OrgIDs[0])
 		cctx.SetOrgGinContext(ctx, acct.Orgs[0])
 	}

--- a/services/ctl-api/internal/middlewares/org/runner_test.go
+++ b/services/ctl-api/internal/middlewares/org/runner_test.go
@@ -1,0 +1,36 @@
+package org
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+)
+
+// An account carrying org ids but no loaded orgs used to index past the end of
+// Orgs. The panic escaped the recovery middleware, which is registered after this
+// one, so the caller got a proxy 503 with no body rather than an error.
+func TestRunnerMiddlewareOrgsShorterThanOrgIDs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	acct := &app.Account{ID: "acc_one"}
+	acct.OrgIDs = []string{"org_one"}
+
+	rr := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rr)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v1/stacks/inl_one/config", nil)
+	cctx.SetAccountGinContext(ctx, acct)
+
+	m := &runnerMiddleware{}
+	require.NotPanics(t, func() { m.Handler()(ctx) })
+
+	assert.True(t, ctx.IsAborted())
+	require.NotEmpty(t, ctx.Errors)
+	assert.Contains(t, ctx.Errors[0].Error(), "org", "must fail on the missing org, not on a missing account")
+}

--- a/services/ctl-api/internal/pkg/api/base.go
+++ b/services/ctl-api/internal/pkg/api/base.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"go.uber.org/fx"
 	"go.uber.org/zap"
@@ -52,6 +53,8 @@ func (a *API) middlewareDebugWrapper(name string, fn gin.HandlerFunc) gin.Handle
 	}
 }
 
+const panickerMiddlewareName = "panicker"
+
 func (a *API) registerMiddlewares() error {
 	// register middlewares
 	middlewaresLookup := make(map[string]gin.HandlerFunc, 0)
@@ -59,7 +62,20 @@ func (a *API) registerMiddlewares() error {
 		middlewaresLookup[middleware.Name()] = middleware.Handler()
 	}
 
+	// gin.CustomRecovery only recovers what runs after it, and gin.New() installs no
+	// recovery of its own, so a panic in an earlier middleware kills the connection
+	// and the caller sees a proxy 503 with no body instead of an error response.
+	ordered := make([]string, 0, len(a.configuredMiddlewares))
+	if slices.Contains(a.configuredMiddlewares, panickerMiddlewareName) {
+		ordered = append(ordered, panickerMiddlewareName)
+	}
 	for _, middleware := range a.configuredMiddlewares {
+		if middleware != panickerMiddlewareName {
+			ordered = append(ordered, middleware)
+		}
+	}
+
+	for _, middleware := range ordered {
 		a.l.Info(fmt.Sprintf("registering middleware: %s", middleware), zap.String("name", middleware))
 		fn, ok := middlewaresLookup[middleware]
 		if !ok {


### PR DESCRIPTION
A customer pointing their stack module at the wrong kind of token got a 503 with an empty body instead of a 403, which sent them debugging the wrong thing. Cause is that gin.New() installs no recovery and panicker is configured last, but gin.CustomRecovery only covers what runs after it, so a panic in auth, runner_org or any earlier middleware terminates the connection and the caller sees a proxy 503. The recovery middleware is now registered first whatever the configured order says.

The panic itself is in runner_org, which length-checks OrgIDs and then indexes Orgs, a different slice, so an account loaded without its roles' orgs goes out of range. It now returns an authorization error instead, with a regression test that panics without the guard.

Also serves runner_nested_template_url alongside vpc_nested_template_url on the aws block, so a module can deploy a vendor's customised runner template rather than always building its own. The azure side of that rides along with nuonco/nuon#2421.