### PR TITLE
fix: (ctl-api): normalize logstream endpoint URL joins

### DIFF
--- a/services/ctl-api/internal/pkg/log/otel.go
+++ b/services/ctl-api/internal/pkg/log/otel.go
@@ -14,16 +14,11 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
 )
 
-const (
-	defaultOTLPLogsEndpointTmpl string = "%s/v1/log-streams/%s/logs"
-)
-
 func NewOTELProvider(logStream *app.LogStream) (*log.LoggerProvider, error) {
 	ctx := context.Background()
 	ctx, cancelFn := context.WithCancel(ctx)
 
-	endpoint := fmt.Sprintf(defaultOTLPLogsEndpointTmpl, logStream.RunnerAPIURL, logStream.ID)
-	u, err := url.Parse(endpoint)
+	u, err := url.Parse(logStream.RunnerAPIURL)
 	if err != nil {
 		cancelFn()
 		return nil, fmt.Errorf("invalid log stream endpoint: %w", err)
@@ -32,6 +27,7 @@ func NewOTELProvider(logStream *app.LogStream) (*log.LoggerProvider, error) {
 		cancelFn()
 		return nil, fmt.Errorf("log stream endpoint must be an absolute HTTP(S) URL")
 	}
+	endpoint := u.JoinPath("v1", "log-streams", logStream.ID, "logs").String()
 
 	rsrc := getResource(logStream.ID, generics.ToStringMap(logStream.Attrs))
 	// Explicit timeouts and limits mirror the OTel Logs SDK/exporter v0.18.0

--- a/services/ctl-api/internal/pkg/log/otel_test.go
+++ b/services/ctl-api/internal/pkg/log/otel_test.go
@@ -110,6 +110,48 @@ func TestLogStreamIgnoresOTELEnvironment(t *testing.T) {
 	}
 }
 
+func TestLogStreamEndpointPath(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.invalid/collector")
+	t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://logs.invalid/other/logs")
+	for _, tc := range []struct {
+		basePath string
+		wantPath string
+	}{
+		{"", "/v1/log-streams/stream-test/logs"},
+		{"/", "/v1/log-streams/stream-test/logs"},
+		{"/runner", "/runner/v1/log-streams/stream-test/logs"},
+		{"/runner/", "/runner/v1/log-streams/stream-test/logs"},
+	} {
+		t.Run(tc.basePath, func(t *testing.T) {
+			requests := make(chan *http.Request, 1)
+			receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				requests <- r
+				w.Header().Set("Content-Type", "application/x-protobuf")
+			}))
+			t.Cleanup(receiver.Close)
+			stream := &app.LogStream{ID: "stream-test", RunnerAPIURL: receiver.URL + tc.basePath, WriteToken: "stream-token"}
+			provider, err := NewOTELProvider(stream)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+			logger, err := NewLogStreamLogger(stream, provider, zap.NewNop())
+			require.NoError(t, err)
+			logger.Info("planning deployment")
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			require.NoError(t, provider.ForceFlush(ctx))
+			select {
+			case req := <-requests:
+				require.Equal(t, tc.wantPath, req.RequestURI)
+				require.Equal(t, http.MethodPost, req.Method)
+				require.Equal(t, "Bearer stream-token", req.Header.Get("Authorization"))
+			case <-ctx.Done():
+				t.Fatal("log stream endpoint did not receive the export")
+			}
+		})
+	}
+}
+
 func TestLogStreamTLSIgnoresOTELTrust(t *testing.T) {
 	receiver := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/x-protobuf")

--- a/services/ctl-api/internal/pkg/queue/activities/activities.go
+++ b/services/ctl-api/internal/pkg/queue/activities/activities.go
@@ -4,23 +4,32 @@ import (
 	"github.com/go-playground/validator/v10"
 	"go.uber.org/fx"
 	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
 )
 
 type Params struct {
 	fx.In
 
-	V  *validator.Validate
-	DB *gorm.DB `name:"psql"`
+	V          *validator.Validate
+	DB         *gorm.DB `name:"psql"`
+	Cfg        *internal.Config
+	AcctClient *account.Client
 }
 
 type Activities struct {
-	v  *validator.Validate
-	db *gorm.DB `name:"psql"`
+	v          *validator.Validate
+	db         *gorm.DB `name:"psql"`
+	cfg        *internal.Config
+	acctClient *account.Client
 }
 
 func New(params Params) *Activities {
 	return &Activities{
-		v:  params.V,
-		db: params.DB,
+		v:          params.V,
+		db:         params.DB,
+		cfg:        params.Cfg,
+		acctClient: params.AcctClient,
 	}
 }

--- a/services/ctl-api/internal/pkg/queue/activities/hydrate_log_stream.go
+++ b/services/ctl-api/internal/pkg/queue/activities/hydrate_log_stream.go
@@ -1,0 +1,43 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/generics"
+)
+
+const queueLogStreamTokenDuration = time.Hour
+
+type HydrateLogStreamRequest struct {
+	LogStreamID string `validate:"required"`
+	OrgID       string `validate:"required"`
+}
+
+// @temporal-gen-v2 activity
+// @start-to-close-timeout 1m
+func (a *Activities) HydrateLogStream(ctx context.Context, req *HydrateLogStreamRequest) (*app.LogStream, error) {
+	if err := a.v.Struct(req); err != nil {
+		return nil, err
+	}
+
+	var stream app.LogStream
+	res := a.db.WithContext(ctx).
+		Where(app.LogStream{ID: req.LogStreamID, OrgID: req.OrgID}).
+		First(&stream)
+	if res.Error != nil {
+		return nil, generics.TemporalGormError(res.Error, fmt.Sprintf("unable to get log stream %s", req.LogStreamID))
+	}
+
+	token, err := a.acctClient.CreateToken(ctx, account.ServiceAccountEmail(stream.ID), queueLogStreamTokenDuration)
+	if err != nil {
+		return nil, fmt.Errorf("create log stream token: %w", err)
+	}
+
+	stream.RunnerAPIURL = a.cfg.RunnerAPIURL
+	stream.WriteToken = token.Token
+	return &stream, nil
+}

