### PR TITLE
fix: (ctl-api) isolate workflow logs from OTEL environment settings

### DIFF
--- a/services/ctl-api/internal/pkg/log/otel.go
+++ b/services/ctl-api/internal/pkg/log/otel.go
@@ -3,6 +3,9 @@ package log
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
+	"time"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/sdk/log"
@@ -19,24 +22,50 @@ func NewOTELProvider(logStream *app.LogStream) (*log.LoggerProvider, error) {
 	ctx := context.Background()
 	ctx, cancelFn := context.WithCancel(ctx)
 
-	url := fmt.Sprintf(defaultOTLPLogsEndpointTmpl, logStream.RunnerAPIURL, logStream.ID)
+	endpoint := fmt.Sprintf(defaultOTLPLogsEndpointTmpl, logStream.RunnerAPIURL, logStream.ID)
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		cancelFn()
+		return nil, fmt.Errorf("invalid log stream endpoint: %w", err)
+	}
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		cancelFn()
+		return nil, fmt.Errorf("log stream endpoint must be an absolute HTTP(S) URL")
+	}
 
+	rsrc := getResource(logStream.ID, generics.ToStringMap(logStream.Attrs))
+	client := &http.Client{
+		Transport: &logStreamTransport{next: http.DefaultTransport, resource: rsrc},
+		Timeout:   10 * time.Second,
+	}
+
+	// Product log delivery must not inherit operational telemetry settings.
 	logExporter, err := otlploghttp.New(ctx,
-		otlploghttp.WithEndpointURL(url),
+		otlploghttp.WithEndpointURL(endpoint),
 		otlploghttp.WithHeaders(map[string]string{
 			"Authorization": "Bearer " + logStream.WriteToken,
 		}),
+		otlploghttp.WithTLSClientConfig(nil),
+		otlploghttp.WithTimeout(client.Timeout),
+		otlploghttp.WithCompression(otlploghttp.NoCompression),
+		otlploghttp.WithHTTPClient(client),
 	)
 	if err != nil {
 		cancelFn()
 		return nil, fmt.Errorf("unable to initialize otlp log exporter: %w", err)
 	}
 
-	rsrc := getResource(logStream.ID, generics.ToStringMap(logStream.Attrs))
 	lp := log.NewLoggerProvider(
 		log.WithResource(rsrc),
+		log.WithAttributeCountLimit(128),
+		log.WithAttributeValueLengthLimit(-1),
 		log.WithProcessor(
-			log.NewBatchProcessor(logExporter),
+			log.NewBatchProcessor(logExporter,
+				log.WithMaxQueueSize(2048),
+				log.WithExportMaxBatchSize(512),
+				log.WithExportInterval(time.Second),
+				log.WithExportTimeout(30*time.Second),
+			),
 		),
 	)
 

--- a/services/ctl-api/internal/pkg/log/otel.go
+++ b/services/ctl-api/internal/pkg/log/otel.go
@@ -34,12 +34,13 @@ func NewOTELProvider(logStream *app.LogStream) (*log.LoggerProvider, error) {
 	}
 
 	rsrc := getResource(logStream.ID, generics.ToStringMap(logStream.Attrs))
+	// Explicit timeouts and limits mirror the OTel Logs SDK/exporter v0.18.0
+	// defaults so OTEL environment overrides cannot change product log delivery.
 	client := &http.Client{
 		Transport: &logStreamTransport{next: http.DefaultTransport, resource: rsrc},
 		Timeout:   10 * time.Second,
 	}
 
