### PR TITLE
refactor(ui): removed deployment plan gate based on availabe installs

### DIFF
--- a/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditor.stories.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditor.stories.tsx
@@ -98,6 +98,54 @@ export const NoInstalls = () => (
   </ModalStory>
 )
 
+export const NoInstallsWithAllInstallsGroup = () => (
+  <ModalStory label="Open deployment plan">
+    <DeploymentPlanEditor
+      initialGroups={[
+        {
+          id: 'group-all',
+          name: 'Everything',
+          install_ids: [],
+          label_selector: null,
+          selection_mode: 'all',
+          order: 0,
+          max_parallel: 1,
+          auto_approve_on_policies_passing: false,
+        },
+      ]}
+      availableInstalls={[]}
+      loadingInstalls={false}
+      isSaving={false}
+      onSave={noop}
+      onCancel={noop}
+      orgId="org123"
+      runbooks={runbooks}
+      loadingRunbooks={false}
+      initialPostDeployRunbookIds={[]}
+    />
+  </ModalStory>
+)
+
+export const AllInstallsGroup = () => (
+  <ModalStory label="Open deployment plan">
+    <DeploymentPlanEditor
+      initialGroups={[
+        {
+          id: 'group-all',
+          name: 'Everything',
+          install_ids: [],
+          label_selector: null,
+          selection_mode: 'all',
+          order: 0,
+          max_parallel: 2,
+          auto_approve_on_policies_passing: false,
+        },
+      ]}
+      {...baseProps}
+    />
+  </ModalStory>
+)
+
 export const WithPostDeployRunbooks = () => (
   <ModalStory label="Open deployment plan">
     <DeploymentPlanEditor

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditor.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditor.tsx
@@ -69,6 +69,7 @@ export const DeploymentPlanEditor = ({
       name: g.name || `Group ${g.order + 1}`,
       install_ids: g.selection_mode === 'manual' ? g.install_ids : [],
       label_selector: g.selection_mode === 'labels' ? g.label_selector : undefined,
+      all_installs: g.selection_mode === 'all',
       max_parallel: g.max_parallel,
     })),
   } as TAppBranchConfig), [groups])
