### PR TITLE
feat: (ctl-api) Add control-plane OTLP metrics foundation

### DIFF
--- a/services/ctl-api/internal/app/mcp/server/otel_metrics.go
+++ b/services/ctl-api/internal/app/mcp/server/otel_metrics.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/metrics"
+)
+
+func (s *Server) otelMetricsMiddleware(next http.Handler) http.Handler {
+	if s.httpMetrics == nil {
+		return next
+	}
+	return s.httpMetrics.Handler("mcp", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		route := "/"
+		switch r.URL.Path {
+		case "/livez", "/readyz", "/.well-known/oauth-protected-resource":
+			route = r.URL.Path
+		}
+		metrics.SetHTTPRoute(r.Context(), route)
+		next.ServeHTTP(w, r)
+	}))
+}

--- a/services/ctl-api/internal/app/mcp/server/otel_metrics_test.go
+++ b/services/ctl-api/internal/app/mcp/server/otel_metrics_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/metrics"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.uber.org/zap"
+)
+
+func TestOTELMetricsIncludesAuthFailuresWithoutRawPaths(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+	m, err := metrics.NewHTTPMetrics(provider)
+	require.NoError(t, err)
+	s := &Server{httpMetrics: m, l: zap.NewNop()}
+	handler := s.otelMetricsMiddleware(s.authContextMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("unauthenticated request reached handler")
+	})))
+	for _, path := range []string{"/", "/arbitrary-a?token=hidden", "/arbitrary-b"} {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest("POST", path, nil))
+		require.Equal(t, http.StatusUnauthorized, response.Code)
+	}
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &data))
+	found := false
+	for _, scope := range data.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name == "http.server.request.duration" {
+				found = true
+				points := metric.Data.(metricdata.Histogram[float64]).DataPoints
+				require.Len(t, points, 1)
+				require.EqualValues(t, 3, points[0].Count)
+				route, _ := points[0].Attributes.Value("http.route")
+				require.Equal(t, "/", route.AsString())
+				api, _ := points[0].Attributes.Value("nuon.api")
+				require.Equal(t, "mcp", api.AsString())
+			}
+		}
+	}
+	require.True(t, found)
+}

--- a/services/ctl-api/internal/app/mcp/server/server.go
+++ b/services/ctl-api/internal/app/mcp/server/server.go
@@ -21,18 +21,20 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+	controlplanemetrics "github.com/nuonco/nuon/services/ctl-api/internal/pkg/metrics"
 )
 
 type Params struct {
 	fx.In
 
-	LC         fx.Lifecycle
-	Shutdowner fx.Shutdowner
-	DB         *gorm.DB `name:"psql"`
-	L          *zap.Logger
-	Cfg        *internal.Config
-	MW         metrics.Writer
-	Services   []api.Service `group:"services"`
+	LC          fx.Lifecycle
+	Shutdowner  fx.Shutdowner
+	DB          *gorm.DB `name:"psql"`
+	L           *zap.Logger
+	Cfg         *internal.Config
+	MW          metrics.Writer
+	HTTPMetrics *controlplanemetrics.HTTPMetrics
+	Services    []api.Service `group:"services"`
 }
 
 // orgSelectionTTL bounds how long an idle org selection is retained.
