### PR TITLE
fix: hydrate validation log stream

### DIFF
--- a/services/ctl-api/internal/app/installs/signals/componentdeployapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentdeployapplyplan/signal.go
@@ -192,7 +192,11 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		}
 	}()
 
-	ctx = cctx.SetLogStreamWorkflowContext(ctx, &installDeploy.LogStream)
+	logStream, err := activities.AwaitGetLogStreamByLogStreamID(ctx, installDeploy.LogStream.ID)
+	if err != nil {
+		return errors.Wrap(err, "unable to hydrate log stream")
+	}
+	ctx = cctx.SetLogStreamWorkflowContext(ctx, logStream)
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
 		return err

--- a/services/ctl-api/internal/app/installs/signals/componentteardownapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/componentteardownapplyplan/signal.go
@@ -202,7 +202,11 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		return errors.Wrap(err, "unable to update install workflow")
 	}
 
-	ctx = cctx.SetLogStreamWorkflowContext(ctx, &installDeploy.LogStream)
+	logStream, err := activities.AwaitGetLogStreamByLogStreamID(ctx, installDeploy.LogStream.ID)
+	if err != nil {
+		return errors.Wrap(err, "unable to hydrate log stream")
+	}
+	ctx = cctx.SetLogStreamWorkflowContext(ctx, logStream)
 	l, err := log.WorkflowLogger(ctx)
 	if err != nil {
 		return err

--- a/services/ctl-api/internal/app/installs/signals/deprovisionsandboxapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/deprovisionsandboxapplyplan/signal.go
@@ -186,7 +186,11 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		}
 	}()
 
-	ctx = cctx.SetLogStreamWorkflowContext(ctx, &installRun.LogStream)
+	logStream, err := activities.AwaitGetLogStreamByLogStreamID(ctx, installRun.LogStream.ID)
+	if err != nil {
+		return errors.Wrap(err, "unable to hydrate log stream")
+	}
+	ctx = cctx.SetLogStreamWorkflowContext(ctx, logStream)
 	l := workflow.GetLogger(ctx)
 
 	defer func() {

--- a/services/ctl-api/internal/app/installs/signals/provisionsandboxapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/provisionsandboxapplyplan/signal.go
@@ -190,7 +190,11 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 
 	s.updateRunStatus(ctx, sandboxRun.ID, app.SandboxRunStatusProvisioning, "provisioning sandbox")
 
-	ctx = cctx.SetLogStreamWorkflowContext(ctx, &sandboxRun.LogStream)
+	logStream, err := activities.AwaitGetLogStreamByLogStreamID(ctx, sandboxRun.LogStream.ID)
+	if err != nil {
+		return errors.Wrap(err, "unable to hydrate log stream")
+	}
+	ctx = cctx.SetLogStreamWorkflowContext(ctx, logStream)
 	l := workflow.GetLogger(ctx)
 
 	defer func() {

--- a/services/ctl-api/internal/app/installs/signals/reprovisionsandboxapplyplan/signal.go
+++ b/services/ctl-api/internal/app/installs/signals/reprovisionsandboxapplyplan/signal.go
@@ -190,7 +190,11 @@ func (s *Signal) Execute(ctx workflow.Context) error {
 		}
 	}()
 
-	ctx = cctx.SetLogStreamWorkflowContext(ctx, &sandboxRun.LogStream)
+	logStream, err := activities.AwaitGetLogStreamByLogStreamID(ctx, sandboxRun.LogStream.ID)
+	if err != nil {
+		return errors.Wrap(err, "unable to hydrate log stream")
+	}
+	ctx = cctx.SetLogStreamWorkflowContext(ctx, logStream)
 	l := workflow.GetLogger(ctx)
 
 	defer func() {

--- a/services/ctl-api/internal/app/installs/worker/activities/get_log_stream.go
+++ b/services/ctl-api/internal/app/installs/worker/activities/get_log_stream.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/account"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
 )
 
 type GetLogStreamRequest struct {
@@ -18,11 +20,23 @@ func (a *Activities) GetLogStream(ctx context.Context, req GetLogStreamRequest) 
 }
 
 func (a *Activities) getLogStream(ctx context.Context, logStreamID string) (*app.LogStream, error) {
+	orgID, err := cctx.OrgIDFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get org id from context: %w", err)
+	}
+
 	installLogStream := app.LogStream{}
-	res := a.db.WithContext(ctx).First(&installLogStream, "id = ?", logStreamID)
+	res := a.db.WithContext(ctx).Where("id = ? AND org_id = ?", logStreamID, orgID).First(&installLogStream)
 	if res.Error != nil {
 		return nil, fmt.Errorf("unable to get install deploy: %w", res.Error)
 	}
 
+	token, err := a.acctClient.CreateToken(ctx, account.ServiceAccountEmail(installLogStream.ID), defaultLogStreamTokenDuration)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create log stream token: %w", err)
+	}
+
+	installLogStream.RunnerAPIURL = a.cfg.RunnerAPIURL
+	installLogStream.WriteToken = token.Token
 	return &installLogStream, nil
 }

