### PR TITLE
feat: nuon mcp help

### DIFF
--- a/bins/cli/AGENTS.md
+++ b/bins/cli/AGENTS.md
@@ -514,10 +514,20 @@ resources exits 2 with a clear error.
 
 Preferred LLM surface is **`nuon agents`**:
 
+- `nuon agents help`: the **human** setup guide (`cmd/agents_help.go`). `agentsSetupGuide` is the single source: it
+  backs both this command and the `agents` group's `Long`, so `nuon agents`, `nuon agents --help`, and
+  `nuon agents help` all print the same instructions (the subcommand additionally renders the live sign-in, org, and
+  resolved MCP URL). Extend the guide, not one of its callers. Document each client on its own (Claude Code, Cursor,
+  Amp, and a catch-all that tells people to check that client's MCP docs). Do not present `mcpServers` as a
+  universal schema. Every runnable example carries `--allow-writes`. `--url` is a general override when the MCP URL
+  does not follow from the API URL (self-hosted and Nuon BYOC are examples).
+  `mcpClientJSON` renders a block for a given key; reuse it rather than retyping JSON.
 - `nuon agents context` — markdown orientation (auth, selection, MCP URL, timestamps). The document lives in
   `cmd/agents_context.md`, embedded with `go:embed` and rendered as a `text/template` against the fields of
   `agentsContext` (`Authed`, `APIURL`, `MCPURL`, `OrgID`, `AppID`, `InstallID`) — edit the markdown, not Go string
-  literals. Keep its tool table and timestamp rules in sync with `docs/guides/agents/tools.mdx`. Do not duplicate
+  literals. Keep its tool table and timestamp rules in sync with `docs/guides/agents/tools.mdx`, and its per-client
+  registration in sync with `nuon agents help`. Both documents state their purpose up top
+  (human vs. agent) because that split is what users get confused about. Do not duplicate
   client setup recipes, sample queries, or the deprecated `nuon mcp` alias here — those live in
   `docs/guides/agents/` and `cmd/mcp.go`. MCP timestamps are UTC RFC3339 (`…Z`); agents localize before naming a
   day or clock time.

--- a/bins/cli/cmd/agents.go
+++ b/bins/cli/cmd/agents.go
@@ -15,21 +15,10 @@ func (c *cli) agentsCmd() *cobra.Command {
 	agentsCmd := &cobra.Command{
 		Use:   "agents",
 		Short: "Agent-facing helpers for driving Nuon with LLMs",
-		Long: `Commands for LLM agents working with Nuon.
-
-Start here:
-  nuon agents context   Print markdown orientation (auth, selection, how to use MCP)
-  nuon agents mcp       Run a local stdio MCP proxy that injects your API token and org ID
-
-Register with an MCP client:
-
-  claude mcp add --transport stdio nuon -- nuon agents mcp --allow-writes
-  amp mcp add nuon -- nuon agents mcp --allow-writes
-
-Cursor / Cursor Agent: write ~/.cursor/mcp.json then agent mcp enable nuon.
-
-Direct HTTP: point an MCP client at the URL from "nuon agents context"
-with Bearer token and X-Nuon-Org-ID headers.`,
+		// Same guide as "nuon agents help", which adds the live sign-in, org,
+		// and resolved MCP URL. Whichever a user reaches for, they get all of
+		// the setup, not a pointer to the other one.
+		Long:        agentsSetupGuide(nil),
 		GroupID:     AdditionalGroup.ID,
 		Annotations: annotations(skipAuthAnnotation(), outputsAnnotation(OutputTable)),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
@@ -37,6 +26,7 @@ with Bearer token and X-Nuon-Org-ID headers.`,
 		}),
 	}
 
+	agentsCmd.AddCommand(c.agentsHelpCmd())
 	agentsCmd.AddCommand(c.agentsContextCmd())
 	agentsCmd.AddCommand(c.agentsMCPCmd())
 
@@ -76,21 +66,25 @@ Injects Authorization (Bearer) and X-Nuon-Org-ID from ~/.nuon on every
 upstream request. Read-only by default; pass --allow-writes to also
 expose mutating tools (descriptions prefixed with "WRITE OPERATION:").
 
-Example — register:
+Example, register:
 
   claude mcp add --transport stdio nuon -- nuon agents mcp --allow-writes
   amp mcp add nuon -- nuon agents mcp --allow-writes
-  # Cursor: write ~/.cursor/mcp.json, then agent mcp enable nuon
+  # Cursor: save JSON to ~/.cursor/mcp.json, then agent mcp enable nuon
 
-Or add to .mcp.json:
+Clients differ in config file and JSON key. Claude Code uses mcpServers in
+.mcp.json; Cursor uses mcpServers in ~/.cursor/mcp.json; Amp uses the
+amp.mcpServers key in ~/.config/amp/settings.json. Check other clients'
+MCP docs rather than assuming those keys.
 
-  {"mcpServers": {"nuon": {"command": "nuon", "args": ["agents", "mcp", "--allow-writes"]}}}
+` + mcpClientJSON("mcpServers", "  ") + `
 
-Example — override the upstream server:
+Example, override the derived MCP URL when it does not match the API URL:
 
-  nuon agents mcp --allow-writes --url https://mcp.example.com/mcp --name nuon-example
+  nuon agents mcp --allow-writes --url https://mcp.example.nuon.co/mcp --name nuon-example
 
-Run "nuon agents context" to see which MCP URL resolves from your config.`,
+Run "nuon agents help" for per-client setup and "nuon agents context" to see
+which MCP URL resolves from your config.`,
 		PersistentPreRunE: c.persistentPreRunE,
 		Annotations:       outputsAnnotation(OutputTable),
 		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
@@ -108,7 +102,7 @@ Run "nuon agents context" to see which MCP URL resolves from your config.`,
 		}),
 	}
 	cmd.Flags().BoolVar(&allowWrites, "allow-writes", false, "expose mutating tools whose descriptions start with WRITE OPERATION:")
