### PR TITLE
fix(ctl-api): skip branch run steps that have no config changes to act on

### DIFF
--- a/services/ctl-api/internal/app/apps/signals/branches/previewimpact/execute.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/previewimpact/execute.go
@@ -22,6 +22,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return fmt.Errorf("unable to get app branch run: %w", err)
 	}
 
+	if run.NoConfigChanges && !run.Force {
+		l.Info("no config changes, skipping preview impact")
+		return nil
+	}
+
+	if run.AppConfigID == "" {
+		return fmt.Errorf("app branch run %s has no app config ID", s.RunID)
+	}
+
 	groups, err := s.computeImpact(ctx, l, run.AppConfigID)
 	if err != nil {
 		return err

--- a/services/ctl-api/internal/app/apps/signals/branches/previewimpact/execute_test.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/previewimpact/execute_test.go
@@ -1,0 +1,52 @@
+package previewimpact
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	branchactivities "github.com/nuonco/nuon/services/ctl-api/internal/app/apps/signals/branches/activities"
+)
+
+func TestPreviewImpactNoConfigChanges(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		noConfigChanges bool
+		force           bool
+		appConfigID     string
+		wantErr         string
+	}{
+		{name: "nothing to preview is skipped", noConfigChanges: true, appConfigID: ""},
+		{name: "forced run still requires a config", noConfigChanges: true, force: true, appConfigID: "", wantErr: "has no app config ID"},
+		{name: "missing config without the flag is still an error", noConfigChanges: false, appConfigID: "", wantErr: "has no app config ID"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var suite testsuite.WorkflowTestSuite
+			env := suite.NewTestWorkflowEnvironment()
+			env.SetWorkerOptions(worker.Options{DeadlockDetectionTimeout: time.Minute})
+
+			env.OnActivity((*branchactivities.Activities).GetAppBranchRunByID, mock.Anything, mock.Anything, mock.Anything).
+				Return(&app.AppBranchRun{
+					ID:              "run-1",
+					NoConfigChanges: tc.noConfigChanges,
+					Force:           tc.force,
+					AppConfigID:     tc.appConfigID,
+				}, nil)
+
+			sig := &Signal{RunID: "run-1", AppBranchID: "branch-1", AppBranchConfigID: "branch-config-1"}
+			env.ExecuteWorkflow(sig.Execute)
+
+			require.True(t, env.IsWorkflowCompleted())
+			if tc.wantErr == "" {
+				require.NoError(t, env.GetWorkflowError())
+			} else {
+				require.ErrorContains(t, env.GetWorkflowError(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/services/ctl-api/internal/app/apps/signals/branches/previewimpact/signal.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/previewimpact/signal.go
@@ -1,8 +1,6 @@
 package previewimpact
 
 import (
-	"fmt"
-
 	"github.com/go-playground/validator/v10"
 	"github.com/pkg/errors"
 	"go.temporal.io/sdk/workflow"
@@ -44,13 +42,8 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 		return errors.Wrap(err, "validation failed")
 	}
 
-	run, err := activities.AwaitGetAppBranchRunByIDByRunID(ctx, s.RunID)
-	if err != nil {
+	if _, err := activities.AwaitGetAppBranchRunByIDByRunID(ctx, s.RunID); err != nil {
 		return errors.Wrap(err, "app branch run not found")
-	}
-
-	if run.AppConfigID == "" {
-		return fmt.Errorf("app branch run %s has no app config ID", s.RunID)
 	}
 
 	return nil

--- a/services/ctl-api/internal/app/apps/signals/branches/updateinstallgroup/execute.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/updateinstallgroup/execute.go
@@ -40,6 +40,15 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return fmt.Errorf("unable to get app branch run: %w", err)
 	}
 
+	if run.NoConfigChanges && !run.Force {
+		logger.Info("no config changes, skipping install group update")
+		return nil
+	}
+
+	if run.AppConfigID == "" {
+		return fmt.Errorf("app branch run %s has no app config ID", s.RunID)
+	}
+
 	installIDs, groupName, err := s.resolveInstallIDs(ctx)
 	if err != nil {
 		return err

--- a/services/ctl-api/internal/app/apps/signals/branches/updateinstallgroup/signal.go
+++ b/services/ctl-api/internal/app/apps/signals/branches/updateinstallgroup/signal.go
@@ -61,13 +61,8 @@ func (s *Signal) Validate(ctx workflow.Context) error {
 		}
 	}
 
-	run, err := activities.AwaitGetAppBranchRunByIDByRunID(ctx, s.RunID)
-	if err != nil {
+	if _, err := activities.AwaitGetAppBranchRunByIDByRunID(ctx, s.RunID); err != nil {
 		return errors.Wrap(err, "app branch run not found")
-	}
-
-	if run.AppConfigID == "" {
-		return fmt.Errorf("app branch run %s has no app config ID", s.RunID)
 	}
 
 	return nil


### PR DESCRIPTION
A commit that touches only one app in a multi-app repo leaves the other apps with nothing to build, so no app config is created for their branch run. preview install impact and update install group then failed on an empty AppConfigID, and because the check sat in Validate the run died non-retryably with 'app branch run ... has no app config ID'. Every nuonbot image bump in the byoc repo reported a red preview check against the apps it did not touch.

Both now skip when the run reports no config changes, matching what the builds signal already did, and the empty-config error moves out of Validate into Execute so it still fires for a run that genuinely should have had one. A forced run keeps the error rather than silently doing nothing.

Test covers all three cases and fails without the guard.