### PR TITLE
fix: sandbox mode for images bugs

### DIFF
--- a/services/ctl-api/internal/app/components/signals/inlinebuild/signal.go
+++ b/services/ctl-api/internal/app/components/signals/inlinebuild/signal.go
@@ -217,15 +217,9 @@ func (s *Signal) execBuild(ctx workflow.Context, buildID string) error {
 		return notify(errors.Wrap(err, "unable to create plan"))
 	}
 
-	if runPlan.ContainerImagePullPlan != nil {
-		if err := sharedactivities.EnsureGARAuth(ctx, runPlan.ContainerImagePullPlan.RepoCfg); err != nil {
-			s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to get GAR access token")
-			return notify(errors.Wrap(err, "unable to get GAR access token"))
-		}
-		if err := sharedactivities.EnsureACRAuth(ctx, runPlan.ContainerImagePullPlan.RepoCfg); err != nil {
-			s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to get ACR access token")
-			return notify(errors.Wrap(err, "unable to get ACR access token"))
-		}
+	if err := sharedactivities.EnsureContainerImagePullAuth(ctx, runPlan); err != nil {
+		s.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to get image source credentials")
+		return notify(err)
 	}
 
 	planJSON, err := json.Marshal(runPlan)

--- a/services/ctl-api/internal/app/components/worker/evaluate_external_image_policy.go
+++ b/services/ctl-api/internal/app/components/worker/evaluate_external_image_policy.go
@@ -45,6 +45,21 @@ func (w *Workflows) evaluateExternalImagePolicy(ctx workflow.Context, buildID, b
 		return nil
 	}
 
+	build, err := activities.AwaitGetComponentBuildByID(ctx, buildID)
+	if err != nil {
+		w.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, truncateErrorMessage("unable to get build", err))
+		return fmt.Errorf("unable to get component build: %w", err)
+	}
+	org, err := activities.AwaitGetOrgByID(ctx, build.OrgID)
+	if err != nil {
+		w.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, truncateErrorMessage("unable to get org", err))
+		return fmt.Errorf("unable to get org: %w", err)
+	}
+	if !shouldFetchImageMetadataForPolicy(policyCheckResult.HasPolicies, org.SandboxMode) {
+		l.Info("sandbox mode enabled, skipping image metadata fetch and policy evaluation")
+		return nil
+	}
+
 	l.Info("container image policies found, proceeding with metadata fetch")
 
 	logStreamID, err := cctx.GetLogStreamIDWorkflow(ctx)
@@ -254,6 +269,14 @@ func (w *Workflows) recordComponentPolicyEvaluationFailure(ctx workflow.Context,
 }
 
 const maxDescriptionLength = 500
+
+// shouldFetchImageMetadataForPolicy is the gate in front of the
+// fetch-image-metadata job. Sandbox orgs cannot reach vendor registries, and
+// fake metadata would still fail typical deny policies (signature/SBOM), so
+// we skip the fetch and the rest of policy eval together.
+func shouldFetchImageMetadataForPolicy(hasPolicies, orgSandbox bool) bool {
+	return hasPolicies && !orgSandbox
+}
 
 func truncateErrorMessage(prefix string, err error) string {
 	if err == nil {

--- a/services/ctl-api/internal/app/components/worker/exec_build.go
+++ b/services/ctl-api/internal/app/components/worker/exec_build.go
@@ -85,15 +85,9 @@ func (w *Workflows) execBuild(ctx workflow.Context, compID, buildID string, curr
 		return errors.Wrap(err, "unable to create plan")
 	}
 
-	if runPlan.ContainerImagePullPlan != nil {
-		if err := sharedactivities.EnsureGARAuth(ctx, runPlan.ContainerImagePullPlan.RepoCfg); err != nil {
-			w.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to get GAR access token")
-			return errors.Wrap(err, "unable to get GAR access token")
-		}
-		if err := sharedactivities.EnsureACRAuth(ctx, runPlan.ContainerImagePullPlan.RepoCfg); err != nil {
-			w.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, "unable to get ACR access token")
-			return errors.Wrap(err, "unable to get ACR access token")
-		}
+	if err := sharedactivities.EnsureContainerImagePullAuth(ctx, runPlan); err != nil {
+		w.updateBuildStatus(ctx, buildID, app.ComponentBuildStatusError, truncateErrorMessage("unable to get image source credentials", err))
+		return err
 	}
 
 	planJSON, err := json.Marshal(runPlan)

--- a/services/ctl-api/internal/pkg/workflows/activities/ensure_container_image_pull_auth.go
+++ b/services/ctl-api/internal/pkg/workflows/activities/ensure_container_image_pull_auth.go
@@ -1,0 +1,37 @@
+package activities
+
+import (
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/pkg/errors"
+
+	plantypes "github.com/nuonco/nuon/pkg/plans/types"
+)
+
+// EnsureContainerImagePullAuth embeds source-registry credentials into a
+// container image build plan so the runner can pull an image it has no identity
+// for.
+//
+// A sandboxed build is skipped entirely: the control-plane executor short
+// circuits before the copy (see pkg/runner/controlplane.isSandboxableBuildHandler),
+// so minting a real vendor token is work that cannot succeed. Sandbox-mode orgs
+// have no access to the vendor's registry, which turns a job that was supposed
+// to be faked into a hard failure at plan time.
+func EnsureContainerImagePullAuth(ctx workflow.Context, plan *plantypes.BuildPlan) error {
+	if plan == nil || plan.ContainerImagePullPlan == nil {
+		return nil
+	}
+	if plan.SandboxMode != nil && plan.SandboxMode.Enabled {
+		return nil
+	}
+
+	cfg := plan.ContainerImagePullPlan.RepoCfg
+	if err := EnsureGARAuth(ctx, cfg); err != nil {
+		return errors.Wrap(err, "unable to get GAR access token")
+	}
+	if err := EnsureACRAuth(ctx, cfg); err != nil {
+		return errors.Wrap(err, "unable to get ACR access token")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fixes a few issues related to sandbox mode for container images:

1. Auth was still required for GAR images.
1. Image Metadata was not skipped in sandbox-mode.