@@ -76,7 +77,9 @@ export const DeploymentPlanEditor = ({
   const assignedInstallIds = useMemo(() => {
     const assigned = new Set<string>()
     groups.forEach((g) => {
-      if (g.selection_mode === 'labels') {
+      if (g.selection_mode === 'all') {
+        availableInstalls.forEach((i) => assigned.add(i.id))
+      } else if (g.selection_mode === 'labels') {
         const matchLabels = g.label_selector?.match_labels
         if (matchLabels && Object.keys(matchLabels).length > 0) {
           availableInstalls.forEach((i) => {
@@ -96,6 +99,7 @@ export const DeploymentPlanEditor = ({
   )
 
   const groupContentError = (g: IInstallGroup): string | undefined => {
+    if (g.selection_mode === 'all') return undefined
     if (g.selection_mode === 'labels') {
       if (!g.label_selector?.match_labels || Object.keys(g.label_selector.match_labels).length === 0) {
         return 'Add at least one label to match installs.'
@@ -116,8 +120,8 @@ export const DeploymentPlanEditor = ({
     const needsName = groups.some((g) => !g.name.trim())
     const needsInstalls = groups.some((g) => !!groupContentError(g))
     if (needsName && needsInstalls)
-      return 'Every group needs a name and at least one install.'
-    if (needsInstalls) return 'Every group needs at least one install.'
+      return 'Every group needs a name and installs to target.'
+    if (needsInstalls) return 'Every group needs installs or matching labels.'
     if (needsName) return 'Every group needs a name.'
     return undefined
   })()
@@ -129,7 +133,10 @@ export const DeploymentPlanEditor = ({
   }
 
   const addGroup = () => {
-    const group = newGroup(groups.length)
+    const group = newGroup(
+      groups.length,
+      availableInstalls.length === 0 ? 'all' : 'manual'
+    )
     setGroups((curr) => [...curr, group])
     setNewGroupId(group.id)
   }
@@ -185,7 +192,7 @@ export const DeploymentPlanEditor = ({
     onSave(groups, postDeployRunbookIds)
   }
 
-  const canAddGroup = !loadingInstalls && availableInstalls.length > 0
+  const canAddGroup = !loadingInstalls
 
   return (
     <Modal
@@ -223,17 +230,20 @@ export const DeploymentPlanEditor = ({
           <Skeleton height="120px" />
           <Skeleton height="120px" />
         </div>
-      ) : availableInstalls.length === 0 ? (
-        <Banner theme="info">
-          No installs found for this app. Create installs first to configure a
-          deployment plan.
-        </Banner>
       ) : (
         <div className="flex flex-col gap-6">
           <Text variant="subtext" theme="neutral">
             Groups deploy top to bottom. Installs in a group deploy together, up
             to its max parallel. Any install left unassigned is skipped.
           </Text>
+
+          {availableInstalls.length === 0 && (
+            <Banner theme="info">
+              This app has no installs yet. Groups that match on labels or take
+              all installs pick them up as they are created — a group with a
+              hand-picked list needs installs to exist first.
+            </Banner>
+          )}
 
           {groups.length >= 2 && (
             <DeploymentPlanGraph config={previewConfig} installsById={installsById} orgId={orgId} />

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditorContainer.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/DeploymentPlanEditorContainer.tsx
@@ -23,7 +23,11 @@ const toEditorGroups = (config?: TAppBranchConfig): IInstallGroup[] =>
       name: g.name || '',
       install_ids: g.install_ids || [],
       label_selector: g.label_selector || null,
-      selection_mode: hasLabelSelector ? 'labels' as const : 'manual' as const,
+      selection_mode: g.all_installs
+        ? ('all' as const)
+        : hasLabelSelector
+          ? ('labels' as const)
+          : ('manual' as const),
       order: g.order ?? idx,
       max_parallel: g.max_parallel || 1,
       auto_approve_on_policies_passing: !!g.auto_approve_on_policies_passing,
@@ -91,13 +95,15 @@ export const DeploymentPlanEditorContainer = ({
     }) => {
       const installGroupsForApi = groups.map((group, index) => {
         const matchLabels = group.label_selector?.match_labels
+        const useAll = group.selection_mode === 'all'
         const useLabels =
           group.selection_mode === 'labels' && !!matchLabels && Object.keys(matchLabels).length > 0
 
         return {
           name: group.name,
-          install_ids: useLabels ? [] : group.install_ids || [],
+          install_ids: useAll || useLabels ? [] : group.install_ids || [],
           label_selector: useLabels ? group.label_selector : undefined,
+          all_installs: useAll || undefined,
           order: index,
           max_parallel: group.max_parallel || 1,
           auto_approve_on_policies_passing:

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/GroupEditor.stories.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/GroupEditor.stories.tsx
@@ -35,6 +35,17 @@ const labelGroup: IInstallGroup = {
   auto_approve_on_policies_passing: true,
 }
 
+const allInstallsGroup: IInstallGroup = {
+  id: 'group-3',
+  name: 'Everything',
+  install_ids: [],
+  label_selector: null,
+  selection_mode: 'all',
+  order: 2,
+  max_parallel: 1,
+  auto_approve_on_policies_passing: false,
+}
+
 const Wrap = ({ children }: { children: React.ReactNode }) => (
   <div className="max-w-2xl">{children}</div>
 )
@@ -83,6 +94,42 @@ export const EmptyManual = () => (
       totalGroups={1}
       availableInstalls={installs}
       unassignedInstalls={installs}
+      onUpdate={noop}
+      onAddInstalls={noop}
+      onRemoveInstall={noop}
+      onMoveUp={noop}
+      onMoveDown={noop}
+      onDelete={noop}
+    />
+  </Wrap>
+)
+
+export const AllInstalls = () => (
+  <Wrap>
+    <GroupEditor
+      group={allInstallsGroup}
+      index={0}
+      totalGroups={1}
+      availableInstalls={installs}
+      unassignedInstalls={[]}
+      onUpdate={noop}
+      onAddInstalls={noop}
+      onRemoveInstall={noop}
+      onMoveUp={noop}
+      onMoveDown={noop}
+      onDelete={noop}
+    />
+  </Wrap>
+)
+
+export const AllInstallsWithNoInstalls = () => (
+  <Wrap>
+    <GroupEditor
+      group={allInstallsGroup}
+      index={0}
+      totalGroups={1}
+      availableInstalls={[]}
+      unassignedInstalls={[]}
       onUpdate={noop}
       onAddInstalls={noop}
       onRemoveInstall={noop}

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/GroupEditor.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/GroupEditor.tsx
@@ -94,6 +94,7 @@ export const GroupEditor = ({
             options={[
               { value: 'manual', label: 'Manual' },
               { value: 'labels', label: 'Labels' },
+              { value: 'all', label: 'All installs' },
             ]}
             value={group.selection_mode}
             onChange={(mode) => onUpdate({ selection_mode: mode })}
@@ -130,7 +131,9 @@ export const GroupEditor = ({
       </div>
 
       <div className="flex flex-col gap-3 p-4">
-        {group.selection_mode === 'labels' ? (
+        {group.selection_mode === 'all' ? (
+          <AllInstallsSummary installCount={availableInstalls.length} />
+        ) : group.selection_mode === 'labels' ? (
           <LabelSelectorEditor
             groupId={group.id}
             labelSelector={group.label_selector}
@@ -207,6 +210,20 @@ export const GroupEditor = ({
     </Card>
   )
 }
+
+const AllInstallsSummary = ({ installCount }: { installCount: number }) => (
+  <div className="flex flex-col gap-1">
+    <Text variant="subtext" theme="neutral">
+      Every install on this app that no other branch owns is included at deploy
+      time.
+    </Text>
+    <Text variant="subtext" theme="neutral">
+      {installCount === 0
+        ? 'No installs yet — installs join this group as they are created.'
+        : `${installCount} install${installCount === 1 ? '' : 's'} match today.`}
+    </Text>
+  </div>
+)
 
 const LabelSelectorEditor = ({
   groupId,

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/lib.ts
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/lib.ts
@@ -1,11 +1,14 @@
-import type { IInstallGroup } from './types'
+import type { IInstallGroup, InstallSelectionMode } from './types'
 
-export const newGroup = (existingCount: number): IInstallGroup => ({
+export const newGroup = (
+  existingCount: number,
+  selectionMode: InstallSelectionMode = 'manual'
+): IInstallGroup => ({
   id: `group-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
   name: '',
   install_ids: [],
   label_selector: null,
-  selection_mode: 'manual',
+  selection_mode: selectionMode,
   order: existingCount,
   max_parallel: 1,
   auto_approve_on_policies_passing: false,

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/types.ts
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanEditor/types.ts
@@ -3,7 +3,7 @@ export interface ILabelSelector {
   not_match_labels?: Record<string, string>
 }
 
-export type InstallSelectionMode = 'manual' | 'labels'
+export type InstallSelectionMode = 'manual' | 'labels' | 'all'
 
 export interface IInstallGroup {
   id: string

--- a/services/dashboard-ui/client/components/branches/DeploymentPlanGraph/DeploymentPlanGraph.tsx
+++ b/services/dashboard-ui/client/components/branches/DeploymentPlanGraph/DeploymentPlanGraph.tsx
@@ -29,6 +29,7 @@ interface GroupNodeData {
   accent: GraphAccent
   installs: PlanGroupInstall[]
   labelEntries: [string, string][]
+  allInstalls: boolean
   maxParallel: number
   compact: boolean
   orgId: string
@@ -81,7 +82,7 @@ const GroupNode = memo(({ data }: NodeProps<Node<GroupNodeData>>) => {
 
       {installs.length === 0 ? (
         <span className="text-[11px] text-cool-grey-500 dark:text-cool-grey-500">
-          No matching installs
+          {data.allInstalls ? 'All installs — none yet' : 'No matching installs'}
         </span>
       ) : (
         <>
@@ -149,8 +150,13 @@ export const DeploymentPlanGraph = ({ config, installsById, orgId, compact = fal
 
     const built: Node<GroupNodeData>[] = groups.map((group, idx) => {
       const labelEntries = Object.entries(group.label_selector?.match_labels ?? {})
-      const installs: PlanGroupInstall[] =
-        labelEntries.length > 0
+      const installs: PlanGroupInstall[] = group.all_installs
+        ? Object.values(installsById).map((i) => ({
+            id: i.id,
+            name: i.name ?? i.id,
+            labels: i.labels,
+          }))
+        : labelEntries.length > 0
           ? Object.values(installsById)
               .filter((i) => matchesSelector(i.labels, group.label_selector))
               .map((i) => ({ id: i.id, name: i.name ?? i.id, labels: i.labels }))
@@ -171,6 +177,7 @@ export const DeploymentPlanGraph = ({ config, installsById, orgId, compact = fal
           accent: groupAccent(idx),
           installs,
           labelEntries,
+          allInstalls: !!group.all_installs,
           maxParallel: group.max_parallel ?? 1,
           compact,
           orgId,

--- a/services/dashboard-ui/client/components/branches/install-groups/InstallGroupsSection.tsx
+++ b/services/dashboard-ui/client/components/branches/install-groups/InstallGroupsSection.tsx
@@ -72,10 +72,13 @@ export const InstallGroupsSection = ({
     <div className="flex flex-col gap-4">
       {groups.map((group, idx) => {
         const labelEntries = Object.entries(group.label_selector?.match_labels ?? {})
-        const isLabels = labelEntries.length > 0
-        const matched = isLabels
-          ? Object.values(installsById).filter((i) => matchesSelector(i.labels, group.label_selector))
-          : []
+        const isAll = !!group.all_installs
+        const isLabels = !isAll && labelEntries.length > 0
+        const matched = isAll
+          ? Object.values(installsById)
+          : isLabels
+            ? Object.values(installsById).filter((i) => matchesSelector(i.labels, group.label_selector))
+            : []
         const installIds = group.install_ids ?? []
 
         return (
@@ -86,6 +89,11 @@ export const InstallGroupsSection = ({
             <div className="flex items-center justify-between gap-3 flex-wrap">
               <div className="flex items-center gap-2 flex-wrap min-w-0">
                 <Text variant="base" weight="strong">{group.name}</Text>
+                {isAll && (
+                  <Text variant="subtext" theme="neutral">
+                    All installs
+                  </Text>
+                )}
                 {labelEntries.map(([k, v]) => (
                   <LabelBadge key={k} labelKey={k} labelValue={v} size="sm" customColor={labelColors?.[k]} />
                 ))}
@@ -97,7 +105,7 @@ export const InstallGroupsSection = ({
               )}
             </div>
 
-            {isLabels ? (
+            {isAll || isLabels ? (
               matched.length > 0 ? (
                 <div className="flex flex-col gap-1.5">
                   {matched.map((install) => (
@@ -105,7 +113,11 @@ export const InstallGroupsSection = ({
                   ))}
                 </div>
               ) : (
-                <EmptyGroupHint>No installs currently match this group&apos;s labels</EmptyGroupHint>
+                <EmptyGroupHint>
+                  {isAll
+                    ? 'No installs yet — every install on this app joins this group'
+                    : "No installs currently match this group's labels"}
+                </EmptyGroupHint>
               )
             ) : installIds.length > 0 ? (
               <div className="flex flex-col gap-1.5">

--- a/services/dashboard-ui/client/components/branches/shared/branch-config-request.ts
+++ b/services/dashboard-ui/client/components/branches/shared/branch-config-request.ts
@@ -14,9 +14,11 @@ export const installGroupsForApi = (
       max_parallel: g.max_parallel || 1,
       auto_approve_on_policies_passing:
         g.auto_approve_on_policies_passing ?? undefined,
-      ...(hasSelector
-        ? { label_selector: g.label_selector }
-        : { install_ids: g.install_ids || [] }),
+      ...(g.all_installs
+        ? { all_installs: true }
+        : hasSelector
+          ? { label_selector: g.label_selector }
+          : { install_ids: g.install_ids || [] }),
     }
   })
 

--- a/services/dashboard-ui/client/components/installs/CreateInstall/BranchConnectionStep/BranchConnectionStep.tsx
+++ b/services/dashboard-ui/client/components/installs/CreateInstall/BranchConnectionStep/BranchConnectionStep.tsx
@@ -29,17 +29,21 @@ const buildConfigRequest = (
 ): TCreateBranchConfigRequest => {
   const install_groups = (config.install_groups ?? []).map((g, index) => {
     const matchLabels = g.label_selector?.match_labels
-    const isLabelGroup = !!matchLabels && Object.keys(matchLabels).length > 0
-    const install_ids = isLabelGroup
-      ? []
-      : index === targetGroupIndex
-        ? Array.from(new Set([...(g.install_ids ?? []), installId]))
-        : g.install_ids ?? []
+    const isAllGroup = !!g.all_installs
+    const isLabelGroup =
+      !isAllGroup && !!matchLabels && Object.keys(matchLabels).length > 0
+    const install_ids =
+      isAllGroup || isLabelGroup
+        ? []
+        : index === targetGroupIndex
+          ? Array.from(new Set([...(g.install_ids ?? []), installId]))
+          : g.install_ids ?? []
 
     return {
       name: g.name ?? '',
       install_ids,
       label_selector: isLabelGroup ? g.label_selector : undefined,
+      all_installs: isAllGroup || undefined,
       order: index,
       max_parallel: g.max_parallel || 1,
     }
@@ -88,8 +92,9 @@ const BranchGroupRow = ({
 }) => {
   const { addToast } = useToast()
   const queryClient = useQueryClient()
+  const isAll = !!group.all_installs
   const labelEntries = Object.entries(group.label_selector?.match_labels ?? {})
-  const isLabels = labelEntries.length > 0
+  const isLabels = !isAll && labelEntries.length > 0
   const installIds = group.install_ids ?? []
   const alreadyAddedById = installIds.includes(installId)
   const alreadyAddedByLabels =
@@ -100,7 +105,7 @@ const BranchGroupRow = ({
     labelEntries.some(
       ([k, v]) => installLabels?.[k] !== undefined && installLabels[k] !== v
     )
-  const alreadyAdded = isLabels ? alreadyAddedByLabels : alreadyAddedById
+  const alreadyAdded = isAll || (isLabels ? alreadyAddedByLabels : alreadyAddedById)
 
   const invalidateBranch = () => {
     queryClient.invalidateQueries({ queryKey: ['app-branch-with-config', orgId, appId, branchId] })
@@ -163,7 +168,12 @@ const BranchGroupRow = ({
         {labelEntries.map(([k, v]) => (
           <LabelBadge key={k} labelKey={k} labelValue={v} size="sm" />
         ))}
-        {!isLabels && installIds.length > 0 && (
+        {isAll && (
+          <Text variant="subtext" theme="neutral">
+            All installs
+          </Text>
+        )}
+        {!isAll && !isLabels && installIds.length > 0 && (
           <Text variant="subtext" theme="neutral">
             {installIds.length} install{installIds.length !== 1 ? 's' : ''} by ID
           </Text>

--- a/services/dashboard-ui/client/lib/ctl-api/apps/branches/create-branch-config.ts
+++ b/services/dashboard-ui/client/lib/ctl-api/apps/branches/create-branch-config.ts
@@ -22,6 +22,7 @@ export type TCreateBranchConfigRequest = {
       match_labels?: Record<string, string>
       not_match_labels?: Record<string, string>
     } | null
+    all_installs?: boolean
     order: number
     max_parallel?: number
     auto_approve_on_policies_passing?: boolean

--- a/services/dashboard-ui/e2e/specs-ladle/deployment-plan-editor.spec.ts
+++ b/services/dashboard-ui/e2e/specs-ladle/deployment-plan-editor.spec.ts
@@ -4,6 +4,8 @@ const WITH_GROUPS =
   "/?story=branches--deploymentplaneditor--with-groups&mode=preview";
 const NO_GROUPS =
   "/?story=branches--deploymentplaneditor--no-groups&mode=preview";
+const NO_INSTALLS =
+  "/?story=branches--deploymentplaneditor--no-installs&mode=preview";
 
 const openEditor = async (page, story: string) => {
   await page.goto(story, { waitUntil: "domcontentloaded" });
@@ -36,5 +38,41 @@ test.describe("DeploymentPlanEditor behavior", () => {
 
     await dialog.getByRole("button", { name: "Add group" }).click();
     await expect(dialog.getByLabel("Group 1 name")).toBeFocused();
+  });
+
+  test("an app with no installs can still save an all installs group", async ({
+    page,
+  }) => {
+    await openEditor(page, NO_INSTALLS);
+    const dialog = page.getByRole("dialog");
+    const save = dialog.getByRole("button", { name: "Save changes" });
+
+    await expect(save).toBeDisabled();
+
+    await dialog.getByRole("button", { name: "Add group" }).click();
+    await expect(dialog.getByLabel("Group 1 name")).toBeFocused();
+    await expect(dialog.getByRole("button", { name: "All installs" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    await page.keyboard.type("everything");
+    await expect(save).toBeEnabled();
+  });
+
+  test("an app with no installs cannot save a manual group", async ({
+    page,
+  }) => {
+    await openEditor(page, NO_INSTALLS);
+    const dialog = page.getByRole("dialog");
+
+    await dialog.getByRole("button", { name: "Add group" }).click();
+    await page.keyboard.type("everything");
+    await dialog.getByRole("button", { name: "Manual" }).click();
+
+    await expect(page.getByText("Add at least one install.")).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: "Save changes" }),
+    ).toBeDisabled();
   });
 });


### PR DESCRIPTION
Removed the gating on deployment plan editor so users can create label based install groups without any available installs.