@@ -49,6 +51,7 @@ type Server struct {
 	l           *zap.Logger
 	cfg         *internal.Config
 	mw          metrics.Writer
+	httpMetrics *controlplanemetrics.HTTPMetrics
 	services    []api.Service
 	httpServer  *http.Server
 	schemaCache *mcp.SchemaCache
@@ -64,6 +67,7 @@ func New(params Params) *Server {
 		l:             params.L.Named("mcp"),
 		cfg:           params.Cfg,
 		mw:            params.MW,
+		httpMetrics:   params.HTTPMetrics,
 		services:      params.Services,
 		schemaCache:   mcp.NewSchemaCache(),
 		orgSelections: make(map[string]*orgSelection),
@@ -80,7 +84,7 @@ func New(params Params) *Server {
 
 	s.httpServer = &http.Server{
 		Addr:    net.JoinHostPort("0.0.0.0", params.Cfg.MCPHTTPPort),
-		Handler: s.metricsMiddleware(mux),
+		Handler: s.otelMetricsMiddleware(s.metricsMiddleware(mux)),
 	}
 
 	params.LC.Append(fx.Hook{

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -214,10 +214,12 @@ type Config struct {
 	worker.Config `config:",squash"`
 
 	// configs for starting and introspecting service
-	GitRef         string   `config:"git_ref" validate:"required"`
-	Version        string   `config:"version" validate:"required"`
-	MetricsTags    []string `config:"metrics_tags"`
-	DisableMetrics bool     `config:"disable_metrics"`
+	GitRef                   string   `config:"git_ref" validate:"required"`
+	Version                  string   `config:"version" validate:"required"`
+	MetricsTags              []string `config:"metrics_tags"`
+	DisableMetrics           bool     `config:"disable_metrics"`
+	OTELExporterOTLPEndpoint string   `config:"otel_exporter_otlp_endpoint"`
+	OTELExporterOTLPProtocol string   `config:"otel_exporter_otlp_protocol"`
 
 	ServiceName       string `config:"service_name" validate:"required"`
 	ServiceType       string `config:"service_type" validate:"required"`
@@ -397,9 +399,8 @@ type Config struct {
 	WebhookURLs    []string      `config:"webhook_urls"`
 	WebhookTimeout time.Duration `config:"webhook_timeout"`
 
-	// Audit log export. Audit records are the only telemetry ctl-api ships over
-	// OTLP; everything else keeps going to stderr untouched. Leave the endpoint
-	// empty to disable, which is the default until the gateway collector exists.
+	// Audit export requires its own endpoint; the generic OTLP endpoint does not
+	// enable it. An empty endpoint leaves the audit emitter disabled.
 	AuditOTLPEndpoint string `config:"audit_otlp_endpoint"`
 	AuditOTLPToken    string `config:"audit_otlp_token"`
 

--- a/services/ctl-api/internal/fxmodules/infrastructure.go
+++ b/services/ctl-api/internal/fxmodules/infrastructure.go
@@ -38,6 +38,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/secretsmanager"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks/arm"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/stacks/cloudformation"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/telemetry"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/temporal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/temporal/dataconverter"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/temporal/dataconverter/blob"
@@ -145,6 +146,9 @@ var InfrastructureModule = fx.Module("infrastructure",
 	fx.Provide(salesforce.New),
 	fx.Provide(github.New),
 	fx.Provide(metrics.New),
+	fx.Provide(telemetry.NewConfig),
+	fx.Provide(telemetry.NewMeterProvider),
+	fx.Provide(metrics.NewHTTPMetrics),
 	fx.Provide(propagator.New),
 	fx.Provide(validator.New),
 	fx.Provide(notifications.New),

--- a/services/ctl-api/internal/pkg/api/admin_dashboard_api.go
+++ b/services/ctl-api/internal/pkg/api/admin_dashboard_api.go
@@ -15,7 +15,7 @@ func NewAdminDashboardAPI(params Params) (*API, error) {
 		endpointAudit:         params.EndpointAudit,
 	}
 
-	if err := api.init(); err != nil {
+	if err := api.init(params.HTTPMetrics); err != nil {
 		return nil, errors.Wrap(err, "unable to initialize")
 	}
 

--- a/services/ctl-api/internal/pkg/api/auth_api.go
+++ b/services/ctl-api/internal/pkg/api/auth_api.go
@@ -17,7 +17,7 @@ func NewAuthAPI(params Params) (*API, error) {
 		endpointAudit:         params.EndpointAudit,
 	}
 
-	if err := api.init(); err != nil {
+	if err := api.init(params.HTTPMetrics); err != nil {
 		return nil, errors.Wrap(err, "unable to initialize")
 	}
 

--- a/services/ctl-api/internal/pkg/api/base.go
+++ b/services/ctl-api/internal/pkg/api/base.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/metrics"
 )
 
 type API struct {
@@ -35,11 +36,19 @@ type API struct {
 	db *gorm.DB
 }
 
-func (a *API) init() error {
+func (a *API) init(httpMetrics *metrics.HTTPMetrics) error {
 	a.handler = gin.New()
+	if httpMetrics != nil {
+		a.handler.Use(func(c *gin.Context) {
+			metrics.SetHTTPRoute(c.Request.Context(), c.FullPath())
+		})
+	}
 	a.srv = &http.Server{
 		Addr:    fmt.Sprintf("0.0.0.0:%v", a.port),
 		Handler: a.handler.Handler(),
+	}
+	if httpMetrics != nil {
+		a.srv.Handler = httpMetrics.Handler(a.name, a.srv.Handler)
 	}
 
 	return nil

--- a/services/ctl-api/internal/pkg/api/internal_api.go
+++ b/services/ctl-api/internal/pkg/api/internal_api.go
@@ -17,7 +17,7 @@ func NewInternalAPI(params Params) (*API, error) {
 		endpointAudit:         params.EndpointAudit,
 	}
 
-	if err := api.init(); err != nil {
+	if err := api.init(params.HTTPMetrics); err != nil {
 		return nil, errors.Wrap(err, "unable to initialize")
 	}
 

--- a/services/ctl-api/internal/pkg/api/metrics_test.go
+++ b/services/ctl-api/internal/pkg/api/metrics_test.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/metrics"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/telemetry"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/zap"
+)
+
+func TestAPIMetricsAllSurfaces(t *testing.T) {
+	constructors := map[string]func(Params) (*API, error){
+		"public": NewPublicAPI, "internal": NewInternalAPI, "runner": NewRunnerAPI,
+		"auth": NewAuthAPI, "admin-dashboard": NewAdminDashboardAPI, "slack": NewSlackAPI,
+	}
+	for surface, constructor := range constructors {
+		t.Run(surface, func(t *testing.T) {
+			reader := sdkmetric.NewManualReader()
+			provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+			m, err := metrics.NewHTTPMetrics(provider)
+			require.NoError(t, err)
+			a, err := constructor(Params{
+				Cfg: &internal.Config{}, L: zap.NewNop(), LC: fxtest.NewLifecycle(t), HTTPMetrics: m,
+			})
+			require.NoError(t, err)
+			a.handler.Use(gin.CustomRecoveryWithWriter(io.Discard, func(c *gin.Context, _ any) {
+				c.AbortWithStatus(http.StatusInternalServerError)
+			}))
+			a.handler.Use(func(c *gin.Context) {
+				if c.Request.Method == "POST" {
+					c.AbortWithStatus(http.StatusUnauthorized)
+				}
+			})
+			a.handler.GET("/v1/items/:id", func(c *gin.Context) { c.Status(http.StatusOK) })
+			a.handler.POST("/v1/items/:id", func(c *gin.Context) { t.Fatal("auth failure reached handler") })
+			a.handler.GET("/panic", func(c *gin.Context) { panic("test") })
+			a.handler.GET("/readyz", func(c *gin.Context) { c.Status(http.StatusOK) })
+			requests := []struct {
+				method, path string
+				status       int
+			}{
+				{"GET", "/v1/items/a?token=hidden", 200},
+				{"GET", "/v1/items/b", 200},
+				{"POST", "/v1/items/a", 401},
+				{"GET", "/panic", 500},
+				{"GET", "/missing-a", 404},
+				{"GET", "/missing-b", 404},
+				{"GET", "/v1/items/a/", 301},
+				{"CUSTOM_A", "/missing-a", 404},
+				{"CUSTOM_B", "/missing-b", 404},
+				{"GET", "/readyz", 200},
+			}
+			for _, req := range requests {
+				response := httptest.NewRecorder()
+				a.srv.Handler.ServeHTTP(response, httptest.NewRequest(req.method, req.path, nil))
+				require.Equal(t, req.status, response.Code)
+			}
+			var data metricdata.ResourceMetrics
+			require.NoError(t, reader.Collect(context.Background(), &data))
+			observed := map[string]uint64{}
+			for _, scope := range data.ScopeMetrics {
+				for _, metric := range scope.Metrics {
+					if metric.Name != "http.server.request.duration" {
+						continue
+					}
+					for _, point := range metric.Data.(metricdata.Histogram[float64]).DataPoints {
+						api, _ := point.Attributes.Value("nuon.api")
+						require.Equal(t, surface, api.AsString())
+						method, _ := point.Attributes.Value("http.request.method")
+						route, _ := point.Attributes.Value("http.route")
+						status, _ := point.Attributes.Value("http.response.status_code")
+						errorType, hasError := point.Attributes.Value("error.type")
+						require.Equal(t, status.AsInt64() >= 500, hasError)
+						if hasError {
+							require.Equal(t, "500", errorType.AsString())
+						}
+						observed[fmt.Sprintf("%s|%s|%d", method.AsString(), route.AsString(), status.AsInt64())] += point.Count
+					}
+				}
+			}
+			require.Equal(t, map[string]uint64{
+				"GET|/v1/items/:id|200":  2,
+				"POST|/v1/items/:id|401": 1,
+				"GET|/panic|500":         1,
+				"GET||404":               2,
+				"GET||301":               1,
+				"_OTHER||404":            2,
+				"GET|/readyz|200":        1,
+			}, observed)
+		})
+	}
+}
+
+func TestFXShutdownDrainsAPIBeforeMetricExport(t *testing.T) {
+	t.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "3600000")
+	requests := make(chan []byte, 4)
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requests <- body
+		w.Header().Set("Content-Type", "application/x-protobuf")
+	}))
+	defer receiver.Close()
+	entered, release := make(chan struct{}), make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	defer unblock()
+	var a *API
+	var testServer *httptest.Server
+	app := fx.New(fx.NopLogger,
+		fx.Supply(&internal.Config{OTELExporterOTLPEndpoint: receiver.URL, GracefulShutdownTimeout: time.Second}),
+		fx.Provide(telemetry.NewConfig, telemetry.NewMeterProvider, metrics.NewHTTPMetrics),
+		fx.Invoke(func(lc fx.Lifecycle, cfg *internal.Config, m *metrics.HTTPMetrics) {
+			a = &API{cfg: cfg, l: zap.NewNop(), name: "public"}
+			require.NoError(t, a.init(m))
+			a.handler.GET("/drain", func(c *gin.Context) {
+				close(entered)
+				<-release
+				c.Status(http.StatusAccepted)
+			})
+			testServer = httptest.NewUnstartedServer(a.srv.Handler)
+			a.srv = testServer.Config
+			hooks := a.lifecycleHooks(nil)
+			// httptest supplies a reserved ephemeral listener; use the real API stop hook.
+			hooks.OnStart = func(context.Context) error { testServer.Start(); return nil }
+			lc.Append(hooks)
+		}),
+	)
+	require.NoError(t, app.Start(context.Background()))
+	defer func() { unblock(); testServer.Close() }()
+	draining := make(chan struct{})
+	a.srv.RegisterOnShutdown(func() { close(draining) })
+	response := make(chan int, 1)
+	go func() {
+		r, err := testServer.Client().Get(testServer.URL + "/drain")
+		if err != nil {
+			response <- 0
+			return
+		}
+		defer r.Body.Close()
+		_, _ = io.Copy(io.Discard, r.Body)
+		response <- r.StatusCode
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("request did not start")
+	}
+	stopped := make(chan error, 1)
+	go func() { stopped <- app.Stop(context.Background()) }()
+	select {
+	case <-draining:
+	case <-time.After(time.Second):
+		t.Fatal("API shutdown did not start")
+	}
+	unblock()
+	require.NoError(t, <-stopped)
+	require.Equal(t, http.StatusAccepted, <-response)
+	payload := pmetricotlp.NewExportRequest()
+	select {
+	case body := <-requests:
+		require.NoError(t, payload.UnmarshalProto(body))
+	case <-time.After(time.Second):
+		t.Fatal("no shutdown export received")
+	}
+	observed := payload.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	found := false
+	for i := 0; i < observed.Len(); i++ {
+		m := observed.At(i)
+		if m.Name() == "http.server.request.duration" {
+			found = true
+			require.Equal(t, 1, m.Histogram().DataPoints().Len())
+			require.EqualValues(t, 1, m.Histogram().DataPoints().At(0).Count())
+			status, _ := m.Histogram().DataPoints().At(0).Attributes().Get("http.response.status_code")
+			require.EqualValues(t, http.StatusAccepted, status.Int())
+		}
+		if m.Name() == "http.server.active_requests" {
+			require.Zero(t, m.Sum().DataPoints().At(0).IntValue())
+		}
+	}
+	require.True(t, found, "the final export must include the drained request")
+}

--- a/services/ctl-api/internal/pkg/api/params.go
+++ b/services/ctl-api/internal/pkg/api/params.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nuonco/nuon/services/ctl-api/internal"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/metrics"
 )
 
 type Params struct {
@@ -21,4 +22,5 @@ type Params struct {
 	Cfg           *internal.Config
 	DB            *gorm.DB `name:"psql"`
 	EndpointAudit *EndpointAudit
+	HTTPMetrics   *metrics.HTTPMetrics
 }

--- a/services/ctl-api/internal/pkg/api/public_api.go
+++ b/services/ctl-api/internal/pkg/api/public_api.go
@@ -16,7 +16,7 @@ func NewPublicAPI(params Params) (*API, error) {
 		db:                    params.DB,
 		endpointAudit:         params.EndpointAudit,
 	}
-	if err := api.init(); err != nil {
+	if err := api.init(params.HTTPMetrics); err != nil {
 		return nil, errors.Wrap(err, "unable to initialize")
 	}
 

--- a/services/ctl-api/internal/pkg/api/runner_api.go
+++ b/services/ctl-api/internal/pkg/api/runner_api.go
@@ -17,7 +17,7 @@ func NewRunnerAPI(params Params) (*API, error) {
 		endpointAudit:         params.EndpointAudit,
 	}
 
-	if err := api.init(); err != nil {
+	if err := api.init(params.HTTPMetrics); err != nil {
 		return nil, errors.Wrap(err, "unable to initialize")
 	}
 

--- a/services/ctl-api/internal/pkg/api/slack_api.go
+++ b/services/ctl-api/internal/pkg/api/slack_api.go
@@ -23,7 +23,7 @@ func NewSlackAPI(params Params) (*API, error) {
 		endpointAudit:         params.EndpointAudit,
 	}
 
-	if err := api.init(); err != nil {
+	if err := api.init(params.HTTPMetrics); err != nil {
 		return nil, errors.Wrap(err, "unable to initialize")
 	}
 

--- a/services/ctl-api/internal/pkg/metrics/http.go
+++ b/services/ctl-api/internal/pkg/metrics/http.go
@@ -1,0 +1,102 @@
+package metrics
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/felixge/httpsnoop"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type HTTPMetrics struct {
+	duration metric.Float64Histogram
+	active   metric.Int64UpDownCounter
+	methods  map[string]bool
+}
+
+func NewHTTPMetrics(provider metric.MeterProvider) (*HTTPMetrics, error) {
+	meter := provider.Meter("github.com/nuonco/nuon/services/ctl-api/http")
+	duration, err := meter.Float64Histogram("http.server.request.duration",
+		metric.WithUnit("s"),
+		metric.WithDescription("Duration of HTTP server requests."),
+		metric.WithExplicitBucketBoundaries(.005, .01, .025, .05, .075, .1, .25, .5, .75, 1, 2.5, 5, 7.5, 10),
+	)
+	if err != nil {
+		return nil, err
+	}
+	active, err := meter.Int64UpDownCounter("http.server.active_requests",
+		metric.WithUnit("{request}"),
+		metric.WithDescription("Number of active HTTP server requests."),
+	)
+	if err != nil {
+		return nil, err
+	}
+	methods := "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
+	if configured, ok := os.LookupEnv("OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS"); ok {
+		methods = configured
+	}
+	m := &HTTPMetrics{duration: duration, active: active, methods: make(map[string]bool)}
+	for _, method := range strings.Split(methods, ",") {
+		if method = strings.TrimSpace(method); method != "" {
+			m.methods[method] = true
+		}
+	}
+	return m, nil
+}
+
+func (m *HTTPMetrics) Start(ctx context.Context, api, method, scheme string) func(string, int) {
+	if !m.methods[method] {
+		method = "_OTHER"
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("nuon.api", api),
+		attribute.String("http.request.method", method),
+		attribute.String("url.scheme", scheme),
+	}
+	activeAttrs := metric.WithAttributes(attrs...)
+	m.active.Add(ctx, 1, activeAttrs)
+	started := time.Now()
+	return func(route string, status int) {
+		m.active.Add(ctx, -1, activeAttrs)
+		attrs = append(attrs, attribute.Int("http.response.status_code", status))
+		if route != "" {
+			attrs = append(attrs, attribute.String("http.route", route))
+		}
+		if status >= http.StatusInternalServerError {
+			attrs = append(attrs, attribute.String("error.type", strconv.Itoa(status)))
+		}
+		m.duration.Record(ctx, time.Since(started).Seconds(), metric.WithAttributes(attrs...))
+	}
+}
+
+type httpRouteKey struct{}
+
+type httpRoute struct {
+	template string
+}
+
+func SetHTTPRoute(ctx context.Context, template string) {
+	if route, ok := ctx.Value(httpRouteKey{}).(*httpRoute); ok {
+		route.template = template
+	}
+}
+
+func (m *HTTPMetrics) Handler(api string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scheme := "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
+		route := &httpRoute{}
+		r = r.WithContext(context.WithValue(r.Context(), httpRouteKey{}, route))
+		finish := m.Start(r.Context(), api, r.Method, scheme)
+		status := http.StatusInternalServerError
+		defer func() { finish(route.template, status) }()
+		status = httpsnoop.CaptureMetrics(next, w, r).Code
+	})
+}

--- a/services/ctl-api/internal/pkg/metrics/http_test.go
+++ b/services/ctl-api/internal/pkg/metrics/http_test.go
@@ -1,0 +1,76 @@
+package metrics
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestHTTPMetricsActiveAndStreaming(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+	m, err := NewHTTPMetrics(provider)
+	require.NoError(t, err)
+	collect := func() metricdata.ResourceMetrics {
+		var data metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(context.Background(), &data))
+		return data
+	}
+	handler := m.Handler("auth", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		SetHTTPRoute(r.Context(), "/oauth/token")
+		data := collect()
+		require.Len(t, data.ScopeMetrics, 1)
+		require.Len(t, data.ScopeMetrics[0].Metrics, 1)
+		require.Equal(t, "http.server.active_requests", data.ScopeMetrics[0].Metrics[0].Name)
+		for _, metric := range data.ScopeMetrics[0].Metrics {
+			if metric.Name == "http.server.active_requests" {
+				points := metric.Data.(metricdata.Sum[int64]).DataPoints
+				require.Len(t, points, 1)
+				require.EqualValues(t, 1, points[0].Value)
+				require.Equal(t, attribute.NewSet(
+					attribute.String("nuon.api", "auth"),
+					attribute.String("http.request.method", "POST"),
+					attribute.String("url.scheme", "https"),
+				), points[0].Attributes)
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+		w.(http.Flusher).Flush()
+		_, err := w.Write([]byte("streamed"))
+		require.NoError(t, err)
+	}))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest("POST", "https://example.com/oauth/token?secret=hidden", nil))
+	require.Equal(t, "streamed", response.Body.String())
+	require.True(t, response.Flushed)
+	data := collect()
+	require.Len(t, data.ScopeMetrics, 1)
+	require.Len(t, data.ScopeMetrics[0].Metrics, 2)
+	for _, metric := range data.ScopeMetrics[0].Metrics {
+		switch metric.Name {
+		case "http.server.active_requests":
+			require.Zero(t, metric.Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+		case "http.server.request.duration":
+			point := metric.Data.(metricdata.Histogram[float64]).DataPoints[0]
+			require.EqualValues(t, 1, point.Count)
+			require.GreaterOrEqual(t, point.Sum, .02)
+			require.Less(t, point.Sum, 10.0)
+			require.Equal(t, []float64{.005, .01, .025, .05, .075, .1, .25, .5, .75, 1, 2.5, 5, 7.5, 10}, point.Bounds)
+			require.Equal(t, attribute.NewSet(
+				attribute.String("nuon.api", "auth"),
+				attribute.String("http.request.method", "POST"),
+				attribute.String("url.scheme", "https"),
+				attribute.String("http.route", "/oauth/token"),
+				attribute.Int("http.response.status_code", 200),
+			), point.Attributes)
+		}
+	}
+}

--- a/services/ctl-api/internal/pkg/telemetry/README.md
+++ b/services/ctl-api/internal/pkg/telemetry/README.md
@@ -1,0 +1,152 @@
+# Control-plane operational telemetry
+
+This package configures OTLP metric export for the control plane. It provides an
+injected process resource and meter provider, including shutdown handling.
+HTTP metric instrumentation lives in `internal/pkg/metrics`.
+
+`internal/pkg/otel` remains separate: it owns product-facing OTLP payload types
+and ingestion conversion helpers. This package exports telemetry about Nuon's
+control plane; it does not ingest or process runner/application telemetry.
+
+Metrics export automatically when an OTLP endpoint is configured. With no endpoint,
+the meter provider is a no-op. This package does not configure log or trace
+providers.
+
+## Enable export
+
+Configure each API process to send OTLP/HTTP protobuf to a control-plane-local
+Collector or an authenticated OTLP backend:
+
+```sh
+OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_EXPORTER_OTLP_TIMEOUT=5000
+OTEL_RESOURCE_ATTRIBUTES=nuon.control_plane.id=cp-example,deployment.environment.name=production
+```
+
+The loopback URL assumes a sidecar Collector. Use a private Collector service
+address for a separate deployment; use HTTPS across untrusted networks. Restrict
+Collector ingress to control-plane workloads. The existing application relay
+requires runner credentials and is not this metrics endpoint.
+
+`OTEL_EXPORTER_OTLP_ENDPOINT` is the shared base URL; metrics append `/v1/metrics`
+while retaining any base path. `OTEL_EXPORTER_OTLP_PROTOCOL` defaults to
+`http/protobuf`. The same fields can be set in service configuration as
+`otel_exporter_otlp_endpoint` and `otel_exporter_otlp_protocol`; environment values
+take precedence. A configured invalid endpoint or unsupported protocol fails
+configuration rather than silently selecting a destination. No endpoint means no
+export, not an implicit localhost destination.
+
+Use the generic base endpoint rather than `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`.
+With export enabled, nonempty metrics-specific transport overrides (endpoint, protocol, headers,
+certificate, client certificate/key, timeout, compression and insecure) are
+configuration errors. With no shared endpoint, transport settings are ignored and
+no exporter is constructed. This prevents the SDK's signal-specific precedence
+from silently diverging from the common transport policy.
+
+Standard SDK settings supply headers and TLS certificates, including
+`OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_CERTIFICATE`,
+`OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE`, and `OTEL_EXPORTER_OTLP_CLIENT_KEY`.
+Configure these generic settings consistently for all signals and keep credentials
+in deployment secrets. Invalid headers, unreadable/invalid certificates and
+incomplete client certificate/key pairs fail configuration instead of allowing the
+SDK to log and ignore them. Header values use percent encoding; `+` stays literal.
+Certificates require HTTPS. `OTEL_EXPORTER_OTLP_INSECURE`, if supplied, must be
+`true` for HTTP or `false` for HTTPS; it cannot override the endpoint scheme.
+`OTEL_EXPORTER_OTLP_COMPRESSION` accepts `gzip` or `none`.
+
+`OTEL_EXPORTER_OTLP_TIMEOUT` is a positive integer in milliseconds (SDK default:
+10,000). Invalid values fail configuration. The metrics reader uses the SDK's
+periodic export behavior, with a 60-second interval by default;
+`OTEL_METRIC_EXPORT_INTERVAL` and `OTEL_METRIC_EXPORT_TIMEOUT` remain signal-specific
+reader tuning, not destination/credential settings. Existing trace/log settings
+are not rejected or migrated by this package.
+
+Generic OTLP transport settings can also apply to existing log exporters in the
+same process. Audit export is a no-op unless `AUDIT_OTLP_ENDPOINT` (service config:
+`audit_otlp_endpoint`) is explicitly configured; the generic endpoint alone does
+not enable it. If enabled without `AUDIT_OTLP_TOKEN`, it can inherit generic OTLP
+headers, including credentials. Existing workflow log exporters set their own
+headers but can still inherit generic TLS, timeout and compression settings.
+Review signal-specific `OTEL_EXPORTER_OTLP_LOGS_*` settings and explicit exporter
+options before using different receivers or credentials for logs and metrics.
+
+The default resource includes `service.name`, `service.version`, a random
+process-lifetime `service.instance.id`, `nuon.service.type`, and
+`nuon.service.deployment`. `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` can
+override resource values. Set a stable, opaque `nuon.control_plane.id` for the
+BYOC deployment. If overriding `service.instance.id`, keep it unique per live
+process; do not use one shared replica identifier. `nuon.service.deployment` is
+the existing service deployment configuration, not a customer/install identity.
+
+`DISABLE_METRICS` continues to control the existing Datadog path. It does not
+disable this independent export. The OTel configuration/resource and meter provider
+are injected, not installed globally; existing providers are not replaced.
+Construct the shared configuration once per process,
+not once per signal, to reuse the same generated instance ID.
+
+The SDK exports operator-supplied `OTEL_RESOURCE_ATTRIBUTES` without an attribute
+allowlist. Do not put credentials or sensitive identifiers in resource
+configuration. Keep instance identity through export so replica counters remain
+separate.
+
+## Metrics
+
+| Metric | Type | Unit | Dimensions |
+| --- | --- | --- | --- |
+| `http.server.request.duration` | Explicit-bucket histogram | seconds | `nuon.api`, `http.request.method`, `url.scheme`, `http.response.status_code`, matched `http.route`, `error.type` for 5xx |
+| `http.server.active_requests` | Up/down counter | requests | `nuon.api`, `http.request.method`, `url.scheme` |
+
+`nuon.api` is one of `public`, `runner`, `auth`, `internal`, `admin-dashboard`,
+`slack`, or `mcp`. Metrics measure HTTP handling, not Temporal signals, individual
+MCP tool outcomes, database operations, or downstream runner execution.
+
+Histogram count supplies request volume; 5xx counts divided by total counts
+supply an HTTP error ratio. The explicit boundaries in seconds are:
+`0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10`.
+Aggregation and temporality are fixed to explicit histograms and cumulative
+values. Apply rates per instance before aggregating across replicas.
+
+Gin routes use templates such as `/v1/apps/:app_id`. Unmatched requests and
+router-generated redirects have no route label. MCP's catch-all route is `/`.
+Raw paths, query strings, headers, user/org identifiers, and request bodies are
+not metric dimensions. Unknown methods become `_OTHER`; the standard
+`OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS` setting can override the known method
+list. Scheme reflects the connection to the API, not untrusted forwarded headers.
+Health requests are included and can be excluded by route in alert queries.
+Streaming request duration measures the full handler lifetime.
+
+## Failure behavior
+
+Requests update in-memory aggregations; network export runs periodically outside
+the request path. Each instrument is limited to 2,000 attribute sets with SDK
+overflow aggregation. Exemplars are disabled so internal trace IDs are not
+exported with customer metrics. FX orders API shutdown before provider shutdown.
+The final export is best-effort: if API drain exhausts the application stop budget,
+FX can skip the provider hook. When invoked, provider shutdown has a five-second
+deadline bounded by the remaining application shutdown context.
+
+Exporter errors pass through unchanged to the SDK error handler or flush/shutdown
+caller, preserving endpoint, HTTP status and receiver response details supplied by
+the SDK for debugging. Exporter initialization errors retain their underlying
+cause. Diagnostics may contain sensitive receiver data. This package does not
+replace the global OTel error handler.
+
+The SDK has no persistent queue. Cumulative counts can survive a temporary export
+failure while the process lives, but intermediate timing resolution is lost;
+process loss can lose unexported data. Collector buffering and destination routing
+are configured separately. Use missing-data alerts and independent availability
+probes; an API cannot report its own total outage through this export path.
+
+## Testing
+
+Run the tests and request-recording benchmark from the repository root:
+
+```sh
+go test -race ./services/ctl-api/internal/pkg/telemetry ./services/ctl-api/internal/pkg/metrics ./services/ctl-api/internal/pkg/api ./services/ctl-api/internal/app/mcp/server
+go test -run '^$' -bench '^BenchmarkHTTPMetrics$' -benchmem ./services/ctl-api/internal/pkg/telemetry
+```
+
+The benchmark measures `Start`/finish recording with no endpoint, a healthy
+receiver and a blocked receiver. It does not measure the full HTTP stack or
+production process memory usage.

--- a/services/ctl-api/internal/pkg/telemetry/config.go
+++ b/services/ctl-api/internal/pkg/telemetry/config.go
@@ -1,0 +1,101 @@
+package telemetry
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"math"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"golang.org/x/net/http/httpguts"
+)
+
+type Config struct {
+	Endpoint string
+	Resource *resource.Resource
+}
+
+func NewConfig(cfg *internal.Config) (*Config, error) {
+	endpoint := cfg.OTELExporterOTLPEndpoint
+	if endpoint != "" {
+		u, err := url.Parse(endpoint)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+			return nil, fmt.Errorf("OTEL requires an HTTP(S) OTLP endpoint without userinfo, query, or fragment")
+		}
+		if protocol := cfg.OTELExporterOTLPProtocol; protocol != "" && protocol != "http/protobuf" {
+			return nil, fmt.Errorf("OTEL supports only the http/protobuf protocol")
+		}
+		if err := validateTransportEnv(u.Scheme); err != nil {
+			return nil, err
+		}
+	}
+
+	rsrc, err := resource.New(context.Background(),
+		resource.WithAttributes(
+			attribute.String("service.name", cfg.ServiceName),
+			attribute.String("service.version", cfg.Version),
+			attribute.String("service.instance.id", uuid.NewString()),
+			attribute.String("nuon.service.type", cfg.ServiceType),
+			attribute.String("nuon.service.deployment", cfg.ServiceDeployment),
+		),
+		resource.WithFromEnv(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("invalid OTEL_RESOURCE_ATTRIBUTES")
+	}
+	return &Config{Endpoint: endpoint, Resource: rsrc}, nil
+}
+
+func validateTransportEnv(scheme string) error {
+	for _, suffix := range []string{"ENDPOINT", "PROTOCOL", "HEADERS", "CERTIFICATE", "CLIENT_CERTIFICATE", "CLIENT_KEY", "TIMEOUT", "COMPRESSION", "INSECURE"} {
+		key := "OTEL_EXPORTER_OTLP_METRICS_" + suffix
+		if os.Getenv(key) != "" {
+			return fmt.Errorf("%s is unsupported; use OTEL_EXPORTER_OTLP_%s", key, suffix)
+		}
+	}
+	if value := os.Getenv("OTEL_EXPORTER_OTLP_TIMEOUT"); value != "" {
+		ms, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || ms <= 0 || ms > math.MaxInt64/int64(time.Millisecond) {
+			return fmt.Errorf("OTEL_EXPORTER_OTLP_TIMEOUT must be positive milliseconds within time.Duration range")
+		}
+	}
+	if value := os.Getenv("OTEL_EXPORTER_OTLP_COMPRESSION"); value != "" && value != "gzip" && value != "none" {
+		return fmt.Errorf("OTEL_EXPORTER_OTLP_COMPRESSION must be gzip or none")
+	}
+	if value := os.Getenv("OTEL_EXPORTER_OTLP_INSECURE"); value != "" {
+		if !strings.EqualFold(value, "true") && !strings.EqualFold(value, "false") || strings.EqualFold(value, "true") != (scheme == "http") {
+			return fmt.Errorf("OTEL_EXPORTER_OTLP_INSECURE must agree with the endpoint's HTTP(S) scheme")
+		}
+	}
+	if value := os.Getenv("OTEL_EXPORTER_OTLP_HEADERS"); value != "" {
+		for _, pair := range strings.Split(value, ",") {
+			name, encoded, ok := strings.Cut(pair, "=")
+			value, err := url.PathUnescape(encoded)
+			if !ok || err != nil || !httpguts.ValidHeaderFieldName(strings.TrimSpace(name)) || !httpguts.ValidHeaderFieldValue(value) {
+				return fmt.Errorf("invalid OTEL_EXPORTER_OTLP_HEADERS")
+			}
+		}
+	}
+	if path := os.Getenv("OTEL_EXPORTER_OTLP_CERTIFICATE"); path != "" {
+		pem, err := os.ReadFile(path)
+		if scheme != "https" || err != nil || !x509.NewCertPool().AppendCertsFromPEM(pem) {
+			return fmt.Errorf("OTEL_EXPORTER_OTLP_CERTIFICATE requires HTTPS and a readable PEM certificate")
+		}
+	}
+	cert, key := os.Getenv("OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE"), os.Getenv("OTEL_EXPORTER_OTLP_CLIENT_KEY")
+	if cert != "" || key != "" {
+		if _, err := tls.LoadX509KeyPair(cert, key); err != nil || scheme != "https" {
+			return fmt.Errorf("OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE and OTEL_EXPORTER_OTLP_CLIENT_KEY require HTTPS and a valid certificate/key pair")
+		}
+	}
+	return nil
+}

--- a/services/ctl-api/internal/pkg/telemetry/config_test.go
+++ b/services/ctl-api/internal/pkg/telemetry/config_test.go
@@ -1,0 +1,139 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nuonco/nuon/pkg/services/config"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name, endpoint, protocol, wantError string
+	}{
+		{name: "unconfigured"},
+		{name: "http", endpoint: "http://localhost:4318"},
+		{name: "https with base path", endpoint: "https://example.com/otel/", protocol: "http/protobuf"},
+		{name: "missing scheme", endpoint: "localhost:4318", wantError: "OTLP endpoint"},
+		{name: "missing host", endpoint: "https:///otel", wantError: "OTLP endpoint"},
+		{name: "invalid URL", endpoint: "http://%", wantError: "OTLP endpoint"},
+		{name: "credentials", endpoint: "https://user:secret@example.com", wantError: "OTLP endpoint"},
+		{name: "query", endpoint: "https://example.com?token=secret", wantError: "OTLP endpoint"},
+		{name: "fragment", endpoint: "https://example.com#metrics", wantError: "OTLP endpoint"},
+		{name: "unsupported protocol", endpoint: "http://localhost:4318", protocol: "grpc", wantError: "http/protobuf"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := NewConfig(&internal.Config{
+				OTELExporterOTLPEndpoint: tc.endpoint,
+				OTELExporterOTLPProtocol: tc.protocol,
+			})
+			if tc.wantError != "" {
+				require.ErrorContains(t, err, tc.wantError)
+				require.Nil(t, cfg)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.endpoint, cfg.Endpoint)
+		})
+	}
+}
+
+func TestSharedResourceDefaults(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	serviceConfig := &internal.Config{
+		ServiceName:       "ctl-api",
+		Version:           "test-version",
+		ServiceType:       "api",
+		ServiceDeployment: "runner",
+	}
+	first, err := NewConfig(serviceConfig)
+	require.NoError(t, err)
+	attrs := map[string]string{}
+	for _, attr := range first.Resource.Attributes() {
+		attrs[string(attr.Key)] = attr.Value.AsString()
+	}
+	require.Equal(t, "ctl-api", attrs["service.name"])
+	require.Equal(t, "test-version", attrs["service.version"])
+	require.Equal(t, "api", attrs["nuon.service.type"])
+	require.Equal(t, "runner", attrs["nuon.service.deployment"])
+	_, err = uuid.Parse(attrs["service.instance.id"])
+	require.NoError(t, err)
+	second, err := NewConfig(serviceConfig)
+	require.NoError(t, err)
+	require.False(t, first.Resource.Equal(second.Resource))
+}
+
+func TestSharedConfigFileAndEnvironment(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "")
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("otel_exporter_otlp_endpoint: https://file.example.com/otel\notel_exporter_otlp_protocol: http/protobuf\n"), 0600))
+	var serviceConfig internal.Config
+	require.NoError(t, config.NewFileLoader(path).LoadInto(nil, &serviceConfig))
+	cfg, err := NewConfig(&serviceConfig)
+	require.NoError(t, err)
+	require.Equal(t, "https://file.example.com/otel", cfg.Endpoint)
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://env.example.com/otel")
+	require.NoError(t, config.NewFileLoader(path).LoadInto(nil, &serviceConfig))
+	cfg, err = NewConfig(&serviceConfig)
+	require.NoError(t, err)
+	require.Equal(t, "https://env.example.com/otel", cfg.Endpoint)
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+	require.NoError(t, config.NewFileLoader(path).LoadInto(nil, &serviceConfig))
+	_, err = NewConfig(&serviceConfig)
+	require.ErrorContains(t, err, "http/protobuf")
+}
+
+func TestRejectSignalSpecificTransport(t *testing.T) {
+	for _, suffix := range []string{"ENDPOINT", "PROTOCOL", "HEADERS", "CERTIFICATE", "CLIENT_CERTIFICATE", "CLIENT_KEY", "TIMEOUT", "COMPRESSION", "INSECURE"} {
+		t.Run(suffix, func(t *testing.T) {
+			key := "OTEL_EXPORTER_OTLP_METRICS_" + suffix
+			t.Setenv(key, "secret-value")
+			_, err := NewConfig(&internal.Config{OTELExporterOTLPEndpoint: "https://example.com"})
+			require.ErrorContains(t, err, key)
+			require.NotContains(t, err.Error(), "secret-value")
+			_, err = NewConfig(&internal.Config{})
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestInvalidGenericTransportFailsClosed(t *testing.T) {
+	for _, tc := range []struct{ key, value string }{
+		{"HEADERS", "secret-value"},
+		{"HEADERS", "bad key=secret-value"},
+		{"HEADERS", "Authorization=%secret-value"},
+		{"HEADERS", "Authorization=secret-value%0d%0aInjected:value"},
+		{"CERTIFICATE", "/nonexistent/secret-value"},
+		{"CLIENT_CERTIFICATE", "/nonexistent/secret-value"},
+		{"CLIENT_KEY", "/nonexistent/secret-value"},
+		{"TIMEOUT", "secret-value"},
+		{"TIMEOUT", "0"},
+		{"TIMEOUT", "-1"},
+		{"TIMEOUT", "9223372036854775807"},
+		{"COMPRESSION", "secret-value"},
+		{"INSECURE", "secret-value"},
+		{"INSECURE", "true"},
+	} {
+		t.Run(tc.key+"/"+tc.value, func(t *testing.T) {
+			key := "OTEL_EXPORTER_OTLP_" + tc.key
+			t.Setenv(key, tc.value)
+			_, err := NewConfig(&internal.Config{OTELExporterOTLPEndpoint: "https://example.com"})
+			require.ErrorContains(t, err, "OTEL_EXPORTER_OTLP_")
+			require.NotContains(t, err.Error(), "secret-value")
+			_, err = NewConfig(&internal.Config{})
+			require.NoError(t, err)
+		})
+	}
+	path := filepath.Join(t.TempDir(), "invalid.pem")
+	require.NoError(t, os.WriteFile(path, []byte("secret-value"), 0600))
+	t.Setenv("OTEL_EXPORTER_OTLP_CERTIFICATE", path)
+	_, err := NewConfig(&internal.Config{OTELExporterOTLPEndpoint: "https://example.com"})
+	require.ErrorContains(t, err, "OTEL_EXPORTER_OTLP_CERTIFICATE")
+	require.NotContains(t, err.Error(), path)
+}

--- a/services/ctl-api/internal/pkg/telemetry/metrics.go
+++ b/services/ctl-api/internal/pkg/telemetry/metrics.go
@@ -1,0 +1,49 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/exemplar"
+	"go.uber.org/fx"
+)
+
+func NewMeterProvider(lc fx.Lifecycle, cfg *Config) (metric.MeterProvider, error) {
+	if cfg.Endpoint == "" {
+		return noop.NewMeterProvider(), nil
+	}
+
+	endpoint, err := url.JoinPath(cfg.Endpoint, "v1/metrics")
+	if err != nil {
+		return nil, fmt.Errorf("configure OTEL metric endpoint: %w", err)
+	}
+	exporter, err := otlpmetrichttp.New(context.Background(),
+		otlpmetrichttp.WithEndpointURL(endpoint),
+		otlpmetrichttp.WithTemporalitySelector(sdkmetric.CumulativeTemporalitySelector),
+		otlpmetrichttp.WithAggregationSelector(sdkmetric.DefaultAggregationSelector),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to configure OTLP metric exporter: %w", err)
+	}
+
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(cfg.Resource),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter)),
+		sdkmetric.WithCardinalityLimit(2000),
+		sdkmetric.WithExemplarFilter(exemplar.AlwaysOffFilter),
+	)
+	lc.Append(fx.Hook{
+		OnStop: func(ctx context.Context) error {
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			return provider.Shutdown(ctx)
+		},
+	})
+	return provider, nil
+}