-	// Product log delivery must not inherit operational telemetry settings.
 	logExporter, err := otlploghttp.New(ctx,
 		otlploghttp.WithEndpointURL(endpoint),
 		otlploghttp.WithHeaders(map[string]string{

--- a/services/ctl-api/internal/pkg/log/otel_test.go
+++ b/services/ctl-api/internal/pkg/log/otel_test.go
@@ -1,0 +1,161 @@
+package log
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/otel"
+	"go.uber.org/zap"
+)
+
+func TestLogStreamIgnoresOTELEnvironment(t *testing.T) {
+	for _, prefix := range []string{"OTEL_EXPORTER_OTLP_", "OTEL_EXPORTER_OTLP_LOGS_"} {
+		t.Run(prefix, func(t *testing.T) {
+			type request struct {
+				path, authorization, encoding, extraHeader string
+				body                                       []byte
+			}
+			requests := make(chan request, 16)
+			receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				select {
+				case <-r.Context().Done():
+					return
+				case <-time.After(20 * time.Millisecond):
+				}
+				requests <- request{r.URL.Path, r.Header.Get("Authorization"), r.Header.Get("Content-Encoding"), r.Header.Get("X-Collector"), body}
+				w.Header().Set("Content-Type", "application/x-protobuf")
+			}))
+			t.Cleanup(receiver.Close)
+
+			for _, p := range []string{"OTEL_EXPORTER_OTLP_", "OTEL_EXPORTER_OTLP_LOGS_"} {
+				for _, key := range []string{"ENDPOINT", "HEADERS", "INSECURE", "PROTOCOL", "CERTIFICATE", "CLIENT_CERTIFICATE", "CLIENT_KEY", "TIMEOUT", "COMPRESSION"} {
+					t.Setenv(p+key, "")
+				}
+			}
+			for key, value := range map[string]string{
+				"ENDPOINT":           "https://collector.invalid/other",
+				"HEADERS":            "Authorization=collector-token,X-Collector=unexpected",
+				"INSECURE":           "false",
+				"PROTOCOL":           "grpc",
+				"CERTIFICATE":        filepath.Join(t.TempDir(), "missing-ca.pem"),
+				"CLIENT_CERTIFICATE": filepath.Join(t.TempDir(), "missing-cert.pem"),
+				"CLIENT_KEY":         filepath.Join(t.TempDir(), "missing-key.pem"),
+				"TIMEOUT":            "1",
+				"COMPRESSION":        "gzip",
+			} {
+				t.Setenv(prefix+key, value)
+			}
+			for key, value := range map[string]string{
+				"OTEL_BLRP_MAX_QUEUE_SIZE":                    "1",
+				"OTEL_BLRP_MAX_EXPORT_BATCH_SIZE":             "1",
+				"OTEL_BLRP_SCHEDULE_DELAY":                    "3600000",
+				"OTEL_BLRP_EXPORT_TIMEOUT":                    "1",
+				"OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT":        "1",
+				"OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT": "1",
+				"OTEL_SERVICE_NAME":                           "collector-service",
+				"OTEL_RESOURCE_ATTRIBUTES":                    "service.name=other,log_stream.id=other,unexpected=value",
+				"OTEL_SDK_DISABLED":                           "true",
+				"OTEL_LOGS_EXPORTER":                          "none",
+			} {
+				t.Setenv(key, value)
+			}
+
+			stream := &app.LogStream{ID: "stream-test", RunnerAPIURL: receiver.URL, WriteToken: "stream-token"}
+			provider, err := NewOTELProvider(stream)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+			logger, err := NewLogStreamLogger(stream, provider, zap.NewNop())
+			require.NoError(t, err)
+			for i := 0; i < 8; i++ {
+				logger.Info("planning deployment", zap.Int("sequence", i), zap.String("phase", "planning"))
+			}
+
+			select {
+			case req := <-requests:
+				require.Equal(t, "/v1/log-streams/stream-test/logs", req.path)
+				require.Equal(t, "Bearer stream-token", req.authorization)
+				require.Empty(t, req.extraHeader)
+				require.Empty(t, req.encoding)
+				payload := plogotlp.NewExportRequest()
+				require.NoError(t, payload.UnmarshalProto(req.body))
+				resources := payload.Logs().ResourceLogs()
+				require.Equal(t, 1, resources.Len())
+				require.Equal(t, map[string]any{"service.name": "api", "log_stream.id": "stream-test"}, resources.At(0).Resource().Attributes().AsRaw())
+				records := resources.At(0).ScopeLogs().At(0).LogRecords()
+				require.Equal(t, 8, records.Len())
+				for i := 0; i < records.Len(); i++ {
+					record := records.At(i)
+					require.Equal(t, "planning deployment", record.Body().Str())
+					require.Equal(t, map[string]any{"sequence": int64(i), "phase": "planning"}, record.Attributes().AsRaw())
+					require.Zero(t, record.DroppedAttributesCount())
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("workflow logs were not exported with their own batching and transport settings")
+			}
+			require.Equal(t, "https://collector.invalid/other", os.Getenv(prefix+"ENDPOINT"))
+			require.Equal(t, "1", os.Getenv("OTEL_BLRP_MAX_QUEUE_SIZE"))
+		})
+	}
+}
+
+func TestLogStreamTLSIgnoresOTELTrust(t *testing.T) {
+	receiver := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-protobuf")
+	}))
+	t.Cleanup(receiver.Close)
+	certPath := filepath.Join(t.TempDir(), "collector-ca.pem")
+	require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: receiver.Certificate().Raw}), 0600))
+	for _, prefix := range []string{"OTEL_EXPORTER_OTLP_", "OTEL_EXPORTER_OTLP_LOGS_"} {
+		t.Run(prefix, func(t *testing.T) {
+			exportErrors := make(chan error, 4)
+			previousHandler := otel.GetErrorHandler()
+			otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) { exportErrors <- err }))
+			t.Cleanup(func() { otel.SetErrorHandler(previousHandler) })
+			t.Setenv(prefix+"CERTIFICATE", certPath)
+			t.Setenv(prefix+"INSECURE", "true")
+			t.Setenv("OTEL_BLRP_SCHEDULE_DELAY", "3600000")
+			provider, err := NewOTELProvider(&app.LogStream{ID: "stream-test", RunnerAPIURL: receiver.URL, WriteToken: "stream-token"})
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+			logger, err := NewLogStreamLogger(nil, provider, zap.NewNop())
+			require.NoError(t, err)
+			logger.Info("planning deployment")
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			require.NoError(t, provider.ForceFlush(ctx))
+			select {
+			case err := <-exportErrors:
+				var unknownAuthority x509.UnknownAuthorityError
+				require.ErrorAs(t, err, &unknownAuthority)
+			case <-ctx.Done():
+				t.Fatal("OTEL certificate settings changed log-stream TLS trust")
+			}
+		})
+	}
+}
+
+func TestLogStreamRejectsInvalidEndpoint(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector.invalid")
+	for _, endpoint := range []string{"", "http://%", "ftp://example.com"} {
+		t.Run(endpoint, func(t *testing.T) {
+			provider, err := NewOTELProvider(&app.LogStream{ID: "stream-test", RunnerAPIURL: endpoint})
+			if provider != nil {
+				t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+			}
+			require.Error(t, err)
+			require.Nil(t, provider)
+		})
+	}
+}

