### PR TITLE
feat: nuon mcp observability

### DIFF
--- a/sdks/nuon-go/client/operations/operations_client.go
+++ b/sdks/nuon-go/client/operations/operations_client.go
@@ -16696,7 +16696,7 @@ func (a *Client) GetSlackInstallURL(params *GetSlackInstallURLParams, authInfo r
 /*
 GetStackServiceAccount gets an install stack s service account
 
-Return the service account an install stack's Terraform module authenticates as, and whether it holds a usable API token. Never returns a token value: create one with POST /v1/service-accounts/{account_id}/tokens, which returns it once.
+Return the service account an install stack's Terraform module authenticates as, whether it holds a usable API token, and the runner API URL its provider authenticates against. Never returns a token value: create one with POST /v1/service-accounts/{account_id}/tokens, which returns it once.
 */
 func (a *Client) GetStackServiceAccount(params *GetStackServiceAccountParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetStackServiceAccountOK, error) {
 	// NOTE: parameters are not validated before sending

--- a/sdks/nuon-go/models/service_stack_service_account_response.go
+++ b/sdks/nuon-go/models/service_stack_service_account_response.go
@@ -30,6 +30,9 @@ type ServiceStackServiceAccountResponse struct {
 	// HasLiveToken is false whether no token was ever created or every one has
 	// expired or been revoked; the caller fixes both the same way.
 	HasLiveToken bool `json:"has_live_token,omitempty"`
+
+	// Without it a dashboard points the module's provider at production.
+	RunnerAPIURL string `json:"runner_api_url,omitempty"`
 }
 
 // Validate validates this service stack service account response

--- a/services/ctl-api/internal/app/mcp/server/metrics.go
+++ b/services/ctl-api/internal/app/mcp/server/metrics.go
@@ -1,0 +1,165 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+const (
+	mcpMetricsContext = "mcp_api"
+	mcpTargetLatency  = 50 * time.Millisecond
+)
+
+type mcpCallStatus struct {
+	isError bool
+}
+
+func (s *Server) metricsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.mw == nil || r.URL.Path == "/livez" || r.URL.Path == "/readyz" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		startTS := time.Now()
+		metricCtx := &cctx.MetricContext{
+			RequestURI: r.URL.RequestURI(),
+			Endpoint:   mcpEndpointFromRequest(r),
+			Method:     r.Method,
+			Context:    mcpMetricsContext,
+		}
+		callStatus := &mcpCallStatus{}
+		ctx := context.WithValue(r.Context(), keys.MetricsKey, metricCtx)
+		ctx = context.WithValue(ctx, mcpCallStatusKey{}, callStatus)
+
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		defer func() {
+			recovered := recover()
+			if recovered != nil {
+				metricCtx.IsPanic = true
+				rec.status = http.StatusInternalServerError
+			}
+			if r.Context().Err() == context.DeadlineExceeded {
+				metricCtx.IsTimeout = true
+			}
+
+			status := "ok"
+			if rec.status >= 400 || callStatus.isError {
+				status = "err"
+			}
+
+			duration := time.Since(startTS)
+			tags := []string{
+				"status:" + status,
+				"status_code_class:" + fmt.Sprintf("%dxx", rec.status/100),
+				"endpoint:" + metricCtx.Endpoint,
+				"method:" + metricCtx.Method,
+				"context:" + mcpMetricsContext,
+				"within_target_latency:" + strconv.FormatBool(duration < mcpTargetLatency),
+				"is_panic:" + strconv.FormatBool(metricCtx.IsPanic),
+				"is_timeout:" + strconv.FormatBool(metricCtx.IsTimeout),
+				"is_deprecated:" + strconv.FormatBool(metricCtx.IsDeprecated),
+			}
+
+			s.mw.Gauge("api.request.size", float64(r.ContentLength), tags)
+			s.mw.Timing("api.request.latency", duration, tags)
+			s.mw.Gauge("gorm_operation.endpoint_count", float64(metricCtx.DBQueryCount), tags)
+
+			if recovered != nil {
+				panic(recovered)
+			}
+		}()
+
+		next.ServeHTTP(rec, r.WithContext(ctx))
+	})
+}
+
+func (s *Server) receivingMetricsMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
+	return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+		if metricCtx, err := cctx.MetricsContextFromGinContext(ctx); err == nil {
+			toolName := mcpToolName(req)
+			metricCtx.Endpoint = mcpRPCEndpoint(method, toolName)
+			metricCtx.OrgID = keys.OrgIDFromContext(ctx)
+		}
+
+		res, err := next(ctx, method, req)
+		if callStatus, ok := ctx.Value(mcpCallStatusKey{}).(*mcpCallStatus); ok {
+			if err != nil {
+				callStatus.isError = true
+			}
+			if cr, ok := res.(*mcp.CallToolResult); ok && cr != nil && cr.IsError {
+				callStatus.isError = true
+			}
+		}
+		return res, err
+	}
+}
+
+type mcpCallStatusKey struct{}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	if r.wroteHeader {
+		return
+	}
+	r.wroteHeader = true
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(p []byte) (int, error) {
+	if !r.wroteHeader {
+		r.WriteHeader(http.StatusOK)
+	}
+	return r.ResponseWriter.Write(p)
+}
+
+func (r *statusRecorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
+}
+
+func (r *statusRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func mcpEndpointFromRequest(r *http.Request) string {
+	if r.URL.Path == "/" || r.URL.Path == "" {
+		return "unauthenticated"
+	}
+	return strings.ReplaceAll(r.URL.Path, "-", "_")
+}
+
+func mcpRPCEndpoint(method, toolName string) string {
+	endpoint := strings.ReplaceAll(method, "-", "_")
+	if method == "tools/call" && toolName != "" {
+		return endpoint + "/" + strings.ReplaceAll(toolName, "-", "_")
+	}
+	return endpoint
+}
+
+func mcpToolName(req mcp.Request) string {
+	switch p := req.GetParams().(type) {
+	case *mcp.CallToolParamsRaw:
+		return p.Name
+	case *mcp.CallToolParams:
+		return p.Name
+	default:
+		return ""
+	}
+}

--- a/services/ctl-api/internal/app/mcp/server/metrics_test.go
+++ b/services/ctl-api/internal/app/mcp/server/metrics_test.go
@@ -1,0 +1,213 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+)
+
+type capturedMetric struct {
+	name  string
+	tags  []string
+	value float64
+}
+
+type capturingMetricsWriter struct {
+	mu      sync.Mutex
+	gauges  []capturedMetric
+	timings []capturedMetric
+}
+
+func (*capturingMetricsWriter) Incr(string, []string)                  {}
+func (*capturingMetricsWriter) Decr(string, []string)                  {}
+func (*capturingMetricsWriter) Count(string, int64, []string)          {}
+func (*capturingMetricsWriter) Distribution(string, float64, []string) {}
+func (*capturingMetricsWriter) Event(*statsd.Event)                    {}
+func (*capturingMetricsWriter) Flush()                                 {}
+
+func (w *capturingMetricsWriter) Gauge(name string, value float64, tags []string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.gauges = append(w.gauges, capturedMetric{name: name, value: value, tags: append([]string(nil), tags...)})
+}
+
+func (w *capturingMetricsWriter) Timing(name string, value time.Duration, tags []string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.timings = append(w.timings, capturedMetric{name: name, value: float64(value), tags: append([]string(nil), tags...)})
+}
+
+func (w *capturingMetricsWriter) timingForEndpoint(endpoint string) (capturedMetric, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, metric := range w.timings {
+		if metric.name == "api.request.latency" && hasTag(metric.tags, "endpoint:"+endpoint) {
+			return metric, true
+		}
+	}
+	return capturedMetric{}, false
+}
+
+func hasTag(tags []string, want string) bool {
+	for _, tag := range tags {
+		if tag == want {
+			return true
+		}
+	}
+	return false
+}
+
+type failingMCPService struct {
+	stubMCPService
+}
+
+func (failingMCPService) RegisterMCPTools(server *mcp.Server) {
+	mcp.AddTool(server, api.MCPReadTool(
+		"fail",
+		"Fail",
+		"return a tool error",
+	), func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, any, error) {
+		return nil, nil, errors.New("tool failed")
+	})
+}
+
+type metricContextMCPService struct {
+	stubMCPService
+}
+
+func (metricContextMCPService) RegisterMCPTools(server *mcp.Server) {
+	mcp.AddTool(server, api.MCPReadTool(
+		"metric_context",
+		"Metric context",
+		"return the request metric context",
+	), func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+		metricCtx, err := cctx.MetricsContextFromGinContext(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		return api.MCPJSONResult(map[string]string{
+			"endpoint": metricCtx.Endpoint,
+			"org_id":   metricCtx.OrgID,
+		})
+	})
+}
+
+func newMetricsTestServer(t *testing.T, service api.Service, writer *capturingMetricsWriter) *httptest.Server {
+	t.Helper()
+
+	s := &Server{
+		mw:            writer,
+		services:      []api.Service{service},
+		schemaCache:   mcp.NewSchemaCache(),
+		orgSelections: make(map[string]*orgSelection),
+	}
+	mcpHandler := s.newMCPHandler()
+	handler := s.metricsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := withMCPAuth(r.Context(), "org_a", "acc_test")
+		mcpHandler.ServeHTTP(w, r.WithContext(ctx))
+	}))
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestMCPMetricsTagsToolCalls(t *testing.T) {
+	writer := &capturingMetricsWriter{}
+	ts := newMetricsTestServer(t, stubMCPService{}, writer)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{Endpoint: ts.URL}, nil)
+	require.NoError(t, err)
+	defer session.Close()
+
+	_, err = session.CallTool(context.Background(), &mcp.CallToolParams{Name: "echo_org"})
+	require.NoError(t, err)
+
+	metric, ok := writer.timingForEndpoint("tools/call/echo_org")
+	require.True(t, ok)
+	assert.True(t, hasTag(metric.tags, "context:mcp_api"))
+	assert.True(t, hasTag(metric.tags, "method:POST"))
+	assert.True(t, hasTag(metric.tags, "status:ok"))
+	assert.True(t, hasTag(metric.tags, "status_code_class:2xx"))
+	assert.True(t, hasTag(metric.tags, "is_panic:false"))
+	assert.True(t, hasTag(metric.tags, "is_timeout:false"))
+	assert.True(t, hasTag(metric.tags, "is_deprecated:false"))
+}
+
+func TestMCPMetricsMarksToolErrors(t *testing.T) {
+	writer := &capturingMetricsWriter{}
+	ts := newMetricsTestServer(t, failingMCPService{}, writer)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{Endpoint: ts.URL}, nil)
+	require.NoError(t, err)
+	defer session.Close()
+
+	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: "fail"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+
+	metric, ok := writer.timingForEndpoint("tools/call/fail")
+	require.True(t, ok)
+	assert.True(t, hasTag(metric.tags, "status:err"))
+	assert.True(t, hasTag(metric.tags, "status_code_class:2xx"))
+}
+
+func TestMCPMetricsPopulatesDatabaseMetricContext(t *testing.T) {
+	writer := &capturingMetricsWriter{}
+	ts := newMetricsTestServer(t, metricContextMCPService{}, writer)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{Endpoint: ts.URL}, nil)
+	require.NoError(t, err)
+	defer session.Close()
+
+	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: "metric_context"})
+	require.NoError(t, err)
+	require.Len(t, result.Content, 1)
+	text, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.JSONEq(t, `{"endpoint":"tools/call/metric_context","org_id":"org_a"}`, text.Text)
+}
+
+func TestMCPMetricsSkipsHealthChecks(t *testing.T) {
+	writer := &capturingMetricsWriter{}
+	handler := (&Server{mw: writer}).metricsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/livez", nil))
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+	assert.Empty(t, writer.timings)
+	assert.Empty(t, writer.gauges)
+}
+
+func TestMCPMetricsRecordsPanics(t *testing.T) {
+	writer := &capturingMetricsWriter{}
+	handler := (&Server{mw: writer}).metricsMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("test panic")
+	}))
+
+	assert.Panics(t, func() {
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/", nil))
+	})
+
+	metric, ok := writer.timingForEndpoint("unauthenticated")
+	require.True(t, ok)
+	assert.True(t, hasTag(metric.tags, "status:err"))
+	assert.True(t, hasTag(metric.tags, "status_code_class:5xx"))
+	assert.True(t, hasTag(metric.tags, "is_panic:true"))
+}

