### PR TITLE
feat: Enable CloudFormation telemetry ingress by default

### DIFF
--- a/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template.go
@@ -62,7 +62,7 @@ func (t *Templates) getAWSTemplate(inp *stacks.TemplateInput) (*cloudformation.T
 			parameter := cloudformation.Parameter{
 				Type:          "String",
 				Description:   ptr("Provision an internal OTLP HTTP endpoint for this install (additional AWS charges apply)"),
-				Default:       "false",
+				Default:       "true",
 				AllowedValues: []any{"true", "false"},
 			}
 			runnerParams["EnableTelemetryIngress"] = parameter

--- a/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template_test.go
+++ b/services/ctl-api/internal/pkg/stacks/cloudformation/aws_eks_template_test.go
@@ -157,7 +157,7 @@ Outputs:
 			assert.NotContains(t, tmpl.Parameters, "VpcId")
 			assert.NotContains(t, tmpl.Parameters, "TelemetrySourcePrefixListId")
 			parameter := tmpl.Parameters["EnableTelemetryIngress"]
-			assert.Equal(t, "false", parameter.Default)
+			assert.Equal(t, "true", parameter.Default)
 			assert.Equal(t, []any{"true", "false"}, parameter.AllowedValues)
 			condition := rendered["Conditions"].(map[string]any)["TelemetryIngressEnabled"]
 			assert.Equal(t, map[string]any{"Fn::Equals": []any{map[string]any{"Ref": "EnableTelemetryIngress"}, "true"}}, condition)


### PR DESCRIPTION
Default EnableTelemetryIngress to true in generated AWS parent stacks. Customers can still opt out with false; runtime telemetry forwarding remains unchanged.
