### PR TITLE
fix: isolate OCI auth cache in image metadata and terraform archive pulls

### DIFF
--- a/pkg/oci/metadata/fetcher.go
+++ b/pkg/oci/metadata/fetcher.go
@@ -93,6 +93,23 @@ type FetchOptions struct {
 	Guardrails *FetchGuardrails
 }
 
+// Always isolate: a nil repo.Client falls back to the process-global auth.DefaultClient
+// and its host-keyed auth.DefaultCache, which replays a dead token (ECR TTL 12h) and can
+// attach one fetch's credential to another's anonymous pull of the same host.
+func newAuthClient(serverAddr string, regAuth *RegistryAuth) *auth.Client {
+	client := &auth.Client{
+		Client: retry.DefaultClient,
+		Cache:  auth.NewCache(),
+	}
+	if regAuth != nil && regAuth.Username != "" {
+		client.Credential = auth.StaticCredential(serverAddr, auth.Credential{
+			Username: regAuth.Username,
+			Password: regAuth.Password,
+		})
+	}
+	return client
+}
+
 func FetchImageMetadata(ctx context.Context, opts *FetchOptions) (*ImageMetadata, error) {
 	normalizedImage := dockerhub.NormalizeReference(opts.Image)
 	repo, err := remote.NewRepository(normalizedImage)
@@ -100,25 +117,18 @@ func FetchImageMetadata(ctx context.Context, opts *FetchOptions) (*ImageMetadata
 		return nil, fmt.Errorf("unable to create repository client: %w", err)
 	}
 
-	if opts.Auth != nil && opts.Auth.Username != "" {
-		serverAddr := opts.Auth.ServerAddress
-		serverAddr = strings.TrimPrefix(serverAddr, "https://")
+	serverAddr := ""
+	if opts.Auth != nil {
+		serverAddr = strings.TrimPrefix(opts.Auth.ServerAddress, "https://")
 		serverAddr = strings.TrimPrefix(serverAddr, "http://")
-		if serverAddr == "" {
-			parts := strings.SplitN(opts.Image, "/", 2)
-			if len(parts) > 0 {
-				serverAddr = parts[0]
-			}
-		}
-		repo.Client = &auth.Client{
-			Client: retry.DefaultClient,
-			Cache:  auth.DefaultCache,
-			Credential: auth.StaticCredential(serverAddr, auth.Credential{
-				Username: opts.Auth.Username,
-				Password: opts.Auth.Password,
-			}),
+	}
+	if serverAddr == "" {
+		parts := strings.SplitN(opts.Image, "/", 2)
+		if len(parts) > 0 {
+			serverAddr = parts[0]
 		}
 	}
+	repo.Client = newAuthClient(serverAddr, opts.Auth)
 
 	tag := opts.Tag
 	if tag == "" {

--- a/pkg/oci/metadata/fetcher_test.go
+++ b/pkg/oci/metadata/fetcher_test.go
@@ -1,9 +1,17 @@
 package metadata
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
 )
 
 func TestDecodeInTotoStatement(t *testing.T) {
@@ -39,4 +47,66 @@ func TestDecodeInTotoStatement(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Guards the 12h-ECR-token replay: a shared cache pins the first token per host, and a
+// nil client falls back to the same global cache for anonymous pulls.
+func TestNewAuthClientDoesNotShareGlobalCache(t *testing.T) {
+	authed := newAuthClient("registry.example.com", &RegistryAuth{Username: "AWS", Password: "first"})
+	second := newAuthClient("registry.example.com", &RegistryAuth{Username: "AWS", Password: "second"})
+
+	require.NotSame(t, auth.DefaultCache, authed.Cache, "must not reuse the process-global default cache")
+	require.NotSame(t, authed.Cache, second.Cache, "each fetch must get its own cache")
+	require.NotNil(t, authed.Credential)
+
+	for name, regAuth := range map[string]*RegistryAuth{
+		"nil auth":       nil,
+		"empty username": {Username: ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			anon := newAuthClient("public.ecr.aws", regAuth)
+			require.NotNil(t, anon.Cache, "anonymous fetch must still get its own cache")
+			require.NotSame(t, auth.DefaultCache, anon.Cache)
+			require.Nil(t, anon.Credential, "anonymous fetch must not attach credentials")
+		})
+	}
+}
+
+// ECR advertises Basic auth, and oras-go caches Basic per host under a constant key,
+// consulting the cache before Credential. A shared cache therefore replays the first
+// token for a host even after the caller supplies a fresh one.
+func TestNewAuthClientSendsRotatedCredential(t *testing.T) {
+	want := "tokenA"
+	var sent []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, pass, _ := r.BasicAuth()
+		if pass == "" {
+			w.Header().Set("WWW-Authenticate", `Basic realm="reg",service="ecr.amazonaws.com"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		sent = append(sent, pass)
+		if pass != want {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"acme/app","tags":["v1"]}`))
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	probe := func(password string) error {
+		repo, err := remote.NewRepository(host + "/acme/app")
+		require.NoError(t, err)
+		repo.PlainHTTP = true
+		repo.Client = newAuthClient(host, &RegistryAuth{Username: "AWS", Password: password})
+		return repo.Tags(context.Background(), "", func([]string) error { return nil })
+	}
+
+	require.NoError(t, probe("tokenA"))
+
+	want = "tokenB" // as when ECR re-mints the 12h token
+	require.NoError(t, probe("tokenB"), "must send the rotated credential, not a cached one")
+	require.Equal(t, []string{"tokenA", "tokenB"}, sent)
 }

--- a/pkg/terraform/archive/oci/pull.go
+++ b/pkg/terraform/archive/oci/pull.go
@@ -26,7 +26,7 @@ func (o *oci) getSrc() (oras.ReadOnlyTarget, error) {
 	}
 	repo.Client = &auth.Client{
 		Client: retry.DefaultClient,
-		Cache:  auth.DefaultCache,
+		Cache:  auth.NewCache(),
 		Credential: auth.StaticCredential(o.Image.Registry, auth.Credential{
 			Username: o.Auth.Username,
 			Password: o.Auth.Token,


### PR DESCRIPTION
`FetchImageMetadata` and the terraform archive puller shared oras-go's process-global `auth.DefaultCache`, which is keyed only by registry host, so a long-lived control-plane worker pinned the first ECR token it saw and replayed it after the 12h TTL — every `external_image` build against a private registry then failed with a 403 on the manifest HEAD. Each fetch now gets its own cache, and the metadata fetcher always installs an isolated client so the anonymous path no longer falls back to `auth.DefaultClient` and pick up another fetch's cached credential for the same host. Matches the fix #1947 applied to `pkg/runner/oci`; recurred in prod whenever a components worker pod outlived 12h (observed Sep 5, Sep 7, Sep 11), with a rollout restart as the only workaround.