-	cmd.Flags().StringVar(&mcpURL, "url", "", "upstream MCP server URL (derived from api.<hostname>, or localhost; otherwise required)")
+	cmd.Flags().StringVar(&mcpURL, "url", "", "upstream MCP server URL, for example https://mcp.example.nuon.co/mcp. Derived from api.<hostname> by default; pass this when the MCP URL does not follow from the API URL")
 	cmd.Flags().StringVar(&serverName, "name", "", "MCP server name exposed to the client (default nuon, derived from the configured API URL)")
 
 	return cmd

--- a/bins/cli/cmd/agents_context.md
+++ b/bins/cli/cmd/agents_context.md
@@ -1,6 +1,8 @@
 # Nuon agent context
 
-Use this document to orient before creating or changing Nuon resources.
+**Purpose:** this document is for you, the agent. It templates out the current CLI selection, how to reach Nuon over MCP, the tool catalog, and links for everything else Nuon. Read it before creating or changing Nuon resources.
+
+`nuon agents help` is the human-facing companion: the same setup, written for the person you are working with, checked against their config. Point them at it rather than improvising setup steps.
 
 ## Current CLI selection
 
@@ -32,9 +34,56 @@ nuon agents mcp --allow-writes
 
 The proxy sets `X-Nuon-Org-ID`. Do not call `select_org` unless that header is missing.
 
-The upstream URL (`{{.MCPURL}}`) comes from `api_url` in the CLI config. Override with `--url` / `--name` on the registered command (`nuon agents mcp --allow-writes --url … --name …`). A non-default `-C` config goes on the same command.
+### Registering the proxy with a client
 
