### PR TITLE
feat: nuonctl mcp

### DIFF
--- a/services/ctl-api/cmd/nuonctl_mcp_api.go
+++ b/services/ctl-api/cmd/nuonctl_mcp_api.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+
+	"github.com/nuonco/nuon/pkg/profiles"
+	"github.com/nuonco/nuon/services/ctl-api/internal/fxmodules"
+)
+
+func (c *cli) registerNuonctlMCPAPI() error {
+	cmd := &cobra.Command{
+		Use:   "nuonctl-mcp-api",
+		Short: "run the employee-only nuonctl MCP server",
+		Run:   c.runNuonctlMCPAPI,
+	}
+	rootCmd.AddCommand(cmd)
+	return nil
+}
+
+func (c *cli) runNuonctlMCPAPI(cmd *cobra.Command, _ []string) {
+	providers := make([]fx.Option, 0)
+	providers = append(providers, c.providers()...)
+
+	profilerOptions := profiles.LoadOptionsFromEnv()
+	providers = append(providers, profiles.Module(profilerOptions))
+
+	providers = append(providers,
+		fxmodules.NuonctlMCPServicesModule,
+		fxmodules.NuonctlMCPAPIModule,
+	)
+
+	fx.New(providers...).Run()
+}

--- a/services/ctl-api/cmd/nuonctl_mcp_api_test.go
+++ b/services/ctl-api/cmd/nuonctl_mcp_api_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/fxmodules"
+)
+
+func TestNuonctlMCPAPIGraph(t *testing.T) {
+	c := &cli{}
+	options := c.providers()
+	options = append(options,
+		fxmodules.NuonctlMCPServicesModule,
+		fxmodules.NuonctlMCPAPIModule,
+	)
+
+	require.NoError(t, fx.ValidateApp(options...))
+}

--- a/services/ctl-api/cmd/root.go
+++ b/services/ctl-api/cmd/root.go
@@ -18,6 +18,7 @@ func Execute() {
 	c.registerAdminDashboardAPI()
 	c.registerSlackAPI()
 	c.registerMCPAPI()
+	c.registerNuonctlMCPAPI()
 	c.registerWorker()
 	c.registerConsumer()
 	c.registerStartup()

--- a/services/ctl-api/internal/app/mcp/server/auth.go
+++ b/services/ctl-api/internal/app/mcp/server/auth.go
@@ -67,6 +67,10 @@ func accountHasOrgAccess(acct *app.Account, orgID string) bool {
 	return false
 }
 
+func (s *Server) accountAllowed(acct *app.Account) bool {
+	return !s.requireEmployee || acct.IsEmployee
+}
+
 func extractBearerToken(r *http.Request) string {
 	auth := r.Header.Get("Authorization")
 	if auth == "" {

--- a/services/ctl-api/internal/app/mcp/server/metrics_test.go
+++ b/services/ctl-api/internal/app/mcp/server/metrics_test.go
@@ -104,14 +104,15 @@ func (metricContextMCPService) RegisterMCPTools(server *mcp.Server) {
 	})
 }
 
-func newMetricsTestServer(t *testing.T, service api.Service, writer *capturingMetricsWriter) *httptest.Server {
+func newMetricsTestServer(t *testing.T, service api.MCPService, writer *capturingMetricsWriter) *httptest.Server {
 	t.Helper()
 
 	s := &Server{
-		mw:            writer,
-		services:      []api.Service{service},
-		schemaCache:   mcp.NewSchemaCache(),
-		orgSelections: make(map[string]*orgSelection),
+		mw:                 writer,
+		mcpServices:        []api.MCPService{service},
+		schemaCache:        mcp.NewSchemaCache(),
+		implementationName: "nuon-ctl",
+		orgSelections:      make(map[string]*orgSelection),
 	}
 	mcpHandler := s.newMCPHandler()
 	handler := s.metricsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/services/ctl-api/internal/app/mcp/server/oauth.go
+++ b/services/ctl-api/internal/app/mcp/server/oauth.go
@@ -64,3 +64,12 @@ func (s *Server) writeUnauthorized(w http.ResponseWriter, r *http.Request) {
 		"error_description": "missing or invalid access token",
 	})
 }
+
+func (s *Server) writeForbidden(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error":             "access_denied",
+		"error_description": fmt.Sprintf("%s MCP is limited to Nuon employees", s.implementationName),
+	})
+}