--- a/services/ctl-api/internal/pkg/log/otel_transport.go
+++ b/services/ctl-api/internal/pkg/log/otel_transport.go
@@ -1,0 +1,51 @@
+package log
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+type logStreamTransport struct {
+	next     http.RoundTripper
+	resource *resource.Resource
+}
+
+func (t *logStreamTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("read log stream export: %w", err)
+	}
+	payload := plogotlp.NewExportRequest()
+	if err := payload.UnmarshalProto(body); err != nil {
+		return nil, fmt.Errorf("decode log stream export: %w", err)
+	}
+
+	// The Logs SDK merges environment attributes even with an explicit resource.
+	// Replace the wire resource without mutating the SDK's shared resource.
+	resources := payload.Logs().ResourceLogs()
+	for i := 0; i < resources.Len(); i++ {
+		r := resources.At(i)
+		r.SetSchemaUrl(t.resource.SchemaURL())
+		r.Resource().SetDroppedAttributesCount(0)
+		attrs := r.Resource().Attributes()
+		attrs.Clear()
+		for _, attr := range t.resource.Attributes() {
+			attrs.PutStr(string(attr.Key), attr.Value.AsString())
+		}
+	}
+	body, err = payload.MarshalProto()
+	if err != nil {
+		return nil, fmt.Errorf("encode log stream export: %w", err)
+	}
+	clone := req.Clone(req.Context())
+	clone.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(body)), nil }
+	clone.Body, _ = clone.GetBody()
+	clone.ContentLength = int64(len(body))
+	return t.next.RoundTrip(clone)
+}