--- a/services/ctl-api/internal/pkg/telemetry/metrics_benchmark_test.go
+++ b/services/ctl-api/internal/pkg/telemetry/metrics_benchmark_test.go
@@ -1,0 +1,70 @@
+package telemetry
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/metrics"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
+)
+
+func BenchmarkHTTPMetrics(b *testing.B) {
+	for _, mode := range []string{"absent", "healthy", "blocked"} {
+		b.Run(mode, func(b *testing.B) {
+			var blocked atomic.Bool
+			blocked.Store(mode == "blocked")
+			started := make(chan struct{})
+			release := make(chan struct{})
+			var once sync.Once
+			receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				once.Do(func() { close(started) })
+				if blocked.Load() {
+					select {
+					case <-r.Context().Done():
+						return
+					case <-release:
+					}
+				}
+				w.Header().Set("Content-Type", "application/x-protobuf")
+			}))
+			defer receiver.Close()
+			b.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "10")
+			lc := fxtest.NewLifecycle(b)
+			cfg := &internal.Config{}
+			if mode != "absent" {
+				cfg.OTELExporterOTLPEndpoint = receiver.URL
+			}
+			shared, err := NewConfig(cfg)
+			require.NoError(b, err)
+			provider, err := NewMeterProvider(lc, shared)
+			require.NoError(b, err)
+			lc.RequireStart()
+			defer func() { blocked.Store(false); close(release); lc.RequireStop() }()
+			m, err := metrics.NewHTTPMetrics(provider)
+			require.NoError(b, err)
+			m.Start(context.Background(), "public", "GET", "http")("/v1/apps/:id", 200)
+			if mode != "absent" {
+				select {
+				case <-started:
+				case <-time.After(time.Second):
+					b.Fatal("periodic exporter did not start")
+				}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				m.Start(context.Background(), "public", "GET", "http")("/v1/apps/:id", 200)
+			}
+			b.StopTimer()
+		})
+	}
+}