--- a/services/ctl-api/internal/pkg/queue/activities/hydrate_log_stream_test.go
+++ b/services/ctl-api/internal/pkg/queue/activities/hydrate_log_stream_test.go
@@ -1,0 +1,111 @@
+package activities_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+	"gorm.io/gorm"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
+	"github.com/nuonco/nuon/services/ctl-api/tests"
+	"github.com/nuonco/nuon/services/ctl-api/tests/testseed"
+)
+
+type hydrateLogStreamDeps struct {
+	fx.In
+
+	DB         *gorm.DB `name:"psql"`
+	Cfg        *internal.Config
+	AcctClient *account.Client
+	Activities *activities.Activities
+	Seeder     *testseed.Seeder
+}
+
+type HydrateLogStreamTestSuite struct {
+	tests.BaseDBTestSuite
+
+	fxApp *fxtest.App
+	deps  hydrateLogStreamDeps
+}
+
+func TestHydrateLogStreamSuite(t *testing.T) {
+	tests.SkipIfNotIntegration(t)
+	suite.Run(t, new(HydrateLogStreamTestSuite))
+}
+
+func (s *HydrateLogStreamTestSuite) SetupSuite() {
+	s.BaseDBTestSuite.SetupSuite()
+
+	options := append(
+		tests.CtlApiFXOptions(s.T()),
+		fx.Provide(activities.New),
+		fx.Populate(&s.deps),
+	)
+	s.fxApp = fxtest.New(s.T(), options...)
+	s.fxApp.RequireStart()
+	s.SetDB(s.deps.DB)
+}
+
+func (s *HydrateLogStreamTestSuite) TearDownSuite() {
+	s.fxApp.RequireStop()
+}
+
+func (s *HydrateLogStreamTestSuite) TestHydratesCredentialsWithoutPersistingThemOnLogStream() {
+	t := s.T()
+	ctx, _ := s.deps.Seeder.EnsureAccount(context.Background(), t)
+	ctx, org := s.deps.Seeder.EnsureOrg(ctx, t)
+
+	stream := &app.LogStream{OwnerType: "test", Open: true}
+	require.NoError(t, s.deps.DB.WithContext(ctx).Create(stream).Error)
+	_, err := s.deps.AcctClient.CreateServiceAccount(ctx, stream.ID, "")
+	require.NoError(t, err)
+
+	originalRunnerAPIURL := s.deps.Cfg.RunnerAPIURL
+	s.deps.Cfg.RunnerAPIURL = "https://runner.example.com"
+	t.Cleanup(func() {
+		s.deps.Cfg.RunnerAPIURL = originalRunnerAPIURL
+	})
+
+	hydrated, err := s.deps.Activities.HydrateLogStream(ctx, &activities.HydrateLogStreamRequest{
+		LogStreamID: stream.ID,
+		OrgID:       org.ID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, stream.ID, hydrated.ID)
+	require.Equal(t, "https://runner.example.com", hydrated.RunnerAPIURL)
+	require.NotEmpty(t, hydrated.WriteToken)
+
+	var token app.Token
+	require.NoError(t, s.deps.DB.WithContext(ctx).
+		Where(app.Token{Token: hydrated.WriteToken}).
+		First(&token).Error)
+	require.True(t, token.ExpiresAt.After(time.Now().Add(55*time.Minute)))
+
+	var persisted app.LogStream
+	require.NoError(t, s.deps.DB.WithContext(ctx).First(&persisted, app.LogStream{ID: stream.ID}).Error)
+	require.Empty(t, persisted.RunnerAPIURL)
+	require.Empty(t, persisted.WriteToken)
+}
+
+func (s *HydrateLogStreamTestSuite) TestRejectsAnotherOrgLogStream() {
+	t := s.T()
+	ctx, _ := s.deps.Seeder.EnsureAccount(context.Background(), t)
+	ctx, _ = s.deps.Seeder.EnsureOrg(ctx, t)
+
+	stream := &app.LogStream{OwnerType: "test", Open: true}
+	require.NoError(t, s.deps.DB.WithContext(ctx).Create(stream).Error)
+
+	_, err := s.deps.Activities.HydrateLogStream(ctx, &activities.HydrateLogStreamRequest{
+		LogStreamID: stream.ID,
+		OrgID:       "org00000000000000000000000",
+	})
+	require.Error(t, err)
+}

--- a/services/ctl-api/internal/pkg/queue/handler/execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/execute.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nuonco/nuon/pkg/metrics"
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/callback"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/log"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/queuecctx"
@@ -79,14 +80,14 @@ func (h *handler) executeHandler(ctx workflow.Context, cb callback.Ref) (resp *E
 	}
 
 	execCtx, cancel := workflow.WithCancel(ctx)
+	defer cancel()
 
-	// Restore the enqueuer's identity onto the execution context.
-	if h.queueSignal != nil {
-		execCtx = queuecctx.ApplyWorkflow(execCtx, h.queueSignal.SignalContext)
+	execCtx, err := h.signalExecutionContext(execCtx)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to restore signal context")
 	}
 	h.executingCtx = execCtx
 	h.executingCancel = cancel
-	defer cancel()
 
 	start := workflow.Now(ctx)
 	_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
@@ -97,7 +98,7 @@ func (h *handler) executeHandler(ctx workflow.Context, cb callback.Ref) (resp *E
 		},
 	})
 
