### PR TITLE
fix: re-try job execution status instead of failing immediately

### DIFF
--- a/services/ctl-api/internal/app/runners/worker/activities/get_job_execution_status.go
+++ b/services/ctl-api/internal/app/runners/worker/activities/get_job_execution_status.go
@@ -12,7 +12,7 @@ type GetJobExecutionStatusRequest struct {
 }
 
 // @temporal-gen-v2 activity
-// @max-retries 1
+// @max-retries 3
 func (a *Activities) GetJobExecutionStatus(ctx context.Context, req GetJobExecutionStatusRequest) (app.RunnerJobExecutionStatus, error) {
 	jobExecution, err := a.getRunnerJobExecution(ctx, req.JobExecutionID)
 	if err != nil {

--- a/services/ctl-api/internal/app/runners/worker/monitor_job_execution.go
+++ b/services/ctl-api/internal/app/runners/worker/monitor_job_execution.go
@@ -205,7 +205,12 @@ func (w *Workflows) monitorJobExecution(ctx workflow.Context, job *app.RunnerJob
 			JobExecutionID: jobExecution.ID,
 		})
 		if err != nil {
-			return false, err
+			// This loop already re-polls every defaultJobPollPeriod, so a transient
+			// failure of a single status check (e.g. an activity timeout under
+			// worker load) shouldn't kill an otherwise-healthy job. Log and retry
+			// on the next tick instead of failing the job immediately.
+			l.Warn("unable to get job execution status this tick, will retry next poll", zap.Error(err))
+			continue
 		}
 
 		// handle the job execution status


### PR DESCRIPTION
## Summary

`GetJobExecutionStatus` is intermittently failing sandbox provision jobs that are still running. This PR updates it to allow 3 retries to handle transient issues.