--- a/services/ctl-api/internal/pkg/log/otel_transport_test.go
+++ b/services/ctl-api/internal/pkg/log/otel_transport_test.go
@@ -1,0 +1,91 @@
+package log
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestLogStreamTransportPreservesRecordsAndRetries(t *testing.T) {
+	payload := plogotlp.NewExportRequest()
+	for _, message := range []string{"planning", "executing"} {
+		r := payload.Logs().ResourceLogs().AppendEmpty()
+		r.SetSchemaUrl("https://example.com/environment-schema")
+		r.Resource().Attributes().PutStr("unexpected", "environment")
+		r.Resource().SetDroppedAttributesCount(3)
+		for _, scope := range []string{"workflow", "activity"} {
+			s := r.ScopeLogs().AppendEmpty()
+			s.Scope().SetName(scope)
+			s.Scope().SetVersion("test-version")
+			s.SetSchemaUrl("https://example.com/log-schema")
+			l := s.LogRecords().AppendEmpty()
+			l.Body().SetStr(message)
+			l.Attributes().PutStr("phase", message)
+			l.SetTraceID(pcommon.TraceID{1, 2, 3})
+			l.SetSpanID(pcommon.SpanID{4, 5, 6})
+			l.SetTimestamp(123)
+			l.SetObservedTimestamp(456)
+		}
+	}
+	original, err := payload.MarshalProto()
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, "https://runner.example.com/v1/log-streams/test/logs", bytes.NewReader(original))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer stream-token")
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	var sent [][]byte
+	transport := &logStreamTransport{
+		resource: getResource("stream-test", map[string]string{"operation": "build"}),
+		next: roundTripperFunc(func(out *http.Request) (*http.Response, error) {
+			require.NotSame(t, req, out)
+			require.Equal(t, req.Method, out.Method)
+			require.Equal(t, req.URL, out.URL)
+			require.Equal(t, req.Header, out.Header)
+			body, err := io.ReadAll(out.Body)
+			require.NoError(t, err)
+			require.NoError(t, out.Body.Close())
+			require.EqualValues(t, len(body), out.ContentLength)
+			replay, err := out.GetBody()
+			require.NoError(t, err)
+			replayed, err := io.ReadAll(replay)
+			require.NoError(t, err)
+			require.NoError(t, replay.Close())
+			require.Equal(t, body, replayed)
+			sent = append(sent, body)
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		}),
+	}
+	for i := 0; i < 2; i++ {
+		req.Body, err = req.GetBody()
+		require.NoError(t, err)
+		_, err = transport.RoundTrip(req)
+		require.NoError(t, err)
+		require.EqualValues(t, len(original), req.ContentLength)
+	}
+	require.Equal(t, sent[0], sent[1])
+	decoded := plogotlp.NewExportRequest()
+	require.NoError(t, decoded.UnmarshalProto(sent[0]))
+	resources := decoded.Logs().ResourceLogs()
+	require.Equal(t, 2, resources.Len())
+	for i := 0; i < resources.Len(); i++ {
+		r := resources.At(i)
+		require.Empty(t, r.SchemaUrl())
+		require.Zero(t, r.Resource().DroppedAttributesCount())
+		require.Equal(t, map[string]any{"service.name": "api", "log_stream.id": "stream-test", "operation": "build"}, r.Resource().Attributes().AsRaw())
+		originalResource := payload.Logs().ResourceLogs().At(i)
+		originalResource.Resource().CopyTo(r.Resource())
+		r.SetSchemaUrl(originalResource.SchemaUrl())
+	}
+	restored, err := decoded.MarshalProto()
+	require.NoError(t, err)
+	require.Equal(t, original, restored)
+}

