### PR TITLE
fix: refactor component config views

### DIFF
--- a/services/ctl-api/internal/app/apps/helpers/get_full_config.go
+++ b/services/ctl-api/internal/app/apps/helpers/get_full_config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nuonco/nuon/services/ctl-api/internal/app"
 	"github.com/nuonco/nuon/services/ctl-api/internal/middlewares/stderr"
 	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/cctx"
+	"github.com/nuonco/nuon/services/ctl-api/internal/pkg/db/plugins/views"
 )
 
 func (h *Helpers) GetFullAppConfig(ctx context.Context, appConfigID string, skipAdditionalChecks bool) (*app.AppConfig, error) {
@@ -81,11 +82,12 @@ func (h *Helpers) GetFullAppConfig(ctx context.Context, appConfigID string, skip
 		missingComponents := []app.ComponentConfigConnection{}
 		// a newer row's dependency ids can name components absent from this version
 		var boundedCfgIDs []string
-		res = h.db.WithContext(ctx).Raw(`
+		res = h.db.WithContext(ctx).Raw(fmt.Sprintf(`
 			SELECT DISTINCT ON (component_id) id
-			FROM component_config_connections_view_v1
+			FROM %s
 			WHERE component_id IN ? AND app_config_version <= ?
 			ORDER BY component_id, app_config_version DESC`,
+			views.CurrentViewName(h.db, &app.ComponentConfigConnection{})),
 			missingComponentIds, appCfg.Version,
 		).Scan(&boundedCfgIDs)
 		if res.Error != nil {

--- a/services/ctl-api/internal/app/apps/helpers/get_full_config_bench_test.go
+++ b/services/ctl-api/internal/app/apps/helpers/get_full_config_bench_test.go
@@ -100,7 +100,7 @@ func fullConfigBenchmarkHelper(t testing.TB, actions int) *appshelpers.Helpers {
 		{"image", app.ComponentTypeExternalImage}, {"job", app.ComponentTypeJob}, {"pulumi", app.ComponentTypePulumi},
 	} {
 		add("components", "id name type", c.id, c.id, string(c.typ))
-		add("component_config_connections_view_v1", "app_config_id id component_id", "config", c.id+"-connection", c.id)
+		add("component_config_connections_view_v2", "app_config_id id component_id", "config", c.id+"-connection", c.id)
 	}
 	add("helm_component_configs", "component_config_connection_id id chart_name", "helm-connection", "helm-config", "my-chart")
 	add("terraform_module_component_configs", "component_config_connection_id id version", "terraform-connection", "terraform-config", "latest")

--- a/services/ctl-api/internal/app/component_config_connection.go
+++ b/services/ctl-api/internal/app/component_config_connection.go
@@ -178,14 +178,14 @@ func (c *ComponentConfigConnection) UseView() bool {
 }
 
 func (c *ComponentConfigConnection) ViewVersion() string {
-	return "v1"
+	return "v2"
 }
 
 func (c *ComponentConfigConnection) Views(db *gorm.DB) []migrations.View {
 	return []migrations.View{
 		{
-			Name:          views.DefaultViewName(db, &ComponentConfigConnection{}, 1),
-			SQL:           viewsql.ComponentConfigConnectionsV1,
+			Name:          views.DefaultViewName(db, &ComponentConfigConnection{}, 2),
+			SQL:           viewsql.ComponentConfigConnectionsV2,
 			AlwaysReapply: true,
 		},
 		{
@@ -203,6 +203,14 @@ func (a *ComponentConfigConnection) Indexes(db *gorm.DB) []migrations.Index {
 			Columns: []string{
 				"component_id",
 				"deleted_at",
+			},
+		},
+		{
+			Name: indexes.Name(db, &ComponentConfigConnection{}, "component_id_created_at"),
+			Columns: []string{
+				"component_id",
+				"created_at",
+				"id",
 			},
 		},
 		{

--- a/services/ctl-api/internal/app/components/helpers/scope.go
+++ b/services/ctl-api/internal/app/components/helpers/scope.go
@@ -12,8 +12,8 @@ func PreloadLatestConfig(db *gorm.DB) *gorm.DB {
 	return db.
 		Preload("ComponentConfigs", func(db *gorm.DB) *gorm.DB {
 			return db.
-				Table(views.DefaultViewName(db,
-					&app.ComponentConfigConnection{}, 1)).
+				Table(views.CurrentViewName(db,
+					&app.ComponentConfigConnection{})).
 				Order("created_at DESC").Limit(1)
 		}).
 

--- a/services/ctl-api/internal/pkg/db/viewsql/component_config_connections_v2.sql
+++ b/services/ctl-api/internal/pkg/db/viewsql/component_config_connections_v2.sql
@@ -1,0 +1,22 @@
+SELECT
+    ccc.*,
+    (
+        SELECT n FROM (
+            SELECT ccc2.id AS id,
+                   row_number() OVER (ORDER BY ccc2.created_at, ccc2.id) AS n
+            FROM component_config_connections ccc2
+            WHERE ccc2.component_id = ccc.component_id
+        ) sub
+        WHERE sub.id = ccc.id
+    ) AS version,
+    (
+        SELECT n FROM (
+            SELECT ac2.id AS id,
+                   row_number() OVER (ORDER BY ac2.created_at, ac2.id) AS n
+            FROM app_configs ac2
+            WHERE ac2.app_id = ac.app_id
+        ) sub
+        WHERE sub.id = ac.id
+    ) AS app_config_version
+FROM component_config_connections ccc
+JOIN app_configs ac ON ac.id = ccc.app_config_id

--- a/services/ctl-api/internal/pkg/db/viewsql/latest_component_config_connections_view_v1.sql
+++ b/services/ctl-api/internal/pkg/db/viewsql/latest_component_config_connections_view_v1.sql
@@ -1,21 +1,13 @@
-WITH component_config_connections_with_count AS (
-  SELECT
-       rje.*,
-
-       ROW_NUMBER() OVER (
-	  PARTITION BY component_id
-	  ORDER BY
-	    created_at
-       ) AS version,
-
-       ROW_NUMBER() OVER (PARTITION BY rje.component_id ORDER BY rje.created_at DESC) as execution_number
-  FROM
-     component_config_connections rje
-)
-
-SELECT
-	rje.*
-FROM
-	component_config_connections_with_count rje
-WHERE
-	rje.execution_number = 1
+SELECT DISTINCT ON (ccc.component_id)
+    ccc.*,
+    (
+        SELECT n FROM (
+            SELECT ccc2.id AS id,
+                   row_number() OVER (ORDER BY ccc2.created_at, ccc2.id) AS n
+            FROM component_config_connections ccc2
+            WHERE ccc2.component_id = ccc.component_id
+        ) sub
+        WHERE sub.id = ccc.id
+    ) AS version
+FROM component_config_connections ccc
+ORDER BY ccc.component_id, ccc.created_at DESC, ccc.id DESC

--- a/services/ctl-api/internal/pkg/db/viewsql/viewsql.go
+++ b/services/ctl-api/internal/pkg/db/viewsql/viewsql.go
@@ -61,6 +61,9 @@ var AppSandboxConfigsLatestViewV1 string
 //go:embed component_config_connections_v1.sql
 var ComponentConfigConnectionsV1 string
 
+//go:embed component_config_connections_v2.sql
+var ComponentConfigConnectionsV2 string
+
 //go:embed latest_component_config_connections_view_v1.sql
 var LatestComponentConfigConnectionsV1 string
 


### PR DESCRIPTION
## Summary
  - Rewrite `component_config_connections` views so `WHERE id` / `app_config_id` can use indexes instead of windowing the whole table.
  - `GetAppConfig` and `GetComponentBuildForPolicyEval` were spending ~300ms on 1-row
  
  we should plan to store the version number or deprecate the property all together.