--- a/services/ctl-api/internal/pkg/cctx/log_stream.go
+++ b/services/ctl-api/internal/pkg/cctx/log_stream.go
@@ -14,17 +14,25 @@ func SetLogStreamContext(ctx context.Context, ls *app.LogStream) context.Context
 	return context.WithValue(ctx, keys.LogStreamCtxKey, ls)
 }
 
+func ClearLogStreamContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, keys.LogStreamCtxKey, struct{}{})
+}
+
 func GetLogStreamContext(ctx ValueContext) (*app.LogStream, error) {
-	ls := ctx.Value(keys.LogStreamCtxKey)
-	if ls == nil {
+	ls, ok := ctx.Value(keys.LogStreamCtxKey).(*app.LogStream)
+	if !ok || ls == nil {
 		return nil, fmt.Errorf("log stream not set on context")
 	}
 
-	return ls.(*app.LogStream), nil
+	return ls, nil
 }
 
 func SetLogStreamWorkflowContext(ctx workflow.Context, ls *app.LogStream) workflow.Context {
 	return workflow.WithValue(ctx, keys.LogStreamCtxKey, ls)
+}
+
+func ClearLogStreamWorkflowContext(ctx workflow.Context) workflow.Context {
+	return workflow.WithValue(ctx, keys.LogStreamCtxKey, struct{}{})
 }
 
 func GetLogStreamIDWorkflow(ctx ValueContext) (string, error) {
@@ -37,10 +45,10 @@ func GetLogStreamIDWorkflow(ctx ValueContext) (string, error) {
 }
 
 func GetLogStreamWorkflow(ctx ValueContext) (*app.LogStream, error) {
-	val := ctx.Value(keys.LogStreamCtxKey)
-	if val == nil {
+	ls, ok := ctx.Value(keys.LogStreamCtxKey).(*app.LogStream)
+	if !ok || ls == nil {
 		return nil, fmt.Errorf("no log stream found")
 	}
 
-	return val.(*app.LogStream), nil
+	return ls, nil
 }

--- a/services/ctl-api/internal/pkg/queue/handler/execute.go
+++ b/services/ctl-api/internal/pkg/queue/handler/execute.go
@@ -82,7 +82,7 @@ func (h *handler) executeHandler(ctx workflow.Context, cb callback.Ref) (resp *E
 	execCtx, cancel := workflow.WithCancel(ctx)
 	defer cancel()
 
-	execCtx, err := h.signalExecutionContext(execCtx)
+	execCtx, err := h.signalContext(execCtx, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to restore signal context")
 	}
@@ -158,7 +158,7 @@ func (h *handler) executeHandler(ctx workflow.Context, cb callback.Ref) (resp *E
 	return nil, nil
 }
 
-func (h *handler) signalExecutionContext(ctx workflow.Context) (workflow.Context, error) {
+func (h *handler) signalContext(ctx workflow.Context, refreshLogStream bool) (workflow.Context, error) {
 	if h.queueSignal == nil {
 		return ctx, nil
 	}
@@ -169,14 +169,20 @@ func (h *handler) signalExecutionContext(ctx workflow.Context) (workflow.Context
 		return ctx, nil
 	}
 
-	stream, err := activities.AwaitHydrateLogStream(ctx, &activities.HydrateLogStreamRequest{
-		LogStreamID: signalCtx.LogStreamID,
-		OrgID:       signalCtx.OrgID,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to hydrate signal log stream")
+	if refreshLogStream {
+		h.signalLogStream = nil
 	}
-	return cctx.SetLogStreamWorkflowContext(ctx, stream), nil
+	if h.signalLogStream == nil {
+		stream, err := activities.AwaitHydrateLogStream(ctx, &activities.HydrateLogStreamRequest{
+			LogStreamID: signalCtx.LogStreamID,
+			OrgID:       signalCtx.OrgID,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to hydrate signal log stream")
+		}
+		h.signalLogStream = stream
+	}
+	return cctx.SetLogStreamWorkflowContext(ctx, h.signalLogStream), nil
 }
 
 // emitExecuteMetrics records the latency and execution count for the signal's

--- a/services/ctl-api/internal/pkg/queue/handler/execute_test.go
+++ b/services/ctl-api/internal/pkg/queue/handler/execute_test.go
@@ -16,7 +16,7 @@ import (
 	queuecctx "github.com/nuonco/nuon/services/ctl-api/internal/pkg/queue/cctx"
 )
 
-func TestSignalExecutionContextHydratesLogStream(t *testing.T) {
+func TestSignalContextHydratesLogStreamOnceAcrossPhases(t *testing.T) {
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
 	env.SetDataConverter(converter.NewCompositeDataConverter(
@@ -48,7 +48,15 @@ func TestSignalExecutionContextHydratesLogStream(t *testing.T) {
 			},
 		}
 
-		execCtx, err := h.signalExecutionContext(ctx)
+		validateCtx, err := h.signalContext(ctx, true)
+		if err != nil {
+			return "", err
+		}
+		if _, err := cctx.GetLogStreamWorkflow(validateCtx); err != nil {
+			return "", err
+		}
+
+		execCtx, err := h.signalContext(ctx, false)
 		if err != nil {
 			return "", err
 		}

--- a/services/ctl-api/internal/pkg/queue/handler/handler.go
+++ b/services/ctl-api/internal/pkg/queue/handler/handler.go
@@ -93,8 +93,9 @@ type handler struct {
 	callbacks callback.Refs
 
 	// state that is loaded during run, but not passed between continue-as-news
-	queueSignal *app.QueueSignal
-	sig         signal.Signal
+	queueSignal     *app.QueueSignal
+	sig             signal.Signal
+	signalLogStream *app.LogStream
 }
 
 // setFinished marks the handler as finished with a terminal status and optional error description.

--- a/services/ctl-api/internal/pkg/queue/handler/validate.go
+++ b/services/ctl-api/internal/pkg/queue/handler/validate.go
@@ -56,6 +56,14 @@ func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *
 		return nil, errors.New("signal was empty can not proceed")
 	}
 
+	var err error
+	ctx, err = h.signalContext(ctx, true)
+	if err != nil {
+		finStatus, finDesc = app.StatusError, err.Error()
+		return nil, errors.Wrap(err, "unable to restore signal context")
+	}
+	l, _ = log.WorkflowLogger(ctx)
+
 	// mark the signal as in-progress in the DB
 	if !h.skipValidateStamps() {
 		_ = statusactivities.LocalAwaitUpdateQueueSignalStatusV2(ctx, statusactivities.UpdateQueueSignalStatusV2Request{
@@ -86,7 +94,7 @@ func (h *handler) validateHandler(ctx workflow.Context, cb callback.Ref) (resp *
 	}
 
 	start := workflow.Now(ctx)
-	err := h.runSignalValidate(ctx)
+	err = h.runSignalValidate(ctx)
 	dur := workflow.Now(ctx).Sub(start)
 
 	// run after-phase hooks (best-effort)

--- a/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx.go
+++ b/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx.go
@@ -28,6 +28,7 @@ func FromContext(ctx cctx.ValueContext) qcctx.SignalContext {
 // Apply restores the captured context values onto a context.Context so that
 // downstream consumers (e.g. Temporal propagators) see the original values.
 func Apply(ctx context.Context, sc qcctx.SignalContext) context.Context {
+	ctx = cctx.ClearLogStreamContext(ctx)
 	if sc.AccountID != "" {
 		ctx = cctx.SetAccountIDContext(ctx, sc.AccountID)
 	}
@@ -45,6 +46,7 @@ func Apply(ctx context.Context, sc qcctx.SignalContext) context.Context {
 // signal's Execute (and any activities it schedules via the Temporal
 // propagator) see the enqueuer's identity rather than the queue workflow's.
 func ApplyWorkflow(ctx workflow.Context, sc qcctx.SignalContext) workflow.Context {
+	ctx = cctx.ClearLogStreamWorkflowContext(ctx)
 	if sc.AccountID != "" {
 		ctx = cctx.SetAccountIDWorkflowContext(ctx, sc.AccountID)
 	}

--- a/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx_test.go
+++ b/services/ctl-api/internal/pkg/queue/queuecctx/queuecctx_test.go
@@ -14,7 +14,12 @@ import (
 )
 
 func TestApplyDoesNotInstallPartialLogStream(t *testing.T) {
-	ctx := Apply(context.Background(), qcctx.SignalContext{LogStreamID: "log-stream-id"})
+	ctx := cctx.SetLogStreamContext(context.Background(), &app.LogStream{
+		ID:           "inherited-log-stream",
+		RunnerAPIURL: "https://runner.example.com",
+		WriteToken:   "inherited-token",
+	})
+	ctx = Apply(ctx, qcctx.SignalContext{LogStreamID: "log-stream-id"})
 
 	_, err := cctx.GetLogStreamContext(ctx)
 	require.Error(t, err)
@@ -25,6 +30,11 @@ func TestApplyWorkflowDoesNotInstallPartialLogStream(t *testing.T) {
 	env := suite.NewTestWorkflowEnvironment()
 
 	env.ExecuteWorkflow(func(ctx workflow.Context) (bool, error) {
+		ctx = cctx.SetLogStreamWorkflowContext(ctx, &app.LogStream{
+			ID:           "inherited-log-stream",
+			RunnerAPIURL: "https://runner.example.com",
+			WriteToken:   "inherited-token",
+		})
 		ctx = ApplyWorkflow(ctx, qcctx.SignalContext{LogStreamID: "log-stream-id"})
 		_, err := cctx.GetLogStreamWorkflow(ctx)
 		return err != nil, nil


### PR DESCRIPTION
Make each queue signal's logging context independent from the long-lived queue workflow. Signals with a log stream ID load fresh credentials once for validation and execution; signals without one explicitly clear any inherited stream instead of accidentally using stale partial context. Stage reproduced both cases: planning succeeded with a hydrated stream, while sandbox apply exposed the inherited-stream case.