--- a/services/ctl-api/internal/pkg/telemetry/README.md
+++ b/services/ctl-api/internal/pkg/telemetry/README.md
@@ -66,10 +66,21 @@ Generic OTLP transport settings can also apply to existing log exporters in the
 same process. Audit export is a no-op unless `AUDIT_OTLP_ENDPOINT` (service config:
 `audit_otlp_endpoint`) is explicitly configured; the generic endpoint alone does
 not enable it. If enabled without `AUDIT_OTLP_TOKEN`, it can inherit generic OTLP
-headers, including credentials. Existing workflow log exporters set their own
-headers but can still inherit generic TLS, timeout and compression settings.
-Review signal-specific `OTEL_EXPORTER_OTLP_LOGS_*` settings and explicit exporter
-options before using different receivers or credentials for logs and metrics.
+headers, including credentials. Review signal-specific `OTEL_EXPORTER_OTLP_LOGS_*`
+settings and explicit exporter options before enabling audit delivery alongside
+operational metrics.
+
+Workflow product logs are isolated separately in `internal/pkg/log`. Their stream
+URL, token and resource attributes come from the log stream, not OTEL settings.
+Transport uses system TLS trust, no client certificate, no compression and a
+10-second timeout. Batching uses a 2,048-record queue, 512-record batches, a
+one-second interval and a 30-second export timeout; records allow 128 attributes
+with unlimited string length. These settings override generic and logs-specific
+OTEL configuration. The transport replaces SDK-added resource attributes with the
+stream resource before sending, preserving records and scopes. Standard Go HTTP
+proxy settings still apply. The SDK's experimental `OTEL_GO_X_OBSERVABILITY` and
+`OTEL_GO_X_SELF_OBSERVABILITY` flags can still enable internal SDK metrics; they
+have no per-provider disable option and do not change product-log payloads.
 
 The default resource includes `service.name`, `service.version`, a random
 process-lifetime `service.instance.id`, `nuon.service.type`, and

--- a/services/ctl-api/internal/pkg/telemetry/README.md
+++ b/services/ctl-api/internal/pkg/telemetry/README.md
@@ -70,17 +70,8 @@ headers, including credentials. Review signal-specific `OTEL_EXPORTER_OTLP_LOGS_
 settings and explicit exporter options before enabling audit delivery alongside
 operational metrics.
 
-Workflow product logs are isolated separately in `internal/pkg/log`. Their stream
-URL, token and resource attributes come from the log stream, not OTEL settings.
-Transport uses system TLS trust, no client certificate, no compression and a
-10-second timeout. Batching uses a 2,048-record queue, 512-record batches, a
-one-second interval and a 30-second export timeout; records allow 128 attributes
-with unlimited string length. These settings override generic and logs-specific
-OTEL configuration. The transport replaces SDK-added resource attributes with the
-stream resource before sending, preserving records and scopes. Standard Go HTTP
-proxy settings still apply. The SDK's experimental `OTEL_GO_X_OBSERVABILITY` and
-`OTEL_GO_X_SELF_OBSERVABILITY` flags can still enable internal SDK metrics; they
-have no per-provider disable option and do not change product-log payloads.
+Workflow log delivery is configured separately in `internal/pkg/log` and does not
+inherit OTEL environment settings for transport, resources, or record processing.
 
 The default resource includes `service.name`, `service.version`, a random
 process-lifetime `service.instance.id`, `nuon.service.type`, and


### PR DESCRIPTION
Isolates workflow log delivery from generic and logs-specific OTEL environment settings, so control-plane telemetry configuration cannot change its destination, credentials, resource attributes, TLS, batching, or record limits.

Includes regression tests for environment isolation, TLS trust, and payload preservation. Race-enabled tests pass for the log, telemetry, and metrics packages.