--- a/services/ctl-api/internal/app/mcp/server/oauth_test.go
+++ b/services/ctl-api/internal/app/mcp/server/oauth_test.go
@@ -59,12 +59,34 @@ func TestWriteUnauthorizedSetsWWWAuthenticate(t *testing.T) {
 		w.Header().Get("WWW-Authenticate"))
 }
 
+func TestWriteForbidden(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	(&Server{implementationName: "nuonctl"}).writeForbidden(w)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.JSONEq(t, `{
+		"error": "access_denied",
+		"error_description": "nuonctl MCP is limited to Nuon employees"
+	}`, w.Body.String())
+}
+
 func TestAccountHasOrgAccess(t *testing.T) {
 	acct := &app.Account{OrgIDs: []string{"org_a", "org_b"}}
 	assert.True(t, accountHasOrgAccess(acct, "org_a"))
 	assert.True(t, accountHasOrgAccess(acct, "org_b"))
 	assert.False(t, accountHasOrgAccess(acct, "org_c"))
 	assert.False(t, accountHasOrgAccess(&app.Account{}, "org_a"))
+}
+
+func TestAccountAllowed(t *testing.T) {
+	employee := &app.Account{IsEmployee: true}
+	external := &app.Account{IsEmployee: false}
+
+	assert.True(t, (&Server{}).accountAllowed(employee))
+	assert.True(t, (&Server{}).accountAllowed(external))
+	assert.True(t, (&Server{requireEmployee: true}).accountAllowed(employee))
+	assert.False(t, (&Server{requireEmployee: true}).accountAllowed(external))
 }
 
 func newTestServer() *Server {

--- a/services/ctl-api/internal/app/mcp/server/server.go
+++ b/services/ctl-api/internal/app/mcp/server/server.go
@@ -37,6 +37,19 @@ type Params struct {
 	Services    []api.Service `group:"services"`
 }
 
+type NuonctlParams struct {
+	fx.In
+
+	LC          fx.Lifecycle
+	Shutdowner  fx.Shutdowner
+	DB          *gorm.DB `name:"psql"`
+	L           *zap.Logger
+	Cfg         *internal.Config
+	MW          metrics.Writer
+	HTTPMetrics *controlplanemetrics.HTTPMetrics
+	Services    []api.MCPService `group:"nuonctl_mcp_services"`
+}
+
 // orgSelectionTTL bounds how long an idle org selection is retained.
 const orgSelectionTTL = 30 * time.Minute
 
@@ -52,9 +65,14 @@ type Server struct {
 	cfg         *internal.Config
 	mw          metrics.Writer
 	httpMetrics *controlplanemetrics.HTTPMetrics
-	services    []api.Service
+	mcpServices []api.MCPService
 	httpServer  *http.Server
 	schemaCache *mcp.SchemaCache
+
+	implementationName string
+	requireEmployee    bool
+	serverPurpose      string
+	orgInstructions    string
 
 	mu            sync.RWMutex
 	orgSelections map[string]*orgSelection
@@ -62,16 +80,77 @@ type Server struct {
 }
 
 func New(params Params) *Server {
+	mcpServices := make([]api.MCPService, 0, len(params.Services))
+	for _, svc := range params.Services {
+		if mcpSvc, ok := svc.(api.MCPService); ok {
+			mcpServices = append(mcpServices, mcpSvc)
+		}
+	}
+
+	return newServer(
+		params.LC,
+		params.Shutdowner,
+		params.DB,
+		params.L,
+		params.Cfg,
+		params.MW,
+		params.HTTPMetrics,
+		mcpServices,
+		params.Cfg.MCPHTTPPort,
+		"nuon-ctl",
+		false,
+		"Nuon control plane MCP server.",
+		"If no org is selected, call list_orgs then select_org.",
+	)
+}
+
+func NewNuonctl(params NuonctlParams) *Server {
+	return newServer(
+		params.LC,
+		params.Shutdowner,
+		params.DB,
+		params.L,
+		params.Cfg,
+		params.MW,
+		params.HTTPMetrics,
+		params.Services,
+		params.Cfg.NuonctlMCPHTTPPort,
+		"nuonctl",
+		true,
+		"Nuon employee-only nuonctl MCP server.",
+		"If no org is selected, run nuon orgs select and reconnect.",
+	)
+}
+
+func newServer(
+	lc fx.Lifecycle,
+	shutdowner fx.Shutdowner,
+	db *gorm.DB,
+	l *zap.Logger,
+	cfg *internal.Config,
+	mw metrics.Writer,
+	httpMetrics *controlplanemetrics.HTTPMetrics,
+	mcpServices []api.MCPService,
+	port string,
+	implementationName string,
+	requireEmployee bool,
+	serverPurpose string,
+	orgInstructions string,
+) *Server {
 	s := &Server{
-		db:            params.DB,
-		l:             params.L.Named("mcp"),
-		cfg:           params.Cfg,
-		mw:            params.MW,
-		httpMetrics:   params.HTTPMetrics,
-		services:      params.Services,
-		schemaCache:   mcp.NewSchemaCache(),
-		orgSelections: make(map[string]*orgSelection),
-		stopJanitor:   make(chan struct{}),
+		db:                 db,
+		l:                  l.Named("mcp"),
+		cfg:                cfg,
+		mw:                 mw,
+		httpMetrics:        httpMetrics,
+		mcpServices:        mcpServices,
+		schemaCache:        mcp.NewSchemaCache(),
+		implementationName: implementationName,
+		requireEmployee:    requireEmployee,
+		serverPurpose:      serverPurpose,
+		orgInstructions:    orgInstructions,
+		orgSelections:      make(map[string]*orgSelection),
+		stopJanitor:        make(chan struct{}),
 	}
 
 	mcpHandler := s.newMCPHandler()
@@ -83,17 +162,17 @@ func New(params Params) *Server {
 	mux.Handle("/", s.authContextMiddleware(mcpHandler))
 
 	s.httpServer = &http.Server{
-		Addr:    net.JoinHostPort("0.0.0.0", params.Cfg.MCPHTTPPort),
+		Addr:    net.JoinHostPort("0.0.0.0", port),
 		Handler: s.otelMetricsMiddleware(s.metricsMiddleware(mux)),
 	}
 
-	params.LC.Append(fx.Hook{
+	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
 			s.l.Info("starting MCP server", zap.String("addr", s.httpServer.Addr))
 			go func() {
 				if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 					s.l.Error("MCP server error", zap.Error(err))
-					_ = params.Shutdowner.Shutdown()
+					_ = shutdowner.Shutdown()
 				}
 			}()
 			go s.runSelectionJanitor()
@@ -138,18 +217,16 @@ func (s *Server) getServerForRequest(r *http.Request) *mcp.Server {
 	orgID := keys.OrgIDFromContext(r.Context())
 
 	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "nuon-ctl",
+		Name:    s.implementationName,
 		Version: "1.0.0",
 	}, &mcp.ServerOptions{
 		SchemaCache:  s.schemaCache,
-		Instructions: fmt.Sprintf("Nuon control plane MCP server. Authenticated as account %s in org %q. If no org is selected, call list_orgs then select_org. %s %s", accountID, orgID, api.MCPTimeInstructions, api.MCPPoliciesInstructions),
+		Instructions: fmt.Sprintf("%s Authenticated as account %s in org %q. %s %s %s", s.serverPurpose, accountID, orgID, s.orgInstructions, api.MCPTimeInstructions, api.MCPPoliciesInstructions),
 	})
 	server.AddReceivingMiddleware(s.receivingMetricsMiddleware)
 
-	for _, svc := range s.services {
-		if mcpSvc, ok := svc.(api.MCPService); ok {
-			mcpSvc.RegisterMCPTools(server)
-		}
+	for _, svc := range s.mcpServices {
+		svc.RegisterMCPTools(server)
 	}
 
 	return server
@@ -256,6 +333,11 @@ func (s *Server) authContextMiddleware(next http.Handler) http.Handler {
 		if err != nil {
 			l.Warn("MCP auth failed", zap.Error(err))
 			s.writeUnauthorized(w, r)
+			return
+		}
+		if !s.accountAllowed(acct) {
+			l.Warn("MCP employee access denied", zap.String("account_id", acct.ID))
+			s.writeForbidden(w)
 			return
 		}
 

--- a/services/ctl-api/internal/app/mcp/server/stateless_test.go
+++ b/services/ctl-api/internal/app/mcp/server/stateless_test.go
@@ -46,7 +46,11 @@ func withMCPAuth(ctx context.Context, orgID, accountID string) context.Context {
 func newStatelessTestServer(t *testing.T, orgID string) *httptest.Server {
 	t.Helper()
 
-	s := &Server{services: []api.Service{stubMCPService{}}, schemaCache: mcp.NewSchemaCache()}
+	s := &Server{
+		mcpServices:        []api.MCPService{stubMCPService{}},
+		schemaCache:        mcp.NewSchemaCache(),
+		implementationName: "nuon-ctl",
+	}
 
 	handler := s.newMCPHandler()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/services/ctl-api/internal/app/nuonctl-mcp/service/mcp_whoami.go
+++ b/services/ctl-api/internal/app/nuonctl-mcp/service/mcp_whoami.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+type mcpWhoamiInput struct{}
+
+func (s *service) mcpWhoami(ctx context.Context, _ *mcp.CallToolRequest, _ mcpWhoamiInput) (*mcp.CallToolResult, any, error) {
+	acct, err := cctx.AccountFromContext(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	orgs := make([]map[string]string, 0, len(acct.Orgs))
+	for _, org := range acct.Orgs {
+		orgs = append(orgs, map[string]string{"id": org.ID, "name": org.Name})
+	}
+
+	out := map[string]any{
+		"account": map[string]any{
+			"id":       acct.ID,
+			"email":    acct.Email,
+			"employee": acct.IsEmployee,
+		},
+		"orgs":        orgs,
+		"current_org": nil,
+	}
+
+	if orgID := keys.OrgIDFromContext(ctx); orgID != "" {
+		currentOrg := map[string]string{"id": orgID}
+		for _, org := range acct.Orgs {
+			if org.ID == orgID {
+				currentOrg["name"] = org.Name
+				break
+			}
+		}
+		out["current_org"] = currentOrg
+	} else if len(orgs) > 1 {
+		out["hint"] = "No org selected. Run nuon orgs select."
+	}
+
+	return api.MCPJSONResult(out)
+}

--- a/services/ctl-api/internal/app/nuonctl-mcp/service/mcp_whoami_test.go
+++ b/services/ctl-api/internal/app/nuonctl-mcp/service/mcp_whoami_test.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/app"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx/keys"
+)
+
+func TestMCPWhoami(t *testing.T) {
+	acct := &app.Account{
+		ID:         "acc_test",
+		Email:      "dev@nuon.co",
+		IsEmployee: true,
+		Orgs: []*app.Org{
+			{ID: "org_a", Name: "Development"},
+		},
+	}
+	ctx := cctx.SetAccountContext(context.Background(), acct)
+	ctx = context.WithValue(ctx, keys.OrgIDCtxKey, "org_a")
+
+	result, _, err := New().mcpWhoami(ctx, &mcp.CallToolRequest{}, mcpWhoamiInput{})
+	require.NoError(t, err)
+	require.Len(t, result.Content, 1)
+
+	text, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.JSONEq(t, `{
+		"account": {"id":"acc_test","email":"dev@nuon.co","employee":true},
+		"orgs": [{"id":"org_a","name":"Development"}],
+		"current_org": {"id":"org_a","name":"Development"}
+	}`, text.Text)
+}

--- a/services/ctl-api/internal/app/nuonctl-mcp/service/service.go
+++ b/services/ctl-api/internal/app/nuonctl-mcp/service/service.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/api"
+)
+
+type service struct{}
+
+var _ api.MCPService = (*service)(nil)
+
+func New() *service {
+	return &service{}
+}
+
+func (s *service) RegisterMCPTools(server *mcp.Server) {
+	mcp.AddTool(server, api.MCPReadTool(
+		"whoami",
+		"Who am I",
+		"Get the authenticated Nuon employee account and organization context. Use this first to confirm nuonctl MCP authentication.",
+	), s.mcpWhoami)
+}

--- a/services/ctl-api/internal/config.go
+++ b/services/ctl-api/internal/config.go
@@ -24,6 +24,7 @@ func init() {
 	config.RegisterDefault("admin_dashboard_http_port", "8087")
 	config.RegisterDefault("slack_http_port", "8089")
 	config.RegisterDefault("mcp_http_port", "8088")
+	config.RegisterDefault("nuonctl_mcp_http_port", "8091")
 	// Slack secrets: dev-only insecure defaults so the slack-libs FX module
 	// (statejwt.New) and signing.Middleware construction don't fail boot
 	// when no SLACK_* env is set. Prod overrides via env. Same pattern as
@@ -235,6 +236,7 @@ type Config struct {
 	AdminDashboardDistDir  string `config:"admin_dashboard_dist_dir"`
 	SlackHTTPPort          string `config:"slack_http_port" validate:"required"`
 	MCPHTTPPort            string `config:"mcp_http_port"`
+	NuonctlMCPHTTPPort     string `config:"nuonctl_mcp_http_port"`
 
 	WorkerHealthcheckPort    string `config:"worker_healthcheck_port"`
 	WorkerHealthcheckEnabled bool   `config:"worker_healthcheck_enabled"`

--- a/services/ctl-api/internal/fxmodules/mcp.go
+++ b/services/ctl-api/internal/fxmodules/mcp.go
@@ -9,3 +9,7 @@ import (
 var MCPAPIModule = fx.Module("mcp-api",
 	fx.Invoke(mcpserver.New),
 )
+
+var NuonctlMCPAPIModule = fx.Module("nuonctl-mcp-api",
+	fx.Invoke(mcpserver.NewNuonctl),
+)

--- a/services/ctl-api/internal/fxmodules/services.go
+++ b/services/ctl-api/internal/fxmodules/services.go
@@ -14,6 +14,7 @@ import (
 	identityprovidersservice "github.com/nuonco/nuon/services/ctl-api/internal/app/identity-providers/service"
 	installsservice "github.com/nuonco/nuon/services/ctl-api/internal/app/installs/service"
 	notebooksservice "github.com/nuonco/nuon/services/ctl-api/internal/app/notebooks/service"
+	nuonctlmcpservice "github.com/nuonco/nuon/services/ctl-api/internal/app/nuonctl-mcp/service"
 	oidcfederationservice "github.com/nuonco/nuon/services/ctl-api/internal/app/oidc-federation/service"
 	onboardingservice "github.com/nuonco/nuon/services/ctl-api/internal/app/onboarding/service"
 	orgsservice "github.com/nuonco/nuon/services/ctl-api/internal/app/orgs/service"
@@ -103,6 +104,10 @@ var SlackServicesModule = fx.Module("slack-services", sharedServices)
 // tools through authservice, so pulling it in would only impose authservice's
 // config requirements (NUON_AUTH_CLIENT_SECRET et al) on the mcp deployment.
 var MCPServicesModule = fx.Module("mcp-services", sharedServices)
+
+var NuonctlMCPServicesModule = fx.Module("nuonctl-mcp-services",
+	fx.Provide(api.AsNuonctlMCPService(nuonctlmcpservice.New)),
+)
 
 // AllServicesModule provides all services including authservice (for dev mode).
 var AllServicesModule = fx.Module("all-services",

--- a/services/ctl-api/internal/pkg/api/mcp_service.go
+++ b/services/ctl-api/internal/pkg/api/mcp_service.go
@@ -4,10 +4,19 @@ import (
 	"encoding/json"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/fx"
 )
 
 type MCPService interface {
 	RegisterMCPTools(server *mcp.Server)
+}
+
+func AsNuonctlMCPService(f any) any {
+	return fx.Annotate(
+		f,
+		fx.As(new(MCPService)),
+		fx.ResultTags(`group:"nuonctl_mcp_services"`),
+	)
 }
 
 func MCPJSONResult(v any) (*mcp.CallToolResult, any, error) {


### PR DESCRIPTION
## Summary

Add an employee-only `nuonctl-mcp-api` process next to the public MCP server. It reuses ctl-api auth from `~/.nuon`, rejects non-`@nuon.co` accounts, and currently exposes `whoami`.

This pr change primarily sets up the nuonctl mcp service (local dev only)