-**Direct HTTP:** point an MCP client at `{{.MCPURL}}` with `Authorization: Bearer <api_token>` and `X-Nuon-Org-ID: <org_id>` (required for multi-org accounts without `select_org`). Client setup: https://docs.nuon.co/guides/agents
+Each client has its own config file, JSON key, and (sometimes) an add command. Check that client's MCP docs rather than assuming a shared schema. The process to spawn is `nuon` with arguments `agents`, `mcp`, and `--allow-writes`.
+
+`--allow-writes` exposes the mutating tools (descriptions start with `WRITE OPERATION:`). That flag only lists them; the identity still needs org Admin (`org_admin`), not Read-only. See https://docs.nuon.co/concepts/access-control. Every example below includes it; omit it only for a read-only proxy.
+
+**Claude Code.** `claude mcp add --transport stdio nuon -- nuon agents mcp --allow-writes`, or `.mcp.json` in a project:
+
+```json
+{
+  "mcpServers": {
+    "nuon": {
+      "command": "nuon",
+      "args": ["agents", "mcp", "--allow-writes"]
+    }
+  }
+}
+```
+
+**Cursor.** No add command. Save to `~/.cursor/mcp.json` (all projects) or `.cursor/mcp.json` (one project), then run `agent mcp enable nuon`:
+
+```json
+{
+  "mcpServers": {
+    "nuon": {
+      "command": "nuon",
+      "args": ["agents", "mcp", "--allow-writes"]
+    }
+  }
+}
+```
+
+**Amp.** `amp mcp add nuon -- nuon agents mcp --allow-writes` (add `--workspace` to scope it to one workspace), or `~/.config/amp/settings.json` (user) / `.amp/settings.json` (workspace). Amp's key is `amp.mcpServers`:
+
+```json
+{
+  "amp.mcpServers": {
+    "nuon": {
+      "command": "nuon",
+      "args": ["agents", "mcp", "--allow-writes"]
+    }
+  }
+}
+```
+
+**Other clients.** Use that client's MCP docs for the file path and JSON key. Point it at the `nuon` binary with arguments `agents`, `mcp`, and `--allow-writes`.
+
+### Overriding the MCP URL
+
+The upstream URL (`{{.MCPURL}}`) is derived from `api_url` in the CLI config, turning `api.<host>` into `mcp.<host>/mcp`. Pass `--url` on the registered command when the MCP URL does not follow from the API URL, for example a self-hosted or Nuon BYOC control plane, or any deployment where the two hostnames differ. Pass `--name` to rename the server in the client's list. A non-default `-C` config goes on the same command.
 
 ## Creating something new (starter checklist)
 