--- a/services/ctl-api/internal/pkg/telemetry/metrics_test.go
+++ b/services/ctl-api/internal/pkg/telemetry/metrics_test.go
@@ -1,0 +1,437 @@
+package telemetry
+
+import (
+	"compress/gzip"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nuonco/nuon/pkg/services/config"
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/metrics"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestMeterProviderWithoutEndpoint(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "not-a-url")
+	lc := fxtest.NewLifecycle(t)
+	cfg, err := NewConfig(&internal.Config{})
+	require.NoError(t, err)
+	provider, err := NewMeterProvider(lc, cfg)
+	require.NoError(t, err)
+	require.IsType(t, noop.NewMeterProvider(), provider)
+	lc.RequireStart().RequireStop()
+}
+
+func TestMeterProviderExportsAndFlushesOnShutdown(t *testing.T) {
+	type request struct {
+		path, authorization string
+		body                []byte
+	}
+	requests := make(chan request, 8)
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requests <- request{r.URL.Path, r.Header.Get("Authorization"), body}
+		w.Header().Set("Content-Type", "application/x-protobuf")
+	}))
+	t.Cleanup(receiver.Close)
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", receiver.URL+"/tenant/")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "Authorization=Bearer%20test-token")
+	t.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "3600000")
+	t.Setenv("OTEL_METRICS_EXEMPLAR_FILTER", "always_on")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", "delta")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION", "base2_exponential_bucket_histogram")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "nuon.control_plane.id=cp-test,service.instance.id=replica-a")
+	t.Setenv("OTEL_SERVICE_NAME", "control-plane-api")
+	lc := fxtest.NewLifecycle(t)
+	globalMeter, globalTracer := otel.GetMeterProvider(), otel.GetTracerProvider()
+	serviceConfig := &internal.Config{
+		DisableMetrics:    true,
+		ServiceName:       "ctl-api",
+		ServiceType:       "api",
+		ServiceDeployment: "public",
+		Version:           "test-version",
+	}
+	require.NoError(t, config.NewFileLoader(filepath.Join(t.TempDir(), "config.yaml")).LoadInto(nil, serviceConfig))
+	cfg, err := NewConfig(serviceConfig)
+	require.NoError(t, err)
+	provider, err := NewMeterProvider(lc, cfg)
+	require.NoError(t, err)
+	require.Same(t, globalMeter, otel.GetMeterProvider())
+	require.Same(t, globalTracer, otel.GetTracerProvider())
+	lc.RequireStart()
+	stopped := false
+	t.Cleanup(func() {
+		if !stopped {
+			lc.RequireStop()
+		}
+	})
+	m, err := metrics.NewHTTPMetrics(provider)
+	require.NoError(t, err)
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{1}, SpanID: trace.SpanID{2}, TraceFlags: trace.FlagsSampled,
+	}))
+	m.Start(ctx, "public", "GET", "https")("/v1/apps/:id", 200)
+	require.NoError(t, provider.(*sdkmetric.MeterProvider).ForceFlush(ctx))
+	check := func(wantCount uint64) {
+		t.Helper()
+		select {
+		case req := <-requests:
+			require.Equal(t, "/tenant/v1/metrics", req.path)
+			require.Equal(t, "Bearer test-token", req.authorization)
+			payload := pmetricotlp.NewExportRequest()
+			require.NoError(t, payload.UnmarshalProto(req.body))
+			rms := payload.Metrics().ResourceMetrics()
+			require.Equal(t, 1, rms.Len())
+			attrs := rms.At(0).Resource().Attributes().AsRaw()
+			require.Equal(t, "cp-test", attrs["nuon.control_plane.id"])
+			require.Equal(t, "replica-a", attrs["service.instance.id"])
+			require.Equal(t, "control-plane-api", attrs["service.name"])
+			require.Equal(t, "test-version", attrs["service.version"])
+			metrics := rms.At(0).ScopeMetrics().At(0).Metrics()
+			found := false
+			for i := 0; i < metrics.Len(); i++ {
+				metric := metrics.At(i)
+				if metric.Name() == "http.server.request.duration" {
+					found = true
+					require.Equal(t, "s", metric.Unit())
+					require.Equal(t, pmetric.AggregationTemporalityCumulative, metric.Histogram().AggregationTemporality())
+					points := metric.Histogram().DataPoints()
+					require.Equal(t, 1, points.Len())
+					require.Equal(t, wantCount, points.At(0).Count())
+					require.Zero(t, points.At(0).Exemplars().Len())
+				}
+			}
+			require.True(t, found)
+		case <-time.After(time.Second):
+			t.Fatal("no OTLP metric export received")
+		}
+	}
+	check(1)
+	m.Start(ctx, "public", "GET", "https")("/v1/apps/:id", 200)
+	lc.RequireStop()
+	stopped = true
+	check(2)
+}
+
+func TestSlowMetricExporterDoesNotBlockHTTPRequests(t *testing.T) {
+	started := make(chan struct{})
+	var first sync.Once
+	var unavailable atomic.Bool
+	unavailable.Store(true)
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		if unavailable.Load() {
+			first.Do(func() { close(started) })
+			<-r.Context().Done()
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-protobuf")
+	}))
+	t.Cleanup(receiver.Close)
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
+	t.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "3600000")
+	lc := fxtest.NewLifecycle(t)
+	cfg, err := NewConfig(&internal.Config{OTELExporterOTLPEndpoint: receiver.URL, ServiceName: "ctl-api"})
+	require.NoError(t, err)
+	provider, err := NewMeterProvider(lc, cfg)
+	require.NoError(t, err)
+	lc.RequireStart()
+	t.Cleanup(func() { lc.RequireStop() })
+	m, err := metrics.NewHTTPMetrics(provider)
+	require.NoError(t, err)
+	m.Start(context.Background(), "runner", "GET", "http")("/v1/jobs", 200)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	flushed := make(chan error, 1)
+	go func() { flushed <- provider.(*sdkmetric.MeterProvider).ForceFlush(ctx) }()
+	select {
+	case <-started:
+	case <-ctx.Done():
+		t.Fatal("export did not reach receiver")
+	}
+	completed := make(chan int, 1)
+	go func() {
+		handler := m.Handler("runner", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			metrics.SetHTTPRoute(r.Context(), "/v1/jobs")
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest("GET", "/v1/jobs", nil))
+		completed <- response.Code
+	}()
+	select {
+	case code := <-completed:
+		require.Equal(t, http.StatusAccepted, code)
+	case <-time.After(time.Second):
+		t.Fatal("request blocked on telemetry export")
+	}
+	cancel()
+	require.Error(t, <-flushed)
+	unavailable.Store(false)
+	require.NoError(t, provider.(*sdkmetric.MeterProvider).ForceFlush(context.Background()))
+}
+
+func TestGenericTLSHeadersAndCompression(t *testing.T) {
+	requests := make(chan []byte, 2)
+	receiver := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer a+b,c=token" || r.Header.Get("Content-Encoding") != "gzip" || len(r.TLS.PeerCertificates) != 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		reader, err := gzip.NewReader(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		defer reader.Close()
+		body, _ := io.ReadAll(reader)
+		requests <- body
+		w.Header().Set("Content-Type", "application/x-protobuf")
+	}))
+	receiver.TLS = &tls.Config{ClientAuth: tls.RequireAnyClientCert}
+	receiver.StartTLS()
+	t.Cleanup(receiver.Close)
+	cert := receiver.TLS.Certificates[0]
+	key, err := x509.MarshalPKCS8PrivateKey(cert.PrivateKey)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	certPath, keyPath := filepath.Join(dir, "cert.pem"), filepath.Join(dir, "key.pem")
+	require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]}), 0600))
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key}), 0600))
+	t.Setenv("OTEL_EXPORTER_OTLP_CERTIFICATE", certPath)
+	t.Setenv("OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE", certPath)
+	t.Setenv("OTEL_EXPORTER_OTLP_CLIENT_KEY", keyPath)
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "Authorization=Bearer%20a+b%2Cc=token")
+	t.Setenv("OTEL_EXPORTER_OTLP_COMPRESSION", "gzip")
+	t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "false")
+	t.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "3600000")
+	lc := fxtest.NewLifecycle(t)
+	cfg, err := NewConfig(&internal.Config{OTELExporterOTLPEndpoint: receiver.URL})
+	require.NoError(t, err)
+	provider, err := NewMeterProvider(lc, cfg)
+	require.NoError(t, err)
+	lc.RequireStart()
+	t.Cleanup(func() { lc.RequireStop() })
+	counter, err := provider.Meter("test").Int64Counter("test.count")
+	require.NoError(t, err)
+	counter.Add(context.Background(), 7)
+	require.NoError(t, provider.(*sdkmetric.MeterProvider).ForceFlush(context.Background()))
+	payload := pmetricotlp.NewExportRequest()
+	require.NoError(t, payload.UnmarshalProto(<-requests))
+	require.EqualValues(t, 7, payload.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).IntValue())
+}
+
+func TestExportErrorDetailsAndRecovery(t *testing.T) {
+	var reject atomic.Bool
+	reject.Store(true)
+	requests := make(chan []byte, 2)
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if reject.Load() {
+			http.Error(w, "collector authentication rejected", http.StatusUnauthorized)
+			return
+		}
+		requests <- body
+		w.Header().Set("Content-Type", "application/x-protobuf")
+	}))
+	t.Cleanup(receiver.Close)
+	t.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "3600000")
+	lc := fxtest.NewLifecycle(t)
+	cfg, err := NewConfig(&internal.Config{OTELExporterOTLPEndpoint: receiver.URL + "/tenant"})
+	require.NoError(t, err)
+	provider, err := NewMeterProvider(lc, cfg)
+	require.NoError(t, err)
+	lc.RequireStart()
+	t.Cleanup(func() { reject.Store(false); lc.RequireStop() })
+	counter, err := provider.Meter("test").Int64Counter("test.count")
+	require.NoError(t, err)
+	counter.Add(context.Background(), 3)
+	err = provider.(*sdkmetric.MeterProvider).ForceFlush(context.Background())
+	require.ErrorContains(t, err, "collector authentication rejected")
+	require.ErrorContains(t, err, "401 Unauthorized")
+	require.ErrorContains(t, err, receiver.URL+"/tenant/v1/metrics")
+	reject.Store(false)
+	counter.Add(context.Background(), 5)
+	require.NoError(t, provider.(*sdkmetric.MeterProvider).ForceFlush(context.Background()))
+	payload := pmetricotlp.NewExportRequest()
+	require.NoError(t, payload.UnmarshalProto(<-requests))
+	require.EqualValues(t, 8, payload.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).IntValue())
+}
+
+func TestExporterTimeoutAndShutdownDeadline(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		exportTimeout string
+		stopTimeout   time.Duration
+	}{
+		{"export timeout", "50", time.Second},
+		{"application deadline", "60000", 100 * time.Millisecond},
+		{"provider deadline", "60000", 10 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var reached atomic.Int64
+			receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				reached.Add(1)
+				<-r.Context().Done()
+			}))
+			t.Cleanup(receiver.Close)
+			t.Setenv("OTEL_EXPORTER_OTLP_TIMEOUT", tc.exportTimeout)
+			t.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "3600000")
+			lc := fxtest.NewLifecycle(t)
+			cfg, err := NewConfig(&internal.Config{OTELExporterOTLPEndpoint: receiver.URL})
+			require.NoError(t, err)
+			provider, err := NewMeterProvider(lc, cfg)
+			require.NoError(t, err)
+			lc.RequireStart()
+			counter, err := provider.Meter("test").Int64Counter("test.count")
+			require.NoError(t, err)
+			counter.Add(context.Background(), 1)
+			ctx, cancel := context.WithTimeout(context.Background(), tc.stopTimeout)
+			defer cancel()
+			started := time.Now()
+			err = lc.Stop(ctx)
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+			require.Less(t, time.Since(started), min(tc.stopTimeout, 5*time.Second)+time.Second)
+			require.GreaterOrEqual(t, reached.Load(), int64(1))
+		})
+	}
+}
+
+func TestCardinalityOverflowPreservesCounts(t *testing.T) {
+	requests := make(chan []byte, 4)
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requests <- body
+		w.Header().Set("Content-Type", "application/x-protobuf")
+	}))
+	t.Cleanup(receiver.Close)
+	t.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "3600000")
+	lc := fxtest.NewLifecycle(t)
+	cfg, err := NewConfig(&internal.Config{OTELExporterOTLPEndpoint: receiver.URL})
+	require.NoError(t, err)
+	provider, err := NewMeterProvider(lc, cfg)
+	require.NoError(t, err)
+	lc.RequireStart()
+	t.Cleanup(func() { lc.RequireStop() })
+	m, err := metrics.NewHTTPMetrics(provider)
+	require.NoError(t, err)
+	for batch := 0; batch < 2; batch++ {
+		var wg sync.WaitGroup
+		for worker := 0; worker < 4; worker++ {
+			wg.Add(1)
+			go func(worker int) {
+				defer wg.Done()
+				for i := 0; i < 1500; i++ {
+					m.Start(context.Background(), "public", "GET", "http")(fmt.Sprintf("/route/%d/%d/%d", batch, worker, i), 200)
+				}
+			}(worker)
+		}
+		wg.Wait()
+		require.NoError(t, provider.(*sdkmetric.MeterProvider).ForceFlush(context.Background()))
+		payload := pmetricotlp.NewExportRequest()
+		require.NoError(t, payload.UnmarshalProto(<-requests))
+		observed := payload.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+		found := false
+		for i := 0; i < observed.Len(); i++ {
+			m := observed.At(i)
+			if m.Name() == "http.server.active_requests" {
+				require.Equal(t, 1, m.Sum().DataPoints().Len())
+				require.Zero(t, m.Sum().DataPoints().At(0).IntValue())
+			}
+			if m.Name() != "http.server.request.duration" {
+				continue
+			}
+			found = true
+			points := m.Histogram().DataPoints()
+			require.Equal(t, 2000, points.Len())
+			var total, overflow uint64
+			for j := 0; j < points.Len(); j++ {
+				point := points.At(j)
+				total += point.Count()
+				if value, ok := point.Attributes().Get("otel.metric.overflow"); ok && value.Bool() {
+					overflow += point.Count()
+				}
+			}
+			require.EqualValues(t, (batch+1)*6000, total)
+			require.EqualValues(t, (batch+1)*6000-1999, overflow)
+		}
+		require.True(t, found)
+	}
+}
+
+func TestPeriodicExportSeparatesProcessResources(t *testing.T) {
+	var mu sync.Mutex
+	observed := map[string]int64{}
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		payload := pmetricotlp.NewExportRequest()
+		if err := payload.UnmarshalProto(body); err != nil {
+			w.WriteHeader(400)
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		rms := payload.Metrics().ResourceMetrics()
+		for i := 0; i < rms.Len(); i++ {
+			rm := rms.At(i)
+			cp, _ := rm.Resource().Attributes().Get("nuon.control_plane.id")
+			if cp.Str() != "cp-test" {
+				w.WriteHeader(400)
+				return
+			}
+			id, _ := rm.Resource().Attributes().Get("service.instance.id")
+			if rm.ScopeMetrics().Len() > 0 {
+				observed[id.Str()] = rm.ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).IntValue()
+			}
+		}
+		w.Header().Set("Content-Type", "application/x-protobuf")
+	}))
+	t.Cleanup(receiver.Close)
+	t.Setenv("OTEL_METRIC_EXPORT_INTERVAL", "20")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "nuon.control_plane.id=cp-test")
+	expected := map[string]int64{}
+	for _, count := range []int64{7, 2} {
+		lc := fxtest.NewLifecycle(t)
+		cfg, err := NewConfig(&internal.Config{OTELExporterOTLPEndpoint: receiver.URL, ServiceName: "ctl-api"})
+		require.NoError(t, err)
+		id, _ := cfg.Resource.Set().Value("service.instance.id")
+		expected[id.AsString()] = count
+		provider, err := NewMeterProvider(lc, cfg)
+		require.NoError(t, err)
+		lc.RequireStart()
+		t.Cleanup(func() { lc.RequireStop() })
+		counter, err := provider.Meter("test").Int64Counter("test.count")
+		require.NoError(t, err)
+		counter.Add(context.Background(), count)
+	}
+	require.Len(t, expected, 2)
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return reflect.DeepEqual(expected, observed)
+	}, 2*time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
## Summary
- Add shared operational telemetry configuration and process resources, separate from product OTLP ingestion.
- Enable `http/protobuf` metric export when `OTEL_EXPORTER_OTLP_ENDPOINT` is configured; use a no-op provider otherwise. Keep Datadog emission independent.
- Record request duration and active requests across six API surfaces and MCP, with bounded labels and cardinality, cumulative histograms, and asynchronous export.

## Validation
- Targeted telemetry, metrics, API, and MCP package tests passed.
- Telemetry race tests passed.
- Coverage includes TLS/mTLS, headers/compression, error details and recovery, cardinality overflow, resource identity, and shutdown deadlines.