-	err := h.runSignalExecute(execCtx)
+	err = h.runSignalExecute(execCtx)
 	dur := workflow.Now(ctx).Sub(start)
 
 	// run after-phase hooks (best-effort)
@@ -155,6 +156,27 @@ func (h *handler) executeHandler(ctx workflow.Context, cb callback.Ref) (resp *E
 
 	finStatus, finDesc = app.StatusSuccess, ""
 	return nil, nil
+}
+
+func (h *handler) signalExecutionContext(ctx workflow.Context) (workflow.Context, error) {
+	if h.queueSignal == nil {
+		return ctx, nil
+	}
+
+	signalCtx := h.queueSignal.SignalContext
+	ctx = queuecctx.ApplyWorkflow(ctx, signalCtx)
+	if signalCtx.LogStreamID == "" {
+		return ctx, nil
+	}
+
+	stream, err := activities.AwaitHydrateLogStream(ctx, &activities.HydrateLogStreamRequest{
+		LogStreamID: signalCtx.LogStreamID,
+		OrgID:       signalCtx.OrgID,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to hydrate signal log stream")
+	}
+	return cctx.SetLogStreamWorkflowContext(ctx, stream), nil
 }
 
 // emitExecuteMetrics records the latency and execution count for the signal's

--- a/services/ctl-api/internal/pkg/queue/handler/execute_test.go
+++ b/services/ctl-api/internal/pkg/queue/handler/execute_test.go
@@ -1,0 +1,67 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+
+	pkgdataconverter "github.com/nuonco/nuon/pkg/temporal/dataconverter"
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/activities"
+	queuecctx "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/cctx"
+)
+
+func TestSignalExecutionContextHydratesLogStream(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.SetDataConverter(converter.NewCompositeDataConverter(
+		converter.NewNilPayloadConverter(),
+		converter.NewByteSlicePayloadConverter(),
+		pkgdataconverter.NewJSONConverter(),
+	))
+
+	env.OnActivity(
+		new(activities.Activities).HydrateLogStream,
+		mock.Anything,
+		mock.MatchedBy(func(req *activities.HydrateLogStreamRequest) bool {
+			return req.LogStreamID == "log-stream-id" && req.OrgID == "org-id"
+		}),
+	).Return(&app.LogStream{
+		ID:           "log-stream-id",
+		OrgID:        "org-id",
+		RunnerAPIURL: "https://runner.example.com",
+		WriteToken:   "write-token",
+	}, nil).Once()
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) (string, error) {
+		h := &handler{
+			queueSignal: &app.QueueSignal{
+				SignalContext: queuecctx.SignalContext{
+					OrgID:       "org-id",
+					LogStreamID: "log-stream-id",
+				},
+			},
+		}
+
+		execCtx, err := h.signalExecutionContext(ctx)
+		if err != nil {
+			return "", err
+		}
+		stream, err := cctx.GetLogStreamWorkflow(execCtx)
+		if err != nil {
+			return "", err
+		}
+		return stream.RunnerAPIURL + "|" + stream.WriteToken, nil
+	})
+
+	require.NoError(t, env.GetWorkflowError())
+	var credentials string
+	require.NoError(t, env.GetWorkflowResult(&credentials))
+	require.Equal(t, "https://runner.example.com|write-token", credentials)
+	env.AssertExpectations(t)
+}