--- a/bins/cli/cmd/agents_help.go
+++ b/bins/cli/cmd/agents_help.go
@@ -1,0 +1,210 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nuonco/nuon/bins/cli/internal/services/mcpserver"
+	"github.com/nuonco/nuon/pkg/cli/styles"
+)
+
+// mcpClientJSON renders a client config block. Keys differ by client
+// (mcpServers, amp.mcpServers, and others); pass the key the client uses.
+func mcpClientJSON(key, indent string) string {
+	block := `{
+  "` + key + `": {
+    "nuon": {
+      "command": "nuon",
+      "args": ["agents", "mcp", "--allow-writes"]
+    }
+  }
+}`
+
+	lines := strings.Split(block, "\n")
+	for i, line := range lines {
+		lines[i] = indent + line
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// agentsStatus is the live CLI state woven into the setup guide. It is nil
+// when the guide backs static help text, which is built before flags have
+// selected a config file.
+type agentsStatus struct {
+	APIURL    string
+	SignedIn  bool
+	OrgID     string
+	MCPURL    string
+	MCPURLErr error
+}
+
+func (c *cli) agentsStatus() *agentsStatus {
+	st := &agentsStatus{APIURL: "https://api.nuon.co"}
+	if c.cfg != nil {
+		if c.cfg.APIURL != "" {
+			st.APIURL = c.cfg.APIURL
+		}
+		st.SignedIn = c.cfg.APIToken != ""
+		st.OrgID = c.cfg.OrgID
+	}
+	st.MCPURL, st.MCPURLErr = mcpserver.EndpointFromAPIURL(st.APIURL)
+
+	return st
+}
+
+// agentsSetupGuide is the single source for agent setup instructions: it backs
+// both "nuon agents help" and the "nuon agents" help text, so the two never
+// disagree about a client's config file or a flag.
+func agentsSetupGuide(st *agentsStatus) string {
+	var b strings.Builder
+	p := func(lines ...string) {
+		for _, line := range lines {
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+
+	p(
+		"Drive Nuon with an LLM agent.",
+		"",
+		"  nuon agents help      For humans: get set up. This guide.",
+		"  nuon agents context   For your agent: orientation, tool catalog, sample",
+		"                        queries, current org/app/install selection.",
+		"  nuon agents mcp       The stdio MCP proxy a client runs. Registered below.",
+		"",
+		"1. Sign in and select an org",
+		"",
+	)
+
+	if st != nil {
+		if st.SignedIn {
+			p("  " + styles.TextSuccess.Render("✓") + " Signed in to " + st.APIURL)
+		} else {
+			p("  " + styles.TextError.Render("✗") + " Not signed in")
+		}
+		if st.OrgID != "" {
+			p("  " + styles.TextSuccess.Render("✓") + " Org " + st.OrgID)
+		} else {
+			p("  " + styles.TextError.Render("✗") + " No org selected")
+		}
+		p("")
+	}
+
+	p(
+		"  Both are required:",
+		"",
+		"    nuon auth login    writes api_token to ~/.nuon",
+		"    nuon orgs select   writes org_id to ~/.nuon",
+		"",
+		"  Everything below reads both from ~/.nuon, so no token or org ID goes",
+		"  into your agent's config.",
+		"",
+		"2. Register the MCP server with your agent",
+		"",
+		"  Each client has its own config file, JSON key, and (sometimes) an add",
+		"  command. Check that client's MCP docs rather than assuming a shared",
+		"  schema. The process to spawn is nuon with arguments agents, mcp, and",
+		"  --allow-writes.",
+		"",
+		"  --allow-writes exposes the mutating tools (descriptions start with \"WRITE",
+		"  OPERATION:\"). That flag only lists them; the identity still needs org",
+		"  Admin (org_admin), not Read-only. See",
+		"  https://docs.nuon.co/concepts/access-control. Leave the flag off for a",
+		"  read-only proxy.",
+		"",
+		"  Claude Code",
+		"",
+		"    claude mcp add --transport stdio nuon -- nuon agents mcp --allow-writes",
+		"",
+		"    Or as .mcp.json in a project:",
+		"",
+		mcpClientJSON("mcpServers", "      "),
+		"",
+		"  Cursor",
+		"",
+		"    Cursor has no add command. Save this as ~/.cursor/mcp.json (all",
+		"    projects) or .cursor/mcp.json (one project):",
+		"",
+		mcpClientJSON("mcpServers", "      "),
+		"",
+		"    Then enable it:",
+		"",
+		"      agent mcp enable nuon",
+		"",
+		"  Amp",
+		"",
+		"    amp mcp add nuon -- nuon agents mcp --allow-writes",
+		"",
+		"    Add --workspace to that command to scope it to one workspace. By file,",
+		"    Amp's key is amp.mcpServers, in ~/.config/amp/settings.json (you) or",
+		"    .amp/settings.json (a workspace):",
+		"",
+		mcpClientJSON("amp.mcpServers", "      "),
+		"",
+		"  Other clients",
+		"",
+		"    Use that client's MCP docs for the file path and JSON key. Point it at",
+		"    the nuon binary with arguments agents, mcp, and --allow-writes.",
+		"",
+		"3. Check it works",
+		"",
+		"    nuon agents context",
+		"",
+		"  Then ask your agent to run the whoami tool.",
+		"",
+		"Overriding the MCP URL",
+		"",
+		"  The proxy derives its MCP URL from api_url in ~/.nuon, turning api.<host>",
+		"  into mcp.<host>/mcp. Pass --url when the MCP URL does not follow from the",
+		"  API URL, for example a self-hosted or Nuon BYOC control plane, or any",
+		"  deployment where the two hostnames differ. Pass --name to rename the",
+		"  server in your client's list. Both go on the command the client runs:",
+		"",
+		"    claude mcp add --transport stdio nuon -- nuon agents mcp \\",
+		"      --allow-writes --url https://mcp.example.nuon.co/mcp --name nuon-example",
+		"",
+	)
+
+	if st != nil {
+		if st.MCPURLErr != nil {
+			p(
+				"  "+styles.TextError.Render("Your api_url ("+st.APIURL+") does not follow that"),
+				"  "+styles.TextError.Render("pattern, so --url is required."),
+			)
+		} else {
+			p("  Yours resolves to " + st.MCPURL + ".")
+		}
+		p("")
+	}
+
+	p(
+		"  A non-default CLI config carries its own token, org, and api_url: put -C",
+		"  on the registered command too (Cursor and Amp: inside args).",
+		"",
+		"Docs: https://docs.nuon.co/guides/agents",
+	)
+
+	return b.String()
+}
+
+func (c *cli) agentsHelpCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "help",
+		Short: "Set up an agent to work with Nuon (for humans)",
+		Long: `Print the agent setup guide: signing in, selecting an org, registering the
+MCP server with Claude Code, Cursor, or Amp, and overriding the derived MCP URL.
+
+Same guide as "nuon agents --help", plus your own sign-in, org, and resolved
+MCP URL. For the document to hand your agent, use "nuon agents context".`,
+		PersistentPreRunE: c.persistentPreRunE,
+		Annotations:       annotations(skipAuthAnnotation(), outputsAnnotation(OutputTable)),
+		Run: c.wrapCmd(func(cmd *cobra.Command, _ []string) error {
+			// cobra's cmd.Print* writes to stderr; this guide is the output.
+			fmt.Fprintln(cmd.OutOrStdout(), agentsSetupGuide(c.agentsStatus()))
+			return nil
+		}),
+	}
+}

--- a/docs/guides/agents/mcp-walkthrough.mdx
+++ b/docs/guides/agents/mcp-walkthrough.mdx
@@ -16,13 +16,37 @@ icon: "route"
 
 Add the stdio proxy. Token and org stay in `~/.nuon`.
 
+Each client has its own config file, JSON key, and (sometimes) an add command. Check that client's MCP docs rather than assuming a shared schema. The process to spawn is `nuon` with arguments `agents`, `mcp`, and `--allow-writes`.
+
 <CodeGroup>
 ```bash Claude Code
 claude mcp add --transport stdio nuon -- nuon agents mcp --allow-writes
 ```
 
+```json Claude Code (by file)
+{
+  "mcpServers": {
+    "nuon": {
+      "command": "nuon",
+      "args": ["agents", "mcp", "--allow-writes"]
+    }
+  }
+}
+```
+
 ```bash Amp
 amp mcp add nuon -- nuon agents mcp --allow-writes
+```
+
+```json Amp (by file)
+{
+  "amp.mcpServers": {
+    "nuon": {
+      "command": "nuon",
+      "args": ["agents", "mcp", "--allow-writes"]
+    }
+  }
+}
 ```
 
 ```json Cursor
@@ -37,11 +61,21 @@ amp mcp add nuon -- nuon agents mcp --allow-writes
 ```
 </CodeGroup>
 
-Cursor has no `mcp add`. Save the JSON as `~/.cursor/mcp.json` or project `.cursor/mcp.json`, then `agent mcp enable nuon`.
+Claude Code: add command above, or save the JSON as `.mcp.json` in the project.
 
-Examples include `--allow-writes` so mutating tools are available. Your token must have create permission.
+Amp: add command above, or save the JSON under `amp.mcpServers` in `~/.config/amp/settings.json` (user) or `.amp/settings.json` (workspace).
 
-The proxy derives its URL from the configured API hostname (`api.<hostname>` becomes `mcp.<hostname>/mcp`). Override it with `--url` (and `--name` for the client's MCP list) on the registered command. Full examples: [Connect](/guides/agents/overview#connect) and [Override the server](/guides/agents/overview#override-the-server).
+Cursor has no `mcp add`. Save the JSON as `~/.cursor/mcp.json` (all projects) or `.cursor/mcp.json` (one project), then:
+
+```bash
+agent mcp enable nuon
+```
+
+Examples include `--allow-writes` so mutating tools are available. That flag only lists write tools; the identity still needs [Admin](/concepts/access-control) (`org_admin`), not Read-only.
+
+The proxy derives its URL from the configured API hostname (`api.<hostname>` becomes `mcp.<hostname>/mcp`). Pass `--url` when the MCP URL does not follow from the API URL, for example a self-hosted or Nuon BYOC control plane, or any deployment where the hostnames differ. Use `--name` to rename it in the client's MCP list. Full examples: [Connect](/guides/agents/overview#connect) and [Overriding the MCP URL](/guides/agents/overview#overriding-the-mcp-url).
+
+`nuon agents help` prints all of this against your own config.
 
 </Step>
 

--- a/docs/guides/agents/overview.mdx
+++ b/docs/guides/agents/overview.mdx
@@ -28,32 +28,39 @@ Use an LLM client to read and operate orgs, apps, installs, and workflows, or to
 
 ## Prerequisites
 
+Both are required. They write the credentials every setup below reads:
+
 ```bash
-nuon auth login
-nuon orgs select
+nuon auth login    # writes api_token to ~/.nuon
+nuon orgs select   # writes org_id to ~/.nuon
 ```
 
-`nuon agents context` prints your auth, selected org/app/install, MCP HTTP URL, and how to read timestamps (UTC/`Z`, convert to local before naming a day or clock time).
+Two commands print this page from the CLI:
+
+- `nuon agents help`: for you, the same setup, checked against your own config.
+- `nuon agents context`: for your agent: auth, selected org/app/install, MCP HTTP URL, tool catalog, and how to read timestamps (UTC/`Z`, convert to local before naming a day or clock time).
 
 ## Connect
 
-**Recommended:** register the stdio proxy so the client runs `nuon agents mcp --allow-writes`. Token and org stay in `~/.nuon`. The proxy derives its URL from the configured API hostname (`api.<hostname>` becomes `mcp.<hostname>/mcp`) and registers as `nuon`.
+**Recommended:** register the stdio proxy so the client runs `nuon agents mcp --allow-writes`. Token and org stay in `~/.nuon`, so nothing secret goes into the client config. The proxy derives its URL from the configured API hostname (`api.<hostname>` becomes `mcp.<hostname>/mcp`) and registers as `nuon`.
 
 ### Setup (stdio)
 
-<CodeGroup>
-```bash Claude Code
+Each client has its own config file, JSON key, and (sometimes) an add command. Check that client's MCP docs rather than assuming a shared schema. The process every client should spawn is `nuon` with arguments `agents`, `mcp`, and `--allow-writes`.
+
+Examples include `--allow-writes` so mutating tools are available. That flag only lists write tools; the identity still needs [Admin](/concepts/access-control) (`org_admin`), not Read-only. Omit the flag only if you want a read-only proxy.
+
+You do not need `select_org` when the org is already in the CLI config (the stdio proxy sends `X-Nuon-Org-ID`).
+
+#### Claude Code
+
+```bash
 claude mcp add --transport stdio nuon -- nuon agents mcp --allow-writes
 ```
 
-```bash Amp
-amp mcp add nuon -- nuon agents mcp --allow-writes
+Or `.mcp.json` in a project:
 
-# this workspace only
-amp mcp add nuon --workspace -- nuon agents mcp --allow-writes
-```
-
-```json Cursor
+```json
 {
   "mcpServers": {
     "nuon": {
@@ -63,35 +70,75 @@ amp mcp add nuon --workspace -- nuon agents mcp --allow-writes
   }
 }
 ```
-</CodeGroup>
 
-Cursor has no `mcp add`. Save the JSON as `~/.cursor/mcp.json` or project `.cursor/mcp.json`, then `agent mcp enable nuon`.
+#### Cursor
 
-Examples include `--allow-writes` so mutating tools are available. Your token must have create permission. Omit the flag only if you want a read-only proxy.
+Cursor has no `mcp add`. Save this as `~/.cursor/mcp.json` (all projects) or `.cursor/mcp.json` (one project), then enable it:
 
-You do not need `select_org` when the org is already in the CLI config (the stdio proxy sends `X-Nuon-Org-ID`).
-
-### Override the server
-
-The proxy derives its upstream URL from `api_url` in your CLI config when the hostname starts with `api.` (`https://api.nuon.co` → `https://mcp.nuon.co/mcp`). To point somewhere else, pass `--url`; to change the name in the client's MCP list, pass `--name`. Put those flags on the command the client runs:
-
-```bash
-nuon agents mcp --allow-writes --url https://mcp.example.com/mcp --name nuon-example
-claude mcp add --transport stdio nuon -- nuon agents mcp --allow-writes --url https://mcp.example.com/mcp --name nuon-example
-amp mcp add nuon -- nuon agents mcp --allow-writes --url https://mcp.example.com/mcp --name nuon-example
+```json
+{
+  "mcpServers": {
+    "nuon": {
+      "command": "nuon",
+      "args": ["agents", "mcp", "--allow-writes"]
+    }
+  }
+}
 ```
 
-A non-default CLI config (`nuon -C /path/to/config agents mcp --allow-writes`) carries its own token, org, and `api_url`. Put `-C` and `--allow-writes` on the registered command (Cursor: in `args`).
+```bash
+agent mcp enable nuon
+```
 
-Run `nuon agents context` to confirm which MCP URL resolves before registering.
+#### Amp
 
-## Related CLI flags
+```bash
+amp mcp add nuon -- nuon agents mcp --allow-writes
 
-These apply to `nuon` commands, not MCP tools:
+# this workspace only
+amp mcp add nuon --workspace -- nuon agents mcp --allow-writes
+```
 
-| Flag | Purpose |
-| --- | --- |
-| `--output agent` | Single JSON envelope on stdout (`{"ok":true,"data":...}`) |
-| `--read-only` | Block mutating CLI commands (exit 2) |
+Or `~/.config/amp/settings.json` (user) / `.amp/settings.json` (workspace). Amp's key is `amp.mcpServers`:
 
-See [CLI commands](/cli-commands) for the full reference.
+```json
+{
+  "amp.mcpServers": {
+    "nuon": {
+      "command": "nuon",
+      "args": ["agents", "mcp", "--allow-writes"]
+    }
+  }
+}
+```
+
+#### Other clients
+
+Use that client's MCP docs for the file path and JSON key. Point it at the `nuon` binary with arguments `agents`, `mcp`, and `--allow-writes`.
+
+### Overriding the MCP URL
+
+The proxy derives its upstream URL from `api_url` in your CLI config when the hostname starts with `api.` (`https://api.nuon.co` → `https://mcp.nuon.co/mcp`). Pass `--url` when the MCP URL does not follow from the API URL, for example a self-hosted or Nuon BYOC control plane, or any deployment where the two hostnames differ. To change the name in the client's MCP list, pass `--name`. Put those flags on the command the client runs, next to `--allow-writes`:
+
+```bash
+nuon agents mcp --allow-writes --url https://mcp.example.nuon.co/mcp --name nuon-example
+claude mcp add --transport stdio nuon -- nuon agents mcp --allow-writes --url https://mcp.example.nuon.co/mcp --name nuon-example
+amp mcp add nuon -- nuon agents mcp --allow-writes --url https://mcp.example.nuon.co/mcp --name nuon-example
+```
+
+For a client configured by file, extra flags go inside `args`. Use that client's JSON key (examples above):
+
+```json
+{
+  "mcpServers": {
+    "nuon": {
+      "command": "nuon",
+      "args": ["agents", "mcp", "--allow-writes", "--url", "https://mcp.example.nuon.co/mcp"]
+    }
+  }
+}
+```
+
+A non-default CLI config (`nuon -C /path/to/config agents mcp --allow-writes`) carries its own token, org, and `api_url`. Put `-C` and `--allow-writes` on the registered command (in `args` when the client is configured by file).
+
+Run `nuon agents help` or `nuon agents context` to confirm which MCP URL resolves before registering.

--- a/docs/guides/agents/sample-queries.mdx
+++ b/docs/guides/agents/sample-queries.mdx
@@ -7,7 +7,7 @@ keywords: ["MCP", "agents", "sample queries", "prompts"]
 
 Copy a prompt into Claude Code, Cursor, or Amp after [MCP is connected](/guides/agents/overview). The client should pick tools from the [catalog](/guides/agents/tools); you do not need to name them.
 
-Write prompts need `--allow-writes` on the stdio proxy.
+Write prompts need `--allow-writes` on the stdio proxy and [Admin](/concepts/access-control) (`org_admin`) on the identity.
 
 Replace names like `acme-prod` with your own install, app, or workflow IDs.
 

--- a/docs/guides/agents/tools.mdx
+++ b/docs/guides/agents/tools.mdx
@@ -5,9 +5,9 @@ icon: "wrench"
 keywords: ["MCP", "tools", "agents", "whoami", "list_installs"]
 ---
 
-Writes are hidden from the stdio proxy unless `--allow-writes` is set. Setup examples always include that flag; HTTP MCP lists writes whenever the token can create.
+Writes are hidden from the stdio proxy unless `--allow-writes` is set. Setup examples always include that flag. HTTP MCP lists writes when the identity has [Admin](/concepts/access-control) (`org_admin`).
 
-Timestamps in tool JSON are UTC (Zulu) RFC3339 and end in `Z` (for example `2026-09-04T04:23:00Z`). If you name a calendar day, clock time, or age, convert that UTC instant to the local machine’s timezone first. Do not say “today” or “yesterday” from the UTC date digits — that calendar day can be a day ahead of local time.
+Timestamps in tool JSON are UTC (Zulu) RFC3339 and end in `Z` (for example `2026-09-04T04:23:00Z`). If you name a calendar day, clock time, or age, convert that UTC instant to the local machine’s timezone first. Do not say “today” or “yesterday” from the UTC date digits. That calendar day can be a day ahead of local time.
 
 For prompts to paste into a client, see [Sample queries](/guides/agents/sample-queries). To connect, see [Agents](/guides/agents/overview).
 
@@ -25,6 +25,6 @@ For prompts to paste into a client, see [Sample queries](/guides/agents/sample-q
 
 ## Writes
 
-Mutating tools are prefixed with `WRITE OPERATION:` in their descriptions. The stdio proxy hides them unless you pass `--allow-writes`. Your token must also have create permission.
+Mutating tools are prefixed with `WRITE OPERATION:` in their descriptions. The stdio proxy hides them unless you pass `--allow-writes`. The identity still needs [Admin](/concepts/access-control) (`org_admin`), not Read-only.
 
 Destructive tools (deprovision, approve/reject, preview apply, and similar) should be confirmed with the user before the client sets flags such as `confirm=true` or `mode=apply`.


### PR DESCRIPTION
Summary

  • Add nuon agents help as the human setup guide, shared with nuon agents --help: sign in, per-client MCP registration (Claude Code, Cursor, Amp), and --url when the MCP URL does not follow from the API URL.
  • Put the same JSON snippets and --allow-writes examples in CLI help, nuon agents context, and the agents docs.