--- a/services/ctl-api/internal/app/mcp/server/server.go
+++ b/services/ctl-api/internal/app/mcp/server/server.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 
+	"github.com/nuonco/nuon/pkg/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
@@ -30,6 +31,7 @@ type Params struct {
 	DB         *gorm.DB `name:"psql"`
 	L          *zap.Logger
 	Cfg        *internal.Config
+	MW         metrics.Writer
 	Services   []api.Service `group:"services"`
 }
 
@@ -46,6 +48,7 @@ type Server struct {
 	db          *gorm.DB
 	l           *zap.Logger
 	cfg         *internal.Config
+	mw          metrics.Writer
 	services    []api.Service
 	httpServer  *http.Server
 	schemaCache *mcp.SchemaCache
@@ -60,6 +63,7 @@ func New(params Params) *Server {
 		db:            params.DB,
 		l:             params.L.Named("mcp"),
 		cfg:           params.Cfg,
+		mw:            params.MW,
 		services:      params.Services,
 		schemaCache:   mcp.NewSchemaCache(),
 		orgSelections: make(map[string]*orgSelection),
@@ -76,7 +80,7 @@ func New(params Params) *Server {
 
 	s.httpServer = &http.Server{
 		Addr:    net.JoinHostPort("0.0.0.0", params.Cfg.MCPHTTPPort),
-		Handler: mux,
+		Handler: s.metricsMiddleware(mux),
 	}
 
 	params.LC.Append(fx.Hook{
@@ -136,6 +140,7 @@ func (s *Server) getServerForRequest(r *http.Request) *mcp.Server {
 		SchemaCache:  s.schemaCache,
 		Instructions: fmt.Sprintf("Nuon control plane MCP server. Authenticated as account %s in org %q. If no org is selected, call list_orgs then select_org. %s", accountID, orgID, api.MCPTimeInstructions),
 	})
+	server.AddReceivingMiddleware(s.receivingMetricsMiddleware)
 
 	for _, svc := range s.services {
 		if mcpSvc, ok := svc.(api.MCPService); ok {


### PR DESCRIPTION
  Summary

  • Add request metrics to the ctl-api MCP server using the same series as the Gin APIs (api.request.latency, api.request.size, gorm_operation.endpoint_count), tagged with context:mcp_api.
  • Tag MCP traffic by JSON-RPC method/tool, mark tool errors even when HTTP is 200, skip health probes, and seed MetricContext so GORM queries from MCP tools are attributable.