--- a/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx.go
+++ b/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx.go
@@ -5,7 +5,6 @@ import (
 
 	"go.temporal.io/sdk/workflow"
 
-	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 	qcctx "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/cctx"
 )
@@ -38,9 +37,6 @@ func Apply(ctx context.Context, sc qcctx.SignalContext) context.Context {
 	if sc.TraceID != "" {
 		ctx = cctx.SetTraceIDContext(ctx, sc.TraceID)
 	}
-	if sc.LogStreamID != "" {
-		ctx = cctx.SetLogStreamContext(ctx, &app.LogStream{ID: sc.LogStreamID})
-	}
 	return ctx
 }
 
@@ -57,9 +53,6 @@ func ApplyWorkflow(ctx workflow.Context, sc qcctx.SignalContext) workflow.Contex
 	}
 	if sc.TraceID != "" {
 		ctx = cctx.SetTraceIDWorkflowContext(ctx, sc.TraceID)
-	}
-	if sc.LogStreamID != "" {
-		ctx = cctx.SetLogStreamWorkflowContext(ctx, &app.LogStream{ID: sc.LogStreamID})
 	}
 	return ctx
 }

--- a/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx_test.go
+++ b/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx_test.go
@@ -1,0 +1,49 @@
+package queuecctx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	qcctx "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/cctx"
+)
+
+func TestApplyDoesNotInstallPartialLogStream(t *testing.T) {
+	ctx := Apply(context.Background(), qcctx.SignalContext{LogStreamID: "log-stream-id"})
+
+	_, err := cctx.GetLogStreamContext(ctx)
+	require.Error(t, err)
+}
+
+func TestApplyWorkflowDoesNotInstallPartialLogStream(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) (bool, error) {
+		ctx = ApplyWorkflow(ctx, qcctx.SignalContext{LogStreamID: "log-stream-id"})
+		_, err := cctx.GetLogStreamWorkflow(ctx)
+		return err != nil, nil
+	})
+
+	require.NoError(t, env.GetWorkflowError())
+	var missing bool
+	require.NoError(t, env.GetWorkflowResult(&missing))
+	require.True(t, missing)
+}
+
+func TestFromContextCapturesLogStreamIDWithoutCredentials(t *testing.T) {
+	ctx := cctx.SetLogStreamContext(context.Background(), &app.LogStream{
+		ID:           "log-stream-id",
+		RunnerAPIURL: "https://runner.example.com",
+		WriteToken:   "secret-token",
+	})
+
+	signalCtx := FromContext(ctx)
+
+	require.Equal(t, "log-stream-id", signalCtx.LogStreamID)
+}


### PR DESCRIPTION
Normalize workflow log-stream endpoint paths and restore complete per-signal logging context across the durable queue boundary. Queue handlers now reload the log stream by ID and org, mint a fresh short-lived write token, and apply the configured runner API URL before signal execution; bearer tokens are not copied into queue JSON. This also prevents the long-lived queue workflow from inheriting an ID-only stream from whichever signal started it. Covered by queue-context, handler, PostgreSQL hydration, process-job, and log endpoint tests.